### PR TITLE
fix(phase-8.0): settings.json hooks use $HOME absolute paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,28 +2,53 @@
   "hooks": {
     "SessionStart": [
       {
-        "command": ".claude/scripts/plan-status.sh --verbose"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/skills/plan-autopilot/scripts/plan-status.sh --verbose"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
       {
-        "command": ".claude/scripts/plan-status.sh --compact"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/skills/plan-autopilot/scripts/plan-status.sh --compact"
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": ".claude/scripts/plan-guard.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/skills/plan-autopilot/scripts/plan-guard.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": ".claude/scripts/plan-remind.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/skills/plan-autopilot/scripts/plan-remind.sh"
+          }
+        ]
       },
       {
         "matcher": "Read",
-        "command": ".claude/scripts/plan-track-reads.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/skills/plan-autopilot/scripts/plan-track-reads.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Linter auto-fixed the hooks schema format (added `matcher`+nested `hooks` array — correct) but also changed command paths from `~/.claude/skills/plan-autopilot/scripts/...` (absolute) to `.claude/scripts/...` (relative to a directory that was intentionally removed). Result: every hook silently failed, producing garbled error output.

## Root cause
- `.claude/scripts/` directory was removed intentionally because scripts should live at `~/.claude/skills/plan-autopilot/scripts/` (the skill install location)
- Linter rewrote `~/...` → `.claude/scripts/...` assuming it was a project-local path
- All 4 hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse) failed
- Claude Code surfaced failures as "hook error" + raw keystroke leak (user's Korean input without IME → sksmsep-style garbage)

## Fix
Use `\$HOME/.claude/skills/plan-autopilot/scripts/...` instead of `~/...`:
- Shell expands `\$HOME` reliably (tilde expansion varies by context)
- No per-project scripts copy/symlink
- Skill updates propagate automatically
- Schema format (matcher + nested hooks array) preserved from linter fix

Updated the skill template to match so future installs are correct.

## Test plan
- [x] JSON validity: `jq . .claude/settings.json` → valid
- [x] All 4 scripts exist + executable at `\$HOME/.claude/skills/plan-autopilot/scripts/`
- [x] SessionStart (--verbose) outputs STATUS block
- [x] UserPromptSubmit (--compact) outputs 1-line status
- [x] PostToolUse Read tracker: logs entries with timestamps
- [x] PreToolUse guard: scope-miss file → pass (rc=0)
- [x] PreToolUse guard: scope-match + design read → pass (rc=0)
- [x] PreToolUse guard: scope-match + log empty → BLOCK (rc=2, helpful message)
- [x] PostToolUse remind: scope-match → reminder on stderr (rc=0)
- [x] PostToolUse remind: scope-miss → silent (rc=0)

All 10 scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)