### PR TITLE
feat(phase-7.7): game engine audio integration (Step 2)

### DIFF
--- a/apps/server/internal/engine/engine.go
+++ b/apps/server/internal/engine/engine.go
@@ -283,6 +283,22 @@ func (e *GameProgressionEngine) enterCurrentPhase(ctx context.Context) error {
 	}
 	for _, pc := range e.config.Phases {
 		if pc.ID == phase.ID {
+			// Auto-inject SET_BGM ahead of user-defined onEnter when the phase
+			// declares a bgmId. onEnter actions can still override afterwards.
+			if pc.BGMId != "" {
+				bgmParams, _ := json.Marshal(map[string]any{
+					"mediaId": pc.BGMId,
+					"fadeMs":  1500,
+				})
+				bgmAction := PhaseActionPayload{
+					Action: ActionSetBGM,
+					Params: bgmParams,
+				}
+				if err := e.dispatcher.Dispatch(ctx, bgmAction); err != nil {
+					// Best-effort: log and continue — BGM failure must not block phase entry.
+					e.logger.Printf("engine: failed to dispatch auto SET_BGM for phase %s: %v", pc.ID, err)
+				}
+			}
 			return e.dispatcher.DispatchBatch(ctx, pc.OnEnter)
 		}
 	}

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -22,6 +22,7 @@ const (
 	ActionPlaySound           PhaseAction = "PLAY_SOUND"
 	ActionPlayMedia           PhaseAction = "PLAY_MEDIA"
 	ActionSetBGM              PhaseAction = "SET_BGM"
+	ActionStopAudio           PhaseAction = "STOP_AUDIO"
 	ActionMuteChat            PhaseAction = "MUTE_CHAT"
 	ActionUnmuteChat          PhaseAction = "UNMUTE_CHAT"
 	ActionOpenGroupChat       PhaseAction = "OPEN_GROUP_CHAT"
@@ -39,14 +40,22 @@ type PhaseActionPayload struct {
 
 // PhaseConfig defines a single phase in configJson.phases[].
 type PhaseConfig struct {
-	ID          string               `json:"id"`
-	Name        string               `json:"name"`
-	Type        string               `json:"type"`                  // e.g. "discussion", "investigation", "voting"
-	Duration    int                  `json:"duration,omitempty"`    // seconds, 0 = unlimited
-	OnEnter     []PhaseActionPayload `json:"onEnter,omitempty"`
-	OnExit      []PhaseActionPayload `json:"onExit,omitempty"`
-	Triggers    []TriggerConfig      `json:"triggers,omitempty"`    // Hybrid/Event용
-	NextPhaseID string               `json:"nextPhaseId,omitempty"` // Event용 (비선형)
+	ID             string                `json:"id"`
+	Name           string                `json:"name"`
+	Type           string                `json:"type"`                     // e.g. "discussion", "investigation", "voting"
+	Duration       int                   `json:"duration,omitempty"`       // seconds, 0 = unlimited
+	BGMId          string                `json:"bgmId,omitempty"`          // phase-level BGM (auto SET_BGM on enter)
+	ReadingSection *ReadingSectionConfig `json:"readingSection,omitempty"` // optional reading dialogue section
+	OnEnter        []PhaseActionPayload  `json:"onEnter,omitempty"`
+	OnExit         []PhaseActionPayload  `json:"onExit,omitempty"`
+	Triggers       []TriggerConfig       `json:"triggers,omitempty"`    // Hybrid/Event용
+	NextPhaseID    string                `json:"nextPhaseId,omitempty"` // Event용 (비선형)
+}
+
+// ReadingSectionConfig describes an optional reading (dialogue) section inside a phase.
+// When present, the ReadingModule takes over and the BGMId here overrides phase BGM.
+type ReadingSectionConfig struct {
+	BGMId string `json:"bgmId,omitempty"`
 }
 
 // TriggerConfig defines a conditional trigger for Hybrid/Event strategies.
@@ -69,11 +78,21 @@ type PhaseInfo struct {
 
 // GameConfig represents the parsed configJson from a theme.
 type GameConfig struct {
-	Strategy    string            `json:"strategy"`    // "script", "hybrid", "event"
-	GmMode      string            `json:"gmMode"`      // "REQUIRED", "NONE", "OPTIONAL"
-	Phases      []PhaseConfig     `json:"phases"`
-	Modules     []ModuleConfig    `json:"modules"`
-	Settings    json.RawMessage   `json:"settings,omitempty"`
+	Strategy    string          `json:"strategy"` // "script", "hybrid", "event"
+	GmMode      string          `json:"gmMode"`   // "REQUIRED", "NONE", "OPTIONAL"
+	Phases      []PhaseConfig   `json:"phases"`
+	Modules     []ModuleConfig  `json:"modules"`
+	MediaAssets []MediaAsset    `json:"mediaAssets,omitempty"` // media asset catalog for reference validation
+	Settings    json.RawMessage `json:"settings,omitempty"`
+}
+
+// MediaAsset is a minimal media catalog entry included in configJson for validation.
+// Populated on theme publish from theme_media; used by validators to check bgmId references.
+type MediaAsset struct {
+	ID       string `json:"id"`                 // theme_media.id
+	Type     string `json:"type"`               // "BGM" | "SFX" | "VOICE"
+	URL      string `json:"url,omitempty"`      // resolved URL (CDN or YouTube)
+	Duration int    `json:"duration,omitempty"` // seconds, 0 = unknown
 }
 
 // ModuleConfig is the per-module configuration from configJson.modules[].

--- a/apps/server/internal/engine/validation.go
+++ b/apps/server/internal/engine/validation.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -95,10 +96,67 @@ func ValidateConfig(config GameConfig) error {
 		}
 	}
 
+	// 6. Media asset reference validation
+	if len(config.MediaAssets) > 0 || hasMediaReferences(config) {
+		mediaSet := make(map[string]bool, len(config.MediaAssets))
+		for _, asset := range config.MediaAssets {
+			mediaSet[asset.ID] = true
+		}
+		for _, phase := range config.Phases {
+			if phase.BGMId != "" && !mediaSet[phase.BGMId] {
+				errs = append(errs, fmt.Sprintf("phase %q references unknown media %q", phase.ID, phase.BGMId))
+			}
+			if phase.ReadingSection != nil && phase.ReadingSection.BGMId != "" && !mediaSet[phase.ReadingSection.BGMId] {
+				errs = append(errs, fmt.Sprintf("phase %q readingSection references unknown media %q", phase.ID, phase.ReadingSection.BGMId))
+			}
+			for _, action := range append(append([]PhaseActionPayload{}, phase.OnEnter...), phase.OnExit...) {
+				if action.Action != ActionPlayMedia && action.Action != ActionSetBGM {
+					continue
+				}
+				var p struct {
+					MediaID string `json:"mediaId"`
+				}
+				if len(action.Params) == 0 {
+					continue
+				}
+				if err := json.Unmarshal(action.Params, &p); err != nil || p.MediaID == "" {
+					continue
+				}
+				if !mediaSet[p.MediaID] {
+					errs = append(errs, fmt.Sprintf("phase %q action %s references unknown media %q", phase.ID, action.Action, p.MediaID))
+				}
+			}
+		}
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("config validation:\n  - %s", strings.Join(errs, "\n  - "))
 	}
 	return nil
+}
+
+// hasMediaReferences reports whether the config contains any media references that
+// would require the mediaAssets catalog to be populated.
+func hasMediaReferences(config GameConfig) bool {
+	for _, phase := range config.Phases {
+		if phase.BGMId != "" {
+			return true
+		}
+		if phase.ReadingSection != nil && phase.ReadingSection.BGMId != "" {
+			return true
+		}
+		for _, action := range phase.OnEnter {
+			if action.Action == ActionPlayMedia || action.Action == ActionSetBGM {
+				return true
+			}
+		}
+		for _, action := range phase.OnExit {
+			if action.Action == ActionPlayMedia || action.Action == ActionSetBGM {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func validateAction(action PhaseActionPayload, enabled map[string]bool) error {

--- a/apps/server/internal/module/media/audio.go
+++ b/apps/server/internal/module/media/audio.go
@@ -1,0 +1,159 @@
+// Package media provides audio/media playback modules.
+//
+// AudioModule is a PhaseReactor that translates audio-related PhaseActions
+// (PLAY_SOUND, PLAY_MEDIA, SET_BGM, STOP_AUDIO) into EventBus events that
+// the WebSocket layer can broadcast to clients.
+//
+// It also subscribes to ReadingModule events:
+//   - reading.line_changed → audio.play_voice (auto voice playback per line)
+//   - reading.completed    → audio.set_bgm   (restore phase BGM after reading)
+package media
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func init() {
+	engine.Register("audio", func() engine.Module { return NewAudioModule() })
+}
+
+// AudioModule reacts to audio PhaseActions and bridges reading events to audio events.
+type AudioModule struct {
+	mu           sync.RWMutex
+	deps         engine.ModuleDeps
+	currentBGMId string
+	phaseBGMId   string // base BGM for the current phase (used to restore after reading override)
+	subIDs       []int
+}
+
+// NewAudioModule creates a new AudioModule instance (per session).
+func NewAudioModule() *AudioModule {
+	return &AudioModule{}
+}
+
+func (m *AudioModule) Name() string { return "audio" }
+
+func (m *AudioModule) Init(_ context.Context, deps engine.ModuleDeps, _ json.RawMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deps = deps
+
+	// reading.line_changed → emit audio.play_voice if a voiceId is present.
+	lineSub := deps.EventBus.Subscribe("reading.line_changed", func(e engine.Event) {
+		payload, ok := e.Payload.(map[string]any)
+		if !ok {
+			return
+		}
+		voiceID, _ := payload["voiceId"].(string)
+		if voiceID == "" {
+			return
+		}
+		deps.EventBus.Publish(engine.Event{
+			Type:    "audio.play_voice",
+			Payload: map[string]any{"voiceId": voiceID},
+		})
+	})
+
+	// reading.completed → restore the phase BGM (best-effort; no-op if unset).
+	completedSub := deps.EventBus.Subscribe("reading.completed", func(_ engine.Event) {
+		m.mu.RLock()
+		restoreBGM := m.phaseBGMId
+		m.mu.RUnlock()
+		if restoreBGM == "" {
+			return
+		}
+		deps.EventBus.Publish(engine.Event{
+			Type:    "audio.set_bgm",
+			Payload: map[string]any{"mediaId": restoreBGM, "fadeMs": 1500},
+		})
+	})
+
+	m.subIDs = append(m.subIDs, lineSub, completedSub)
+	return nil
+}
+
+func (m *AudioModule) BuildState() (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state := map[string]any{
+		"currentBGMId": m.currentBGMId,
+		"phaseBGMId":   m.phaseBGMId,
+	}
+	return json.Marshal(state)
+}
+
+// HandleMessage is unused: AudioModule is driven entirely by PhaseActions and EventBus.
+func (m *AudioModule) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
+	return fmt.Errorf("audio: no direct messages supported")
+}
+
+func (m *AudioModule) Cleanup(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.deps.EventBus != nil {
+		for _, id := range m.subIDs {
+			m.deps.EventBus.Unsubscribe(id)
+		}
+	}
+	m.subIDs = nil
+	return nil
+}
+
+// SupportedActions declares the PhaseActions this module reacts to.
+func (m *AudioModule) SupportedActions() []engine.PhaseAction {
+	return []engine.PhaseAction{
+		engine.ActionPlaySound,
+		engine.ActionPlayMedia,
+		engine.ActionSetBGM,
+		engine.ActionStopAudio,
+	}
+}
+
+// ReactTo translates an audio PhaseAction into an EventBus event.
+//
+// SET_BGM updates both currentBGMId and phaseBGMId. ReadingModule overrides
+// during a reading section should publish audio.set_bgm on the EventBus
+// directly (not via PhaseAction) so phaseBGMId stays pinned to the phase BGM
+// and can be restored on reading.completed.
+func (m *AudioModule) ReactTo(_ context.Context, action engine.PhaseActionPayload) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var eventType string
+	switch action.Action {
+	case engine.ActionPlaySound:
+		eventType = "audio.play_sound"
+	case engine.ActionPlayMedia:
+		eventType = "audio.play_media"
+	case engine.ActionSetBGM:
+		eventType = "audio.set_bgm"
+		var p struct {
+			MediaID string `json:"mediaId"`
+		}
+		if len(action.Params) > 0 {
+			_ = json.Unmarshal(action.Params, &p)
+		}
+		m.currentBGMId = p.MediaID
+		m.phaseBGMId = p.MediaID
+	case engine.ActionStopAudio:
+		eventType = "audio.stop"
+	default:
+		return fmt.Errorf("audio: unsupported action %q", action.Action)
+	}
+
+	m.deps.EventBus.Publish(engine.Event{
+		Type:    eventType,
+		Payload: json.RawMessage(action.Params),
+	})
+	return nil
+}

--- a/apps/server/internal/module/media/audio_test.go
+++ b/apps/server/internal/module/media/audio_test.go
@@ -1,0 +1,145 @@
+package media
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+type testLogger struct{}
+
+func (testLogger) Printf(format string, v ...any) {}
+
+func newTestDeps(t *testing.T) (engine.ModuleDeps, *engine.EventBus) {
+	t.Helper()
+	log := testLogger{}
+	bus := engine.NewEventBus(log)
+	deps := engine.ModuleDeps{
+		SessionID: uuid.New(),
+		EventBus:  bus,
+		Logger:    log,
+	}
+	return deps, bus
+}
+
+func TestAudioModule_SupportedActions(t *testing.T) {
+	m := NewAudioModule()
+	actions := m.SupportedActions()
+	want := map[engine.PhaseAction]bool{
+		engine.ActionPlaySound: true,
+		engine.ActionPlayMedia: true,
+		engine.ActionSetBGM:    true,
+		engine.ActionStopAudio: true,
+	}
+	if len(actions) != len(want) {
+		t.Fatalf("SupportedActions length = %d, want %d", len(actions), len(want))
+	}
+	for _, a := range actions {
+		if !want[a] {
+			t.Errorf("unexpected action %q", a)
+		}
+	}
+}
+
+func TestAudioModule_ReactTo_SetBGM(t *testing.T) {
+	deps, bus := newTestDeps(t)
+	m := NewAudioModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer func() { _ = m.Cleanup(context.Background()) }()
+
+	received := make(chan engine.Event, 1)
+	bus.Subscribe("audio.set_bgm", func(e engine.Event) {
+		received <- e
+	})
+
+	params, _ := json.Marshal(map[string]any{"mediaId": "bgm-123", "fadeMs": 2000})
+	err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionSetBGM,
+		Params: params,
+	})
+	if err != nil {
+		t.Fatalf("ReactTo: %v", err)
+	}
+
+	select {
+	case <-received:
+		// ok
+	default:
+		t.Fatal("expected audio.set_bgm event to be published")
+	}
+
+	// State should be updated.
+	state, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	var parsed struct {
+		CurrentBGMId string `json:"currentBGMId"`
+		PhaseBGMId   string `json:"phaseBGMId"`
+	}
+	if err := json.Unmarshal(state, &parsed); err != nil {
+		t.Fatalf("Unmarshal state: %v", err)
+	}
+	if parsed.CurrentBGMId != "bgm-123" {
+		t.Errorf("currentBGMId = %q, want bgm-123", parsed.CurrentBGMId)
+	}
+	if parsed.PhaseBGMId != "bgm-123" {
+		t.Errorf("phaseBGMId = %q, want bgm-123", parsed.PhaseBGMId)
+	}
+}
+
+func TestAudioModule_ReactTo_UnsupportedAction(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	m := NewAudioModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer func() { _ = m.Cleanup(context.Background()) }()
+
+	err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionOpenVoting,
+	})
+	if err == nil {
+		t.Error("expected error for unsupported action, got nil")
+	}
+}
+
+func TestAudioModule_ReadingLineChanged_PublishesPlayVoice(t *testing.T) {
+	deps, bus := newTestDeps(t)
+	m := NewAudioModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer func() { _ = m.Cleanup(context.Background()) }()
+
+	received := make(chan engine.Event, 1)
+	bus.Subscribe("audio.play_voice", func(e engine.Event) {
+		received <- e
+	})
+
+	// Simulate ReadingModule emitting line_changed with voiceId.
+	bus.Publish(engine.Event{
+		Type: "reading.line_changed",
+		Payload: map[string]any{
+			"lineIndex":  0,
+			"totalLines": 5,
+			"voiceId":    "voice-abc",
+		},
+	})
+
+	select {
+	case e := <-received:
+		payload, _ := e.Payload.(map[string]any)
+		if payload["voiceId"] != "voice-abc" {
+			t.Errorf("voiceId = %v, want voice-abc", payload["voiceId"])
+		}
+	default:
+		t.Fatal("expected audio.play_voice event to be published")
+	}
+}

--- a/apps/server/internal/module/progression/reading.go
+++ b/apps/server/internal/module/progression/reading.go
@@ -18,6 +18,8 @@ type ReadingModule struct {
 	// config
 	advanceMode    string // "gm", "auto", "player"
 	defaultVoiceID string
+	bgmId          string
+	lines          []readingLineConfig
 
 	// state
 	currentLineIndex int
@@ -26,9 +28,15 @@ type ReadingModule struct {
 }
 
 type readingConfig struct {
-	AdvanceMode    string `json:"AdvanceMode"`
-	DefaultVoiceID string `json:"DefaultVoiceID"`
-	TotalLines     int    `json:"TotalLines"`
+	AdvanceMode    string              `json:"AdvanceMode"`
+	DefaultVoiceID string              `json:"DefaultVoiceID"`
+	TotalLines     int                 `json:"TotalLines"`
+	Lines          []readingLineConfig `json:"Lines,omitempty"`
+	BGMId          string              `json:"BGMId,omitempty"`
+}
+
+type readingLineConfig struct {
+	VoiceID string `json:"VoiceID,omitempty"`
 }
 
 // NewReadingModule creates a new ReadingModule instance.
@@ -58,11 +66,32 @@ func (m *ReadingModule) Init(ctx context.Context, deps engine.ModuleDeps, config
 
 	m.advanceMode = cfg.AdvanceMode
 	m.defaultVoiceID = cfg.DefaultVoiceID
+	m.bgmId = cfg.BGMId
+	m.lines = cfg.Lines
 	m.totalLines = cfg.TotalLines
+	if m.totalLines == 0 && len(m.lines) > 0 {
+		m.totalLines = len(m.lines)
+	}
 	m.currentLineIndex = 0
 	m.isActive = true
 
+	// If section BGM configured, emit override on activation
+	if m.bgmId != "" {
+		deps.EventBus.Publish(engine.Event{
+			Type:    "audio.set_bgm",
+			Payload: map[string]any{"mediaId": m.bgmId, "fadeMs": 1000},
+		})
+	}
+
 	return nil
+}
+
+// resolveVoiceID returns the voiceID for a given line index, falling back to default.
+func (m *ReadingModule) resolveVoiceID(idx int) string {
+	if idx >= 0 && idx < len(m.lines) && m.lines[idx].VoiceID != "" {
+		return m.lines[idx].VoiceID
+	}
+	return m.defaultVoiceID
 }
 
 func (m *ReadingModule) HandleMessage(ctx context.Context, playerID uuid.UUID, msgType string, payload json.RawMessage) error {
@@ -94,6 +123,7 @@ func (m *ReadingModule) HandleMessage(ctx context.Context, playerID uuid.UUID, m
 		m.currentLineIndex++
 		lineIndex := m.currentLineIndex
 		totalLines := m.totalLines
+		voiceID := m.resolveVoiceID(lineIndex)
 		completed := m.currentLineIndex >= m.totalLines-1
 		if completed {
 			m.isActive = false
@@ -101,8 +131,12 @@ func (m *ReadingModule) HandleMessage(ctx context.Context, playerID uuid.UUID, m
 		m.mu.Unlock()
 
 		m.deps.EventBus.Publish(engine.Event{
-			Type:    "reading.line_changed",
-			Payload: map[string]any{"lineIndex": lineIndex, "totalLines": totalLines},
+			Type: "reading.line_changed",
+			Payload: map[string]any{
+				"lineIndex":  lineIndex,
+				"totalLines": totalLines,
+				"voiceId":    voiceID,
+			},
 		})
 
 		// Check if this was the last line
@@ -113,6 +147,19 @@ func (m *ReadingModule) HandleMessage(ctx context.Context, playerID uuid.UUID, m
 			})
 		}
 		return nil
+
+	case "reading:voice_ended":
+		if !m.isActive {
+			m.mu.Unlock()
+			return nil
+		}
+		if m.advanceMode != "auto" {
+			m.mu.Unlock()
+			return nil // non-auto modes ignore voice_ended
+		}
+		m.mu.Unlock()
+		// Trigger advance by recursing (self message)
+		return m.HandleMessage(ctx, playerID, "reading:advance", nil)
 
 	case "reading:jump":
 		if !m.isActive {
@@ -134,6 +181,7 @@ func (m *ReadingModule) HandleMessage(ctx context.Context, playerID uuid.UUID, m
 		m.currentLineIndex = p.LineIndex
 		lineIndex := m.currentLineIndex
 		totalLines := m.totalLines
+		voiceID := m.resolveVoiceID(lineIndex)
 		completed := m.currentLineIndex >= m.totalLines-1
 		if completed {
 			m.isActive = false
@@ -141,8 +189,12 @@ func (m *ReadingModule) HandleMessage(ctx context.Context, playerID uuid.UUID, m
 		m.mu.Unlock()
 
 		m.deps.EventBus.Publish(engine.Event{
-			Type:    "reading.line_changed",
-			Payload: map[string]any{"lineIndex": lineIndex, "totalLines": totalLines},
+			Type: "reading.line_changed",
+			Payload: map[string]any{
+				"lineIndex":  lineIndex,
+				"totalLines": totalLines,
+				"voiceId":    voiceID,
+			},
 		})
 
 		// Check if jumped to last line
@@ -188,7 +240,17 @@ func (m *ReadingModule) Schema() json.RawMessage {
 		"properties": {
 			"AdvanceMode": {"type": "string", "enum": ["gm", "auto", "player"], "default": "gm"},
 			"DefaultVoiceID": {"type": "string"},
-			"TotalLines": {"type": "integer", "minimum": 0}
+			"TotalLines": {"type": "integer", "minimum": 0},
+			"BGMId": {"type": "string"},
+			"Lines": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"VoiceID": {"type": "string"}
+					}
+				}
+			}
 		}
 	}`)
 }

--- a/apps/server/internal/module/register.go
+++ b/apps/server/internal/module/register.go
@@ -8,5 +8,6 @@ import (
 	_ "github.com/mmp-platform/server/internal/module/core"
 	_ "github.com/mmp-platform/server/internal/module/decision"
 	_ "github.com/mmp-platform/server/internal/module/exploration"
+	_ "github.com/mmp-platform/server/internal/module/media"
 	_ "github.com/mmp-platform/server/internal/module/progression"
 )


### PR DESCRIPTION
## Summary

Phase 7.7 (오디오/미디어) Step 2 — 게임 엔진에 오디오 훅을 추가. 페이즈별 BGM 자동 전환, 리딩 섹션의 voice 연동, module-independent 오디오 액션 처리.

## What's included

- **PhaseAction 확장**: `ActionStopAudio` 추가
- **AudioModule (PhaseReactor)**: PLAY_SOUND/PLAY_MEDIA/SET_BGM/STOP_AUDIO를 EventBus로 변환 발행
- **EventBus 구독**: `reading.line_changed` → `audio.play_voice` 자동 발행, `reading.completed` → 페이즈 BGM 복귀
- **enterCurrentPhase**: `PhaseConfig.bgmId` 자동 SET_BGM 주입 (onEnter 앞)
- **ReadingModule 확장**: 줄별 VoiceID 오버라이드, 섹션 BGM, `reading:voice_ended` 핸들러
- **validation.go**: `mediaAssets` 참조 무결성 검증 (bgmId + PLAY_MEDIA/SET_BGM)
- **4개 AudioModule 유닛 테스트**

## Architecture decisions

- AudioModule은 `ActionRequiresModule`에 등록 안 함 → module-independent 브로드캐스트 경로
- 서버는 "무엇을 재생하라"만 지시, 실제 오디오는 클라이언트 책임
- advanceMode=auto에서 voice 완료는 클라이언트가 `reading:voice_ended` 전송

## Test plan

- [x] `go build ./...` — 통과
- [x] `go vet ./...` — 통과
- [x] `go test ./internal/engine/ ./internal/module/...` — 전체 통과 (7개 모듈 패키지)
- [x] 신규 AudioModule 테스트 4/4 PASS
- [x] 기존 ReadingModule 테스트 회귀 없음

## Deferred to follow-up

- 리딩 섹션 BGM 오버라이드 + 복귀 로직 (현재는 단순화)
- WS 브로드캐스트 배선 (audio.* 이벤트 → 클라이언트) — Step 3에서 프론트 통합 시

🤖 Generated with [Claude Code](https://claude.com/claude-code)