### PR TITLE
fix(phase-8.0): use 'completed' PR status to match plan-wave.sh schema

### DIFF
--- a/.claude/active-plan.json
+++ b/.claude/active-plan.json
@@ -69,7 +69,7 @@
         "scope": ["docs/plans/2026-04-08-engine-integration/**", ".claude/**", "CLAUDE.md", "memory/**"],
         "tasks_total": 10,
         "tasks_done": 10,
-        "status": "done",
+        "status": "completed",
         "branch": "feat/phase-8.0/pr-0-docs-infra",
         "commit": "b1d35b8",
         "merged_via_pr": [11, 12, 13]


### PR DESCRIPTION
PR-14 set PR-0 status to 'done' but `plan-wave.sh check-deps` expects 'completed'. One-character schema alignment so W1 dep check passes.