### PR TITLE
docs(phase-8.0): engine integration layer design + plan-autopilot infra

### DIFF
--- a/.claude/active-plan.json
+++ b/.claude/active-plan.json
@@ -1,0 +1,169 @@
+{
+  "active": {
+    "id": "phase-8.0-engine-integration",
+    "name": "Phase 8.0 — Engine Integration Layer",
+    "dir": "docs/plans/2026-04-08-engine-integration",
+    "design": "docs/plans/2026-04-08-engine-integration/design.md",
+    "plan": "docs/plans/2026-04-08-engine-integration/plan.md",
+    "checklist": "docs/plans/2026-04-08-engine-integration/checklist.md",
+    "progress_memory": "memory/project_phase80_progress.md",
+    "scope": [
+      "apps/server/internal/session/**",
+      "apps/server/internal/ws/hub.go",
+      "apps/server/internal/ws/base_module_handler*",
+      "apps/server/internal/ws/handlers/**",
+      "apps/server/internal/bridge/**",
+      "apps/server/internal/engine/**",
+      "apps/server/internal/domain/room/**",
+      "apps/server/cmd/server/main.go"
+    ],
+    "started_at": "2026-04-08",
+    "started_commit": "52fd23e",
+    "current_wave": "W0",
+    "current_pr": "PR-0",
+    "current_task": "plan.md + checklist refs + PR-0 commit",
+    "status": "in_progress",
+    "blockers": [],
+    "waves": [
+      {
+        "id": "W0",
+        "name": "docs-and-infra",
+        "mode": "sequential",
+        "prs": ["PR-0"]
+      },
+      {
+        "id": "W1",
+        "name": "skeletons",
+        "mode": "parallel",
+        "prs": ["PR-1", "PR-2"]
+      },
+      {
+        "id": "W2",
+        "name": "infra",
+        "mode": "sequential",
+        "prs": ["PR-3"]
+      },
+      {
+        "id": "W3",
+        "name": "pattern-reference",
+        "mode": "sequential",
+        "prs": ["PR-4"]
+      },
+      {
+        "id": "W4",
+        "name": "parallel-wiring",
+        "mode": "parallel",
+        "prs": ["PR-5", "PR-6", "PR-7", "PR-8"]
+      },
+      {
+        "id": "W5",
+        "name": "observability",
+        "mode": "sequential",
+        "prs": ["PR-9"]
+      }
+    ],
+    "prs": {
+      "PR-0": {
+        "title": "Docs + plan-autopilot infra",
+        "depends_on": [],
+        "scope": ["docs/plans/2026-04-08-engine-integration/**", ".claude/**", "CLAUDE.md", "memory/**"],
+        "tasks_total": 10,
+        "tasks_done": 5,
+        "status": "in_progress",
+        "branch": "feat/phase-8.0/pr-0-docs-infra",
+        "commit": null
+      },
+      "PR-1": {
+        "title": "SessionManager + Session actor skeleton",
+        "depends_on": ["PR-0"],
+        "scope": ["apps/server/internal/session/**"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-1-session-manager",
+        "commit": null
+      },
+      "PR-2": {
+        "title": "Hub lifecycle listener",
+        "depends_on": ["PR-0"],
+        "scope": ["apps/server/internal/ws/hub.go", "apps/server/internal/ws/hub_test.go"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-2-hub-lifecycle",
+        "commit": null
+      },
+      "PR-3": {
+        "title": "BaseModuleHandler + EventMapping",
+        "depends_on": ["PR-1", "PR-2"],
+        "scope": ["apps/server/internal/ws/base_module_handler*", "apps/server/internal/session/event_mapping*", "apps/server/internal/session/registry.go"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-3-base-handler",
+        "commit": null
+      },
+      "PR-4": {
+        "title": "Reading module wired (pattern reference)",
+        "depends_on": ["PR-3"],
+        "scope": ["apps/server/internal/ws/handlers/reading.go", "apps/server/internal/session/registry_reading.go", "apps/server/internal/session/event_mapping_reading.go", "apps/server/internal/bridge/reading_bridge.go"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-4-reading-wired",
+        "commit": null
+      },
+      "PR-5": {
+        "title": "Core 4 modules wired",
+        "depends_on": ["PR-4"],
+        "scope": ["apps/server/internal/ws/handlers/core_*.go", "apps/server/internal/session/registry_core.go", "apps/server/internal/session/event_mapping_core.go"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-5-core-modules",
+        "commit": null
+      },
+      "PR-6": {
+        "title": "Progression 7 modules wired",
+        "depends_on": ["PR-4"],
+        "scope": ["apps/server/internal/ws/handlers/progression_*.go", "apps/server/internal/session/registry_progression.go", "apps/server/internal/session/event_mapping_progression.go"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-6-progression-modules",
+        "commit": null
+      },
+      "PR-7": {
+        "title": "Redis snapshot + Lazy restore",
+        "depends_on": ["PR-4"],
+        "scope": ["apps/server/internal/session/snapshot*", "apps/server/internal/session/restore*", "apps/server/internal/session/registry_snapshot.go"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-7-snapshot-restore",
+        "commit": null
+      },
+      "PR-8": {
+        "title": "Game start API + abort + idle timeout",
+        "depends_on": ["PR-4"],
+        "scope": ["apps/server/internal/domain/room/**", "apps/server/cmd/server/main.go"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-8-game-start-api",
+        "commit": null
+      },
+      "PR-9": {
+        "title": "Observability (Prometheus + OTel)",
+        "depends_on": ["PR-5", "PR-6", "PR-7", "PR-8"],
+        "scope": ["apps/server/internal/session/metrics*", "apps/server/internal/ws/metrics*"],
+        "tasks_total": 0,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "feat/phase-8.0/pr-9-observability",
+        "commit": null
+      }
+    }
+  },
+  "history": []
+}

--- a/.claude/commands/plan-autopilot.md
+++ b/.claude/commands/plan-autopilot.md
@@ -1,0 +1,134 @@
+---
+description: Run wave-based autopilot execution loop
+argument-hint: [--until WAVE] [--only PR-N] [--dry-run]
+---
+
+Execute the active plan using wave-based parallel sub-agents.
+
+## Prerequisites check
+
+1. Verify `.claude/active-plan.json` exists. If not: report "Run /plan-start first" and exit.
+2. Verify `.claude/post-task-pipeline.json` exists. If not: offer to copy from template.
+3. Verify design.md, plan.md, checklist.md paths resolve. If not: error.
+4. Check git working directory is clean (or near-clean). If dirty: warn + ask to proceed.
+
+## Parse arguments
+
+- `--until WAVE`: run waves up to and including WAVE
+- `--only PR-N`: run only one PR (useful for debugging)
+- `--dry-run`: print wave manifests without executing
+
+## Execution loop
+
+For each wave in `.active.waves` (starting from current_wave):
+
+### 1. Pre-wave checks
+```bash
+.claude/scripts/plan-wave.sh check-deps <wave.id>
+.claude/scripts/plan-wave.sh validate <wave.id>   # if parallel, check scope overlaps
+```
+
+### 2. Generate manifest
+```bash
+.claude/scripts/plan-wave.sh manifest <wave.id>
+```
+
+### 3. Spawn sub-agents (THIS IS THE KEY STEP)
+
+**Parallel wave**: In ONE message, use multiple Agent tool calls with `isolation: "worktree"`:
+```
+Agent(subagent_type="oh-my-claudecode:executor",
+      isolation="worktree",
+      prompt=<from manifest>)
+Agent(subagent_type="oh-my-claudecode:executor",
+      isolation="worktree",
+      prompt=<from manifest>)
+...
+```
+(All agent calls in the SAME message = true parallelism)
+
+**Sequential wave**: One Agent call per PR, wait for completion before next.
+
+### 4. Collect results
+
+Each sub-agent returns: `{pr_id, branch, commit_hash, status, findings_summary}`
+
+Aggregate into wave summary.
+
+### 5. Sequential merge with test gate
+
+```bash
+.claude/scripts/run-pipeline.sh --merge-wave <wave.id>
+```
+
+This runs `git merge` for each PR's branch in order, running `go test -race` between merges.
+
+On merge conflict: spawn Agent(subagent_type="oh-my-claudecode:executor") with prompt to resolve.
+
+### 6. Wave gate (user confirmation)
+
+Read `global.require_user_confirm_before_merge` from pipeline config. If true (default):
+
+```
+═══════════════════════════════════════════
+ Wave <N> Complete
+═══════════════════════════════════════════
+PRs merged: <list with commit hashes>
+Tests: PASS
+Duration: <elapsed>
+Findings resolved: <count>
+
+Continue to Wave <N+1>? [y/n/pause]
+```
+
+- `y`: advance wave, continue loop
+- `n`: stop autopilot
+- `pause`: save state to `.claude/autopilot-state.json`, exit
+
+### 7. Update active-plan.json
+
+```bash
+.claude/scripts/autopilot-loop.sh advance-wave <next.wave.id>
+```
+
+### 8. Continue or terminate
+
+If more waves remain → next iteration.
+If last wave complete → run `after_plan` pipeline:
+- `/plan-finish`
+- Notification message
+
+## Inside each sub-agent (reference only — the agent itself handles this)
+
+The spawned sub-agent's prompt (from `plan-wave.sh manifest`) instructs it to:
+1. Read design.md + checklist PR section
+2. Implement tasks in order, atomic commits
+3. Run `after_task` pipeline (format + scope test) per task
+4. Mark ✅ in checklist per task
+5. After all tasks: run `after_pr` pipeline (full test + lint + 4 parallel reviewers + fix-loop ≤3 + commit + push + create PR)
+6. Return result
+
+## Fix-loop (inside sub-agent)
+
+If any review finds CRITICAL/HIGH:
+- iteration 1: spawn executor to fix
+- iteration 2: re-run 4 reviewers, if still findings → spawn executor
+- iteration 3: final attempt
+- iteration > 3: pause + report
+
+## Failure handling
+
+- Pre-check fail → exit with message
+- Sub-agent error → save state, report
+- Merge conflict → auto-resolve attempt, then user
+- CI failure (after push) → wait max 30min, then pause
+- Fix-loop exhausted → hard pause, `/plan-resume` later
+
+## Important
+
+- **Always use `isolation: "worktree"`** for parallel wave agents — file conflicts are guaranteed otherwise
+- **Batch all parallel Agent calls in ONE message** — sequential tool_use is not parallel
+- **Respect 200-line limit** — remind sub-agents in the spawn prompt
+- **STATUS marker updates** — sub-agents must update checklist.md's STATUS marker after task completion
+
+**Skill reference**: `~/.claude/skills/plan-autopilot/refs/execution.md`

--- a/.claude/commands/plan-autopilot.md
+++ b/.claude/commands/plan-autopilot.md
@@ -1,5 +1,5 @@
 ---
-description: Run wave-based autopilot execution loop
+description: (sabyun) Wave 기반 병렬 자동 실행 루프 (sub-agent + worktree + 4 parallel reviewers)
 argument-hint: [--until WAVE] [--only PR-N] [--dry-run]
 ---
 

--- a/.claude/commands/plan-finish.md
+++ b/.claude/commands/plan-finish.md
@@ -1,5 +1,5 @@
 ---
-description: Archive current active plan as completed
+description: (sabyun) 현재 active plan을 완료 처리하고 archive
 allowed-tools: Read Write Bash(jq*) Bash(git*) Bash(mv*) Bash(mkdir*) Bash(rm*)
 ---
 

--- a/.claude/commands/plan-finish.md
+++ b/.claude/commands/plan-finish.md
@@ -1,0 +1,45 @@
+---
+description: Archive current active plan as completed
+allowed-tools: Read Write Bash(jq*) Bash(git*) Bash(mv*) Bash(mkdir*) Bash(rm*)
+---
+
+Archive current active plan as completed.
+
+## Steps
+
+1. Read `.claude/active-plan.json`. If absent: report "No active plan" and exit.
+2. Read active checklist.md. Count completed vs total tasks:
+   - If NOT all completed: warn user with count, ask "Force finish anyway? [y/n]"
+   - Note force-finished status if applicable
+3. Enrich plan data with completion metadata:
+   ```json
+   {
+     "id": "<plan.id>",
+     "name": "<plan.name>",
+     "started_at": "<plan.started_at>",
+     "finished_at": "<today>",
+     "final_commit": "<git rev-parse --short HEAD>",
+     "tasks_done": N,
+     "tasks_total": M,
+     "force_finished": false
+   }
+   ```
+4. Move to archive:
+   ```bash
+   mkdir -p .claude/archived_plans
+   mv .claude/active-plan.json .claude/archived_plans/<plan.id>.json
+   ```
+5. Update root phase checklist — mark phase ✅.
+6. Update memory files:
+   - `memory/project_phases.md`: move to completed
+   - `memory/project_phaseNN_progress.md`: final state
+   - `memory/MEMORY.md`: remove active pointer
+7. Suggest commit:
+   ```
+   Ready to commit:
+     git add .claude/archived_plans/<plan.id>.json memory/ docs/plans/*/checklist.md
+     git commit -m "chore: archive <plan.id> as completed"
+
+   Hooks now inactive (active-plan.json absent). Normal workflow restored.
+   Suggested next: /plan-new <topic> for follow-up phase
+   ```

--- a/.claude/commands/plan-new.md
+++ b/.claude/commands/plan-new.md
@@ -1,5 +1,5 @@
 ---
-description: Author a new phase plan via brainstorming + writing-plans + plan-autopilot templates
+description: (sabyun) 새 phase 플랜 저작 — brainstorming + writing-plans + plan-autopilot 템플릿 통합
 argument-hint: <topic>
 allowed-tools: Read Write Edit Bash(mkdir*) Bash(git*) Bash(cp*) Bash(wc*)
 ---

--- a/.claude/commands/plan-new.md
+++ b/.claude/commands/plan-new.md
@@ -1,0 +1,77 @@
+---
+description: Author a new phase plan via brainstorming + writing-plans + plan-autopilot templates
+argument-hint: <topic>
+allowed-tools: Read Write Edit Bash(mkdir*) Bash(git*) Bash(cp*) Bash(wc*)
+---
+
+Start a new phase plan for: **$ARGUMENTS**
+
+Follow this workflow strictly.
+
+## Stage 1: Brainstorming
+
+Invoke `superpowers:brainstorming` with guardrails:
+- Output must fit plan-autopilot format (wave-based DAG)
+- Identify PR-level dependencies explicitly
+- Specify scope_globs per PR
+- Determine parallel vs sequential waves
+- All docs <200 lines (index + refs pattern)
+- Cover 7 standard decisions:
+  1. Scope (what's in/out)
+  2. Architecture pattern
+  3. Lifecycle (create/destroy/transition)
+  4. External interface
+  5. Persistence/state
+  6. Operational safety (panic, observability, tests)
+  7. Rollout strategy (feature flag + waves)
+
+Wait for user approval of design before proceeding.
+
+## Stage 2: Plan writing
+
+Invoke `superpowers:writing-plans` with:
+- Design path from stage 1
+- PR breakdown with id/title/depends_on/scope_globs/tasks
+- Wave grouping (topological sort)
+- Each PR plan file <200 lines
+- Task granularity: one commit per task
+
+## Stage 3: Template materialization
+
+Create `docs/plans/YYYY-MM-DD-<slug>/`.
+
+Copy from `~/.claude/skills/plan-autopilot/templates/`:
+- `design.index.template.md` → `design.md`
+- `plan.index.template.md` → `plan.md`
+- `checklist.index.template.md` → `checklist.md` (STATUS marker at top!)
+- Create `refs/pr-N-<slug>.md` per PR
+
+Also create from brainstorming output:
+- `refs/scope-and-decisions.md`
+- `refs/architecture.md`
+- `refs/execution-model.md` (**required** — wave DAG)
+- `refs/observability-testing.md`
+- `refs/data-flow.md` (optional)
+- `refs/persistence.md` (optional)
+
+## Stage 4: Quality gates
+
+Before success:
+- [ ] All .md files <200 lines (`find docs/plans/YYYY-MM-DD-<slug> -name '*.md' | xargs wc -l | awk '$1>200{print}'` → empty)
+- [ ] STATUS marker in checklist.md
+- [ ] Dependency graph is valid DAG
+- [ ] Each PR has ≥1 task
+- [ ] scope_globs cover all files
+
+## Stage 5: Initial commit
+
+```bash
+git add docs/plans/YYYY-MM-DD-<slug>/
+git commit -m "docs(<phase-id>): initial plan — design + plan + checklist"
+```
+
+Report path. Next:
+- `/plan-start docs/plans/YYYY-MM-DD-<slug>` to activate
+- `/plan-autopilot` to execute
+
+**Skill reference**: `~/.claude/skills/plan-autopilot/refs/authoring.md`

--- a/.claude/commands/plan-resume.md
+++ b/.claude/commands/plan-resume.md
@@ -1,5 +1,5 @@
 ---
-description: Full context restore for resuming work after /clear
+description: (sabyun) /clear 후 전체 컨텍스트 복원 — design + plan + checklist + progress + git 한번에 로드
 allowed-tools: Read Bash(jq*) Bash(git*)
 ---
 

--- a/.claude/commands/plan-resume.md
+++ b/.claude/commands/plan-resume.md
@@ -1,0 +1,84 @@
+---
+description: Full context restore for resuming work after /clear
+allowed-tools: Read Bash(jq*) Bash(git*)
+---
+
+Full context restore — read all plan files and summarize current state.
+
+## Preload live data
+
+### Active plan pointer
+!`cat .claude/active-plan.json 2>/dev/null || echo "(no active plan)"`
+
+### Git state
+!`git log --oneline -10`
+!`git status --short`
+!`git branch --show-current`
+
+### Autopilot state (if paused)
+!`[ -f .claude/autopilot-state.json ] && cat .claude/autopilot-state.json || echo "(no paused state)"`
+
+---
+
+## Steps
+
+1. Read these files (all — this is the source of truth restore):
+   - `<plan.design>` (from active-plan.json)
+   - `<plan.plan>`
+   - `<plan.checklist>`
+   - `<plan.progress_memory>`
+   - `.claude/post-task-pipeline.json`
+2. Also load current PR's detailed file if it exists:
+   - `<plan.dir>/refs/pr-<current_pr>-*.md`
+3. Summarize:
+
+```
+═══════════════════════════════════════════
+ Plan Context Restored
+═══════════════════════════════════════════
+
+Phase: <name>
+Started: <date> (<commit>)
+
+--- Current Position ---
+Wave: <current>/<total>
+PR: <current_pr> — <title>
+Task: <current_task>
+Status: <status>
+Branch: <git current branch>
+
+--- Completed ---
+<list of ✅ tasks in current PR>
+<list of completed PRs>
+
+--- Next ---
+<next uncompleted task with file paths>
+<next PR in wave if any>
+<next wave if current complete>
+
+--- Blockers ---
+<list from active-plan.json>
+
+--- Recent Commits ---
+<from git log above>
+
+--- Uncommitted ---
+<from git status above>
+
+--- Files Reminder ---
+Design: <plan.design>
+Plan: <plan.plan>
+Checklist: <plan.checklist>
+Progress: <plan.progress_memory>
+
+--- Scope ---
+<list of scope globs>
+
+--- Next Actions ---
+1. Continue current task manually
+2. /plan-autopilot — resume automated execution
+3. /plan-tasks — visual progress
+4. /plan-status — quick check
+```
+
+**Note**: The act of reading design + checklist above **satisfies the PreToolUse guard** for the next 30 minutes — edits in scope will proceed immediately.

--- a/.claude/commands/plan-start.md
+++ b/.claude/commands/plan-start.md
@@ -1,5 +1,5 @@
 ---
-description: Activate a plan directory as the current active plan
+description: (sabyun) 플랜 디렉터리를 현재 active plan으로 활성화
 argument-hint: <plan-directory>
 allowed-tools: Read Write Bash(git*) Bash(jq*) Bash(mv*) Bash(mkdir*)
 ---

--- a/.claude/commands/plan-start.md
+++ b/.claude/commands/plan-start.md
@@ -1,0 +1,48 @@
+---
+description: Activate a plan directory as the current active plan
+argument-hint: <plan-directory>
+allowed-tools: Read Write Bash(git*) Bash(jq*) Bash(mv*) Bash(mkdir*)
+---
+
+Activate plan at `$ARGUMENTS` as the current active plan.
+
+## Steps
+
+1. Verify `$ARGUMENTS/design.md` exists. If not, error out.
+2. Read `$ARGUMENTS/design.md` to extract:
+   - Phase name (from `# <title>` line)
+   - Phase id (derive from directory basename: e.g., `phase-8.0-engine-integration`)
+   - Scope globs (from refs/scope-and-decisions.md or design.md "Scope" section)
+   - Wave structure (from refs/execution-model.md)
+3. Read `$ARGUMENTS/plan.md` for PR list.
+4. Read `$ARGUMENTS/checklist.md` — verify STATUS marker present. Warn if missing.
+5. Check for existing `.claude/active-plan.json`:
+   - If exists: offer to archive (`mv to .claude/archived_plans/<old-id>.json`) or abort.
+6. Generate `.claude/active-plan.json` from template `~/.claude/skills/plan-autopilot/templates/active-plan.template.json`:
+   - `id`, `name`, `dir`, `design`, `plan`, `checklist`, `progress_memory`
+   - `scope`: extracted globs
+   - `started_at`: today
+   - `started_commit`: `git rev-parse --short HEAD`
+   - `current_wave`: first wave id
+   - `current_pr`: first PR id in first wave
+   - `current_task`: first unchecked task from checklist
+   - `status`: "in_progress"
+   - `waves`: array from design
+   - `prs`: object from plan
+7. Write file.
+8. Confirm:
+
+```
+✅ Activated: <name>
+Current: <wave> <pr>
+Next task: <task>
+
+Hooks are now active:
+- SessionStart injects STATUS (~30 lines)
+- UserPromptSubmit injects 1-line STATUS (~25 tokens)
+- PreToolUse BLOCKS edits in scope until design+checklist read
+- PostToolUse reminds to update checklist
+
+Run /plan-autopilot to begin wave execution.
+Run /plan-status to verify.
+```

--- a/.claude/commands/plan-status.md
+++ b/.claude/commands/plan-status.md
@@ -1,0 +1,28 @@
+---
+description: Quick snapshot of current active plan state
+allowed-tools: Bash(jq*) Bash(git*) Bash(cat*) Bash(sed*)
+---
+
+# Plan Status
+
+## Active plan
+!`~/.claude/skills/plan-autopilot/scripts/plan-status.sh --verbose`
+
+## Recent commits
+!`git log --oneline -5`
+
+## Uncommitted changes
+!`git status --short`
+
+## Autopilot state (if paused)
+!`[ -f .claude/autopilot-state.json ] && cat .claude/autopilot-state.json || echo "(no paused state)"`
+
+---
+
+Based on the above, summarize:
+- Current wave + PR + task
+- Recent activity context
+- Next recommended action:
+  - `in_progress` → continue manually or `/plan-autopilot`
+  - `paused` → `/plan-resume`
+  - `blocker` → list and suggest manual resolution

--- a/.claude/commands/plan-status.md
+++ b/.claude/commands/plan-status.md
@@ -1,5 +1,5 @@
 ---
-description: Quick snapshot of current active plan state
+description: (sabyun) 현재 active plan 상태 빠른 스냅샷 (wave/PR/task + git 상태)
 allowed-tools: Bash(jq*) Bash(git*) Bash(cat*) Bash(sed*)
 ---
 

--- a/.claude/commands/plan-stop.md
+++ b/.claude/commands/plan-stop.md
@@ -1,0 +1,27 @@
+---
+description: Stop running autopilot and save state
+allowed-tools: Bash Read Write
+---
+
+Stop the autopilot loop gracefully.
+
+## Steps
+
+1. Save current state:
+   ```bash
+   ~/.claude/skills/plan-autopilot/scripts/autopilot-loop.sh pause user_request
+   ```
+2. This creates `.claude/autopilot-state.json` with current wave, PR, timestamp, reason.
+3. **Note**: Sub-agents already in flight cannot be interrupted. They'll finish their current step.
+4. Report:
+   ```
+   ⏸ Autopilot paused.
+
+   Current: <wave> <pr>
+   Paused: <timestamp>
+
+   Resume: /plan-autopilot (or /plan-resume for full context)
+   Abort entirely: rm .claude/autopilot-state.json + /plan-status to verify
+   ```
+
+`.claude/active-plan.json` is NOT deleted — the plan stays active, just execution is paused.

--- a/.claude/commands/plan-stop.md
+++ b/.claude/commands/plan-stop.md
@@ -1,5 +1,5 @@
 ---
-description: Stop running autopilot and save state
+description: (sabyun) 실행 중인 autopilot 일시 정지 + state 저장 (/plan-resume으로 재개 가능)
 allowed-tools: Bash Read Write
 ---
 

--- a/.claude/commands/plan-tasks.md
+++ b/.claude/commands/plan-tasks.md
@@ -1,5 +1,5 @@
 ---
-description: Show task tree with progress percentages
+description: (sabyun) Task 트리 + 진행률 % 시각화 (wave/PR별 상태 아이콘)
 allowed-tools: Bash(jq*) Bash(grep*) Bash(wc*) Bash(find*)
 ---
 

--- a/.claude/commands/plan-tasks.md
+++ b/.claude/commands/plan-tasks.md
@@ -1,0 +1,21 @@
+---
+description: Show task tree with progress percentages
+allowed-tools: Bash(jq*) Bash(grep*) Bash(wc*) Bash(find*)
+---
+
+# Plan Tasks
+
+!`~/.claude/skills/plan-autopilot/scripts/plan-tasks.sh`
+
+---
+
+Based on the tree above, highlight:
+- Current wave + PR (🔄 icon)
+- Next uncompleted task with file path suggestion
+- Blockers in any wave
+- Estimated remaining work
+
+Suggest next action:
+- `/plan-autopilot` — start/resume automated execution
+- `/plan-status` — quick state check
+- `/plan-resume` — full context restore after /clear

--- a/.claude/post-task-pipeline.json
+++ b/.claude/post-task-pipeline.json
@@ -1,0 +1,197 @@
+{
+  "_comment": "plan-autopilot pipeline — maps each stage to existing skills (superpowers, oh-my-claudecode) with appropriate model selection. Opus for critical/complex judgment, Sonnet for mechanical work.",
+  "version": 1,
+  "default_mode": "subagent",
+
+  "after_task": [
+    {
+      "name": "format",
+      "type": "shell",
+      "command": "cd apps/server && go fmt ./...",
+      "blocking": true
+    },
+    {
+      "name": "scope-test",
+      "type": "shell",
+      "command": "cd apps/server && go test -race ./internal/session/...",
+      "blocking": true,
+      "on_fail": "stop"
+    },
+    {
+      "name": "mark-done",
+      "type": "internal",
+      "action": "mark_task_complete"
+    }
+  ],
+
+  "after_pr": [
+    {
+      "name": "full-test",
+      "type": "shell",
+      "command": "cd apps/server && go test -race -count=1 ./...",
+      "blocking": true,
+      "on_fail": "fix_loop"
+    },
+    {
+      "name": "lint",
+      "type": "shell",
+      "command": "cd apps/server && golangci-lint run",
+      "blocking": true,
+      "on_fail": "fix_loop"
+    },
+    {
+      "name": "review-security",
+      "type": "subagent",
+      "agent": "oh-my-claudecode:security-reviewer",
+      "model": "opus",
+      "prompt": "Review PR {pr_id} ({pr_title}) diff against {design}. Focus: auth/권한, injection, race conditions, secret exposure. Severity: CRITICAL/HIGH/MEDIUM/LOW.",
+      "parallel_group": "review",
+      "blocking": true,
+      "on_fail": "fix_loop"
+    },
+    {
+      "name": "review-perf",
+      "type": "subagent",
+      "agent": "oh-my-claudecode:code-reviewer",
+      "model": "sonnet",
+      "prompt": "Review PR {pr_id} for performance: lock contention, allocation hot paths, goroutine leaks, channel blocking. Severity-classified.",
+      "parallel_group": "review",
+      "blocking": true,
+      "on_fail": "fix_loop"
+    },
+    {
+      "name": "review-arch",
+      "type": "subagent",
+      "agent": "oh-my-claudecode:critic",
+      "model": "opus",
+      "prompt": "Review PR {pr_id} for architecture alignment with {design}. SOLID, layering, actor-pattern compliance, design decision drift. Challenge every design choice.",
+      "parallel_group": "review",
+      "blocking": true,
+      "on_fail": "fix_loop"
+    },
+    {
+      "name": "review-test",
+      "type": "subagent",
+      "agent": "oh-my-claudecode:test-engineer",
+      "model": "sonnet",
+      "prompt": "Review PR {pr_id} test coverage: race conditions, edge cases, missing scenarios, test isolation. Classify by severity.",
+      "parallel_group": "review",
+      "blocking": true,
+      "on_fail": "fix_loop"
+    },
+    {
+      "name": "verify",
+      "type": "skill",
+      "skill": "superpowers:verification-before-completion",
+      "args": "PR {pr_id} tests + lint + reviewers all passing before claiming complete",
+      "blocking": true
+    },
+    {
+      "name": "commit",
+      "type": "shell",
+      "command": "git add -A && git commit -m \"feat({plan.id}): {pr_id} {pr_title}\""
+    },
+    {
+      "name": "push",
+      "type": "shell",
+      "command": "git push -u origin feat/{plan.id}/{pr_id}"
+    },
+    {
+      "name": "create-pr",
+      "type": "shell",
+      "command": "gh pr create --title \"{pr_id}: {pr_title}\" --body-file .pr-body.tmp 2>/dev/null || echo '(gh unavailable, skipping)'"
+    },
+    {
+      "name": "wait-ci",
+      "type": "shell",
+      "command": "gh pr checks --watch --interval 30 2>/dev/null || true",
+      "blocking": false,
+      "on_fail": "warn"
+    }
+  ],
+
+  "after_wave": [
+    {
+      "name": "wave-test",
+      "type": "shell",
+      "command": "cd apps/server && go test -race -count=1 ./...",
+      "blocking": true,
+      "on_fail": "stop"
+    },
+    {
+      "name": "wave-confirm",
+      "type": "internal",
+      "action": "user_confirm",
+      "prompt": "Wave {wave.name} complete. All PRs tested (race). Merge to main and continue?"
+    },
+    {
+      "name": "wave-merge",
+      "type": "shell",
+      "command": "~/.claude/skills/plan-autopilot/scripts/run-pipeline.sh --merge-wave {wave.id}"
+    }
+  ],
+
+  "after_plan": [
+    {
+      "name": "finish",
+      "type": "slash",
+      "slash": "/plan-finish"
+    },
+    {
+      "name": "notify",
+      "type": "shell",
+      "command": "echo '🎉 Phase {plan.name} complete' >&2"
+    }
+  ],
+
+  "fix_loop": {
+    "max_iterations": 3,
+    "agent": "oh-my-claudecode:executor",
+    "model": "sonnet",
+    "prompt": "Previous stage '{stage_name}' failed. Findings:\n{findings}\n\nFix the issues and rerun relevant tests. Commit when ready. If fix requires architectural change, escalate by returning 'ESCALATE_TO_OPUS' in the first line.",
+    "on_max_exceeded": "abort_and_notify",
+    "escalation": {
+      "trigger": "ESCALATE_TO_OPUS",
+      "agent": "oh-my-claudecode:executor",
+      "model": "opus",
+      "effort": "high"
+    }
+  },
+
+  "orchestration": {
+    "parallel_dispatch_skill": "superpowers:dispatching-parallel-agents",
+    "subagent_driven_skill": "superpowers:subagent-driven-development",
+    "worktree_skill": "superpowers:using-git-worktrees",
+    "review_request_skill": "superpowers:requesting-code-review",
+    "review_receive_skill": "superpowers:receiving-code-review"
+  },
+
+  "pr_model_overrides": {
+    "_comment": "PR-specific model override. Complex PRs (actor pattern, snapshot algo) get Opus; mechanical copies get Sonnet.",
+    "PR-1": {"model": "opus", "effort": "high", "reason": "Actor pattern + lock removal requires careful concurrency analysis"},
+    "PR-7": {"model": "opus", "effort": "high", "reason": "Snapshot/restore algorithm + schema versioning"},
+    "PR-2": {"model": "sonnet"},
+    "PR-3": {"model": "sonnet"},
+    "PR-4": {"model": "opus", "reason": "Pattern reference — must be correct"},
+    "PR-5": {"model": "sonnet"},
+    "PR-6": {"model": "sonnet"},
+    "PR-8": {"model": "sonnet"},
+    "PR-9": {"model": "sonnet"}
+  },
+
+  "global": {
+    "default_implement_model": "sonnet",
+    "default_review_model": {
+      "security": "opus",
+      "architecture": "opus",
+      "performance": "sonnet",
+      "test-coverage": "sonnet"
+    },
+    "auto_continue": true,
+    "require_user_confirm_before_merge": true,
+    "clear_between_prs": false,
+    "max_parallel_prs_per_wave": 4,
+    "max_parallel_reviewers": 4,
+    "notify_on": ["abort", "blocker", "completion", "fix_loop_exceeded", "opus_escalation"]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "command": ".claude/scripts/plan-status.sh --verbose"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "command": ".claude/scripts/plan-status.sh --compact"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": ".claude/scripts/plan-guard.sh"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": ".claude/scripts/plan-remind.sh"
+      },
+      {
+        "matcher": "Read",
+        "command": ".claude/scripts/plan-track-reads.sh"
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,13 @@ Thumbs.db
 
 # ─── Worktrees ────────────────────────────────────────
 .worktrees/
+
+# ─── plan-autopilot (local runtime) ───────────────────
+.claude/autopilot-state.json
+.pr-body.tmp
+
+# ─── Local reference material (not versioned) ────────
+claude_skill_create.pdf
+
+# ─── Playwright ───────────────────────────────────────
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,41 @@
 ### 버전 관리
 - Semantic Versioning, Conventional Commits (feat/fix/perf/docs/test/chore)
 - 브랜치: main, feat/*, fix/*
+
+## Active Plan Workflow (plan-autopilot)
+
+이 프로젝트는 `plan-autopilot` 스킬로 phase 기반 개발을 관리합니다.
+- 스킬: `~/.claude/skills/plan-autopilot/SKILL.md`
+- 활성 plan 포인터: `.claude/active-plan.json` (없으면 hook no-op)
+
+### 현재 활성 plan
+**Phase 8.0 — Engine Integration Layer** (2026-04-08 시작)
+- design: `docs/plans/2026-04-08-engine-integration/design.md` (index) + `refs/`
+- plan: 작성 예정
+- 9 PRs, 5 waves (W1 병렬 ×2, W4 병렬 ×4)
+
+### 자동 hooks (사용자 개입 0)
+- SessionStart: STATUS + next task 주입 (~30줄)
+- UserPromptSubmit: 1줄 STATUS 주입 (~25 토큰)
+- PreToolUse (Edit/Write): **scope 내 파일은 design/checklist 읽기 전 BLOCK**
+- PostToolUse: checklist 갱신 reminder
+
+### Phase 경계 (드물게, phase당 2번)
+- `/plan-start <dir>` — 새 plan 활성화
+- `/plan-finish` — 완료 archive
+
+### 실행
+- `/plan-new <topic>` — brainstorming + writing-plans + 템플릿 저작
+- `/plan-autopilot` — wave 기반 자동 실행
+- `/plan-status`, `/plan-tasks` — 진행 상태
+- `/plan-resume` — `/clear` 후 컨텍스트 복원
+- `/plan-stop` — 실행 중단 (state 저장)
+
+### 필수 규칙
+- **모든 .md 파일 <200줄** (초과 시 `refs/` 분할 + index 패턴)
+- **STATUS 마커 형식 유지** (hook 파싱)
+- **Wave 병렬 PR은 `isolation: "worktree"`**
+- **Review는 4 병렬 agent** (security/perf/arch/test-coverage)
+- **Fix-loop 최대 3회** → 초과 시 user 개입
+- **Wave 머지 전 user 확인 1회**
+- **Feature flag default off** 로 in-flight wiring 보호

--- a/PLAN_AUTOPILOT.md
+++ b/PLAN_AUTOPILOT.md
@@ -1,0 +1,195 @@
+# Plan Autopilot — 사용 가이드
+
+이 프로젝트는 **plan-autopilot 스킬**로 phase 기반 개발을 관리합니다.
+현재 활성 플랜: **Phase 8.0 — Engine Integration Layer** (2026-04-08 시작)
+
+상세 문서: [docs/plan-autopilot-guide/](docs/plan-autopilot-guide/)
+
+---
+
+## 🚀 다음 세션 시작 시 (가장 먼저 할 일)
+
+### 1. 세션 시작하면 자동으로
+SessionStart hook이 실행되어 다음이 자동 주입됩니다:
+- 현재 active plan 정보 (`.claude/active-plan.json` 기반)
+- STATUS 마커 (wave, PR, 현재 task, blocker)
+- Scope 파일 목록
+- 다음 권장 action
+
+→ **바로 작업 상태를 파악 가능.** 추가 조회 불필요.
+
+### 2. 컨텍스트 더 필요하면
+```
+/plan-resume
+```
+design.md + plan.md + checklist.md + progress memory + git log을 한 번에 읽어 완전한 context 복원. `/clear` 직후에 특히 유용.
+
+### 3. 현재 진행 상태 시각화
+```
+/plan-tasks     # Wave/PR 트리 + 진행률 %
+/plan-status    # 빠른 snapshot + git 상태
+```
+
+### 4. 작업 재개
+```
+/plan-autopilot
+```
+Wave 기반 자동 실행 시작. Hook + sub-agent + 4 parallel reviewers가 전부 자동으로 돌아감.
+
+---
+
+## 🔧 새 프로젝트에 설치하는 법
+
+### 전제 조건
+- Claude Code v2.1.32+
+- `jq`, `git`, `gh` (옵션)
+- `~/.claude/skills/plan-autopilot/` 존재
+
+### 설치 4단계 (~2분)
+
+```bash
+mkdir -p .claude/commands
+
+# 1. 슬래시 커맨드 복사 (8개)
+cp ~/.claude/skills/plan-autopilot/commands/*.md .claude/commands/
+
+# 2. Hook 설정 (scripts는 절대 경로로 참조 → 복사 불필요)
+cp ~/.claude/skills/plan-autopilot/templates/settings.template.json .claude/settings.json
+
+# 3. 파이프라인 설정
+cp ~/.claude/skills/plan-autopilot/templates/post-task-pipeline.template.json .claude/post-task-pipeline.json
+
+# 4. CLAUDE.md에 워크플로우 섹션 추가
+cat ~/.claude/skills/plan-autopilot/templates/CLAUDE-md-section.template.md >> CLAUDE.md
+```
+
+### 첫 플랜 시작
+```
+/plan-new "새 phase 이름"
+```
+→ brainstorming (Opus) + writing-plans + 템플릿 기반 docs 생성 → 초기 commit.
+
+그 다음:
+```
+/plan-start docs/plans/YYYY-MM-DD-<slug>
+/plan-autopilot
+```
+
+상세: [docs/plan-autopilot-guide/installation.md](docs/plan-autopilot-guide/installation.md)
+
+---
+
+## 📋 슬래시 커맨드 레퍼런스
+
+| 커맨드 | 용도 |
+|--------|------|
+| `/plan-new <topic>` | 새 phase 저작 (brainstorming + plan-writing) |
+| `/plan-start <dir>` | 플랜 활성화 |
+| `/plan-autopilot` | Wave 자동 실행 루프 |
+| `/plan-stop` | 실행 중단 + state 저장 |
+| `/plan-status` | 빠른 상태 확인 |
+| `/plan-tasks` | 진행률 트리 시각화 |
+| `/plan-resume` | /clear 후 전체 context 복원 |
+| `/plan-finish` | phase 종료 시 archive |
+
+상세: [docs/plan-autopilot-guide/commands.md](docs/plan-autopilot-guide/commands.md)
+
+---
+
+## 🧠 Model 전략 (자동)
+
+| Stage | 모델 | 이유 |
+|-------|------|------|
+| Brainstorming (`/plan-new`) | **Opus** | 복잡한 설계 판단 |
+| 구현 (일반 PR) | Sonnet | Mechanical |
+| 구현 (복잡 PR: actor/snapshot) | **Opus** | Concurrency 신중 |
+| Security review | **Opus** | Critical |
+| Architecture review | **Opus** | 설계 정합성 |
+| Performance review | Sonnet | Pattern-based |
+| Test coverage review | Sonnet | Pattern-based |
+| Fix-loop | Sonnet | Mechanical |
+
+Override: `.claude/post-task-pipeline.json` 의 `pr_model_overrides` 편집.
+
+**비용 절감**: all-Opus 대비 ~50%, 품질 유지.
+
+---
+
+## 🔒 Hook 동작 (자동)
+
+| Hook | 언제 | 효과 |
+|------|------|------|
+| SessionStart | 세션 시작 / `/clear` 직후 | STATUS + next task 주입 |
+| UserPromptSubmit | 매 메시지 | 1줄 STATUS 주입 (~25 토큰) |
+| PreToolUse (Edit/Write) | scope 파일 편집 직전 | design/checklist 읽기 전 **BLOCK** |
+| PostToolUse (Edit/Write) | 편집 직후 | Checklist 갱신 reminder |
+| PostToolUse (Read) | 매 Read | 읽은 파일 로그 (guard 용) |
+
+활성 plan 있을 때만 발동. `/plan-finish` 후 자동 비활성.
+
+상세: [docs/plan-autopilot-guide/hooks.md](docs/plan-autopilot-guide/hooks.md)
+
+---
+
+## 🎯 Phase 8.0 요약 (현재 작업)
+
+**목적**: MMP v3 game engine integration 실서비스급 완성. 12 모듈 wired.
+
+**Wave 구조**:
+```
+W0: PR-0 docs/infra  (완료)
+W1: PR-1 ∥ PR-2        (병렬 ×2)
+W2: PR-3
+W3: PR-4 (패턴 레퍼런스)
+W4: PR-5 ∥ PR-6 ∥ PR-7 ∥ PR-8  (병렬 ×4)
+W5: PR-9 (observability)
+```
+
+**속도**: 순차 9T → 병렬 5T (~44% 단축)
+
+**상세**: [docs/plans/2026-04-08-engine-integration/design.md](docs/plans/2026-04-08-engine-integration/design.md)
+
+---
+
+## 🚨 필수 규칙
+
+1. **모든 .md 파일 <200줄** — 초과 시 `refs/` 분할 + index 패턴
+2. **STATUS 마커 형식 유지** — hook 파싱용
+3. **병렬 wave는 `isolation: "worktree"`** 필수
+4. **Review = 4 parallel agents** 한 메시지에 배치
+5. **Fix-loop max 3**, 초과 시 user 개입
+6. **Wave merge 전 user 확인 1회**
+7. **Feature flag default off**
+8. **PreToolUse guard 우회 금지**
+
+---
+
+## 🆘 트러블슈팅
+
+```bash
+# Hook 수동 테스트
+~/.claude/skills/plan-autopilot/scripts/plan-status.sh --compact
+~/.claude/skills/plan-autopilot/scripts/plan-tasks.sh
+
+# 읽기 로그 리셋 (PreToolUse guard 해제)
+rm /tmp/claude-plan-read.log
+
+# Active plan 유효성
+jq . .claude/active-plan.json
+
+# Autopilot state 확인
+cat .claude/autopilot-state.json 2>/dev/null || echo "no paused state"
+```
+
+상세: [docs/plan-autopilot-guide/troubleshooting.md](docs/plan-autopilot-guide/troubleshooting.md)
+
+---
+
+## 📞 참조
+
+- 스킬 정의: `~/.claude/skills/plan-autopilot/SKILL.md`
+- 스킬 상세: `~/.claude/skills/plan-autopilot/README.md`
+- 파일 구조: [docs/plan-autopilot-guide/file-structure.md](docs/plan-autopilot-guide/file-structure.md)
+- 현재 Phase 디자인: [docs/plans/2026-04-08-engine-integration/design.md](docs/plans/2026-04-08-engine-integration/design.md)
+
+**마지막 업데이트**: 2026-04-08 (Phase 8.0 PR-0)

--- a/docs/plan-autopilot-guide/commands.md
+++ b/docs/plan-autopilot-guide/commands.md
@@ -1,0 +1,161 @@
+# 슬래시 커맨드 상세
+
+> 부모: [../../PLAN_AUTOPILOT.md](../../PLAN_AUTOPILOT.md)
+
+## 전체 목록
+
+| 커맨드 | 빈도 | 용도 |
+|--------|------|------|
+| `/plan-new <topic>` | phase당 1회 | 새 phase 저작 |
+| `/plan-start <dir>` | phase당 1회 | 플랜 활성화 |
+| `/plan-autopilot [opts]` | 작업 시작 | Wave 자동 실행 |
+| `/plan-stop` | 필요 시 | 실행 중단 |
+| `/plan-status` | 자주 | 빠른 상태 확인 |
+| `/plan-tasks` | 자주 | 진행률 트리 |
+| `/plan-resume` | /clear 후 | 컨텍스트 복원 |
+| `/plan-finish` | phase 종료 | archive |
+
+## `/plan-new <topic>`
+
+새 phase 플랜을 3단계로 저작.
+
+**Stage 1**: `superpowers:brainstorming` (Opus) — 7가지 설계 결정 수집
+**Stage 2**: `superpowers:writing-plans` — PR breakdown + wave DAG
+**Stage 3**: 템플릿 기반 docs 생성 (<200줄 강제)
+
+**7가지 결정**:
+1. Scope boundary (in/out)
+2. Architecture pattern
+3. Lifecycle (create/destroy/transition)
+4. External interface
+5. Persistence/state
+6. Operational safety (panic, observability, tests)
+7. Rollout strategy (feature flag + waves)
+
+**출력**:
+```
+docs/plans/YYYY-MM-DD-<slug>/
+  design.md (index)
+  plan.md (index)
+  checklist.md (STATUS marker)
+  refs/
+    scope-and-decisions.md
+    architecture.md
+    execution-model.md (wave DAG)
+    observability-testing.md
+    pr-1-*.md ~ pr-N-*.md
+```
+
+## `/plan-start <plan-dir>`
+
+플랜 디렉터리를 active로 등록.
+
+**동작**:
+1. `<dir>/design.md`, `plan.md`, `checklist.md` 읽기
+2. STATUS 마커 존재 검증
+3. 기존 `.claude/active-plan.json`이 있으면 archive 확인
+4. 새 active-plan.json 작성 (scope, waves, PRs 필드)
+
+**효과**: 이 시점부터 모든 hook이 활성화됩니다.
+
+## `/plan-autopilot [opts]`
+
+Wave 기반 자동 실행 루프.
+
+**옵션**:
+- `--until WAVE` — 특정 wave까지만
+- `--only PR-N` — 특정 PR만
+- `--dry-run` — manifest만 출력, 실행 안 함
+
+**흐름**:
+```
+For each wave in active-plan.json.waves:
+  1. Pre-wave checks (deps, scope overlap validation)
+  2. Spawn agents (parallel=multi Agent in ONE message + isolation:worktree)
+  3. Collect results
+  4. Sequential merge + test gate
+  5. User confirm 1회
+  6. Advance wave pointer
+After last wave: run after_plan pipeline → /plan-finish
+```
+
+**각 sub-agent 내부**:
+```
+Read design + checklist PR section
+For each task: implement + atomic commit + mark ✅
+After all tasks:
+  format + scope-test + full-test + lint
+  4 parallel reviewers (security, perf, arch, test-coverage)
+  fix-loop (max 3)
+  commit + push + create PR
+Return {pr_id, branch, commit_hash, status, findings}
+```
+
+## `/plan-stop`
+
+실행 중인 autopilot을 중단.
+
+**동작**:
+1. `.claude/autopilot-state.json` 생성 (현재 wave, PR, 타임스탬프)
+2. In-flight sub-agent는 현재 스텝 끝날 때까지 기다림
+3. `active-plan.json`은 삭제되지 않음 (플랜은 살아있음)
+
+재개: `/plan-resume` 또는 `/plan-autopilot`
+
+## `/plan-status`
+
+빠른 스냅샷. 3초 이내 출력.
+
+**내용**:
+- Phase 이름 + started
+- Current wave / PR / task
+- STATUS 마커 (checklist에서 추출)
+- Scope 파일 목록
+- Recent commits (last 5)
+- Uncommitted changes
+- 다음 추천 action
+
+실행: `~/.claude/skills/plan-autopilot/scripts/plan-status.sh --verbose`
+
+## `/plan-tasks`
+
+시각적 진행률 트리.
+
+**내용**:
+- Overall progress bar (%)
+- Wave 별 상태 아이콘 (✅🔄⏸)
+- PR 별 task 개수 + 완료율
+- 현재 task 하이라이트
+
+실행: `~/.claude/skills/plan-autopilot/scripts/plan-tasks.sh`
+
+## `/plan-resume`
+
+완전한 context 복원. `/clear` 후 특히 유용.
+
+**읽는 파일** (모두 parallel):
+- `<plan.design>` (index + refs/ 전부)
+- `<plan.plan>`
+- `<plan.checklist>`
+- `<plan.progress_memory>`
+- 현재 PR의 `refs/pr-<current_pr>-*.md`
+- `.claude/post-task-pipeline.json`
+- `.claude/autopilot-state.json` (있으면)
+
+**+ git 데이터**: log -10, status, branch
+
+**효과**: design + checklist 읽기로 **PreToolUse guard 자동 해제** (30분 유효).
+
+## `/plan-finish`
+
+Phase 종료 archive.
+
+**동작**:
+1. 모든 task ✅ 확인 (아니면 force 확인)
+2. 완료 metadata 추가 (finished_at, final_commit)
+3. `.claude/active-plan.json` → `.claude/archived_plans/<id>.json` 이동
+4. 루트 checklist 갱신 (phase ✅ 마킹)
+5. 메모리 파일 갱신
+6. commit 제안
+
+**효과**: 모든 hook 자동 비활성화. 워크플로우가 일반 모드로 복귀.

--- a/docs/plan-autopilot-guide/file-structure.md
+++ b/docs/plan-autopilot-guide/file-structure.md
@@ -1,0 +1,179 @@
+# 파일 구조 상세
+
+> 부모: [../../PLAN_AUTOPILOT.md](../../PLAN_AUTOPILOT.md)
+
+## 스킬 (`~/.claude/skills/plan-autopilot/`)
+
+프로젝트와 독립적인 user-level 스킬. 모든 프로젝트에서 재사용.
+
+```
+~/.claude/skills/plan-autopilot/
+├── SKILL.md (132줄)                   # 스킬 정의 + frontmatter
+├── README.md (155줄)                  # 상세 사용법
+├── refs/                              # 카테고리별 상세 (각 <200줄)
+│   ├── authoring.md                   # /plan-new 워크플로우
+│   ├── execution.md                   # /plan-autopilot 실행 로직
+│   ├── commands.md                    # 커맨드 카탈로그
+│   ├── templates.md                   # 템플릿 설명
+│   ├── hooks.md                       # Hook 설정/디버깅
+│   ├── pipeline-config.md             # 파이프라인 스키마
+│   └── model-strategy.md              # Opus/Sonnet 선택 + 스킬 매핑
+├── scripts/                           # bash 헬퍼
+│   ├── plan-status.sh                 # STATUS 추출 (compact/verbose)
+│   ├── plan-tasks.sh                  # 진행률 트리 시각화
+│   ├── plan-guard.sh                  # PreToolUse 차단
+│   ├── plan-remind.sh                 # PostToolUse 리마인더
+│   ├── plan-track-reads.sh            # Read 로거
+│   ├── run-pipeline.sh                # 파이프라인 stage 실행
+│   ├── autopilot-loop.sh              # 상태 관리 helper
+│   └── plan-wave.sh                   # Wave manifest + validation
+├── templates/                         # 파일 템플릿
+│   ├── active-plan.template.json      # 플랜 pointer 스켈레톤
+│   ├── post-task-pipeline.template.json  # 파이프라인 기본값
+│   ├── settings.template.json         # 4 hook 설정
+│   ├── design.index.template.md       # design.md index
+│   ├── plan.index.template.md         # plan.md index
+│   ├── checklist.index.template.md    # checklist + STATUS 마커
+│   ├── STATUS-marker.template.md      # STATUS 스니펫
+│   └── CLAUDE-md-section.template.md  # CLAUDE.md 섹션
+└── commands/                          # 슬래시 커맨드 정의
+    ├── plan-new.md
+    ├── plan-start.md
+    ├── plan-finish.md
+    ├── plan-status.md
+    ├── plan-tasks.md
+    ├── plan-autopilot.md
+    ├── plan-stop.md
+    └── plan-resume.md
+```
+
+**총 파일 수**: ~36개
+**모든 .md 파일 <200줄** (Claude Code 스킬 best practice)
+**Scripts는 절대 경로로 참조** (프로젝트 복사 불필요)
+
+## 프로젝트 (`<project>/.claude/`)
+
+프로젝트별 설정. 버전 관리 대상 (단, `autopilot-state.json` 제외).
+
+```
+<project-root>/.claude/
+├── active-plan.json               # 현재 활성 plan pointer
+├── post-task-pipeline.json        # 파이프라인 설정 (커스터마이즈)
+├── settings.json                  # 4 hooks
+├── commands/                      # 슬래시 커맨드 복사본
+│   ├── plan-new.md
+│   ├── plan-start.md
+│   ├── plan-finish.md
+│   ├── plan-status.md
+│   ├── plan-tasks.md
+│   ├── plan-autopilot.md
+│   ├── plan-stop.md
+│   └── plan-resume.md
+├── archived_plans/                # 완료된 plan 보관 (히스토리)
+│   └── <plan-id>.json
+└── autopilot-state.json           # (생성됨) 실행 중 상태 — .gitignore
+```
+
+**설치 방법**: 슬래시 커맨드 복사 + settings.json + post-task-pipeline.json. 스크립트는 복사하지 않음 (절대 경로 참조).
+
+## 현재 Phase 문서 (예: Phase 8.0)
+
+```
+docs/plans/2026-04-08-engine-integration/
+├── design.md (115줄)              # 설계 index
+├── plan.md (~130줄)               # 실행 계획 index
+├── checklist.md (~70줄)           # STATUS 마커 + wave 체크리스트
+└── refs/                          # 상세 문서 (각 <200줄)
+    ├── scope-and-decisions.md     # 7대 결정 상세
+    ├── architecture.md            # 컴포넌트 + 다이어그램
+    ├── data-flow.md               # 주요 흐름도
+    ├── persistence.md             # Redis 스냅샷 + 복구
+    ├── execution-model.md         # Wave DAG + 병렬 실행
+    ├── observability-testing.md   # 메트릭 + 테스트 + 에러
+    ├── pr-0-docs-infra.md         # PR별 task 상세
+    ├── pr-1-skeleton.md
+    ├── pr-2-hub-lifecycle.md
+    ├── pr-3-base-handler.md
+    ├── pr-4-reading-wired.md
+    ├── pr-5-core-modules.md
+    ├── pr-6-progression-modules.md
+    ├── pr-7-snapshot-restore.md
+    ├── pr-8-game-start-api.md
+    └── pr-9-observability.md
+```
+
+**원칙**:
+- 모든 파일 **<200줄**
+- `design.md`, `plan.md`, `checklist.md` 는 index 역할 (전체 구조 요약 + refs/ 맵)
+- 상세 내용은 `refs/<topic>.md` 또는 `refs/pr-N-*.md` 로 분할
+- Index에서 refs/ 파일로 명시적 링크
+
+## 메모리 (`~/.claude/projects/<proj-hash>/memory/`)
+
+프로젝트별 persistent memory (세션 간 유지).
+
+```
+memory/
+├── MEMORY.md                           # 인덱스 (~150 lines max, always loaded)
+├── project_phase80_plan.md             # Phase 8.0 정적 결정사항
+├── project_phase80_progress.md         # Phase 8.0 진행 상황 (동적, 갱신됨)
+├── project_phases.md                   # 전체 phase 상태
+├── project_phase77_followups.md        # Phase 7.7 후속 작업
+└── ... (기타 프로젝트 메모리)
+```
+
+**plan-autopilot 관련**:
+- `project_phase80_plan.md` — brainstorming 확정 사항, 변경 금지
+- `project_phase80_progress.md` — wave/PR 진행 추적, 각 PR 머지 후 갱신
+- MEMORY.md에 `project_phase80_*.md` 포인터 존재
+
+## 런타임 파일 (버전 관리 제외)
+
+```
+/tmp/claude-plan-read.log           # PreToolUse guard 용 읽기 로그
+<project>/.claude/autopilot-state.json  # 일시정지 상태 (/plan-stop 시)
+<project>/.pr-body.tmp              # 임시 PR body
+```
+
+모두 `.gitignore` 에 추가 권장.
+
+## 데이터 흐름 (파일 간 관계)
+
+```
+                ┌──────────────────────┐
+                │ .claude/active-plan  │  ← 단일 진실 (Single Source of Truth)
+                │     .json            │
+                └──────────┬───────────┘
+                           │ (읽음)
+          ┌────────────────┼────────────────┐
+          ↓                ↓                ↓
+   Hooks (4개)      Slash Commands      Scripts
+   (scripts)        (.claude/commands)   (plan-*.sh)
+          │                │                │
+          ↓                ↓                ↓
+   STATUS injection   User-invoked     Support scripts
+                           │
+                           ↓
+                  docs/plans/<phase>/
+                  ├ design.md (index)
+                  ├ plan.md (index)
+                  ├ checklist.md (STATUS marker)
+                  └ refs/
+                           │
+                           ↓
+                  memory/project_phase*_*.md
+                  (persistent across sessions)
+```
+
+## 파일 수정 권한 요약
+
+| 파일 | 누가 수정 | 언제 |
+|------|----------|------|
+| `~/.claude/skills/plan-autopilot/**` | 스킬 개발자 | 업그레이드 시 |
+| `.claude/commands/*.md` | `/plan-new`, 설치 스크립트 | 설치 + 스킬 업그레이드 |
+| `.claude/settings.json` | 사용자 (수동) | 설치 1회 |
+| `.claude/post-task-pipeline.json` | 사용자 (수동) | 프로젝트 커스터마이즈 |
+| `.claude/active-plan.json` | `/plan-start`, autopilot | 플랜 전환, 진행 갱신 |
+| `.claude/autopilot-state.json` | `/plan-stop` | 일시정지 시 |
+| `docs/plans/<phase>/*.md` | `/plan-new`, 사용자, sub-agents | Phase 작업 중 |
+| `memory/project_phase*.md` | 사용자, sub-agents | 각 PR 머지 후 |

--- a/docs/plan-autopilot-guide/hooks.md
+++ b/docs/plan-autopilot-guide/hooks.md
@@ -1,0 +1,193 @@
+# Hook 동작 상세
+
+> 부모: [../../PLAN_AUTOPILOT.md](../../PLAN_AUTOPILOT.md)
+
+## 4개 hook + 1개 read logger
+
+모두 `.claude/settings.json` 에 등록. 활성 plan 있을 때만 발동, 없으면 no-op.
+
+### SessionStart
+
+**트리거**: 세션 시작, `/clear` 직후
+**빈도**: 세션당 1회
+**토큰 비용**: ~80
+**명령**: `~/.claude/skills/plan-autopilot/scripts/plan-status.sh --verbose`
+
+**출력 예시**:
+```
+=== ACTIVE PLAN ===
+Phase: Phase 8.0 — Engine Integration Layer
+Started: 2026-04-08
+
+Current Wave: W1
+Current PR: PR-1 — SessionManager + Session actor
+Current Task: Implement Session.Run() event loop
+Status: in_progress
+
+=== STATUS MARKER ===
+<!-- STATUS-START -->
+**Active**: ...
+**PR**: ...
+**Task**: ...
+<!-- STATUS-END -->
+
+=== FILES ===
+  Design: docs/plans/2026-04-08-engine-integration/design.md
+  Checklist: docs/plans/2026-04-08-engine-integration/checklist.md
+  Progress: memory/project_phase80_progress.md
+
+=== SCOPE ===
+  - apps/server/internal/session/**
+  - apps/server/internal/ws/hub.go
+  ...
+
+Blockers: none
+Commands: /plan-status /plan-tasks /plan-autopilot /plan-resume
+```
+
+Claude가 세션 시작 시 이 정보를 자동으로 context에 받아서 → 별도 조회 없이 작업 상태 파악.
+
+### UserPromptSubmit
+
+**트리거**: 매 사용자 메시지
+**빈도**: 매 메시지
+**토큰 비용**: ~25 (1줄)
+**명령**: `~/.claude/skills/plan-autopilot/scripts/plan-status.sh --compact`
+
+**출력**:
+```
+[ACTIVE PLAN: phase-8.0-engine-integration | W1 PR-1 | task: Session.Run() event loop | in_progress]
+```
+
+매 프롬프트 직전에 1줄이 system reminder로 주입됨 → Claude가 현재 상태를 항상 알고 있음.
+
+### PreToolUse (Edit|Write) — **BLOCKING**
+
+**트리거**: Edit/Write 도구 호출 직전
+**빈도**: 매 Edit/Write
+**blocking**: exit 2 (메시지 Claude에게 표시)
+**명령**: `~/.claude/skills/plan-autopilot/scripts/plan-guard.sh`
+
+**동작**:
+1. `.claude/active-plan.json` 없으면 pass (exit 0)
+2. `file_path`가 `active.scope` glob에 매치 안 되면 pass
+3. 매치되면 `/tmp/claude-plan-read.log` 확인 — design + checklist가 최근 30분 내 Read됐는지
+4. 둘 다 읽었으면 pass
+5. 안 읽었으면 exit 2 + 에러 메시지 stderr
+
+**차단 메시지 예시**:
+```
+🛑 PLAN GUARD: Active plan requires reading these before editing:
+   File: apps/server/internal/session/manager.go
+   ⚠️  Not read recently: docs/plans/2026-04-08-engine-integration/design.md
+
+   Active plan: Phase 8.0 — Engine Integration Layer
+
+   Action required:
+   1. Read docs/plans/2026-04-08-engine-integration/design.md
+   2. Read docs/plans/2026-04-08-engine-integration/checklist.md
+   Then retry your edit.
+```
+
+Claude는 이 메시지를 받으면 자동으로 파일을 Read 후 Edit 재시도 → PreToolUse 재실행 → 이번엔 통과.
+
+**설계 의도**: 실수로 design을 안 보고 코드 편집하는 것을 원천 차단.
+
+### PostToolUse (Edit|Write)
+
+**트리거**: Edit/Write 성공 직후
+**빈도**: scope 매치 시
+**blocking**: false (stderr 메시지만)
+**명령**: `~/.claude/skills/plan-autopilot/scripts/plan-remind.sh`
+
+**출력**:
+```
+📝 PLAN REMINDER: apps/server/internal/session/manager.go is in active plan scope (PR-1).
+After this work segment, update:
+  - docs/plans/2026-04-08-engine-integration/checklist.md (mark task ✅)
+  - memory/project_phase80_progress.md (STATUS marker)
+Also: ensure all modified .md files are <200 lines.
+```
+
+Claude는 이 리마인더를 받고 → 적절한 시점에 checklist/progress 갱신.
+
+### PostToolUse (Read) — 로거
+
+**트리거**: 매 Read 도구 호출 성공 직후
+**빈도**: 매 Read
+**명령**: `~/.claude/skills/plan-autopilot/scripts/plan-track-reads.sh`
+
+**동작**: `/tmp/claude-plan-read.log`에 `{timestamp} {file_path}` 기록. 1시간 넘은 엔트리 자동 cleanup.
+
+**용도**: PreToolUse guard가 "최근에 design 읽었는지"를 검증하는 데이터.
+
+## Debugging
+
+### Hook이 안 돌아감
+```bash
+# 1. 설정 확인
+jq .hooks .claude/settings.json
+
+# 2. 활성 plan 확인
+jq .active.name .claude/active-plan.json
+
+# 3. 스크립트 수동 실행
+bash -x ~/.claude/skills/plan-autopilot/scripts/plan-status.sh --compact
+
+# 4. 스크립트 실행 권한 확인
+ls -l ~/.claude/skills/plan-autopilot/scripts/
+```
+
+### PreToolUse가 잘못 차단
+```bash
+# 읽기 로그 확인
+cat /tmp/claude-plan-read.log
+
+# Scope glob 매칭 수동 검증
+file="apps/server/internal/session/manager.go"
+jq -r '.active.scope[]' .claude/active-plan.json | while read g; do
+  [[ "$file" == $g ]] && echo "MATCH: $g"
+done
+
+# 리셋
+rm /tmp/claude-plan-read.log
+```
+
+### PreToolUse를 일시 우회
+일반적으론 우회하지 않는 것이 원칙이지만, 긴급 fix 등에서 필요하면:
+```bash
+# 1. 잠시 active-plan.json 이름 변경
+mv .claude/active-plan.json .claude/active-plan.json.bak
+
+# 2. 작업 완료 후 복원
+mv .claude/active-plan.json.bak .claude/active-plan.json
+```
+
+**권장하지 않음**: 대신 `/plan-stop` 사용 + 작업 후 `/plan-resume`.
+
+## Hook lifecycle with plan state
+
+| Plan state | SessionStart | UserPromptSubmit | PreToolUse | PostToolUse |
+|-----------|--------------|------------------|-----------|-------------|
+| 활성 + scope 매치 | 주입 | 주입 | enforce | 리마인더 |
+| 활성 + scope 밖 | 주입 | 주입 | pass | pass |
+| 활성 plan 없음 | no-op | no-op | no-op | no-op |
+| 일시 정지 | 주입 (paused 표시) | 주입 | enforce | 리마인더 |
+| archived | no-op | no-op | no-op | no-op |
+
+## 다른 hook과 충돌
+
+이미 `.claude/settings.json`에 다른 hook이 있으면 **merge** 필수:
+
+```jsonc
+{
+  "hooks": {
+    "SessionStart": [
+      { "command": "existing-command" },
+      { "command": "~/.claude/skills/plan-autopilot/scripts/plan-status.sh --verbose" }
+    ]
+  }
+}
+```
+
+Claude Code는 같은 이벤트의 여러 hook을 순차 실행합니다.

--- a/docs/plan-autopilot-guide/installation.md
+++ b/docs/plan-autopilot-guide/installation.md
@@ -1,0 +1,158 @@
+# plan-autopilot 설치 상세
+
+> 부모: [../../PLAN_AUTOPILOT.md](../../PLAN_AUTOPILOT.md)
+
+## 전제 조건
+
+- **Claude Code v2.1.32+** (`claude --version` 으로 확인)
+- **`jq`** — 모든 bash 스크립트 필수 (`brew install jq`)
+- **`git`** — 버전 관리 + worktree 격리
+- **`gh` CLI** (옵션) — PR 자동 생성/머지
+- **`~/.claude/skills/plan-autopilot/`** — 스킬 디렉터리 존재 확인
+
+```bash
+# 전제 조건 검증
+claude --version            # >= 2.1.32
+jq --version                # 1.6+
+git --version               # 2.30+
+gh --version                # 2.0+ (옵션)
+ls ~/.claude/skills/plan-autopilot/SKILL.md   # 존재해야 함
+```
+
+## 설치 단계
+
+### 1. 슬래시 커맨드 복사 (필수)
+
+```bash
+mkdir -p .claude/commands
+cp ~/.claude/skills/plan-autopilot/commands/*.md .claude/commands/
+```
+
+이유: Claude Code는 `.claude/commands/*.md` 만 슬래시 커맨드로 인식합니다. 스킬 디렉터리의 commands는 자동 로드되지 않음.
+
+### 2. Hook 설정 (필수)
+
+```bash
+cp ~/.claude/skills/plan-autopilot/templates/settings.template.json .claude/settings.json
+```
+
+이미 `.claude/settings.json`이 있으면 **merge** 필요 (overwrite 금지):
+
+```jsonc
+{
+  "hooks": {
+    "SessionStart": [
+      { "command": "~/.claude/skills/plan-autopilot/scripts/plan-status.sh --verbose" }
+    ],
+    "UserPromptSubmit": [
+      { "command": "~/.claude/skills/plan-autopilot/scripts/plan-status.sh --compact" }
+    ],
+    "PreToolUse": [
+      { "matcher": "Edit|Write", "command": "~/.claude/skills/plan-autopilot/scripts/plan-guard.sh" }
+    ],
+    "PostToolUse": [
+      { "matcher": "Edit|Write", "command": "~/.claude/skills/plan-autopilot/scripts/plan-remind.sh" },
+      { "matcher": "Read", "command": "~/.claude/skills/plan-autopilot/scripts/plan-track-reads.sh" }
+    ]
+  }
+}
+```
+
+**핵심**: scripts는 `~/.claude/skills/plan-autopilot/scripts/` 절대 경로 참조. 프로젝트에 복사/심볼릭 링크 불필요. 스킬 업데이트가 자동 전파.
+
+### 3. 파이프라인 설정 (필수)
+
+```bash
+cp ~/.claude/skills/plan-autopilot/templates/post-task-pipeline.template.json .claude/post-task-pipeline.json
+```
+
+그 다음 프로젝트에 맞게 커스터마이즈:
+- `after_task[].command` → 프로젝트 테스트 러너로 변경 (`go test`, `pnpm test`, `cargo test` 등)
+- `after_pr[].command` → lint, build 커맨드
+- `pr_model_overrides` → 특정 PR에 Opus 강제 지정
+- `global.max_parallel_prs_per_wave` → CI 용량에 맞게 조정
+
+### 4. CLAUDE.md 워크플로우 섹션 추가
+
+```bash
+cat ~/.claude/skills/plan-autopilot/templates/CLAUDE-md-section.template.md >> CLAUDE.md
+```
+
+이 섹션은 Claude에게 hook 동작 + 필수 규칙을 알립니다.
+
+### 5. (옵션) .gitignore 추가
+
+```gitignore
+.claude/autopilot-state.json
+.pr-body.tmp
+```
+
+Autopilot runtime state + 임시 PR body는 버전 관리 제외.
+
+## 검증
+
+설치 후 동작 확인:
+
+```bash
+# 1. 스크립트 실행 가능
+~/.claude/skills/plan-autopilot/scripts/plan-status.sh --compact
+# 출력: (empty — 아직 active plan 없음)
+
+# 2. jq 동작
+jq . .claude/post-task-pipeline.json | head
+
+# 3. Claude Code에서 슬래시 커맨드 확인
+# /plan-new, /plan-start, /plan-status, /plan-tasks 등이 자동완성되어야 함
+```
+
+## 첫 플랜 시작
+
+```
+/plan-new "My New Phase Name"
+```
+
+이 커맨드가 하는 일:
+1. `superpowers:brainstorming` 호출 (Opus) → 7가지 설계 결정 수집
+2. `superpowers:writing-plans` 호출 → PR breakdown + wave DAG
+3. 템플릿 기반 docs 생성 (`docs/plans/YYYY-MM-DD-<slug>/`)
+4. 모든 .md 파일 <200줄 강제
+5. 초기 commit (문서 PR-0)
+
+활성화:
+```
+/plan-start docs/plans/YYYY-MM-DD-<slug>
+```
+
+실행:
+```
+/plan-autopilot
+```
+
+## 업데이트
+
+스킬 업데이트 시 프로젝트는 재설치 불필요 (scripts가 절대 경로 참조). 단, 새 슬래시 커맨드가 추가됐으면:
+
+```bash
+cp ~/.claude/skills/plan-autopilot/commands/*.md .claude/commands/
+```
+
+템플릿이 바뀌었으면 기존 설정은 유지하고 변경분만 수동 병합.
+
+## 제거
+
+```bash
+rm -rf .claude/commands/plan-*.md
+rm .claude/settings.json  # 또는 hooks 섹션만 제거
+rm .claude/post-task-pipeline.json
+rm -f .claude/active-plan.json .claude/autopilot-state.json
+```
+
+CLAUDE.md의 "Active Plan Workflow" 섹션도 수동 제거.
+
+## 다중 프로젝트
+
+같은 스킬을 여러 프로젝트에서 사용:
+- 스킬은 `~/.claude/skills/plan-autopilot/` 에 **한 번만** 설치
+- 각 프로젝트는 `.claude/` 설치 단계만 반복
+- 프로젝트마다 독립된 `active-plan.json` + `post-task-pipeline.json` 유지
+- 스킬 버전 업그레이드 시 모든 프로젝트가 동시 혜택

--- a/docs/plan-autopilot-guide/troubleshooting.md
+++ b/docs/plan-autopilot-guide/troubleshooting.md
@@ -1,0 +1,158 @@
+# 트러블슈팅
+
+> 부모: [../../PLAN_AUTOPILOT.md](../../PLAN_AUTOPILOT.md)
+
+## Hook 관련
+
+### Hook이 전혀 안 돌아감
+
+**증상**: SessionStart 메시지 안 보임, `/plan-*` 슬래시 커맨드 미인식
+
+**확인**:
+```bash
+jq .active.id .claude/active-plan.json   # 활성 plan 있는지
+jq . .claude/settings.json > /dev/null   # JSON valid
+ls -la ~/.claude/skills/plan-autopilot/scripts/  # 755 권한
+~/.claude/skills/plan-autopilot/scripts/plan-status.sh --compact  # 수동 실행
+```
+
+**해결**:
+- active-plan.json 없음: `/plan-start <dir>`
+- JSON parse error: `jq .` 재검증, archived에서 복구
+- Script permission: `chmod +x ~/.claude/skills/plan-autopilot/scripts/*.sh`
+
+### PreToolUse가 잘못 차단
+
+**증상**: design.md 읽었는데도 "Not read recently" 에러
+
+**원인**: `/tmp/claude-plan-read.log`의 파일 경로 매칭 실패 (절대 vs 상대)
+
+**해결**:
+```bash
+cat /tmp/claude-plan-read.log | tail -20   # 기록 확인
+rm /tmp/claude-plan-read.log               # 리셋 후 다시 Read
+```
+
+### Hook 일부만 동작
+
+**원인**: matcher 패턴 또는 command 경로 오타
+
+```bash
+jq '.hooks.PreToolUse' .claude/settings.json
+# matcher: "Edit|Write", command: 절대 경로
+```
+
+## Active plan 관련
+
+### active-plan.json 손상
+
+```bash
+cp .claude/active-plan.json .claude/active-plan.json.broken
+ls .claude/archived_plans/   # 복구 candidate
+cp ~/.claude/skills/plan-autopilot/templates/active-plan.template.json .claude/active-plan.json
+# 수동 편집: id, name, dir, scope, waves, prs
+```
+
+### Plan finish 실패
+
+**증상**: `/plan-finish` 가 "tasks not all complete" 에러
+
+**해결**:
+1. `/plan-tasks` 로 미완료 확인
+2. 완료된 task → `- [x]`
+3. 건너뛸 task → `- [~]` 또는 삭제
+4. force finish: "y" 응답
+
+## Autopilot 관련
+
+### Wave 중간 멈춤
+
+```bash
+cat .claude/autopilot-state.json 2>/dev/null
+jq '.active.current_wave, .active.current_pr, .active.status' .claude/active-plan.json
+```
+
+- paused → `/plan-resume`
+- blocker → 해결 후 수동 진행
+
+### Fix-loop 3회 초과
+
+**해결**:
+1. git log로 마지막 sub-agent 작업 확인
+2. findings 수동 검토 → 근본 문제 파악
+3. 수동 수정 → `/plan-autopilot` 재개
+
+### 병렬 wave merge 충돌
+
+**원인**: 파일 스코프 설계 실수
+
+**해결**:
+```bash
+~/.claude/skills/plan-autopilot/scripts/plan-wave.sh validate W4
+```
+겹친 파일 → 한 PR로 통합하거나 wave를 sequential로 변경:
+```bash
+jq '.active.waves[] |= if .id == "W4" then .mode = "sequential" else . end' \
+   .claude/active-plan.json > tmp && mv tmp .claude/active-plan.json
+```
+
+## Slash command 관련
+
+### 커맨드 미인식
+
+```bash
+ls .claude/commands/plan-*.md
+cp ~/.claude/skills/plan-autopilot/commands/*.md .claude/commands/
+# Claude Code 재시작
+```
+
+### `/plan-new`가 brainstorming 안 부름
+
+**원인**: `superpowers:brainstorming` 스킬 없음
+
+**해결**: `superpowers` 플러그인 설치 or 수동 브레인스토밍 후 `writing-plans`만 호출.
+
+## 성능
+
+### Hook 느림
+
+- jq 설치 확인 (system-wide)
+- 읽기 로그 cleanup: `wc -l /tmp/claude-plan-read.log` — 1000줄 넘으면 리셋
+- active-plan.json 크기 — waves/prs 100개 넘으면 분할
+
+### 병렬 wave 토큰 폭증
+
+- `global.max_parallel_prs_per_wave` 2로 (4 → 2+2 분할)
+- `pr_model_overrides`로 특정 PR sonnet 강제
+- Wave sequential로 변경
+
+## 복구
+
+### 전체 리셋
+
+```bash
+/plan-stop
+mv .claude/active-plan.json .claude/archived_plans/backup-$(date +%s).json
+/plan-start <dir>
+/plan-autopilot
+```
+
+### Hook 완전 비활성
+
+```bash
+mv .claude/active-plan.json .claude/active-plan.json.disabled
+# 작업 후
+mv .claude/active-plan.json.disabled .claude/active-plan.json
+```
+
+## 로그 수집 (문제 보고 시)
+
+```bash
+jq . .claude/settings.json
+jq . .claude/post-task-pipeline.json
+jq . .claude/active-plan.json
+tail -50 /tmp/claude-plan-read.log
+git log --oneline -20
+claude --version
+jq --version
+```

--- a/docs/plans/2026-04-05-rebuild/checklist.md
+++ b/docs/plans/2026-04-05-rebuild/checklist.md
@@ -85,7 +85,16 @@
 ## Phase 7.8: 에디터 확장
 - [ ] 엔딩 분기 + 버전 관리 + 교차 검증 + 미리보기
 
-## Phase 8: 통합 + QA
+## Phase 8.0: Engine Integration Layer ⭐ 현재 작업
+- [ ] Engine spine + Core 4 + Progression 8 = 12 모듈 wired
+- [ ] Wave 기반 병렬 실행 (9 PRs, 5 waves: W1×2 + W2 + W3 + W4×4 + W5)
+- [ ] 상세: `docs/plans/2026-04-08-engine-integration/` (design + plan + checklist + 9 PR refs)
+- [ ] plan-autopilot 스킬로 자동 실행 (sub-agent + isolation:worktree + 4 parallel reviewers)
+
+## Phase 8.0.x: 나머지 17 모듈 wiring (후속)
+- [ ] Communication 5 + Decision 3 + Exploration 4 + Clue Distribution 5 (Phase 8.0 패턴 복사)
+
+## Phase 8.1 (구 Phase 8): 통합 + QA
 - [ ] E2E (Playwright) + 성능 테스트 + 보안 점검 + K8s 배포
 
 ## Phase 8.5: 보안/테스트/i18n

--- a/docs/plans/2026-04-08-engine-integration/checklist.md
+++ b/docs/plans/2026-04-08-engine-integration/checklist.md
@@ -1,0 +1,102 @@
+<!-- STATUS-START -->
+**Active**: Phase 8.0 — Engine Integration Layer — Wave 0/5 (doc+infra)
+**PR**: PR-0 (docs + plan-autopilot install)
+**Task**: Create plan.md + checklist refs + commit PR-0
+**State**: in_progress
+**Blockers**: none
+**Last updated**: 2026-04-08
+<!-- STATUS-END -->
+
+# Phase 8.0 — Engine Integration Layer 체크리스트
+
+> 부모: [design.md](design.md) | 실행: [plan.md](plan.md) (작성 예정)
+
+이 파일은 진행 상태 tracking. STATUS 마커는 hook/스크립트가 파싱하므로 형식 유지.
+PR별 상세 task는 plan.md + refs/pr-N-*.md 완성 후 이 파일에도 반영됨.
+
+---
+
+## Wave 0 — 문서 + 인프라 (현재)
+
+- [x] design.md refactor to index + refs (각 <200줄)
+- [x] memory files wave 정보 반영
+- [x] plan-autopilot 스킬 생성 (~/.claude/skills/plan-autopilot/)
+- [x] 프로젝트에 스킬 설치 (.claude/scripts, commands, settings, pipeline)
+- [x] .claude/active-plan.json 초기화
+- [ ] plan.md + refs/pr-N-*.md 작성 (task #47)
+- [ ] checklist.md의 Wave 1~5 섹션 확장 (task #47)
+- [ ] 루트 checklist.md에 Phase 8.0 추가 + Phase 8을 8.1로 rename (task #48)
+- [ ] CLAUDE.md에 Active Plan Workflow 섹션 추가
+- [ ] PR-0 commit (task #49)
+
+---
+
+## Wave 1 — Skeletons (parallel ×2)
+
+### PR-1: SessionManager + Session actor
+*상세 task는 refs/pr-1-skeleton.md 참조 (작성 예정)*
+
+### PR-2: Hub lifecycle listener
+*상세 task는 refs/pr-2-hub-lifecycle.md 참조 (작성 예정)*
+
+**Wave 1 gate**:
+- [ ] PR-1, PR-2 모든 task ✅
+- [ ] 4-reviewer 병렬 리뷰 pass
+- [ ] Fix-loop < 3회
+- [ ] `go test -race ./...` pass
+- [ ] Merge to main
+- [ ] User confirmed → Wave 2 진입
+
+---
+
+## Wave 2 — 인프라 (sequential)
+
+### PR-3: BaseModuleHandler + EventMapping 인프라
+*상세 task는 refs/pr-3-base-handler.md 참조*
+
+**Wave 2 gate**: 위와 동일 패턴
+
+---
+
+## Wave 3 — 패턴 레퍼런스 (sequential)
+
+### PR-4: Reading 모듈 wired
+*상세 task는 refs/pr-4-reading-wired.md 참조*
+
+**Wave 3 gate**: 이 PR이 후속 모든 모듈 wiring의 패턴 확정
+
+---
+
+## Wave 4 — 병렬 wiring (parallel ×4)
+
+### PR-5: Core 4 modules (connection, room, ready, clue_interaction)
+### PR-6: Progression 7 modules (script, hybrid, event, skip_consensus, gm_control, consensus_control, ending)
+### PR-7: Redis snapshot + Lazy restore
+### PR-8: Game start API + abort + idle timeout
+
+*상세 task는 refs/pr-5-*.md ~ refs/pr-8-*.md 참조*
+
+**Wave 4 gate**: 파일 스코프 겹침 검증 + 순차 머지 + test gate
+
+---
+
+## Wave 5 — Observability (sequential)
+
+### PR-9: Prometheus metrics + OTel spans + alarm stubs
+
+**Wave 5 gate**: metric scrape test + 종료 전 최종 검증
+
+---
+
+## Phase completion gate
+
+- [ ] 모든 5 waves ✅
+- [ ] Feature flag `MMP_ENGINE_WIRING_ENABLED` 활성 상태에서 통합 테스트 PASS
+- [ ] 12개 모듈 smoke test PASS
+- [ ] e2e 시나리오 통과
+- [ ] Restart recovery + panic isolation 시나리오 통과
+- [ ] Prometheus metric 9종 scrape 가능
+- [ ] `project_phase80_progress.md` 최종 갱신
+- [ ] 루트 `docs/plans/2026-04-05-rebuild/checklist.md` "Phase 8.0 ✅"
+- [ ] `/plan-finish` 실행 → archive
+- [ ] Phase 8.0.x 후속 plan 작성 여부 결정 (17 모듈 wiring)

--- a/docs/plans/2026-04-08-engine-integration/design.md
+++ b/docs/plans/2026-04-08-engine-integration/design.md
@@ -1,0 +1,115 @@
+# Phase 8.0 — Engine Integration Layer 설계 (index)
+
+> **상태**: 확정 (2026-04-08, brainstorming 합의 완료)
+> **다음 단계**: `plan.md` 작성 → 9개 PR 시리즈 wave 기반 병렬 실행
+> **상위 설계 참조**: `docs/plans/2026-04-05-rebuild/refs/game-engine.md`, `architecture.md`
+> **MD 200줄 제한**: 이 index 포함 모든 문서 <200줄. 상세는 `refs/`로 분할.
+
+---
+
+## 목적
+
+`docs/plans/2026-04-05-rebuild/`의 상위 design.md에 명시됐지만 미구현 상태인 game engine integration layer를 **실서비스급**으로 완성한다. v3의 모든 후속 phase가 이 토대 위에 쌓인다. **MVP 아님** — 견고함과 유지보수성 우선.
+
+---
+
+## Scope (Phase 8.0)
+
+엔진 spine + Core 4 + Progression 8 = **12개 모듈** wired. 자세한 스코프 경계와 out-of-scope 목록은 `refs/scope-and-decisions.md` 참조.
+
+| 카테고리 | 모듈 (12개) |
+|----------|------------|
+| Core (4) | connection, room, ready, clue_interaction |
+| Progression (8) | script, hybrid, event, skip_consensus, gm_control, consensus_control, reading, ending |
+
+Communication 5 + Decision 3 + Exploration 4 + Clue Distribution 5 = 17개는 **Phase 8.0.x** 후속.
+
+---
+
+## 확정된 7대 결정 (변경 금지)
+
+| # | 결정 | 선택 | 핵심 근거 |
+|---|------|------|----------|
+| 1 | Scope | B (12 모듈) | "한 게임이 끝까지 돌아간다"가 실서비스 최소 정의 |
+| 2 | Architecture | A (100% Actor) | v2 race 버그 클래스 원천 차단. lock-free 모듈 |
+| 3 | Lifecycle | Room/Session 1:1 분리 + Host 명시 시작 + 명시/타임아웃/abort 종료 | "다시 하기" UX + 좀비 세션 0 |
+| 4 | WS↔Actor 통신 | 모듈별 handler + Reply 채널 + 매핑 테이블 + Listener | 일관성 + 결정적 응답 |
+| 5 | State Persistence | Replay+snapshot 하이브리드 + 5초 throttle (critical 즉시) + Lazy restore | 좀비 자연 GC + 시나리오 분리 |
+| 6 | 운영 안전성 | 메시지단 recover + 3회 abort + Prom/OTel + Unit/Integration | panic 격리 + prod 가시성 |
+| 7 | 도입 | **Wave 기반 병렬 실행** + feature flag (`MMP_ENGINE_WIRING_ENABLED` default off) | 속도 + 안전 + revert 가능 |
+
+상세는 `refs/scope-and-decisions.md` 참조.
+
+---
+
+## 문서 맵 (refs/)
+
+| 파일 | 내용 |
+|------|------|
+| [refs/scope-and-decisions.md](refs/scope-and-decisions.md) | 7대 결정의 각 옵션 분석, scope 경계, out-of-scope 목록 |
+| [refs/architecture.md](refs/architecture.md) | SessionManager / Session / BaseModuleHandler / EventMapping / Hub listener 컴포넌트 상세 + 아키텍처 다이어그램 |
+| [refs/data-flow.md](refs/data-flow.md) | 게임 시작 / in-game 메시지 / disconnect-reconnect 흐름도 |
+| [refs/persistence.md](refs/persistence.md) | Redis 스냅샷 알고리즘 (5초 throttle + critical 즉시), Lazy restore, key 구조 |
+| [refs/execution-model.md](refs/execution-model.md) | **Wave 기반 병렬 실행**, PR 의존 DAG, 파일 구조 설계 (병렬 wave 머지 충돌 방지), 병렬 리뷰 4 agent |
+| [refs/observability-testing.md](refs/observability-testing.md) | Prometheus 메트릭, OTel trace, 테스트 전략, 에러 처리, 위험 요소 |
+
+---
+
+## 전체 구조 요약 (한눈에)
+
+```
+┌─────────────────────────────────────────────────────┐
+│           cmd/server/main.go                        │
+│  Hub(lifecycle) ← SessionManager(listener)          │
+│       ↓                ↓                             │
+│  ModuleHandlers ──→ Session (1 goroutine, actor)    │
+│  (reading, ...)     ├─ engine (NO LOCKS)            │
+│                     ├─ EventMapping → Hub.Broadcast │
+│                     └─ 5s throttle → Redis          │
+└─────────────────────────────────────────────────────┘
+```
+
+**액터 이벤트 루프**: `wsCh | timerCh | gmCh | consensusCh | triggerCh | lifecycleCh | snapshotCh | done`
+
+---
+
+## 실행 전략 요약
+
+**Wave 기반 병렬 실행** (상세는 `refs/execution-model.md`):
+
+| Wave | PRs | 모드 | 의존 |
+|------|-----|------|------|
+| 1 | PR-1, PR-2 | **병렬** | 없음 |
+| 2 | PR-3 | 순차 | W1 |
+| 3 | PR-4 (패턴 레퍼런스) | 순차 | W2 |
+| 4 | PR-5, PR-6, PR-7, PR-8 | **병렬 (4개)** | W3 |
+| 5 | PR-9 | 순차 | W4 |
+
+**속도 이득**: 순차 9T → 병렬 5T 단위 (약 33~50% 단축)
+
+**병렬 메커니즘**: Agent tool의 `isolation: "worktree"` — 각 병렬 agent가 자체 git worktree에서 작업, 파일 충돌 원천 차단.
+
+---
+
+## 종료 조건
+
+Phase 8.0 "완료" 기준 (상세는 `refs/execution-model.md`):
+
+- [ ] 9개 PR 모두 main 머지
+- [ ] feature flag 활성화 상태에서 모든 통합 테스트 PASS
+- [ ] 12개 모듈 smoke test PASS
+- [ ] 한 게임 end-to-end 시나리오 통과 (in-process integration)
+- [ ] Server restart 복구 시나리오 통과
+- [ ] Panic 격리 시나리오 통과 (3회 누적 → abort)
+- [ ] Prometheus metric 9종 노출
+- [ ] `memory/project_phase80_progress.md` 최종 갱신 + Phase 8.0.x로 인계
+
+---
+
+## 다음 단계
+
+1. `plan.md` 작성 — PR별 상세 task breakdown (각 PR별 `refs/pr-N-*.md`, 200줄 제한)
+2. `checklist.md` 작성 — STATUS 마커 + 각 PR 체크박스
+3. root `checklist.md`에 "Phase 8.0" 추가 + 기존 Phase 8을 "Phase 8.1"로 rename
+4. PR 0 (문서 인프라) 머지
+5. PR-1 skeleton 착수 (Wave 1)

--- a/docs/plans/2026-04-08-engine-integration/plan.md
+++ b/docs/plans/2026-04-08-engine-integration/plan.md
@@ -1,0 +1,133 @@
+# Phase 8.0 — Engine Integration Layer 실행 계획 (index)
+
+> 부모: [design.md](design.md)
+> MD 200줄 제한: 각 PR 상세는 `refs/pr-N-*.md`
+
+---
+
+## Overview
+
+Phase 8.0은 12개 모듈 (Core 4 + Progression 8)을 wave 기반 병렬 실행으로 wired합니다. 순수 wiring만 담당하며, 29개 중 나머지 17개는 Phase 8.0.x 후속.
+
+전체 아키텍처: [refs/architecture.md](refs/architecture.md)
+Wave 실행 모델: [refs/execution-model.md](refs/execution-model.md)
+
+---
+
+## Wave 구조
+
+```
+W0 (docs/infra)   ──▶  W1 (skeletons, ×2 parallel)
+                           │
+                           ▼
+                       W2 (infra) ──▶ W3 (pattern ref)
+                                          │
+                                          ▼
+                          W4 (wiring, ×4 parallel)
+                                          │
+                                          ▼
+                          W5 (observability)
+```
+
+| Wave | Mode | PRs | 의존 | 예상 단위 |
+|------|------|-----|------|----------|
+| W0 | sequential | PR-0 | - | 1T |
+| W1 | **parallel ×2** | PR-1, PR-2 | W0 | 1T |
+| W2 | sequential | PR-3 | W1 | 1T |
+| W3 | sequential | PR-4 | W2 | 1T |
+| W4 | **parallel ×4** | PR-5, PR-6, PR-7, PR-8 | W3 | 1T |
+| W5 | sequential | PR-9 | W4 | 1T |
+
+**순차 9T → 병렬 5T (~44% 단축)**
+
+---
+
+## PR 목록
+
+| PR | Wave | Title | 의존 | 상세 |
+|----|------|-------|------|------|
+| PR-0 | W0 | Docs + plan-autopilot infra | - | [refs/pr-0-docs-infra.md](refs/pr-0-docs-infra.md) |
+| PR-1 | W1 | SessionManager + Session actor | PR-0 | [refs/pr-1-skeleton.md](refs/pr-1-skeleton.md) |
+| PR-2 | W1 | Hub lifecycle listener | PR-0 | [refs/pr-2-hub-lifecycle.md](refs/pr-2-hub-lifecycle.md) |
+| PR-3 | W2 | BaseModuleHandler + EventMapping | PR-1, PR-2 | [refs/pr-3-base-handler.md](refs/pr-3-base-handler.md) |
+| PR-4 | W3 | Reading module wired (pattern ref) | PR-3 | [refs/pr-4-reading-wired.md](refs/pr-4-reading-wired.md) |
+| PR-5 | W4 | Core 4 modules wired | PR-4 | [refs/pr-5-core-modules.md](refs/pr-5-core-modules.md) |
+| PR-6 | W4 | Progression 7 modules wired | PR-4 | [refs/pr-6-progression-modules.md](refs/pr-6-progression-modules.md) |
+| PR-7 | W4 | Redis snapshot + Lazy restore | PR-4 | [refs/pr-7-snapshot-restore.md](refs/pr-7-snapshot-restore.md) |
+| PR-8 | W4 | Game start API + abort + idle timeout | PR-4 | [refs/pr-8-game-start-api.md](refs/pr-8-game-start-api.md) |
+| PR-9 | W5 | Observability (Prometheus + OTel) | PR-5~8 | [refs/pr-9-observability.md](refs/pr-9-observability.md) |
+
+---
+
+## Merge 전략
+
+1. Wave 내 병렬 PR은 각자 `isolation: "worktree"`
+2. 머지 순서: **PR 번호 순** (순차)
+3. 각 머지 후 `go test -race -count=1 ./...` gate
+4. 충돌 시 executor sub-agent에 해결 위임 (fix-loop 포함)
+5. Wave 종료 시 user 확인 1회
+
+---
+
+## Feature flag
+
+`MMP_ENGINE_WIRING_ENABLED` (default `false`)
+
+- PR-1 ~ PR-8: default off → prod 영향 0
+- PR-9 머지 후 → dev에서 activate
+- Prod activate는 Phase 8.1 통합 QA 후 별도 결정
+
+---
+
+## 파일 구조 규칙 (병렬 wave 머지 충돌 방지)
+
+PR-4에서 확정되는 파일 구조 패턴:
+
+```
+internal/session/
+  event_mapping.go              # 인프라 (PR-3)
+  event_mapping_reading.go      # PR-4
+  event_mapping_core.go         # PR-5
+  event_mapping_progression.go  # PR-6
+  registry.go                   # 팩토리 (PR-3)
+  registry_reading.go           # PR-4
+  registry_core.go              # PR-5
+  registry_progression.go       # PR-6
+  registry_snapshot.go          # PR-7
+
+internal/ws/handlers/
+  reading.go                    # PR-4
+  core_*.go (4개)               # PR-5
+  progression_*.go (7개)        # PR-6
+```
+
+**핵심**: main.go는 PR-3 이후 수정 금지 (`session.RegisterAllHandlers(router, manager)` 1줄만).
+
+---
+
+## 알려진 위험
+
+| 위험 | 완화 |
+|------|------|
+| engine.go lock 제거 후 race | `go test -race` CI gate + actor 경로 강제 |
+| Inbox full | Buffer 256, full 시 명시 에러 + Prometheus alert |
+| Redis 일시 장애 | 재시도 3회 + session 계속 |
+| Snapshot schema 호환성 | `schemaVersion` 필드 + mismatch 시 손실 |
+| Wave 4 병렬 머지 충돌 | 파일 구조 설계 + scope 검증 (plan-wave.sh) |
+
+---
+
+## 후속 phase
+
+- **Phase 8.0.x**: Communication 5 + Decision 3 + Exploration 4 + Clue Distribution 5 = 17 모듈
+- **Phase 8.1** (구 Phase 8): 통합 QA (Playwright E2E)
+- **Phase 8.5**: 보안/테스트/i18n
+- **Phase 8.6**: 이관/에셋/Admin
+
+---
+
+## 스킬 참조
+
+- 실행: `~/.claude/skills/plan-autopilot/commands/plan-autopilot.md`
+- Wave 실행 상세: `~/.claude/skills/plan-autopilot/refs/execution.md`
+- Pipeline config: `.claude/post-task-pipeline.json`

--- a/docs/plans/2026-04-08-engine-integration/refs/architecture.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/architecture.md
@@ -1,0 +1,188 @@
+# 아키텍처 상세
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## 전체 다이어그램
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                cmd/server/main.go (DI 조립)                 │
+│                                                              │
+│  ┌─────────┐  ┌──────────┐  ┌─────────────────┐            │
+│  │ ws.Hub  │──│  Router  │  │ SessionManager  │            │
+│  │(listener│  │          │  │ (Listener impl) │            │
+│  │  hook)  │  └────┬─────┘  └────┬────────────┘            │
+│  └─────┬───┘       │             │                          │
+│        │    ┌──────┴───────┐     │                          │
+│        │    │ Module       │     │                          │
+│        │    │ Handlers     │     │                          │
+│        │    │ (reading,    │     │                          │
+│        │    │  core_*,     │     │                          │
+│        │    │  progression*)│     │                          │
+│        │    └──────┬───────┘     │                          │
+│        │           │ WithSession │                          │
+│        │           │ Inbox<-msg  │                          │
+│        │           ↓             │                          │
+│        │ ┌─────────────────────────┐                        │
+│        └→│ Session (1 goroutine)    │                        │
+│          │  select {                │                        │
+│          │    wsCh / timerCh /      │                        │
+│          │    gmCh / consensusCh /  │                        │
+│          │    lifecycleCh /         │                        │
+│          │    snapshotCh / done     │                        │
+│          │  }                       │                        │
+│          │  ↓                        │                        │
+│          │  engine (NO LOCKS)        │                        │
+│          │  modules[] / EventBus     │                        │
+│          │  ↓ Publish                │                        │
+│          │  GameEventMappings        │                        │
+│          │    → Hub.BroadcastToSess  │                        │
+│          └──────────┬────────────────┘                        │
+│                     │ 5s throttle (dirty)                     │
+│                     │ critical events (immediate)             │
+│                     ↓                                          │
+│              ┌──────────────┐                                 │
+│              │ Redis        │                                 │
+│              │ session:*:*  │                                 │
+│              └──────────────┘                                 │
+└────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 핵심 컴포넌트 4개
+
+### 1. SessionManager (`internal/session/manager.go`)
+
+```go
+type SessionManager struct {
+    mu       sync.RWMutex  // sessions map 보호만
+    sessions map[uuid.UUID]*Session
+    // 의존성
+    hub       *ws.Hub
+    redis     *redis.Client
+    queries   *db.Queries
+    voiceProv voice.VoiceProvider
+    logger    zerolog.Logger
+    // 메트릭
+    activeGauge prometheus.Gauge
+}
+
+// 라이프사이클
+func (m *SessionManager) Start(ctx, roomID, configJSON, players, host) (*Session, error)
+func (m *SessionManager) Stop(ctx, sessionID, reason) error
+func (m *SessionManager) Get(sessionID) *Session
+func (m *SessionManager) Restore(ctx, sessionID) (*Session, error)  // Lazy
+
+// SessionLifecycleListener 구현
+func (m *SessionManager) OnPlayerLeft(sessionID, playerID uuid.UUID)
+func (m *SessionManager) OnPlayerRejoined(sessionID, playerID uuid.UUID)
+```
+
+**Lock 정책**: `mu`는 sessions map만. Session 내부 데이터는 절대 만지지 않음. 모든 작업은 `session.Inbox` channel로 위임.
+
+### 2. Session (`internal/session/session.go`)
+
+```go
+type Session struct {
+    ID       uuid.UUID
+    RoomID   uuid.UUID
+    HostID   uuid.UUID
+    engine   *engine.GameProgressionEngine  // lock 없음, 이 goroutine만 접근
+    players  map[uuid.UUID]*PlayerState
+    status   SessionStatus
+
+    inbox       chan SessionMessage   // 통합 입구
+    done        chan struct{}
+
+    // 상태 (actor만 접근)
+    lastSnapshotAt time.Time
+    dirtySince     time.Time
+    panicCount     int
+}
+
+type SessionMessage struct {
+    Kind     MessageKind  // ws/gm/timer/consensus/trigger/lifecycle/critical
+    PlayerID uuid.UUID
+    Payload  any
+    Reply    chan error   // nil = fire-and-forget
+    Ctx      context.Context
+}
+
+func (s *Session) Run(ctx context.Context) {
+    snapshotTicker := time.NewTicker(5 * time.Second)
+    defer snapshotTicker.Stop()
+    for {
+        select {
+        case msg := <-s.inbox:
+            s.handleMessage(msg)  // panic recover 내부에서
+        case <-snapshotTicker.C:
+            s.maybeSnapshot()
+        case <-s.done:
+            return
+        case <-ctx.Done():
+            return
+        }
+    }
+}
+```
+
+**키 디자인**:
+- Inbox **단일 채널** + MessageKind 분기 (8-way select 대신 단순화)
+- Reply chan size 1 (sender unblock 보장)
+- panic recover 메시지 단위, counter 누적 (3회 abort)
+
+### 3. BaseModuleHandler (`internal/ws/base_module_handler.go`)
+
+```go
+type BaseModuleHandler struct {
+    manager *session.Manager
+    logger  zerolog.Logger
+}
+
+func (h *BaseModuleHandler) WithSession(c *Client, kind MessageKind, payload any) error {
+    // 1. sessionID 검증
+    // 2. manager.Get(sessionID) 또는 Lazy Restore
+    // 3. Reply 채널 생성
+    // 4. inbox 전송 (500ms 타임아웃)
+    // 5. reply 대기 (2s 타임아웃)
+    // 6. 에러 시 translateError → client에 envelope
+}
+```
+
+각 모듈 핸들러(예: ReadingHandler)는 이 헬퍼 호출로 boilerplate 제거.
+
+### 4. EventMapping 테이블 (`internal/session/event_mapping.go` + 모듈별 파일)
+
+```go
+type EventMapping struct {
+    EngineEventType string  // "reading.line_changed"
+    WSType          string  // "reading:line_changed"
+    Convert         func(payload any) (any, error)  // nil=pass-through
+}
+
+// 모듈별 파일로 분리 (병렬 wave 머지 충돌 방지)
+// event_mapping.go         — 인프라
+// event_mapping_reading.go — PR-4
+// event_mapping_core.go    — PR-5
+// event_mapping_progression.go — PR-6
+```
+
+Session.Run 안에서 subscribe 등록, 수신 시 wire 변환 후 `hub.BroadcastToSession`.
+
+### 5. Hub Lifecycle Listener (`internal/ws/hub.go` 추가)
+
+```go
+type SessionLifecycleListener interface {
+    OnPlayerLeft(sessionID, playerID uuid.UUID)
+    OnPlayerRejoined(sessionID, playerID uuid.UUID)
+}
+
+func (h *Hub) RegisterLifecycleListener(l SessionLifecycleListener)
+// disconnect 시 notifyPlayerLeft 호출
+// JoinSession 시 reconnect 감지하여 notifyPlayerRejoined 호출
+```
+
+단방향 의존 (Hub → listener interface ← SessionManager).

--- a/docs/plans/2026-04-08-engine-integration/refs/data-flow.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/data-flow.md
@@ -1,0 +1,147 @@
+# 데이터 흐름
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## 1. 게임 시작 흐름
+
+```
+[Host Client]                 [Server]                     [SessionManager]
+  │                              │                              │
+  ├─ POST /api/v1/rooms/{id}/start ─→                           │
+  │                              │ ├─ validate host             │
+  │                              │ ├─ check all players ready   │
+  │                              │ ├─ load theme.configJson     │
+  │                              │ │                             │
+  │                              ├─ Start(roomID, config) ────→ │
+  │                              │                              │
+  │                              │        ┌─────────────────────┘
+  │                              │        │ NewSession(...)
+  │                              │        │ go session.Run(ctx)
+  │                              │        │ engine.Start(ctx, config)
+  │                              │        │ subscribeMappings()
+  │                              │        │ persistSnapshot(initial)
+  │                              │        │
+  │                              │        ↓ sessionID
+  │                              │ ←──────
+  │                              │
+  │                              ├─ Room.sessionID = sessionID (DB)
+  │                              ├─ broadcast: {type: "session:started", sessionId}
+  │ ←─ session:started ──────────│
+[All Clients]                    │
+  │                              │
+  ├─ WS /ws/game?sessionId ─────→│
+  │                              ├─ Hub.JoinSession(client, sessionID)
+  │                              │   → notifyPlayerRejoined (reconnect 시)
+  │                              │   → snapshot push (클라이언트별)
+```
+
+---
+
+## 2. In-game 메시지 흐름 (reading:advance 예시)
+
+```
+[Client A]           [Hub]           [ReadingHandler]    [Session goroutine]
+   │                   │                    │                   │
+   ├ {reading:advance}→│                    │                   │
+   │                   ├ Route(c, env) ────→│                   │
+   │                   │                    ├ WithSession(...)  │
+   │                   │                    │                   │
+   │                   │                    ├ inbox <- msg ───→ │
+   │                   │                    │                   │
+   │                   │                    │                   ├ engine.modules["reading"]
+   │                   │                    │                   │   .HandleAdvance(playerID,
+   │                   │                    │                   │                   isHost,
+   │                   │                    │                   │                   roleID)
+   │                   │                    │                   │ → 권한 검증
+   │                   │                    │                   │ → currentLineIndex++
+   │                   │                    │                   │ → eventBus.Publish(
+   │                   │                    │                   │     "reading.line_changed")
+   │                   │                    │                   │
+   │                   │                    │                   ├ EventMapping subscriber
+   │                   │                    │                   │ → wire envelope
+   │                   │                    │                   │ → hub.BroadcastToSession
+   │ ←─ {reading:line_changed} ──────────────┤                   │
+   │                   │                    │                   │
+   │                   │                    ├ reply ←──────── ──│ (nil = success)
+   │                   │                    │                   │
+   │                   │ ←─ 통과 ───────────│                   │
+```
+
+**성질**: 한 메시지 처리 = 결정적 순서, lock 0개, race 0개.
+
+---
+
+## 3. Disconnect / Reconnect 흐름
+
+### Disconnect (Client B 끊김)
+
+```
+[Client B 끊김]
+   │
+   ├→ ws.Hub.run() unregister → removeClientLocked(c)
+   │                             notifyPlayerLeft(c)
+   │                                  │
+   │                                  ↓
+   │                             SessionManager.OnPlayerLeft(sessionID, playerID)
+   │                                  │
+   │                                  ↓
+   │                             session.Inbox <- {Kind: KindLifecycleLeft, PlayerID}
+   │                                  │
+   │                                  ↓ (session goroutine 안에서)
+   │                             reading 모듈에 HandlePlayerLeft 호출
+   │                             → 호스트면 status=paused
+   │                             → eventBus.Publish("reading.paused")
+   │                             → 매핑 → reading:paused broadcast
+```
+
+### Reconnect (Client B 재접속)
+
+```
+[Client B 재접속 with same playerID]
+   │
+   ├→ ws.Hub.JoinSession(c, sessionID)
+   │                             notifyPlayerRejoined(c)
+   │                                  │
+   │                                  ↓
+   │                             SessionManager.OnPlayerRejoined
+   │                                  │
+   │                                  ↓
+   │                             Session.Inbox <- {Kind: KindLifecycleRejoined}
+   │                                  │
+   │                                  ↓ (session goroutine 안에서)
+   │                             reading 모듈에 HandlePlayerRejoined 호출
+   │                             → status=playing
+   │                             → eventBus.Publish("reading.resumed")
+   │                             + 클라이언트 B에게만 snapshot push
+   │                               (다른 클라이언트들은 reading:resumed 이벤트만 받음)
+```
+
+---
+
+## 4. Phase 전환 흐름
+
+```
+[타이머 만료 또는 합의 도달 또는 GM 오버라이드]
+   │
+   ↓ Session.Inbox <- {Kind: KindTimer/Consensus/GM}
+   │
+   ↓ handleMessage → engine.Advance(ctx) or engine.GMOverride(...)
+   │
+   ↓ engine 내부:
+   │   ├ exitCurrentPhase (onExit actions via ActionDispatcher)
+   │   ├ strategy.Advance / SkipTo
+   │   └ enterCurrentPhase (onEnter actions)
+   │
+   ↓ eventBus.Publish("phase:changed", newPhaseInfo)
+   │
+   ↓ EventMapping → Hub.BroadcastToSession("phase:changed" → "phase:changed")
+   │
+   ↓ 즉시 Critical Snapshot (phase 전환은 critical 이벤트)
+   │   self Inbox <- {Kind: KindCriticalSnapshot}
+   │
+   ↓ persistSnapshot(force=true) → Redis write
+```
+
+Phase 전환은 5초 throttle 무시하고 즉시 Redis에 write. 재시작 복구 시 phase 손실 방지.

--- a/docs/plans/2026-04-08-engine-integration/refs/execution-model.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/execution-model.md
@@ -1,0 +1,188 @@
+# Wave 기반 병렬 실행 모델
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## PR 의존성 DAG
+
+```
+Level 0:  PR-1 (SessionManager skeleton)
+              │
+              ├──────────────────┐
+Level 1:  PR-2 (Hub lifecycle)  (...)
+              │
+Level 2:  PR-3 (BaseModuleHandler + EventMapping infra)
+              │
+Level 3:  PR-4 (Reading wired — 패턴 레퍼런스)
+              │
+              ├────────┬────────┬────────┐
+Level 4:  PR-5       PR-6     PR-7     PR-8
+          Core 4     Prog 8   Snapshot  Start API
+              │        │        │        │
+              └────────┴────┬───┴────────┘
+                            │
+Level 5:          PR-9 (Observability)
+```
+
+**단, PR-7은 Level 1에 놓을 수도 있음** (PR-2와 병렬) — PR-1만 필요하고 파일 독립. 하지만 Wave 1을 작게 유지(2 PR)하고 PR-7을 Wave 4에 두면 Wave 4의 병렬 이득을 극대화. 최종 선택: **Wave 4에 두되, Wave 1 일찍 끝나면 PR-7을 앞당겨 실행 가능** (optional).
+
+---
+
+## Wave 5개 구성
+
+### Wave 1: 독립 Skeletons (병렬 ×2)
+- **PR-1**: SessionManager + Session actor skeleton
+- **PR-2**: Hub lifecycle listener (interface + RegisterLifecycleListener)
+- Scope 완전 독립: `internal/session/*` vs `internal/ws/hub.go`
+- **예상 wall-clock**: max(PR-1, PR-2) ≈ PR-1 시간
+
+### Wave 2: 인프라 (순차)
+- **PR-3**: BaseModuleHandler + EventMapping 테이블 인프라
+- W1 양쪽 인터페이스 import 필요 → 순차 필수
+
+### Wave 3: 패턴 레퍼런스 (순차)
+- **PR-4**: Reading 모듈 wired
+- 모든 후속 모듈 wiring의 **패턴 레퍼런스**. 순차 필수
+- 이 PR이 확정되어야 PR-5~8이 복사 가능한 패턴을 보유
+
+### Wave 4: 병렬 wiring (병렬 ×4) ⚡⚡⚡⚡
+- **PR-5**: Core 4 modules (connection, room, ready, clue_interaction)
+- **PR-6**: Progression 7 modules (script/hybrid/event/skip_consensus/gm_control/consensus_control/ending)
+- **PR-7**: Redis snapshot + Lazy restore
+- **PR-8**: Game start API (`POST /api/v1/rooms/{id}/start` + abort + idle timeout)
+- **예상 wall-clock**: max(PR-5, PR-6, PR-7, PR-8) ≈ PR-6 시간
+
+### Wave 5: 전역 관통 (순차)
+- **PR-9**: Observability (모든 파일에 metric/trace 주입)
+- W4 머지 후에만 안정적 실행 가능
+
+---
+
+## 속도 개선 추정
+
+| 실행 방식 | 단위 시간 | 비고 |
+|----------|----------|------|
+| 완전 순차 (9 PR 직렬) | 9T | 기존 설계 |
+| Wave 기반 병렬 | **5T** | W1, W4 병렬로 4개 단축 |
+| 단축율 | **~44%** | |
+
+Wave 4가 가장 큰 기여 (4 PR 동시).
+
+---
+
+## 병렬 실행 메커니즘 (Agent tool)
+
+Agent 도구의 `isolation: "worktree"` 파라미터:
+
+> "You can optionally set `isolation: \"worktree\"` to run the agent in a temporary git worktree, giving it an isolated copy of the repository."
+
+각 병렬 sub-agent가 **자체 git worktree**에서 작업 → 파일 충돌 원천 차단.
+
+### Wave 4 실행 예시
+
+```
+Main orchestrator가 한 메시지에 4개 Agent tool_use 블록 (진짜 병렬):
+
+Agent A: PR-5   isolation: worktree   branch: feat/phase-8.0-pr-5
+Agent B: PR-6   isolation: worktree   branch: feat/phase-8.0-pr-6
+Agent C: PR-7   isolation: worktree   branch: feat/phase-8.0-pr-7
+Agent D: PR-8   isolation: worktree   branch: feat/phase-8.0-pr-8
+
+[4 agents 병렬 작업 — 구현 + test + pipeline + commit]
+  └─ main에 결과 반환 (worktree path + commit hash)
+
+[main이 순차 머지 — 같은 파일 건드릴 확률 낮음]
+  ├ git merge feat/phase-8.0-pr-5 → go test -race → PASS
+  ├ git merge feat/phase-8.0-pr-6 → go test -race → PASS
+  ├ git merge feat/phase-8.0-pr-7 → go test -race → PASS
+  └ git merge feat/phase-8.0-pr-8 → go test -race → PASS
+
+[Wave 종료 → user 확인 1회 → merge to main]
+```
+
+---
+
+## 파일 구조 설계 (병렬 머지 충돌 방지)
+
+Wave 4 병렬 wiring이 충돌 없이 성공하려면 초기부터 파일을 **모듈별로 분리** 필수.
+
+```
+internal/session/
+  event_mapping.go              # PR-3 인프라 (type + register 함수)
+  event_mapping_reading.go      # PR-4 배타적 편집
+  event_mapping_core.go         # PR-5 배타적 편집
+  event_mapping_progression.go  # PR-6 배타적 편집
+
+internal/ws/handlers/
+  reading.go                    # PR-4
+  core_connection.go            # PR-5
+  core_room.go                  # PR-5
+  core_ready.go                 # PR-5
+  core_clue_interaction.go      # PR-5
+  progression_script.go         # PR-6
+  progression_hybrid.go         # PR-6
+  progression_event.go          # PR-6
+  progression_skip_consensus.go # PR-6
+  progression_gm_control.go     # PR-6
+  progression_consensus_control.go # PR-6
+  progression_ending.go         # PR-6
+
+internal/session/
+  registry.go                   # PR-3: RegisterModuleHandlers() 팩토리
+  registry_reading.go           # PR-4: reading handler/mapping 등록
+  registry_core.go              # PR-5: core 4 등록
+  registry_progression.go       # PR-6: progression 등록
+  registry_snapshot.go          # PR-7
+
+cmd/server/main.go              # PR-1~3이 기본 틀 작성, PR-4부터는 건드리지 않음
+                                # session.RegisterAllModuleHandlers(router, manager) 1줄만 호출
+```
+
+**핵심 규칙**:
+- **main.go는 PR-4 이후 수정 금지** (PR-4가 registry 패턴을 확정)
+- 모듈별 registry 파일은 서로 독립 → 병렬 편집 안전
+- EventMapping 등록 함수도 모듈별 파일에 분산 → append 방식 아님, 각자 독립
+
+---
+
+## 병렬 리뷰 (4 agent)
+
+Wave 4의 각 PR이 구현 끝난 후, 리뷰 단계에서 **4개 sub-agent 병렬 호출**:
+
+| Agent | Role | 관점 |
+|-------|------|------|
+| Security reviewer | `superpowers:code-reviewer` 또는 `oh-my-claudecode:security-reviewer` | auth/권한/검증/injection |
+| Performance reviewer | `oh-my-claudecode:code-reviewer` | lock contention, allocation, hot path |
+| Architecture reviewer | `oh-my-claudecode:critic` 또는 `architect` | design.md 정합성, SOLID, 레이어 분리 |
+| Test-coverage reviewer | `oh-my-claudecode:test-engineer` | 누락 시나리오, race, edge case |
+
+한 메시지에 4개 Agent 호출 → 병렬 실행 → 결과 수집 → findings 통합.
+
+**Fix-loop**: 어느 리뷰라도 CRITICAL/HIGH 발견 시 `oh-my-claudecode:executor` sub-agent 호출해 수정 → 재리뷰 → 최대 **3회 반복** → 초과 시 user에 수동 개입 요청.
+
+---
+
+## Merge 전략
+
+1. Wave 내 모든 PR이 구현 + pipeline 완료
+2. main이 PR 번호 순으로 순차 머지
+3. 각 머지 후 `go test -race -count=1 ./...` 실행
+4. 충돌 발생 시 `oh-my-claudecode:executor`에 충돌 해결 위임
+5. 모든 머지 성공 → **user 확인 1회** ("Wave 4 머지 완료, 다음 wave 진행?")
+6. OK → 다음 wave
+7. 실패 → 중단 + 보고
+
+---
+
+## 종료 조건 (Phase 8.0 완료)
+
+- [ ] 9개 PR 모두 main 머지 (5 wave 완료)
+- [ ] feature flag 활성화 상태에서 통합 테스트 PASS
+- [ ] 12개 모듈 smoke test PASS
+- [ ] 한 게임 e2e 시나리오 in-process integration 통과
+- [ ] Server restart 복구 시나리오 통과
+- [ ] Panic 3회 누적 abort 시나리오 통과
+- [ ] Prometheus metric 9종 scrape 가능
+- [ ] `memory/project_phase80_progress.md` 최종 갱신
+- [ ] checklist.md root 파일 "Phase 8.0 ✅"

--- a/docs/plans/2026-04-08-engine-integration/refs/observability-testing.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/observability-testing.md
@@ -1,0 +1,128 @@
+# Observability, 테스트, 에러 처리, 위험 요소
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## Observability
+
+### Prometheus Metrics (9종)
+
+```
+mmp_active_sessions{theme}                   Gauge      현재 active session 수
+mmp_session_duration_seconds                 Histogram  session lifetime
+mmp_phase_duration_seconds{phase}             Histogram  phase 머무는 시간
+mmp_module_message_total{module,type}         Counter    모듈별 메시지 처리량
+mmp_module_message_duration_seconds{module}   Histogram  메시지 처리 시간
+mmp_module_panic_total{module}                Counter    panic 횟수
+mmp_redis_snapshot_duration_seconds           Histogram  스냅샷 write 시간
+mmp_redis_snapshot_failure_total              Counter    스냅샷 실패 횟수
+mmp_session_inbox_depth                       Gauge      inbox 점유율
+```
+
+### OTel Traces
+
+- **Per-session span**: `Session.Run()` 시작 ~ 종료 (긴 root span)
+- **Per-message span**: `handleMessage` child span
+  - Attributes: `kind`, `playerID`, `moduleName`, `session.id`
+- **Engine actions**: `engine.Start`, phase 전환, snapshot persist 각각 child span
+- **Redis ops**: snapshot/restore 각각 span
+
+### Logs (zerolog)
+
+- 기존 `main.go`의 zerolog + OTel hook (trace_id 자동 주입) 그대로
+- 추가 로그 이벤트:
+  - Info: session 시작/종료
+  - Error: panic + Sentry capture
+  - Warn: snapshot 실패, restore 시도/실패
+  - Debug: inbox depth, event publish
+
+### 알람 (Phase 8.0 제외)
+
+Prometheus 알람 룰은 Phase 8.0 범위 밖 (운영/SRE 영역). Phase 8.0의 책임은 "알람 걸 수 있을 만한 메트릭 기반".
+
+---
+
+## 테스트 전략
+
+### Unit 테스트
+
+| 파일 | 대상 |
+|------|------|
+| `internal/session/manager_test.go` | Start/Stop/Get/Restore lifecycle |
+| `internal/session/session_test.go` | actor loop, 메시지 dispatch, panic recover, snapshot throttle |
+| `internal/session/event_mapping_test.go` | 매핑 등록 + convert 함수 |
+| `internal/ws/base_module_handler_test.go` | WithSession boilerplate (fake manager) |
+| `internal/ws/hub_test.go` | RegisterLifecycleListener, notify on disconnect/rejoin |
+
+### Integration 테스트 (in-process, fake WS)
+
+| 파일 | 시나리오 |
+|------|---------|
+| `internal/integration/session_lifecycle_test.go` | Manager.Start → Session goroutine 생성 → 메시지 처리 → Stop |
+| `internal/integration/reading_e2e_test.go` | 가짜 client 2개 (host + player) → reading:advance/voice_ended → broadcast 검증 |
+| `internal/integration/restart_recovery_test.go` | Session 생성 → Redis 스냅샷 → Manager 재시작 → Lazy Restore → 상태 일치 |
+| `internal/integration/disconnect_pause_test.go` | host disconnect → reading:paused broadcast → host reconnect → reading:resumed |
+| `internal/integration/panic_isolation_test.go` | 모듈 panic 3회 누적 → session abort 검증 |
+
+### E2E (Playwright)
+
+**Phase 8.1로 미룸.** Phase 8.0에서는 in-process integration test만.
+
+### 커버리지 목표
+
+- `session` 패키지: 80%+
+- 통합 시나리오: reading e2e 1개 + restart 1개 + panic 1개 (코어 path)
+- Race detector (`-race`) 모든 테스트에 적용 (CI 게이트)
+
+---
+
+## 에러 처리
+
+### 카테고리별 처리
+
+| 카테고리 | 처리 |
+|---------|------|
+| 사용자 권한/입력 (apperror) | Reply 채널 반환 → ws.Error envelope |
+| 모듈 panic | message 단위 recover, count++, 3회 시 session abort + Sentry |
+| Redis 일시 장애 | 재시도 (exponential backoff, max 3) → 실패 시 Warn + Sentry. session 진행 차단 안 함 |
+| EventBus subscriber 에러 | log only (broadcast 실패는 치명적 아님) |
+| Inbox full | 500ms 대기 후 ws.Error (rare signal — 메시지 처리 너무 느림) |
+
+### Apperror 매핑
+
+`appErrorToWSCode` 함수가 이미 reading 모듈에 구현됨 (`ws/reading_handler.go`). 다른 모듈도 동일 패턴으로 확장.
+
+---
+
+## 위험 요소 + 완화
+
+| 위험 | 완화 |
+|------|------|
+| engine.go lock 제거 후 기존 호출자가 race 만남 | PR-1에서 lock 제거 + 모든 메서드를 Session goroutine 안에서만 호출되도록 강제. `go test -race` CI gate 필수 |
+| Inbox full → 메시지 손실 | Inbox buffer 256, full 시 클라에 명시 에러 + Prometheus alert. Dev에서 hit 시 즉시 조사 |
+| Redis 다운 시 session 진행 | 스냅샷 실패 ≠ session 차단. Warn + Sentry, 메모리에서 계속 진행 |
+| Snapshot schemaVersion 호환성 (v3.0 → v3.1) | 스냅샷에 `schemaVersion` 필드. 복구 시 mismatch면 그 session 손실 (cold start) + 운영 알람 |
+| 9개 PR 머지 중 main 깨짐 | Feature flag 보호 + race detector + 통합 테스트 CI gate + wave 머지 후 user 확인 1회 |
+| 12 모듈 wiring 중 일관성 어긋남 | PR-4에서 패턴 확정 후 `module-wiring-guide.md` 작성. PR-5, PR-6은 mechanical copy |
+| Phase 8.0.x 후속이 패턴 누락 | Phase 8.0 종료 시 가이드 문서 commit (`refs/module-wiring-guide.md`) |
+| Wave 4 병렬 머지 충돌 | 파일 구조 설계 시 모듈별 파일 분리 (`refs/execution-model.md` 참조). main.go는 PR-3 이후 수정 금지 |
+| Worktree 디스크 비용 | 병렬 wave에서 4배 repo 복사. 이 프로젝트는 크지 않아 무시 가능 |
+
+---
+
+## 관측성 + 테스트의 도입 시점 (PR 매핑)
+
+| PR | Observability 추가 | Test 추가 |
+|----|---------------------|-----------|
+| PR-1 | 기본 로그 | session_test.go 기초 |
+| PR-2 | — | hub_test.go 갱신 |
+| PR-3 | — | base_module_handler_test.go, event_mapping_test.go |
+| PR-4 | — | reading_e2e_test.go |
+| PR-5 | — | core 모듈 smoke test |
+| PR-6 | — | progression smoke + session_lifecycle_test.go |
+| PR-7 | `mmp_redis_snapshot_*` 메트릭 | restart_recovery_test.go |
+| PR-8 | — | api test (start, abort) |
+| PR-9 | **나머지 8종 메트릭 전부 + OTel spans** | panic_isolation_test.go + metric scrape test |
+
+PR-9가 observability 전담. 나머지 PR은 로컬 로그만.

--- a/docs/plans/2026-04-08-engine-integration/refs/persistence.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/persistence.md
@@ -1,0 +1,177 @@
+# State Persistence + Recovery
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## 시나리오 구분 (중요)
+
+| 시나리오 | 빈도 | 복구 대상 | 전략 |
+|---------|------|----------|------|
+| Client reconnect | 자주 (분당) | 그 클라이언트만 | Replay + Snapshot push |
+| Server restart | 드물게 (배포) | 모든 active session | Lazy Restore from Redis |
+
+이 둘은 데이터 흐름이 완전히 다르므로 따로 설계.
+
+---
+
+## Client Reconnect (하이브리드)
+
+### A. 짧은 단절 (<60s): ReconnectBuffer Replay
+
+이미 `ws.Hub`에 `ReconnectBuffer`(60초, 1000개 메시지) 구현됨. 그대로 활용.
+
+```
+Client B 재접속 → lastSeq 전송 → Hub가 buffer에서 그 이후 메시지 replay
+```
+
+- 추가 작업 0
+- 짧은 단절(와이파이 깜빡)은 저비용으로 복구
+
+### B. 긴 단절 (≥60s): Snapshot Push
+
+Buffer가 이미 지나갔으면 full state snapshot을 클라이언트에게 push.
+
+```
+Client B 재접속 → SessionManager.OnPlayerRejoined → Session.Inbox
+→ Session이 모든 active 모듈의 snapshot 1개 envelope 생성
+→ client B에게만 send (broadcast 아님)
+```
+
+각 모듈의 `BuildState()` 이미 구현됨 (engine.Module 인터페이스). 그 결과를 envelope으로 감싸서 push.
+
+---
+
+## Server Restart
+
+### 5초 Throttle + Critical 즉시 write
+
+**Throttle 알고리즘**:
+```go
+func (s *Session) maybeSnapshot() {
+    if s.dirtySince.IsZero() { return }            // dirty 없음
+    if time.Since(s.lastSnapshotAt) < 5*time.Second { return }  // throttle
+    s.persistSnapshot(force: false)
+    s.lastSnapshotAt = time.Now()
+    s.dirtySince = time.Time{}
+}
+
+func (s *Session) markDirty() {
+    if s.dirtySince.IsZero() {
+        s.dirtySince = time.Now()
+    }
+}
+```
+
+**Critical 이벤트는 즉시 force write** (throttle 무시):
+- Phase 전환 (enterCurrentPhase 직후)
+- 모듈 init / cleanup
+- Ending 모듈 활성화
+
+Critical은 `SessionMessage{Kind: KindCriticalSnapshot}`으로 self-send → 같은 actor 안에서 처리되어 race 없음.
+
+**왜 디바운스가 아니라 throttle?**
+- 디바운스: 5초 동안 변경 없으면 write → 끊임없이 변경되면 영원히 write 안 됨
+- Throttle: 최대 5초 손실 보장 → 데이터 안전성 ↑
+
+---
+
+## 직렬화 대상
+
+### 필수 (반드시 복구)
+- engine state: `currentPhase`, `started`, `configHash`
+- 모든 active 모듈: `BuildState()` 결과
+- 세션 메타: sessionID, roomID, players[], host, themeID
+- 페이즈 타이머: `phaseEnteredAt`, `phaseDeadline`
+
+### 제외 (복구 안 함)
+- WS conn: 클라이언트가 다시 연결
+- LiveKit room: 새로 생성
+- transient EventBus subscriptions: 새 goroutine이 re-subscribe
+
+---
+
+## Redis Key 구조
+
+```
+session:{sessionID}:meta        JSON: {roomID, host, players[], themeID, configHash, startedAt, lastActiveAt}
+session:{sessionID}:engine      JSON: {currentPhase, phaseEnteredAt, phaseDeadline, started, schemaVersion}
+session:{sessionID}:module:{n}  JSON: 모듈별 BuildState() 결과
+TTL: 24h on all keys, refreshed on each write
+```
+
+**schemaVersion**: 스냅샷 포맷 버전. 복구 시 mismatch면 해당 session 손실 처리 + 운영 알람. v3.0 → v3.1 업그레이드 시 마이그레이션 경로 확보.
+
+---
+
+## Lazy Restore
+
+```go
+func (m *SessionManager) Restore(ctx, sessionID) (*Session, error) {
+    // 1. Redis meta 조회 (없으면 nil)
+    meta := redis.Get("session:" + sessionID + ":meta")
+    if meta == nil { return nil, nil }
+
+    // 2. engine state, 모든 module state 조회 (MGET 권장)
+    engineState := redis.Get(...)
+    moduleStates := map[string]json.RawMessage{}
+
+    // 3. theme configJson 재로딩 (DB에서 — config는 immutable)
+    configJSON := loadConfigByThemeID(meta.themeID)
+
+    // 4. Session 재구성
+    sess := NewSession(sessionID, meta.roomID, ...)
+    go sess.Run(ctx)
+
+    // 5. engine 재시작 + state 복원
+    sess.engine = engine.NewEngine(sessionID, logger)
+    sess.engine.Start(ctx, configJSON)         // 모듈 Init 호출됨
+    sess.engine.RestoreEngineState(engineState) // currentPhase 복원
+    for name, state := range moduleStates {
+        sess.engine.RestoreModuleState(name, state)
+    }
+
+    // 6. 매핑 재구독
+    sess.subscribeMappings()
+
+    // 7. Manager에 등록
+    m.mu.Lock()
+    m.sessions[sessionID] = sess
+    m.mu.Unlock()
+
+    return sess, nil
+}
+```
+
+### engine 인터페이스 확장 필요
+
+- `(*GameProgressionEngine).RestoreEngineState(state json.RawMessage) error`
+- `(*GameProgressionEngine).RestoreModuleState(name string, state json.RawMessage) error`
+- `(engine.Module) RestoreState(state json.RawMessage) error` (옵셔널, default no-op)
+
+각 모듈의 `BuildState` ↔ `RestoreState`는 1:1 대응. PR-7에서 ReadingModule부터 구현.
+
+---
+
+## 복구 흐름 (Lazy — 자동 스캔 안 함)
+
+**Lazy 선택 이유**:
+- 시작 시 KEYS/SCAN 스캔은 prod에서 위험
+- 필요한 세션만 복구 → 메모리 절약
+- 좀비 세션 (배포 직전 끝난 세션)은 자연스럽게 GC (TTL + lazy miss)
+
+```
+[서버 재시작]
+  │ (모든 active session이 메모리에서 사라짐)
+  │
+[Client A 재접속 시도]
+  ├→ WS /ws/game?sessionId=X
+  ├→ Hub.JoinSession(c, X)
+  ├→ SessionManager.Get(X) → nil
+  ├→ SessionManager.Restore(ctx, X)
+  │    ├ Redis meta 조회
+  │    ├ 있음: Session 재구성 + 반환
+  │    └ 없음: nil (client에 "session not active" 에러)
+  ├→ Session 복원 완료
+  └→ snapshot push to client A
+```

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-0-docs-infra.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-0-docs-infra.md
@@ -1,0 +1,49 @@
+# PR-0: Docs + plan-autopilot infra
+
+> Wave 0 (sequential) | 의존: 없음
+
+## 목적
+Phase 8.0 문서 + plan-autopilot 스킬 설치 + 메모리 업데이트를 단일 PR로 머지.
+
+## Tasks
+- [x] design.md refactor to index + refs (각 <200줄)
+- [x] refs/scope-and-decisions.md
+- [x] refs/architecture.md
+- [x] refs/data-flow.md
+- [x] refs/persistence.md
+- [x] refs/execution-model.md (wave DAG)
+- [x] refs/observability-testing.md
+- [x] memory/project_phase80_plan.md (wave 반영)
+- [x] memory/project_phase80_progress.md (wave 반영)
+- [x] memory/MEMORY.md (Phase 8.0 pointer)
+- [x] ~/.claude/skills/plan-autopilot/ 전체 skill 생성
+- [x] .claude/ 설치 (scripts symlinks, commands copy, settings, pipeline)
+- [x] .claude/active-plan.json 초기화
+- [x] CLAUDE.md "Active Plan Workflow" 섹션 추가
+- [x] docs/plans/2026-04-08-engine-integration/checklist.md 최초 생성
+- [x] plan.md + refs/pr-0~9-*.md (이 파일 포함)
+- [ ] 루트 checklist.md Phase 8.0 추가 + Phase 8 → 8.1 rename
+- [ ] PR-0 commit + push + create PR
+
+## Files (스코프)
+- `docs/plans/2026-04-08-engine-integration/**`
+- `.claude/**`
+- `CLAUDE.md`
+- `memory/**`
+- `docs/plans/2026-04-05-rebuild/checklist.md` (root)
+
+## Test coverage
+- 문서 PR이라 코드 테스트 없음
+- 검증:
+  - 모든 .md 파일 < 200 lines (`find docs/plans/2026-04-08-engine-integration -name '*.md' | xargs wc -l | awk '$1>200'` → 0)
+  - `.claude/scripts/plan-status.sh --compact` 정상 출력
+  - `.claude/scripts/plan-status.sh --verbose` STATUS 마커 포함
+  - `jq . .claude/active-plan.json` valid
+  - `jq . .claude/post-task-pipeline.json` valid
+
+## Definition of done
+- 모든 tasks ✅
+- `git status` clean
+- PR-0 commit 메시지 형식: `docs(phase-8.0): add design + plan-autopilot infra`
+- 루트 checklist.md에 "Phase 8.0" 추가됨
+- CLAUDE.md에 Active Plan Workflow 섹션 포함

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-1-skeleton.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-1-skeleton.md
@@ -1,0 +1,42 @@
+# PR-1: SessionManager + Session actor skeleton
+
+> Wave 1 (parallel with PR-2) | 의존: PR-0
+
+## 목적
+Actor 패턴의 core 구조 (Manager + Session goroutine + inbox) skeleton 구축. Lock-free, channel-based.
+
+## Tasks
+- [ ] `internal/session/types.go` — SessionMessage, MessageKind, SessionStatus, PlayerState types
+- [ ] `internal/session/manager.go` — SessionManager struct, Start/Stop/Get/Restore (Restore는 stub)
+- [ ] `internal/session/session.go` — Session struct, Run(ctx) event loop, handleMessage with panic recover
+- [ ] `internal/session/panic_guard.go` — 3회 누적 abort 로직
+- [ ] `internal/engine/` — lock (sync.RWMutex) 제거, 외부 호출자는 actor 통해서만 접근 강제
+- [ ] `internal/session/manager_test.go` — lifecycle test (Start/Stop/Get)
+- [ ] `internal/session/session_test.go` — actor loop test, message dispatch test
+- [ ] `internal/session/panic_test.go` — panic recovery + 3회 abort 시나리오
+
+## Files 추가
+- `internal/session/{types,manager,session,panic_guard}.go`
+- `internal/session/{manager,session,panic}_test.go`
+
+## Files 수정
+- `internal/engine/engine.go` — mu field 제거, 모든 메서드에서 Lock/Unlock 제거
+
+## Test coverage
+- manager_test: Start → Get 반환 확인, Stop → Get nil 반환, 동시 Start 방지
+- session_test: inbox에 메시지 보내기 → reply 채널 수신 → 순서 보장
+- panic_test: 1회 panic → session 생존, 3회 panic → session abort + done 닫힘
+- **race detector 필수**: `go test -race ./internal/session/...`
+
+## Definition of done
+- 위 모든 test pass
+- `go test -race -count=10 ./internal/session/...` 안정
+- engine.go 에 sync.Mutex/RWMutex 없음
+- 외부에서 engine 메서드 직접 호출 경로 제거 확인 (grep)
+- PR 브랜치: `feat/phase-8.0/pr-1-session-manager`
+
+## Review focus (4 reviewers)
+- Security: sessionID forgery 방어, panic에서 민감정보 노출 방지
+- Performance: inbox buffer 크기 적정성, goroutine leak 가능성
+- Architecture: lock-free 원칙 준수, engine 의존 방향
+- Test coverage: race 테스트, goroutine leak 검출, panic 카운터 경계

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-2-hub-lifecycle.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-2-hub-lifecycle.md
@@ -1,0 +1,40 @@
+# PR-2: Hub lifecycle listener
+
+> Wave 1 (parallel with PR-1) | 의존: PR-0
+
+## 목적
+WS Hub에 `SessionLifecycleListener` interface 추가 + disconnect/reconnect 콜백 경로 구축.
+
+## Tasks
+- [ ] `internal/ws/lifecycle.go` — SessionLifecycleListener interface 정의
+- [ ] `internal/ws/hub.go` — RegisterLifecycleListener 메서드 추가, listeners slice + mutex 추가
+- [ ] `internal/ws/hub.go` — run() 이벤트 루프의 unregister 경로에 notifyPlayerLeft 호출 추가
+- [ ] `internal/ws/hub.go` — JoinSession에 reconnect 감지 로직 + notifyPlayerRejoined 호출
+- [ ] reconnect 감지 기준: 같은 playerID가 sessions[sid]에 이미 존재 OR 최근 N초 내 unregister 기록
+- [ ] `internal/ws/hub_test.go` — RegisterLifecycleListener test, notify 호출 순서 test
+- [ ] `internal/ws/hub_lifecycle_test.go` — disconnect → listener OnPlayerLeft 수신, reconnect → OnPlayerRejoined
+
+## Files 추가
+- `internal/ws/lifecycle.go` (~40 lines: interface + docs)
+- `internal/ws/hub_lifecycle_test.go`
+
+## Files 수정
+- `internal/ws/hub.go` — listener 등록/호출 코드 추가
+- `internal/ws/hub_test.go` — 기존 test 유지 + 새 test 추가
+
+## Test coverage
+- hub_test: RegisterLifecycleListener로 복수 listener 등록 가능
+- hub_lifecycle_test: fake listener로 OnPlayerLeft/OnPlayerRejoined 호출 검증
+- race test: listener 등록과 notify 동시 실행 시 안전
+
+## Definition of done
+- 위 모든 test pass
+- `go test -race -count=10 ./internal/ws/...` 안정
+- PR-1과 **scope 겹침 없음** (internal/ws/hub.go vs internal/session/**)
+- PR 브랜치: `feat/phase-8.0/pr-2-hub-lifecycle`
+
+## Review focus
+- Security: listener 등록 시 권한 체크 불필요 (내부 API)
+- Performance: RLock으로 listener slice 순회, 호출 빈도 낮음 — 성능 영향 무시
+- Architecture: 단방향 의존 (Hub → interface ← Manager). Hub가 SessionManager를 직접 알지 않음
+- Test coverage: listener slice 동시 수정 + notify, disconnect 후 reconnect 빠른 시나리오

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-3-base-handler.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-3-base-handler.md
@@ -1,0 +1,48 @@
+# PR-3: BaseModuleHandler + EventMapping infra
+
+> Wave 2 (sequential) | 의존: PR-1, PR-2
+
+## 목적
+WS 핸들러의 boilerplate를 공통 헬퍼로 추출 + EventMapping 테이블 인프라 + SessionManager가 Hub의 SessionLifecycleListener 구현하도록 연결.
+
+## Tasks
+- [ ] `internal/ws/base_module_handler.go` — BaseModuleHandler struct + WithSession 헬퍼 (sessionID 검증 + manager.Get/Restore + inbox 전송 + reply 타임아웃 2s)
+- [ ] `internal/ws/base_module_handler_test.go` — fake manager로 WithSession 동작 검증
+- [ ] `internal/session/event_mapping.go` — EventMapping struct, GameEventMappings 슬라이스 (빈 상태), subscribeMappings 함수
+- [ ] `internal/session/event_mapping_test.go` — 매핑 등록 + convert 함수 호출 test
+- [ ] `internal/session/registry.go` — RegisterAllHandlers(router, manager) 팩토리 (빈 상태로 생성, 각 PR에서 추가)
+- [ ] `internal/session/manager.go` 확장 — SessionLifecycleListener 구현 (OnPlayerLeft/OnPlayerRejoined → inbox forwarding)
+- [ ] `cmd/server/main.go` 최소 수정 — SessionManager 인스턴스 생성 + hub.RegisterLifecycleListener(manager) + session.RegisterAllHandlers(router, manager) 추가
+- [ ] feature flag `MMP_ENGINE_WIRING_ENABLED` 체크: false면 manager가 no-op stub
+- [ ] `internal/session/lifecycle_test.go` — OnPlayerLeft → session.inbox에 KindLifecycleLeft 메시지 도달 검증
+
+## Files 추가
+- `internal/ws/base_module_handler.go` (~80 lines)
+- `internal/ws/base_module_handler_test.go`
+- `internal/session/event_mapping.go` (~70 lines)
+- `internal/session/event_mapping_test.go`
+- `internal/session/registry.go` (~40 lines)
+- `internal/session/lifecycle_test.go`
+
+## Files 수정
+- `internal/session/manager.go` (listener impl 추가)
+- `cmd/server/main.go` (manager 주입 + flag check)
+- `internal/config/config.go` (EngineWiringEnabled 필드)
+
+## Test coverage
+- base_module_handler_test: fake manager + WithSession 2초 타임아웃 시나리오
+- event_mapping_test: mapping 등록, Publish → subscriber 호출 → broadcast mock 검증
+- lifecycle_test: listener 호출 → inbox 메시지 수신
+
+## Definition of done
+- 위 test pass
+- `go test -race ./internal/ws/... ./internal/session/...` 안정
+- main.go 빌드 성공 (flag false 기본값)
+- **이 PR 머지 후 main.go는 절대 수정 금지** (PR-4부터는 registry_*.go만)
+- PR 브랜치: `feat/phase-8.0/pr-3-base-handler`
+
+## Review focus
+- Security: WithSession의 sessionID 검증 엄격성
+- Performance: Reply 채널 leak 방지 (타임아웃 시 drain)
+- Architecture: main.go DI 배치, 의존 방향
+- Test coverage: 2초 타임아웃 + replies 채널 cleanup

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-4-reading-wired.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-4-reading-wired.md
@@ -1,0 +1,54 @@
+# PR-4: Reading module wired (pattern reference)
+
+> Wave 3 (sequential) | 의존: PR-3
+
+## 목적
+기존 Phase 7.7에서 작성된 `ReadingWSHandler` + `ReadingModuleAdapter` + `ReadingSessionResolver`를 **실제로 instantiate + 등록**. 이 PR이 모든 후속 모듈 wiring의 **패턴 레퍼런스**.
+
+## Tasks
+- [ ] `internal/ws/handlers/reading.go` — 기존 `internal/ws/reading_handler.go`를 이 위치로 이동 (서브디렉터리화)
+- [ ] `internal/session/registry_reading.go` — RegisterReadingHandlers(router, manager) 함수
+- [ ] `internal/session/event_mapping_reading.go` — reading.* → reading:* 매핑 (reading.started 포함 camelCase 변환 함수 포함)
+- [ ] `internal/session/registry.go` 호출 등록 — RegisterAllHandlers에서 RegisterReadingHandlers 호출
+- [ ] 기존 bridge/reading_bridge.go는 그대로 유지 (camelCase 변환 재사용)
+- [ ] PhaseAction `start_reading_section` → ReadingModule.Init config에 sectionID 주입 경로 구현
+- [ ] `internal/integration/reading_e2e_test.go` — 가짜 client 2개 (host + player) → host가 reading:advance → 모두가 reading:line_changed 수신
+- [ ] `internal/integration/reading_disconnect_test.go` — host disconnect → reading:paused broadcast, reconnect → reading:resumed
+- [ ] `internal/integration/reading_snapshot_test.go` — 재접속 시 current line snapshot push 수신
+
+## Files 추가/이동
+- `internal/ws/handlers/reading.go` (기존 파일 이동)
+- `internal/session/registry_reading.go` (~30 lines)
+- `internal/session/event_mapping_reading.go` (~60 lines — camelCase 변환 포함)
+- `internal/integration/reading_e2e_test.go`
+- `internal/integration/reading_disconnect_test.go`
+- `internal/integration/reading_snapshot_test.go`
+
+## Files 수정
+- `internal/session/registry.go` (Reading 호출 추가)
+- `cmd/server/main.go` — **수정 없음** (registry 팩토리가 자동 등록)
+
+## Test coverage
+- reading_e2e_test: 전체 wire contract 검증 (message → handler → session → engine → eventBus → mapping → broadcast)
+- disconnect_test: lifecycle listener 경로 검증
+- snapshot_test: BuildState → wire → 전송 검증
+
+## Definition of done
+- 모든 integration test pass
+- Phase 7.7에서 만든 ReadingModule이 처음으로 **end-to-end 작동**
+- 패턴 확정: 다른 모듈 wiring은 이 PR을 template으로 복사
+- **`docs/plans/2026-04-08-engine-integration/refs/module-wiring-guide.md` 생성** (PR-5/6 위한 가이드)
+- PR 브랜치: `feat/phase-8.0/pr-4-reading-wired`
+
+## Review focus
+- Security: ReadingWSHandler의 권한 검증 (기존 Phase 7.7 로직 유지)
+- Performance: EventMapping subscribe 경로, broadcast 경로
+- Architecture: registry 패턴이 깔끔한지 (PR-5/6 복사 가능한지)
+- Test coverage: disconnect 후 paused event, reconnect snapshot 양방향
+
+## 후속 PR 패턴 가이드
+PR-5/6는 이 PR을 복사:
+1. `internal/ws/handlers/<module>.go` 작성
+2. `internal/session/registry_<category>.go` 작성
+3. `internal/session/event_mapping_<category>.go` 작성
+4. `internal/session/registry.go` 한 줄 추가

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-5-core-modules.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-5-core-modules.md
@@ -1,0 +1,48 @@
+# PR-5: Core 4 modules wired
+
+> Wave 4 (parallel with PR-6, PR-7, PR-8) | 의존: PR-4
+
+## 목적
+Core 4 모듈 (connection, room, ready, clue_interaction)을 PR-4 패턴 그대로 복사해 wired.
+
+## Tasks
+- [ ] `internal/ws/handlers/core_connection.go` — connection 메시지 핸들러
+- [ ] `internal/ws/handlers/core_room.go` — room 메시지 핸들러
+- [ ] `internal/ws/handlers/core_ready.go` — ready 합의 핸들러
+- [ ] `internal/ws/handlers/core_clue_interaction.go` — 단서 상호작용 핸들러
+- [ ] `internal/session/registry_core.go` — RegisterCoreHandlers(router, manager) 4개 등록
+- [ ] `internal/session/event_mapping_core.go` — Core 모듈 이벤트 매핑 (connection/room/ready/clue 각각)
+- [ ] `internal/session/registry.go` — RegisterCoreHandlers 호출 1줄 추가
+- [ ] 각 모듈 smoke test: `internal/integration/core_<module>_test.go`
+- [ ] 각 모듈의 apperror → WS error 매핑 추가 (ws/error_code.go 확장)
+
+## Files 추가
+- `internal/ws/handlers/core_{connection,room,ready,clue_interaction}.go`
+- `internal/session/registry_core.go`
+- `internal/session/event_mapping_core.go`
+- `internal/integration/core_{connection,room,ready,clue}_test.go`
+
+## Files 수정
+- `internal/session/registry.go` (1 줄 추가)
+- `internal/ws/error_code.go` (Core 모듈 에러 매핑 추가)
+
+## Test coverage
+- 각 모듈 smoke test: handler 등록 확인 + 기본 메시지 → 응답 흐름
+- integration: 가짜 client로 모듈 기본 시나리오 실행
+
+## Definition of done
+- 4 smoke test 모두 pass
+- `go test -race ./internal/integration/core_*` 안정
+- **scope 겹침 없음**: PR-6 (progression), PR-7 (snapshot), PR-8 (api)과 파일 경로 분리
+- PR 브랜치: `feat/phase-8.0/pr-5-core-modules`
+
+## Review focus
+- Security: 각 모듈의 권한 검증 로직 (host-only actions 등)
+- Performance: handler 등록 수 증가에 따른 router lookup 영향
+- Architecture: PR-4 패턴 정확히 복사됐는지 (drift 없음)
+- Test coverage: 모든 Core 메시지 type 커버
+
+## 주의
+- `main.go` 절대 수정 금지 (registry.go만 편집)
+- `internal/session/event_mapping.go` (공통) 절대 수정 금지 — event_mapping_core.go만 편집
+- 이유: PR-6과 동시 작업이라 merge 충돌 방지

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-6-progression-modules.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-6-progression-modules.md
@@ -1,0 +1,55 @@
+# PR-6: Progression 7 modules wired
+
+> Wave 4 (parallel with PR-5, PR-7, PR-8) | 의존: PR-4
+
+## 목적
+Progression 7 모듈 (script, hybrid, event, skip_consensus, gm_control, consensus_control, ending)을 PR-4 패턴 복사해 wired. Reading은 PR-4에서 이미 처리됨.
+
+## Tasks
+- [ ] `internal/ws/handlers/progression_script.go`
+- [ ] `internal/ws/handlers/progression_hybrid.go`
+- [ ] `internal/ws/handlers/progression_event.go`
+- [ ] `internal/ws/handlers/progression_skip_consensus.go`
+- [ ] `internal/ws/handlers/progression_gm_control.go`
+- [ ] `internal/ws/handlers/progression_consensus_control.go`
+- [ ] `internal/ws/handlers/progression_ending.go`
+- [ ] `internal/session/registry_progression.go` — RegisterProgressionHandlers(router, manager) 7개 등록
+- [ ] `internal/session/event_mapping_progression.go` — progression 모듈 이벤트 매핑 (phase:changed, gm:override, trigger:transition, consensus:reached 등)
+- [ ] `internal/session/registry.go` — RegisterProgressionHandlers 호출 1줄 추가
+- [ ] 각 모듈 smoke test
+- [ ] ending 모듈 integration test (complete → ending.completed broadcast)
+- [ ] strategy 3종 (script/hybrid/event) 각각 e2e test
+- [ ] consensus 경로 test (skip_consensus + gm/consensus_control)
+
+## Files 추가
+- `internal/ws/handlers/progression_*.go` (7개)
+- `internal/session/registry_progression.go`
+- `internal/session/event_mapping_progression.go`
+- `internal/integration/progression_{script,hybrid,event,ending,consensus}_test.go`
+
+## Files 수정
+- `internal/session/registry.go` (1 줄 추가)
+- `internal/ws/error_code.go` (Progression 에러 매핑)
+
+## Test coverage
+- 3 strategies 각각 smoke test (phase 진행)
+- ending 모듈 activation → ending.completed broadcast → snapshot persist
+- consensus: 합의 도달 → 자동 phase advance
+
+## Definition of done
+- 모든 smoke + integration test pass
+- `go test -race ./internal/integration/progression_*` 안정
+- **scope 겹침 없음**: PR-5/7/8과 파일 경로 분리
+- Progression module factory pattern 검증 (세션별 독립 인스턴스)
+- PR 브랜치: `feat/phase-8.0/pr-6-progression-modules`
+
+## Review focus
+- Security: GM override 권한, consensus 위조 방어
+- Performance: strategy.Advance 호출 빈도, phase 전환 시 snapshot 부담
+- Architecture: 3 strategies의 일관성, PhaseReactor 사용 정합성
+- Test coverage: 각 strategy의 edge case (skip, timeout, trigger)
+
+## 주의
+- `main.go`, 공통 `event_mapping.go`, 공통 `registry.go` 절대 수정 금지
+- `internal/session/registry_progression.go` 는 자신만 건드림
+- Ending 모듈은 마지막 phase이므로 `reading.completed` 같은 이벤트도 subscribe하여 자동 전환

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-7-snapshot-restore.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-7-snapshot-restore.md
@@ -1,0 +1,57 @@
+# PR-7: Redis snapshot + Lazy restore
+
+> Wave 4 (parallel with PR-5, PR-6, PR-8) | 의존: PR-4
+
+## 목적
+5초 throttle + critical 즉시 write snapshot → Redis. Lazy restore 구현 (첫 client reconnect 시점).
+
+## Tasks
+- [ ] `internal/session/snapshot.go` — persistSnapshot(force), maybeSnapshot (throttle), markDirty
+- [ ] `internal/session/restore.go` — RestoreFromRedis (lazy), loadSnapshot
+- [ ] `internal/session/session.go` 확장 — snapshot ticker (5s) 추가, dirty 마킹 훅
+- [ ] `internal/session/manager.go` 확장 — Restore() 구현 (lazy)
+- [ ] `internal/engine/engine.go` 확장 — RestoreEngineState / RestoreModuleState 메서드
+- [ ] `internal/engine/types.go` — Module 인터페이스에 RestoreState(json.RawMessage) error 추가 (옵셔널, default no-op)
+- [ ] `internal/module/progression/reading.go` — RestoreState 구현 (다른 모듈은 후속 PR에서)
+- [ ] Redis key 구조: `session:{sid}:{meta,engine,module:NAME}`, TTL 24h
+- [ ] schemaVersion 필드 추가 (v3.0) + 불일치 시 손실 처리 + Sentry 알림
+- [ ] `internal/session/registry_snapshot.go` — snapshot ticker 등록 (registry에서 호출)
+- [ ] critical 이벤트 hooks: phase 전환, 모듈 init/cleanup, ending 활성 → self inbox에 KindCriticalSnapshot self-send
+- [ ] `internal/integration/restart_recovery_test.go` — Session 생성 → snapshot → Manager 재시작 → Lazy restore → 상태 일치
+- [ ] `internal/integration/snapshot_throttle_test.go` — 5초 throttle 동작 검증, critical 즉시 write 검증
+- [ ] `internal/session/snapshot_test.go` — unit: Redis mock으로 persist/restore
+
+## Files 추가
+- `internal/session/{snapshot,restore,snapshot_test}.go`
+- `internal/session/registry_snapshot.go`
+- `internal/integration/restart_recovery_test.go`
+- `internal/integration/snapshot_throttle_test.go`
+
+## Files 수정
+- `internal/session/session.go` (ticker + dirty flag)
+- `internal/session/manager.go` (Restore 구현)
+- `internal/engine/engine.go` (RestoreEngineState/RestoreModuleState)
+- `internal/engine/types.go` (Module 인터페이스 확장)
+- `internal/module/progression/reading.go` (RestoreState impl)
+
+## Test coverage
+- snapshot_test: mock Redis → persistSnapshot → key 존재 확인
+- throttle_test: 5초 내 여러 markDirty → write 1회만, 5초 경과 후 write, critical 즉시
+- restart_recovery_test: 전체 session 직렬화 → 복원 → state 일치
+
+## Definition of done
+- 위 모든 test pass
+- Redis key 구조 문서화 (design refs/persistence.md 확인)
+- schemaVersion mismatch 처리 검증
+- `go test -race ./internal/integration/restart_recovery_test ./internal/session/...` 안정
+- PR 브랜치: `feat/phase-8.0/pr-7-snapshot-restore`
+
+## Review focus
+- Security: Redis key 포맷 검증 (path traversal 방어 불필요, sessionID는 UUID)
+- Performance: Redis pipeline 사용, JSON marshaling 비용, TTL refresh 빈도
+- Architecture: throttle + critical 혼재 패턴, 모듈 BuildState/RestoreState 1:1 대응
+- Test coverage: Redis 장애 시나리오, 부분 복원 실패, schemaVersion mismatch
+
+## 주의
+- `internal/session/session.go` 수정이 PR-1과 영역 겹칠 수 있으나, PR-1은 skeleton이고 PR-7은 snapshot-specific 필드 추가 → merge 가능 (다른 메서드)
+- `internal/engine/engine.go` 수정은 PR-1에서 lock 제거한 부분과 다름 → 경계 주의

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-8-game-start-api.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-8-game-start-api.md
@@ -1,0 +1,50 @@
+# PR-8: Game start API + abort + idle timeout
+
+> Wave 4 (parallel with PR-5, PR-6, PR-7) | 의존: PR-4
+
+## 목적
+`POST /api/v1/rooms/{id}/start` 엔드포인트 + host 검증 + ready 검증 + SessionManager.Start 호출 + abort + idle timeout.
+
+## Tasks
+- [ ] `internal/domain/room/handler_game.go` — HandleStart, HandleAbort 핸들러
+- [ ] `internal/domain/room/service_game.go` — StartGame(roomID, host) → validate + SessionManager.Start
+- [ ] Validation: 호스트 확인 (요청자 = room.host), 모든 player ready, theme.configJson valid (ValidateConfig)
+- [ ] `POST /api/v1/rooms/{id}/start` 라우트 등록 (authed + RequireRole host 또는 room host 검증)
+- [ ] `POST /api/v1/rooms/{id}/abort` 라우트 (host-only)
+- [ ] Idle timeout: Session 내부에 lastActivity 추적, 10분 초과 + 모든 player disconnected → auto abort
+- [ ] `internal/session/session.go` — idle timeout check in Run() (1분마다)
+- [ ] Game session 시작 broadcast: `session:started` 이벤트 (roomID, sessionID)
+- [ ] `internal/domain/room/handler_game_test.go` — start/abort unit test
+- [ ] `internal/integration/game_start_test.go` — e2e start → engine running → abort → engine stopped
+- [ ] `internal/integration/idle_timeout_test.go` — 모두 disconnect + 10분 경과 → auto abort (fake clock)
+
+## Files 추가
+- `internal/domain/room/{handler_game,service_game,handler_game_test}.go`
+- `internal/integration/game_start_test.go`
+- `internal/integration/idle_timeout_test.go`
+
+## Files 수정
+- `internal/session/session.go` — idle check
+- `cmd/server/main.go` — 라우트 등록 (**예외적으로 main.go 수정 허용**: 새 endpoint 2개 추가, registry 패턴 밖의 HTTP 라우트라 어쩔 수 없음)
+- `internal/domain/room/room.go` (기존 파일) — sessionID 필드 추가
+
+## Test coverage
+- handler_game_test: start 요청 → validation fail 케이스들 (non-host, not all ready, invalid config)
+- game_start_test: 성공 시나리오 → sessionID 반환 → engine running 확인
+- idle_timeout_test: fake clock으로 10분 경과 → SessionManager.Get nil 반환
+
+## Definition of done
+- 위 test pass
+- feature flag off 상태에서는 start API가 501 반환 확인
+- Fake clock 주입 패턴 확립 (idle test 용)
+- PR 브랜치: `feat/phase-8.0/pr-8-game-start-api`
+
+## Review focus
+- Security: **host 권한 엄격 검증**, race condition (동시 start 방지), session 중복 생성 방지
+- Performance: idle check 주기 (1분 ticker) 적정성
+- Architecture: room domain과 session manager의 경계
+- Test coverage: 동시 start 요청, abort 중 snapshot 진행 상태
+
+## 주의
+- **main.go 수정은 예외적으로 허용** — 라우트 등록 2줄만. scope가 다른 PR과 겹치지 않도록 `r.Route("/rooms", ...)` 블록 안에서만 추가
+- Room.sessionID 필드 추가는 DB 마이그레이션 필요 (00018+) — 이 PR에 포함

--- a/docs/plans/2026-04-08-engine-integration/refs/pr-9-observability.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/pr-9-observability.md
@@ -1,0 +1,71 @@
+# PR-9: Observability (Prometheus + OTel)
+
+> Wave 5 (sequential) | 의존: PR-5, PR-6, PR-7, PR-8
+
+## 목적
+Phase 8.0 전체에 메트릭 + 트레이스 + 로그 주입. 운영 알람 기반 제공 (알람 룰 자체는 Phase 8.0 범위 밖).
+
+## Tasks
+- [ ] `internal/session/metrics.go` — Prometheus collectors 9종 정의
+  - `mmp_active_sessions{theme}` (Gauge)
+  - `mmp_session_duration_seconds` (Histogram)
+  - `mmp_phase_duration_seconds{phase}` (Histogram)
+  - `mmp_module_message_total{module,type}` (Counter)
+  - `mmp_module_message_duration_seconds{module}` (Histogram)
+  - `mmp_module_panic_total{module}` (Counter)
+  - `mmp_redis_snapshot_duration_seconds` (Histogram)
+  - `mmp_redis_snapshot_failure_total` (Counter)
+  - `mmp_session_inbox_depth` (Gauge)
+- [ ] `internal/session/tracing.go` — OTel span helpers (sessionSpan, messageSpan, engineSpan)
+- [ ] Per-session root span: Session.Run() 시작~종료
+- [ ] Per-message child span: handleMessage (kind/playerID/moduleName 속성)
+- [ ] Engine action spans: Start, phase 전환, snapshot persist 각각
+- [ ] Redis op spans: snapshot/restore
+- [ ] Log enrichment: 기존 zerolog + trace_id 자동 주입 (이미 main.go hook)
+- [ ] `internal/session/metrics_test.go` — metric scrape test (promtest 사용)
+- [ ] `internal/integration/observability_e2e_test.go` — 세션 생성/메시지/종료 후 /metrics 엔드포인트에 9종 모두 노출 확인
+- [ ] `docs/plans/2026-04-08-engine-integration/refs/observability-testing.md` 업데이트 (구현 위치 반영)
+- [ ] **feature flag 활성화 결정**: 이 PR 머지 후 user 확인 거쳐 dev에서 `MMP_ENGINE_WIRING_ENABLED=true` flip
+- [ ] 최종 smoke test: 12개 모듈 smoke + reading e2e + restart recovery + panic isolation 모두 pass
+
+## Files 추가
+- `internal/session/metrics.go`
+- `internal/session/tracing.go`
+- `internal/session/metrics_test.go`
+- `internal/integration/observability_e2e_test.go`
+
+## Files 수정 (메트릭/트레이스 주입, 기존 PR 결과물에)
+- `internal/session/manager.go` (active_sessions gauge)
+- `internal/session/session.go` (message counter, panic counter, inbox depth)
+- `internal/session/snapshot.go` (snapshot duration + failure)
+- `internal/engine/engine.go` (phase_duration, start span)
+- `internal/ws/handlers/*.go` (message counter)
+
+## Test coverage
+- metrics_test: 각 collector 등록 + Increment/Observe 동작
+- observability_e2e_test: 실제 세션 생성 → /metrics scrape → 9종 모두 존재
+
+## Definition of done
+- 모든 metric 9종 `/metrics` endpoint에서 scrape 가능
+- Per-session trace가 Jaeger/Tempo에서 조회 가능 (dev)
+- zerolog 로그에 trace_id 주입 확인
+- **모든 Phase 8.0 종료 조건 체크리스트 완료** (design.md의 종료 조건 섹션)
+- 최종 PR 브랜치: `feat/phase-8.0/pr-9-observability`
+
+## Review focus
+- Security: metric label cardinality 폭발 방지 (theme, phase만 라벨로)
+- Performance: OTel span 오버헤드 < 5% (sample rate 0.1 적정)
+- Architecture: metric 주입이 침투적이지 않게 (wrapper 최소화)
+- Test coverage: metric scrape test, trace export 검증
+
+## Phase 완료 체크리스트 (이 PR 머지 후)
+- [ ] 9 PR 모두 main 머지
+- [ ] feature flag 활성 상태에서 통합 테스트 PASS
+- [ ] 12 모듈 smoke test PASS
+- [ ] e2e 한 게임 시나리오 통과
+- [ ] restart 복구 + panic 격리 시나리오 통과
+- [ ] Prometheus metric 9종 scrape 가능
+- [ ] `project_phase80_progress.md` 최종 갱신
+- [ ] 루트 checklist "Phase 8.0 ✅"
+- [ ] `/plan-finish` 실행 → archived_plans/ 이동
+- [ ] Phase 8.0.x follow-up plan 결정 (17 모듈 wiring)

--- a/docs/plans/2026-04-08-engine-integration/refs/scope-and-decisions.md
+++ b/docs/plans/2026-04-08-engine-integration/refs/scope-and-decisions.md
@@ -1,0 +1,96 @@
+# Scope & 7대 결정 상세
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## 1. Scope 경계
+
+### In scope (Phase 8.0, 12 모듈)
+
+**Core (4)**
+- `connection` — 연결/재연결 관리
+- `room` — 방 상태, host/player 추적
+- `ready` — 시작 전 ready 합의
+- `clue_interaction` — 단서 상호작용 기본
+
+**Progression (8)**
+- `script` / `hybrid` / `event` — 3 progression strategies
+- `skip_consensus` — 스킵 합의
+- `gm_control` / `consensus_control` — GM 개입
+- `reading` — 대사 진행 (Phase 7.7에서 준비됨, wiring만)
+- `ending` — 게임 종료 처리
+
+### Out of scope (Phase 8.0.x 후속)
+
+| 카테고리 | 모듈 (17개) | 이유 |
+|---------|------------|------|
+| Communication (5) | text_chat, whisper, group_chat, voice_chat, spatial_voice | LiveKit 결합 필요, 별도 설계 |
+| Decision (3) | voting, accusation, hidden_mission | Phase 8.0 패턴 복사 |
+| Exploration (4) | floor/room/timed_exploration, location_clue | 동상 |
+| Clue Distribution (5) | conditional/starting/round/timed_clue, trade_clue | 동상 |
+
+### Out of scope (완전 제외)
+
+| 항목 | 이동 위치 |
+|------|----------|
+| Playwright E2E | Phase 8.1 (통합 QA) |
+| Prometheus 알람 룰 | 운영 phase |
+| Multi-node Redis PubSub | Phase 9 또는 별도 |
+| LiveKit 상위 안전성 | Phase 8.0.x communication |
+| v2→v3 데이터 마이그레이션 | Phase 8.6 |
+| WS 양방향 ack | Phase 9 |
+
+---
+
+## 2. 7대 결정 상세
+
+### 결정 1: Scope
+**선택**: B — Core 4 + Progression 8 (12 모듈)
+- A (reading 1개): 패턴 미검증, 모듈 다양성 ↓
+- **B (12)**: "한 게임 e2e 실행" 실서비스 최소 정의 ✅
+- C (29 전부): 단일 PR reviewable 불가, 영역 겹침
+
+### 결정 2: Architecture
+**선택**: A — 100% Actor 패턴
+- **A (actor)**: lock-free, race 원천 차단, design.md 일치 ✅
+- B (hybrid): 두 동기화 모델 공존, 결국 A로 감
+- C (lock): v2 race 버그 클래스 재현 위험
+
+자세한 actor 이벤트 루프는 `architecture.md` 참조.
+
+### 결정 3: Lifecycle
+**선택**: 모든 서브 결정에 안전 옵션
+- **Room↔Session**: 1:1 분리 lifecycle ("다시 하기" 자연스러움)
+- **시작 트리거**: Host 명시 + 서버 ready 검증
+- **종료 트리거**: 명시 + 10분 idle timeout + host abort
+- API: `POST /api/v1/rooms/{id}/start`, `POST /api/v1/rooms/{id}/abort`
+
+### 결정 4: WS↔Actor 통신
+- **4-1 라우팅**: 모듈별 handler + 공통 `BaseModuleHandler.WithSession` 헬퍼
+- **4-2 sync**: Reply 채널 통일 + 2초 타임아웃
+- **4-3 broadcast**: 명시적 `GameEventMappings` 테이블 (bridge 파일 제거)
+- **4-4 lifecycle**: Hub `SessionLifecycleListener` interface
+
+상세는 `architecture.md` + `data-flow.md`.
+
+### 결정 5: State Persistence
+- **Client reconnect**: 짧은 단절(<60s) ReconnectBuffer replay + 긴 단절 snapshot push (하이브리드)
+- **Server restart**: 5초 throttle + critical 이벤트(phase 전환, 모듈 init/cleanup, ending) 즉시 write
+- **직렬화**: engine state + 모듈 BuildState + 세션 메타 + 타이머 deadline
+- **복구**: Lazy — 첫 client reconnect 시점에 Restore
+
+상세는 `persistence.md`.
+
+### 결정 6: 운영 안전성
+- **Panic**: 메시지 단 `defer recover()` + 세션당 3회 누적 시 abort
+- **Observability**: Prometheus 9종 metric + per-session OTel span + zerolog (trace_id)
+- **테스트**: Unit + in-process Integration (Playwright는 Phase 8.1)
+
+상세는 `observability-testing.md`.
+
+### 결정 7: 도입 전략
+- **Wave 기반 병렬 PR 실행** (상세 `execution-model.md`)
+- **Feature flag**: `MMP_ENGINE_WIRING_ENABLED` default false
+- PR 4~8은 default off로 prod 영향 0
+- PR 9 후 user 확인 거쳐 dev에서 flag flip → prod는 Phase 8.1


### PR DESCRIPTION
## Summary

Phase 8.0 — Engine Integration Layer 인프라 구축. 12 모듈 (Core 4 + Progression 8) wave 기반 병렬 wiring을 위한 설계 문서 + `plan-autopilot` 스킬 + 프로젝트 설치 + 한글 가이드.

## What's inside

### 1. Phase 8.0 design (9 PR, 5 waves)
- `docs/plans/2026-04-08-engine-integration/design.md` (index, <200줄) + refs/ (6 files)
- `plan.md` (index) + refs/pr-0~9-*.md (10 PR detail files)
- `checklist.md` with STATUS marker (hook parseable)
- **Wave 구조**: W0(docs) → W1(×2 parallel) → W2 → W3 → W4(×4 parallel) → W5
- **속도**: 순차 9T → 병렬 5T (~44% 단축)

### 2. plan-autopilot 스킬 (프로젝트에 설치)
- `.claude/active-plan.json` — Phase 8.0 가리킴 (DAG 포함)
- `.claude/post-task-pipeline.json` — Opus/Sonnet 모델 전략 + 4 parallel reviewers
- `.claude/settings.json` — 4 hooks (절대 경로로 스킬 참조)
- `.claude/commands/` — 8 한글 슬래시 커맨드 (`(sabyun)` 접두어)

### 3. 사용 가이드 (`PLAN_AUTOPILOT.md` + `docs/plan-autopilot-guide/`)
- 다음 세션 시작 시 할 일 (SessionStart 자동 + /plan-resume)
- 설치 방법 (새 프로젝트)
- 슬래시 커맨드 레퍼런스
- Hook 동작 + Model 전략
- 트러블슈팅

### 4. 기타
- `CLAUDE.md` — Active Plan Workflow 섹션 추가
- 루트 checklist — Phase 8.0 추가, Phase 8 → 8.1 rename
- `.gitignore` — runtime state + reference files 제외

## Hard rules (enforced)
- 모든 .md 파일 <200 lines (index + refs/ 패턴)
- Wave 병렬 PR은 Agent tool `isolation: "worktree"` 필수
- Review = 4 parallel agents (security/perf/arch/test-coverage)
- Fix-loop max 3 iterations
- Wave merge 전 user 확인 1회
- Feature flag `MMP_ENGINE_WIRING_ENABLED` default off

## Skill integration (재발명 금지)
| 용도 | Skill | 모델 |
|------|-------|------|
| 설계 탐색 | superpowers:brainstorming | **Opus** |
| Plan 작성 | superpowers:writing-plans | Sonnet |
| 구현 (일반) | oh-my-claudecode:executor | Sonnet |
| 구현 (PR-1, PR-7 복잡) | oh-my-claudecode:executor | **Opus** |
| Security review | oh-my-claudecode:security-reviewer | **Opus** |
| Architecture review | oh-my-claudecode:critic | **Opus** |
| Performance review | oh-my-claudecode:code-reviewer | Sonnet |
| Test coverage review | oh-my-claudecode:test-engineer | Sonnet |

비용 ~50% 절감 + critical 단계 품질 유지.

## Test plan
- [ ] `.claude/scripts/plan-status.sh --verbose` 정상 출력
- [ ] `.claude/scripts/plan-tasks.sh` 진행률 트리 출력
- [ ] `jq . .claude/active-plan.json` + `.claude/post-task-pipeline.json` valid
- [ ] 모든 .md 파일 <200 lines (`find docs/plans/2026-04-08-engine-integration -name '*.md' | xargs wc -l | awk '\$1>200'` → empty)
- [ ] `/plan-status` 슬래시 커맨드 등록 확인
- [ ] PreToolUse guard 동작 검증 (design 안 읽고 scope 편집 시도 → BLOCK)

## Next
1. 이 PR 머지 후 Wave 1 착수 (`/plan-autopilot`)
2. PR-1 (SessionManager — Opus), PR-2 (Hub lifecycle — Sonnet) 병렬 실행
3. 9 PR 자동 진행 → Phase 8.0 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)