### PR TITLE
fix(phase-e): followup — GameErrorBoundary, ephemeral broadcast, stagger

### DIFF
--- a/apps/server/internal/domain/sound/handler.go
+++ b/apps/server/internal/domain/sound/handler.go
@@ -115,7 +115,7 @@ func (h *WSHandler) handlePlay(c *ws.Client, env *ws.Envelope) {
 		return
 	}
 
-	h.hub.BroadcastToSession(c.SessionID, broadcast)
+	h.hub.BroadcastToSessionEphemeral(c.SessionID, broadcast)
 
 	h.logger.Debug().
 		Str("soundId", payload.SoundID).

--- a/apps/server/internal/ws/hub.go
+++ b/apps/server/internal/ws/hub.go
@@ -166,6 +166,23 @@ func (h *Hub) LeaveSession(c *Client) {
 // BroadcastToSession sends an envelope to every client in the given session
 // and records it in the session's reconnection buffer.
 func (h *Hub) BroadcastToSession(sessionID uuid.UUID, env *Envelope) {
+	h.broadcastToSession(sessionID, env, uuid.Nil, true)
+}
+
+// BroadcastToSessionExcept sends an envelope to every client in the session
+// except the specified sender, and records it in the reconnection buffer.
+func (h *Hub) BroadcastToSessionExcept(sessionID uuid.UUID, env *Envelope, excludeID uuid.UUID) {
+	h.broadcastToSession(sessionID, env, excludeID, true)
+}
+
+// BroadcastToSessionEphemeral sends an envelope to every client in the session
+// but does NOT record it in the reconnection buffer. Use for ephemeral events
+// like sound effects that should not be replayed on reconnect.
+func (h *Hub) BroadcastToSessionEphemeral(sessionID uuid.UUID, env *Envelope) {
+	h.broadcastToSession(sessionID, env, uuid.Nil, false)
+}
+
+func (h *Hub) broadcastToSession(sessionID uuid.UUID, env *Envelope, excludeID uuid.UUID, buffer bool) {
 	h.mu.RLock()
 	sess, ok := h.sessions[sessionID]
 	if !ok {
@@ -181,11 +198,14 @@ func (h *Hub) BroadcastToSession(sessionID uuid.UUID, env *Envelope) {
 	h.mu.RUnlock()
 
 	// Push to reconnection buffer before sending.
-	if buf != nil {
+	if buffer && buf != nil {
 		buf.Push(env)
 	}
 
 	for _, c := range clients {
+		if excludeID != uuid.Nil && c.ID == excludeID {
+			continue
+		}
 		c.SendMessage(env)
 	}
 }

--- a/apps/web/src/components/error/GameErrorBoundary.tsx
+++ b/apps/web/src/components/error/GameErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+import type { ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { captureApiError } from "@/lib/sentry";
+import { Button } from "@/shared/components/ui";
+
+function GameFallback({ error, resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="fixed inset-0 z-[80] flex flex-col items-center justify-center gap-4 bg-slate-950">
+      <AlertTriangle className="h-12 w-12 text-red-400" />
+      <h2 className="text-lg font-semibold text-slate-200">
+        게임에 문제가 발생했습니다
+      </h2>
+      <p className="text-sm text-slate-400">
+        잠시 후 다시 시도하거나, 로비로 돌아가세요
+      </p>
+      {import.meta.env.DEV && (
+        <pre className="max-w-lg overflow-auto rounded bg-slate-900 p-4 text-left text-xs text-red-300">
+          {error.message}
+        </pre>
+      )}
+      <div className="flex gap-3">
+        <Button variant="primary" onClick={resetErrorBoundary}>
+          다시 시도
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            window.location.href = "/lobby";
+          }}
+        >
+          로비로 돌아가기
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function GameErrorBoundary({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary
+      FallbackComponent={GameFallback}
+      onError={(error, info) => {
+        captureApiError(error);
+        if (import.meta.env.DEV) {
+          console.error("[GameErrorBoundary]", error, info.componentStack);
+        }
+      }}
+      onReset={() => {
+        window.location.reload();
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/src/components/error/index.ts
+++ b/apps/web/src/components/error/index.ts
@@ -1,3 +1,4 @@
 export { GlobalErrorBoundary } from "./GlobalErrorBoundary";
+export { GameErrorBoundary } from "./GameErrorBoundary";
 export { PageErrorBoundary } from "./PageErrorBoundary";
 export { ComponentErrorBoundary } from "./ComponentErrorBoundary";

--- a/apps/web/src/features/game/components/VotingPanel.tsx
+++ b/apps/web/src/features/game/components/VotingPanel.tsx
@@ -41,7 +41,7 @@ function VoteBar({
   const animatedVotes = useCountUp(result.votes);
   const widthPct = maxVotes > 0 ? (animatedVotes / maxVotes) * 100 : 0;
   const barColor = isTop ? "bg-amber-500" : "bg-slate-600";
-  const delay = `${staggerIndex * 300}ms`;
+  const delay = `${staggerIndex * 100}ms`;
 
   return (
     <div

--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -19,6 +19,7 @@ import {
   NetworkOverlay,
 } from "@/features/game/components";
 import { AudioProvider } from "@/features/audio/AudioProvider";
+import { GameErrorBoundary } from "@/components/error";
 
 // ---------------------------------------------------------------------------
 // 다른 에이전트가 생성 중인 컴포넌트 (lazy import)
@@ -114,6 +115,7 @@ function GamePageInner({ sessionId, isChatOpen, setIsChatOpen }: GamePageInnerPr
 
   return (
     <AudioProvider>
+    <GameErrorBoundary>
     <NetworkOverlay />
     <div className="flex h-screen flex-col bg-slate-950">
       {/* 상단: GameHUD */}
@@ -168,6 +170,7 @@ function GamePageInner({ sessionId, isChatOpen, setIsChatOpen }: GamePageInnerPr
         </div>
       )}
     </div>
+    </GameErrorBoundary>
     </AudioProvider>
   );
 }


### PR DESCRIPTION
## Summary
Phase E 6전문가 팀 크로스 리뷰에서 도출된 후속 수정사항

- **GameErrorBoundary**: 게임 전용 에러 바운더리 추가 (전체 앱 크래시 방지, "다시 시도"/"로비로" 액션)
- **BroadcastToSessionExcept**: 발신자 제외 broadcast 지원 (향후 발신자 중복 재생 방지용)
- **BroadcastToSessionEphemeral**: reconnect buffer 미저장 broadcast (sound:play 재접속 burst 방지)
- **VotingPanel stagger**: 300ms→100ms (8명 기준 2.1초→0.7초, 적절한 리듬감)

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `go build ./...` 통과
- [ ] 게임 중 컴포넌트 에러 시 GameErrorBoundary fallback UI 표시 확인
- [ ] 재접속 시 밀린 사운드 이벤트 미재생 확인
- [ ] 투표 결과 stagger 애니메이션 타이밍 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)