### PR TITLE
PR-A2: EventBus Rewrite (typed pub/sub)

### DIFF
--- a/apps/server/internal/engine/event_bus.go
+++ b/apps/server/internal/engine/event_bus.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"context"
+	"runtime/debug"
+	"sync"
+
+	"github.com/rs/zerolog"
+)
+
+// GameEvent is a placeholder type until PR-A1 (module_types.go) is merged.
+// TODO(phase-9.0): rebase onto PR-A1 GameEvent
+type GameEvent struct {
+	// Topic is the event routing key (e.g. "player.joined", "phase.advanced").
+	Topic   string
+	Payload any
+}
+
+// Subscriber is the interface that typed event listeners must implement.
+// OnEvent is called for every published event whose topic matches the subscription.
+// Returning a non-nil error does not stop sibling subscribers; errors are collected
+// and returned in aggregate by TypedEventBus.Publish.
+type Subscriber interface {
+	OnEvent(ctx context.Context, evt GameEvent) error
+}
+
+// Publisher is the interface for typed event publishing.
+// Publish dispatches evt to all registered subscribers for evt.Topic and
+// returns the collected (non-nil) errors. A nil slice means full success.
+type Publisher interface {
+	Publish(ctx context.Context, evt GameEvent) []error
+}
+
+// TypedEventBus is a session-scoped, typed pub/sub event bus.
+// It replaces the callback-based EventBus for the Phase 9.0 GenrePlugin architecture.
+// Each game session owns its own TypedEventBus instance — no global singleton.
+//
+// Concurrency: safe for concurrent Subscribe/Unsubscribe/Publish calls.
+// Subscriber panics are recovered per-subscriber; a panicking subscriber
+// never takes down sibling subscribers or the caller.
+type TypedEventBus struct {
+	mu     sync.RWMutex
+	subs   map[string][]Subscriber
+	log    zerolog.Logger
+	closed bool
+}
+
+// NewTypedEventBus creates a new session-scoped typed event bus.
+// The provided logger is used for panic recovery diagnostics.
+func NewTypedEventBus(log zerolog.Logger) *TypedEventBus {
+	return &TypedEventBus{
+		subs: make(map[string][]Subscriber),
+		log:  log,
+	}
+}
+
+// Subscribe registers sub for events published on topic.
+// No-ops if the bus is closed.
+func (b *TypedEventBus) Subscribe(topic string, sub Subscriber) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+	b.subs[topic] = append(b.subs[topic], sub)
+}
+
+// Unsubscribe removes the first occurrence of sub from the topic's subscriber list.
+// It compares by identity (pointer equality). No-ops if sub is not found.
+func (b *TypedEventBus) Unsubscribe(topic string, sub Subscriber) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	list := b.subs[topic]
+	for i, s := range list {
+		if s == sub {
+			b.subs[topic] = append(list[:i], list[i+1:]...)
+			return
+		}
+	}
+}
+
+// Publish dispatches evt to all subscribers registered for evt.Topic.
+// It returns the aggregate slice of non-nil errors returned by subscribers.
+// A nil return means all subscribers completed without error.
+//
+// Panics in subscribers are recovered: the panic is logged via zerolog and
+// treated as an error (wrapped in panicError), so sibling subscribers are
+// always called regardless of panicking neighbours.
+//
+// Publish is a no-op if the bus is closed or if no subscribers exist for the topic.
+func (b *TypedEventBus) Publish(ctx context.Context, evt GameEvent) []error {
+	b.mu.RLock()
+	if b.closed {
+		b.mu.RUnlock()
+		return nil
+	}
+	// Snapshot subscribers under read-lock to avoid holding the lock during calls.
+	src := b.subs[evt.Topic]
+	if len(src) == 0 {
+		b.mu.RUnlock()
+		return nil
+	}
+	snapshot := make([]Subscriber, len(src))
+	copy(snapshot, src)
+	b.mu.RUnlock()
+
+	var errs []error
+	for _, sub := range snapshot {
+		if err := b.callSafe(ctx, sub, evt); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// callSafe calls sub.OnEvent, recovering any panic.
+// A recovered panic is logged and returned as a panicError.
+func (b *TypedEventBus) callSafe(ctx context.Context, sub Subscriber, evt GameEvent) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			b.log.Error().
+				Str("topic", evt.Topic).
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("engine/event_bus: subscriber panic recovered")
+			retErr = &panicError{topic: evt.Topic, value: r}
+		}
+	}()
+	return sub.OnEvent(ctx, evt)
+}
+
+// Close shuts down the bus and clears all subscribers for GC.
+// Any subsequent Publish or Subscribe calls are silently no-oped.
+func (b *TypedEventBus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.closed = true
+	b.subs = nil
+}
+
+// panicError wraps a recovered panic value so callers can distinguish it from
+// a normal subscriber error if needed.
+type panicError struct {
+	topic string
+	value any
+}
+
+func (e *panicError) Error() string {
+	return "subscriber panic on topic " + e.topic
+}

--- a/apps/server/internal/engine/event_bus_test.go
+++ b/apps/server/internal/engine/event_bus_test.go
@@ -1,0 +1,320 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// nopSubscriber calls the provided function when OnEvent fires.
+type funcSubscriber struct {
+	fn func(ctx context.Context, evt GameEvent) error
+}
+
+func (s *funcSubscriber) OnEvent(ctx context.Context, evt GameEvent) error {
+	return s.fn(ctx, evt)
+}
+
+func newSub(fn func(ctx context.Context, evt GameEvent) error) Subscriber {
+	return &funcSubscriber{fn: fn}
+}
+
+func nopLogger() zerolog.Logger {
+	return zerolog.Nop()
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: publish → subscribers receive
+// ---------------------------------------------------------------------------
+
+func TestTypedEventBus_PublishReceived(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	var got string
+	sub := newSub(func(_ context.Context, evt GameEvent) error {
+		got = evt.Payload.(string)
+		return nil
+	})
+	bus.Subscribe("player.joined", sub)
+
+	errs := bus.Publish(context.Background(), GameEvent{Topic: "player.joined", Payload: "alice"})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if got != "alice" {
+		t.Fatalf("expected payload 'alice', got %q", got)
+	}
+}
+
+func TestTypedEventBus_MultipleSubscribersAllReceive(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	var count atomic.Int32
+	for i := 0; i < 3; i++ {
+		bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error {
+			count.Add(1)
+			return nil
+		}))
+	}
+
+	bus.Publish(context.Background(), GameEvent{Topic: "evt"})
+	if count.Load() != 3 {
+		t.Fatalf("expected 3 calls, got %d", count.Load())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscribe/Unsubscribe lifecycle
+// ---------------------------------------------------------------------------
+
+func TestTypedEventBus_UnsubscribePreventsCalls(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	var called bool
+	sub := newSub(func(_ context.Context, _ GameEvent) error {
+		called = true
+		return nil
+	})
+	bus.Subscribe("evt", sub)
+	bus.Unsubscribe("evt", sub)
+
+	bus.Publish(context.Background(), GameEvent{Topic: "evt"})
+	if called {
+		t.Fatal("subscriber should not be called after unsubscribe")
+	}
+}
+
+func TestTypedEventBus_UnsubscribeOnlyRemovesFirst(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	var count atomic.Int32
+	sub := newSub(func(_ context.Context, _ GameEvent) error {
+		count.Add(1)
+		return nil
+	})
+	// Subscribe same instance twice.
+	bus.Subscribe("evt", sub)
+	bus.Subscribe("evt", sub)
+	// Unsubscribe removes only the first occurrence.
+	bus.Unsubscribe("evt", sub)
+
+	bus.Publish(context.Background(), GameEvent{Topic: "evt"})
+	if count.Load() != 1 {
+		t.Fatalf("expected 1 call after removing one of two identical subs, got %d", count.Load())
+	}
+}
+
+func TestTypedEventBus_SubscribeAfterClosedIsNoOp(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	bus.Close()
+
+	var called bool
+	bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error {
+		called = true
+		return nil
+	}))
+	// Bus is closed, so Publish should also be a no-op.
+	bus.Publish(context.Background(), GameEvent{Topic: "evt"})
+	if called {
+		t.Fatal("subscriber registered after close should never be called")
+	}
+}
+
+func TestTypedEventBus_PublishAfterCloseIsNoOp(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+
+	var called bool
+	bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error {
+		called = true
+		return nil
+	}))
+	bus.Close()
+
+	errs := bus.Publish(context.Background(), GameEvent{Topic: "evt"})
+	if called {
+		t.Fatal("subscriber should not be called after Close")
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected nil errs after close, got %v", errs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent publish from N goroutines
+// ---------------------------------------------------------------------------
+
+func TestTypedEventBus_ConcurrentPublish(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	const goroutines = 50
+	var count atomic.Int64
+	bus.Subscribe("concurrent", newSub(func(_ context.Context, _ GameEvent) error {
+		count.Add(1)
+		return nil
+	}))
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bus.Publish(context.Background(), GameEvent{Topic: "concurrent"})
+		}()
+	}
+	wg.Wait()
+
+	if count.Load() != goroutines {
+		t.Fatalf("expected %d calls, got %d", goroutines, count.Load())
+	}
+}
+
+func TestTypedEventBus_ConcurrentSubscribeAndPublish(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	var wg sync.WaitGroup
+	// Concurrent subscribers being added while publishes happen.
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			bus.Subscribe("race", newSub(func(_ context.Context, _ GameEvent) error { return nil }))
+		}()
+		go func() {
+			defer wg.Done()
+			bus.Publish(context.Background(), GameEvent{Topic: "race"})
+		}()
+	}
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Panicking subscriber does not break sibling subscribers
+// ---------------------------------------------------------------------------
+
+func TestTypedEventBus_PanicIsolation(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	var siblingCalled bool
+	bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error {
+		panic("deliberate panic")
+	}))
+	bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error {
+		siblingCalled = true
+		return nil
+	}))
+
+	errs := bus.Publish(context.Background(), GameEvent{Topic: "evt"})
+	if !siblingCalled {
+		t.Fatal("sibling subscriber should be called even when prior subscriber panics")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for the panicking subscriber, got %d", len(errs))
+	}
+	var pe *panicError
+	if !errors.As(errs[0], &pe) {
+		t.Fatalf("expected panicError, got %T: %v", errs[0], errs[0])
+	}
+}
+
+func TestTypedEventBus_PanicErrorContainsTopic(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	bus.Subscribe("phase.advanced", newSub(func(_ context.Context, _ GameEvent) error {
+		panic("boom")
+	}))
+
+	errs := bus.Publish(context.Background(), GameEvent{Topic: "phase.advanced"})
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+	// Error message must mention the topic.
+	msg := errs[0].Error()
+	if msg == "" {
+		t.Fatal("panicError.Error() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error aggregation: subscriber errors collected, others still run
+// ---------------------------------------------------------------------------
+
+func TestTypedEventBus_ErrorAggregation(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	errA := fmt.Errorf("subscriber A failed")
+	errB := fmt.Errorf("subscriber B failed")
+
+	bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error { return errA }))
+	bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error { return errB }))
+	bus.Subscribe("evt", newSub(func(_ context.Context, _ GameEvent) error { return nil }))
+
+	errs := bus.Publish(context.Background(), GameEvent{Topic: "evt"})
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %d", len(errs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unknown topic publish is a no-op
+// ---------------------------------------------------------------------------
+
+func TestTypedEventBus_UnknownTopicIsNoOp(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	// No subscribers registered for "unknown".
+	errs := bus.Publish(context.Background(), GameEvent{Topic: "unknown.topic"})
+	if len(errs) != 0 {
+		t.Fatalf("expected nil for unknown topic, got %v", errs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Context cancellation: subscriber honours ctx, returns error
+// ---------------------------------------------------------------------------
+
+func TestTypedEventBus_ContextCancellation(t *testing.T) {
+	bus := NewTypedEventBus(nopLogger())
+	defer bus.Close()
+
+	bus.Subscribe("evt", newSub(func(ctx context.Context, _ GameEvent) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	errs := bus.Publish(ctx, GameEvent{Topic: "evt"})
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error from cancelled context, got %d", len(errs))
+	}
+	if !errors.Is(errs[0], context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", errs[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscriber interface compliance
+// ---------------------------------------------------------------------------
+
+// Verify TypedEventBus implements Publisher at compile time.
+var _ Publisher = (*TypedEventBus)(nil)

--- a/docs/plans/2026-04-10-editor-engine-redesign/checklist.md
+++ b/docs/plans/2026-04-10-editor-engine-redesign/checklist.md
@@ -29,8 +29,8 @@
 - [ ] Phase 8.0 Migration: `engine/types.go` → plugin.go 교체, GameProgressionEngine 제거
 
 #### PR-A2: EventBus (EventListener)
-- [ ] `engine/event_bus.go` — EventListener interface, Subscribe, Publish (에러 수집)
-- [ ] `engine/event_bus_test.go` — error isolation, 동시 구독, 성능
+- [x] `engine/event_bus.go` — EventListener interface, Subscribe, Publish (에러 수집)
+- [x] `engine/event_bus_test.go` — error isolation, 동시 구독, 성능
 - [ ] Phase 8.0 Migration: 기존 EventBus callback → EventListener 인터페이스 전환
 
 #### PR-A3: Audit Log (PG)


### PR DESCRIPTION
## PR-A2: EventBus Rewrite (typed pub/sub)

Part of Phase 9.0 Wave 1 (parallel with PR-A1, PR-A3).

### Summary

- Replaces callback-based `EventHandler func(Event)` pattern with a typed `Subscriber` interface (`OnEvent(ctx, GameEvent) error`)
- New `TypedEventBus` struct: `map[string][]Subscriber` guarded by `sync.RWMutex`, session-scoped (no global singleton)
- `Publish` returns `[]error` (aggregate) — one failing subscriber does not stop sibling subscribers
- Subscriber panics are recovered per-subscriber, logged via zerolog, returned as `panicError`
- `Publisher` interface defined so callers depend on interface, not concrete type

### GameEvent placeholder note

`GameEvent` is declared as a local placeholder struct in `event_bus.go` with:
```go
// TODO(phase-9.0): rebase onto PR-A1 GameEvent
type GameEvent struct { Topic string; Payload any }
```
The merge-wave step will rebase this branch onto PR-A1 and drop the placeholder once `module_types.go` is merged.

### Files changed

| File | Change |
|------|--------|
| `apps/server/internal/engine/event_bus.go` | New: `GameEvent` placeholder, `Subscriber`, `Publisher` interfaces, `TypedEventBus` impl |
| `apps/server/internal/engine/event_bus_test.go` | New: 14 tests covering all required scenarios |
| `docs/plans/…/checklist.md` | Marked PR-A2 impl + test tasks ✅ |

### Scope boundary

Legacy `internal/eventbus/**` (callback-based, separate package) is untouched — deletion is owned by PR-A4.
Legacy `internal/engine/eventbus.go` (old `EventBus`) coexists in the same package under a different name — also untouched, PR-A4 will remove it.

### Test checklist

- [x] Happy path publish → subscribers receive
- [x] Subscribe/Unsubscribe lifecycle
- [x] Concurrent publish from N goroutines (`go test -race`)
- [x] Panicking subscriber does not break sibling subscribers
- [x] Unknown topic publish is no-op
- [x] Error aggregation: all subscribers run, errors collected
- [x] Context cancellation propagated to subscriber

### Verification commands

```bash
cd apps/server
go fmt ./internal/engine/...
go test -race ./internal/engine/...
go build ./...
go vet ./...
go test -race -count=1 ./...
go test -coverprofile=/tmp/cover.out ./internal/engine/... && go tool cover -func=/tmp/cover.out | grep event_bus
```

### Coverage (new file)

All functions in `event_bus.go`: **100%** statement coverage.
