### PR TITLE
chore(phase-8.0): close out W0 — expand checklist + advance to W1

### DIFF
--- a/.claude/active-plan.json
+++ b/.claude/active-plan.json
@@ -19,10 +19,10 @@
     ],
     "started_at": "2026-04-08",
     "started_commit": "52fd23e",
-    "current_wave": "W0",
-    "current_pr": "PR-0",
-    "current_task": "plan.md + checklist refs + PR-0 commit",
-    "status": "in_progress",
+    "current_wave": "W1",
+    "current_pr": "PR-1",
+    "current_task": "Spawn W1 parallel agents (SessionManager + Hub lifecycle)",
+    "status": "pending",
     "blockers": [],
     "waves": [
       {
@@ -68,10 +68,11 @@
         "depends_on": [],
         "scope": ["docs/plans/2026-04-08-engine-integration/**", ".claude/**", "CLAUDE.md", "memory/**"],
         "tasks_total": 10,
-        "tasks_done": 5,
-        "status": "in_progress",
+        "tasks_done": 10,
+        "status": "done",
         "branch": "feat/phase-8.0/pr-0-docs-infra",
-        "commit": null
+        "commit": "b1d35b8",
+        "merged_via_pr": [11, 12, 13]
       },
       "PR-1": {
         "title": "SessionManager + Session actor skeleton",

--- a/docs/plans/2026-04-08-engine-integration/checklist.md
+++ b/docs/plans/2026-04-08-engine-integration/checklist.md
@@ -1,88 +1,140 @@
 <!-- STATUS-START -->
-**Active**: Phase 8.0 — Engine Integration Layer — Wave 0/5 (doc+infra)
-**PR**: PR-0 (docs + plan-autopilot install)
-**Task**: Create plan.md + checklist refs + commit PR-0
-**State**: in_progress
+**Active**: Phase 8.0 — Engine Integration Layer — Wave 1/5 (skeletons)
+**PR**: PR-1 + PR-2 (parallel)
+**Task**: Spawn W1 parallel agents (SessionManager + Hub lifecycle)
+**State**: pending
 **Blockers**: none
 **Last updated**: 2026-04-08
 <!-- STATUS-END -->
 
 # Phase 8.0 — Engine Integration Layer 체크리스트
 
-> 부모: [design.md](design.md) | 실행: [plan.md](plan.md) (작성 예정)
+> 부모: [design.md](design.md) | 실행: [plan.md](plan.md)
 
 이 파일은 진행 상태 tracking. STATUS 마커는 hook/스크립트가 파싱하므로 형식 유지.
-PR별 상세 task는 plan.md + refs/pr-N-*.md 완성 후 이 파일에도 반영됨.
+PR별 상세 task 정의는 `refs/pr-N-*.md` (이 파일은 요약 + 진행 체크).
 
 ---
 
-## Wave 0 — 문서 + 인프라 (현재)
+## Wave 0 — 문서 + 인프라 ✅
 
 - [x] design.md refactor to index + refs (각 <200줄)
 - [x] memory files wave 정보 반영
-- [x] plan-autopilot 스킬 생성 (~/.claude/skills/plan-autopilot/)
-- [x] 프로젝트에 스킬 설치 (.claude/scripts, commands, settings, pipeline)
+- [x] plan-autopilot 스킬 생성 + 프로젝트 설치
 - [x] .claude/active-plan.json 초기화
-- [ ] plan.md + refs/pr-N-*.md 작성 (task #47)
-- [ ] checklist.md의 Wave 1~5 섹션 확장 (task #47)
-- [ ] 루트 checklist.md에 Phase 8.0 추가 + Phase 8을 8.1로 rename (task #48)
-- [ ] CLAUDE.md에 Active Plan Workflow 섹션 추가
-- [ ] PR-0 commit (task #49)
+- [x] plan.md + refs/pr-0~9-*.md 작성
+- [x] 루트 checklist.md Phase 8.0 추가 + Phase 8 → 8.1 rename
+- [x] CLAUDE.md "Active Plan Workflow" 섹션 추가
+- [x] PR-0 commit (PR #11 + #12 + #13)
 
 ---
 
 ## Wave 1 — Skeletons (parallel ×2)
 
-### PR-1: SessionManager + Session actor
-*상세 task는 refs/pr-1-skeleton.md 참조 (작성 예정)*
+### PR-1: SessionManager + Session actor — refs/pr-1-skeleton.md
+- [ ] `internal/session/types.go` (SessionMessage / MessageKind / SessionStatus)
+- [ ] `internal/session/manager.go` (Start/Stop/Get/Restore stub)
+- [ ] `internal/session/session.go` (Run loop + handleMessage + panic recover)
+- [ ] `internal/session/panic_guard.go` (3회 누적 abort)
+- [ ] `internal/engine/engine.go` lock 제거 (sync.RWMutex 삭제)
+- [ ] `internal/session/{manager,session,panic}_test.go` + `go test -race`
 
-### PR-2: Hub lifecycle listener
-*상세 task는 refs/pr-2-hub-lifecycle.md 참조 (작성 예정)*
+### PR-2: Hub lifecycle listener — refs/pr-2-hub-lifecycle.md
+- [ ] `internal/ws/lifecycle.go` (SessionLifecycleListener interface)
+- [ ] `internal/ws/hub.go` (RegisterLifecycleListener + notify on un/register)
+- [ ] reconnect 감지 로직 (JoinSession 경로)
+- [ ] `internal/ws/{hub,hub_lifecycle}_test.go` + race
 
-**Wave 1 gate**:
+### Wave 1 gate
 - [ ] PR-1, PR-2 모든 task ✅
-- [ ] 4-reviewer 병렬 리뷰 pass
-- [ ] Fix-loop < 3회
+- [ ] 4-reviewer 병렬 리뷰 pass / fix-loop ≤ 3
 - [ ] `go test -race ./...` pass
-- [ ] Merge to main
-- [ ] User confirmed → Wave 2 진입
+- [ ] PR-1 → PR-2 순차 merge to main
+- [ ] User 확인 → Wave 2 진입
 
 ---
 
 ## Wave 2 — 인프라 (sequential)
 
-### PR-3: BaseModuleHandler + EventMapping 인프라
-*상세 task는 refs/pr-3-base-handler.md 참조*
+### PR-3: BaseModuleHandler + EventMapping infra — refs/pr-3-base-handler.md
+- [ ] `internal/ws/base_module_handler.go` (WithSession 헬퍼 + 2s reply timeout)
+- [ ] `internal/session/event_mapping.go` (EventMapping 구조 + subscribe)
+- [ ] `internal/session/registry.go` (RegisterAllHandlers 팩토리)
+- [ ] `internal/session/manager.go` SessionLifecycleListener 구현
+- [ ] `cmd/server/main.go` 최소 수정 (manager DI + RegisterAllHandlers)
+- [ ] feature flag `MMP_ENGINE_WIRING_ENABLED` (default false → no-op stub)
+- [ ] base_module / event_mapping / lifecycle test (race)
 
-**Wave 2 gate**: 위와 동일 패턴
+**Wave 2 gate**: 위와 동일 패턴. **이 PR 머지 후 main.go 수정 금지**.
 
 ---
 
 ## Wave 3 — 패턴 레퍼런스 (sequential)
 
-### PR-4: Reading 모듈 wired
-*상세 task는 refs/pr-4-reading-wired.md 참조*
+### PR-4: Reading 모듈 wired — refs/pr-4-reading-wired.md
+- [ ] `internal/ws/handlers/reading.go` (기존 reading_handler.go 이동)
+- [ ] `internal/session/registry_reading.go`
+- [ ] `internal/session/event_mapping_reading.go` (camelCase 변환 포함)
+- [ ] `internal/session/registry.go` 호출 1줄 추가
+- [ ] PhaseAction `start_reading_section` → ReadingModule.Init 경로
+- [ ] integration: reading e2e / disconnect / snapshot 3 test
+- [ ] `refs/module-wiring-guide.md` 생성 (PR-5/6용 template)
 
-**Wave 3 gate**: 이 PR이 후속 모든 모듈 wiring의 패턴 확정
+**Wave 3 gate**: 이 PR이 후속 모든 모듈 wiring의 패턴 확정.
 
 ---
 
 ## Wave 4 — 병렬 wiring (parallel ×4)
 
-### PR-5: Core 4 modules (connection, room, ready, clue_interaction)
-### PR-6: Progression 7 modules (script, hybrid, event, skip_consensus, gm_control, consensus_control, ending)
-### PR-7: Redis snapshot + Lazy restore
-### PR-8: Game start API + abort + idle timeout
+### PR-5: Core 4 modules — refs/pr-5-core-modules.md
+- [ ] `internal/ws/handlers/core_{connection,room,ready,clue_interaction}.go`
+- [ ] `internal/session/registry_core.go` + `event_mapping_core.go`
+- [ ] `internal/session/registry.go` 1줄 추가
+- [ ] `internal/ws/error_code.go` Core 매핑
+- [ ] 4 smoke test + integration
 
-*상세 task는 refs/pr-5-*.md ~ refs/pr-8-*.md 참조*
+### PR-6: Progression 7 modules — refs/pr-6-progression-modules.md
+- [ ] `internal/ws/handlers/progression_{script,hybrid,event,skip_consensus,gm_control,consensus_control,ending}.go`
+- [ ] `internal/session/registry_progression.go` + `event_mapping_progression.go`
+- [ ] `internal/session/registry.go` 1줄 추가
+- [ ] strategy 3종 e2e + ending + consensus test
 
-**Wave 4 gate**: 파일 스코프 겹침 검증 + 순차 머지 + test gate
+### PR-7: Redis snapshot + Lazy restore — refs/pr-7-snapshot-restore.md
+- [ ] `internal/session/{snapshot,restore}.go` (5s throttle + critical 즉시 + markDirty)
+- [ ] `internal/session/session.go` 확장 (snapshot ticker)
+- [ ] `internal/session/manager.go` Restore lazy
+- [ ] `internal/engine/engine.go` RestoreEngineState/RestoreModuleState
+- [ ] `internal/engine/types.go` Module.RestoreState 인터페이스
+- [ ] `internal/module/progression/reading.go` RestoreState 구현
+- [ ] schemaVersion v3.0 + mismatch 손실 처리
+- [ ] integration: restart_recovery / snapshot_throttle
+
+### PR-8: Game start API + abort + idle timeout — refs/pr-8-game-start-api.md
+- [ ] `internal/domain/room/{handler_game,service_game}.go` (host 검증, ready, ValidateConfig)
+- [ ] `POST /api/v1/rooms/{id}/{start,abort}` 라우트
+- [ ] `internal/session/session.go` idle timeout 1분 ticker (10분 + all disconnected → abort)
+- [ ] `cmd/server/main.go` 라우트 등록 (예외 허용)
+- [ ] Room.sessionID 필드 + DB migration
+- [ ] handler unit test + game_start / idle_timeout integration
+
+### Wave 4 gate
+- [ ] 4 PR scope 겹침 검증 (`plan-wave.sh validate W4`)
+- [ ] 순차 머지 + 머지 사이 `go test -race ./...`
+- [ ] User 확인 → Wave 5
 
 ---
 
 ## Wave 5 — Observability (sequential)
 
-### PR-9: Prometheus metrics + OTel spans + alarm stubs
+### PR-9: Prometheus + OTel — refs/pr-9-observability.md
+- [ ] `internal/session/metrics.go` (9 collectors)
+- [ ] `internal/session/tracing.go` (session/message/engine span)
+- [ ] manager/session/snapshot/engine/handlers 메트릭+스팬 주입
+- [ ] zerolog trace_id 주입 확인
+- [ ] metrics_test + observability_e2e_test (9종 scrape)
+- [ ] `refs/observability-testing.md` 구현 위치 반영
+- [ ] **feature flag flip 결정** (user 확인) → dev `MMP_ENGINE_WIRING_ENABLED=true`
+- [ ] 12 모듈 smoke + reading e2e + restart recovery + panic isolation 최종 검증
 
 **Wave 5 gate**: metric scrape test + 종료 전 최종 검증
 
@@ -91,7 +143,7 @@ PR별 상세 task는 plan.md + refs/pr-N-*.md 완성 후 이 파일에도 반영
 ## Phase completion gate
 
 - [ ] 모든 5 waves ✅
-- [ ] Feature flag `MMP_ENGINE_WIRING_ENABLED` 활성 상태에서 통합 테스트 PASS
+- [ ] Feature flag 활성 상태에서 통합 테스트 PASS
 - [ ] 12개 모듈 smoke test PASS
 - [ ] e2e 시나리오 통과
 - [ ] Restart recovery + panic isolation 시나리오 통과


### PR DESCRIPTION
## Summary
- W0 (PR-0)는 #11/#12/#13으로 사실상 완료됐으나 state 파일이 stale 상태였음
- `checklist.md` Wave 1~5 섹션을 `refs/pr-1~9-*.md`의 task 목록으로 확장 (stub → 구체적 task)
- `.claude/active-plan.json`에서 PR-0 → done, current_wave → W1, current_pr → PR-1
- progress memory도 동기화
- 코드 변경 없음, 순수 docs/state hygiene

## Test plan
- [x] `jq . .claude/active-plan.json` valid
- [x] checklist.md 154줄 (<200 제한 OK)
- [x] STATUS 마커 형식 유지 (hook 파싱 호환)

## Next
머지 후 W1 병렬 agent (PR-1 SessionManager + PR-2 Hub lifecycle)을 worktree isolation으로 spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)