### PR TITLE
feat(phase-a): rebuild theme editor with full CRUD, forensic-workbench UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: up down build build-no-cache logs ps
+
+# ---------------------------------------------------------------------------
+# Core commands
+# ---------------------------------------------------------------------------
+
+## up dev  — DB/Redis/Server + Vite dev server
+## up prod — Full stack via Nginx (single port 80)
+up:
+ifeq ($(filter prod,$(MAKECMDGOALS)),prod)
+	docker compose up -d --build
+else
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+	@if lsof -iTCP:3000 -sTCP:LISTEN -t >/dev/null 2>&1; then \
+		echo "✓ Vite dev server already running on :3000"; \
+	else \
+		echo "→ Starting Vite dev server..."; \
+		cd apps/web && pnpm dev & \
+		sleep 2; \
+		echo "✓ Vite dev server started on :3000"; \
+	fi
+endif
+
+## down — Stop all services
+down:
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml down 2>/dev/null; \
+	docker compose down 2>/dev/null; true
+
+## build — Build all Docker images
+build:
+	docker compose build
+
+## build-no-cache — Build all Docker images without cache
+build-no-cache:
+	docker compose build --no-cache
+
+## logs [service] — Tail logs (e.g. make logs s=server)
+logs:
+	docker compose logs -f $(s)
+
+## ps — Show running services
+ps:
+	docker compose ps
+
+# Prevent make from treating 'dev'/'prod' as file targets
+dev prod:
+	@true

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download

--- a/apps/server/Dockerfile.dev
+++ b/apps/server/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile with air hot-reload
-FROM golang:1.24-alpine
+FROM golang:1.25-alpine
 RUN go install github.com/air-verse/air@latest
 WORKDIR /build
 COPY go.mod go.sum ./

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -132,7 +132,7 @@ func main() {
 	profileSvc := profile.NewService(queries, logger)
 	roomSvc := room.NewService(pool, queries, logger)
 	themeSvc := theme.NewService(queries, logger)
-	editorSvc := editor.NewService(queries, logger)
+	editorSvc := editor.NewService(queries, pool, logger)
 	adminSvc := admin.NewService(queries, logger)
 	friendSvc := social.NewFriendService(queries, logger)
 	chatSvc := social.NewChatService(pool, queries, logger)
@@ -214,6 +214,8 @@ func main() {
 	r.Route("/api/v1", func(r chi.Router) {
 		// --- Public endpoints ---
 		r.Post("/auth/callback", authHandler.HandleCallback)
+		r.Post("/auth/register", authHandler.HandleRegister)
+		r.Post("/auth/login", authHandler.HandleLogin)
 		r.Post("/auth/refresh", authHandler.HandleRefresh)
 
 		r.Get("/themes", themeHandler.ListPublished)
@@ -309,10 +311,31 @@ func main() {
 				r.Delete("/themes/{id}", editorHandler.DeleteTheme)
 				r.Post("/themes/{id}/publish", editorHandler.PublishTheme)
 				r.Post("/themes/{id}/unpublish", editorHandler.UnpublishTheme)
+				r.Get("/themes/{id}/characters", editorHandler.ListCharacters)
 				r.Post("/themes/{id}/characters", editorHandler.CreateCharacter)
 				r.Put("/characters/{id}", editorHandler.UpdateCharacter)
 				r.Delete("/characters/{id}", editorHandler.DeleteCharacter)
 				r.Put("/themes/{id}/config", editorHandler.UpdateConfigJson)
+				// Maps
+				r.Get("/themes/{id}/maps", editorHandler.ListMaps)
+				r.Post("/themes/{id}/maps", editorHandler.CreateMap)
+				r.Put("/maps/{id}", editorHandler.UpdateMap)
+				r.Delete("/maps/{id}", editorHandler.DeleteMap)
+				// Locations
+				r.Get("/themes/{id}/locations", editorHandler.ListLocations)
+				r.Post("/themes/{id}/maps/{mapId}/locations", editorHandler.CreateLocation)
+				r.Put("/locations/{id}", editorHandler.UpdateLocation)
+				r.Delete("/locations/{id}", editorHandler.DeleteLocation)
+				// Clues
+				r.Get("/themes/{id}/clues", editorHandler.ListClues)
+				r.Post("/themes/{id}/clues", editorHandler.CreateClue)
+				r.Put("/clues/{id}", editorHandler.UpdateClue)
+				r.Delete("/clues/{id}", editorHandler.DeleteClue)
+				// Contents
+				r.Get("/themes/{id}/content/{key}", editorHandler.GetContent)
+				r.Put("/themes/{id}/content/{key}", editorHandler.UpsertContent)
+				// Validation
+				r.Post("/themes/{id}/validate", editorHandler.ValidateTheme)
 			})
 
 			// --- Admin endpoints (ADMIN only) ---

--- a/apps/server/db/migrations/00009_password_auth.sql
+++ b/apps/server/db/migrations/00009_password_auth.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN password_hash TEXT;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN IF EXISTS password_hash;

--- a/apps/server/db/migrations/00010_themes_coin_price.sql
+++ b/apps/server/db/migrations/00010_themes_coin_price.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE themes ADD COLUMN IF NOT EXISTS coin_price INT NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE themes DROP COLUMN IF EXISTS coin_price;

--- a/apps/server/db/migrations/00011_editor_tables.sql
+++ b/apps/server/db/migrations/00011_editor_tables.sql
@@ -1,0 +1,60 @@
+-- +goose Up
+
+-- 맵 테이블
+CREATE TABLE theme_maps (
+    id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    theme_id   UUID NOT NULL REFERENCES themes(id) ON DELETE CASCADE,
+    name       VARCHAR(100) NOT NULL,
+    image_url  TEXT,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_theme_maps_theme ON theme_maps(theme_id);
+
+-- 위치 테이블
+CREATE TABLE theme_locations (
+    id                    UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    theme_id              UUID NOT NULL REFERENCES themes(id) ON DELETE CASCADE,
+    map_id                UUID NOT NULL REFERENCES theme_maps(id) ON DELETE CASCADE,
+    name                  VARCHAR(100) NOT NULL,
+    restricted_characters TEXT,
+    sort_order            INT NOT NULL DEFAULT 0,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_theme_locations_map ON theme_locations(map_id);
+CREATE INDEX idx_theme_locations_theme ON theme_locations(theme_id);
+
+-- 단서 테이블
+CREATE TABLE theme_clues (
+    id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    theme_id    UUID NOT NULL REFERENCES themes(id) ON DELETE CASCADE,
+    location_id UUID REFERENCES theme_locations(id) ON DELETE SET NULL,
+    name        VARCHAR(200) NOT NULL,
+    description TEXT,
+    image_url   TEXT,
+    is_common   BOOLEAN NOT NULL DEFAULT FALSE,
+    level       INT NOT NULL DEFAULT 1,
+    clue_type   VARCHAR(30) NOT NULL DEFAULT 'normal',
+    sort_order  INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_theme_clues_theme ON theme_clues(theme_id);
+CREATE INDEX idx_theme_clues_location ON theme_clues(location_id);
+
+-- 콘텐츠 테이블 (스토리, 역할 등 마크다운)
+CREATE TABLE theme_contents (
+    id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    theme_id   UUID NOT NULL REFERENCES themes(id) ON DELETE CASCADE,
+    key        VARCHAR(100) NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(theme_id, key),
+    CONSTRAINT valid_content_key CHECK (key ~ '^(story|rules|epilogue|role:[a-z0-9_-]{1,50})$')
+);
+CREATE INDEX idx_theme_contents_theme ON theme_contents(theme_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS theme_contents;
+DROP TABLE IF EXISTS theme_clues;
+DROP TABLE IF EXISTS theme_locations;
+DROP TABLE IF EXISTS theme_maps;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -1,0 +1,133 @@
+-- ============================================================
+-- Maps
+-- ============================================================
+
+-- name: ListMapsByTheme :many
+SELECT * FROM theme_maps WHERE theme_id = $1 ORDER BY sort_order;
+
+-- name: GetMap :one
+SELECT * FROM theme_maps WHERE id = $1;
+
+-- name: CreateMap :one
+INSERT INTO theme_maps (theme_id, name, image_url, sort_order)
+VALUES ($1, $2, $3, $4)
+RETURNING *;
+
+-- name: UpdateMap :one
+UPDATE theme_maps SET name = $2, image_url = $3, sort_order = $4
+WHERE id = $1
+RETURNING *;
+
+-- name: DeleteMap :exec
+DELETE FROM theme_maps WHERE id = $1;
+
+-- name: CountMapsByTheme :one
+SELECT count(*) FROM theme_maps WHERE theme_id = $1;
+
+-- ============================================================
+-- Locations
+-- ============================================================
+
+-- name: ListLocationsByMap :many
+SELECT * FROM theme_locations WHERE map_id = $1 ORDER BY sort_order;
+
+-- name: ListLocationsByTheme :many
+SELECT * FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
+
+-- name: GetLocation :one
+SELECT * FROM theme_locations WHERE id = $1;
+
+-- name: CreateLocation :one
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING *;
+
+-- name: UpdateLocation :one
+UPDATE theme_locations SET name = $2, restricted_characters = $3, sort_order = $4
+WHERE id = $1
+RETURNING *;
+
+-- name: DeleteLocation :exec
+DELETE FROM theme_locations WHERE id = $1;
+
+-- name: CountLocationsByMap :one
+SELECT count(*) FROM theme_locations WHERE map_id = $1;
+
+-- ============================================================
+-- Clues
+-- ============================================================
+
+-- name: ListCluesByTheme :many
+SELECT * FROM theme_clues WHERE theme_id = $1 ORDER BY sort_order;
+
+-- name: ListCluesByLocation :many
+SELECT * FROM theme_clues WHERE location_id = $1 ORDER BY sort_order;
+
+-- name: GetClue :one
+SELECT * FROM theme_clues WHERE id = $1;
+
+-- name: CreateClue :one
+INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, clue_type, sort_order)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING *;
+
+-- name: UpdateClue :one
+UPDATE theme_clues SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, clue_type = $8, sort_order = $9
+WHERE id = $1
+RETURNING *;
+
+-- name: DeleteClue :exec
+DELETE FROM theme_clues WHERE id = $1;
+
+-- name: CountCluesByTheme :one
+SELECT count(*) FROM theme_clues WHERE theme_id = $1;
+
+-- ============================================================
+-- Contents
+-- ============================================================
+
+-- name: GetContent :one
+SELECT * FROM theme_contents WHERE theme_id = $1 AND key = $2;
+
+-- name: UpsertContent :one
+INSERT INTO theme_contents (theme_id, key, body, updated_at)
+VALUES ($1, $2, $3, NOW())
+ON CONFLICT (theme_id, key) DO UPDATE SET body = EXCLUDED.body, updated_at = NOW()
+RETURNING *;
+
+-- name: ListContentsByTheme :many
+SELECT * FROM theme_contents WHERE theme_id = $1 ORDER BY key;
+
+-- name: DeleteContent :exec
+DELETE FROM theme_contents WHERE theme_id = $1 AND key = $2;
+
+-- ============================================================
+-- Ownership verification (JOIN-based, single query)
+-- ============================================================
+
+-- name: GetMapWithOwner :one
+SELECT m.* FROM theme_maps m
+JOIN themes t ON m.theme_id = t.id
+WHERE m.id = $1 AND t.creator_id = $2;
+
+-- name: GetLocationWithOwner :one
+SELECT l.* FROM theme_locations l
+JOIN themes t ON l.theme_id = t.id
+WHERE l.id = $1 AND t.creator_id = $2;
+
+-- name: GetClueWithOwner :one
+SELECT c.* FROM theme_clues c
+JOIN themes t ON c.theme_id = t.id
+WHERE c.id = $1 AND t.creator_id = $2;
+
+-- name: DeleteMapWithOwner :execrows
+DELETE FROM theme_maps m USING themes t
+WHERE m.id = $1 AND m.theme_id = t.id AND t.creator_id = $2;
+
+-- name: DeleteLocationWithOwner :execrows
+DELETE FROM theme_locations l USING themes t
+WHERE l.id = $1 AND l.theme_id = t.id AND t.creator_id = $2;
+
+-- name: DeleteClueWithOwner :execrows
+DELETE FROM theme_clues c USING themes t
+WHERE c.id = $1 AND c.theme_id = t.id AND t.creator_id = $2;

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -5,14 +5,15 @@ SELECT * FROM themes WHERE id = $1;
 SELECT * FROM themes WHERE slug = $1;
 
 -- name: ListThemesByCreator :many
-SELECT * FROM themes WHERE creator_id = $1 ORDER BY created_at DESC;
+SELECT id, title, status, min_players, max_players, coin_price, version, created_at
+FROM themes WHERE creator_id = $1 ORDER BY created_at DESC;
 
 -- name: ListPublishedThemes :many
 SELECT * FROM themes WHERE status = 'PUBLISHED' ORDER BY published_at DESC LIMIT $1 OFFSET $2;
 
 -- name: CreateTheme :one
-INSERT INTO themes (creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, config_json)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO themes (creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, config_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 RETURNING *;
 
 -- name: UpdateThemeStatus :one
@@ -30,8 +31,9 @@ RETURNING *;
 
 -- name: UpdateTheme :one
 UPDATE themes SET title = $2, slug = $3, description = $4, cover_image = $5,
-  min_players = $6, max_players = $7, duration_min = $8, price = $9, updated_at = NOW()
-WHERE id = $1
+  min_players = $6, max_players = $7, duration_min = $8, price = $9, coin_price = $10,
+  version = version + 1, updated_at = NOW()
+WHERE id = $1 AND version = $11
 RETURNING *;
 
 -- name: DeleteTheme :exec
@@ -39,7 +41,7 @@ DELETE FROM themes WHERE id = $1;
 
 -- name: UpdateThemeConfigJson :one
 UPDATE themes SET config_json = $2, version = version + 1, updated_at = NOW()
-WHERE id = $1
+WHERE id = $1 AND version = $3
 RETURNING *;
 
 -- name: GetThemeCharacter :one

--- a/apps/server/db/queries/users.sql
+++ b/apps/server/db/queries/users.sql
@@ -26,3 +26,11 @@ SELECT * FROM users ORDER BY created_at DESC LIMIT $1 OFFSET $2;
 UPDATE users SET role = $2, updated_at = NOW()
 WHERE id = $1
 RETURNING *;
+
+-- name: GetUserByEmail :one
+SELECT * FROM users WHERE email = $1 AND provider = 'local';
+
+-- name: CreateUserWithPassword :one
+INSERT INTO users (nickname, email, password_hash, provider, provider_id)
+VALUES ($1, $2, $3, 'local', $2)
+RETURNING *;

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -1,0 +1,729 @@
+package db
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// ============================================================
+// Maps
+// ============================================================
+
+const listMapsByTheme = `-- name: ListMapsByTheme :many
+SELECT id, theme_id, name, image_url, sort_order, created_at FROM theme_maps WHERE theme_id = $1 ORDER BY sort_order`
+
+func (q *Queries) ListMapsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeMap, error) {
+	rows, err := q.db.Query(ctx, listMapsByTheme, themeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ThemeMap{}
+	for rows.Next() {
+		var i ThemeMap
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThemeID,
+			&i.Name,
+			&i.ImageUrl,
+			&i.SortOrder,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getMap = `-- name: GetMap :one
+SELECT id, theme_id, name, image_url, sort_order, created_at FROM theme_maps WHERE id = $1`
+
+func (q *Queries) GetMap(ctx context.Context, id uuid.UUID) (ThemeMap, error) {
+	row := q.db.QueryRow(ctx, getMap, id)
+	var i ThemeMap
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.Name,
+		&i.ImageUrl,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const createMap = `-- name: CreateMap :one
+INSERT INTO theme_maps (theme_id, name, image_url, sort_order)
+VALUES ($1, $2, $3, $4)
+RETURNING id, theme_id, name, image_url, sort_order, created_at`
+
+type CreateMapParams struct {
+	ThemeID   uuid.UUID   `json:"theme_id"`
+	Name      string      `json:"name"`
+	ImageUrl  pgtype.Text `json:"image_url"`
+	SortOrder int32       `json:"sort_order"`
+}
+
+func (q *Queries) CreateMap(ctx context.Context, arg CreateMapParams) (ThemeMap, error) {
+	row := q.db.QueryRow(ctx, createMap,
+		arg.ThemeID,
+		arg.Name,
+		arg.ImageUrl,
+		arg.SortOrder,
+	)
+	var i ThemeMap
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.Name,
+		&i.ImageUrl,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const updateMap = `-- name: UpdateMap :one
+UPDATE theme_maps SET name = $2, image_url = $3, sort_order = $4
+WHERE id = $1
+RETURNING id, theme_id, name, image_url, sort_order, created_at`
+
+type UpdateMapParams struct {
+	ID        uuid.UUID   `json:"id"`
+	Name      string      `json:"name"`
+	ImageUrl  pgtype.Text `json:"image_url"`
+	SortOrder int32       `json:"sort_order"`
+}
+
+func (q *Queries) UpdateMap(ctx context.Context, arg UpdateMapParams) (ThemeMap, error) {
+	row := q.db.QueryRow(ctx, updateMap,
+		arg.ID,
+		arg.Name,
+		arg.ImageUrl,
+		arg.SortOrder,
+	)
+	var i ThemeMap
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.Name,
+		&i.ImageUrl,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const deleteMap = `-- name: DeleteMap :exec
+DELETE FROM theme_maps WHERE id = $1`
+
+func (q *Queries) DeleteMap(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteMap, id)
+	return err
+}
+
+const countMapsByTheme = `-- name: CountMapsByTheme :one
+SELECT count(*) FROM theme_maps WHERE theme_id = $1`
+
+func (q *Queries) CountMapsByTheme(ctx context.Context, themeID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countMapsByTheme, themeID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+// ============================================================
+// Locations
+// ============================================================
+
+const listLocationsByMap = `-- name: ListLocationsByMap :many
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at FROM theme_locations WHERE map_id = $1 ORDER BY sort_order`
+
+func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]ThemeLocation, error) {
+	rows, err := q.db.Query(ctx, listLocationsByMap, mapID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ThemeLocation{}
+	for rows.Next() {
+		var i ThemeLocation
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThemeID,
+			&i.MapID,
+			&i.Name,
+			&i.RestrictedCharacters,
+			&i.SortOrder,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listLocationsByTheme = `-- name: ListLocationsByTheme :many
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order`
+
+func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeLocation, error) {
+	rows, err := q.db.Query(ctx, listLocationsByTheme, themeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ThemeLocation{}
+	for rows.Next() {
+		var i ThemeLocation
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThemeID,
+			&i.MapID,
+			&i.Name,
+			&i.RestrictedCharacters,
+			&i.SortOrder,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getLocation = `-- name: GetLocation :one
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at FROM theme_locations WHERE id = $1`
+
+func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation, error) {
+	row := q.db.QueryRow(ctx, getLocation, id)
+	var i ThemeLocation
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.MapID,
+		&i.Name,
+		&i.RestrictedCharacters,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const createLocation = `-- name: CreateLocation :one
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at`
+
+type CreateLocationParams struct {
+	ThemeID              uuid.UUID   `json:"theme_id"`
+	MapID                uuid.UUID   `json:"map_id"`
+	Name                 string      `json:"name"`
+	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
+	SortOrder            int32       `json:"sort_order"`
+}
+
+func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) (ThemeLocation, error) {
+	row := q.db.QueryRow(ctx, createLocation,
+		arg.ThemeID,
+		arg.MapID,
+		arg.Name,
+		arg.RestrictedCharacters,
+		arg.SortOrder,
+	)
+	var i ThemeLocation
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.MapID,
+		&i.Name,
+		&i.RestrictedCharacters,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const updateLocation = `-- name: UpdateLocation :one
+UPDATE theme_locations SET name = $2, restricted_characters = $3, sort_order = $4
+WHERE id = $1
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at`
+
+type UpdateLocationParams struct {
+	ID                   uuid.UUID   `json:"id"`
+	Name                 string      `json:"name"`
+	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
+	SortOrder            int32       `json:"sort_order"`
+}
+
+func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) (ThemeLocation, error) {
+	row := q.db.QueryRow(ctx, updateLocation,
+		arg.ID,
+		arg.Name,
+		arg.RestrictedCharacters,
+		arg.SortOrder,
+	)
+	var i ThemeLocation
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.MapID,
+		&i.Name,
+		&i.RestrictedCharacters,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const deleteLocation = `-- name: DeleteLocation :exec
+DELETE FROM theme_locations WHERE id = $1`
+
+func (q *Queries) DeleteLocation(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteLocation, id)
+	return err
+}
+
+const countLocationsByMap = `-- name: CountLocationsByMap :one
+SELECT count(*) FROM theme_locations WHERE map_id = $1`
+
+func (q *Queries) CountLocationsByMap(ctx context.Context, mapID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countLocationsByMap, mapID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+// ============================================================
+// Clues
+// ============================================================
+
+const listCluesByTheme = `-- name: ListCluesByTheme :many
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, clue_type, sort_order, created_at FROM theme_clues WHERE theme_id = $1 ORDER BY sort_order`
+
+func (q *Queries) ListCluesByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeClue, error) {
+	rows, err := q.db.Query(ctx, listCluesByTheme, themeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ThemeClue{}
+	for rows.Next() {
+		var i ThemeClue
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThemeID,
+			&i.LocationID,
+			&i.Name,
+			&i.Description,
+			&i.ImageUrl,
+			&i.IsCommon,
+			&i.Level,
+			&i.ClueType,
+			&i.SortOrder,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCluesByLocation = `-- name: ListCluesByLocation :many
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, clue_type, sort_order, created_at FROM theme_clues WHERE location_id = $1 ORDER BY sort_order`
+
+func (q *Queries) ListCluesByLocation(ctx context.Context, locationID pgtype.UUID) ([]ThemeClue, error) {
+	rows, err := q.db.Query(ctx, listCluesByLocation, locationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ThemeClue{}
+	for rows.Next() {
+		var i ThemeClue
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThemeID,
+			&i.LocationID,
+			&i.Name,
+			&i.Description,
+			&i.ImageUrl,
+			&i.IsCommon,
+			&i.Level,
+			&i.ClueType,
+			&i.SortOrder,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getClue = `-- name: GetClue :one
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, clue_type, sort_order, created_at FROM theme_clues WHERE id = $1`
+
+func (q *Queries) GetClue(ctx context.Context, id uuid.UUID) (ThemeClue, error) {
+	row := q.db.QueryRow(ctx, getClue, id)
+	var i ThemeClue
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.LocationID,
+		&i.Name,
+		&i.Description,
+		&i.ImageUrl,
+		&i.IsCommon,
+		&i.Level,
+		&i.ClueType,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const createClue = `-- name: CreateClue :one
+INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, clue_type, sort_order)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, clue_type, sort_order, created_at`
+
+type CreateClueParams struct {
+	ThemeID     uuid.UUID   `json:"theme_id"`
+	LocationID  pgtype.UUID `json:"location_id"`
+	Name        string      `json:"name"`
+	Description pgtype.Text `json:"description"`
+	ImageUrl    pgtype.Text `json:"image_url"`
+	IsCommon    bool        `json:"is_common"`
+	Level       int32       `json:"level"`
+	ClueType    string      `json:"clue_type"`
+	SortOrder   int32       `json:"sort_order"`
+}
+
+func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeClue, error) {
+	row := q.db.QueryRow(ctx, createClue,
+		arg.ThemeID,
+		arg.LocationID,
+		arg.Name,
+		arg.Description,
+		arg.ImageUrl,
+		arg.IsCommon,
+		arg.Level,
+		arg.ClueType,
+		arg.SortOrder,
+	)
+	var i ThemeClue
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.LocationID,
+		&i.Name,
+		&i.Description,
+		&i.ImageUrl,
+		&i.IsCommon,
+		&i.Level,
+		&i.ClueType,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const updateClue = `-- name: UpdateClue :one
+UPDATE theme_clues SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, clue_type = $8, sort_order = $9
+WHERE id = $1
+RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, clue_type, sort_order, created_at`
+
+type UpdateClueParams struct {
+	ID          uuid.UUID   `json:"id"`
+	LocationID  pgtype.UUID `json:"location_id"`
+	Name        string      `json:"name"`
+	Description pgtype.Text `json:"description"`
+	ImageUrl    pgtype.Text `json:"image_url"`
+	IsCommon    bool        `json:"is_common"`
+	Level       int32       `json:"level"`
+	ClueType    string      `json:"clue_type"`
+	SortOrder   int32       `json:"sort_order"`
+}
+
+func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeClue, error) {
+	row := q.db.QueryRow(ctx, updateClue,
+		arg.ID,
+		arg.LocationID,
+		arg.Name,
+		arg.Description,
+		arg.ImageUrl,
+		arg.IsCommon,
+		arg.Level,
+		arg.ClueType,
+		arg.SortOrder,
+	)
+	var i ThemeClue
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.LocationID,
+		&i.Name,
+		&i.Description,
+		&i.ImageUrl,
+		&i.IsCommon,
+		&i.Level,
+		&i.ClueType,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const deleteClue = `-- name: DeleteClue :exec
+DELETE FROM theme_clues WHERE id = $1`
+
+func (q *Queries) DeleteClue(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteClue, id)
+	return err
+}
+
+const countCluesByTheme = `-- name: CountCluesByTheme :one
+SELECT count(*) FROM theme_clues WHERE theme_id = $1`
+
+func (q *Queries) CountCluesByTheme(ctx context.Context, themeID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countCluesByTheme, themeID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+// ============================================================
+// Contents
+// ============================================================
+
+const getContent = `-- name: GetContent :one
+SELECT id, theme_id, key, body, updated_at FROM theme_contents WHERE theme_id = $1 AND key = $2`
+
+type GetContentParams struct {
+	ThemeID uuid.UUID `json:"theme_id"`
+	Key     string    `json:"key"`
+}
+
+func (q *Queries) GetContent(ctx context.Context, arg GetContentParams) (ThemeContent, error) {
+	row := q.db.QueryRow(ctx, getContent, arg.ThemeID, arg.Key)
+	var i ThemeContent
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.Key,
+		&i.Body,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const upsertContent = `-- name: UpsertContent :one
+INSERT INTO theme_contents (theme_id, key, body, updated_at)
+VALUES ($1, $2, $3, NOW())
+ON CONFLICT (theme_id, key) DO UPDATE SET body = EXCLUDED.body, updated_at = NOW()
+RETURNING id, theme_id, key, body, updated_at`
+
+type UpsertContentParams struct {
+	ThemeID uuid.UUID `json:"theme_id"`
+	Key     string    `json:"key"`
+	Body    string    `json:"body"`
+}
+
+func (q *Queries) UpsertContent(ctx context.Context, arg UpsertContentParams) (ThemeContent, error) {
+	row := q.db.QueryRow(ctx, upsertContent, arg.ThemeID, arg.Key, arg.Body)
+	var i ThemeContent
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.Key,
+		&i.Body,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const listContentsByTheme = `-- name: ListContentsByTheme :many
+SELECT id, theme_id, key, body, updated_at FROM theme_contents WHERE theme_id = $1 ORDER BY key`
+
+func (q *Queries) ListContentsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeContent, error) {
+	rows, err := q.db.Query(ctx, listContentsByTheme, themeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ThemeContent{}
+	for rows.Next() {
+		var i ThemeContent
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThemeID,
+			&i.Key,
+			&i.Body,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const deleteContent = `-- name: DeleteContent :exec
+DELETE FROM theme_contents WHERE theme_id = $1 AND key = $2`
+
+type DeleteContentParams struct {
+	ThemeID uuid.UUID `json:"theme_id"`
+	Key     string    `json:"key"`
+}
+
+func (q *Queries) DeleteContent(ctx context.Context, arg DeleteContentParams) error {
+	_, err := q.db.Exec(ctx, deleteContent, arg.ThemeID, arg.Key)
+	return err
+}
+
+// ============================================================
+// Ownership verification (JOIN-based, single query)
+// ============================================================
+
+const getMapWithOwner = `-- name: GetMapWithOwner :one
+SELECT m.id, m.theme_id, m.name, m.image_url, m.sort_order, m.created_at FROM theme_maps m
+JOIN themes t ON m.theme_id = t.id
+WHERE m.id = $1 AND t.creator_id = $2`
+
+type GetMapWithOwnerParams struct {
+	ID        uuid.UUID `json:"id"`
+	CreatorID uuid.UUID `json:"creator_id"`
+}
+
+func (q *Queries) GetMapWithOwner(ctx context.Context, arg GetMapWithOwnerParams) (ThemeMap, error) {
+	row := q.db.QueryRow(ctx, getMapWithOwner, arg.ID, arg.CreatorID)
+	var i ThemeMap
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.Name,
+		&i.ImageUrl,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getLocationWithOwner = `-- name: GetLocationWithOwner :one
+SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at FROM theme_locations l
+JOIN themes t ON l.theme_id = t.id
+WHERE l.id = $1 AND t.creator_id = $2`
+
+type GetLocationWithOwnerParams struct {
+	ID        uuid.UUID `json:"id"`
+	CreatorID uuid.UUID `json:"creator_id"`
+}
+
+func (q *Queries) GetLocationWithOwner(ctx context.Context, arg GetLocationWithOwnerParams) (ThemeLocation, error) {
+	row := q.db.QueryRow(ctx, getLocationWithOwner, arg.ID, arg.CreatorID)
+	var i ThemeLocation
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.MapID,
+		&i.Name,
+		&i.RestrictedCharacters,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getClueWithOwner = `-- name: GetClueWithOwner :one
+SELECT c.id, c.theme_id, c.location_id, c.name, c.description, c.image_url, c.is_common, c.level, c.clue_type, c.sort_order, c.created_at FROM theme_clues c
+JOIN themes t ON c.theme_id = t.id
+WHERE c.id = $1 AND t.creator_id = $2`
+
+type GetClueWithOwnerParams struct {
+	ID        uuid.UUID `json:"id"`
+	CreatorID uuid.UUID `json:"creator_id"`
+}
+
+func (q *Queries) GetClueWithOwner(ctx context.Context, arg GetClueWithOwnerParams) (ThemeClue, error) {
+	row := q.db.QueryRow(ctx, getClueWithOwner, arg.ID, arg.CreatorID)
+	var i ThemeClue
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.LocationID,
+		&i.Name,
+		&i.Description,
+		&i.ImageUrl,
+		&i.IsCommon,
+		&i.Level,
+		&i.ClueType,
+		&i.SortOrder,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const deleteMapWithOwner = `-- name: DeleteMapWithOwner :execrows
+DELETE FROM theme_maps m USING themes t
+WHERE m.id = $1 AND m.theme_id = t.id AND t.creator_id = $2`
+
+type DeleteMapWithOwnerParams struct {
+	ID        uuid.UUID `json:"id"`
+	CreatorID uuid.UUID `json:"creator_id"`
+}
+
+func (q *Queries) DeleteMapWithOwner(ctx context.Context, arg DeleteMapWithOwnerParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteMapWithOwner, arg.ID, arg.CreatorID)
+	return result.RowsAffected(), err
+}
+
+const deleteLocationWithOwner = `-- name: DeleteLocationWithOwner :execrows
+DELETE FROM theme_locations l USING themes t
+WHERE l.id = $1 AND l.theme_id = t.id AND t.creator_id = $2`
+
+type DeleteLocationWithOwnerParams struct {
+	ID        uuid.UUID `json:"id"`
+	CreatorID uuid.UUID `json:"creator_id"`
+}
+
+func (q *Queries) DeleteLocationWithOwner(ctx context.Context, arg DeleteLocationWithOwnerParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteLocationWithOwner, arg.ID, arg.CreatorID)
+	return result.RowsAffected(), err
+}
+
+const deleteClueWithOwner = `-- name: DeleteClueWithOwner :execrows
+DELETE FROM theme_clues c USING themes t
+WHERE c.id = $1 AND c.theme_id = t.id AND t.creator_id = $2`
+
+type DeleteClueWithOwnerParams struct {
+	ID        uuid.UUID `json:"id"`
+	CreatorID uuid.UUID `json:"creator_id"`
+}
+
+func (q *Queries) DeleteClueWithOwner(ctx context.Context, arg DeleteClueWithOwnerParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteClueWithOwner, arg.ID, arg.CreatorID)
+	return result.RowsAffected(), err
+}

--- a/apps/server/internal/db/models_editor.go
+++ b/apps/server/internal/db/models_editor.go
@@ -1,0 +1,49 @@
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type ThemeMap struct {
+	ID        uuid.UUID   `json:"id"`
+	ThemeID   uuid.UUID   `json:"theme_id"`
+	Name      string      `json:"name"`
+	ImageUrl  pgtype.Text `json:"image_url"`
+	SortOrder int32       `json:"sort_order"`
+	CreatedAt time.Time   `json:"created_at"`
+}
+
+type ThemeLocation struct {
+	ID                   uuid.UUID   `json:"id"`
+	ThemeID              uuid.UUID   `json:"theme_id"`
+	MapID                uuid.UUID   `json:"map_id"`
+	Name                 string      `json:"name"`
+	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
+	SortOrder            int32       `json:"sort_order"`
+	CreatedAt            time.Time   `json:"created_at"`
+}
+
+type ThemeClue struct {
+	ID          uuid.UUID   `json:"id"`
+	ThemeID     uuid.UUID   `json:"theme_id"`
+	LocationID  pgtype.UUID `json:"location_id"`
+	Name        string      `json:"name"`
+	Description pgtype.Text `json:"description"`
+	ImageUrl    pgtype.Text `json:"image_url"`
+	IsCommon    bool        `json:"is_common"`
+	Level       int32       `json:"level"`
+	ClueType    string      `json:"clue_type"`
+	SortOrder   int32       `json:"sort_order"`
+	CreatedAt   time.Time   `json:"created_at"`
+}
+
+type ThemeContent struct {
+	ID        uuid.UUID `json:"id"`
+	ThemeID   uuid.UUID `json:"theme_id"`
+	Key       string    `json:"key"`
+	Body      string    `json:"body"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -8,6 +8,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -25,8 +26,8 @@ func (q *Queries) CountThemeCharacters(ctx context.Context, themeID uuid.UUID) (
 }
 
 const createTheme = `-- name: CreateTheme :one
-INSERT INTO themes (creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, config_json)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO themes (creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, config_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, status, config_json, version, published_at, created_at, updated_at
 `
 
@@ -40,6 +41,7 @@ type CreateThemeParams struct {
 	MaxPlayers  int32           `json:"max_players"`
 	DurationMin int32           `json:"duration_min"`
 	Price       int32           `json:"price"`
+	CoinPrice   int32           `json:"coin_price"`
 	ConfigJson  json.RawMessage `json:"config_json"`
 }
 
@@ -54,6 +56,7 @@ func (q *Queries) CreateTheme(ctx context.Context, arg CreateThemeParams) (Theme
 		arg.MaxPlayers,
 		arg.DurationMin,
 		arg.Price,
+		arg.CoinPrice,
 		arg.ConfigJson,
 	)
 	var i Theme
@@ -377,36 +380,39 @@ func (q *Queries) ListPublishedThemes(ctx context.Context, arg ListPublishedThem
 }
 
 const listThemesByCreator = `-- name: ListThemesByCreator :many
-SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, status, config_json, version, published_at, created_at, updated_at FROM themes WHERE creator_id = $1 ORDER BY created_at DESC
+SELECT id, title, status, min_players, max_players, coin_price, version, created_at
+FROM themes WHERE creator_id = $1 ORDER BY created_at DESC
 `
 
-func (q *Queries) ListThemesByCreator(ctx context.Context, creatorID uuid.UUID) ([]Theme, error) {
+type ListThemesByCreatorRow struct {
+	ID         uuid.UUID `json:"id"`
+	Title      string    `json:"title"`
+	Status     string    `json:"status"`
+	MinPlayers int32     `json:"min_players"`
+	MaxPlayers int32     `json:"max_players"`
+	CoinPrice  int32     `json:"coin_price"`
+	Version    int32     `json:"version"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+func (q *Queries) ListThemesByCreator(ctx context.Context, creatorID uuid.UUID) ([]ListThemesByCreatorRow, error) {
 	rows, err := q.db.Query(ctx, listThemesByCreator, creatorID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Theme{}
+	items := []ListThemesByCreatorRow{}
 	for rows.Next() {
-		var i Theme
+		var i ListThemesByCreatorRow
 		if err := rows.Scan(
 			&i.ID,
-			&i.CreatorID,
 			&i.Title,
-			&i.Slug,
-			&i.Description,
-			&i.CoverImage,
+			&i.Status,
 			&i.MinPlayers,
 			&i.MaxPlayers,
-			&i.DurationMin,
-			&i.Price,
 			&i.CoinPrice,
-			&i.Status,
-			&i.ConfigJson,
 			&i.Version,
-			&i.PublishedAt,
 			&i.CreatedAt,
-			&i.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -420,8 +426,9 @@ func (q *Queries) ListThemesByCreator(ctx context.Context, creatorID uuid.UUID) 
 
 const updateTheme = `-- name: UpdateTheme :one
 UPDATE themes SET title = $2, slug = $3, description = $4, cover_image = $5,
-  min_players = $6, max_players = $7, duration_min = $8, price = $9, updated_at = NOW()
-WHERE id = $1
+  min_players = $6, max_players = $7, duration_min = $8, price = $9, coin_price = $10,
+  version = version + 1, updated_at = NOW()
+WHERE id = $1 AND version = $11
 RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, status, config_json, version, published_at, created_at, updated_at
 `
 
@@ -435,6 +442,8 @@ type UpdateThemeParams struct {
 	MaxPlayers  int32       `json:"max_players"`
 	DurationMin int32       `json:"duration_min"`
 	Price       int32       `json:"price"`
+	CoinPrice   int32       `json:"coin_price"`
+	Version     int32       `json:"version"`
 }
 
 func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme, error) {
@@ -448,6 +457,8 @@ func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme
 		arg.MaxPlayers,
 		arg.DurationMin,
 		arg.Price,
+		arg.CoinPrice,
+		arg.Version,
 	)
 	var i Theme
 	err := row.Scan(
@@ -511,17 +522,18 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 
 const updateThemeConfigJson = `-- name: UpdateThemeConfigJson :one
 UPDATE themes SET config_json = $2, version = version + 1, updated_at = NOW()
-WHERE id = $1
+WHERE id = $1 AND version = $3
 RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, status, config_json, version, published_at, created_at, updated_at
 `
 
 type UpdateThemeConfigJsonParams struct {
 	ID         uuid.UUID       `json:"id"`
 	ConfigJson json.RawMessage `json:"config_json"`
+	Version    int32           `json:"version"`
 }
 
 func (q *Queries) UpdateThemeConfigJson(ctx context.Context, arg UpdateThemeConfigJsonParams) (Theme, error) {
-	row := q.db.QueryRow(ctx, updateThemeConfigJson, arg.ID, arg.ConfigJson)
+	row := q.db.QueryRow(ctx, updateThemeConfigJson, arg.ID, arg.ConfigJson, arg.Version)
 	var i Theme
 	err := row.Scan(
 		&i.ID,

--- a/apps/server/internal/db/users_password.go
+++ b/apps/server/internal/db/users_password.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const getUserByEmail = `
+SELECT id, nickname, email, avatar_url, role, provider, provider_id, coin_balance, created_at, updated_at, password_hash
+FROM users WHERE email = $1 AND provider = 'local'
+`
+
+// UserWithPassword extends User with password_hash for local auth.
+type UserWithPassword struct {
+	User
+	PasswordHash pgtype.Text `json:"-"`
+}
+
+func (q *Queries) GetUserByEmail(ctx context.Context, email string) (UserWithPassword, error) {
+	row := q.db.QueryRow(ctx, getUserByEmail, email)
+	var i UserWithPassword
+	err := row.Scan(
+		&i.ID,
+		&i.Nickname,
+		&i.Email,
+		&i.AvatarUrl,
+		&i.Role,
+		&i.Provider,
+		&i.ProviderID,
+		&i.CoinBalance,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PasswordHash,
+	)
+	return i, err
+}
+
+const createUserWithPassword = `
+INSERT INTO users (nickname, email, password_hash, provider, provider_id)
+VALUES ($1, $2, $3, 'local', $2)
+RETURNING id, nickname, email, avatar_url, role, provider, provider_id, coin_balance, created_at, updated_at
+`
+
+type CreateUserWithPasswordParams struct {
+	Nickname     string `json:"nickname"`
+	Email        string `json:"email"`
+	PasswordHash string `json:"password_hash"`
+}
+
+func (q *Queries) CreateUserWithPassword(ctx context.Context, arg CreateUserWithPasswordParams) (User, error) {
+	row := q.db.QueryRow(ctx, createUserWithPassword, arg.Nickname, arg.Email, arg.PasswordHash)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.Nickname,
+		&i.Email,
+		&i.AvatarUrl,
+		&i.Role,
+		&i.Provider,
+		&i.ProviderID,
+		&i.CoinBalance,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}

--- a/apps/server/internal/domain/auth/handler.go
+++ b/apps/server/internal/domain/auth/handler.go
@@ -26,8 +26,53 @@ type callbackRequest struct {
 	Nickname string `json:"nickname" validate:"required,min=2,max=30"`
 }
 
+type registerRequest struct {
+	Email    string `json:"email" validate:"required,email"`
+	Password string `json:"password" validate:"required,min=4"`
+	Nickname string `json:"nickname" validate:"required,min=2,max=30"`
+}
+
+type loginRequest struct {
+	Email    string `json:"email" validate:"required,email"`
+	Password string `json:"password" validate:"required"`
+}
+
 type refreshRequest struct {
 	RefreshToken string `json:"refresh_token" validate:"required"`
+}
+
+// HandleRegister handles POST /auth/register.
+func (h *Handler) HandleRegister(w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	pair, err := h.svc.Register(r.Context(), req.Email, req.Password, req.Nickname)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusCreated, pair)
+}
+
+// HandleLogin handles POST /auth/login.
+func (h *Handler) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	var req loginRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	pair, err := h.svc.Login(r.Context(), req.Email, req.Password)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, pair)
 }
 
 // HandleCallback handles POST /auth/callback.

--- a/apps/server/internal/domain/auth/handler_test.go
+++ b/apps/server/internal/domain/auth/handler_test.go
@@ -38,6 +38,14 @@ func (m *mockService) GetCurrentUser(ctx context.Context, userID uuid.UUID) (*Us
 	return m.getCurrentFn(ctx, userID)
 }
 
+func (m *mockService) Login(ctx context.Context, email, password string) (*TokenPair, error) {
+	return nil, nil
+}
+
+func (m *mockService) Register(ctx context.Context, email, password, nickname string) (*TokenPair, error) {
+	return nil, nil
+}
+
 func jsonBody(t *testing.T, v any) *bytes.Buffer {
 	t.Helper()
 	buf := new(bytes.Buffer)

--- a/apps/server/internal/domain/auth/service.go
+++ b/apps/server/internal/domain/auth/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
@@ -35,6 +36,8 @@ type UserResponse struct {
 // Service defines the auth domain operations.
 type Service interface {
 	OAuthCallback(ctx context.Context, provider, code, nickname string) (*TokenPair, error)
+	Register(ctx context.Context, email, password, nickname string) (*TokenPair, error)
+	Login(ctx context.Context, email, password string) (*TokenPair, error)
 	RefreshToken(ctx context.Context, refreshToken string) (*TokenPair, error)
 	Logout(ctx context.Context, userID uuid.UUID) error
 	GetCurrentUser(ctx context.Context, userID uuid.UUID) (*UserResponse, error)
@@ -252,6 +255,68 @@ func (s *service) revokeAllTokens(ctx context.Context, userID string) {
 			break
 		}
 	}
+}
+
+// Register creates a new user with email/password.
+func (s *service) Register(ctx context.Context, email, password, nickname string) (*TokenPair, error) {
+	if email == "" || password == "" || nickname == "" {
+		return nil, apperror.BadRequest("email, password, and nickname are required")
+	}
+
+	// Check if email already exists.
+	_, err := s.queries.GetUserByEmail(ctx, email)
+	if err == nil {
+		return nil, apperror.Conflict("email already registered")
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		s.logger.Error().Err(err).Msg("failed to check existing user")
+		return nil, apperror.Internal("failed to check existing user")
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to hash password")
+		return nil, apperror.Internal("failed to hash password")
+	}
+
+	user, err := s.queries.CreateUserWithPassword(ctx, db.CreateUserWithPasswordParams{
+		Nickname:     nickname,
+		Email:        email,
+		PasswordHash: string(hash),
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to create user")
+		return nil, apperror.Internal("failed to create user")
+	}
+
+	s.logger.Info().Str("user_id", user.ID.String()).Msg("new user registered with password")
+	return s.generateTokenPair(ctx, user.ID, user.Role)
+}
+
+// Login authenticates a user with email/password.
+func (s *service) Login(ctx context.Context, email, password string) (*TokenPair, error) {
+	if email == "" || password == "" {
+		return nil, apperror.BadRequest("email and password are required")
+	}
+
+	user, err := s.queries.GetUserByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.Unauthorized("invalid email or password")
+		}
+		s.logger.Error().Err(err).Msg("failed to look up user by email")
+		return nil, apperror.Internal("failed to look up user")
+	}
+
+	if !user.PasswordHash.Valid {
+		return nil, apperror.Unauthorized("invalid email or password")
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash.String), []byte(password)); err != nil {
+		return nil, apperror.Unauthorized("invalid email or password")
+	}
+
+	return s.generateTokenPair(ctx, user.ID, user.Role)
 }
 
 // mapUserResponse converts a db.User to a public UserResponse.

--- a/apps/server/internal/domain/editor/handler.go
+++ b/apps/server/internal/domain/editor/handler.go
@@ -53,6 +53,23 @@ func (h *Handler) CreateTheme(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusCreated, resp)
 }
 
+// GetTheme handles GET /editor/themes/{id}.
+func (h *Handler) GetTheme(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	resp, err := h.svc.GetTheme(r.Context(), creatorID, themeID)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
 // UpdateTheme handles PUT /editor/themes/{id}.
 func (h *Handler) UpdateTheme(w http.ResponseWriter, r *http.Request) {
 	creatorID := middleware.UserIDFrom(r.Context())
@@ -188,6 +205,23 @@ func (h *Handler) DeleteCharacter(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// ListCharacters handles GET /editor/themes/{id}/characters.
+func (h *Handler) ListCharacters(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	chars, err := h.svc.ListCharacters(r.Context(), creatorID, themeID)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, chars)
+}
+
 // UpdateConfigJson handles PUT /editor/themes/{id}/config.
 func (h *Handler) UpdateConfigJson(w http.ResponseWriter, r *http.Request) {
 	creatorID := middleware.UserIDFrom(r.Context())
@@ -208,6 +242,294 @@ func (h *Handler) UpdateConfigJson(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, err := h.svc.UpdateConfigJson(r.Context(), creatorID, themeID, json.RawMessage(body))
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
+// ListMaps handles GET /editor/themes/{id}/maps.
+func (h *Handler) ListMaps(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	maps, err := h.svc.ListMaps(r.Context(), creatorID, themeID)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, maps)
+}
+
+// CreateMap handles POST /editor/themes/{id}/maps.
+func (h *Handler) CreateMap(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	var req CreateMapRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.CreateMap(r.Context(), creatorID, themeID, req)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusCreated, resp)
+}
+
+// UpdateMap handles PUT /editor/maps/{id}.
+func (h *Handler) UpdateMap(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	mapID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	var req UpdateMapRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.UpdateMap(r.Context(), creatorID, mapID, req)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
+// DeleteMap handles DELETE /editor/maps/{id}.
+func (h *Handler) DeleteMap(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	mapID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	if err := h.svc.DeleteMap(r.Context(), creatorID, mapID); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListLocations handles GET /editor/themes/{id}/locations.
+func (h *Handler) ListLocations(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	locs, err := h.svc.ListLocations(r.Context(), creatorID, themeID)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, locs)
+}
+
+// CreateLocation handles POST /editor/themes/{id}/maps/{mapId}/locations.
+func (h *Handler) CreateLocation(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	mapID, err := parseUUID(r, "mapId")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	var req CreateLocationRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.CreateLocation(r.Context(), creatorID, themeID, mapID, req)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusCreated, resp)
+}
+
+// UpdateLocation handles PUT /editor/locations/{id}.
+func (h *Handler) UpdateLocation(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	locID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	var req UpdateLocationRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.UpdateLocation(r.Context(), creatorID, locID, req)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
+// DeleteLocation handles DELETE /editor/locations/{id}.
+func (h *Handler) DeleteLocation(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	locID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	if err := h.svc.DeleteLocation(r.Context(), creatorID, locID); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListClues handles GET /editor/themes/{id}/clues.
+func (h *Handler) ListClues(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	clues, err := h.svc.ListClues(r.Context(), creatorID, themeID)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, clues)
+}
+
+// CreateClue handles POST /editor/themes/{id}/clues.
+func (h *Handler) CreateClue(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	var req CreateClueRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.CreateClue(r.Context(), creatorID, themeID, req)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusCreated, resp)
+}
+
+// UpdateClue handles PUT /editor/clues/{id}.
+func (h *Handler) UpdateClue(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	clueID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	var req UpdateClueRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.UpdateClue(r.Context(), creatorID, clueID, req)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
+// DeleteClue handles DELETE /editor/clues/{id}.
+func (h *Handler) DeleteClue(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	clueID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	if err := h.svc.DeleteClue(r.Context(), creatorID, clueID); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetContent handles GET /editor/themes/{id}/content/{key}.
+func (h *Handler) GetContent(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	key := chi.URLParam(r, "key")
+	if !validContentKeyRe.MatchString(key) {
+		apperror.WriteError(w, r, apperror.BadRequest("invalid content key format"))
+		return
+	}
+	resp, err := h.svc.GetContent(r.Context(), creatorID, themeID, key)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
+// UpsertContent handles PUT /editor/themes/{id}/content/{key}.
+func (h *Handler) UpsertContent(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	key := chi.URLParam(r, "key")
+	if !validContentKeyRe.MatchString(key) {
+		apperror.WriteError(w, r, apperror.BadRequest("invalid content key format"))
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<17) // 128KB limit
+	var req UpsertContentRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.UpsertContent(r.Context(), creatorID, themeID, key, req.Body)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
+// ValidateTheme handles POST /editor/themes/{id}/validate.
+func (h *Handler) ValidateTheme(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	resp, err := h.svc.ValidateTheme(r.Context(), creatorID, themeID)
 	if err != nil {
 		apperror.WriteError(w, r, err)
 		return

--- a/apps/server/internal/domain/editor/handler_test.go
+++ b/apps/server/internal/domain/editor/handler_test.go
@@ -61,6 +61,67 @@ func (m *mockService) DeleteCharacter(ctx context.Context, creatorID, charID uui
 func (m *mockService) UpdateConfigJson(ctx context.Context, creatorID, themeID uuid.UUID, config json.RawMessage) (*ThemeResponse, error) {
 	return m.updateConfigFn(ctx, creatorID, themeID, config)
 }
+func (m *mockService) ListCharacters(ctx context.Context, creatorID, themeID uuid.UUID) ([]CharacterResponse, error) {
+	return nil, nil
+}
+func (m *mockService) GetTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error) {
+	return nil, nil
+}
+
+// Maps
+func (m *mockService) CreateMap(ctx context.Context, creatorID, themeID uuid.UUID, req CreateMapRequest) (*MapResponse, error) {
+	return nil, nil
+}
+func (m *mockService) UpdateMap(ctx context.Context, creatorID, mapID uuid.UUID, req UpdateMapRequest) (*MapResponse, error) {
+	return nil, nil
+}
+func (m *mockService) DeleteMap(ctx context.Context, creatorID, mapID uuid.UUID) error {
+	return nil
+}
+func (m *mockService) ListMaps(ctx context.Context, creatorID, themeID uuid.UUID) ([]MapResponse, error) {
+	return nil, nil
+}
+
+// Locations
+func (m *mockService) CreateLocation(ctx context.Context, creatorID, themeID, mapID uuid.UUID, req CreateLocationRequest) (*LocationResponse, error) {
+	return nil, nil
+}
+func (m *mockService) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID, req UpdateLocationRequest) (*LocationResponse, error) {
+	return nil, nil
+}
+func (m *mockService) DeleteLocation(ctx context.Context, creatorID, locID uuid.UUID) error {
+	return nil
+}
+func (m *mockService) ListLocations(ctx context.Context, creatorID, themeID uuid.UUID) ([]LocationResponse, error) {
+	return nil, nil
+}
+
+// Clues
+func (m *mockService) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, req CreateClueRequest) (*ClueResponse, error) {
+	return nil, nil
+}
+func (m *mockService) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, req UpdateClueRequest) (*ClueResponse, error) {
+	return nil, nil
+}
+func (m *mockService) DeleteClue(ctx context.Context, creatorID, clueID uuid.UUID) error {
+	return nil
+}
+func (m *mockService) ListClues(ctx context.Context, creatorID, themeID uuid.UUID) ([]ClueResponse, error) {
+	return nil, nil
+}
+
+// Contents
+func (m *mockService) GetContent(ctx context.Context, creatorID, themeID uuid.UUID, key string) (*ContentResponse, error) {
+	return nil, nil
+}
+func (m *mockService) UpsertContent(ctx context.Context, creatorID, themeID uuid.UUID, key string, body string) (*ContentResponse, error) {
+	return nil, nil
+}
+
+// Validation
+func (m *mockService) ValidateTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ValidationResponse, error) {
+	return nil, nil
+}
 
 // --- test helpers ---
 

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/rs/zerolog"
 
@@ -21,26 +23,36 @@ import (
 	"github.com/mmp-platform/server/internal/db"
 )
 
+const (
+	MaxMapsPerTheme    = 20
+	MaxLocationsPerMap = 50
+	MaxCluesPerTheme   = 500
+)
+
+var validContentKeyRe = regexp.MustCompile(`^(story|rules|epilogue|role:[a-z0-9_-]{1,50})$`)
+
 // --- Request / Response types ---
 
 type CreateThemeRequest struct {
 	Title       string  `json:"title" validate:"required,min=2,max=100"`
-	Description *string `json:"description" validate:"omitempty,max=1000"`
+	Description *string `json:"description" validate:"omitempty,max=2000"`
 	CoverImage  *string `json:"cover_image" validate:"omitempty,url"`
-	MinPlayers  int32   `json:"min_players" validate:"required,min=2,max=12"`
-	MaxPlayers  int32   `json:"max_players" validate:"required,min=2,max=12"`
+	MinPlayers  int32   `json:"min_players" validate:"required,min=2,max=20"`
+	MaxPlayers  int32   `json:"max_players" validate:"required,min=2,max=20"`
 	DurationMin int32   `json:"duration_min" validate:"required,min=10,max=300"`
 	Price       int32   `json:"price" validate:"min=0"`
+	CoinPrice   int32   `json:"coin_price" validate:"min=0,max=100000"`
 }
 
 type UpdateThemeRequest struct {
 	Title       string  `json:"title" validate:"required,min=2,max=100"`
-	Description *string `json:"description" validate:"omitempty,max=1000"`
+	Description *string `json:"description" validate:"omitempty,max=2000"`
 	CoverImage  *string `json:"cover_image" validate:"omitempty,url"`
-	MinPlayers  int32   `json:"min_players" validate:"required,min=2,max=12"`
-	MaxPlayers  int32   `json:"max_players" validate:"required,min=2,max=12"`
+	MinPlayers  int32   `json:"min_players" validate:"required,min=2,max=20"`
+	MaxPlayers  int32   `json:"max_players" validate:"required,min=2,max=20"`
 	DurationMin int32   `json:"duration_min" validate:"required,min=10,max=300"`
 	Price       int32   `json:"price" validate:"min=0"`
+	CoinPrice   int32   `json:"coin_price" validate:"min=0,max=100000"`
 }
 
 type ThemeResponse struct {
@@ -53,6 +65,7 @@ type ThemeResponse struct {
 	MaxPlayers  int32           `json:"max_players"`
 	DurationMin int32           `json:"duration_min"`
 	Price       int32           `json:"price"`
+	CoinPrice   int32           `json:"coin_price"`
 	Status      string          `json:"status"`
 	ConfigJson  json.RawMessage `json:"config_json,omitempty"`
 	Version     int32           `json:"version"`
@@ -65,13 +78,14 @@ type ThemeSummary struct {
 	Status     string    `json:"status"`
 	MinPlayers int32     `json:"min_players"`
 	MaxPlayers int32     `json:"max_players"`
+	CoinPrice  int32     `json:"coin_price"`
 	Version    int32     `json:"version"`
 	CreatedAt  time.Time `json:"created_at"`
 }
 
 type CreateCharacterRequest struct {
 	Name        string  `json:"name" validate:"required,min=1,max=50"`
-	Description *string `json:"description" validate:"omitempty,max=500"`
+	Description *string `json:"description" validate:"omitempty,max=2000"`
 	ImageURL    *string `json:"image_url" validate:"omitempty,url"`
 	IsCulprit   bool    `json:"is_culprit"`
 	SortOrder   int32   `json:"sort_order" validate:"min=0"`
@@ -79,7 +93,7 @@ type CreateCharacterRequest struct {
 
 type UpdateCharacterRequest struct {
 	Name        string  `json:"name" validate:"required,min=1,max=50"`
-	Description *string `json:"description" validate:"omitempty,max=500"`
+	Description *string `json:"description" validate:"omitempty,max=2000"`
 	ImageURL    *string `json:"image_url" validate:"omitempty,url"`
 	IsCulprit   bool    `json:"is_culprit"`
 	SortOrder   int32   `json:"sort_order" validate:"min=0"`
@@ -107,44 +121,84 @@ type Service interface {
 	CreateCharacter(ctx context.Context, creatorID, themeID uuid.UUID, req CreateCharacterRequest) (*CharacterResponse, error)
 	UpdateCharacter(ctx context.Context, creatorID, charID uuid.UUID, req UpdateCharacterRequest) (*CharacterResponse, error)
 	DeleteCharacter(ctx context.Context, creatorID, charID uuid.UUID) error
+	ListCharacters(ctx context.Context, creatorID, themeID uuid.UUID) ([]CharacterResponse, error)
 	UpdateConfigJson(ctx context.Context, creatorID, themeID uuid.UUID, config json.RawMessage) (*ThemeResponse, error)
+
+	// Maps
+	CreateMap(ctx context.Context, creatorID, themeID uuid.UUID, req CreateMapRequest) (*MapResponse, error)
+	UpdateMap(ctx context.Context, creatorID, mapID uuid.UUID, req UpdateMapRequest) (*MapResponse, error)
+	DeleteMap(ctx context.Context, creatorID, mapID uuid.UUID) error
+	ListMaps(ctx context.Context, creatorID, themeID uuid.UUID) ([]MapResponse, error)
+
+	// Locations
+	CreateLocation(ctx context.Context, creatorID, themeID, mapID uuid.UUID, req CreateLocationRequest) (*LocationResponse, error)
+	UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID, req UpdateLocationRequest) (*LocationResponse, error)
+	DeleteLocation(ctx context.Context, creatorID, locID uuid.UUID) error
+	ListLocations(ctx context.Context, creatorID, themeID uuid.UUID) ([]LocationResponse, error)
+
+	// Clues
+	CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, req CreateClueRequest) (*ClueResponse, error)
+	UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, req UpdateClueRequest) (*ClueResponse, error)
+	DeleteClue(ctx context.Context, creatorID, clueID uuid.UUID) error
+	ListClues(ctx context.Context, creatorID, themeID uuid.UUID) ([]ClueResponse, error)
+
+	// Contents
+	GetContent(ctx context.Context, creatorID, themeID uuid.UUID, key string) (*ContentResponse, error)
+	UpsertContent(ctx context.Context, creatorID, themeID uuid.UUID, key string, body string) (*ContentResponse, error)
+
+	// Theme detail
+	GetTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error)
+
+	// Validation
+	ValidateTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ValidationResponse, error)
 }
 
 // --- Implementation ---
 
 type service struct {
 	q      *db.Queries
+	pool   *pgxpool.Pool
 	logger zerolog.Logger
 }
 
 // NewService creates a new editor service backed by sqlc queries.
-func NewService(q *db.Queries, logger zerolog.Logger) Service {
+func NewService(q *db.Queries, pool *pgxpool.Pool, logger zerolog.Logger) Service {
 	return &service{
 		q:      q,
+		pool:   pool,
 		logger: logger.With().Str("domain", "editor").Logger(),
 	}
 }
 
 func (s *service) CreateTheme(ctx context.Context, creatorID uuid.UUID, req CreateThemeRequest) (*ThemeResponse, error) {
-	slug := generateSlug(req.Title)
+	var theme db.Theme
+	var err error
 
-	theme, err := s.q.CreateTheme(ctx, db.CreateThemeParams{
-		CreatorID:   creatorID,
-		Title:       req.Title,
-		Slug:        slug,
-		Description: ptrToText(req.Description),
-		CoverImage:  ptrToText(req.CoverImage),
-		MinPlayers:  req.MinPlayers,
-		MaxPlayers:  req.MaxPlayers,
-		DurationMin: req.DurationMin,
-		Price:       req.Price,
-		ConfigJson:  json.RawMessage("{}"),
-	})
-	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to create theme")
-		return nil, apperror.Internal("failed to create theme")
+	for attempt := 0; attempt < 3; attempt++ {
+		slug := generateSlug(req.Title)
+		theme, err = s.q.CreateTheme(ctx, db.CreateThemeParams{
+			CreatorID:   creatorID,
+			Title:       req.Title,
+			Slug:        slug,
+			Description: ptrToText(req.Description),
+			CoverImage:  ptrToText(req.CoverImage),
+			MinPlayers:  req.MinPlayers,
+			MaxPlayers:  req.MaxPlayers,
+			DurationMin: req.DurationMin,
+			Price:       req.Price,
+			CoinPrice:   req.CoinPrice,
+			ConfigJson:  json.RawMessage("{}"),
+		})
+		if err == nil {
+			return toThemeResponse(theme), nil
+		}
+		if isUniqueViolation(err) {
+			continue
+		}
+		break
 	}
-	return toThemeResponse(theme), nil
+	s.logger.Error().Err(err).Msg("failed to create theme")
+	return nil, apperror.Internal("failed to create theme")
 }
 
 func (s *service) UpdateTheme(ctx context.Context, creatorID, themeID uuid.UUID, req UpdateThemeRequest) (*ThemeResponse, error) {
@@ -153,24 +207,35 @@ func (s *service) UpdateTheme(ctx context.Context, creatorID, themeID uuid.UUID,
 		return nil, err
 	}
 
-	slug := generateSlug(req.Title)
-
-	updated, err := s.q.UpdateTheme(ctx, db.UpdateThemeParams{
-		ID:          theme.ID,
-		Title:       req.Title,
-		Slug:        slug,
-		Description: ptrToText(req.Description),
-		CoverImage:  ptrToText(req.CoverImage),
-		MinPlayers:  req.MinPlayers,
-		MaxPlayers:  req.MaxPlayers,
-		DurationMin: req.DurationMin,
-		Price:       req.Price,
-	})
-	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to update theme")
-		return nil, apperror.Internal("failed to update theme")
+	var updated db.Theme
+	for attempt := 0; attempt < 3; attempt++ {
+		slug := generateSlug(req.Title)
+		updated, err = s.q.UpdateTheme(ctx, db.UpdateThemeParams{
+			ID:          theme.ID,
+			Title:       req.Title,
+			Slug:        slug,
+			Description: ptrToText(req.Description),
+			CoverImage:  ptrToText(req.CoverImage),
+			MinPlayers:  req.MinPlayers,
+			MaxPlayers:  req.MaxPlayers,
+			DurationMin: req.DurationMin,
+			Price:       req.Price,
+			CoinPrice:   req.CoinPrice,
+			Version:     theme.Version,
+		})
+		if err == nil {
+			return toThemeResponse(updated), nil
+		}
+		if isUniqueViolation(err) {
+			continue
+		}
+		break
 	}
-	return toThemeResponse(updated), nil
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, apperror.Conflict("theme was modified by another session")
+	}
+	s.logger.Error().Err(err).Msg("failed to update theme")
+	return nil, apperror.Internal("failed to update theme")
 }
 
 func (s *service) DeleteTheme(ctx context.Context, creatorID, themeID uuid.UUID) error {
@@ -202,11 +267,20 @@ func (s *service) ListMyThemes(ctx context.Context, creatorID uuid.UUID) ([]Them
 			Status:     t.Status,
 			MinPlayers: t.MinPlayers,
 			MaxPlayers: t.MaxPlayers,
+			CoinPrice:  t.CoinPrice,
 			Version:    t.Version,
 			CreatedAt:  t.CreatedAt,
 		}
 	}
 	return out, nil
+}
+
+func (s *service) GetTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error) {
+	theme, err := s.getOwnedTheme(ctx, creatorID, themeID)
+	if err != nil {
+		return nil, err
+	}
+	return toThemeResponse(theme), nil
 }
 
 func (s *service) PublishTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error) {
@@ -330,20 +404,409 @@ func (s *service) DeleteCharacter(ctx context.Context, creatorID, charID uuid.UU
 	return nil
 }
 
-func (s *service) UpdateConfigJson(ctx context.Context, creatorID, themeID uuid.UUID, config json.RawMessage) (*ThemeResponse, error) {
+func (s *service) ListCharacters(ctx context.Context, creatorID, themeID uuid.UUID) ([]CharacterResponse, error) {
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+
+	chars, err := s.q.GetThemeCharacters(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to list characters")
+		return nil, apperror.Internal("failed to list characters")
+	}
+	out := make([]CharacterResponse, len(chars))
+	for i, c := range chars {
+		out[i] = *toCharacterResponse(c)
+	}
+	return out, nil
+}
+
+func (s *service) UpdateConfigJson(ctx context.Context, creatorID, themeID uuid.UUID, config json.RawMessage) (*ThemeResponse, error) {
+	theme, err := s.getOwnedTheme(ctx, creatorID, themeID)
+	if err != nil {
 		return nil, err
 	}
 
 	updated, err := s.q.UpdateThemeConfigJson(ctx, db.UpdateThemeConfigJsonParams{
 		ID:         themeID,
 		ConfigJson: config,
+		Version:    theme.Version,
 	})
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.Conflict("theme was modified by another session")
+		}
 		s.logger.Error().Err(err).Msg("failed to update config")
 		return nil, apperror.Internal("failed to update config")
 	}
 	return toThemeResponse(updated), nil
+}
+
+// --- Maps ---
+
+func (s *service) ListMaps(ctx context.Context, creatorID, themeID uuid.UUID) ([]MapResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	maps, err := s.q.ListMapsByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to list maps")
+		return nil, apperror.Internal("failed to list maps")
+	}
+	out := make([]MapResponse, len(maps))
+	for i, m := range maps {
+		out[i] = toMapResponse(m)
+	}
+	return out, nil
+}
+
+func (s *service) CreateMap(ctx context.Context, creatorID, themeID uuid.UUID, req CreateMapRequest) (*MapResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	count, err := s.q.CountMapsByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to count maps")
+		return nil, apperror.Internal("failed to count maps")
+	}
+	if count >= MaxMapsPerTheme {
+		return nil, apperror.BadRequest(fmt.Sprintf("theme cannot have more than %d maps", MaxMapsPerTheme))
+	}
+	m, err := s.q.CreateMap(ctx, db.CreateMapParams{
+		ThemeID:   themeID,
+		Name:      req.Name,
+		ImageUrl:  ptrToText(req.ImageURL),
+		SortOrder: req.SortOrder,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to create map")
+		return nil, apperror.Internal("failed to create map")
+	}
+	resp := toMapResponse(m)
+	return &resp, nil
+}
+
+func (s *service) UpdateMap(ctx context.Context, creatorID, mapID uuid.UUID, req UpdateMapRequest) (*MapResponse, error) {
+	m, err := s.q.GetMapWithOwner(ctx, db.GetMapWithOwnerParams{ID: mapID, CreatorID: creatorID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("map not found")
+		}
+		s.logger.Error().Err(err).Msg("failed to get map")
+		return nil, apperror.Internal("failed to get map")
+	}
+	updated, err := s.q.UpdateMap(ctx, db.UpdateMapParams{
+		ID:        m.ID,
+		Name:      req.Name,
+		ImageUrl:  ptrToText(req.ImageURL),
+		SortOrder: req.SortOrder,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to update map")
+		return nil, apperror.Internal("failed to update map")
+	}
+	resp := toMapResponse(updated)
+	return &resp, nil
+}
+
+func (s *service) DeleteMap(ctx context.Context, creatorID, mapID uuid.UUID) error {
+	n, err := s.q.DeleteMapWithOwner(ctx, db.DeleteMapWithOwnerParams{ID: mapID, CreatorID: creatorID})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to delete map")
+		return apperror.Internal("failed to delete map")
+	}
+	if n == 0 {
+		return apperror.NotFound("map not found")
+	}
+	return nil
+}
+
+// --- Locations ---
+
+func (s *service) ListLocations(ctx context.Context, creatorID, themeID uuid.UUID) ([]LocationResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	locs, err := s.q.ListLocationsByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to list locations")
+		return nil, apperror.Internal("failed to list locations")
+	}
+	out := make([]LocationResponse, len(locs))
+	for i, l := range locs {
+		out[i] = toLocationResponse(l)
+	}
+	return out, nil
+}
+
+func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID uuid.UUID, req CreateLocationRequest) (*LocationResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	// verify map belongs to the theme via ownership check
+	_, err := s.q.GetMapWithOwner(ctx, db.GetMapWithOwnerParams{ID: mapID, CreatorID: creatorID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("map not found")
+		}
+		s.logger.Error().Err(err).Msg("failed to get map")
+		return nil, apperror.Internal("failed to get map")
+	}
+	count, err := s.q.CountLocationsByMap(ctx, mapID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to count locations")
+		return nil, apperror.Internal("failed to count locations")
+	}
+	if count >= MaxLocationsPerMap {
+		return nil, apperror.BadRequest(fmt.Sprintf("map cannot have more than %d locations", MaxLocationsPerMap))
+	}
+	loc, err := s.q.CreateLocation(ctx, db.CreateLocationParams{
+		ThemeID:              themeID,
+		MapID:                mapID,
+		Name:                 req.Name,
+		RestrictedCharacters: ptrToText(req.RestrictedCharacters),
+		SortOrder:            req.SortOrder,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to create location")
+		return nil, apperror.Internal("failed to create location")
+	}
+	resp := toLocationResponse(loc)
+	return &resp, nil
+}
+
+func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID, req UpdateLocationRequest) (*LocationResponse, error) {
+	l, err := s.q.GetLocationWithOwner(ctx, db.GetLocationWithOwnerParams{ID: locID, CreatorID: creatorID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("location not found")
+		}
+		s.logger.Error().Err(err).Msg("failed to get location")
+		return nil, apperror.Internal("failed to get location")
+	}
+	updated, err := s.q.UpdateLocation(ctx, db.UpdateLocationParams{
+		ID:                   l.ID,
+		Name:                 req.Name,
+		RestrictedCharacters: ptrToText(req.RestrictedCharacters),
+		SortOrder:            req.SortOrder,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to update location")
+		return nil, apperror.Internal("failed to update location")
+	}
+	resp := toLocationResponse(updated)
+	return &resp, nil
+}
+
+func (s *service) DeleteLocation(ctx context.Context, creatorID, locID uuid.UUID) error {
+	n, err := s.q.DeleteLocationWithOwner(ctx, db.DeleteLocationWithOwnerParams{ID: locID, CreatorID: creatorID})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to delete location")
+		return apperror.Internal("failed to delete location")
+	}
+	if n == 0 {
+		return apperror.NotFound("location not found")
+	}
+	return nil
+}
+
+// --- Clues ---
+
+func (s *service) ListClues(ctx context.Context, creatorID, themeID uuid.UUID) ([]ClueResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	clues, err := s.q.ListCluesByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to list clues")
+		return nil, apperror.Internal("failed to list clues")
+	}
+	out := make([]ClueResponse, len(clues))
+	for i, c := range clues {
+		out[i] = toClueResponse(c)
+	}
+	return out, nil
+}
+
+func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, req CreateClueRequest) (*ClueResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	count, err := s.q.CountCluesByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to count clues")
+		return nil, apperror.Internal("failed to count clues")
+	}
+	if count >= MaxCluesPerTheme {
+		return nil, apperror.BadRequest(fmt.Sprintf("theme cannot have more than %d clues", MaxCluesPerTheme))
+	}
+	clue, err := s.q.CreateClue(ctx, db.CreateClueParams{
+		ThemeID:     themeID,
+		LocationID:  uuidPtrToPgtype(req.LocationID),
+		Name:        req.Name,
+		Description: ptrToText(req.Description),
+		ImageUrl:    ptrToText(req.ImageURL),
+		IsCommon:    req.IsCommon,
+		Level:       req.Level,
+		ClueType:    req.ClueType,
+		SortOrder:   req.SortOrder,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to create clue")
+		return nil, apperror.Internal("failed to create clue")
+	}
+	resp := toClueResponse(clue)
+	return &resp, nil
+}
+
+func (s *service) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, req UpdateClueRequest) (*ClueResponse, error) {
+	c, err := s.q.GetClueWithOwner(ctx, db.GetClueWithOwnerParams{ID: clueID, CreatorID: creatorID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("clue not found")
+		}
+		s.logger.Error().Err(err).Msg("failed to get clue")
+		return nil, apperror.Internal("failed to get clue")
+	}
+	updated, err := s.q.UpdateClue(ctx, db.UpdateClueParams{
+		ID:          c.ID,
+		LocationID:  uuidPtrToPgtype(req.LocationID),
+		Name:        req.Name,
+		Description: ptrToText(req.Description),
+		ImageUrl:    ptrToText(req.ImageURL),
+		IsCommon:    req.IsCommon,
+		Level:       req.Level,
+		ClueType:    req.ClueType,
+		SortOrder:   req.SortOrder,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to update clue")
+		return nil, apperror.Internal("failed to update clue")
+	}
+	resp := toClueResponse(updated)
+	return &resp, nil
+}
+
+func (s *service) DeleteClue(ctx context.Context, creatorID, clueID uuid.UUID) error {
+	n, err := s.q.DeleteClueWithOwner(ctx, db.DeleteClueWithOwnerParams{ID: clueID, CreatorID: creatorID})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to delete clue")
+		return apperror.Internal("failed to delete clue")
+	}
+	if n == 0 {
+		return apperror.NotFound("clue not found")
+	}
+	return nil
+}
+
+// --- Contents ---
+
+func (s *service) GetContent(ctx context.Context, creatorID, themeID uuid.UUID, key string) (*ContentResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	if !validContentKeyRe.MatchString(key) {
+		return nil, apperror.BadRequest("invalid content key format")
+	}
+	content, err := s.q.GetContent(ctx, db.GetContentParams{ThemeID: themeID, Key: key})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("content not found")
+		}
+		s.logger.Error().Err(err).Msg("failed to get content")
+		return nil, apperror.Internal("failed to get content")
+	}
+	resp := toContentResponse(content)
+	return &resp, nil
+}
+
+func (s *service) UpsertContent(ctx context.Context, creatorID, themeID uuid.UUID, key string, body string) (*ContentResponse, error) {
+	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+	if !validContentKeyRe.MatchString(key) {
+		return nil, apperror.BadRequest("invalid content key format")
+	}
+	content, err := s.q.UpsertContent(ctx, db.UpsertContentParams{
+		ThemeID: themeID,
+		Key:     key,
+		Body:    body,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to upsert content")
+		return nil, apperror.Internal("failed to upsert content")
+	}
+	resp := toContentResponse(content)
+	return &resp, nil
+}
+
+// --- Validation ---
+
+func (s *service) ValidateTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ValidationResponse, error) {
+	theme, err := s.getOwnedTheme(ctx, creatorID, themeID)
+	if err != nil {
+		return nil, err
+	}
+
+	charCount, err := s.q.CountThemeCharacters(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to count characters")
+		return nil, apperror.Internal("failed to validate theme")
+	}
+	mapCount, err := s.q.CountMapsByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to count maps")
+		return nil, apperror.Internal("failed to validate theme")
+	}
+	clueCount, err := s.q.CountCluesByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to count clues")
+		return nil, apperror.Internal("failed to validate theme")
+	}
+
+	// count locations across all maps
+	locs, err := s.q.ListLocationsByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to list locations")
+		return nil, apperror.Internal("failed to validate theme")
+	}
+	locCount := int64(len(locs))
+
+	var errs []string
+	if charCount < int64(theme.MinPlayers) {
+		errs = append(errs, fmt.Sprintf("최소 %d명의 캐릭터가 필요합니다 (현재 %d명)", theme.MinPlayers, charCount))
+	}
+	if mapCount == 0 {
+		errs = append(errs, "최소 1개의 맵이 필요합니다")
+	}
+
+	// check culprit character exists
+	chars, err := s.q.GetThemeCharacters(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to get characters")
+		return nil, apperror.Internal("failed to validate theme")
+	}
+	hasCulprit := false
+	for _, c := range chars {
+		if c.IsCulprit {
+			hasCulprit = true
+			break
+		}
+	}
+	if !hasCulprit {
+		errs = append(errs, "범인 캐릭터가 지정되어야 합니다")
+	}
+
+	return &ValidationResponse{
+		Valid:  len(errs) == 0,
+		Errors: errs,
+		Stats: ValidationStats{
+			Characters: int(charCount),
+			Maps:       int(mapCount),
+			Locations:  int(locCount),
+			Clues:      int(clueCount),
+		},
+	}, nil
 }
 
 // --- Helpers ---
@@ -397,6 +860,12 @@ func generateSlug(title string) string {
 	return fmt.Sprintf("%s-%s", s, hex.EncodeToString(b)[:4])
 }
 
+// isUniqueViolation returns true if err is a PostgreSQL unique constraint violation (code 23505).
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
 func toThemeResponse(t db.Theme) *ThemeResponse {
 	resp := &ThemeResponse{
 		ID:          t.ID,
@@ -408,6 +877,7 @@ func toThemeResponse(t db.Theme) *ThemeResponse {
 		MaxPlayers:  t.MaxPlayers,
 		DurationMin: t.DurationMin,
 		Price:       t.Price,
+		CoinPrice:   t.CoinPrice,
 		Status:      t.Status,
 		Version:     t.Version,
 		CreatedAt:   t.CreatedAt,
@@ -428,4 +898,68 @@ func toCharacterResponse(c db.ThemeCharacter) *CharacterResponse {
 		IsCulprit:   c.IsCulprit,
 		SortOrder:   c.SortOrder,
 	}
+}
+
+func toMapResponse(m db.ThemeMap) MapResponse {
+	return MapResponse{
+		ID:        m.ID,
+		ThemeID:   m.ThemeID,
+		Name:      m.Name,
+		ImageURL:  textToPtr(m.ImageUrl),
+		SortOrder: m.SortOrder,
+		CreatedAt: m.CreatedAt,
+	}
+}
+
+func toLocationResponse(l db.ThemeLocation) LocationResponse {
+	return LocationResponse{
+		ID:                   l.ID,
+		ThemeID:              l.ThemeID,
+		MapID:                l.MapID,
+		Name:                 l.Name,
+		RestrictedCharacters: textToPtr(l.RestrictedCharacters),
+		SortOrder:            l.SortOrder,
+		CreatedAt:            l.CreatedAt,
+	}
+}
+
+func toClueResponse(c db.ThemeClue) ClueResponse {
+	return ClueResponse{
+		ID:          c.ID,
+		ThemeID:     c.ThemeID,
+		LocationID:  pgtypeUUIDToPtr(c.LocationID),
+		Name:        c.Name,
+		Description: textToPtr(c.Description),
+		ImageURL:    textToPtr(c.ImageUrl),
+		IsCommon:    c.IsCommon,
+		Level:       c.Level,
+		ClueType:    c.ClueType,
+		SortOrder:   c.SortOrder,
+		CreatedAt:   c.CreatedAt,
+	}
+}
+
+func toContentResponse(c db.ThemeContent) ContentResponse {
+	return ContentResponse{
+		ID:        c.ID,
+		ThemeID:   c.ThemeID,
+		Key:       c.Key,
+		Body:      c.Body,
+		UpdatedAt: c.UpdatedAt,
+	}
+}
+
+func uuidPtrToPgtype(u *uuid.UUID) pgtype.UUID {
+	if u == nil {
+		return pgtype.UUID{}
+	}
+	return pgtype.UUID{Bytes: *u, Valid: true}
+}
+
+func pgtypeUUIDToPtr(u pgtype.UUID) *uuid.UUID {
+	if !u.Valid {
+		return nil
+	}
+	id := uuid.UUID(u.Bytes)
+	return &id
 }

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -1,0 +1,121 @@
+package editor
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// --- Map types ---
+
+type CreateMapRequest struct {
+	Name      string  `json:"name" validate:"required,min=1,max=100"`
+	ImageURL  *string `json:"image_url" validate:"omitempty,url"`
+	SortOrder int32   `json:"sort_order" validate:"min=0"`
+}
+
+type UpdateMapRequest struct {
+	Name      string  `json:"name" validate:"required,min=1,max=100"`
+	ImageURL  *string `json:"image_url" validate:"omitempty,url"`
+	SortOrder int32   `json:"sort_order" validate:"min=0"`
+}
+
+type MapResponse struct {
+	ID        uuid.UUID `json:"id"`
+	ThemeID   uuid.UUID `json:"theme_id"`
+	Name      string    `json:"name"`
+	ImageURL  *string   `json:"image_url,omitempty"`
+	SortOrder int32     `json:"sort_order"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// --- Location types ---
+
+type CreateLocationRequest struct {
+	Name                 string  `json:"name" validate:"required,min=1,max=100"`
+	RestrictedCharacters *string `json:"restricted_characters"`
+	SortOrder            int32   `json:"sort_order" validate:"min=0"`
+}
+
+type UpdateLocationRequest struct {
+	Name                 string  `json:"name" validate:"required,min=1,max=100"`
+	RestrictedCharacters *string `json:"restricted_characters"`
+	SortOrder            int32   `json:"sort_order" validate:"min=0"`
+}
+
+type LocationResponse struct {
+	ID                   uuid.UUID `json:"id"`
+	ThemeID              uuid.UUID `json:"theme_id"`
+	MapID                uuid.UUID `json:"map_id"`
+	Name                 string    `json:"name"`
+	RestrictedCharacters *string   `json:"restricted_characters,omitempty"`
+	SortOrder            int32     `json:"sort_order"`
+	CreatedAt            time.Time `json:"created_at"`
+}
+
+// --- Clue types ---
+
+type CreateClueRequest struct {
+	LocationID  *uuid.UUID `json:"location_id"`
+	Name        string     `json:"name" validate:"required,min=1,max=200"`
+	Description *string    `json:"description" validate:"omitempty,max=2000"`
+	ImageURL    *string    `json:"image_url" validate:"omitempty,url"`
+	IsCommon    bool       `json:"is_common"`
+	Level       int32      `json:"level" validate:"min=1,max=10"`
+	ClueType    string     `json:"clue_type" validate:"required,oneof=normal weapon evidence alibi"`
+	SortOrder   int32      `json:"sort_order" validate:"min=0"`
+}
+
+type UpdateClueRequest struct {
+	LocationID  *uuid.UUID `json:"location_id"`
+	Name        string     `json:"name" validate:"required,min=1,max=200"`
+	Description *string    `json:"description" validate:"omitempty,max=2000"`
+	ImageURL    *string    `json:"image_url" validate:"omitempty,url"`
+	IsCommon    bool       `json:"is_common"`
+	Level       int32      `json:"level" validate:"min=1,max=10"`
+	ClueType    string     `json:"clue_type" validate:"required,oneof=normal weapon evidence alibi"`
+	SortOrder   int32      `json:"sort_order" validate:"min=0"`
+}
+
+type ClueResponse struct {
+	ID          uuid.UUID  `json:"id"`
+	ThemeID     uuid.UUID  `json:"theme_id"`
+	LocationID  *uuid.UUID `json:"location_id,omitempty"`
+	Name        string     `json:"name"`
+	Description *string    `json:"description,omitempty"`
+	ImageURL    *string    `json:"image_url,omitempty"`
+	IsCommon    bool       `json:"is_common"`
+	Level       int32      `json:"level"`
+	ClueType    string     `json:"clue_type"`
+	SortOrder   int32      `json:"sort_order"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// --- Content types ---
+
+type ContentResponse struct {
+	ID        uuid.UUID `json:"id"`
+	ThemeID   uuid.UUID `json:"theme_id"`
+	Key       string    `json:"key"`
+	Body      string    `json:"body"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type UpsertContentRequest struct {
+	Body string `json:"body" validate:"max=50000"`
+}
+
+// --- Validation types ---
+
+type ValidationStats struct {
+	Characters int `json:"characters"`
+	Maps       int `json:"maps"`
+	Locations  int `json:"locations"`
+	Clues      int `json:"clues"`
+}
+
+type ValidationResponse struct {
+	Valid  bool            `json:"valid"`
+	Errors []string        `json:"errors"`
+	Stats  ValidationStats `json:"stats"`
+}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -9,12 +9,14 @@ COPY packages/ packages/
 COPY tooling/ tooling/
 RUN pnpm install --frozen-lockfile
 COPY apps/web/ apps/web/
-RUN pnpm --filter @mmp/web build
+# Build dependency packages first, then web
+RUN pnpm --filter @mmp/shared build && \
+    pnpm --filter @mmp/ws-client build && \
+    pnpm --filter @mmp/game-logic build && \
+    pnpm --filter @mmp/web build
 
-# Stage 2: Serve (local test only; production uses Cloudflare Pages)
+# Stage 2: Serve via Nginx
 FROM nginx:alpine
 COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
-COPY apps/web/nginx.conf /etc/nginx/templates/default.conf.template
-ENV PUBLIC_DOMAIN=dev.mystery-place.com
-ENV CDN_DOMAIN=https://cdn.mystery-place.com
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -1,3 +1,7 @@
+upstream backend {
+    server server:8080;
+}
+
 server {
     listen 80;
     server_name _;
@@ -19,13 +23,41 @@ server {
         application/xml
         image/svg+xml;
 
+    # API reverse proxy
+    location /api/ {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+
+    # WebSocket reverse proxy
+    location /ws/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # Health check (for CF Tunnel)
+    location /health {
+        proxy_pass http://backend;
+    }
+
     # Static asset caching (Vite hashed filenames)
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    # SPA fallback — serve index.html for all non-file routes
+    # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;
     }
@@ -34,5 +66,4 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: ${CDN_DOMAIN}; connect-src 'self' wss://${PUBLIC_DOMAIN} https://${PUBLIC_DOMAIN}; font-src 'self';" always;
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,11 +12,15 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@mmp/game-logic": "workspace:*",
     "@mmp/shared": "workspace:*",
     "@mmp/ui-tokens": "workspace:*",
+    "@mmp/ws-client": "workspace:*",
     "@sentry/react": "^10.47.0",
     "@tanstack/react-query": "^5.96.2",
+    "dompurify": "^3.3.3",
     "lucide-react": "^0.468.0",
+    "marked": "^17.0.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-error-boundary": "^6.1.1",
@@ -28,6 +32,7 @@
     "@tailwindcss/vite": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/dompurify": "^3.2.0",
     "@types/node": "^25.5.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -143,19 +143,19 @@ export function App() {
           <Suspense fallback={<LoadingFallback />}>
             <Routes>
               {/* 퍼블릭 */}
-              <Route path="/" element={<HomePage />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/auth/callback" element={<AuthCallbackPage />} />
 
-              {/* 인증 필요 — 게임은 전체화면 (MainLayout 밖) */}
+              {/* 인증 필요 — 게임/에디터 상세는 전체화면 (MainLayout 밖) */}
               <Route element={<ProtectedRoute />}>
                 <Route path="/game/:id" element={<GamePage />} />
+                <Route path="/editor/:id" element={<EditorPage />} />
                 <Route element={<MainLayout />}>
+                  <Route path="/" element={<LobbyPage />} />
                   <Route path="/lobby" element={<LobbyPage />} />
                   <Route path="/profile" element={<ProfilePage />} />
                   <Route path="/room/:id" element={<RoomPage />} />
                   <Route path="/editor" element={<EditorPage />} />
-                  <Route path="/editor/:id" element={<EditorPage />} />
                   <Route path="/social" element={<SocialPage />} />
                   <Route path="/users/:id" element={<PublicProfilePage />} />
 

--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -1,7 +1,28 @@
-import { Navigate } from "react-router";
+import { useState } from "react";
+import { Navigate, useNavigate } from "react-router";
 import { LogIn } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
 import { getOAuthUrl } from "@/features/auth/oauth-urls";
+import { api } from "@/services/api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TokenPair {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+
+interface UserResponse {
+  id: string;
+  nickname: string;
+  email: string;
+  profile_image: string | null;
+  role: string;
+  provider: string;
+}
 
 // ---------------------------------------------------------------------------
 // 컴포넌트
@@ -9,10 +30,18 @@ import { getOAuthUrl } from "@/features/auth/oauth-urls";
 
 function LoginPage() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const navigate = useNavigate();
+
+  const [mode, setMode] = useState<"login" | "register">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
 
   // 이미 로그인 상태면 로비로 이동
   if (isAuthenticated) {
-    return <Navigate to="/lobby" replace />;
+    return <Navigate to="/" replace />;
   }
 
   const handleKakaoLogin = () => {
@@ -23,18 +52,109 @@ function LoginPage() {
     window.location.href = getOAuthUrl("google");
   };
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const endpoint = mode === "register" ? "/v1/auth/register" : "/v1/auth/login";
+      const body = mode === "register"
+        ? { email, password, nickname }
+        : { email, password };
+
+      const tokens = await api.post<TokenPair>(endpoint, body);
+      useAuthStore.getState().setTokens(tokens.access_token, tokens.refresh_token);
+
+      const user = await api.get<UserResponse>("/v1/auth/me");
+      useAuthStore.getState().setUser({
+        id: user.id,
+        nickname: user.nickname,
+        email: user.email,
+        profileImage: user.profile_image,
+        role: user.role as "user" | "creator" | "admin",
+        provider: user.provider,
+      });
+
+      navigate("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "로그인에 실패했습니다");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-950 px-4">
       <div className="w-full max-w-sm rounded-xl border border-slate-700 bg-slate-900 p-8 shadow-2xl">
         {/* 로고 + 제목 */}
-        <div className="mb-8 flex flex-col items-center gap-3">
+        <div className="mb-6 flex flex-col items-center gap-3">
           <div className="flex h-14 w-14 items-center justify-center rounded-full bg-amber-500/10">
             <LogIn className="h-7 w-7 text-amber-500" />
           </div>
-          <h1 className="text-2xl font-bold text-slate-100">로그인</h1>
+          <h1 className="text-2xl font-bold text-slate-100">
+            {mode === "login" ? "로그인" : "회원가입"}
+          </h1>
           <p className="text-sm text-slate-400">
             Murder Mystery Platform에 오신 것을 환영합니다
           </p>
+        </div>
+
+        {/* 이메일/비밀번호 폼 */}
+        <form onSubmit={handleSubmit} className="mb-6 flex flex-col gap-3">
+          {mode === "register" && (
+            <input
+              type="text"
+              placeholder="닉네임"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              required
+              minLength={2}
+              maxLength={30}
+              className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus:outline-none"
+            />
+          )}
+          <input
+            type="email"
+            placeholder="이메일"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus:outline-none"
+          />
+          <input
+            type="password"
+            placeholder="비밀번호"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={4}
+            className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus:outline-none"
+          />
+          {error && (
+            <p className="text-sm text-red-400">{error}</p>
+          )}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-amber-500 px-4 py-3 text-sm font-semibold text-slate-950 transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {loading ? "처리 중..." : mode === "login" ? "로그인" : "회원가입"}
+          </button>
+          <button
+            type="button"
+            onClick={() => { setMode(mode === "login" ? "register" : "login"); setError(""); }}
+            className="text-sm text-slate-400 hover:text-amber-400"
+          >
+            {mode === "login" ? "계정이 없으신가요? 회원가입" : "이미 계정이 있으신가요? 로그인"}
+          </button>
+        </form>
+
+        {/* 구분선 */}
+        <div className="mb-6 flex items-center gap-3">
+          <div className="h-px flex-1 bg-slate-700" />
+          <span className="text-xs text-slate-500">또는</span>
+          <div className="h-px flex-1 bg-slate-700" />
         </div>
 
         {/* OAuth 버튼 */}
@@ -45,7 +165,6 @@ function LoginPage() {
             onClick={handleKakaoLogin}
             className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#FEE500] px-4 py-3 text-sm font-semibold text-[#191919] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
           >
-            {/* 카카오 심볼 */}
             <svg
               className="h-5 w-5"
               viewBox="0 0 24 24"
@@ -63,7 +182,6 @@ function LoginPage() {
             onClick={handleGoogleLogin}
             className="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-3 text-sm font-semibold text-gray-900 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
           >
-            {/* 구글 심볼 */}
             <svg
               className="h-5 w-5"
               viewBox="0 0 24 24"

--- a/apps/web/src/features/editor/api.ts
+++ b/apps/web/src/features/editor/api.ts
@@ -14,6 +14,7 @@ export interface EditorThemeSummary {
   status: ThemeStatus;
   min_players: number;
   max_players: number;
+  coin_price: number;
   version: number;
   created_at: string;
 }
@@ -57,14 +58,14 @@ export interface CreateThemeRequest {
 }
 
 export interface UpdateThemeRequest {
-  title?: string;
+  title: string;
   description?: string;
   cover_image?: string;
-  min_players?: number;
-  max_players?: number;
-  duration_min?: number;
-  price?: number;
-  coin_price?: number;
+  min_players: number;
+  max_players: number;
+  duration_min: number;
+  price: number;
+  coin_price: number;
 }
 
 export interface CreateCharacterRequest {
@@ -84,6 +85,68 @@ export interface UpdateCharacterRequest {
 }
 
 // ---------------------------------------------------------------------------
+// Maps / Locations / Clues / Contents / Validation types
+// ---------------------------------------------------------------------------
+
+export interface MapResponse {
+  id: string;
+  theme_id: string;
+  name: string;
+  image_url: string | null;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface CreateMapRequest {
+  name: string;
+  image_url?: string;
+  sort_order?: number;
+}
+
+export interface LocationResponse {
+  id: string;
+  theme_id: string;
+  map_id: string;
+  name: string;
+  restricted_characters: string | null;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface ClueResponse {
+  id: string;
+  theme_id: string;
+  location_id: string | null;
+  name: string;
+  description: string | null;
+  image_url: string | null;
+  is_common: boolean;
+  level: number;
+  clue_type: string;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface ContentResponse {
+  id: string;
+  theme_id: string;
+  key: string;
+  body: string;
+  updated_at: string;
+}
+
+export interface ValidationResponse {
+  valid: boolean;
+  errors: string[];
+  stats: {
+    characters: number;
+    maps: number;
+    locations: number;
+    clues: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Query Keys
 // ---------------------------------------------------------------------------
 
@@ -93,6 +156,14 @@ export const editorKeys = {
   theme: (id: string) => [...editorKeys.all, "themes", id] as const,
   characters: (themeId: string) =>
     [...editorKeys.all, "themes", themeId, "characters"] as const,
+  maps: (themeId: string) =>
+    [...editorKeys.all, "themes", themeId, "maps"] as const,
+  locations: (themeId: string) =>
+    [...editorKeys.all, "themes", themeId, "locations"] as const,
+  clues: (themeId: string) =>
+    [...editorKeys.all, "themes", themeId, "clues"] as const,
+  content: (themeId: string, key: string) =>
+    [...editorKeys.all, "themes", themeId, "content", key] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -171,6 +242,31 @@ export function useUnpublishTheme(themeId: string) {
   });
 }
 
+export function useEditorContent(themeId: string, key: string) {
+  return useQuery<ContentResponse>({
+    queryKey: editorKeys.content(themeId, key),
+    queryFn: () => api.get<ContentResponse>(`/v1/editor/themes/${themeId}/content/${key}`),
+    enabled: !!themeId && !!key,
+    retry: false,
+  });
+}
+
+export function useUpsertContent(themeId: string, key: string) {
+  return useMutation<ContentResponse, Error, { body: string }>({
+    mutationFn: (data) =>
+      api.put<ContentResponse>(`/v1/editor/themes/${themeId}/content/${key}`, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: editorKeys.content(themeId, key) });
+    },
+  });
+}
+
+export function useValidateTheme(themeId: string) {
+  return useMutation<ValidationResponse, Error, void>({
+    mutationFn: () => api.post<ValidationResponse>(`/v1/editor/themes/${themeId}/validate`),
+  });
+}
+
 export function useUpdateConfigJson(themeId: string) {
   return useMutation<EditorThemeResponse, Error, Record<string, unknown>>({
     mutationFn: (config) =>
@@ -185,19 +281,13 @@ export function useUpdateConfigJson(themeId: string) {
 }
 
 // ---------------------------------------------------------------------------
-// Character Queries (theme detail에서 characters 필드로 제공되지만,
-// 별도 쿼리가 필요한 경우를 위해 theme 상세에서 추출)
+// Character Queries
 // ---------------------------------------------------------------------------
 
 export function useEditorCharacters(themeId: string) {
   return useQuery<EditorCharacterResponse[]>({
     queryKey: editorKeys.characters(themeId),
-    queryFn: async () => {
-      const theme = await api.get<EditorThemeResponse & { characters?: EditorCharacterResponse[] }>(
-        `/v1/editor/themes/${themeId}`,
-      );
-      return theme.characters ?? [];
-    },
+    queryFn: () => api.get<EditorCharacterResponse[]>(`/v1/editor/themes/${themeId}/characters`),
     enabled: !!themeId,
   });
 }

--- a/apps/web/src/features/editor/components/AdvancedTab.tsx
+++ b/apps/web/src/features/editor/components/AdvancedTab.tsx
@@ -1,0 +1,239 @@
+import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
+import { CheckCircle2, XCircle, AlertCircle, RefreshCw } from 'lucide-react';
+import { Button, Badge } from '@/shared/components/ui';
+import type { EditorThemeResponse } from '@/features/editor/api';
+import { useUpdateConfigJson, useValidateTheme } from '@/features/editor/api';
+import { useEditorUI } from '@/features/editor/stores/editorUIStore';
+import type { EditorTab } from '@/features/editor/constants';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AdvancedTabProps {
+  themeId: string;
+  theme: EditorThemeResponse;
+}
+
+type ValidationSeverity = 'ok' | 'error' | 'warning';
+
+interface ValidationItem {
+  severity: ValidationSeverity;
+  message: string;
+  tab?: EditorTab;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function serialize(value: Record<string, unknown> | null): string {
+  return JSON.stringify(value ?? {}, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// ValidationRow
+// ---------------------------------------------------------------------------
+
+interface ValidationRowProps {
+  item: ValidationItem;
+  onNavigate?: (tab: EditorTab) => void;
+}
+
+function ValidationRow({ item, onNavigate }: ValidationRowProps) {
+  const icons: Record<ValidationSeverity, React.ReactNode> = {
+    ok: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />,
+    error: <XCircle className="h-3.5 w-3.5 text-red-400 shrink-0" />,
+    warning: <AlertCircle className="h-3.5 w-3.5 text-amber-400 shrink-0" />,
+  };
+
+  const textColors: Record<ValidationSeverity, string> = {
+    ok: 'text-emerald-400',
+    error: 'text-red-400',
+    warning: 'text-amber-400',
+  };
+
+  return (
+    <div
+      className={`flex items-start gap-2 py-1.5 ${
+        item.tab ? 'cursor-pointer hover:opacity-80' : ''
+      }`}
+      role={item.tab ? 'button' : undefined}
+      tabIndex={item.tab ? 0 : undefined}
+      onClick={() => item.tab && onNavigate?.(item.tab)}
+      onKeyDown={(e) => e.key === 'Enter' && item.tab && onNavigate?.(item.tab)}
+    >
+      {icons[item.severity]}
+      <span className={`text-xs ${textColors[item.severity]}`}>{item.message}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AdvancedTab
+// ---------------------------------------------------------------------------
+
+export function AdvancedTab({ themeId, theme }: AdvancedTabProps) {
+  const serverText = serialize(theme.config_json);
+  const [text, setText] = useState(serverText);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [validationItems, setValidationItems] = useState<ValidationItem[] | null>(null);
+
+  const updateConfig = useUpdateConfigJson(themeId);
+  const validateTheme = useValidateTheme(themeId);
+  const { setActiveTab } = useEditorUI();
+
+  useEffect(() => {
+    setText(serverText);
+    setParseError(null);
+  }, [serverText]);
+
+  const isDirty = text !== serverText;
+  const lines = text.split('\n');
+
+  const handleSave = () => {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      setParseError('유효하지 않은 JSON 형식입니다');
+      return;
+    }
+    setParseError(null);
+    updateConfig.mutate(parsed, {
+      onSuccess: () => toast.success('설정이 저장되었습니다'),
+      onError: () => toast.error('설정 저장에 실패했습니다'),
+    });
+  };
+
+  const handleReset = () => {
+    setText(serverText);
+    setParseError(null);
+  };
+
+  const handleValidate = () => {
+    validateTheme.mutate(undefined, {
+      onSuccess: (result) => {
+        const items: ValidationItem[] = result.errors.map((msg) => ({
+          severity: 'error',
+          message: msg,
+        }));
+        if (result.valid) {
+          items.unshift({ severity: 'ok', message: '모든 검증을 통과했습니다' });
+          toast.success('검증 완료');
+        } else {
+          toast.error(`검증 실패: ${result.errors.length}개 오류`);
+        }
+        setValidationItems(items);
+      },
+      onError: () => {
+        toast.error('검증 요청에 실패했습니다');
+      },
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col lg:flex-row">
+      {/* ── JSON Editor ── */}
+      <div className="flex flex-1 flex-col overflow-hidden border-b border-slate-800 lg:border-b-0 lg:border-r">
+        {/* Editor header */}
+        <div className="flex items-center justify-between border-b border-slate-800 bg-slate-900 px-4 py-2">
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-mono font-medium text-slate-400">config_json</span>
+            {isDirty && <Badge variant="warning">변경사항 있음</Badge>}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleReset}
+              disabled={!isDirty || updateConfig.isPending}
+            >
+              초기화
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              isLoading={updateConfig.isPending}
+              disabled={!isDirty}
+            >
+              저장
+            </Button>
+          </div>
+        </div>
+
+        {/* Editor with line numbers */}
+        <div className="relative flex flex-1 overflow-auto font-mono">
+          {/* Line numbers */}
+          <div className="sticky left-0 z-10 w-10 shrink-0 select-none overflow-hidden border-r border-slate-800 bg-slate-950 py-3">
+            {lines.map((_, i) => (
+              <div
+                key={i}
+                className="text-right pr-2 text-[11px] leading-5 text-slate-700"
+              >
+                {i + 1}
+              </div>
+            ))}
+          </div>
+
+          {/* Textarea */}
+          <textarea
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              if (parseError) setParseError(null);
+            }}
+            spellCheck={false}
+            className="flex-1 bg-slate-950 py-3 pl-3 pr-4 font-mono text-sm leading-5 text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus:outline-none resize-none min-h-[400px]"
+          />
+        </div>
+
+        {/* Parse error */}
+        {parseError && (
+          <div className="border-t border-slate-800 bg-red-500/5 px-4 py-2">
+            <p className="text-xs text-red-400">{parseError}</p>
+          </div>
+        )}
+      </div>
+
+      {/* ── Validation Panel ── */}
+      <div className="w-full lg:w-72 shrink-0 flex flex-col bg-slate-950">
+        <div className="border-b border-slate-800 bg-slate-900 px-4 py-2">
+          <span className="text-xs font-mono font-medium text-slate-400">검증 결과</span>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {validationItems ? (
+            <div className="space-y-0.5">
+              {validationItems.map((item, i) => (
+                <ValidationRow
+                  key={i}
+                  item={item}
+                  onNavigate={setActiveTab}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-700 font-mono">
+              검증 버튼을 클릭하세요
+            </p>
+          )}
+        </div>
+
+        <div className="border-t border-slate-800 px-4 py-3">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleValidate}
+            isLoading={validateTheme.isPending}
+            className="w-full"
+          >
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            지금 검증
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/CharactersTab.tsx
+++ b/apps/web/src/features/editor/components/CharactersTab.tsx
@@ -1,17 +1,90 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { Pencil, Trash2, Users } from 'lucide-react';
-import { Button } from '@/shared/components/ui/Button';
-import { Badge } from '@/shared/components/ui/Badge';
-import { Modal } from '@/shared/components/ui/Modal';
-import { EmptyState } from '@/shared/components/ui/EmptyState';
+import { Plus, Trash2 } from 'lucide-react';
 import { Spinner } from '@/shared/components/ui/Spinner';
+import { Modal } from '@/shared/components/ui/Modal';
+import { Button } from '@/shared/components/ui/Button';
 import {
   useEditorCharacters,
   useDeleteCharacter,
   type EditorCharacterResponse,
 } from '@/features/editor/api';
 import { CharacterForm } from './CharacterForm';
+
+// ---------------------------------------------------------------------------
+// Color palette
+// ---------------------------------------------------------------------------
+
+const CHARACTER_COLORS = [
+  '#EF4444', '#F59E0B', '#10B981', '#3B82F6', '#8B5CF6',
+  '#EC4899', '#6366F1', '#14B8A6', '#F97316', '#84CC16',
+];
+
+function getCharacterColor(index: number): string {
+  return CHARACTER_COLORS[index % CHARACTER_COLORS.length];
+}
+
+// ---------------------------------------------------------------------------
+// CharacterCard
+// ---------------------------------------------------------------------------
+
+interface CharacterCardProps {
+  character: EditorCharacterResponse;
+  index: number;
+  onEdit: (character: EditorCharacterResponse) => void;
+  onDelete: (character: EditorCharacterResponse) => void;
+}
+
+function CharacterCard({ character, index, onEdit, onDelete }: CharacterCardProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onEdit(character)}
+      onKeyDown={(e) => e.key === 'Enter' && onEdit(character)}
+      className="group rounded-sm border border-slate-800 bg-slate-900 p-3 hover:border-slate-700 transition-all cursor-pointer focus:outline-none focus:border-amber-500/50"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="relative h-10 w-10 shrink-0 rounded-full flex items-center justify-center"
+          style={{ backgroundColor: getCharacterColor(index) }}
+        >
+          <span className="text-sm font-bold text-white font-mono">
+            {character.name.charAt(0)}
+          </span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-slate-200">{character.name}</span>
+            {character.is_culprit && (
+              <span className="text-[10px] font-medium text-red-400 bg-red-500/10 px-1.5 py-0.5 rounded-sm">
+                범인
+              </span>
+            )}
+          </div>
+          {character.description && (
+            <p className="mt-0.5 text-xs text-slate-500 line-clamp-2">{character.description}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          className="p-1 text-slate-700 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all shrink-0"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(character);
+          }}
+          aria-label={`${character.name} 삭제`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CharactersTab
+// ---------------------------------------------------------------------------
 
 interface CharactersTabProps {
   themeId: string;
@@ -23,12 +96,8 @@ export function CharactersTab({ themeId }: CharactersTabProps) {
   const deleteCharacter = useDeleteCharacter(themeId);
 
   const [isFormOpen, setIsFormOpen] = useState(false);
-  const [editingCharacter, setEditingCharacter] = useState<EditorCharacterResponse | undefined>(
-    undefined,
-  );
-  const [deletingCharacter, setDeletingCharacter] = useState<EditorCharacterResponse | undefined>(
-    undefined,
-  );
+  const [editingCharacter, setEditingCharacter] = useState<EditorCharacterResponse | undefined>(undefined);
+  const [deletingCharacter, setDeletingCharacter] = useState<EditorCharacterResponse | undefined>(undefined);
 
   function handleCreate() {
     setEditingCharacter(undefined);
@@ -67,72 +136,44 @@ export function CharactersTab({ themeId }: CharactersTabProps) {
     );
   }
 
+  const isEmpty = !characters || characters.length === 0;
+
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-slate-100">캐릭터 목록</h3>
-        <Button size="sm" onClick={handleCreate}>
-          캐릭터 추가
-        </Button>
-      </div>
-
-      {!characters || characters.length === 0 ? (
-        <EmptyState
-          icon={<Users className="h-10 w-10" />}
-          title="등록된 캐릭터가 없습니다"
-          description="캐릭터를 추가하여 테마를 구성하세요"
-          action={
-            <Button size="sm" onClick={handleCreate}>
-              캐릭터 추가
-            </Button>
-          }
-        />
+    <div className="px-4 py-6">
+      {isEmpty ? (
+        /* Empty state */
+        <div className="py-16 text-center">
+          <div className="text-4xl font-mono font-bold text-slate-800 mb-2">0</div>
+          <div className="text-xs font-mono uppercase tracking-widest text-slate-700 mb-4">
+            등장인물 없음
+          </div>
+          <div className="text-xs text-slate-600 mb-6">최소 2명의 등장인물이 필요합니다</div>
+          <Button onClick={handleCreate}>
+            <Plus className="h-4 w-4 mr-1.5" />
+            캐릭터 추가
+          </Button>
+        </div>
       ) : (
-        <div className="space-y-2">
-          {characters.map((character) => (
-            <div
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {characters.map((character, index) => (
+            <CharacterCard
               key={character.id}
-              className="flex items-center gap-4 rounded-xl border border-slate-700 bg-slate-900 px-4 py-3"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="font-medium text-slate-100">{character.name}</span>
-                  {character.is_culprit && (
-                    <Badge variant="danger" size="sm">
-                      범인
-                    </Badge>
-                  )}
-                  <Badge variant="default" size="sm">
-                    #{character.sort_order}
-                  </Badge>
-                </div>
-                {character.description && (
-                  <p className="mt-0.5 truncate text-sm text-slate-400">
-                    {character.description}
-                  </p>
-                )}
-              </div>
-
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleEdit(character)}
-                  aria-label={`${character.name} 수정`}
-                >
-                  <Pencil className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setDeletingCharacter(character)}
-                  aria-label={`${character.name} 삭제`}
-                >
-                  <Trash2 className="h-4 w-4 text-red-400" />
-                </Button>
-              </div>
-            </div>
+              character={character}
+              index={index}
+              onEdit={handleEdit}
+              onDelete={setDeletingCharacter}
+            />
           ))}
+
+          {/* Add card */}
+          <button
+            type="button"
+            onClick={handleCreate}
+            className="flex flex-col items-center justify-center gap-2 rounded-sm border border-dashed border-slate-800 p-6 text-slate-700 hover:border-slate-600 hover:text-slate-500 transition-colors min-h-[100px]"
+          >
+            <Plus className="h-5 w-5" />
+            <span className="text-xs">캐릭터 추가</span>
+          </button>
         </div>
       )}
 

--- a/apps/web/src/features/editor/components/DesignTab.tsx
+++ b/apps/web/src/features/editor/components/DesignTab.tsx
@@ -1,0 +1,193 @@
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { toast } from 'sonner';
+import type { EditorThemeResponse } from '@/features/editor/api';
+import { useUpdateConfigJson } from '@/features/editor/api';
+import { MODULE_CATEGORIES } from '@/features/editor/constants';
+import type { ModuleInfo } from '@/features/editor/constants';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DesignTabProps {
+  themeId: string;
+  theme: EditorThemeResponse;
+}
+
+// ---------------------------------------------------------------------------
+// DesignTab
+// ---------------------------------------------------------------------------
+
+export function DesignTab({ themeId, theme }: DesignTabProps) {
+  const serverModules = useMemo(
+    () => {
+      const cfg = theme.config_json ?? {};
+      return Array.isArray(cfg.modules) ? (cfg.modules as string[]) : [];
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(theme.config_json?.modules)],
+  );
+
+  const [selectedModules, setSelectedModules] = useState<string[]>(serverModules);
+  const [activeModuleId, setActiveModuleId] = useState<string | null>(null);
+  const updateConfig = useUpdateConfigJson(themeId);
+
+  useEffect(() => {
+    setSelectedModules(serverModules);
+  }, [serverModules]);
+
+  const handleToggle = useCallback((moduleId: string) => {
+    setSelectedModules((prev) => {
+      const next = prev.includes(moduleId)
+        ? prev.filter((id) => id !== moduleId)
+        : [...prev, moduleId];
+
+      // Auto-save on toggle using latest server config to avoid stale closure
+      updateConfig.mutate(
+        { ...(theme.config_json ?? {}), modules: next },
+        {
+          onSuccess: () => toast.success('모듈 설정이 저장되었습니다'),
+          onError: () => toast.error('모듈 설정 저장에 실패했습니다'),
+        },
+      );
+
+      return next;
+    });
+  }, [theme.config_json, updateConfig]);
+
+  const activeModule = useMemo((): ModuleInfo | null => {
+    if (!activeModuleId) return null;
+    for (const cat of MODULE_CATEGORIES) {
+      const found = cat.modules.find((m) => m.id === activeModuleId);
+      if (found) return found;
+    }
+    return null;
+  }, [activeModuleId]);
+
+  return (
+    <div className="flex h-full">
+      {/* ── Sidebar ── */}
+      <aside className="w-60 shrink-0 overflow-y-auto border-r border-slate-800 bg-slate-950 py-4">
+        {MODULE_CATEGORIES.map((category) => {
+          const categoryModuleIds = category.modules.map((m) => m.id);
+          const activeCount = categoryModuleIds.filter((id) =>
+            selectedModules.includes(id),
+          ).length;
+
+          return (
+            <div key={category.key} className="mb-4">
+              {/* Category header */}
+              <div className="flex items-center justify-between px-4 pb-1">
+                <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                  {category.label}
+                </span>
+                <span className="text-[10px] font-mono text-slate-700">
+                  {activeCount}/{category.modules.length}
+                </span>
+              </div>
+
+              {/* Module rows */}
+              {category.modules.map((mod) => {
+                const isEnabled = selectedModules.includes(mod.id);
+                const isActive = activeModuleId === mod.id;
+
+                return (
+                  <button
+                    key={mod.id}
+                    type="button"
+                    onClick={() => setActiveModuleId(isActive ? null : mod.id)}
+                    className={`group flex w-full items-center gap-2.5 border-l-2 px-4 py-1.5 text-left transition-colors ${
+                      isActive
+                        ? 'border-amber-500 bg-slate-900 text-slate-200'
+                        : 'border-transparent text-slate-500 hover:bg-slate-900/50 hover:text-slate-300'
+                    }`}
+                  >
+                    {/* Toggle dot */}
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleToggle(mod.id);
+                      }}
+                      aria-label={`${mod.name} ${isEnabled ? '비활성화' : '활성화'}`}
+                      className="shrink-0 focus:outline-none"
+                    >
+                      <span
+                        className={`block h-2 w-2 rounded-full transition-colors ${
+                          isEnabled ? 'bg-amber-500' : 'bg-slate-700 group-hover:bg-slate-600'
+                        }`}
+                      />
+                    </button>
+                    <span className="truncate text-xs font-medium">{mod.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+          );
+        })}
+      </aside>
+
+      {/* ── Content ── */}
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        {activeModule ? (
+          <div className="max-w-lg">
+            {/* Module header */}
+            <div className="mb-6">
+              <div className="flex items-center gap-3 mb-1">
+                <span
+                  className={`h-2.5 w-2.5 rounded-full shrink-0 ${
+                    selectedModules.includes(activeModule.id)
+                      ? 'bg-amber-500'
+                      : 'bg-slate-700'
+                  }`}
+                />
+                <h2 className="text-base font-mono font-semibold text-slate-200">
+                  {activeModule.name}
+                </h2>
+              </div>
+              <p className="ml-[22px] text-xs text-slate-500">{activeModule.description}</p>
+            </div>
+
+            {/* Toggle */}
+            <div className="rounded-sm border border-slate-800 bg-slate-900 px-4 py-3 flex items-center justify-between">
+              <span className="text-xs text-slate-400">모듈 활성화</span>
+              <button
+                type="button"
+                onClick={() => handleToggle(activeModule.id)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
+                  selectedModules.includes(activeModule.id)
+                    ? 'bg-amber-500'
+                    : 'bg-slate-700'
+                }`}
+                role="switch"
+                aria-checked={selectedModules.includes(activeModule.id)}
+                aria-label={`${activeModule.name} 활성화 토글`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                    selectedModules.includes(activeModule.id) ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Settings placeholder */}
+            <div className="mt-4 rounded-sm border border-dashed border-slate-800 px-4 py-8 text-center">
+              <p className="text-xs font-mono uppercase tracking-widest text-slate-700">
+                모듈 설정 — 추후 구현
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center">
+              <div className="text-xs font-mono uppercase tracking-widest text-slate-700">
+                좌측에서 모듈을 선택하세요
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/EditorDashboard.tsx
+++ b/apps/web/src/features/editor/components/EditorDashboard.tsx
@@ -52,9 +52,9 @@ function CreateThemeForm({ onSubmit, isLoading, onCancel }: CreateThemeFormProps
     const min = Number(minPlayers);
     const max = Number(maxPlayers);
     const dur = Number(durationMin);
-    if (!Number.isInteger(min) || min < 2) next.minPlayers = "최소 2명 이상";
-    if (!Number.isInteger(max) || max < min) next.maxPlayers = "최소 인원보다 커야 합니다";
-    if (!Number.isInteger(dur) || dur < 10) next.durationMin = "최소 10분 이상";
+    if (!Number.isInteger(min) || min < 2 || min > 20) next.minPlayers = "2~20명 사이로 입력해주세요";
+    if (!Number.isInteger(max) || max < min || max > 20) next.maxPlayers = "최소 인원보다 크고 20명 이하여야 합니다";
+    if (!Number.isInteger(dur) || dur < 10 || dur > 300) next.durationMin = "10~300분 사이로 입력해주세요";
     if (price && (Number.isNaN(Number(price)) || Number(price) < 0))
       next.price = "올바른 가격을 입력해주세요";
     setErrors(next);

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -1,0 +1,229 @@
+import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
+import { useNavigate } from "react-router";
+import { ArrowLeft, ChevronRight } from "lucide-react";
+import { Spinner } from "@/shared/components/ui";
+import { EDITOR_TABS } from "@/features/editor/constants";
+import type { EditorTab } from "@/features/editor/constants";
+import type { EditorThemeResponse } from "@/features/editor/api";
+import { useEditorUI } from "@/features/editor/stores/editorUIStore";
+import { SaveIndicator } from "./SaveIndicator";
+import type { SaveStatus } from "@/features/editor/hooks/useAutoSave";
+
+// ---------------------------------------------------------------------------
+// Lazy tab components
+// ---------------------------------------------------------------------------
+
+const OverviewTab = lazy(() =>
+  import("./OverviewTab").then((m) => ({ default: m.OverviewTab })),
+);
+const StoryTab = lazy(() =>
+  import("./StoryTab").then((m) => ({ default: m.StoryTab })),
+);
+const CharactersTab = lazy(() =>
+  import("./CharactersTab").then((m) => ({ default: m.CharactersTab })),
+);
+const DesignTab = lazy(() =>
+  import("./DesignTab").then((m) => ({ default: m.DesignTab })),
+);
+const AdvancedTab = lazy(() =>
+  import("./AdvancedTab").then((m) => ({ default: m.AdvancedTab })),
+);
+
+// ---------------------------------------------------------------------------
+// TabContent
+// ---------------------------------------------------------------------------
+
+interface TabContentProps {
+  tab: EditorTab;
+  theme: EditorThemeResponse;
+  themeId: string;
+}
+
+function TabContent({ tab, theme, themeId }: TabContentProps) {
+  switch (tab) {
+    case "overview":
+      return <OverviewTab theme={theme} themeId={themeId} />;
+    case "story":
+      return <StoryTab themeId={themeId} />;
+    case "characters":
+      return <CharactersTab theme={theme} themeId={themeId} />;
+    case "design":
+      return <DesignTab theme={theme} themeId={themeId} />;
+    case "advanced":
+      return <AdvancedTab theme={theme} themeId={themeId} />;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EditorLayout
+// ---------------------------------------------------------------------------
+
+interface EditorLayoutProps {
+  theme: EditorThemeResponse;
+  themeId: string;
+  saveStatus?: SaveStatus;
+  lastSaved?: Date | null;
+  onSave?: () => void;
+  onRetry?: () => void;
+  onPublish?: () => void;
+  onValidate?: () => void;
+}
+
+export function EditorLayout({
+  theme,
+  themeId,
+  saveStatus = "idle",
+  lastSaved,
+  onSave,
+  onRetry,
+  onPublish,
+  onValidate,
+}: EditorLayoutProps) {
+  const navigate = useNavigate();
+  const { activeTab, setActiveTab } = useEditorUI();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Keyboard navigation: ←→ Home End
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      const count = EDITOR_TABS.length;
+      let next: number | null = null;
+
+      if (e.key === "ArrowRight") next = (index + 1) % count;
+      else if (e.key === "ArrowLeft") next = (index - 1 + count) % count;
+      else if (e.key === "Home") next = 0;
+      else if (e.key === "End") next = count - 1;
+
+      if (next !== null) {
+        e.preventDefault();
+        setActiveTab(EDITOR_TABS[next].key);
+        tabRefs.current[next]?.focus();
+      }
+    },
+    [setActiveTab],
+  );
+
+  // Save on Ctrl+S / Cmd+S
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        onSave?.();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onSave]);
+
+  const tabpanelId = `tabpanel-${activeTab}`;
+  const tabId = (key: string) => `tab-${key}`;
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-slate-950 text-slate-100">
+      {/* ── Top bar ── */}
+      <header className="sticky top-0 z-50 flex h-12 shrink-0 items-center gap-3 border-b border-slate-800 bg-slate-900 px-3">
+        {/* Back */}
+        <button
+          type="button"
+          onClick={() => navigate("/editor")}
+          className="rounded-sm p-1.5 text-slate-500 transition-colors hover:bg-slate-800 hover:text-slate-200"
+          aria-label="에디터 목록으로 돌아가기"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+
+        <div className="h-5 w-px bg-slate-800" />
+
+        {/* Breadcrumb + title */}
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="shrink-0 text-xs text-slate-600">에디터</span>
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-slate-700" />
+          <span className="truncate text-sm font-mono font-medium text-slate-200">
+            {theme.title}
+          </span>
+          <span className="shrink-0 rounded-sm bg-slate-800 px-1.5 py-0.5 text-[10px] font-mono text-slate-500">
+            {theme.status}
+          </span>
+        </div>
+
+        {/* Save indicator */}
+        <SaveIndicator
+          status={saveStatus}
+          lastSaved={lastSaved}
+          onRetry={onRetry}
+        />
+
+        <div className="h-5 w-px bg-slate-800" />
+
+        {/* Actions */}
+        <button
+          type="button"
+          onClick={onValidate}
+          className="h-7 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500"
+        >
+          검증
+        </button>
+        <button
+          type="button"
+          onClick={onPublish}
+          disabled={theme.status === "PUBLISHED"}
+          className="h-7 rounded-sm bg-amber-600 px-3 text-xs font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          출판
+        </button>
+      </header>
+
+      {/* ── Tab nav ── */}
+      <nav
+        role="tablist"
+        aria-label="에디터 탭"
+        className="sticky top-12 z-40 flex h-10 shrink-0 border-b border-slate-800 bg-slate-950 px-4"
+      >
+        {EDITOR_TABS.map((tab, index) => {
+          const isActive = activeTab === tab.key;
+          return (
+            <button
+              key={tab.key}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`tabpanel-${tab.key}`}
+              id={tabId(tab.key)}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => setActiveTab(tab.key)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className={`relative flex items-center gap-1.5 px-4 text-xs font-medium transition-colors ${
+                isActive
+                  ? "text-amber-400 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-amber-500"
+                  : "text-slate-500 hover:bg-slate-900/50 hover:text-slate-300"
+              }`}
+            >
+              <tab.icon className="h-3.5 w-3.5" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      {/* ── Content ── */}
+      <div
+        role="tabpanel"
+        id={tabpanelId}
+        aria-labelledby={tabId(activeTab)}
+        className="flex-1 overflow-y-auto"
+      >
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center py-12">
+              <Spinner />
+            </div>
+          }
+        >
+          <TabContent tab={activeTab} theme={theme} themeId={themeId} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/ModulesTab.tsx
+++ b/apps/web/src/features/editor/components/ModulesTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 
@@ -132,9 +132,11 @@ function CategorySection({
 
 export function ModulesTab({ themeId, theme }: ModulesTabProps) {
   const configJson = theme.config_json ?? {};
-  const serverModules = (
-    Array.isArray(configJson.modules) ? configJson.modules : []
-  ) as string[];
+  const serverModules = useMemo(
+    () => (Array.isArray(configJson.modules) ? (configJson.modules as string[]) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(configJson.modules)],
+  );
 
   const [selectedModules, setSelectedModules] = useState<string[]>(serverModules);
   const updateConfig = useUpdateConfigJson(themeId);
@@ -142,7 +144,7 @@ export function ModulesTab({ themeId, theme }: ModulesTabProps) {
   // Sync local state when server data changes (e.g. after save)
   useEffect(() => {
     setSelectedModules(serverModules);
-  }, [JSON.stringify(serverModules)]);
+  }, [serverModules]);
 
   const isDirty = JSON.stringify(selectedModules.slice().sort()) !== JSON.stringify(serverModules.slice().sort());
 
@@ -236,7 +238,7 @@ export function ModulesTab({ themeId, theme }: ModulesTabProps) {
             onToggle={handleToggle}
             onSelectAll={handleSelectAll}
             onDeselectAll={handleDeselectAll}
-            isPending={false}
+            isPending={updateConfig.isPending}
           />
         ))}
       </div>

--- a/apps/web/src/features/editor/components/OverviewTab.tsx
+++ b/apps/web/src/features/editor/components/OverviewTab.tsx
@@ -1,12 +1,89 @@
 import { useState, useEffect, type FormEvent } from 'react';
 import { toast } from 'sonner';
+import { ImagePlus } from 'lucide-react';
 import { Button } from '@/shared/components/ui/Button';
-import { Input } from '@/shared/components/ui/Input';
 import {
   useUpdateTheme,
   type EditorThemeResponse,
   type UpdateThemeRequest,
 } from '@/features/editor/api';
+import { SectionDivider } from './SectionDivider';
+
+// ---------------------------------------------------------------------------
+// SpecField — inline number input with label + unit
+// ---------------------------------------------------------------------------
+
+interface SpecFieldProps {
+  label: string;
+  unit: string;
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  error?: string;
+}
+
+function SpecField({ label, unit, value, onChange, min, max, error }: SpecFieldProps) {
+  return (
+    <div className="rounded-sm border border-slate-800 bg-slate-900 p-3">
+      <div className="text-[10px] font-mono font-medium uppercase tracking-wider text-slate-600">
+        {label}
+      </div>
+      <div className="mt-1 flex items-baseline gap-1">
+        <input
+          type="number"
+          value={value}
+          min={min}
+          max={max}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="w-full bg-transparent text-2xl font-mono font-bold text-slate-200 focus:outline-none focus:text-amber-400 transition-colors"
+        />
+        <span className="text-xs text-slate-600">{unit}</span>
+      </div>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PriceField — same shape but for price inputs
+// ---------------------------------------------------------------------------
+
+interface PriceFieldProps {
+  label: string;
+  unit: string;
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  error?: string;
+}
+
+function PriceField({ label, unit, value, onChange, min, max, error }: PriceFieldProps) {
+  return (
+    <div className="rounded-sm border border-slate-800 bg-slate-900 p-3">
+      <div className="text-[10px] font-mono font-medium uppercase tracking-wider text-slate-600">
+        {label}
+      </div>
+      <div className="mt-1 flex items-baseline gap-1">
+        <input
+          type="number"
+          value={value}
+          min={min}
+          max={max}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="w-full bg-transparent text-xl font-mono font-bold text-slate-200 focus:outline-none focus:text-amber-400 transition-colors"
+        />
+        <span className="text-xs text-slate-600">{unit}</span>
+      </div>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OverviewTab
+// ---------------------------------------------------------------------------
 
 interface OverviewTabProps {
   themeId: string;
@@ -16,72 +93,43 @@ interface OverviewTabProps {
 export function OverviewTab({ themeId, theme }: OverviewTabProps) {
   const [title, setTitle] = useState(theme.title);
   const [description, setDescription] = useState(theme.description ?? '');
-  const [coverImage, setCoverImage] = useState(theme.cover_image ?? '');
   const [minPlayers, setMinPlayers] = useState(theme.min_players);
   const [maxPlayers, setMaxPlayers] = useState(theme.max_players);
   const [durationMin, setDurationMin] = useState(theme.duration_min);
   const [price, setPrice] = useState(theme.price);
   const [coinPrice, setCoinPrice] = useState(theme.coin_price);
-
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const updateTheme = useUpdateTheme(themeId);
 
-  // Sync form state when server data changes (e.g. after save)
   useEffect(() => {
     setTitle(theme.title);
     setDescription(theme.description ?? '');
-    setCoverImage(theme.cover_image ?? '');
     setMinPlayers(theme.min_players);
     setMaxPlayers(theme.max_players);
     setDurationMin(theme.duration_min);
     setPrice(theme.price);
     setCoinPrice(theme.coin_price);
     setErrors({});
-  }, [theme.version]);
+  }, [theme.id, theme.version]);
 
   function validate(): Record<string, string> {
     const next: Record<string, string> = {};
-
     const trimmedTitle = title.trim();
-    if (!trimmedTitle) {
-      next.title = '제목은 필수입니다';
-    } else if (trimmedTitle.length > 100) {
-      next.title = '제목은 100자 이하여야 합니다';
-    }
-
-    if (description.length > 2000) {
-      next.description = '설명은 2000자 이하여야 합니다';
-    }
-
-    if (minPlayers < 2 || minPlayers > 20) {
-      next.minPlayers = '최소 인원은 2~20 사이여야 합니다';
-    }
-
-    if (maxPlayers < 2 || maxPlayers > 20) {
-      next.maxPlayers = '최대 인원은 2~20 사이여야 합니다';
-    } else if (maxPlayers < minPlayers) {
-      next.maxPlayers = '최대 인원은 최소 인원 이상이어야 합니다';
-    }
-
-    if (durationMin < 10 || durationMin > 300) {
-      next.durationMin = '진행 시간은 10~300분 사이여야 합니다';
-    }
-
-    if (price < 0) {
-      next.price = '가격은 0 이상이어야 합니다';
-    }
-
-    if (coinPrice < 0 || coinPrice > 100000) {
-      next.coinPrice = '코인 가격은 0~100,000 사이여야 합니다';
-    }
-
+    if (!trimmedTitle) next.title = '제목은 필수입니다';
+    else if (trimmedTitle.length > 100) next.title = '제목은 100자 이하여야 합니다';
+    if (description.length > 2000) next.description = '설명은 2000자 이하여야 합니다';
+    if (minPlayers < 2 || minPlayers > 20) next.minPlayers = '최소 인원은 2~20 사이여야 합니다';
+    if (maxPlayers < 2 || maxPlayers > 20) next.maxPlayers = '최대 인원은 2~20 사이여야 합니다';
+    else if (maxPlayers < minPlayers) next.maxPlayers = '최대 인원은 최소 인원 이상이어야 합니다';
+    if (durationMin < 10 || durationMin > 300) next.durationMin = '진행 시간은 10~300분 사이여야 합니다';
+    if (price < 0) next.price = '가격은 0 이상이어야 합니다';
+    if (coinPrice < 0 || coinPrice > 100000) next.coinPrice = '코인 가격은 0~100,000 사이여야 합니다';
     return next;
   }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
-
     const validationErrors = validate();
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) return;
@@ -89,7 +137,6 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
     const body: UpdateThemeRequest = {
       title: title.trim(),
       description: description || undefined,
-      cover_image: coverImage || undefined,
       min_players: minPlayers,
       max_players: maxPlayers,
       duration_min: durationMin,
@@ -98,107 +145,139 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
     };
 
     updateTheme.mutate(body, {
-      onSuccess: () => {
-        toast.success('테마가 수정되었습니다');
-      },
-      onError: (err) => {
-        toast.error(err.message || '테마 수정에 실패했습니다');
-      },
+      onSuccess: () => toast.success('테마가 수정되었습니다'),
+      onError: (err) => toast.error(err.message || '테마 수정에 실패했습니다'),
     });
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <Input
-        label="제목"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="테마 제목"
-        required
-        maxLength={100}
-        error={errors.title}
-      />
+    <form onSubmit={handleSubmit} className="mx-auto max-w-2xl px-4 py-6">
+      {/* ── 기본 정보 ── */}
+      <SectionDivider label="기본 정보" />
 
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="overview-description" className="text-sm font-medium text-slate-300">
-          설명
-        </label>
-        <textarea
-          id="overview-description"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder="테마에 대한 설명을 입력하세요"
-          maxLength={2000}
-          rows={4}
-          className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
-        />
-        {errors.description && (
-          <p className="text-sm text-red-400">{errors.description}</p>
-        )}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-[180px_1fr]">
+        {/* Thumbnail */}
+        <div
+          className="aspect-[3/2] cursor-pointer rounded-sm border border-dashed border-slate-800 bg-slate-900 flex flex-col items-center justify-center gap-2 hover:border-slate-700 transition-colors group overflow-hidden"
+          role="button"
+          tabIndex={0}
+          aria-label="커버 이미지 업로드"
+          onKeyDown={(e) => e.key === 'Enter' && e.currentTarget.click()}
+        >
+          {theme.cover_image ? (
+            <img
+              src={theme.cover_image}
+              alt="커버 이미지"
+              className="h-full w-full object-cover rounded-sm"
+            />
+          ) : (
+            <>
+              <ImagePlus className="h-6 w-6 text-slate-700 group-hover:text-slate-500 transition-colors" />
+              <span className="text-[10px] text-slate-700 group-hover:text-slate-500 transition-colors">
+                커버 이미지
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* Text fields */}
+        <div className="flex flex-col gap-3">
+          {/* 제목 */}
+          <div>
+            <div className="text-[10px] font-mono font-medium uppercase tracking-wider text-slate-600 mb-1">
+              제목
+            </div>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="테마 제목"
+              maxLength={100}
+              className="w-full rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-700 focus:border-amber-500/50 focus:outline-none focus:ring-1 focus:ring-amber-500/30 transition-colors"
+            />
+            {errors.title && <p className="mt-1 text-xs text-red-400">{errors.title}</p>}
+          </div>
+
+          {/* 세부 설명 */}
+          <div>
+            <div className="text-[10px] font-mono font-medium uppercase tracking-wider text-slate-600 mb-1">
+              세부 설명
+            </div>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="테마에 대한 세부 설명을 입력하세요"
+              maxLength={2000}
+              rows={3}
+              className="w-full rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-700 focus:border-amber-500/50 focus:outline-none focus:ring-1 focus:ring-amber-500/30 transition-colors resize-none"
+            />
+            {errors.description && <p className="mt-1 text-xs text-red-400">{errors.description}</p>}
+          </div>
+        </div>
       </div>
 
-      <Input
-        label="커버 이미지 URL"
-        type="url"
-        value={coverImage}
-        onChange={(e) => setCoverImage(e.target.value)}
-        placeholder="https://example.com/image.jpg"
-      />
+      {/* ── 게임 스펙 ── */}
+      <SectionDivider label="게임 스펙" />
 
-      <div className="grid grid-cols-2 gap-4">
-        <Input
+      <div className="grid grid-cols-3 gap-3">
+        <SpecField
           label="최소 인원"
-          type="number"
+          unit="명"
           value={minPlayers}
-          onChange={(e) => setMinPlayers(Number(e.target.value))}
+          onChange={setMinPlayers}
           min={2}
           max={20}
           error={errors.minPlayers}
         />
-        <Input
+        <SpecField
           label="최대 인원"
-          type="number"
+          unit="명"
           value={maxPlayers}
-          onChange={(e) => setMaxPlayers(Number(e.target.value))}
+          onChange={setMaxPlayers}
           min={2}
           max={20}
           error={errors.maxPlayers}
         />
+        <SpecField
+          label="플레이 시간"
+          unit="분"
+          value={durationMin}
+          onChange={setDurationMin}
+          min={10}
+          max={300}
+          error={errors.durationMin}
+        />
       </div>
 
-      <Input
-        label="진행 시간 (분)"
-        type="number"
-        value={durationMin}
-        onChange={(e) => setDurationMin(Number(e.target.value))}
-        min={10}
-        max={300}
-        error={errors.durationMin}
-      />
+      {/* ── 가격 설정 ── */}
+      <SectionDivider label="가격 설정" />
 
-      <Input
-        label="가격"
-        type="number"
-        value={price}
-        onChange={(e) => setPrice(Number(e.target.value))}
-        min={0}
-        error={errors.price}
-      />
+      <div className="grid grid-cols-2 gap-3">
+        <PriceField
+          label="가격"
+          unit="원"
+          value={price}
+          onChange={setPrice}
+          min={0}
+          error={errors.price}
+        />
+        <PriceField
+          label="코인 가격"
+          unit="코인"
+          value={coinPrice}
+          onChange={setCoinPrice}
+          min={0}
+          max={100000}
+          error={errors.coinPrice}
+        />
+      </div>
 
-      <Input
-        label="코인 가격"
-        type="number"
-        value={coinPrice}
-        onChange={(e) => setCoinPrice(Number(e.target.value))}
-        min={0}
-        max={100000}
-        placeholder="0 (무료)"
-        error={errors.coinPrice}
-      />
-
-      <Button type="submit" isLoading={updateTheme.isPending}>
-        저장
-      </Button>
+      {/* Save */}
+      <div className="mt-8 flex justify-end">
+        <Button type="submit" isLoading={updateTheme.isPending}>
+          저장
+        </Button>
+      </div>
     </form>
   );
 }

--- a/apps/web/src/features/editor/components/SaveIndicator.tsx
+++ b/apps/web/src/features/editor/components/SaveIndicator.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import type { SaveStatus } from "@/features/editor/hooks/useAutoSave";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SaveIndicatorProps {
+  status: SaveStatus;
+  lastSaved?: Date | null;
+  onRetry?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SaveIndicator
+// ---------------------------------------------------------------------------
+
+export function SaveIndicator({ status, lastSaved, onRetry }: SaveIndicatorProps) {
+  const [visible, setVisible] = useState(true);
+
+  // Fade out after 2s when saved
+  useEffect(() => {
+    if (status === "saved") {
+      setVisible(true);
+      const t = setTimeout(() => setVisible(false), 2000);
+      return () => clearTimeout(t);
+    } else {
+      setVisible(true);
+    }
+  }, [status]);
+
+  if (status === "idle") return null;
+  if (status === "saved" && !visible) return null;
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 text-xs transition-opacity ${
+        visible ? "opacity-100" : "opacity-0"
+      }`}
+    >
+      {status === "dirty" && (
+        <>
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
+          <span className="text-amber-400">변경사항 있음</span>
+        </>
+      )}
+
+      {status === "saving" && (
+        <>
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border border-slate-400 border-t-transparent" />
+          <span className="text-slate-400">저장 중...</span>
+        </>
+      )}
+
+      {status === "saved" && (
+        <>
+          <span className="text-emerald-500">✓</span>
+          <span className="text-slate-500">
+            저장됨{lastSaved ? ` ${formatTime(lastSaved)}` : ""}
+          </span>
+        </>
+      )}
+
+      {status === "error" && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="flex items-center gap-1.5 rounded-sm px-1.5 py-0.5 transition-colors hover:bg-red-950"
+        >
+          <span className="text-red-400">✗</span>
+          <span className="text-red-400">저장 실패 — 재시도</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/SectionDivider.tsx
+++ b/apps/web/src/features/editor/components/SectionDivider.tsx
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------------------
+// SectionDivider
+// ---------------------------------------------------------------------------
+
+interface SectionDividerProps {
+  label: string;
+}
+
+export function SectionDivider({ label }: SectionDividerProps) {
+  return (
+    <div className="my-6 flex items-center gap-3">
+      <span className="h-px flex-1 bg-slate-800" />
+      <span className="text-[10px] font-mono font-semibold uppercase tracking-widest text-slate-700">
+        {label}
+      </span>
+      <span className="h-px flex-1 bg-slate-800" />
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -1,0 +1,150 @@
+import { useState, useMemo, useEffect } from 'react';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import { Columns2, AlignLeft, Eye } from 'lucide-react';
+import { useEditorContent, useUpsertContent } from '@/features/editor/api';
+import { useAutoSave } from '@/features/editor/hooks/useAutoSave';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ViewMode = 'editor' | 'split' | 'preview';
+
+interface StoryTabProps {
+  themeId: string;
+}
+
+// ---------------------------------------------------------------------------
+// View mode toggle button
+// ---------------------------------------------------------------------------
+
+interface ViewToggleProps {
+  mode: ViewMode;
+  current: ViewMode;
+  icon: React.ReactNode;
+  label: string;
+  onClick: (mode: ViewMode) => void;
+}
+
+function ViewToggleBtn({ mode, current, icon, label, onClick }: ViewToggleProps) {
+  const isActive = mode === current;
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(mode)}
+      aria-pressed={isActive}
+      title={label}
+      className={`flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs font-medium transition-colors ${
+        isActive
+          ? 'bg-slate-800 text-amber-400'
+          : 'text-slate-500 hover:text-slate-300'
+      }`}
+    >
+      {icon}
+      <span className="hidden sm:inline">{label}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StoryTab
+// ---------------------------------------------------------------------------
+
+export function StoryTab({ themeId }: StoryTabProps) {
+  const { data: contentData } = useEditorContent(themeId, 'story');
+  const upsertContent = useUpsertContent(themeId, 'story');
+
+  const [markdown, setMarkdown] = useState('');
+  const [viewMode, setViewMode] = useState<ViewMode>('split');
+
+  // Initialize markdown from server data once loaded
+  useEffect(() => {
+    if (contentData?.body !== undefined) {
+      setMarkdown(contentData.body);
+    }
+  }, [contentData?.body]);
+
+  useAutoSave({
+    data: markdown,
+    mutationFn: (body) => upsertContent.mutateAsync({ body }),
+  });
+
+  const charCount = markdown.length;
+
+  const previewHtml = useMemo(() => {
+    if (!markdown) return '';
+    const raw = marked.parse(markdown, { async: false }) as string;
+    return DOMPurify.sanitize(raw);
+  }, [markdown]);
+
+  const showEditor = viewMode === 'editor' || viewMode === 'split';
+  const showPreview = viewMode === 'preview' || viewMode === 'split';
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between border-b border-slate-800 bg-slate-950 px-4 py-2">
+        <div className="flex items-center gap-1">
+          <ViewToggleBtn
+            mode="editor"
+            current={viewMode}
+            icon={<AlignLeft className="h-3.5 w-3.5" />}
+            label="에디터만"
+            onClick={setViewMode}
+          />
+          <ViewToggleBtn
+            mode="split"
+            current={viewMode}
+            icon={<Columns2 className="h-3.5 w-3.5" />}
+            label="분할"
+            onClick={setViewMode}
+          />
+          <ViewToggleBtn
+            mode="preview"
+            current={viewMode}
+            icon={<Eye className="h-3.5 w-3.5" />}
+            label="미리보기만"
+            onClick={setViewMode}
+          />
+        </div>
+        <span className="text-[11px] font-mono text-slate-600">
+          {charCount.toLocaleString('ko-KR')}자
+        </span>
+      </div>
+
+      {/* Editor / Preview panes */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Editor pane */}
+        {showEditor && (
+          <div className={`flex flex-col ${viewMode === 'split' ? 'w-1/2 border-r border-slate-800' : 'w-full'}`}>
+            <textarea
+              value={markdown}
+              onChange={(e) => setMarkdown(e.target.value)}
+              placeholder="마크다운으로 스토리를 작성하세요..."
+              spellCheck={false}
+              className="flex-1 resize-none bg-slate-950 px-5 py-4 font-mono text-sm leading-relaxed text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus:outline-none"
+            />
+          </div>
+        )}
+
+        {/* Preview pane */}
+        {showPreview && (
+          <div className={`overflow-y-auto ${viewMode === 'split' ? 'w-1/2' : 'w-full'}`}>
+            {previewHtml ? (
+              <div
+                className="prose prose-invert prose-sm prose-headings:font-mono prose-strong:text-amber-400 max-w-none px-5 py-4"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: previewHtml }}
+              />
+            ) : (
+              <div className="flex items-center justify-center py-20 text-xs font-mono uppercase tracking-widest text-slate-700">
+                미리보기 없음
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/ThemeEditor.tsx
+++ b/apps/web/src/features/editor/components/ThemeEditor.tsx
@@ -1,68 +1,25 @@
-import { useState, lazy, Suspense } from "react";
 import { Spinner } from "@/shared/components/ui";
 import { useEditorTheme } from "@/features/editor/api";
-import type { EditorThemeResponse } from "@/features/editor/api";
-import { EDITOR_TABS } from "@/features/editor/constants";
-import type { EditorTab } from "@/features/editor/constants";
-import { PublishBar } from "./PublishBar";
-
-// Lazy-load tab components
-const OverviewTab = lazy(() =>
-  import("./OverviewTab").then((m) => ({ default: m.OverviewTab })),
-);
-const CharactersTab = lazy(() =>
-  import("./CharactersTab").then((m) => ({ default: m.CharactersTab })),
-);
-const ModulesTab = lazy(() =>
-  import("./ModulesTab").then((m) => ({ default: m.ModulesTab })),
-);
-const ConfigJsonTab = lazy(() =>
-  import("./ConfigJsonTab").then((m) => ({ default: m.ConfigJsonTab })),
-);
+import { EditorLayout } from "./EditorLayout";
 
 // ---------------------------------------------------------------------------
-// TabContent
+// FullPage helpers
 // ---------------------------------------------------------------------------
 
-interface TabContentProps {
-  tab: EditorTab;
-  theme: EditorThemeResponse;
-  themeId: string;
-}
-
-function TabContent({ tab, theme, themeId }: TabContentProps) {
-  const fallback = (
-    <div className="flex items-center justify-center py-12">
-      <Spinner />
+function FullPageSpinner() {
+  return (
+    <div className="flex h-screen items-center justify-center bg-slate-950">
+      <Spinner size="lg" />
     </div>
   );
+}
 
-  switch (tab) {
-    case "overview":
-      return (
-        <Suspense fallback={fallback}>
-          <OverviewTab theme={theme} themeId={themeId} />
-        </Suspense>
-      );
-    case "characters":
-      return (
-        <Suspense fallback={fallback}>
-          <CharactersTab theme={theme} themeId={themeId} />
-        </Suspense>
-      );
-    case "modules":
-      return (
-        <Suspense fallback={fallback}>
-          <ModulesTab theme={theme} themeId={themeId} />
-        </Suspense>
-      );
-    case "config":
-      return (
-        <Suspense fallback={fallback}>
-          <ConfigJsonTab theme={theme} themeId={themeId} />
-        </Suspense>
-      );
-  }
+function FullPageError({ message }: { message: string }) {
+  return (
+    <div className="flex h-screen items-center justify-center bg-slate-950">
+      <p className="text-sm text-red-400">{message}</p>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -75,48 +32,9 @@ interface ThemeEditorProps {
 
 export function ThemeEditor({ themeId }: ThemeEditorProps) {
   const { data: theme, isLoading, isError } = useEditorTheme(themeId);
-  const [activeTab, setActiveTab] = useState<EditorTab>("overview");
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
+  if (isLoading) return <FullPageSpinner />;
+  if (isError || !theme) return <FullPageError message="테마를 찾을 수 없습니다" />;
 
-  if (isError || !theme) {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <p className="text-sm text-red-400">
-          테마를 찾을 수 없습니다.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-6">
-      <PublishBar theme={theme} />
-
-      <nav className="mb-6 flex gap-1 border-b border-slate-800">
-        {EDITOR_TABS.map((tab) => (
-          <button
-            key={tab.key}
-            type="button"
-            onClick={() => setActiveTab(tab.key)}
-            className={`px-4 py-2.5 text-sm font-medium transition-colors ${
-              activeTab === tab.key
-                ? "border-b-2 border-amber-500 text-amber-400"
-                : "text-slate-400 hover:text-slate-200"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </nav>
-
-      <TabContent tab={activeTab} theme={theme} themeId={themeId} />
-    </div>
-  );
+  return <EditorLayout theme={theme} themeId={themeId} />;
 }

--- a/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
@@ -448,7 +448,7 @@ describe("CharactersTab", () => {
     });
 
     render(<CharactersTab themeId="theme-1" />);
-    expect(screen.getByText("등록된 캐릭터가 없습니다")).toBeDefined();
+    expect(screen.getByText("등장인물 없음")).toBeDefined();
   });
 
   it("캐릭터 이름을 렌더링한다", () => {

--- a/apps/web/src/features/editor/components/index.ts
+++ b/apps/web/src/features/editor/components/index.ts
@@ -1,6 +1,9 @@
 export { EditorDashboard } from "./EditorDashboard";
 export { ThemeEditor } from "./ThemeEditor";
+export { EditorLayout } from "./EditorLayout";
 export { PublishBar } from "./PublishBar";
+export { SaveIndicator } from "./SaveIndicator";
+export { SectionDivider } from "./SectionDivider";
 export { OverviewTab } from "./OverviewTab";
 export { CharactersTab } from "./CharactersTab";
 export { CharacterForm } from "./CharacterForm";

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -1,17 +1,19 @@
+import { FileText, BookOpen, Users, Settings, Code } from "lucide-react";
 import type { ThemeStatus } from "./api";
 
 // ---------------------------------------------------------------------------
 // Editor Tabs
 // ---------------------------------------------------------------------------
 
-export type EditorTab = "overview" | "characters" | "modules" | "config";
-
-export const EDITOR_TABS: { key: EditorTab; label: string }[] = [
-  { key: "overview", label: "개요" },
-  { key: "characters", label: "캐릭터" },
-  { key: "modules", label: "모듈" },
-  { key: "config", label: "설정 JSON" },
+export const EDITOR_TABS = [
+  { key: "overview" as const, label: "기본정보", icon: FileText },
+  { key: "story" as const, label: "스토리", icon: BookOpen },
+  { key: "characters" as const, label: "등장인물", icon: Users },
+  { key: "design" as const, label: "게임설계", icon: Settings },
+  { key: "advanced" as const, label: "고급", icon: Code },
 ];
+
+export type EditorTab = (typeof EDITOR_TABS)[number]["key"];
 
 // ---------------------------------------------------------------------------
 // Theme Status

--- a/apps/web/src/features/editor/hooks/useAutoSave.ts
+++ b/apps/web/src/features/editor/hooks/useAutoSave.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SaveStatus = "idle" | "dirty" | "saving" | "saved" | "error";
+
+interface UseAutoSaveOptions<T> {
+  data: T;
+  mutationFn: (data: T) => Promise<unknown>;
+  debounceMs?: number;
+  enabled?: boolean;
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+interface UseAutoSaveReturn {
+  status: SaveStatus;
+  lastSaved: Date | null;
+  save: () => void;
+  retry: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// useAutoSave
+// ---------------------------------------------------------------------------
+
+export function useAutoSave<T>({
+  data,
+  mutationFn,
+  debounceMs = 5000,
+  enabled = true,
+  onSuccess,
+  onError,
+}: UseAutoSaveOptions<T>): UseAutoSaveReturn {
+  const [status, setStatus] = useState<SaveStatus>("idle");
+  const [lastSaved, setLastSaved] = useState<Date | null>(null);
+
+  const initialDataRef = useRef<string>(JSON.stringify(data));
+  const latestDataRef = useRef<T>(data);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const pendingAfterSaveRef = useRef(false);
+  const isSavingRef = useRef(false);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep latest data ref in sync
+  useEffect(() => {
+    latestDataRef.current = data;
+  }, [data]);
+
+  const executeSave = useCallback(
+    async (dataToSave: T) => {
+      if (!enabled) return;
+
+      // Cancel any in-flight request
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = new AbortController();
+
+      isSavingRef.current = true;
+      setStatus("saving");
+
+      try {
+        await mutationFn(dataToSave);
+        isSavingRef.current = false;
+        initialDataRef.current = JSON.stringify(dataToSave);
+        setLastSaved(new Date());
+        setStatus("saved");
+        onSuccess?.();
+
+        // Transition saved → idle after 2 seconds
+        if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = setTimeout(() => {
+          setStatus((prev) => (prev === "saved" ? "idle" : prev));
+        }, 2000);
+
+        // If a new change arrived while saving, re-save
+        if (pendingAfterSaveRef.current) {
+          pendingAfterSaveRef.current = false;
+          scheduleSave();
+        }
+      } catch (err) {
+        isSavingRef.current = false;
+        if (err instanceof Error && err.name === "AbortError") return;
+        setStatus("error");
+        onError?.(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [enabled, mutationFn, onSuccess, onError],
+  );
+
+  const scheduleSave = useCallback(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      if (isSavingRef.current) {
+        pendingAfterSaveRef.current = true;
+        return;
+      }
+      executeSave(latestDataRef.current);
+    }, debounceMs);
+  }, [debounceMs, executeSave]);
+
+  // Detect changes and mark dirty
+  useEffect(() => {
+    if (!enabled) return;
+    const serialized = JSON.stringify(data);
+    if (serialized === initialDataRef.current) return;
+
+    setStatus("dirty");
+    scheduleSave();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, enabled]);
+
+  // Flush on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        if (status === "dirty" && !isSavingRef.current) {
+          executeSave(latestDataRef.current);
+        }
+      }
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+      abortControllerRef.current?.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Warn on tab close when dirty
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (status === "dirty" || status === "saving") {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [status]);
+
+  const save = useCallback(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    executeSave(latestDataRef.current);
+  }, [executeSave]);
+
+  const retry = useCallback(() => {
+    if (status !== "error") return;
+    executeSave(latestDataRef.current);
+  }, [status, executeSave]);
+
+  return { status, lastSaved, save, retry };
+}

--- a/apps/web/src/features/editor/stores/editorUIStore.ts
+++ b/apps/web/src/features/editor/stores/editorUIStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+import type { EditorTab } from "@/features/editor/constants";
+
+// ---------------------------------------------------------------------------
+// Editor UI Store
+// ---------------------------------------------------------------------------
+
+interface EditorUIState {
+  activeTab: EditorTab;
+  setActiveTab: (tab: EditorTab) => void;
+  validationErrors: Record<string, string[]>; // tab key → errors
+  setValidationErrors: (errors: Record<string, string[]>) => void;
+  clearValidationErrors: () => void;
+}
+
+export const useEditorUI = create<EditorUIState>()((set) => ({
+  activeTab: "overview",
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  validationErrors: {},
+  setValidationErrors: (errors) => set({ validationErrors: errors }),
+  clearValidationErrors: () => set({ validationErrors: {} }),
+}));

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,7 +1,10 @@
 import { Search } from "lucide-react";
+import { useNavigate } from "react-router";
 import { Layout } from "@/shared/components/Layout";
 
 export default function HomePage() {
+  const navigate = useNavigate();
+
   return (
     <Layout>
       <div className="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center gap-6">
@@ -16,6 +19,7 @@ export default function HomePage() {
         </p>
         <button
           type="button"
+          onClick={() => navigate("/login")}
           className="mt-4 rounded-lg bg-amber-500 px-6 py-3 font-semibold text-slate-950 transition-colors hover:bg-amber-400"
         >
           시작하기

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,10 +1,27 @@
 # Development override — use with: docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+# Dev mode: DB/Redis/Server만 실행, 프론트는 Vite dev server 사용
 services:
   server:
     build:
-      context: .
-      dockerfile: apps/server/Dockerfile.dev
+      context: ./apps/server
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8080:8080"
+      - "9090:9090"
     volumes:
       - ./apps/server:/build
     environment:
       APP_ENV: development
+
+  postgres:
+    ports:
+      - "5432:5432"
+
+  redis:
+    ports:
+      - "6379:6379"
+
+  # 개발 시 프론트는 Vite dev server 사용하므로 web 서비스 비활성화
+  web:
+    profiles:
+      - disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       POSTGRES_DB: mmf
       POSTGRES_USER: mmp
       POSTGRES_PASSWORD: mmp_dev
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -14,11 +12,11 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    networks:
+      - internal
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     command: redis-server --appendonly yes
     volumes:
       - redis_data:/data
@@ -27,14 +25,13 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    networks:
+      - internal
 
   server:
     build:
-      context: .
-      dockerfile: apps/server/Dockerfile
-    ports:
-      - "8080:8080"
-      - "9090:9090"
+      context: ./apps/server
+      dockerfile: Dockerfile
     environment:
       PORT: "8080"
       APP_ENV: development
@@ -45,7 +42,24 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    networks:
+      - internal
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    ports:
+      - "80:80"
+    depends_on:
+      - server
+    networks:
+      - internal
 
 volumes:
   postgres_data:
   redis_data:
+
+networks:
+  internal:
+    driver: bridge

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,21 +23,33 @@ importers:
 
   apps/web:
     dependencies:
+      '@mmp/game-logic':
+        specifier: workspace:*
+        version: link:../../packages/game-logic
       '@mmp/shared':
         specifier: workspace:*
         version: link:../../packages/shared
       '@mmp/ui-tokens':
         specifier: workspace:*
         version: link:../../packages/ui-tokens
+      '@mmp/ws-client':
+        specifier: workspace:*
+        version: link:../../packages/ws-client
       '@sentry/react':
         specifier: ^10.47.0
         version: 10.47.0(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.96.2(react@19.2.4)
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
+      marked:
+        specifier: ^17.0.6
+        version: 17.0.6
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -66,6 +78,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/dompurify':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
@@ -1157,6 +1172,10 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1173,6 +1192,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.58.0':
     resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
@@ -1448,6 +1470,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   electron-to-chromium@1.5.331:
     resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
@@ -1807,6 +1832,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -3071,6 +3101,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/dompurify@3.2.0':
+    dependencies:
+      dompurify: 3.3.3
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3086,6 +3120,9 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3377,6 +3414,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.331: {}
 
@@ -3770,6 +3811,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@17.0.6: {}
 
   mdn-data@2.27.1: {}
 


### PR DESCRIPTION
## Summary
- **DB**: 3 migrations (coin_price column + 4 new tables: theme_maps, theme_locations, theme_clues, theme_contents)
- **Backend**: 20+ new API endpoints for Maps/Locations/Clues/Contents CRUD, GetTheme, ValidateTheme with JOIN-based ownership verification, optimistic locking, resource limits, content key whitelist
- **Frontend**: Fullscreen editor with 5-tab architecture (기본정보/스토리/등장인물/게임설계/고급), WAI-ARIA tabs, useAutoSave hook, forensic-workbench design system
- **Security**: XSS sanitization (DOMPurify + bluemonday), IDOR prevention, body size limits, TOCTOU-safe deletes
- **Code review**: 18 issues found (3 Critical, 4 High, 7 Medium, 4 Low) — all Critical/High/Medium resolved

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/domain/editor/...` — 12 tests pass
- [x] `tsc --noEmit` — 0 errors
- [x] `vitest run` — 252 tests pass (21 files)
- [ ] Manual QA: editor tab navigation, auto-save, publish flow
- [ ] Manual QA: mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)