### PR TITLE
feat(phase-7.5): social system — real-time WS, presence, block filtering

### DIFF
--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -186,15 +186,28 @@ func main() {
 	creatorHandler := creator.NewHandler(creatorSvc)
 	creatorAdminHandler := creator.NewAdminHandler(queries, pool, settlementPipeline, logger)
 
-	// 10. WebSocket Hub
+	// 10. WebSocket Hub (Game)
 	wsRouter := ws.NewRouter(logger)
 	wsHub := ws.NewHub(wsRouter, ws.NoopPubSub{}, logger)
 	defer wsHub.Stop()
-	logger.Info().Msg("websocket hub started")
+	logger.Info().Msg("game websocket hub started")
 
 	// 10.1. Sound WS Handler
 	soundWSHandler := sound.NewWSHandler(wsHub, logger)
 	wsRouter.Handle("sound", soundWSHandler.Handle)
+
+	// 10.2. Social WebSocket Hub (separate from game)
+	socialRouter := ws.NewRouter(logger)
+	socialHub := ws.NewSocialHub(socialRouter, logger)
+	defer socialHub.Stop()
+	logger.Info().Msg("social websocket hub started")
+
+	// 10.3. Social WS Handler + Presence
+	presenceProvider := social.NewPresenceProvider(redisCache.Client())
+	socialWSHandler := social.NewSocialWSHandler(socialHub, chatSvc, friendSvc, presenceProvider, queries, logger)
+	socialRouter.Handle("chat", socialWSHandler.HandleChat)
+	socialRouter.Handle("friend", socialWSHandler.HandleFriend)
+	socialRouter.Handle("presence", socialWSHandler.HandlePresence)
 
 	// 11. HTTP Router
 	r := chi.NewRouter()
@@ -233,7 +246,13 @@ func main() {
 	}
 	gameUpgrade := ws.UpgradeHandler(wsHub, ws.DefaultPlayerIDExtractor, wsCfg, logger)
 	r.Get("/ws/game", gameUpgrade)
-	r.Get("/ws/social", gameUpgrade)
+
+	socialExtractor := ws.JWTPlayerIDExtractor([]byte(cfg.JWTSecret))
+	if cfg.IsDevelopment() {
+		socialExtractor = ws.DefaultPlayerIDExtractor
+	}
+	socialUpgrade := ws.UpgradeHandler(socialHub, socialExtractor, wsCfg, logger)
+	r.Get("/ws/social", socialUpgrade)
 
 	// 16. JWT auth config
 	jwtCfg := middleware.JWTConfig{Secret: []byte(cfg.JWTSecret)}

--- a/apps/server/db/migrations/00014_social_enhancements.sql
+++ b/apps/server/db/migrations/00014_social_enhancements.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+
+-- ── chat_rooms: updated_at 추가 ──
+ALTER TABLE chat_rooms ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE TRIGGER trg_chat_rooms_updated_at BEFORE UPDATE ON chat_rooms
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ── chat_room_members: role 추가 ──
+ALTER TABLE chat_room_members ADD COLUMN role VARCHAR(10) NOT NULL DEFAULT 'MEMBER'
+    CHECK (role IN ('OWNER', 'MEMBER'));
+
+-- ── chat_messages: metadata, deleted_at, IMAGE 타입 ──
+ALTER TABLE chat_messages ADD COLUMN metadata JSONB NOT NULL DEFAULT '{}';
+ALTER TABLE chat_messages ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- CHECK 제약 교체 (IMAGE 타입 추가)
+ALTER TABLE chat_messages DROP CONSTRAINT chat_messages_message_type_check;
+ALTER TABLE chat_messages ADD CONSTRAINT chat_messages_message_type_check
+    CHECK (message_type IN ('TEXT', 'IMAGE', 'SYSTEM', 'GAME_INVITE', 'GAME_RESULT'));
+
+-- ── 새 인덱스 ──
+CREATE INDEX idx_chat_messages_not_deleted ON chat_messages(chat_room_id, id DESC)
+    WHERE deleted_at IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_chat_messages_not_deleted;
+ALTER TABLE chat_messages DROP CONSTRAINT chat_messages_message_type_check;
+ALTER TABLE chat_messages ADD CONSTRAINT chat_messages_message_type_check
+    CHECK (message_type IN ('TEXT', 'SYSTEM', 'GAME_INVITE', 'GAME_RESULT'));
+ALTER TABLE chat_messages DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE chat_messages DROP COLUMN IF EXISTS metadata;
+ALTER TABLE chat_room_members DROP COLUMN IF EXISTS role;
+DROP TRIGGER IF EXISTS trg_chat_rooms_updated_at ON chat_rooms;
+ALTER TABLE chat_rooms DROP COLUMN IF EXISTS updated_at;

--- a/apps/server/db/queries/social.sql
+++ b/apps/server/db/queries/social.sql
@@ -120,7 +120,7 @@ LEFT JOIN LATERAL (
         (ARRAY_AGG(cm.content ORDER BY cm.id DESC))[1] AS last_message,
         MAX(cm.created_at) AS last_message_at
     FROM chat_messages cm
-    WHERE cm.chat_room_id = cr.id
+    WHERE cm.chat_room_id = cr.id AND cm.deleted_at IS NULL
 ) s ON true
 WHERE m.user_id = $1
 ORDER BY s.last_message_at DESC NULLS LAST
@@ -131,8 +131,8 @@ LIMIT $2 OFFSET $3;
 -- ═══════════════════════��═══════════════════════════��═══════════════
 
 -- name: AddChatRoomMember :exec
-INSERT INTO chat_room_members (chat_room_id, user_id)
-VALUES ($1, $2)
+INSERT INTO chat_room_members (chat_room_id, user_id, role)
+VALUES (@chat_room_id, @user_id, @role)
 ON CONFLICT DO NOTHING;
 
 -- name: RemoveChatRoomMember :exec
@@ -160,15 +160,15 @@ WHERE chat_room_id = $1 AND user_id = $2;
 -- ══���════════════════════════════════���═══════════════════════════════
 
 -- name: CreateChatMessage :one
-INSERT INTO chat_messages (chat_room_id, sender_id, content, message_type)
-VALUES ($1, $2, $3, $4)
+INSERT INTO chat_messages (chat_room_id, sender_id, content, message_type, metadata)
+VALUES (@chat_room_id, @sender_id, @content, @message_type, @metadata)
 RETURNING *;
 
 -- name: ListChatMessages :many
 SELECT cm.*, u.nickname AS sender_nickname, u.avatar_url AS sender_avatar
 FROM chat_messages cm
 JOIN users u ON cm.sender_id = u.id
-WHERE cm.chat_room_id = $1
+WHERE cm.chat_room_id = $1 AND cm.deleted_at IS NULL
 ORDER BY cm.id ASC
 LIMIT $2 OFFSET $3;
 
@@ -180,4 +180,57 @@ SELECT COUNT(*) FROM chat_messages cm
 JOIN chat_room_members crm ON cm.chat_room_id = crm.chat_room_id
 WHERE crm.chat_room_id = $1
   AND crm.user_id = $2
-  AND cm.created_at > crm.last_read_at;
+  AND cm.created_at > crm.last_read_at
+  AND cm.deleted_at IS NULL;
+
+-- ═══════════════════════════════════════════════════════════════════
+-- New queries for Phase 7.5
+-- ═══════════════════════════════════════════════════════════════════
+
+-- name: SoftDeleteChatMessage :exec
+UPDATE chat_messages SET deleted_at = NOW()
+WHERE id = $1 AND sender_id = $2 AND deleted_at IS NULL;
+
+-- name: GetChatRoomMemberRole :one
+SELECT role FROM chat_room_members
+WHERE chat_room_id = $1 AND user_id = $2;
+
+-- name: UpdateChatRoomMemberRole :exec
+UPDATE chat_room_members SET role = $3
+WHERE chat_room_id = $1 AND user_id = $2;
+
+-- name: UpdateChatRoomName :one
+UPDATE chat_rooms SET name = $2
+WHERE id = $1
+RETURNING *;
+
+-- name: ListChatMessagesCursor :many
+SELECT cm.*, u.nickname AS sender_nickname, u.avatar_url AS sender_avatar
+FROM chat_messages cm
+JOIN users u ON cm.sender_id = u.id
+WHERE cm.chat_room_id = $1 AND cm.id < $2 AND cm.deleted_at IS NULL
+ORDER BY cm.id DESC
+LIMIT $3;
+
+-- name: CountTotalUnreadMessages :one
+SELECT COALESCE(SUM(cnt), 0)::bigint AS total_unread
+FROM (
+    SELECT COUNT(*) AS cnt
+    FROM chat_messages cm
+    JOIN chat_room_members crm ON cm.chat_room_id = crm.chat_room_id
+    WHERE crm.user_id = $1
+      AND cm.created_at > crm.last_read_at
+      AND cm.deleted_at IS NULL
+) sub;
+
+-- name: SearchFriendsByNickname :many
+SELECT u.id, u.nickname, u.avatar_url, u.role, f.id AS friendship_id, f.created_at
+FROM friendships f
+JOIN users u ON (
+    CASE WHEN f.requester_id = $1 THEN f.addressee_id ELSE f.requester_id END = u.id
+)
+WHERE (f.requester_id = $1 OR f.addressee_id = $1)
+  AND f.status = 'ACCEPTED'
+  AND u.nickname ILIKE '%' || $2 || '%'
+ORDER BY u.nickname
+LIMIT $3;

--- a/apps/server/internal/apperror/codes.go
+++ b/apps/server/internal/apperror/codes.go
@@ -46,6 +46,7 @@ const (
 	ErrChatRoomNotFound       = "CHAT_ROOM_NOT_FOUND"
 	ErrChatNotMember          = "CHAT_NOT_MEMBER"
 	ErrChatInvalidMsgType     = "CHAT_INVALID_MESSAGE_TYPE"
+	ErrChatBlocked            = "CHAT_BLOCKED"
 
 	// Payment errors
 	ErrPaymentDuplicate          = "PAYMENT_DUPLICATE"

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -13,12 +13,14 @@ import (
 )
 
 type ChatMessage struct {
-	ID          int64     `json:"id"`
-	ChatRoomID  uuid.UUID `json:"chat_room_id"`
-	SenderID    uuid.UUID `json:"sender_id"`
-	Content     string    `json:"content"`
-	MessageType string    `json:"message_type"`
-	CreatedAt   time.Time `json:"created_at"`
+	ID          int64              `json:"id"`
+	ChatRoomID  uuid.UUID          `json:"chat_room_id"`
+	SenderID    uuid.UUID          `json:"sender_id"`
+	Content     string             `json:"content"`
+	MessageType string             `json:"message_type"`
+	CreatedAt   time.Time          `json:"created_at"`
+	Metadata    json.RawMessage    `json:"metadata"`
+	DeletedAt   pgtype.Timestamptz `json:"deleted_at"`
 }
 
 type ChatRoom struct {
@@ -27,6 +29,7 @@ type ChatRoom struct {
 	Name      pgtype.Text `json:"name"`
 	CreatedBy uuid.UUID   `json:"created_by"`
 	CreatedAt time.Time   `json:"created_at"`
+	UpdatedAt time.Time   `json:"updated_at"`
 }
 
 type ChatRoomMember struct {
@@ -34,6 +37,7 @@ type ChatRoomMember struct {
 	UserID     uuid.UUID `json:"user_id"`
 	LastReadAt time.Time `json:"last_read_at"`
 	JoinedAt   time.Time `json:"joined_at"`
+	Role       string    `json:"role"`
 }
 
 type CoinPackage struct {

--- a/apps/server/internal/db/social.sql.go
+++ b/apps/server/internal/db/social.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -40,21 +41,22 @@ func (q *Queries) AcceptFriendRequest(ctx context.Context, arg AcceptFriendReque
 
 const addChatRoomMember = `-- name: AddChatRoomMember :exec
 
-INSERT INTO chat_room_members (chat_room_id, user_id)
-VALUES ($1, $2)
+INSERT INTO chat_room_members (chat_room_id, user_id, role)
+VALUES ($1, $2, $3)
 ON CONFLICT DO NOTHING
 `
 
 type AddChatRoomMemberParams struct {
 	ChatRoomID uuid.UUID `json:"chat_room_id"`
 	UserID     uuid.UUID `json:"user_id"`
+	Role       string    `json:"role"`
 }
 
 // ════════��═══════════════════════��══════════════════════════════════
 // Chat Room Members
 // ═══════════════════════��═══════════════════════════��═══════════════
 func (q *Queries) AddChatRoomMember(ctx context.Context, arg AddChatRoomMemberParams) error {
-	_, err := q.db.Exec(ctx, addChatRoomMember, arg.ChatRoomID, arg.UserID)
+	_, err := q.db.Exec(ctx, addChatRoomMember, arg.ChatRoomID, arg.UserID, arg.Role)
 	return err
 }
 
@@ -82,12 +84,32 @@ func (q *Queries) CountPendingRequests(ctx context.Context, addresseeID uuid.UUI
 	return count, err
 }
 
+const countTotalUnreadMessages = `-- name: CountTotalUnreadMessages :one
+SELECT COALESCE(SUM(cnt), 0)::bigint AS total_unread
+FROM (
+    SELECT COUNT(*) AS cnt
+    FROM chat_messages cm
+    JOIN chat_room_members crm ON cm.chat_room_id = crm.chat_room_id
+    WHERE crm.user_id = $1
+      AND cm.created_at > crm.last_read_at
+      AND cm.deleted_at IS NULL
+) sub
+`
+
+func (q *Queries) CountTotalUnreadMessages(ctx context.Context, userID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countTotalUnreadMessages, userID)
+	var total_unread int64
+	err := row.Scan(&total_unread)
+	return total_unread, err
+}
+
 const countUnreadMessages = `-- name: CountUnreadMessages :one
 SELECT COUNT(*) FROM chat_messages cm
 JOIN chat_room_members crm ON cm.chat_room_id = crm.chat_room_id
 WHERE crm.chat_room_id = $1
   AND crm.user_id = $2
   AND cm.created_at > crm.last_read_at
+  AND cm.deleted_at IS NULL
 `
 
 type CountUnreadMessagesParams struct {
@@ -131,16 +153,17 @@ func (q *Queries) CreateBlock(ctx context.Context, arg CreateBlockParams) (UserB
 
 const createChatMessage = `-- name: CreateChatMessage :one
 
-INSERT INTO chat_messages (chat_room_id, sender_id, content, message_type)
-VALUES ($1, $2, $3, $4)
-RETURNING id, chat_room_id, sender_id, content, message_type, created_at
+INSERT INTO chat_messages (chat_room_id, sender_id, content, message_type, metadata)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, chat_room_id, sender_id, content, message_type, created_at, metadata, deleted_at
 `
 
 type CreateChatMessageParams struct {
-	ChatRoomID  uuid.UUID `json:"chat_room_id"`
-	SenderID    uuid.UUID `json:"sender_id"`
-	Content     string    `json:"content"`
-	MessageType string    `json:"message_type"`
+	ChatRoomID  uuid.UUID       `json:"chat_room_id"`
+	SenderID    uuid.UUID       `json:"sender_id"`
+	Content     string          `json:"content"`
+	MessageType string          `json:"message_type"`
+	Metadata    json.RawMessage `json:"metadata"`
 }
 
 // ══════════��═════════════════════════════════════════════════��══════
@@ -152,6 +175,7 @@ func (q *Queries) CreateChatMessage(ctx context.Context, arg CreateChatMessagePa
 		arg.SenderID,
 		arg.Content,
 		arg.MessageType,
+		arg.Metadata,
 	)
 	var i ChatMessage
 	err := row.Scan(
@@ -161,6 +185,8 @@ func (q *Queries) CreateChatMessage(ctx context.Context, arg CreateChatMessagePa
 		&i.Content,
 		&i.MessageType,
 		&i.CreatedAt,
+		&i.Metadata,
+		&i.DeletedAt,
 	)
 	return i, err
 }
@@ -169,7 +195,7 @@ const createChatRoom = `-- name: CreateChatRoom :one
 
 INSERT INTO chat_rooms (type, name, created_by)
 VALUES ($1, $2, $3)
-RETURNING id, type, name, created_by, created_at
+RETURNING id, type, name, created_by, created_at, updated_at
 `
 
 type CreateChatRoomParams struct {
@@ -190,6 +216,7 @@ func (q *Queries) CreateChatRoom(ctx context.Context, arg CreateChatRoomParams) 
 		&i.Name,
 		&i.CreatedBy,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
@@ -269,7 +296,7 @@ func (q *Queries) DeleteFriendshipBetween(ctx context.Context, arg DeleteFriends
 }
 
 const findDMRoom = `-- name: FindDMRoom :one
-SELECT cr.id, cr.type, cr.name, cr.created_by, cr.created_at FROM chat_rooms cr
+SELECT cr.id, cr.type, cr.name, cr.created_by, cr.created_at, cr.updated_at FROM chat_rooms cr
 JOIN chat_room_members m1 ON cr.id = m1.chat_room_id AND m1.user_id = $1
 JOIN chat_room_members m2 ON cr.id = m2.chat_room_id AND m2.user_id = $2
 WHERE cr.type = 'DM'
@@ -290,12 +317,13 @@ func (q *Queries) FindDMRoom(ctx context.Context, arg FindDMRoomParams) (ChatRoo
 		&i.Name,
 		&i.CreatedBy,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
 
 const getChatMessage = `-- name: GetChatMessage :one
-SELECT id, chat_room_id, sender_id, content, message_type, created_at FROM chat_messages WHERE id = $1
+SELECT id, chat_room_id, sender_id, content, message_type, created_at, metadata, deleted_at FROM chat_messages WHERE id = $1
 `
 
 func (q *Queries) GetChatMessage(ctx context.Context, id int64) (ChatMessage, error) {
@@ -308,12 +336,14 @@ func (q *Queries) GetChatMessage(ctx context.Context, id int64) (ChatMessage, er
 		&i.Content,
 		&i.MessageType,
 		&i.CreatedAt,
+		&i.Metadata,
+		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const getChatRoom = `-- name: GetChatRoom :one
-SELECT id, type, name, created_by, created_at FROM chat_rooms WHERE id = $1
+SELECT id, type, name, created_by, created_at, updated_at FROM chat_rooms WHERE id = $1
 `
 
 func (q *Queries) GetChatRoom(ctx context.Context, id uuid.UUID) (ChatRoom, error) {
@@ -325,8 +355,26 @@ func (q *Queries) GetChatRoom(ctx context.Context, id uuid.UUID) (ChatRoom, erro
 		&i.Name,
 		&i.CreatedBy,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const getChatRoomMemberRole = `-- name: GetChatRoomMemberRole :one
+SELECT role FROM chat_room_members
+WHERE chat_room_id = $1 AND user_id = $2
+`
+
+type GetChatRoomMemberRoleParams struct {
+	ChatRoomID uuid.UUID `json:"chat_room_id"`
+	UserID     uuid.UUID `json:"user_id"`
+}
+
+func (q *Queries) GetChatRoomMemberRole(ctx context.Context, arg GetChatRoomMemberRoleParams) (string, error) {
+	row := q.db.QueryRow(ctx, getChatRoomMemberRole, arg.ChatRoomID, arg.UserID)
+	var role string
+	err := row.Scan(&role)
+	return role, err
 }
 
 const getFriendship = `-- name: GetFriendship :one
@@ -463,10 +511,10 @@ func (q *Queries) ListBlocks(ctx context.Context, arg ListBlocksParams) ([]ListB
 }
 
 const listChatMessages = `-- name: ListChatMessages :many
-SELECT cm.id, cm.chat_room_id, cm.sender_id, cm.content, cm.message_type, cm.created_at, u.nickname AS sender_nickname, u.avatar_url AS sender_avatar
+SELECT cm.id, cm.chat_room_id, cm.sender_id, cm.content, cm.message_type, cm.created_at, cm.metadata, cm.deleted_at, u.nickname AS sender_nickname, u.avatar_url AS sender_avatar
 FROM chat_messages cm
 JOIN users u ON cm.sender_id = u.id
-WHERE cm.chat_room_id = $1
+WHERE cm.chat_room_id = $1 AND cm.deleted_at IS NULL
 ORDER BY cm.id ASC
 LIMIT $2 OFFSET $3
 `
@@ -478,14 +526,16 @@ type ListChatMessagesParams struct {
 }
 
 type ListChatMessagesRow struct {
-	ID             int64       `json:"id"`
-	ChatRoomID     uuid.UUID   `json:"chat_room_id"`
-	SenderID       uuid.UUID   `json:"sender_id"`
-	Content        string      `json:"content"`
-	MessageType    string      `json:"message_type"`
-	CreatedAt      time.Time   `json:"created_at"`
-	SenderNickname string      `json:"sender_nickname"`
-	SenderAvatar   pgtype.Text `json:"sender_avatar"`
+	ID             int64              `json:"id"`
+	ChatRoomID     uuid.UUID          `json:"chat_room_id"`
+	SenderID       uuid.UUID          `json:"sender_id"`
+	Content        string             `json:"content"`
+	MessageType    string             `json:"message_type"`
+	CreatedAt      time.Time          `json:"created_at"`
+	Metadata       json.RawMessage    `json:"metadata"`
+	DeletedAt      pgtype.Timestamptz `json:"deleted_at"`
+	SenderNickname string             `json:"sender_nickname"`
+	SenderAvatar   pgtype.Text        `json:"sender_avatar"`
 }
 
 func (q *Queries) ListChatMessages(ctx context.Context, arg ListChatMessagesParams) ([]ListChatMessagesRow, error) {
@@ -504,6 +554,67 @@ func (q *Queries) ListChatMessages(ctx context.Context, arg ListChatMessagesPara
 			&i.Content,
 			&i.MessageType,
 			&i.CreatedAt,
+			&i.Metadata,
+			&i.DeletedAt,
+			&i.SenderNickname,
+			&i.SenderAvatar,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listChatMessagesCursor = `-- name: ListChatMessagesCursor :many
+SELECT cm.id, cm.chat_room_id, cm.sender_id, cm.content, cm.message_type, cm.created_at, cm.metadata, cm.deleted_at, u.nickname AS sender_nickname, u.avatar_url AS sender_avatar
+FROM chat_messages cm
+JOIN users u ON cm.sender_id = u.id
+WHERE cm.chat_room_id = $1 AND cm.id < $2 AND cm.deleted_at IS NULL
+ORDER BY cm.id DESC
+LIMIT $3
+`
+
+type ListChatMessagesCursorParams struct {
+	ChatRoomID uuid.UUID `json:"chat_room_id"`
+	ID         int64     `json:"id"`
+	Limit      int32     `json:"limit"`
+}
+
+type ListChatMessagesCursorRow struct {
+	ID             int64              `json:"id"`
+	ChatRoomID     uuid.UUID          `json:"chat_room_id"`
+	SenderID       uuid.UUID          `json:"sender_id"`
+	Content        string             `json:"content"`
+	MessageType    string             `json:"message_type"`
+	CreatedAt      time.Time          `json:"created_at"`
+	Metadata       json.RawMessage    `json:"metadata"`
+	DeletedAt      pgtype.Timestamptz `json:"deleted_at"`
+	SenderNickname string             `json:"sender_nickname"`
+	SenderAvatar   pgtype.Text        `json:"sender_avatar"`
+}
+
+func (q *Queries) ListChatMessagesCursor(ctx context.Context, arg ListChatMessagesCursorParams) ([]ListChatMessagesCursorRow, error) {
+	rows, err := q.db.Query(ctx, listChatMessagesCursor, arg.ChatRoomID, arg.ID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListChatMessagesCursorRow{}
+	for rows.Next() {
+		var i ListChatMessagesCursorRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChatRoomID,
+			&i.SenderID,
+			&i.Content,
+			&i.MessageType,
+			&i.CreatedAt,
+			&i.Metadata,
+			&i.DeletedAt,
 			&i.SenderNickname,
 			&i.SenderAvatar,
 		); err != nil {
@@ -518,7 +629,7 @@ func (q *Queries) ListChatMessages(ctx context.Context, arg ListChatMessagesPara
 }
 
 const listChatRoomMembers = `-- name: ListChatRoomMembers :many
-SELECT crm.chat_room_id, crm.user_id, crm.last_read_at, crm.joined_at, u.nickname, u.avatar_url
+SELECT crm.chat_room_id, crm.user_id, crm.last_read_at, crm.joined_at, crm.role, u.nickname, u.avatar_url
 FROM chat_room_members crm
 JOIN users u ON crm.user_id = u.id
 WHERE crm.chat_room_id = $1
@@ -530,6 +641,7 @@ type ListChatRoomMembersRow struct {
 	UserID     uuid.UUID   `json:"user_id"`
 	LastReadAt time.Time   `json:"last_read_at"`
 	JoinedAt   time.Time   `json:"joined_at"`
+	Role       string      `json:"role"`
 	Nickname   string      `json:"nickname"`
 	AvatarUrl  pgtype.Text `json:"avatar_url"`
 }
@@ -548,6 +660,7 @@ func (q *Queries) ListChatRoomMembers(ctx context.Context, chatRoomID uuid.UUID)
 			&i.UserID,
 			&i.LastReadAt,
 			&i.JoinedAt,
+			&i.Role,
 			&i.Nickname,
 			&i.AvatarUrl,
 		); err != nil {
@@ -684,7 +797,7 @@ LEFT JOIN LATERAL (
         (ARRAY_AGG(cm.content ORDER BY cm.id DESC))[1] AS last_message,
         MAX(cm.created_at) AS last_message_at
     FROM chat_messages cm
-    WHERE cm.chat_room_id = cr.id
+    WHERE cm.chat_room_id = cr.id AND cm.deleted_at IS NULL
 ) s ON true
 WHERE m.user_id = $1
 ORDER BY s.last_message_at DESC NULLS LAST
@@ -764,6 +877,121 @@ type RemoveChatRoomMemberParams struct {
 func (q *Queries) RemoveChatRoomMember(ctx context.Context, arg RemoveChatRoomMemberParams) error {
 	_, err := q.db.Exec(ctx, removeChatRoomMember, arg.ChatRoomID, arg.UserID)
 	return err
+}
+
+const searchFriendsByNickname = `-- name: SearchFriendsByNickname :many
+SELECT u.id, u.nickname, u.avatar_url, u.role, f.id AS friendship_id, f.created_at
+FROM friendships f
+JOIN users u ON (
+    CASE WHEN f.requester_id = $1 THEN f.addressee_id ELSE f.requester_id END = u.id
+)
+WHERE (f.requester_id = $1 OR f.addressee_id = $1)
+  AND f.status = 'ACCEPTED'
+  AND u.nickname ILIKE '%' || $2 || '%'
+ORDER BY u.nickname
+LIMIT $3
+`
+
+type SearchFriendsByNicknameParams struct {
+	RequesterID uuid.UUID   `json:"requester_id"`
+	Column2     pgtype.Text `json:"column_2"`
+	Limit       int32       `json:"limit"`
+}
+
+type SearchFriendsByNicknameRow struct {
+	ID           uuid.UUID   `json:"id"`
+	Nickname     string      `json:"nickname"`
+	AvatarUrl    pgtype.Text `json:"avatar_url"`
+	Role         string      `json:"role"`
+	FriendshipID uuid.UUID   `json:"friendship_id"`
+	CreatedAt    time.Time   `json:"created_at"`
+}
+
+func (q *Queries) SearchFriendsByNickname(ctx context.Context, arg SearchFriendsByNicknameParams) ([]SearchFriendsByNicknameRow, error) {
+	rows, err := q.db.Query(ctx, searchFriendsByNickname, arg.RequesterID, arg.Column2, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SearchFriendsByNicknameRow{}
+	for rows.Next() {
+		var i SearchFriendsByNicknameRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Nickname,
+			&i.AvatarUrl,
+			&i.Role,
+			&i.FriendshipID,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const softDeleteChatMessage = `-- name: SoftDeleteChatMessage :exec
+
+UPDATE chat_messages SET deleted_at = NOW()
+WHERE id = $1 AND sender_id = $2 AND deleted_at IS NULL
+`
+
+type SoftDeleteChatMessageParams struct {
+	ID       int64     `json:"id"`
+	SenderID uuid.UUID `json:"sender_id"`
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// New queries for Phase 7.5
+// ═══════════════════════════════════════════════════════════════════
+func (q *Queries) SoftDeleteChatMessage(ctx context.Context, arg SoftDeleteChatMessageParams) error {
+	_, err := q.db.Exec(ctx, softDeleteChatMessage, arg.ID, arg.SenderID)
+	return err
+}
+
+const updateChatRoomMemberRole = `-- name: UpdateChatRoomMemberRole :exec
+UPDATE chat_room_members SET role = $3
+WHERE chat_room_id = $1 AND user_id = $2
+`
+
+type UpdateChatRoomMemberRoleParams struct {
+	ChatRoomID uuid.UUID `json:"chat_room_id"`
+	UserID     uuid.UUID `json:"user_id"`
+	Role       string    `json:"role"`
+}
+
+func (q *Queries) UpdateChatRoomMemberRole(ctx context.Context, arg UpdateChatRoomMemberRoleParams) error {
+	_, err := q.db.Exec(ctx, updateChatRoomMemberRole, arg.ChatRoomID, arg.UserID, arg.Role)
+	return err
+}
+
+const updateChatRoomName = `-- name: UpdateChatRoomName :one
+UPDATE chat_rooms SET name = $2
+WHERE id = $1
+RETURNING id, type, name, created_by, created_at, updated_at
+`
+
+type UpdateChatRoomNameParams struct {
+	ID   uuid.UUID   `json:"id"`
+	Name pgtype.Text `json:"name"`
+}
+
+func (q *Queries) UpdateChatRoomName(ctx context.Context, arg UpdateChatRoomNameParams) (ChatRoom, error) {
+	row := q.db.QueryRow(ctx, updateChatRoomName, arg.ID, arg.Name)
+	var i ChatRoom
+	err := row.Scan(
+		&i.ID,
+		&i.Type,
+		&i.Name,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const updateLastReadAt = `-- name: UpdateLastReadAt :exec

--- a/apps/server/internal/domain/social/presence.go
+++ b/apps/server/internal/domain/social/presence.go
@@ -1,0 +1,82 @@
+package social
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	presencePrefix = "mmp:presence:"
+	presenceTTL    = 90 * time.Second
+)
+
+// PresenceProvider manages online/offline status using Redis SETEX.
+type PresenceProvider interface {
+	SetOnline(ctx context.Context, userID uuid.UUID) error
+	SetOffline(ctx context.Context, userID uuid.UUID) error
+	Heartbeat(ctx context.Context, userID uuid.UUID) error
+	IsOnline(ctx context.Context, userID uuid.UUID) (bool, error)
+	GetOnlineFriends(ctx context.Context, friendIDs []uuid.UUID) ([]uuid.UUID, error)
+}
+
+type redisPresence struct {
+	client *redis.Client
+}
+
+// NewPresenceProvider creates a Redis-backed presence provider.
+func NewPresenceProvider(client *redis.Client) PresenceProvider {
+	return &redisPresence{client: client}
+}
+
+func presenceKey(userID uuid.UUID) string {
+	return presencePrefix + userID.String()
+}
+
+func (p *redisPresence) SetOnline(ctx context.Context, userID uuid.UUID) error {
+	return p.client.Set(ctx, presenceKey(userID), "1", presenceTTL).Err()
+}
+
+func (p *redisPresence) SetOffline(ctx context.Context, userID uuid.UUID) error {
+	return p.client.Del(ctx, presenceKey(userID)).Err()
+}
+
+func (p *redisPresence) Heartbeat(ctx context.Context, userID uuid.UUID) error {
+	return p.client.Expire(ctx, presenceKey(userID), presenceTTL).Err()
+}
+
+func (p *redisPresence) IsOnline(ctx context.Context, userID uuid.UUID) (bool, error) {
+	n, err := p.client.Exists(ctx, presenceKey(userID)).Result()
+	if err != nil {
+		return false, fmt.Errorf("presence: check online: %w", err)
+	}
+	return n > 0, nil
+}
+
+func (p *redisPresence) GetOnlineFriends(ctx context.Context, friendIDs []uuid.UUID) ([]uuid.UUID, error) {
+	if len(friendIDs) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]string, len(friendIDs))
+	for i, id := range friendIDs {
+		keys[i] = presenceKey(id)
+	}
+
+	// MGET returns values in order; non-existing keys return nil.
+	vals, err := p.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("presence: get online friends: %w", err)
+	}
+
+	online := make([]uuid.UUID, 0, len(friendIDs))
+	for i, v := range vals {
+		if v != nil {
+			online = append(online, friendIDs[i])
+		}
+	}
+	return online, nil
+}

--- a/apps/server/internal/domain/social/service.go
+++ b/apps/server/internal/domain/social/service.go
@@ -21,6 +21,7 @@ import (
 // validMessageTypes defines the allowed message types for chat messages.
 var validMessageTypes = map[string]bool{
 	"TEXT":        true,
+	"IMAGE":       true,
 	"SYSTEM":      true,
 	"GAME_INVITE": true,
 	"GAME_RESULT": true,
@@ -359,6 +360,19 @@ func (s *chatService) GetOrCreateDMRoom(ctx context.Context, userID, otherID uui
 		return nil, apperror.BadRequest("cannot create DM room with yourself")
 	}
 
+	// Block check: cannot DM a blocked/blocking user.
+	blocked, err := s.queries.IsBlocked(ctx, db.IsBlockedParams{
+		BlockerID: userID,
+		BlockedID: otherID,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to check block status for DM")
+		return nil, apperror.Internal("failed to create DM room")
+	}
+	if blocked {
+		return nil, apperror.New(apperror.ErrChatBlocked, http.StatusForbidden, "cannot create DM with blocked user")
+	}
+
 	// Acquire advisory lock to prevent duplicate DM rooms for the same pair.
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -402,6 +416,7 @@ func (s *chatService) GetOrCreateDMRoom(ctx context.Context, userID, otherID uui
 	if err := qtx.AddChatRoomMember(ctx, db.AddChatRoomMemberParams{
 		ChatRoomID: room.ID,
 		UserID:     userID,
+		Role:       "MEMBER",
 	}); err != nil {
 		s.logger.Error().Err(err).Msg("failed to add member to DM room")
 		return nil, apperror.Internal("failed to create DM room")
@@ -410,6 +425,7 @@ func (s *chatService) GetOrCreateDMRoom(ctx context.Context, userID, otherID uui
 	if err := qtx.AddChatRoomMember(ctx, db.AddChatRoomMemberParams{
 		ChatRoomID: room.ID,
 		UserID:     otherID,
+		Role:       "MEMBER",
 	}); err != nil {
 		s.logger.Error().Err(err).Msg("failed to add member to DM room")
 		return nil, apperror.Internal("failed to create DM room")
@@ -458,10 +474,11 @@ func (s *chatService) CreateGroupRoom(ctx context.Context, creatorID uuid.UUID, 
 		return nil, apperror.Internal("failed to create group room")
 	}
 
-	// Add creator as member.
+	// Add creator as OWNER.
 	if err := qtx.AddChatRoomMember(ctx, db.AddChatRoomMemberParams{
 		ChatRoomID: room.ID,
 		UserID:     creatorID,
+		Role:       "OWNER",
 	}); err != nil {
 		s.logger.Error().Err(err).Msg("failed to add creator to group room")
 		return nil, apperror.Internal("failed to create group room")
@@ -475,6 +492,7 @@ func (s *chatService) CreateGroupRoom(ctx context.Context, creatorID uuid.UUID, 
 		if err := qtx.AddChatRoomMember(ctx, db.AddChatRoomMemberParams{
 			ChatRoomID: room.ID,
 			UserID:     memberID,
+			Role:       "MEMBER",
 		}); err != nil {
 			s.logger.Error().Err(err).Msg("failed to add member to group room")
 			return nil, apperror.Internal("failed to create group room")
@@ -547,6 +565,35 @@ func (s *chatService) SendMessage(ctx context.Context, roomID, senderID uuid.UUI
 		return nil, err
 	}
 
+	// Block check for DM rooms: cannot send to blocked/blocking user.
+	room, err := s.queries.GetChatRoom(ctx, roomID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to get chat room for block check")
+		return nil, apperror.Internal("failed to send message")
+	}
+	if room.Type == "DM" {
+		members, err := s.queries.ListChatRoomMembers(ctx, roomID)
+		if err != nil {
+			s.logger.Error().Err(err).Msg("failed to list members for block check")
+			return nil, apperror.Internal("failed to send message")
+		}
+		for _, m := range members {
+			if m.UserID != senderID {
+				blocked, err := s.queries.IsBlocked(ctx, db.IsBlockedParams{
+					BlockerID: senderID,
+					BlockedID: m.UserID,
+				})
+				if err != nil {
+					s.logger.Error().Err(err).Msg("failed to check block status")
+					return nil, apperror.Internal("failed to send message")
+				}
+				if blocked {
+					return nil, apperror.New(apperror.ErrChatBlocked, http.StatusForbidden, "cannot send message to blocked user")
+				}
+			}
+		}
+	}
+
 	content = strings.TrimSpace(content)
 	if content == "" {
 		return nil, apperror.BadRequest("message content is required")
@@ -567,6 +614,7 @@ func (s *chatService) SendMessage(ctx context.Context, roomID, senderID uuid.UUI
 		SenderID:    senderID,
 		Content:     content,
 		MessageType: messageType,
+		Metadata:    []byte("{}"),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create chat message")

--- a/apps/server/internal/domain/social/service_test.go
+++ b/apps/server/internal/domain/social/service_test.go
@@ -810,8 +810,8 @@ func TestTextToString(t *testing.T) {
 // ===========================================================================
 
 func TestValidMessageTypes(t *testing.T) {
-	valid := []string{"TEXT", "SYSTEM", "GAME_INVITE", "GAME_RESULT"}
-	invalid := []string{"INVALID", "text", "", "IMAGE", "VIDEO"}
+	valid := []string{"TEXT", "IMAGE", "SYSTEM", "GAME_INVITE", "GAME_RESULT"}
+	invalid := []string{"INVALID", "text", "", "VIDEO"}
 
 	for _, mt := range valid {
 		if !validMessageTypes[mt] {

--- a/apps/server/internal/domain/social/ws_handler.go
+++ b/apps/server/internal/domain/social/ws_handler.go
@@ -1,0 +1,269 @@
+package social
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/ws"
+)
+
+// SocialWSHandler handles real-time WebSocket messages for the social system.
+type SocialWSHandler struct {
+	hub      *ws.SocialHub
+	chat     ChatService
+	friends  FriendService
+	presence PresenceProvider
+	queries  *db.Queries
+	logger   zerolog.Logger
+}
+
+// NewSocialWSHandler creates a new handler.
+func NewSocialWSHandler(
+	hub *ws.SocialHub,
+	chat ChatService,
+	friends FriendService,
+	presence PresenceProvider,
+	queries *db.Queries,
+	logger zerolog.Logger,
+) *SocialWSHandler {
+	return &SocialWSHandler{
+		hub:      hub,
+		chat:     chat,
+		friends:  friends,
+		presence: presence,
+		queries:  queries,
+		logger:   logger.With().Str("component", "social.ws").Logger(),
+	}
+}
+
+// HandleChat handles "chat:*" namespace messages.
+func (h *SocialWSHandler) HandleChat(c *ws.Client, env *ws.Envelope) {
+	ctx := context.Background()
+
+	switch env.Type {
+	case "chat:send":
+		h.handleChatSend(ctx, c, env)
+	case "chat:typing":
+		h.handleChatTyping(ctx, c, env)
+	case "chat:read":
+		h.handleChatRead(ctx, c, env)
+	case "chat:join":
+		h.handleChatJoin(ctx, c, env)
+	default:
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "unknown chat action: "+env.Type))
+	}
+}
+
+// HandleFriend handles "friend:*" namespace messages.
+func (h *SocialWSHandler) HandleFriend(c *ws.Client, env *ws.Envelope) {
+	// Friend namespace is mostly server→client push.
+	// Client-originated friend events are handled via REST API.
+	c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "friend events are push-only"))
+}
+
+// HandlePresence handles "presence:*" namespace messages.
+func (h *SocialWSHandler) HandlePresence(c *ws.Client, env *ws.Envelope) {
+	ctx := context.Background()
+
+	switch env.Type {
+	case "presence:heartbeat":
+		if err := h.presence.Heartbeat(ctx, c.ID); err != nil {
+			h.logger.Error().Err(err).Stringer("userId", c.ID).Msg("heartbeat failed")
+		}
+	default:
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "unknown presence action"))
+	}
+}
+
+// --- Chat handlers ---
+
+type chatSendPayload struct {
+	RoomID      uuid.UUID       `json:"room_id"`
+	Content     string          `json:"content"`
+	MessageType string          `json:"message_type"`
+	Metadata    json.RawMessage `json:"metadata,omitempty"`
+}
+
+func (h *SocialWSHandler) handleChatSend(ctx context.Context, c *ws.Client, env *ws.Envelope) {
+	var p chatSendPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "invalid chat:send payload"))
+		return
+	}
+
+	if p.MessageType == "" {
+		p.MessageType = "TEXT"
+	}
+
+	msg, err := h.chat.SendMessage(ctx, p.RoomID, c.ID, p.Content, p.MessageType)
+	if err != nil {
+		h.logger.Warn().Err(err).Stringer("userId", c.ID).Msg("chat:send failed")
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, err.Error()))
+		return
+	}
+
+	// Broadcast to all room members (including sender for confirmation).
+	msgEnv := ws.MustEnvelope("chat:message", msg)
+	h.hub.BroadcastToRoom(p.RoomID, msgEnv, uuid.Nil)
+}
+
+type chatTypingPayload struct {
+	RoomID uuid.UUID `json:"room_id"`
+}
+
+func (h *SocialWSHandler) handleChatTyping(ctx context.Context, c *ws.Client, env *ws.Envelope) {
+	var p chatTypingPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return // silently ignore malformed typing events
+	}
+
+	// Ephemeral broadcast to room members except sender.
+	indicator := ws.MustEnvelope("chat:typing_indicator", map[string]any{
+		"room_id": p.RoomID,
+		"user_id": c.ID,
+	})
+	h.hub.BroadcastToRoom(p.RoomID, indicator, c.ID)
+}
+
+type chatReadPayload struct {
+	RoomID uuid.UUID `json:"room_id"`
+}
+
+func (h *SocialWSHandler) handleChatRead(ctx context.Context, c *ws.Client, env *ws.Envelope) {
+	var p chatReadPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "invalid chat:read payload"))
+		return
+	}
+
+	if err := h.chat.MarkAsRead(ctx, p.RoomID, c.ID); err != nil {
+		h.logger.Warn().Err(err).Stringer("userId", c.ID).Msg("chat:read failed")
+		return
+	}
+
+	// Broadcast read receipt to room members.
+	receipt := ws.MustEnvelope("chat:read_receipt", map[string]any{
+		"room_id": p.RoomID,
+		"user_id": c.ID,
+		"read_at": time.Now(),
+	})
+	h.hub.BroadcastToRoom(p.RoomID, receipt, c.ID)
+}
+
+type chatJoinPayload struct {
+	RoomIDs []uuid.UUID `json:"room_ids"`
+}
+
+func (h *SocialWSHandler) handleChatJoin(ctx context.Context, c *ws.Client, env *ws.Envelope) {
+	var p chatJoinPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "invalid chat:join payload"))
+		return
+	}
+
+	// Register user in each room for broadcast targeting.
+	// Only allow joining rooms where the user is a member.
+	for _, roomID := range p.RoomIDs {
+		isMember, err := h.queries.IsChatRoomMember(ctx, db.IsChatRoomMemberParams{
+			ChatRoomID: roomID,
+			UserID:     c.ID,
+		})
+		if err != nil || !isMember {
+			continue
+		}
+		h.hub.JoinRoom(roomID, c.ID)
+	}
+}
+
+// --- Public push helpers (called from SocialBridge or service layer) ---
+
+// NotifyFriendRequest sends a real-time friend request notification.
+func (h *SocialWSHandler) NotifyFriendRequest(targetID uuid.UUID, req *FriendshipResponse) {
+	env := ws.MustEnvelope("friend:request", req)
+	h.hub.SendToUser(targetID, env)
+}
+
+// NotifyFriendAccepted sends a real-time friend accepted notification.
+func (h *SocialWSHandler) NotifyFriendAccepted(targetID uuid.UUID, resp *FriendshipResponse) {
+	env := ws.MustEnvelope("friend:accepted", resp)
+	h.hub.SendToUser(targetID, env)
+}
+
+// NotifyOnlineStatus sends online/offline status to a list of friend user IDs.
+func (h *SocialWSHandler) NotifyOnlineStatus(userID uuid.UUID, friendIDs []uuid.UUID, online bool) {
+	eventType := "friend:offline"
+	if online {
+		eventType = "friend:online"
+	}
+	env := ws.MustEnvelope(eventType, map[string]any{
+		"user_id": userID,
+	})
+	for _, fid := range friendIDs {
+		h.hub.SendToUser(fid, env)
+	}
+}
+
+// OnConnect is called when a social client connects. Sets presence and joins rooms.
+func (h *SocialWSHandler) OnConnect(ctx context.Context, userID uuid.UUID) {
+	// Set online presence.
+	if err := h.presence.SetOnline(ctx, userID); err != nil {
+		h.logger.Error().Err(err).Stringer("userId", userID).Msg("failed to set online")
+	}
+
+	// Auto-join all user's chat rooms.
+	rooms, err := h.queries.ListUserChatRooms(ctx, db.ListUserChatRoomsParams{
+		UserID: userID,
+		Limit:  100,
+		Offset: 0,
+	})
+	if err != nil {
+		h.logger.Error().Err(err).Stringer("userId", userID).Msg("failed to list rooms on connect")
+		return
+	}
+	for _, r := range rooms {
+		h.hub.JoinRoom(r.ID, userID)
+	}
+
+	// Notify friends that user is online.
+	friends, err := h.queries.ListFriends(ctx, db.ListFriendsParams{
+		RequesterID: userID,
+		Limit:       200,
+		Offset:      0,
+	})
+	if err != nil {
+		h.logger.Error().Err(err).Stringer("userId", userID).Msg("failed to list friends for presence")
+		return
+	}
+	friendIDs := make([]uuid.UUID, len(friends))
+	for i, f := range friends {
+		friendIDs[i] = f.ID
+	}
+	h.NotifyOnlineStatus(userID, friendIDs, true)
+}
+
+// OnDisconnect is called when a social client disconnects.
+func (h *SocialWSHandler) OnDisconnect(ctx context.Context, userID uuid.UUID) {
+	if err := h.presence.SetOffline(ctx, userID); err != nil {
+		h.logger.Error().Err(err).Stringer("userId", userID).Msg("failed to set offline")
+	}
+
+	// Notify friends that user is offline.
+	friends, err := h.queries.ListFriends(ctx, db.ListFriendsParams{
+		RequesterID: userID,
+		Limit:       200,
+		Offset:      0,
+	})
+	if err != nil {
+		return
+	}
+	friendIDs := make([]uuid.UUID, len(friends))
+	for i, f := range friends {
+		friendIDs[i] = f.ID
+	}
+	h.NotifyOnlineStatus(userID, friendIDs, false)
+}

--- a/apps/server/internal/ws/client.go
+++ b/apps/server/internal/ws/client.go
@@ -28,12 +28,20 @@ const (
 	sendBufSize = 256
 )
 
+// ClientHub is the minimal interface a Client needs from its hub.
+// Both Hub (game) and SocialHub implement this.
+type ClientHub interface {
+	Register(c *Client)
+	Unregister(c *Client)
+	Route(sender *Client, env *Envelope)
+}
+
 // Client represents a single WebSocket connection (one player).
 type Client struct {
 	ID        uuid.UUID
 	SessionID uuid.UUID // game session this client belongs to (zero if lobby)
 	conn      *websocket.Conn
-	hub       *Hub
+	hub       ClientHub
 	send      chan []byte
 	seq       uint64 // monotonic server sequence number (atomic)
 	closed    atomic.Bool
@@ -42,7 +50,7 @@ type Client struct {
 }
 
 // NewClient creates a Client bound to the given connection and hub.
-func NewClient(id uuid.UUID, conn *websocket.Conn, hub *Hub, logger zerolog.Logger) *Client {
+func NewClient(id uuid.UUID, conn *websocket.Conn, hub ClientHub, logger zerolog.Logger) *Client {
 	return &Client{
 		ID:     id,
 		conn:   conn,

--- a/apps/server/internal/ws/hub.go
+++ b/apps/server/internal/ws/hub.go
@@ -15,6 +15,9 @@ const (
 	reconnectBufferSize = 1000
 )
 
+// compile-time interface check
+var _ ClientHub = (*Hub)(nil)
+
 // Hub manages all connected WebSocket clients, organized by game session.
 // It runs a single event-loop goroutine that processes register/unregister
 // events, keeping the internal maps free of lock contention.

--- a/apps/server/internal/ws/social_hub.go
+++ b/apps/server/internal/ws/social_hub.go
@@ -1,0 +1,208 @@
+package ws
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// compile-time interface check
+var _ ClientHub = (*SocialHub)(nil)
+
+// SocialHub manages WebSocket clients for the social system (chat, friends, presence).
+// Unlike the game Hub which indexes by sessionID→playerID, SocialHub indexes
+// by userID for direct messaging and chatRoom membership for broadcasting.
+type SocialHub struct {
+	// users maps userID → Client for O(1) direct messaging.
+	users map[uuid.UUID]*Client
+	// rooms maps chatRoomID → set of userIDs for room-level broadcasting.
+	rooms map[uuid.UUID]map[uuid.UUID]struct{}
+
+	register   chan *Client
+	unregister chan *Client
+
+	router *Router
+	logger zerolog.Logger
+
+	mu   sync.RWMutex
+	done chan struct{}
+}
+
+// NewSocialHub creates a SocialHub and starts its event loop.
+func NewSocialHub(router *Router, logger zerolog.Logger) *SocialHub {
+	h := &SocialHub{
+		users:      make(map[uuid.UUID]*Client),
+		rooms:      make(map[uuid.UUID]map[uuid.UUID]struct{}),
+		register:   make(chan *Client, 64),
+		unregister: make(chan *Client, 64),
+		router:     router,
+		logger:     logger.With().Str("component", "ws.social_hub").Logger(),
+		done:       make(chan struct{}),
+	}
+	go h.run()
+	return h
+}
+
+func (h *SocialHub) run() {
+	for {
+		select {
+		case client := <-h.register:
+			h.mu.Lock()
+			// Close existing connection for the same user (single session enforcement).
+			if existing, ok := h.users[client.ID]; ok {
+				existing.Close()
+				h.logger.Info().
+					Stringer("userId", client.ID).
+					Msg("replaced existing social connection")
+			}
+			h.users[client.ID] = client
+			h.mu.Unlock()
+			h.logger.Info().
+				Stringer("userId", client.ID).
+				Msg("social client registered")
+
+		case client := <-h.unregister:
+			h.mu.Lock()
+			// Only remove if it's the current client (not a replacement).
+			if current, ok := h.users[client.ID]; ok && current == client {
+				delete(h.users, client.ID)
+				// Remove from all rooms.
+				for roomID, members := range h.rooms {
+					delete(members, client.ID)
+					if len(members) == 0 {
+						delete(h.rooms, roomID)
+					}
+				}
+			}
+			h.mu.Unlock()
+			client.Close()
+			h.logger.Info().
+				Stringer("userId", client.ID).
+				Msg("social client unregistered")
+
+		case <-h.done:
+			return
+		}
+	}
+}
+
+// Register queues a client for registration.
+func (h *SocialHub) Register(c *Client) {
+	select {
+	case h.register <- c:
+	case <-h.done:
+		c.Close()
+	}
+}
+
+// Unregister queues a client for removal.
+func (h *SocialHub) Unregister(c *Client) {
+	select {
+	case h.unregister <- c:
+	case <-h.done:
+		c.Close()
+	}
+}
+
+// Route dispatches an inbound envelope to the router.
+func (h *SocialHub) Route(sender *Client, env *Envelope) {
+	if h.router == nil {
+		h.logger.Error().Msg("router not set, dropping message")
+		sender.SendMessage(NewErrorEnvelope(ErrCodeInternalError, "server misconfigured"))
+		return
+	}
+	h.router.Route(sender, env)
+}
+
+// JoinRoom adds a user to a chat room for broadcast targeting.
+func (h *SocialHub) JoinRoom(roomID, userID uuid.UUID) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	members, ok := h.rooms[roomID]
+	if !ok {
+		members = make(map[uuid.UUID]struct{})
+		h.rooms[roomID] = members
+	}
+	members[userID] = struct{}{}
+}
+
+// LeaveRoom removes a user from a chat room.
+func (h *SocialHub) LeaveRoom(roomID, userID uuid.UUID) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if members, ok := h.rooms[roomID]; ok {
+		delete(members, userID)
+		if len(members) == 0 {
+			delete(h.rooms, roomID)
+		}
+	}
+}
+
+// SendToUser sends an envelope to a specific user. Returns false if user is offline.
+func (h *SocialHub) SendToUser(userID uuid.UUID, env *Envelope) bool {
+	h.mu.RLock()
+	c := h.users[userID]
+	h.mu.RUnlock()
+
+	if c == nil {
+		return false
+	}
+	c.SendMessage(env)
+	return true
+}
+
+// BroadcastToRoom sends an envelope to all online members of a chat room.
+func (h *SocialHub) BroadcastToRoom(roomID uuid.UUID, env *Envelope, excludeID uuid.UUID) {
+	h.mu.RLock()
+	members, ok := h.rooms[roomID]
+	if !ok {
+		h.mu.RUnlock()
+		return
+	}
+	// Collect clients under read lock.
+	clients := make([]*Client, 0, len(members))
+	for uid := range members {
+		if uid == excludeID {
+			continue
+		}
+		if c, ok := h.users[uid]; ok {
+			clients = append(clients, c)
+		}
+	}
+	h.mu.RUnlock()
+
+	for _, c := range clients {
+		c.SendMessage(env)
+	}
+}
+
+// IsOnline checks if a user has an active social WS connection.
+func (h *SocialHub) IsOnline(userID uuid.UUID) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	_, ok := h.users[userID]
+	return ok
+}
+
+// OnlineCount returns the number of connected social clients.
+func (h *SocialHub) OnlineCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.users)
+}
+
+// Stop shuts down the social hub event loop and closes all clients.
+func (h *SocialHub) Stop() {
+	close(h.done)
+
+	h.mu.Lock()
+	for _, c := range h.users {
+		c.Close()
+	}
+	h.users = make(map[uuid.UUID]*Client)
+	h.rooms = make(map[uuid.UUID]map[uuid.UUID]struct{})
+	h.mu.Unlock()
+}

--- a/apps/server/internal/ws/upgrade.go
+++ b/apps/server/internal/ws/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
@@ -61,9 +62,39 @@ func DefaultPlayerIDExtractor(r *http.Request) (uuid.UUID, error) {
 	return uuid.Parse(raw)
 }
 
+// JWTPlayerIDExtractor returns a PlayerIDExtractor that validates a JWT token
+// from the "token" query parameter and extracts the user ID from the subject claim.
+// This is used for WebSocket connections where Authorization headers are not available.
+func JWTPlayerIDExtractor(secret []byte) PlayerIDExtractor {
+	return func(r *http.Request) (uuid.UUID, error) {
+		tokenStr := r.URL.Query().Get("token")
+		if tokenStr == "" {
+			return uuid.Nil, ErrMissingPlayerID
+		}
+
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (any, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, ErrQueryAuthNotAllowed
+			}
+			return secret, nil
+		})
+		if err != nil || !token.Valid {
+			return uuid.Nil, ErrQueryAuthNotAllowed
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			return uuid.Nil, ErrQueryAuthNotAllowed
+		}
+
+		sub, _ := claims.GetSubject()
+		return uuid.Parse(sub)
+	}
+}
+
 // UpgradeHandler returns an http.HandlerFunc that upgrades HTTP to WebSocket
 // and registers the client with the Hub.
-func UpgradeHandler(hub *Hub, extractPlayerID PlayerIDExtractor, cfg UpgradeConfig, logger zerolog.Logger) http.HandlerFunc {
+func UpgradeHandler(hub ClientHub, extractPlayerID PlayerIDExtractor, cfg UpgradeConfig, logger zerolog.Logger) http.HandlerFunc {
 	log := logger.With().Str("component", "ws.upgrade").Logger()
 	up := newUpgrader(cfg)
 

--- a/apps/web/src/features/social/components/ChatRoom.tsx
+++ b/apps/web/src/features/social/components/ChatRoom.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Send, MessageCircle } from "lucide-react";
+import { Send, MessageCircle, Gamepad2, Trophy } from "lucide-react";
 import { Button, Spinner, EmptyState } from "@/shared/components/ui";
 import {
   useChatMessages,
@@ -8,6 +8,8 @@ import {
 } from "@/features/social/api";
 import type { ChatMessageResponse } from "@/features/social/api";
 import { useAuthStore } from "@/stores/authStore";
+import { useConnectionStore } from "@/stores/connectionStore";
+import { useSocialStore, selectRoomTypingUsers } from "@/stores/socialStore";
 import { MAX_MESSAGE_LENGTH } from "@/features/social/constants";
 
 // ---------------------------------------------------------------------------
@@ -42,6 +44,52 @@ function MessageBubble({ message, isMine }: MessageBubbleProps) {
     return (
       <div className="py-1 text-center text-xs italic text-slate-500">
         {message.content}
+      </div>
+    );
+  }
+
+  // Game invite card
+  if (message.message_type === "GAME_INVITE") {
+    return (
+      <div className={`flex flex-col gap-0.5 ${isMine ? "items-end" : "items-start"}`}>
+        {!isMine && (
+          <span className={`text-xs font-semibold ${getNicknameColor(message.sender_nickname)}`}>
+            {message.sender_nickname}
+          </span>
+        )}
+        <div className="max-w-[75%] rounded-xl border border-amber-700/50 bg-amber-900/20 p-3">
+          <div className="flex items-center gap-2 text-amber-400">
+            <Gamepad2 className="h-4 w-4" />
+            <span className="text-sm font-semibold">게임 초대</span>
+          </div>
+          <p className="mt-1 text-sm text-slate-300">{message.content}</p>
+        </div>
+        <span className="text-[10px] text-slate-600">
+          {formatMessageTime(message.created_at)}
+        </span>
+      </div>
+    );
+  }
+
+  // Game result card
+  if (message.message_type === "GAME_RESULT") {
+    return (
+      <div className={`flex flex-col gap-0.5 ${isMine ? "items-end" : "items-start"}`}>
+        {!isMine && (
+          <span className={`text-xs font-semibold ${getNicknameColor(message.sender_nickname)}`}>
+            {message.sender_nickname}
+          </span>
+        )}
+        <div className="max-w-[75%] rounded-xl border border-emerald-700/50 bg-emerald-900/20 p-3">
+          <div className="flex items-center gap-2 text-emerald-400">
+            <Trophy className="h-4 w-4" />
+            <span className="text-sm font-semibold">게임 결과</span>
+          </div>
+          <p className="mt-1 text-sm text-slate-300">{message.content}</p>
+        </div>
+        <span className="text-[10px] text-slate-600">
+          {formatMessageTime(message.created_at)}
+        </span>
       </div>
     );
   }
@@ -86,8 +134,11 @@ export function ChatRoom({ roomId }: ChatRoomProps) {
   const [text, setText] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const currentUser = useAuthStore((s) => s.user);
+  const socialClient = useConnectionStore((s) => s.socialClient);
+  const typingUsers = useSocialStore(selectRoomTypingUsers(roomId));
   const { data: messages, isLoading } = useChatMessages(roomId);
   const sendMessage = useSendMessage(roomId);
   const markAsRead = useMarkAsRead(roomId);
@@ -104,6 +155,16 @@ export function ChatRoom({ roomId }: ChatRoomProps) {
     }
   }, [messages]);
 
+  // Send typing indicator (debounced)
+  const sendTypingEvent = useCallback(() => {
+    if (!socialClient) return;
+    if (typingTimerRef.current) return; // Already sent recently
+    socialClient.send("chat:typing" as any, { room_id: roomId });
+    typingTimerRef.current = setTimeout(() => {
+      typingTimerRef.current = null;
+    }, 300);
+  }, [socialClient, roomId]);
+
   // Auto-resize textarea
   const handleTextChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
@@ -114,7 +175,11 @@ export function ChatRoom({ roomId }: ChatRoomProps) {
     const el = e.target;
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
-  }, []);
+    // Send typing indicator
+    if (value.trim()) {
+      sendTypingEvent();
+    }
+  }, [sendTypingEvent]);
 
   function handleSend() {
     const trimmed = text.trim();
@@ -176,6 +241,15 @@ export function ChatRoom({ roomId }: ChatRoomProps) {
           </div>
         )}
       </div>
+
+      {/* Typing indicator */}
+      {typingUsers.length > 0 && (
+        <div className="px-4 py-1">
+          <span className="text-xs text-slate-500 animate-pulse">
+            입력 중...
+          </span>
+        </div>
+      )}
 
       {/* Input bar */}
       <div className="border-t border-slate-700 px-4 py-3">

--- a/apps/web/src/features/social/hooks/useSocialSync.ts
+++ b/apps/web/src/features/social/hooks/useSocialSync.ts
@@ -28,8 +28,8 @@ interface ChatReadPayload {
 }
 
 interface ChatTypingPayload {
-  chat_room_id: string;
-  user_ids: string[];
+  room_id: string;
+  user_id: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -39,9 +39,11 @@ interface ChatTypingPayload {
 const SOCIAL_EVENT = {
   FRIEND_ONLINE: "friend:online",
   FRIEND_OFFLINE: "friend:offline",
+  FRIEND_REQUEST: "friend:request",
+  FRIEND_ACCEPTED: "friend:accepted",
   CHAT_MESSAGE: "chat:message",
-  CHAT_READ: "chat:read",
-  CHAT_TYPING: "chat:typing",
+  CHAT_READ_RECEIPT: "chat:read_receipt",
+  CHAT_TYPING_INDICATOR: "chat:typing_indicator",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -115,29 +117,52 @@ export function useSocialSync(): void {
       },
     );
 
-    // chat:read → invalidate room queries
+    // chat:read_receipt → invalidate room queries
     subscribe<ChatReadPayload>(
       client,
-      SOCIAL_EVENT.CHAT_READ,
+      SOCIAL_EVENT.CHAT_READ_RECEIPT,
       (payload) => {
-        queryClient.invalidateQueries({
-          queryKey: socialKeys.chatRoom(payload.chat_room_id),
-        });
         queryClient.invalidateQueries({
           queryKey: socialKeys.chatRooms(),
         });
       },
     );
 
-    // chat:typing → update typing indicator
+    // chat:typing_indicator → update typing indicator
     subscribe<ChatTypingPayload>(
       client,
-      SOCIAL_EVENT.CHAT_TYPING,
+      SOCIAL_EVENT.CHAT_TYPING_INDICATOR,
       (payload) => {
         actionsRef.current.setTyping(
-          payload.chat_room_id,
-          payload.user_ids,
+          payload.room_id,
+          [payload.user_id],
         );
+        // Auto-clear typing after 3 seconds
+        setTimeout(() => {
+          actionsRef.current.setTyping(payload.room_id, []);
+        }, 3000);
+      },
+    );
+
+    // friend:request → invalidate pending requests
+    subscribe<Record<string, unknown>>(
+      client,
+      SOCIAL_EVENT.FRIEND_REQUEST,
+      () => {
+        queryClient.invalidateQueries({
+          queryKey: socialKeys.pending(),
+        });
+      },
+    );
+
+    // friend:accepted → invalidate friends list
+    subscribe<Record<string, unknown>>(
+      client,
+      SOCIAL_EVENT.FRIEND_ACCEPTED,
+      () => {
+        queryClient.invalidateQueries({
+          queryKey: socialKeys.friends(),
+        });
       },
     );
 

--- a/apps/web/src/shared/components/MainLayout.tsx
+++ b/apps/web/src/shared/components/MainLayout.tsx
@@ -1,12 +1,18 @@
 import { Outlet } from "react-router";
 import { Nav } from "@/shared/components/Nav";
 import { Sidebar } from "@/shared/components/Sidebar";
+import { useWsClient } from "@/hooks/useWsClient";
+import { useSocialSync } from "@/features/social/hooks/useSocialSync";
 
 // ---------------------------------------------------------------------------
 // 인증된 유저용 메인 레이아웃 (Nav + Sidebar + Outlet)
 // ---------------------------------------------------------------------------
 
 export function MainLayout() {
+  // Social WS: 인증된 모든 페이지에서 자동 ���결
+  useWsClient({ endpoint: "social" });
+  useSocialSync();
+
   return (
     <div className="min-h-screen bg-slate-950">
       <Nav />

--- a/apps/web/src/shared/components/Sidebar.tsx
+++ b/apps/web/src/shared/components/Sidebar.tsx
@@ -13,9 +13,11 @@ import {
   BadgeDollarSign,
   BarChart3,
   CircleDollarSign,
+  MessageCircle,
 } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
 import { useUIStore } from "@/stores/uiStore";
+import { useSocialStore, selectTotalUnread } from "@/stores/socialStore";
 
 // ---------------------------------------------------------------------------
 // 사이드바 메뉴 항목 타입
@@ -38,6 +40,7 @@ const menuSections: MenuSection[] = [
   {
     items: [
       { to: "/lobby", label: "로비", icon: Gamepad2 },
+      { to: "/social", label: "소셜", icon: MessageCircle },
       { to: "/shop", label: "상점", icon: Coins },
       { to: "/my-themes", label: "내 테마", icon: Library },
     ],
@@ -94,6 +97,7 @@ export function Sidebar() {
   const user = useAuthStore((s) => s.user);
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
+  const totalUnread = useSocialStore(selectTotalUnread);
 
   const userRole = user?.role ?? "user";
 
@@ -162,6 +166,11 @@ export function Sidebar() {
                   >
                     <item.icon className="h-5 w-5" />
                     {item.label}
+                    {item.to === "/social" && totalUnread > 0 && (
+                      <span className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-500 px-1.5 text-xs font-bold text-slate-900">
+                        {totalUnread > 99 ? "99+" : totalUnread}
+                      </span>
+                    )}
                   </NavLink>
                 ))}
               </div>

--- a/apps/web/src/stores/socialStore.ts
+++ b/apps/web/src/stores/socialStore.ts
@@ -119,3 +119,11 @@ export const selectUnreadCount = (roomId: string) => (s: SocialState) =>
 
 export const selectRoomTypingUsers = (roomId: string) => (s: SocialState) =>
   s.typingUsers.get(roomId) ?? [];
+
+export const selectTotalUnread = (s: SocialState) => {
+  let total = 0;
+  for (const count of s.unreadCounts.values()) {
+    total += count;
+  }
+  return total;
+};

--- a/docs/plans/2026-04-06-phase75-social-design.md
+++ b/docs/plans/2026-04-06-phase75-social-design.md
@@ -1,0 +1,129 @@
+# Phase 7.5 소셜 시스템 — 구현 계획서
+
+> 4명 전문가(백엔드/DB/프론트/보안) 토론 결과 종합. 2026-04-06 작성.
+
+## 현황 요약
+
+기존 구현이 예상보다 많이 완료됨. **REST + DB ~85%, 프론트 ~70%, WS 실시간 ~0%**.
+
+| 영역 | 완료 | 남은 핵심 작업 |
+|------|------|---------------|
+| DB 스키마 (00007) | 5개 테이블 존재 | ALTER TABLE: updated_at, role, metadata, deleted_at, IMAGE |
+| sqlc 쿼리 (25개) | CRUD 완비 | 7개 추가 (soft delete, cursor, totalUnread 등) |
+| Go Service | FriendService + ChatService | 차단 필터링, validMessageTypes IMAGE 추가 |
+| Go REST Handler | 전 엔드포인트 연결 | 보안 보강 (rate limit) |
+| **Go WS** | **미구현** | **SocialHub, Presence, WS Handler, Bridge** |
+| 프론트 스토어 | socialStore + connectionStore | totalUnread 추가 |
+| 프론트 hooks | React Query 22개 + useSocialSync | **useSocialSync 마운트**, useInfiniteMessages |
+| 프론트 컴포넌트 | FriendsList + ChatList + ChatRoom | 게임카드, 타이핑 UI, 무한스크롤, 반응형 |
+| 보안 | JWT, CORS, sqlc | **WS JWT 인증, SocialHub 분리, Rate Limit, 차단 우회 방지** |
+
+## 아키텍처 결정
+
+### D1. SocialHub 분리 (게임 Hub 재사용 안 함)
+- 게임: `sessions[sessionID][playerID]` 2레벨, 소셜: `users[userID]` 1레벨
+- 생명주기 차이: 게임(수시간) vs 소셜(영구)
+- ReconnectBuffer: 게임 필요, 소셜 불필요 (DB 영속화)
+- Router/Envelope/PubSub는 재사용
+
+### D2. WS 인증: JWT PlayerIDExtractor
+- 기존 DefaultPlayerIDExtractor(query param)를 JWT 기반으로 교체
+- WS는 Authorization 헤더 불가 → `?token=` 쿼리파라미터로 JWT 전달
+- prod에서 query-param auth 차단 guard 이미 존재, JWT 용은 별도 경로
+
+### D3. Redis Presence: SETEX + heartbeat
+- `mmp:presence:{userID}` — TTL 90초, heartbeat 60초
+- 서버 크래시 시 90초 후 자동 offline
+- 친구 온라인 목록: MGET 일괄 조회 (O(N) 단일 RTT)
+
+### D4. 메시지 metadata: JSONB
+- GAME_INVITE, GAME_RESULT, IMAGE 등 타입별 가변 필드
+- Go에서 `json.RawMessage`로 매핑 (sqlc.yaml에 이미 설정)
+
+### D5. Soft Delete: deleted_at + partial index
+- 카카오톡 "삭제됨" 패턴
+- `idx_chat_messages_not_deleted(chat_room_id, id DESC) WHERE deleted_at IS NULL`
+
+### D6. 프론트 WS 마운트: MainLayout
+- 인증된 모든 페이지에서 소셜 WS 활성화 (알림, unread 배지)
+- MainLayout에서 useWsClient + useSocialSync 호출
+
+---
+
+## 구현 단계 (8 Step)
+
+### Step 1: DB 마이그레이션 + sqlc
+- `00014_social_enhancements.sql` — 5개 컬럼 ALTER + 2개 인덱스
+- `social.sql` 쿼리 수정 5개 + 신규 7개
+- `sqlc generate` 실행
+- `validMessageTypes`에 IMAGE 추가
+
+### Step 2: 보안 보강 — 차단 필터링
+- `SendMessage()` 차단 여부 확인 (DM)
+- `GetOrCreateDMRoom()` 차단 여부 확인
+- `CreateGroupRoom()` 차단/존재 검증
+- `IsBlocked` 양방향 쿼리 추가
+
+### Step 3: SocialHub + JWT WS 인증
+- `ws/social_hub.go` — userID 기반 인덱싱, rooms 맵
+- `ws/upgrade.go` — JWTPlayerIDExtractor 추가
+- 기존 Hub register에 동일 ID 기존 연결 정리 로직
+- SocialHub PubSub 채널: `mmp:social:` prefix
+
+### Step 4: PresenceProvider + SocialWSHandler
+- `domain/social/presence.go` — Redis SETEX presence
+- `domain/social/ws_handler.go` — chat:send/typing/read + friend:* 핸들러
+- WS 메시지 rate limiter (메시지 전송 100ms cooldown)
+
+### Step 5: SocialBridge + EventBus 이벤트
+- `bridge/social_bridge.go` — 게임→소셜 이벤트 파이프라인
+- `eventbus/events.go` — GameInviteSent, GameEnded 이벤트 추가
+- main.go DI 조립 + `/ws/social` 재연결
+
+### Step 6: 프론트엔드 WS 마운트 + 실시간
+- MainLayout에 useWsClient({endpoint:"social"}) + useSocialSync() 마운트
+- @mmp/shared WsEventType에 소셜 이벤트 추가
+- 타이핑 인디케이터 UI + 전송 (300ms debounce)
+- totalUnread 계산 + Nav/Sidebar 배지
+
+### Step 7: 프론트엔드 기능 완성
+- GameInviteCard + GameResultCard 메시지 렌더링
+- useInfiniteMessages (역방향 무한 스크롤)
+- 옵티미스틱 업데이트 (메시지 전송)
+- 읽음 확인 표시 UI (체크마크)
+- 친구 요청 실시간 알림 (toast)
+- 모바일 반응형 (768px 이하 리스트↔채팅 전환)
+
+### Step 8: 테스트 + 통합 검증
+- Go: SocialHub, Presence, WSHandler, Bridge 테스트
+- FE: 신규 컴포넌트 테스트 추가
+- E2E: WS 연결 → 메시지 전송 → 수신 → 읽음 확인 시나리오
+
+---
+
+## WS 메시지 타입 정리
+
+| Type | 방향 | 설명 |
+|------|------|------|
+| `chat:send` | C→S | 메시지 전송 (DB 저장 + broadcast) |
+| `chat:typing` | C→S | 타이핑 시작 (ephemeral, DB 불필요) |
+| `chat:read` | C→S | 읽음 확인 (DB 업데이트 + broadcast) |
+| `chat:message` | S→C | 새 메시지 도착 |
+| `chat:typing_indicator` | S→C | 타이핑 중 알림 |
+| `chat:read_receipt` | S→C | 읽음 확인 전파 |
+| `friend:request` | S→C | 친구 요청 수신 |
+| `friend:accepted` | S→C | 친구 수락 알림 |
+| `friend:online` | S→C | 온라인 상태 변경 |
+| `friend:offline` | S→C | 오프라인 상태 변경 |
+| `presence:heartbeat` | C→S | 온라인 상태 갱신 (60초 간격) |
+
+## 보안 체크리스트
+
+- [ ] SocialHub/Router 분리 (게임 namespace 접근 차단)
+- [ ] JWT WS 인증 (DefaultPlayerIDExtractor 교체)
+- [ ] 사용자당 WS 연결 수 제한 (기존 연결 정리)
+- [ ] REST rate limiter (Redis sliding window, 소셜 30req/min)
+- [ ] WS 메시지 rate limiter (100ms cooldown)
+- [ ] 차단 사용자 메시지 필터링 (DM 전송/생성)
+- [ ] 그룹 채팅 멤버 추가 시 차단/존재 검증
+- [ ] 온라인 상태 친구에게만 노출


### PR DESCRIPTION
## Summary
- **SocialHub** 분리 생성 (게임 Hub과 독립, userID 기반 라우팅)
- **ClientHub 인터페이스** 추출로 Client가 Hub/SocialHub 양쪽에서 동작
- **JWT WS 인증** (`JWTPlayerIDExtractor`) + dev mode fallback
- **PresenceProvider** (Redis SETEX + 90s TTL + heartbeat)
- **SocialWSHandler** — chat:send/typing/read, friend:*, presence:heartbeat
- **차단 필터링** — SendMessage, GetOrCreateDMRoom에서 block 검증
- **DB 마이그레이션** — updated_at, role, metadata, deleted_at, IMAGE 타입
- **프론트엔드** — MainLayout에 WS 마운트, 타이핑 인디케이터, 게임카드 UI, unread 배지

## Changes
- 20 files changed, +1302 / -63
- 4 new Go files (social_hub, presence, ws_handler, migration)
- Go tests PASS, pnpm build 성공

## Test plan
- [ ] Go 테스트 통과 (`go test ./internal/domain/social/... ./internal/ws/...`)
- [ ] pnpm build 성공 (TypeScript 0 errors)
- [ ] `/ws/social` 연결 시 SocialHub에 등록 확인
- [ ] 채팅 메시지 전송 → 실시간 수신 확인
- [ ] 차단된 사용자 DM 전송 차단 확인
- [ ] 타이핑 인디케이터 표시 확인
- [ ] Sidebar unread 배지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)