### PR TITLE
feat(game-runtime): PR-3 — gameSessionStore + WS handlers + game hooks

### DIFF
--- a/apps/web/src/features/game/hooks/useGameSession.ts
+++ b/apps/web/src/features/game/hooks/useGameSession.ts
@@ -1,0 +1,95 @@
+import { useEffect } from "react";
+import { WsEventType } from "@mmp/shared";
+import type { GamePhase, GameState, Player } from "@mmp/shared";
+
+import { useAuthStore } from "@/stores/authStore";
+import { useGameSessionStore } from "@/stores/gameSessionStore";
+import { useWsEvent } from "@/hooks/useWsEvent";
+
+// ---------------------------------------------------------------------------
+// WS payload types
+// ---------------------------------------------------------------------------
+
+interface PhaseChangedPayload {
+  phase: GamePhase;
+  deadline: number | null;
+  round: number;
+}
+
+interface SessionStatePayload {
+  state: GameState;
+}
+
+interface GameStartPayload {
+  state: GameState;
+}
+
+interface PlayerJoinedPayload {
+  player: Player;
+}
+
+interface PlayerLeftPayload {
+  playerId: string;
+}
+
+interface ModuleStatePayload {
+  moduleId: string;
+  settings: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronises game WS events into the gameSessionStore.
+ * Must be called once in the game session root component.
+ */
+export function useGameSession(): void {
+  const myId = useAuthStore((s) => s.user?.id ?? null);
+
+  // Register my player ID once available
+  useEffect(() => {
+    if (myId) {
+      // No-op: initGame is triggered by GAME_START event
+    }
+  }, [myId]);
+
+  // game:start — initialise store with full server state
+  useWsEvent<GameStartPayload>("game", WsEventType.GAME_START, (payload) => {
+    const currentMyId = useAuthStore.getState().user?.id;
+    if (currentMyId) {
+      useGameSessionStore.getState().initGame(payload.state, currentMyId);
+    }
+  });
+
+  // session:state — full state sync (reconnect / snapshot)
+  useWsEvent<SessionStatePayload>("game", WsEventType.SESSION_STATE, (payload) => {
+    useGameSessionStore.getState().setGameState(payload.state);
+  });
+
+  // game:phase:change — phase transition
+  useWsEvent<PhaseChangedPayload>("game", WsEventType.GAME_PHASE_CHANGE, (payload) => {
+    useGameSessionStore.getState().setPhase(payload.phase, payload.deadline, payload.round);
+  });
+
+  // game:end — reset session state
+  useWsEvent<void>("game", WsEventType.GAME_END, () => {
+    useGameSessionStore.getState().resetGame();
+  });
+
+  // session:player:joined
+  useWsEvent<PlayerJoinedPayload>("game", WsEventType.SESSION_PLAYER_JOINED, (payload) => {
+    useGameSessionStore.getState().addPlayer(payload.player);
+  });
+
+  // session:player:left
+  useWsEvent<PlayerLeftPayload>("game", WsEventType.SESSION_PLAYER_LEFT, (payload) => {
+    useGameSessionStore.getState().removePlayer(payload.playerId);
+  });
+
+  // module:state — full module settings replacement
+  useWsEvent<ModuleStatePayload>("game", WsEventType.MODULE_STATE, (payload) => {
+    useGameSessionStore.getState().updateModuleState(payload.moduleId, payload.settings);
+  });
+}

--- a/apps/web/src/features/game/hooks/useGameWS.ts
+++ b/apps/web/src/features/game/hooks/useGameWS.ts
@@ -1,0 +1,73 @@
+import { useCallback } from "react";
+import type { WsClient } from "@mmp/ws-client";
+import { WsClientState } from "@mmp/ws-client";
+import type { WsEventType } from "@mmp/shared";
+
+import { useAuthStore, selectAccessToken } from "@/stores/authStore";
+import { useConnectionStore } from "@/stores/connectionStore";
+import { useWsClient } from "@/hooks/useWsClient";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseGameWSReturn {
+  client: WsClient | null;
+  state: WsClientState;
+  isConnected: boolean;
+  isReconnecting: boolean;
+  send: <T>(type: WsEventType, payload: T) => void;
+  connect: () => void;
+  disconnect: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages the game WebSocket connection for a session.
+ * Wraps useWsClient with game-specific defaults:
+ * - exponential backoff reconnect (1s, 2s, 4s, 8s … max 30s) via WsClient
+ * - token via query param `?token=` (not Authorization header)
+ *
+ * @param sessionId - The game session ID to connect to.
+ */
+export function useGameWS(sessionId: string | null): UseGameWSReturn {
+  const { client, state, send, connect, disconnect } = useWsClient({
+    endpoint: "game",
+    sessionId: sessionId ?? undefined,
+    autoConnect: !!sessionId,
+  });
+
+  return {
+    client,
+    state,
+    isConnected: state === WsClientState.CONNECTED,
+    isReconnecting: state === WsClientState.RECONNECTING,
+    send,
+    connect,
+    disconnect,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Utility: manual game connect with custom reconnect options
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a stable `connectGame` function that respects the current token.
+ * Useful in cases where the caller needs to initiate the connection imperatively.
+ */
+export function useConnectGame(): (sessionId: string) => void {
+  const accessToken = useAuthStore(selectAccessToken);
+  const connectGame = useConnectionStore((s) => s.connectGame);
+
+  return useCallback(
+    (sessionId: string) => {
+      if (!accessToken) return;
+      connectGame(sessionId, accessToken);
+    },
+    [accessToken, connectGame],
+  );
+}

--- a/apps/web/src/stores/__tests__/gameSelectors.test.ts
+++ b/apps/web/src/stores/__tests__/gameSelectors.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { PlayerRole } from "@mmp/shared";
+
+import { useGameSessionStore } from "../gameSessionStore";
+import {
+  selectMyPlayer,
+  selectAmIHost,
+  selectAlivePlayers,
+  selectAllReady,
+  selectPlayerCount,
+} from "../gameSelectors";
+import { makePlayer } from "./gameSessionStore.test";
+
+// ---------------------------------------------------------------------------
+// Selector tests
+// ---------------------------------------------------------------------------
+
+const BLANK_STATE = {
+  sessionId: null,
+  phase: null,
+  players: [],
+  modules: [],
+  round: 0,
+  phaseDeadline: null,
+  isGameActive: false,
+  myPlayerId: null,
+  myRole: null,
+};
+
+describe("gameSelectors", () => {
+  beforeEach(() => {
+    useGameSessionStore.setState(BLANK_STATE);
+  });
+
+  describe("selectMyPlayer", () => {
+    it("내 Player 객체를 반환한다", () => {
+      const me = makePlayer({ id: "p1" });
+      useGameSessionStore.setState({ players: [me], myPlayerId: "p1" });
+      expect(selectMyPlayer(useGameSessionStore.getState())).toEqual(me);
+    });
+
+    it("myPlayerId가 없으면 undefined를 반환한다", () => {
+      useGameSessionStore.setState({ players: [makePlayer()], myPlayerId: null });
+      expect(selectMyPlayer(useGameSessionStore.getState())).toBeUndefined();
+    });
+
+    it("해당 ID가 없으면 undefined를 반환한다", () => {
+      useGameSessionStore.setState({ players: [makePlayer({ id: "p1" })], myPlayerId: "p99" });
+      expect(selectMyPlayer(useGameSessionStore.getState())).toBeUndefined();
+    });
+  });
+
+  describe("selectAmIHost", () => {
+    it("내가 호스트면 true", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "p1", isHost: true })],
+        myPlayerId: "p1",
+      });
+      expect(selectAmIHost(useGameSessionStore.getState())).toBe(true);
+    });
+
+    it("내가 호스트가 아니면 false", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "p1", isHost: false })],
+        myPlayerId: "p1",
+      });
+      expect(selectAmIHost(useGameSessionStore.getState())).toBe(false);
+    });
+
+    it("myPlayerId가 없으면 false", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "p1", isHost: true })],
+        myPlayerId: null,
+      });
+      expect(selectAmIHost(useGameSessionStore.getState())).toBe(false);
+    });
+  });
+
+  describe("selectAlivePlayers", () => {
+    it("생존 플레이어만 반환한다", () => {
+      useGameSessionStore.setState({
+        players: [
+          makePlayer({ id: "p1", isAlive: true }),
+          makePlayer({ id: "p2", isAlive: false }),
+          makePlayer({ id: "p3", isAlive: true }),
+        ],
+      });
+      const alive = selectAlivePlayers(useGameSessionStore.getState());
+      expect(alive).toHaveLength(2);
+      expect(alive.map((p) => p.id)).toEqual(["p1", "p3"]);
+    });
+
+    it("모두 사망이면 빈 배열을 반환한다", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "p1", isAlive: false })],
+      });
+      expect(selectAlivePlayers(useGameSessionStore.getState())).toEqual([]);
+    });
+  });
+
+  describe("selectAllReady", () => {
+    it("호스트 제외 전원 준비 완료면 true", () => {
+      useGameSessionStore.setState({
+        players: [
+          makePlayer({ id: "host", isHost: true, isReady: false }),
+          makePlayer({ id: "p1", isReady: true }),
+        ],
+      });
+      expect(selectAllReady(useGameSessionStore.getState())).toBe(true);
+    });
+
+    it("준비 안 한 플레이어가 있으면 false", () => {
+      useGameSessionStore.setState({
+        players: [
+          makePlayer({ id: "p1", isReady: true }),
+          makePlayer({ id: "p2", isReady: false }),
+        ],
+      });
+      expect(selectAllReady(useGameSessionStore.getState())).toBe(false);
+    });
+
+    it("비호스트가 없으면 true (vacuous)", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "host", isHost: true, isReady: false })],
+      });
+      expect(selectAllReady(useGameSessionStore.getState())).toBe(true);
+    });
+  });
+
+  describe("selectPlayerCount", () => {
+    it("플레이어 수를 반환한다", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "p1" }), makePlayer({ id: "p2" })],
+      });
+      expect(selectPlayerCount(useGameSessionStore.getState())).toBe(2);
+    });
+
+    it("빈 배열이면 0을 반환한다", () => {
+      useGameSessionStore.setState({ players: [] });
+      expect(selectPlayerCount(useGameSessionStore.getState())).toBe(0);
+    });
+  });
+});

--- a/apps/web/src/stores/__tests__/gameSessionStore.test.ts
+++ b/apps/web/src/stores/__tests__/gameSessionStore.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { GamePhase, GameState, ModuleConfig, Player, PlayerRole } from "@mmp/shared";
+
+import { useGameSessionStore } from "../gameSessionStore";
+import {
+  selectMyPlayer,
+  selectAmIHost,
+  selectAlivePlayers,
+  selectAllReady,
+  selectPlayerCount,
+} from "../gameSelectors";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: "p1",
+    nickname: "Alice",
+    role: null,
+    isAlive: true,
+    isHost: false,
+    isReady: false,
+    connectedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+export function makeModule(overrides: Partial<ModuleConfig> = {}): ModuleConfig {
+  return {
+    id: "mod-1",
+    name: "TestModule",
+    version: "1.0.0",
+    enabled: true,
+    settings: {},
+    ...overrides,
+  };
+}
+
+export function makeGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    sessionId: "session-1",
+    phase: "lobby" as GamePhase,
+    players: [makePlayer()],
+    modules: [makeModule()],
+    round: 1,
+    phaseDeadline: 9999,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+const BLANK_STATE = {
+  sessionId: null,
+  phase: null,
+  players: [],
+  modules: [],
+  round: 0,
+  phaseDeadline: null,
+  isGameActive: false,
+  myPlayerId: null,
+  myRole: null,
+};
+
+// ---------------------------------------------------------------------------
+// Store action tests
+// ---------------------------------------------------------------------------
+
+describe("gameSessionStore — actions", () => {
+  beforeEach(() => {
+    useGameSessionStore.setState(BLANK_STATE);
+  });
+
+  describe("초기 상태", () => {
+    it("sessionId는 null이다", () => {
+      expect(useGameSessionStore.getState().sessionId).toBeNull();
+    });
+
+    it("phase는 null이다", () => {
+      expect(useGameSessionStore.getState().phase).toBeNull();
+    });
+
+    it("isGameActive는 false이다", () => {
+      expect(useGameSessionStore.getState().isGameActive).toBe(false);
+    });
+  });
+
+  describe("initGame", () => {
+    it("전체 상태를 설정한다", () => {
+      const gs = makeGameState();
+      useGameSessionStore.getState().initGame(gs, "p1");
+
+      const s = useGameSessionStore.getState();
+      expect(s.sessionId).toBe("session-1");
+      expect(s.phase).toBe("lobby");
+      expect(s.round).toBe(1);
+      expect(s.phaseDeadline).toBe(9999);
+      expect(s.myPlayerId).toBe("p1");
+      expect(s.isGameActive).toBe(true);
+    });
+
+    it("myRole을 players에서 추출한다", () => {
+      const gs = makeGameState({
+        players: [makePlayer({ id: "p1", role: "detective" as PlayerRole })],
+      });
+      useGameSessionStore.getState().initGame(gs, "p1");
+      expect(useGameSessionStore.getState().myRole).toBe("detective");
+    });
+
+    it("myPlayerId가 players에 없으면 myRole은 null이다", () => {
+      useGameSessionStore.getState().initGame(makeGameState(), "unknown");
+      expect(useGameSessionStore.getState().myRole).toBeNull();
+    });
+  });
+
+  describe("resetGame", () => {
+    it("초기 상태로 복원한다", () => {
+      useGameSessionStore.getState().initGame(makeGameState(), "p1");
+      useGameSessionStore.getState().resetGame();
+
+      const s = useGameSessionStore.getState();
+      expect(s.sessionId).toBeNull();
+      expect(s.phase).toBeNull();
+      expect(s.isGameActive).toBe(false);
+    });
+  });
+
+  describe("setPhase", () => {
+    it("phase, deadline, round를 업데이트한다", () => {
+      useGameSessionStore.getState().setPhase("investigation" as GamePhase, 5000, 2);
+      const s = useGameSessionStore.getState();
+      expect(s.phase).toBe("investigation");
+      expect(s.phaseDeadline).toBe(5000);
+      expect(s.round).toBe(2);
+    });
+
+    it("deadline이 null일 수 있다", () => {
+      useGameSessionStore.getState().setPhase("lobby" as GamePhase, null, 0);
+      expect(useGameSessionStore.getState().phaseDeadline).toBeNull();
+    });
+  });
+
+  describe("addPlayer / removePlayer", () => {
+    it("플레이어를 추가한다", () => {
+      useGameSessionStore.getState().addPlayer(makePlayer({ id: "p1" }));
+      expect(useGameSessionStore.getState().players).toHaveLength(1);
+    });
+
+    it("중복 ID면 교체한다", () => {
+      useGameSessionStore.getState().addPlayer(makePlayer({ id: "p1", nickname: "Alice" }));
+      useGameSessionStore.getState().addPlayer(makePlayer({ id: "p1", nickname: "Alice2" }));
+      expect(useGameSessionStore.getState().players[0].nickname).toBe("Alice2");
+    });
+
+    it("플레이어를 제거한다", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "p1" }), makePlayer({ id: "p2" })],
+      });
+      useGameSessionStore.getState().removePlayer("p1");
+      expect(useGameSessionStore.getState().players).toHaveLength(1);
+      expect(useGameSessionStore.getState().players[0].id).toBe("p2");
+    });
+
+    it("removePlayer시 myRole을 재계산한다", () => {
+      useGameSessionStore.setState({
+        players: [makePlayer({ id: "p1", role: "detective" as PlayerRole })],
+        myPlayerId: "p1",
+        myRole: "detective" as PlayerRole,
+      });
+      useGameSessionStore.getState().removePlayer("p1");
+      expect(useGameSessionStore.getState().myRole).toBeNull();
+    });
+  });
+
+  describe("updateModuleState", () => {
+    it("특정 모듈 settings를 머지한다", () => {
+      useGameSessionStore.setState({
+        modules: [makeModule({ id: "mod-1", settings: { a: 1 } })],
+      });
+      useGameSessionStore.getState().updateModuleState("mod-1", { b: 2 });
+      const mod = useGameSessionStore.getState().modules.find((m) => m.id === "mod-1");
+      expect(mod?.settings).toEqual({ a: 1, b: 2 });
+    });
+
+    it("다른 모듈에 영향 없다", () => {
+      useGameSessionStore.setState({
+        modules: [
+          makeModule({ id: "mod-1", settings: { a: 1 } }),
+          makeModule({ id: "mod-2", settings: { x: 10 } }),
+        ],
+      });
+      useGameSessionStore.getState().updateModuleState("mod-1", { b: 2 });
+      const mod2 = useGameSessionStore.getState().modules.find((m) => m.id === "mod-2");
+      expect(mod2?.settings).toEqual({ x: 10 });
+    });
+  });
+});

--- a/apps/web/src/stores/gameMessageHandlers.ts
+++ b/apps/web/src/stores/gameMessageHandlers.ts
@@ -1,0 +1,105 @@
+import type { WsClient } from "@mmp/ws-client";
+import { WsEventType } from "@mmp/shared";
+import type { GamePhase, GameState, Player } from "@mmp/shared";
+import { useGameSessionStore } from "./gameSessionStore";
+
+// ---------------------------------------------------------------------------
+// WS payload types (matching Go server envelope)
+// ---------------------------------------------------------------------------
+
+interface PhaseChangedPayload {
+  phase: GamePhase;
+  deadline: number | null;
+  round: number;
+}
+
+interface PlayerJoinedPayload {
+  player: Player;
+}
+
+interface PlayerLeftPayload {
+  playerId: string;
+}
+
+interface ModuleEventPayload {
+  moduleId: string;
+  event: string;
+  data: Record<string, unknown>;
+}
+
+interface ModuleStatePayload {
+  moduleId: string;
+  settings: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Handler registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Registers all game-related WS message handlers on the given client.
+ * Returns a cleanup function that removes all listeners.
+ */
+export function registerGameHandlers(client: WsClient): () => void {
+  const store = useGameSessionStore.getState;
+
+  const unsubPhaseChange = client.on<PhaseChangedPayload>(
+    WsEventType.GAME_PHASE_CHANGE,
+    (payload) => {
+      store().setPhase(payload.phase, payload.deadline, payload.round);
+    },
+  );
+
+  const unsubGameState = client.on<GameState>(
+    WsEventType.SESSION_STATE,
+    (payload) => {
+      store().setGameState(payload);
+    },
+  );
+
+  const unsubPlayerJoined = client.on<PlayerJoinedPayload>(
+    WsEventType.SESSION_PLAYER_JOINED,
+    (payload) => {
+      store().addPlayer(payload.player);
+    },
+  );
+
+  const unsubPlayerLeft = client.on<PlayerLeftPayload>(
+    WsEventType.SESSION_PLAYER_LEFT,
+    (payload) => {
+      store().removePlayer(payload.playerId);
+    },
+  );
+
+  const unsubModuleEvent = client.on<ModuleEventPayload>(
+    WsEventType.MODULE_EVENT,
+    (payload) => {
+      // Module events carry arbitrary data — stored as settings update
+      store().updateModuleState(payload.moduleId, { lastEvent: payload });
+    },
+  );
+
+  const unsubModuleState = client.on<ModuleStatePayload>(
+    WsEventType.MODULE_STATE,
+    (payload) => {
+      store().updateModuleState(payload.moduleId, payload.settings);
+    },
+  );
+
+  const unsubGameEnd = client.on<GameState>(
+    WsEventType.GAME_END,
+    (payload) => {
+      store().setGameState(payload);
+    },
+  );
+
+  return () => {
+    unsubPhaseChange();
+    unsubGameState();
+    unsubPlayerJoined();
+    unsubPlayerLeft();
+    unsubModuleEvent();
+    unsubModuleState();
+    unsubGameEnd();
+  };
+}

--- a/apps/web/src/stores/gameSelectors.ts
+++ b/apps/web/src/stores/gameSelectors.ts
@@ -1,0 +1,39 @@
+import type { GameSessionState } from "./gameSessionStore";
+import type { Player } from "@mmp/shared";
+
+// ---------------------------------------------------------------------------
+// Primitive selectors
+// ---------------------------------------------------------------------------
+
+export const selectSessionId = (s: GameSessionState) => s.sessionId;
+export const selectPhase = (s: GameSessionState) => s.phase;
+export const selectPlayers = (s: GameSessionState) => s.players;
+export const selectModules = (s: GameSessionState) => s.modules;
+export const selectRound = (s: GameSessionState) => s.round;
+export const selectPhaseDeadline = (s: GameSessionState) => s.phaseDeadline;
+export const selectIsGameActive = (s: GameSessionState) => s.isGameActive;
+export const selectMyPlayerId = (s: GameSessionState) => s.myPlayerId;
+export const selectMyRole = (s: GameSessionState) => s.myRole;
+
+// ---------------------------------------------------------------------------
+// Derived selectors
+// ---------------------------------------------------------------------------
+
+/** My Player object. */
+export const selectMyPlayer = (s: GameSessionState): Player | undefined =>
+  s.players.find((p) => p.id === s.myPlayerId);
+
+/** Whether the local player is the host. */
+export const selectAmIHost = (s: GameSessionState): boolean =>
+  s.players.some((p) => p.id === s.myPlayerId && p.isHost);
+
+/** Only alive players. */
+export const selectAlivePlayers = (s: GameSessionState): Player[] =>
+  s.players.filter((p) => p.isAlive);
+
+/** Total player count. */
+export const selectPlayerCount = (s: GameSessionState): number => s.players.length;
+
+/** True when all non-host players are ready. */
+export const selectAllReady = (s: GameSessionState): boolean =>
+  s.players.filter((p) => !p.isHost).every((p) => p.isReady);

--- a/apps/web/src/stores/gameSessionStore.ts
+++ b/apps/web/src/stores/gameSessionStore.ts
@@ -1,0 +1,130 @@
+import { create } from "zustand";
+import type { GamePhase, GameState, ModuleConfig, Player, PlayerRole } from "@mmp/shared";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GameSessionState {
+  // Domain state
+  sessionId: string | null;
+  phase: GamePhase | null;
+  players: Player[];
+  modules: ModuleConfig[];
+  round: number;
+  phaseDeadline: number | null;
+  isGameActive: boolean;
+
+  // Local player identity
+  myPlayerId: string | null;
+  myRole: PlayerRole | null;
+}
+
+export interface GameSessionActions {
+  initGame: (state: GameState, myPlayerId: string) => void;
+  resetGame: () => void;
+  setPhase: (phase: GamePhase, deadline: number | null, round: number) => void;
+  setPlayers: (players: Player[]) => void;
+  addPlayer: (player: Player) => void;
+  removePlayer: (playerId: string) => void;
+  updateModuleState: (moduleId: string, settings: Record<string, unknown>) => void;
+  setGameState: (state: GameState) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: GameSessionState = {
+  sessionId: null,
+  phase: null,
+  players: [],
+  modules: [],
+  round: 0,
+  phaseDeadline: null,
+  isGameActive: false,
+  myPlayerId: null,
+  myRole: null,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractMyRole(players: Player[], myPlayerId: string | null): PlayerRole | null {
+  if (!myPlayerId) return null;
+  const me = players.find((p) => p.id === myPlayerId);
+  return me?.role ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useGameSessionStore = create<GameSessionState & GameSessionActions>()(
+  (set, get) => ({
+    ...INITIAL_STATE,
+
+    initGame: (state, myPlayerId) => {
+      set({
+        sessionId: state.sessionId,
+        phase: state.phase,
+        players: state.players,
+        modules: state.modules,
+        round: state.round,
+        phaseDeadline: state.phaseDeadline,
+        isGameActive: true,
+        myPlayerId,
+        myRole: extractMyRole(state.players, myPlayerId),
+      });
+    },
+
+    resetGame: () => {
+      set({ ...INITIAL_STATE });
+    },
+
+    setPhase: (phase, deadline, round) => {
+      set({ phase, phaseDeadline: deadline, round });
+    },
+
+    setPlayers: (players) => {
+      const { myPlayerId } = get();
+      set({ players, myRole: extractMyRole(players, myPlayerId) });
+    },
+
+    addPlayer: (player) => {
+      const { players } = get();
+      const filtered = players.filter((p) => p.id !== player.id);
+      set({ players: [...filtered, player] });
+    },
+
+    removePlayer: (playerId) => {
+      const { players, myPlayerId } = get();
+      const next = players.filter((p) => p.id !== playerId);
+      set({ players: next, myRole: extractMyRole(next, myPlayerId) });
+    },
+
+    updateModuleState: (moduleId, settings) => {
+      const { modules } = get();
+      set({
+        modules: modules.map((m) =>
+          m.id === moduleId ? { ...m, settings: { ...m.settings, ...settings } } : m,
+        ),
+      });
+    },
+
+    setGameState: (state) => {
+      const { myPlayerId } = get();
+      set({
+        sessionId: state.sessionId,
+        phase: state.phase,
+        players: state.players,
+        modules: state.modules,
+        round: state.round,
+        phaseDeadline: state.phaseDeadline,
+        isGameActive: true,
+        myRole: extractMyRole(state.players, myPlayerId),
+      });
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- **gameSessionStore** (`stores/gameSessionStore.ts`): Domain-layer Zustand store holding phase, players, modules, round, phaseDeadline, myPlayerId/myRole
- **gameSelectors** (`stores/gameSelectors.ts`): Pure selectors — selectMyPlayer, selectAmIHost, selectAlivePlayers, selectAllReady, selectPlayerCount
- **gameMessageHandlers** (`stores/gameMessageHandlers.ts`): Registers WS envelope handlers (GAME_PHASE_CHANGE, SESSION_STATE, SESSION_PLAYER_JOINED/LEFT, MODULE_EVENT, MODULE_STATE, GAME_END)
- **useGameSession** (`features/game/hooks/useGameSession.ts`): React hook that syncs all game WS events into gameSessionStore via useWsEvent
- **useGameWS** (`features/game/hooks/useGameWS.ts`): Game WS connection hook wrapping useWsClient with exponential backoff reconnect (1s→2s→4s→8s, max 30s, jitter), token via `?token=` query param

## Architecture

- Follows 3-layer Zustand pattern: Connection (connectionStore) / Domain (gameSessionStore) / UI (selectors)
- Hooks compose existing useWsClient + useWsEvent infrastructure
- gameSessionStore is independent of gameStore (no syncServerTime dependency) — clean for Vitest

## Test plan

- [x] `gameSessionStore.test.ts` — 15 tests: initGame, resetGame, setPhase, addPlayer, removePlayer, updateModuleState
- [x] `gameSelectors.test.ts` — 28 tests: all 5 selectors with edge cases
- [x] All 43 tests pass: `vitest run src/stores/__tests__/gameSessionStore.test.ts src/stores/__tests__/gameSelectors.test.ts`
- [x] All files ≤ 200 lines (max: gameSessionStore.test.ts = 198)
- [ ] Integration: W3 PR-5/6/7 will call useGameSession + useGameWS

## Files changed

| File | Lines | Purpose |
|------|-------|---------|
| `stores/gameSessionStore.ts` | 130 | Domain store |
| `stores/gameSelectors.ts` | 39 | Pure selectors |
| `stores/gameMessageHandlers.ts` | 105 | WS handler registration |
| `features/game/hooks/useGameSession.ts` | 95 | WS→store sync hook |
| `features/game/hooks/useGameWS.ts` | 73 | WS connection hook |
| `stores/__tests__/gameSessionStore.test.ts` | 198 | Store tests |
| `stores/__tests__/gameSelectors.test.ts` | 143 | Selector tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)