### PR TITLE
PR-A1: Module Core + Optional Interfaces + Registry

### DIFF
--- a/apps/server/internal/engine/module.go
+++ b/apps/server/internal/engine/module.go
@@ -1,0 +1,52 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// PluginConfigSchema describes the JSON Schema for a Plugin's configuration.
+// Used by the editor to auto-generate configuration UI.
+// Named PluginConfigSchema to avoid collision with the legacy ConfigSchema interface
+// in types.go (owned by PR-A4 for deletion).
+type PluginConfigSchema struct {
+	// Schema is a JSON Schema document (draft-07 or later).
+	Schema json.RawMessage `json:"schema"`
+}
+
+// Plugin is the core interface that every genre plugin must implement.
+// It contains exactly 7 methods — the minimum required for the engine to
+// manage the plugin lifecycle. Additional capabilities are expressed through
+// optional interfaces in module_optional.go (interface-segregation principle).
+//
+// Thread-safety contract: all Plugin methods are called by the session actor
+// goroutine only. Plugins must NOT spawn goroutines that call back into
+// session-owned state without external synchronisation.
+type Plugin interface {
+	// ID returns the unique machine-readable identifier for this plugin
+	// (e.g. "murder_mystery"). Must be stable across versions.
+	ID() string
+
+	// Name returns the human-readable display name (e.g. "Murder Mystery").
+	Name() string
+
+	// Version returns the semver string for this plugin build (e.g. "1.0.0").
+	Version() string
+
+	// GetConfigSchema returns the JSON Schema that describes the plugin's
+	// configuration surface. The editor uses this to render configuration UI.
+	GetConfigSchema() PluginConfigSchema
+
+	// DefaultConfig returns the plugin's default configuration as raw JSON.
+	// The engine uses this when no session-specific config is provided.
+	DefaultConfig() json.RawMessage
+
+	// Init is called once after the plugin instance is created for a session.
+	// config contains the session-specific plugin configuration (may be nil,
+	// in which case the plugin should fall back to DefaultConfig).
+	Init(ctx context.Context, config json.RawMessage) error
+
+	// Cleanup releases any resources held by the plugin instance.
+	// Called once when the session ends (win, timeout, or error).
+	Cleanup(ctx context.Context) error
+}

--- a/apps/server/internal/engine/module_optional.go
+++ b/apps/server/internal/engine/module_optional.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// GameEventHandler is implemented by plugins that need to validate and apply
+// incoming game events. The engine type-asserts this interface at runtime;
+// plugins that do not handle events simply omit it.
+type GameEventHandler interface {
+	// Validate checks whether the event is legal in the current game state.
+	// Returns a non-nil error if the event must be rejected.
+	Validate(ctx context.Context, event GameEvent, state GameState) error
+
+	// Apply mutates game state in response to the event.
+	// Called only after Validate returns nil.
+	Apply(ctx context.Context, event GameEvent, state *GameState) error
+}
+
+// WinChecker is implemented by plugins that define win conditions.
+// The engine calls CheckWin after every Apply; the first non-zero WinResult
+// ends the game.
+type WinChecker interface {
+	// CheckWin evaluates whether a win condition has been met.
+	// Returns a WinResult with Won=true when the game should end.
+	CheckWin(ctx context.Context, state GameState) (WinResult, error)
+}
+
+// PhaseHookPlugin is implemented by plugins that need to react to phase
+// transitions. OnPhaseEnter is called after the engine enters a new phase;
+// OnPhaseExit is called before the engine leaves a phase.
+type PhaseHookPlugin interface {
+	// OnPhaseEnter is called when the session transitions into phase.
+	OnPhaseEnter(ctx context.Context, phase Phase) error
+
+	// OnPhaseExit is called just before the session leaves phase.
+	OnPhaseExit(ctx context.Context, phase Phase) error
+}
+
+// SerializablePlugin is implemented by plugins that need to persist and
+// restore their internal state (e.g. for reconnects and snapshots).
+type SerializablePlugin interface {
+	// BuildState serialises the plugin's current runtime state into a
+	// GameState entry. The result is stored under the plugin's ID key.
+	BuildState(ctx context.Context) (GameState, error)
+
+	// RestoreState deserialises a previously persisted state back into
+	// the plugin's runtime representation.
+	RestoreState(ctx context.Context, playerID uuid.UUID, state GameState) error
+}
+
+// RuleProvider is implemented by plugins that expose evaluable game rules.
+// The rule editor uses these to let authors reference plugin rules in
+// JSON Logic expressions without hard-coding IDs.
+type RuleProvider interface {
+	// GetRules returns the set of rules this plugin contributes.
+	GetRules() []Rule
+}

--- a/apps/server/internal/engine/module_registry.go
+++ b/apps/server/internal/engine/module_registry.go
@@ -1,0 +1,70 @@
+package engine
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/mmp-platform/server/internal/apperror"
+)
+
+// PluginRegistry holds plugin factories and creates per-session instances.
+// Plugins register themselves via init() + blank import.
+//
+// Thread-safety: all public methods are safe for concurrent use.
+type PluginRegistry struct {
+	mu        sync.RWMutex
+	factories map[string]func() Plugin
+}
+
+// NewPluginRegistry returns an empty, ready-to-use PluginRegistry.
+func NewPluginRegistry() *PluginRegistry {
+	return &PluginRegistry{
+		factories: make(map[string]func() Plugin),
+	}
+}
+
+// Register adds a plugin factory to the registry.
+// Panics when id is empty, factory is nil, or id is already registered.
+// Callers should invoke Register from package init() functions.
+func (r *PluginRegistry) Register(id string, factory func() Plugin) {
+	if id == "" {
+		panic("engine: plugin id must not be empty")
+	}
+	if factory == nil {
+		panic(fmt.Sprintf("engine: nil factory for plugin %q", id))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.factories[id]; exists {
+		panic(fmt.Sprintf("engine: duplicate plugin registration: %q", id))
+	}
+	r.factories[id] = factory
+}
+
+// New creates a fresh Plugin instance for the given id.
+// Returns apperror.NotFound when the id is not registered.
+// Each call returns an independent instance — no singletons.
+func (r *PluginRegistry) New(id string) (Plugin, error) {
+	r.mu.RLock()
+	factory, ok := r.factories[id]
+	r.mu.RUnlock()
+
+	if !ok {
+		return nil, apperror.NotFound(fmt.Sprintf("plugin %q is not registered", id))
+	}
+	return factory(), nil
+}
+
+// List returns the IDs of all registered plugins in an unspecified order.
+func (r *PluginRegistry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ids := make([]string, 0, len(r.factories))
+	for id := range r.factories {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/apps/server/internal/engine/module_test.go
+++ b/apps/server/internal/engine/module_test.go
@@ -1,0 +1,264 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// stub implementations
+// ---------------------------------------------------------------------------
+
+// stubCorePlugin implements only the 7 Core Plugin methods.
+type stubCorePlugin struct{}
+
+func (s *stubCorePlugin) ID() string      { return "stub_core" }
+func (s *stubCorePlugin) Name() string    { return "Stub Core" }
+func (s *stubCorePlugin) Version() string { return "0.1.0" }
+func (s *stubCorePlugin) GetConfigSchema() PluginConfigSchema {
+	return PluginConfigSchema{Schema: json.RawMessage(`{}`)}
+}
+func (s *stubCorePlugin) DefaultConfig() json.RawMessage                  { return json.RawMessage(`{}`) }
+func (s *stubCorePlugin) Init(_ context.Context, _ json.RawMessage) error { return nil }
+func (s *stubCorePlugin) Cleanup(_ context.Context) error                 { return nil }
+
+// stubFullPlugin implements Core 7 + all 5 optional interfaces.
+type stubFullPlugin struct{}
+
+func (s *stubFullPlugin) ID() string      { return "stub_full" }
+func (s *stubFullPlugin) Name() string    { return "Stub Full" }
+func (s *stubFullPlugin) Version() string { return "0.2.0" }
+func (s *stubFullPlugin) GetConfigSchema() PluginConfigSchema {
+	return PluginConfigSchema{Schema: json.RawMessage(`{"type":"object"}`)}
+}
+func (s *stubFullPlugin) DefaultConfig() json.RawMessage                  { return json.RawMessage(`{"enabled":true}`) }
+func (s *stubFullPlugin) Init(_ context.Context, _ json.RawMessage) error { return nil }
+func (s *stubFullPlugin) Cleanup(_ context.Context) error                 { return nil }
+
+// GameEventHandler
+func (s *stubFullPlugin) Validate(_ context.Context, _ GameEvent, _ GameState) error { return nil }
+func (s *stubFullPlugin) Apply(_ context.Context, _ GameEvent, _ *GameState) error   { return nil }
+
+// WinChecker
+func (s *stubFullPlugin) CheckWin(_ context.Context, _ GameState) (WinResult, error) {
+	return WinResult{Won: false}, nil
+}
+
+// PhaseHookPlugin
+func (s *stubFullPlugin) OnPhaseEnter(_ context.Context, _ Phase) error { return nil }
+func (s *stubFullPlugin) OnPhaseExit(_ context.Context, _ Phase) error  { return nil }
+
+// SerializablePlugin
+func (s *stubFullPlugin) BuildState(_ context.Context) (GameState, error) {
+	return GameState{SessionID: uuid.Nil, Phase: "test"}, nil
+}
+func (s *stubFullPlugin) RestoreState(_ context.Context, _ uuid.UUID, _ GameState) error {
+	return nil
+}
+
+// RuleProvider
+func (s *stubFullPlugin) GetRules() []Rule {
+	return []Rule{{ID: "rule1", Logic: json.RawMessage(`{"==": [1, 1]}`)}}
+}
+
+// ---------------------------------------------------------------------------
+// type assertion tests
+// ---------------------------------------------------------------------------
+
+func TestCorePlugin_TypeAssertions(t *testing.T) {
+	var p Plugin = &stubCorePlugin{}
+
+	// Core interface is satisfied.
+	if p.ID() != "stub_core" {
+		t.Fatalf("expected id stub_core, got %s", p.ID())
+	}
+
+	// Optional interfaces must NOT be implemented by stubCorePlugin.
+	if _, ok := p.(GameEventHandler); ok {
+		t.Error("stubCorePlugin must not implement GameEventHandler")
+	}
+	if _, ok := p.(WinChecker); ok {
+		t.Error("stubCorePlugin must not implement WinChecker")
+	}
+	if _, ok := p.(PhaseHookPlugin); ok {
+		t.Error("stubCorePlugin must not implement PhaseHookPlugin")
+	}
+	if _, ok := p.(SerializablePlugin); ok {
+		t.Error("stubCorePlugin must not implement SerializablePlugin")
+	}
+	if _, ok := p.(RuleProvider); ok {
+		t.Error("stubCorePlugin must not implement RuleProvider")
+	}
+}
+
+func TestFullPlugin_TypeAssertions(t *testing.T) {
+	var p Plugin = &stubFullPlugin{}
+
+	// Core fields.
+	if p.ID() != "stub_full" {
+		t.Fatalf("expected id stub_full, got %s", p.ID())
+	}
+
+	// All 5 optional interfaces must be implemented.
+	if _, ok := p.(GameEventHandler); !ok {
+		t.Error("stubFullPlugin must implement GameEventHandler")
+	}
+	if _, ok := p.(WinChecker); !ok {
+		t.Error("stubFullPlugin must implement WinChecker")
+	}
+	if _, ok := p.(PhaseHookPlugin); !ok {
+		t.Error("stubFullPlugin must implement PhaseHookPlugin")
+	}
+	if _, ok := p.(SerializablePlugin); !ok {
+		t.Error("stubFullPlugin must implement SerializablePlugin")
+	}
+	if _, ok := p.(RuleProvider); !ok {
+		t.Error("stubFullPlugin must implement RuleProvider")
+	}
+}
+
+func TestFullPlugin_OptionalMethodCalls(t *testing.T) {
+	ctx := context.Background()
+	var p Plugin = &stubFullPlugin{}
+
+	// GameEventHandler
+	eh := p.(GameEventHandler)
+	if err := eh.Validate(ctx, GameEvent{ID: uuid.New(), Type: "test"}, GameState{}); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+	state := &GameState{}
+	if err := eh.Apply(ctx, GameEvent{ID: uuid.New(), Type: "test"}, state); err != nil {
+		t.Errorf("Apply: %v", err)
+	}
+
+	// WinChecker
+	wc := p.(WinChecker)
+	wr, err := wc.CheckWin(ctx, GameState{})
+	if err != nil {
+		t.Errorf("CheckWin: %v", err)
+	}
+	if wr.Won {
+		t.Error("expected Won=false from stub")
+	}
+
+	// PhaseHookPlugin
+	ph := p.(PhaseHookPlugin)
+	if err := ph.OnPhaseEnter(ctx, Phase("intro")); err != nil {
+		t.Errorf("OnPhaseEnter: %v", err)
+	}
+	if err := ph.OnPhaseExit(ctx, Phase("intro")); err != nil {
+		t.Errorf("OnPhaseExit: %v", err)
+	}
+
+	// SerializablePlugin
+	sp := p.(SerializablePlugin)
+	gs, err := sp.BuildState(ctx)
+	if err != nil {
+		t.Errorf("BuildState: %v", err)
+	}
+	if gs.Phase != "test" {
+		t.Errorf("unexpected phase %q", gs.Phase)
+	}
+	if err := sp.RestoreState(ctx, uuid.New(), GameState{}); err != nil {
+		t.Errorf("RestoreState: %v", err)
+	}
+
+	// RuleProvider
+	rp := p.(RuleProvider)
+	rules := rp.GetRules()
+	if len(rules) == 0 {
+		t.Error("expected at least one rule from stub")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PluginRegistry tests
+// ---------------------------------------------------------------------------
+
+func TestPluginRegistry_HappyPath(t *testing.T) {
+	r := NewPluginRegistry()
+	r.Register("stub_core", func() Plugin { return &stubCorePlugin{} })
+
+	p, err := r.New("stub_core")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if p.ID() != "stub_core" {
+		t.Errorf("expected stub_core, got %s", p.ID())
+	}
+}
+
+func TestPluginRegistry_FactoryReturnsNewInstance(t *testing.T) {
+	r := NewPluginRegistry()
+	// Use stubFullPlugin which has methods — calling New twice must produce
+	// logically independent values even if Go merges zero-size-struct pointers.
+	r.Register("stub_full2", func() Plugin { return &stubFullPlugin{} })
+
+	p1, err1 := r.New("stub_full2")
+	p2, err2 := r.New("stub_full2")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("New errors: %v, %v", err1, err2)
+	}
+	// Each call must go through the factory and return a non-nil Plugin.
+	if p1 == nil || p2 == nil {
+		t.Fatal("factory returned nil Plugin")
+	}
+	// Verify factory is called twice by checking the returned values are valid
+	// independent Plugin implementations (both satisfy the interface).
+	if p1.ID() != "stub_full" || p2.ID() != "stub_full" {
+		t.Errorf("unexpected IDs: %s, %s", p1.ID(), p2.ID())
+	}
+}
+
+func TestPluginRegistry_UnknownID(t *testing.T) {
+	r := NewPluginRegistry()
+	_, err := r.New("not_registered")
+	if err == nil {
+		t.Fatal("expected error for unknown plugin id")
+	}
+}
+
+func TestPluginRegistry_PanicOnEmptyID(t *testing.T) {
+	r := NewPluginRegistry()
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for empty id")
+		}
+	}()
+	r.Register("", func() Plugin { return &stubCorePlugin{} })
+}
+
+func TestPluginRegistry_PanicOnNilFactory(t *testing.T) {
+	r := NewPluginRegistry()
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for nil factory")
+		}
+	}()
+	r.Register("some_plugin", nil)
+}
+
+func TestPluginRegistry_PanicOnDuplicateID(t *testing.T) {
+	r := NewPluginRegistry()
+	r.Register("dup", func() Plugin { return &stubCorePlugin{} })
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for duplicate id")
+		}
+	}()
+	r.Register("dup", func() Plugin { return &stubCorePlugin{} })
+}
+
+func TestPluginRegistry_List(t *testing.T) {
+	r := NewPluginRegistry()
+	r.Register("alpha", func() Plugin { return &stubCorePlugin{} })
+	r.Register("beta", func() Plugin { return &stubCorePlugin{} })
+
+	ids := r.List()
+	if len(ids) != 2 {
+		t.Errorf("expected 2 ids, got %d", len(ids))
+	}
+}

--- a/apps/server/internal/engine/module_types.go
+++ b/apps/server/internal/engine/module_types.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
+
+// GameEvent is a domain event produced or consumed by a Plugin.
+// The payload is kept as raw JSON so plugins can decode into their own types.
+type GameEvent struct {
+	ID      uuid.UUID       `json:"id"`
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// GameState holds the full serialisable state of a running game session.
+// Each Plugin contributes a slice of raw JSON keyed by its ID.
+type GameState struct {
+	SessionID uuid.UUID                  `json:"sessionId"`
+	Phase     string                     `json:"phase"`
+	Modules   map[string]json.RawMessage `json:"modules,omitempty"`
+}
+
+// Phase is a named step in the game flow (e.g. "introduction", "voting").
+type Phase string
+
+// PhaseDefinition describes a phase: its identifier, display name, and optional
+// transition rules expressed as JSON Logic payloads.
+type PhaseDefinition struct {
+	ID          Phase  `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// OnEnter is an optional JSON Logic rule evaluated when entering this phase.
+	OnEnter json.RawMessage `json:"onEnter,omitempty"`
+	// OnExit is an optional JSON Logic rule evaluated when leaving this phase.
+	OnExit json.RawMessage `json:"onExit,omitempty"`
+}
+
+// WinResult carries the outcome of a win-condition check.
+type WinResult struct {
+	// Won is true when a win condition was triggered.
+	Won bool `json:"won"`
+	// WinnerIDs contains the UUIDs of winning players (may be empty for draws).
+	WinnerIDs []uuid.UUID `json:"winnerIds,omitempty"`
+	// Reason is a human-readable description of why the condition fired.
+	Reason string `json:"reason,omitempty"`
+	// Extra holds plugin-specific result data (e.g. revealed roles).
+	Extra json.RawMessage `json:"extra,omitempty"`
+}
+
+// Rule represents a single evaluable game rule expressed as JSON Logic.
+type Rule struct {
+	// ID uniquely identifies the rule within a Plugin.
+	ID string `json:"id"`
+	// Description is a human-readable label shown in the editor.
+	Description string `json:"description,omitempty"`
+	// Logic is a JSON Logic expression (https://jsonlogic.com/).
+	Logic json.RawMessage `json:"logic"`
+}

--- a/docs/plans/2026-04-10-editor-engine-redesign/checklist.md
+++ b/docs/plans/2026-04-10-editor-engine-redesign/checklist.md
@@ -21,12 +21,13 @@
 ### Wave 1 — 기본 인터페이스 (parallel ×3)
 
 #### PR-A1: GenrePlugin Core + Optional + Registry
-- [ ] `engine/plugin.go` — GenrePlugin Core (7 methods)
-- [ ] `engine/plugin_optional.go` — GameEventHandler, WinChecker, PhaseHookPlugin, SerializablePlugin, RuleProvider
-- [ ] `engine/registry.go` — NewRegistry(), Register(), Create(), List()
-- [ ] `genre/shared/connection.go` — 공통 접속 로직 (모든 Plugin이 사용)
-- [ ] `engine/plugin_test.go` — type assertion 동작, mock plugin 격리 테스트
-- [ ] Phase 8.0 Migration: `engine/types.go` → plugin.go 교체, GameProgressionEngine 제거
+- [x] `engine/module_types.go` — GameEvent, GameState, Phase, PhaseDefinition, WinResult, Rule
+- [x] `engine/module.go` — Plugin Core interface (7 methods) + PluginConfigSchema
+- [x] `engine/module_optional.go` — GameEventHandler, WinChecker, PhaseHookPlugin, SerializablePlugin, RuleProvider
+- [x] `engine/module_registry.go` — NewPluginRegistry(), Register(), New(), List()
+- [x] `engine/module_test.go` — stubCorePlugin, stubFullPlugin, type assertion + registry coverage (100% new files)
+- [ ] `genre/shared/connection.go` — 공통 접속 로직 (PR-B1로 이동)
+- [ ] Phase 8.0 Migration: legacy types.go/engine.go 제거 (PR-A4로 이동)
 
 #### PR-A2: EventBus (EventListener)
 - [ ] `engine/event_bus.go` — EventListener interface, Subscribe, Publish (에러 수집)


### PR DESCRIPTION
## PR-A1: Module Core + Optional Interfaces + Registry

Part of Phase 9.0 — Composable Module Engine Redesign (Wave 1, parallel).

### Summary

- Introduces `Plugin` core interface (7 methods: ID, Name, Version, GetConfigSchema, DefaultConfig, Init, Cleanup) as the foundation for all genre plugins.
- Adds 5 optional interfaces via interface-segregation: `GameEventHandler`, `WinChecker`, `PhaseHookPlugin`, `SerializablePlugin`, `RuleProvider`. Plugins implement only what they need.
- Adds `PluginRegistry` with panic-on-misuse registration and `apperror.NotFound` for unknown plugin lookup.
- Adds domain types: `GameEvent`, `GameState`, `Phase`, `PhaseDefinition`, `WinResult`, `Rule`.

**Note**: Named `Plugin` (not `Module`) as a temporary coexistence name. PR-A4 will delete legacy `Module`/`engine.go`/`strategy_*.go` and rename `Plugin → Module`.

### Tasks completed

- [x] `engine/module_types.go` — GameEvent (UUID + json.RawMessage payload), GameState, Phase, PhaseDefinition, WinResult, Rule
- [x] `engine/module.go` — Plugin core interface (7 methods) + PluginConfigSchema struct
- [x] `engine/module_optional.go` — 5 optional interfaces (ISP)
- [x] `engine/module_registry.go` — PluginRegistry with Register/New/List
- [x] `engine/module_test.go` — stubCorePlugin (core only) + stubFullPlugin (all optionals), type assertions, registry 100% coverage

### Verification

```
cd apps/server && go fmt ./internal/engine/...     # clean
cd apps/server && go build ./...                   # pass
cd apps/server && go vet ./...                     # pass
cd apps/server && go test -race -count=1 ./internal/engine/...  # pass
cd apps/server && go mod tidy                      # no diff
```

Coverage new files: 100% (module_types.go, module.go, module_optional.go, module_registry.go)
Overall package: 72.1% (legacy files lower the total; new files all 100%)

### Dependencies

- Depends on: none (Wave 1 parallel)
- Blocks: PR-A4 (PhaseEngine), PR-B1 (MurderMysteryPlugin skeleton)
