### PR TITLE
chore(phase-18.3): security hardening — M-7/M-a/M-e + L-2/L-6/L-7

### DIFF
--- a/apps/server/internal/session/snapshot.go
+++ b/apps/server/internal/session/snapshot.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -106,7 +105,7 @@ func (s *Session) flushSnapshot() {
 // Called on KindStop so PII (role, chat, clues) does not linger for 24h
 // after the game ends (M-5 + M-7 fix).
 // Uses s.Ctx() so the delete inherits session lifetime (L-2).
-// Errors are logged but never bubbled up — snapshots auto-expire via TTL if delete fails.
+// Errors are logged but never bubbled up — snapshots auto-expire via TTL.
 // MUST be called only from the actor goroutine.
 func (s *Session) deleteSnapshot() {
 	if s.cache == nil {
@@ -131,105 +130,4 @@ func (s *Session) deleteSnapshot() {
 	s.logger.Debug().
 		Str("session_id", s.ID.String()).
 		Msg("snapshot: per-player blobs deleted from redis on session stop")
-}
-
-// SendSnapshot dispatches a player-aware snapshot rebuild to the session actor
-// so the PhaseEngine (non-thread-safe) is touched only from its own goroutine.
-// The actor reconstructs state via engine.BuildStateFor(playerID) so role-
-// private data never reaches the wrong client. (Phase 18.1 B-2)
-//
-// When the session is not StatusRunning (recovery path), we fall back to the
-// player-specific Redis blob written by persistSnapshot (M-7 fix).
-//
-// Safe to call from any goroutine.
-func (s *Session) SendSnapshot(playerID uuid.UUID) {
-	if s.sender == nil {
-		return
-	}
-
-	if s.Status() == StatusRunning {
-		// Dispatch rebuild into the actor; errors are logged there.
-		if err := s.Send(SessionMessage{
-			Kind:     KindSnapshotFor,
-			PlayerID: playerID,
-		}); err != nil {
-			s.logger.Warn().Err(err).
-				Str("player_id", playerID.String()).
-				Msg("snapshot: could not enqueue player-aware rebuild, falling back to Redis")
-			s.sendSnapshotFromCache(playerID)
-		}
-		return
-	}
-
-	// Session is not running — use player-specific Redis blob (M-7).
-	s.sendSnapshotFromCache(playerID)
-}
-
-// sendSnapshotFromCache reads the player-specific Redis blob and sends it.
-// Falls back to a session-level key if the player-specific key is missing
-// (e.g. old data written before M-7 fix). Uses s.Ctx() (L-2).
-// MUST only be used when the actor cannot be invoked (session not running).
-func (s *Session) sendSnapshotFromCache(playerID uuid.UUID) {
-	if s.cache == nil {
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(s.Ctx(), 3*time.Second)
-	defer cancel()
-
-	// Try player-specific key first (M-7).
-	data, err := s.cache.Get(ctx, playerSnapshotKey(s.ID, playerID))
-	if err != nil {
-		// Fall back to legacy session-level key.
-		data, err = s.cache.Get(ctx, snapshotKey(s.ID))
-		if err != nil {
-			s.logger.Warn().Err(err).
-				Str("player_id", playerID.String()).
-				Msg("snapshot: redis get failed on reconnect (no player or session blob)")
-			return
-		}
-	}
-
-	var raw json.RawMessage = data
-	env, err := ws.NewEnvelope(TypeSessionState, raw)
-	if err != nil {
-		s.logger.Error().Err(err).Msg("snapshot: envelope build failed")
-		return
-	}
-
-	s.sender.SendToPlayer(playerID, env)
-	s.logger.Debug().
-		Str("player_id", playerID.String()).
-		Str("session_id", s.ID.String()).
-		Msg("snapshot: sent player-specific blob to reconnecting player (recovery path)")
-}
-
-// sendSnapshotForActor is called by the actor goroutine in response to
-// KindSnapshotFor. Reconstructs a per-player engine state and emits the WS
-// envelope directly. MUST be called only from the actor.
-func (s *Session) sendSnapshotForActor(playerID uuid.UUID) {
-	if s.sender == nil || s.engine == nil {
-		return
-	}
-
-	raw, err := s.engine.BuildStateFor(playerID)
-	if err != nil {
-		s.logger.Error().Err(err).
-			Str("player_id", playerID.String()).
-			Msg("snapshot: engine BuildStateFor failed, falling back to cache")
-		s.sendSnapshotFromCache(playerID)
-		return
-	}
-
-	env, err := ws.NewEnvelope(TypeSessionState, raw)
-	if err != nil {
-		s.logger.Error().Err(err).Msg("snapshot: envelope build failed")
-		return
-	}
-
-	s.sender.SendToPlayer(playerID, env)
-	s.logger.Debug().
-		Str("player_id", playerID.String()).
-		Str("session_id", s.ID.String()).
-		Msg("snapshot: sent player-aware state to reconnecting player")
 }

--- a/apps/server/internal/session/snapshot.go
+++ b/apps/server/internal/session/snapshot.go
@@ -57,31 +57,41 @@ func (s *Session) maybeSnapshot() {
 	s.persistSnapshot()
 }
 
-// persistSnapshot serialises the current session state and writes it to Redis.
-// On serialisation failure it logs and continues — the game is never interrupted.
+// persistSnapshot serialises a per-player snapshot for every known player and
+// writes each to Redis under session:{id}:snapshot:{playerID} (M-7).
+// Uses s.Ctx() so the write is cancelled when the session stops (L-2).
+// On any failure it logs and continues — the game is never interrupted.
 // MUST be called only from the actor goroutine (race-free by design).
 func (s *Session) persistSnapshot() {
-	if s.cache == nil {
+	if s.cache == nil || s.engine == nil {
 		return
 	}
 
-	data, err := s.marshalSnapshot()
-	if err != nil {
-		s.logger.Error().Err(err).Msg("snapshot: marshal failed, skipping persist")
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(s.Ctx(), 3*time.Second)
 	defer cancel()
 
-	if err := s.cache.Set(ctx, snapshotKey(s.ID), data, snapshotTTL); err != nil {
-		s.logger.Error().Err(err).Str("key", snapshotKey(s.ID)).Msg("snapshot: redis write failed")
-		return
+	for playerID := range s.players {
+		raw, err := s.engine.BuildStateFor(playerID)
+		if err != nil {
+			s.logger.Error().Err(err).
+				Str("player_id", playerID.String()).
+				Msg("snapshot: BuildStateFor failed, skipping player blob")
+			continue
+		}
+		key := playerSnapshotKey(s.ID, playerID)
+		if err := s.cache.Set(ctx, key, raw, snapshotTTL); err != nil {
+			s.logger.Error().Err(err).
+				Str("key", key).
+				Msg("snapshot: redis write failed for player blob")
+		}
 	}
 
 	s.dirty = false
 	s.lastPersist = time.Now()
-	s.logger.Debug().Str("session_id", s.ID.String()).Msg("snapshot: persisted to redis")
+	s.logger.Debug().
+		Str("session_id", s.ID.String()).
+		Int("players", len(s.players)).
+		Msg("snapshot: per-player blobs persisted to redis")
 }
 
 // flushSnapshot forces an immediate persist regardless of dirty/debounce state.
@@ -92,22 +102,35 @@ func (s *Session) flushSnapshot() {
 	s.persistSnapshot()
 }
 
-// deleteSnapshot proactively removes the Redis snapshot for this session.
+// deleteSnapshot proactively removes all per-player Redis blobs for this session.
 // Called on KindStop so PII (role, chat, clues) does not linger for 24h
-// after the game ends (M-5 fix). Errors are logged but never bubbled up —
-// snapshots auto-expire via TTL if delete fails.
+// after the game ends (M-5 + M-7 fix).
+// Uses s.Ctx() so the delete inherits session lifetime (L-2).
+// Errors are logged but never bubbled up — snapshots auto-expire via TTL if delete fails.
 // MUST be called only from the actor goroutine.
 func (s *Session) deleteSnapshot() {
 	if s.cache == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(s.Ctx(), 3*time.Second)
 	defer cancel()
-	if err := s.cache.Del(ctx, snapshotKey(s.ID)); err != nil {
-		s.logger.Warn().Err(err).Str("key", snapshotKey(s.ID)).Msg("snapshot: redis delete failed (will expire via TTL)")
+
+	keys := make([]string, 0, len(s.players)+1)
+	for playerID := range s.players {
+		keys = append(keys, playerSnapshotKey(s.ID, playerID))
+	}
+	// Also delete the legacy session-level key (if it exists from older runs).
+	keys = append(keys, snapshotKey(s.ID))
+
+	if err := s.cache.Del(ctx, keys...); err != nil {
+		s.logger.Warn().Err(err).
+			Str("session_id", s.ID.String()).
+			Msg("snapshot: redis delete failed (will expire via TTL)")
 		return
 	}
-	s.logger.Debug().Str("session_id", s.ID.String()).Msg("snapshot: deleted from redis on session stop")
+	s.logger.Debug().
+		Str("session_id", s.ID.String()).
+		Msg("snapshot: per-player blobs deleted from redis on session stop")
 }
 
 // SendSnapshot dispatches a player-aware snapshot rebuild to the session actor
@@ -115,10 +138,8 @@ func (s *Session) deleteSnapshot() {
 // The actor reconstructs state via engine.BuildStateFor(playerID) so role-
 // private data never reaches the wrong client. (Phase 18.1 B-2)
 //
-// When the session is not StatusRunning (e.g. still recovering, or stopped),
-// we fall back to the Redis snapshot blob. WARNING: that blob is NOT yet
-// redacted per-player — this fallback MUST be revisited if we ever serve real
-// reconnects during recovery. Tracked as M-7 in Phase 18.2.
+// When the session is not StatusRunning (recovery path), we fall back to the
+// player-specific Redis blob written by persistSnapshot (M-7 fix).
 //
 // Safe to call from any goroutine.
 func (s *Session) SendSnapshot(playerID uuid.UUID) {
@@ -140,28 +161,33 @@ func (s *Session) SendSnapshot(playerID uuid.UUID) {
 		return
 	}
 
-	// Session is not running — fall back to the (non-redacted) Redis blob.
+	// Session is not running — use player-specific Redis blob (M-7).
 	s.sendSnapshotFromCache(playerID)
 }
 
-// sendSnapshotFromCache is the legacy Redis-blob path. MUST only be used when
-// the actor cannot be invoked (session not running). The blob is NOT redacted
-// per-player; tolerable because recovery-path reconnects should be rare and
-// the blob carries the same data the player could see before disconnect.
+// sendSnapshotFromCache reads the player-specific Redis blob and sends it.
+// Falls back to a session-level key if the player-specific key is missing
+// (e.g. old data written before M-7 fix). Uses s.Ctx() (L-2).
+// MUST only be used when the actor cannot be invoked (session not running).
 func (s *Session) sendSnapshotFromCache(playerID uuid.UUID) {
 	if s.cache == nil {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(s.Ctx(), 3*time.Second)
 	defer cancel()
 
-	data, err := s.cache.Get(ctx, snapshotKey(s.ID))
+	// Try player-specific key first (M-7).
+	data, err := s.cache.Get(ctx, playerSnapshotKey(s.ID, playerID))
 	if err != nil {
-		s.logger.Warn().Err(err).
-			Str("player_id", playerID.String()).
-			Msg("snapshot: redis get failed on reconnect")
-		return
+		// Fall back to legacy session-level key.
+		data, err = s.cache.Get(ctx, snapshotKey(s.ID))
+		if err != nil {
+			s.logger.Warn().Err(err).
+				Str("player_id", playerID.String()).
+				Msg("snapshot: redis get failed on reconnect (no player or session blob)")
+			return
+		}
 	}
 
 	var raw json.RawMessage = data
@@ -175,7 +201,7 @@ func (s *Session) sendSnapshotFromCache(playerID uuid.UUID) {
 	s.logger.Debug().
 		Str("player_id", playerID.String()).
 		Str("session_id", s.ID.String()).
-		Msg("snapshot: sent cached blob to reconnecting player (recovery path)")
+		Msg("snapshot: sent player-specific blob to reconnecting player (recovery path)")
 }
 
 // sendSnapshotForActor is called by the actor goroutine in response to

--- a/apps/server/internal/session/snapshot_lifecycle_test.go
+++ b/apps/server/internal/session/snapshot_lifecycle_test.go
@@ -15,7 +15,8 @@ func TestSnapshot_KindStopDeletesSnapshot(t *testing.T) {
 	cache := newFakeCache()
 	sender := &fakeSender{}
 	sessionID, s, _ := startWithSnapshot(t, cache, sender)
-	key := "session:" + sessionID.String() + ":snapshot"
+	// M-7: per-player key prefix.
+	prefix := "session:" + sessionID.String() + ":snapshot:"
 
 	// Populate a snapshot first via KindCriticalSnapshot.
 	reply := make(chan error, 1)
@@ -33,13 +34,13 @@ func TestSnapshot_KindStopDeletesSnapshot(t *testing.T) {
 		t.Fatal("timed out waiting for KindCriticalSnapshot")
 	}
 
-	// Wait for the persist to land.
+	// Wait for the per-player blobs to land.
 	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) && !cache.hasKey(key) {
+	for time.Now().Before(deadline) && !cache.hasAnyKeyWithPrefix(prefix) {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if !cache.hasKey(key) {
-		t.Fatal("precondition: expected snapshot in cache before KindStop")
+	if !cache.hasAnyKeyWithPrefix(prefix) {
+		t.Fatal("precondition: expected per-player snapshot blobs in cache before KindStop")
 	}
 
 	// Graceful stop.
@@ -58,8 +59,8 @@ func TestSnapshot_KindStopDeletesSnapshot(t *testing.T) {
 		t.Fatal("timed out waiting for KindStop reply")
 	}
 
-	// The snapshot key must be gone.
-	if cache.hasKey(key) {
-		t.Errorf("snapshot key %q still present after KindStop (expected delete)", key)
+	// All per-player snapshot blobs must be gone.
+	if cache.hasAnyKeyWithPrefix(prefix) {
+		t.Errorf("per-player snapshot keys still present after KindStop (expected delete)")
 	}
 }

--- a/apps/server/internal/session/snapshot_pr0_helpers_test.go
+++ b/apps/server/internal/session/snapshot_pr0_helpers_test.go
@@ -1,0 +1,29 @@
+package session_test
+
+// snapshot_pr0_helpers_test.go — fakeCache extensions for PR-0 tests.
+
+// countKeysWithPrefix returns how many cache keys start with prefix.
+func (f *fakeCache) countKeysWithPrefix(prefix string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for k := range f.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			n++
+		}
+	}
+	return n
+}
+
+// keysWithPrefix returns all keys that start with prefix.
+func (f *fakeCache) keysWithPrefix(prefix string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for k := range f.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			out = append(out, k)
+		}
+	}
+	return out
+}

--- a/apps/server/internal/session/snapshot_pr0_test.go
+++ b/apps/server/internal/session/snapshot_pr0_test.go
@@ -1,0 +1,186 @@
+package session_test
+
+// snapshot_pr0_test.go — Phase 18.3 PR-0 unit tests
+// Covers: M-7 player-specific recovery, M-a cleanup leak, L-2 ctx cancel.
+// See snapshot_pr0_helpers_test.go for fakeCache extensions used here.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/session"
+	"github.com/rs/zerolog"
+)
+
+
+// ---------------------------------------------------------------------------
+// M-7: per-player snapshot blobs (redaction recovery path)
+// ---------------------------------------------------------------------------
+
+// TestSnapshot_M7_RecoveryUsesPlayerSpecificBlob verifies that the recovery
+// path (session not running) uses the per-player Redis blob rather than a
+// shared session-level blob. Each player must receive the blob written for
+// their own playerID key.
+func TestSnapshot_M7_RecoveryUsesPlayerSpecificBlob(t *testing.T) {
+	fc := newFakeCache()
+	sender := &fakeSender{}
+
+	m := session.NewSessionManager(zerolog.Nop())
+	m.InjectSnapshot(fc, sender)
+	sessionID := uuid.New()
+	s, err := m.Start(context.Background(), sessionID, uuid.New(), newPlayers(2))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitRunning(t, s)
+	t.Cleanup(func() { m.Stop(sessionID) }) //nolint:errcheck
+
+	// Flush a snapshot so per-player blobs are written.
+	reply := make(chan error, 1)
+	_ = s.Send(session.SessionMessage{
+		Kind:  session.KindCriticalSnapshot,
+		Reply: reply,
+		Ctx:   context.Background(),
+	})
+	<-reply
+
+	prefix := "session:" + sessionID.String() + ":snapshot:"
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && !fc.hasAnyKeyWithPrefix(prefix) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !fc.hasAnyKeyWithPrefix(prefix) {
+		t.Fatal("no per-player snapshot keys written to Redis")
+	}
+
+	// Two blobs must exist — one per player in the 2-player session.
+	count := fc.countKeysWithPrefix(prefix)
+	if count < 2 {
+		t.Errorf("expected at least 2 per-player blobs, got %d", count)
+	}
+}
+
+// TestSnapshot_M7_NoPlayerIDCrossContamination verifies that per-player blobs
+// stored under different player keys are distinct (each key exists independently).
+func TestSnapshot_M7_NoPlayerIDCrossContamination(t *testing.T) {
+	fc := newFakeCache()
+	sender := &fakeSender{}
+
+	m := session.NewSessionManager(zerolog.Nop())
+	m.InjectSnapshot(fc, sender)
+	sessionID := uuid.New()
+	s, err := m.Start(context.Background(), sessionID, uuid.New(), newPlayers(2))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitRunning(t, s)
+	t.Cleanup(func() { m.Stop(sessionID) }) //nolint:errcheck
+
+	reply := make(chan error, 1)
+	_ = s.Send(session.SessionMessage{
+		Kind:  session.KindCriticalSnapshot,
+		Reply: reply,
+		Ctx:   context.Background(),
+	})
+	<-reply
+
+	prefix := "session:" + sessionID.String() + ":snapshot:"
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && !fc.hasAnyKeyWithPrefix(prefix) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	keys := fc.keysWithPrefix(prefix)
+	seen := make(map[string]struct{})
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			t.Errorf("duplicate key %q in per-player snapshot store", k)
+		}
+		seen[k] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Errorf("expected 2 distinct per-player keys, got %d", len(seen))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M-a: cleanupOnStartFail — no resource leak
+// ---------------------------------------------------------------------------
+
+// TestStartModularGame_CleanupOnDuplicate verifies that starting a session
+// with an already-active sessionID returns an error and does not leak goroutines.
+// goleak in TestMain will catch any leaked goroutine from the duplicate attempt.
+func TestStartModularGame_CleanupOnDuplicate(t *testing.T) {
+	m := session.NewSessionManager(zerolog.Nop())
+	ctx := context.Background()
+	sessionID := uuid.New()
+
+	// Start first session successfully.
+	s1, err := m.Start(ctx, sessionID, uuid.New(), newPlayers(2))
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	waitRunning(t, s1)
+	t.Cleanup(func() { m.Stop(sessionID) }) //nolint:errcheck
+
+	// Attempt duplicate — must fail without goroutine leak.
+	s2, err := m.Start(ctx, sessionID, uuid.New(), newPlayers(2))
+	if err == nil {
+		t.Fatal("second Start with same sessionID: expected error, got nil")
+	}
+	if s2 != nil {
+		t.Fatal("second Start with same sessionID: expected nil session")
+	}
+	// goleak in TestMain validates no goroutine was leaked by the failed start.
+}
+
+// ---------------------------------------------------------------------------
+// L-2: ctx parent — snapshot ops cancelled with session
+// ---------------------------------------------------------------------------
+
+// TestSnapshot_L2_CtxCancelPropagates verifies that snapshot operations use
+// the session's own context (s.Ctx()), meaning they are automatically cancelled
+// when the session stops. We verify indirectly: after a KindStop the done
+// channel closes and no subsequent Redis writes occur.
+func TestSnapshot_L2_CtxCancelPropagates(t *testing.T) {
+	fc := newFakeCache()
+	sender := &fakeSender{}
+
+	m := session.NewSessionManager(zerolog.Nop())
+	m.InjectSnapshot(fc, sender)
+	sessionID := uuid.New()
+	s, err := m.Start(context.Background(), sessionID, uuid.New(), newPlayers(1))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitRunning(t, s)
+
+	// Stop the session.
+	stopReply := make(chan error, 1)
+	_ = s.Send(session.SessionMessage{
+		Kind:  session.KindStop,
+		Reply: stopReply,
+		Ctx:   context.Background(),
+	})
+	select {
+	case <-stopReply:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for KindStop")
+	}
+
+	// Record key count right after stop.
+	countBefore := fc.countKeysWithPrefix("session:" + sessionID.String() + ":snapshot:")
+
+	// Wait a bit: the ticker interval is 1s; if ctx is properly cancelled no
+	// new writes should occur.
+	time.Sleep(200 * time.Millisecond)
+	countAfter := fc.countKeysWithPrefix("session:" + sessionID.String() + ":snapshot:")
+
+	if countAfter > countBefore {
+		t.Errorf("snapshot writes occurred after session stop (%d→%d) — ctx cancel may not be wired", countBefore, countAfter)
+	}
+}
+
+

--- a/apps/server/internal/session/snapshot_send.go
+++ b/apps/server/internal/session/snapshot_send.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/ws"
+)
+
+// SendSnapshot dispatches a player-aware snapshot rebuild to the session actor
+// so the PhaseEngine (non-thread-safe) is touched only from its own goroutine.
+// The actor reconstructs state via engine.BuildStateFor(playerID) so role-
+// private data never reaches the wrong client. (Phase 18.1 B-2)
+//
+// When the session is not StatusRunning (recovery path), we fall back to the
+// player-specific Redis blob written by persistSnapshot (M-7 fix).
+//
+// Safe to call from any goroutine.
+func (s *Session) SendSnapshot(playerID uuid.UUID) {
+	if s.sender == nil {
+		return
+	}
+
+	if s.Status() == StatusRunning {
+		// Dispatch rebuild into the actor; errors are logged there.
+		if err := s.Send(SessionMessage{
+			Kind:     KindSnapshotFor,
+			PlayerID: playerID,
+		}); err != nil {
+			s.logger.Warn().Err(err).
+				Str("player_id", playerID.String()).
+				Msg("snapshot: could not enqueue player-aware rebuild, falling back to Redis")
+			s.sendSnapshotFromCache(playerID)
+		}
+		return
+	}
+
+	// Session is not running — use player-specific Redis blob (M-7).
+	s.sendSnapshotFromCache(playerID)
+}
+
+// sendSnapshotFromCache reads the player-specific Redis blob and sends it.
+// Falls back to a session-level key if the player-specific key is missing
+// (e.g. old data written before M-7 fix). Uses s.Ctx() (L-2).
+// MUST only be used when the actor cannot be invoked (session not running).
+func (s *Session) sendSnapshotFromCache(playerID uuid.UUID) {
+	if s.cache == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(s.Ctx(), 3*time.Second)
+	defer cancel()
+
+	// Try player-specific key first (M-7).
+	data, err := s.cache.Get(ctx, playerSnapshotKey(s.ID, playerID))
+	if err != nil {
+		// Fall back to legacy session-level key.
+		data, err = s.cache.Get(ctx, snapshotKey(s.ID))
+		if err != nil {
+			s.logger.Warn().Err(err).
+				Str("player_id", playerID.String()).
+				Msg("snapshot: redis get failed on reconnect (no player or session blob)")
+			return
+		}
+	}
+
+	var raw json.RawMessage = data
+	env, err := ws.NewEnvelope(TypeSessionState, raw)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("snapshot: envelope build failed")
+		return
+	}
+
+	s.sender.SendToPlayer(playerID, env)
+	s.logger.Debug().
+		Str("player_id", playerID.String()).
+		Str("session_id", s.ID.String()).
+		Msg("snapshot: sent player-specific blob to reconnecting player (recovery path)")
+}
+
+// sendSnapshotForActor is called by the actor goroutine in response to
+// KindSnapshotFor. Reconstructs a per-player engine state and emits the WS
+// envelope directly. MUST be called only from the actor.
+func (s *Session) sendSnapshotForActor(playerID uuid.UUID) {
+	if s.sender == nil || s.engine == nil {
+		return
+	}
+
+	raw, err := s.engine.BuildStateFor(playerID)
+	if err != nil {
+		s.logger.Error().Err(err).
+			Str("player_id", playerID.String()).
+			Msg("snapshot: engine BuildStateFor failed, falling back to cache")
+		s.sendSnapshotFromCache(playerID)
+		return
+	}
+
+	env, err := ws.NewEnvelope(TypeSessionState, raw)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("snapshot: envelope build failed")
+		return
+	}
+
+	s.sender.SendToPlayer(playerID, env)
+	s.logger.Debug().
+		Str("player_id", playerID.String()).
+		Str("session_id", s.ID.String()).
+		Msg("snapshot: sent player-aware state to reconnecting player")
+}

--- a/apps/server/internal/session/snapshot_serialize.go
+++ b/apps/server/internal/session/snapshot_serialize.go
@@ -37,8 +37,16 @@ type snapshotPlayer struct {
 }
 
 // snapshotKey returns the Redis key for the given session ID.
+// Used for the legacy/fallback full-session blob (kept for backward compat).
 func snapshotKey(id uuid.UUID) string {
 	return snapshotKeyPrefix + id.String() + snapshotKeySuffix
+}
+
+// playerSnapshotKey returns the Redis key for a per-player snapshot blob.
+// Format: session:{sessionID}:snapshot:{playerID}
+// Written by persistSnapshot (M-7); read by sendSnapshotFromCache.
+func playerSnapshotKey(sessionID, playerID uuid.UUID) string {
+	return snapshotKeyPrefix + sessionID.String() + snapshotKeySuffix + ":" + playerID.String()
 }
 
 // marshalSnapshot converts the in-memory session state to a JSON blob.

--- a/apps/server/internal/session/snapshot_test.go
+++ b/apps/server/internal/session/snapshot_test.go
@@ -78,6 +78,31 @@ func (f *fakeCache) hasKey(key string) bool {
 	return ok
 }
 
+// hasAnyKeyWithPrefix returns true if any cache key starts with prefix.
+func (f *fakeCache) hasAnyKeyWithPrefix(prefix string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for k := range f.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
+}
+
+// getFirstWithPrefix returns the value of the first key with the given prefix,
+// or nil if none found.
+func (f *fakeCache) getFirstWithPrefix(prefix string) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for k, v := range f.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			return v
+		}
+	}
+	return nil
+}
+
 // fakeSender records SendToPlayer calls.
 type fakeSender struct {
 	mu       sync.Mutex
@@ -130,7 +155,7 @@ func startWithSnapshot(t *testing.T, c *fakeCache, sender *fakeSender) (uuid.UUI
 // ---------------------------------------------------------------------------
 
 // TestSnapshot_CriticalSnapshotPersistsToRedis verifies that KindCriticalSnapshot
-// causes the session to write a snapshot key into Redis.
+// causes the session to write per-player snapshot keys into Redis (M-7).
 func TestSnapshot_CriticalSnapshotPersistsToRedis(t *testing.T) {
 	cache := newFakeCache()
 	sender := &fakeSender{}
@@ -155,20 +180,20 @@ func TestSnapshot_CriticalSnapshotPersistsToRedis(t *testing.T) {
 		t.Fatal("timed out waiting for KindCriticalSnapshot reply")
 	}
 
-	// Allow the actor goroutine time to execute persistSnapshot.
+	// M-7: persistSnapshot now writes per-player blobs.
+	// Poll until at least one player-specific key appears.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		expectedKey := "session:" + sessionID.String() + ":snapshot"
-		if cache.hasKey(expectedKey) {
+		if cache.hasAnyKeyWithPrefix("session:" + sessionID.String() + ":snapshot:") {
 			return
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	t.Errorf("snapshot key not found in Redis after KindCriticalSnapshot")
+	t.Errorf("no per-player snapshot key found in Redis after KindCriticalSnapshot")
 }
 
-// TestSnapshot_Roundtrip verifies that the persisted JSON can be deserialised
-// and contains the expected session ID.
+// TestSnapshot_Roundtrip verifies that the persisted per-player JSON can be
+// deserialised and contains the expected session ID (M-7: per-player blobs).
 func TestSnapshot_Roundtrip(t *testing.T) {
 	fc := newFakeCache()
 	sender := &fakeSender{}
@@ -179,32 +204,28 @@ func TestSnapshot_Roundtrip(t *testing.T) {
 	_ = s.Send(session.SessionMessage{Kind: session.KindCriticalSnapshot, Reply: reply, Ctx: context.Background()})
 	<-reply
 
-	key := "session:" + sessionID.String() + ":snapshot"
+	// M-7: blobs are now per-player; poll for any player key.
+	prefix := "session:" + sessionID.String() + ":snapshot:"
 	deadline := time.Now().Add(500 * time.Millisecond)
 	var raw []byte
 	for time.Now().Before(deadline) {
-		if v, err := fc.Get(context.Background(), key); err == nil {
-			raw = v
+		if raw = fc.getFirstWithPrefix(prefix); raw != nil {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 	if raw == nil {
-		t.Fatal("snapshot not persisted")
+		t.Fatal("snapshot not persisted (no per-player key found)")
 	}
 
+	// Per-player blobs are raw engine state JSON (BuildStateFor output).
+	// Verify it is valid JSON and contains sessionId.
 	var snap map[string]interface{}
 	if err := json.Unmarshal(raw, &snap); err != nil {
-		t.Fatalf("unmarshal snapshot: %v", err)
+		t.Fatalf("unmarshal per-player snapshot: %v", err)
 	}
 	if snap["sessionId"] != sessionID.String() {
 		t.Errorf("sessionId mismatch: got %v, want %s", snap["sessionId"], sessionID)
-	}
-	if _, ok := snap["players"]; !ok {
-		t.Error("snapshot missing 'players' field")
-	}
-	if _, ok := snap["persistedAt"]; !ok {
-		t.Error("snapshot missing 'persistedAt' field")
 	}
 }
 
@@ -225,11 +246,11 @@ func TestSnapshot_SendSnapshotOnReconnect(t *testing.T) {
 	_ = s.Send(session.SessionMessage{Kind: session.KindCriticalSnapshot, Reply: reply, Ctx: context.Background()})
 	<-reply
 
-	// Wait for Redis write.
-	key := "session:" + sessionID.String() + ":snapshot"
+	// Wait for Redis write — M-7: per-player keys.
+	prefix := "session:" + sessionID.String() + ":snapshot:"
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		if fc.hasKey(key) {
+		if fc.hasAnyKeyWithPrefix(prefix) {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)

--- a/apps/server/internal/session/starter.go
+++ b/apps/server/internal/session/starter.go
@@ -11,6 +11,16 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// cleanupOnStartFail releases engine resources allocated during startModularGame
+// when any failure path is taken before the session is fully operational.
+// Stops all modules via engine.Stop and closes the event bus (M-a fix).
+// Errors are logged but not returned — cleanup is best-effort.
+func cleanupOnStartFail(ctx context.Context, eng *engine.PhaseEngine, logger zerolog.Logger) {
+	if err := eng.Stop(ctx); err != nil {
+		logger.Warn().Err(err).Msg("startModularGame: cleanup engine stop error")
+	}
+}
+
 // errGameRuntimeDisabled is returned when startModularGame is called but the
 // feature flag is off. Callers should fall back to the legacy game path.
 var errGameRuntimeDisabled = apperror.New(
@@ -74,10 +84,11 @@ func startModularGame(
 		logger.Error().Err(err).
 			Str("session_id", cfg.SessionID.String()).
 			Msg("startModularGame: failed to build modules")
+		// L-7: expose only a generic message to the host; details are in server logs.
 		return nil, apperror.New(
 			apperror.ErrBadRequest,
 			http.StatusBadRequest,
-			"failed to build game modules: "+err.Error(),
+			"failed to initialise game modules",
 		)
 	}
 
@@ -116,6 +127,8 @@ func startModularGame(
 		Reply:   startReply,
 		Payload: EngineStartPayload{ModuleConfigs: moduleConfigs},
 	}); err != nil {
+		// M-a: clean up engine resources before returning.
+		cleanupOnStartFail(ctx, eng, logger)
 		s.stop()
 		return nil, err
 	}
@@ -123,6 +136,8 @@ func startModularGame(
 	m.mu.Lock()
 	if _, exists := m.sessions[cfg.SessionID]; exists {
 		m.mu.Unlock()
+		// M-a: clean up engine resources before returning.
+		cleanupOnStartFail(ctx, eng, logger)
 		s.stop()
 		return nil, errSessionAlreadyActive
 	}
@@ -140,6 +155,8 @@ func startModularGame(
 			m.mu.Lock()
 			delete(m.sessions, cfg.SessionID)
 			m.mu.Unlock()
+			// M-a: clean up engine resources before returning.
+			cleanupOnStartFail(ctx, eng, logger)
 			s.stop()
 			return nil, err
 		}
@@ -147,6 +164,8 @@ func startModularGame(
 		m.mu.Lock()
 		delete(m.sessions, cfg.SessionID)
 		m.mu.Unlock()
+		// M-a: clean up engine resources before returning.
+		cleanupOnStartFail(ctx, eng, logger)
 		s.stop()
 		return nil, ctx.Err()
 	}
@@ -161,4 +180,3 @@ func startModularGame(
 
 	return s, nil
 }
-

--- a/apps/server/internal/ws/hub.go
+++ b/apps/server/internal/ws/hub.go
@@ -2,6 +2,8 @@ package ws
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -536,11 +538,16 @@ func (h *Hub) notifyPlayerLeft(sessionID, playerID uuid.UUID, graceful bool) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
+				// L-6: emit panic value as string to avoid file-path leakage;
+				// stack trace logged separately at debug level.
 				h.logger.Error().
-					Interface("panic", r).
+					Str("panic", fmt.Sprint(r)).
 					Stringer("sessionId", sessionID).
 					Stringer("playerId", playerID).
 					Msg("lifecycle listener panicked in OnPlayerLeft")
+				h.logger.Debug().
+					Bytes("stack", debug.Stack()).
+					Msg("lifecycle listener panic stack (OnPlayerLeft)")
 			}
 		}()
 		for _, l := range listeners {
@@ -563,11 +570,16 @@ func (h *Hub) notifyPlayerRejoined(sessionID, playerID uuid.UUID) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
+				// L-6: emit panic value as string to avoid file-path leakage;
+				// stack trace logged separately at debug level.
 				h.logger.Error().
-					Interface("panic", r).
+					Str("panic", fmt.Sprint(r)).
 					Stringer("sessionId", sessionID).
 					Stringer("playerId", playerID).
 					Msg("lifecycle listener panicked in OnPlayerRejoined")
+				h.logger.Debug().
+					Bytes("stack", debug.Stack()).
+					Msg("lifecycle listener panic stack (OnPlayerRejoined)")
 			}
 		}()
 		for _, l := range listeners {

--- a/docs/plans/2026-04-15-phase-18.3-cleanup/checklist.md
+++ b/docs/plans/2026-04-15-phase-18.3-cleanup/checklist.md
@@ -1,8 +1,8 @@
 <!-- STATUS-START -->
 **Active**: Phase 18.3 보안 하드닝 + CI 정비 — Wave 0/2
-**PR**: PR-0 (0%)
-**Task**: 시작 전
-**State**: not_started
+**PR**: PR-0 (100%) — PR #40 ready for review
+**Task**: 완료
+**State**: pr_open
 **Blockers**: none
 **Last updated**: 2026-04-15
 <!-- STATUS-END -->
@@ -15,19 +15,18 @@
 
 ## Wave 0 — 보안 + CI 병렬 (parallel ×2)
 
-### PR-0: Security hardening
-- [ ] Task 1 — M-7 Recovery path redaction: persist 시점에 engine.BuildStateFor(playerID) 결과를 playerID 별 `session:{id}:snapshot:{playerID}` 로 저장 (또는 블롭에서 role/whisper/private_clue 키 제거) + SendSnapshot recovery path 가 player-specific 블롭 조회
-- [ ] Task 2 — M-a startModularGame 실패 시 cleanup: bus.Close, modules Stop, adapter 해제 helper `cleanupOnStartFail` 추가
-- [ ] Task 3 — M-e KindStop 와 엔딩 플로우: 엔딩 phase 종료 → snapshot 필요성 검토, 필요 시 WS 이벤트 기반 final state broadcast 로 대체, 문서화
-- [ ] Task 4 — L-2 persistSnapshot/SendSnapshot/deleteSnapshot ctx parent 를 `s.Ctx()` 로 변경
-- [ ] Task 5 — L-6 panic dump: `Interface("panic", r)` → `Str("panic", fmt.Sprint(r))` + 스택을 debug 레벨로 분리
-- [ ] Task 6 — L-7 모듈 에러 메시지 원문 노출 축소: `starter.go` 에서 에러 wrapping 시 내부 경로 제거, 호스트 facing 은 generic + 로그에만 상세
-- [ ] Task 7 — 신규 단위 테스트 (redaction recovery path, cleanup 검증, ending 경로, ctx parent)
-- [ ] Run after_task pipeline per task
+### PR-0: Security hardening ✅
+- [x] Task 1 — M-7 Recovery path redaction: persist 시점에 engine.BuildStateFor(playerID) 결과를 playerID 별 `session:{id}:snapshot:{playerID}` 로 저장 + SendSnapshot recovery path 가 player-specific 블롭 조회
+- [x] Task 2 — M-a startModularGame 실패 시 cleanup: `cleanupOnStartFail(ctx, eng, logger)` helper 추가, 4개 실패 경로 모두 적용
+- [x] Task 3 — M-e KindStop 와 엔딩 플로우: 분석 완료 — KindStop 은 host explicit 호출만. 코드 변경 불필요. refs/ending-flow.md 작성
+- [x] Task 4 — L-2 persistSnapshot/deleteSnapshot/sendSnapshotFromCache ctx parent 를 `s.Ctx()` 로 변경
+- [x] Task 5 — L-6 panic dump: `Interface("panic", r)` → `Str("panic", fmt.Sprint(r))` + debug 레벨 스택 분리 (hub.go notifyPlayerLeft/notifyPlayerRejoined)
+- [x] Task 6 — L-7 모듈 에러 메시지 원문 노출 축소: starter.go BuildModules 에러 → generic "failed to initialise game modules"
+- [x] Task 7 — 신규 단위 테스트: snapshot_pr0_test.go (M-7 per-player blobs, M-a cleanup/duplicate, L-2 ctx cancel propagation)
 
 **PR-0 gate**:
-- [ ] `go test -race ./internal/session/... ./internal/engine/... ./internal/module/... ./internal/ws/...` pass
-- [ ] PR merged to main
+- [x] `go test -race ./internal/session/... ./internal/engine/... ./internal/module/... ./internal/ws/...` pass
+- [ ] PR merged to main (PR #40 open)
 
 ### PR-1: CI infra debt
 - [ ] Task 1 — CI-1 `config.TestLoad_Defaults`: `os.Unsetenv` 으로 env 격리 + t.Setenv 로 명시 세팅, main CI 녹색

--- a/docs/plans/2026-04-15-phase-18.3-cleanup/refs/ending-flow.md
+++ b/docs/plans/2026-04-15-phase-18.3-cleanup/refs/ending-flow.md
@@ -1,0 +1,78 @@
+# Ending Flow Analysis — Phase 18.3 PR-0 (M-e)
+
+## Question
+
+Does the current `KindStop` / `deleteSnapshot` path interfere with normal game
+endings? Specifically: when a game reaches its final phase, does the code trigger
+`KindStop` → `deleteSnapshot`, and if so, is any snapshot needed afterward?
+
+## Current flow (as of Phase 18.2)
+
+### Normal game path
+
+```
+Host calls AdvancePhase repeatedly
+  → PhaseEngine.AdvancePhase()
+      → e.current++ past last phase
+      → returns (false, nil)  // "no more phases"
+      → publishes "phase:exiting" for last phase
+      → does NOT publish "phase:entered" (no next phase)
+      → does NOT call KindStop
+      → session actor receives (advanced=false, err=nil)
+      → flushSnapshot() called (phase transition = critical event)
+```
+
+`AdvancePhase` returning `false` is the only signal that the game is complete.
+The session actor logs the result but **does not automatically send `KindStop`**.
+
+### KindStop trigger path
+
+`KindStop` is sent only by external callers:
+- `SessionManager.Stop(sessionID)` — called by the game handler after the HTTP
+  request to end the session.
+- Direct `s.Send(SessionMessage{Kind: KindStop})` from tests or GM tooling.
+
+`EndingModule` itself **never publishes a `KindStop` event**. It publishes:
+- `ending.reveal_step` — on each `ending:next_reveal` message
+- `ending.completed` — when all reveal steps are done
+
+Neither event triggers `KindStop`.
+
+### deleteSnapshot timing
+
+`deleteSnapshot` is called **only inside `handleMessage(KindStop)`**, which
+happens when the external caller explicitly ends the session. At that point:
+
+1. All reveal steps are assumed complete (the host triggers stop after ending).
+2. The `flushSnapshot()` from `AdvancePhase` (last phase) has already run.
+3. `deleteSnapshot` removes all per-player blobs (M-7), preventing PII lingering.
+
+## Risk assessment
+
+| Scenario | Risk | Status |
+|----------|------|--------|
+| Reconnect during ending reveal | Player gets live engine state (StatusRunning path) | Safe — actor still running |
+| Reconnect after KindStop but before Redis TTL | No blob to serve | Acceptable — session gone |
+| Snapshot deleted before ending completed | Only if host calls Stop too early | Host responsibility |
+| Ending replay (post-game) | Not currently supported | Out of scope (PR-7) |
+
+## Conclusion
+
+The current flow is **correct**:
+
+- `KindStop` → `deleteSnapshot` is only triggered by explicit host action, not by
+  the engine reaching the last phase.
+- The ending reveal runs while the session is still `StatusRunning`, so
+  reconnecting players receive live `BuildStateFor` snapshots — fully redacted.
+- `flushSnapshot()` on last-phase `AdvancePhase` ensures the final state is
+  persisted in per-player blobs before any `KindStop`.
+
+## Recommendation
+
+No code change needed for M-e. The existing separation between:
+- Engine completion signal (`AdvancePhase → false`)
+- Session termination (`KindStop`)
+
+provides a safe window for the ending reveal sequence. A future PR (PR-7) may
+add a long-lived "final state" archive key (7d TTL) for post-game replay; that
+is tracked separately.


### PR DESCRIPTION
## Summary

- **M-7**: `persistSnapshot` now writes per-player Redis blobs under `session:{id}:snapshot:{playerID}` via `BuildStateFor`. Recovery path reads player-specific key with fallback to legacy session-level key. `deleteSnapshot` removes all per-player keys on `KindStop`. Prevents role/clue data cross-player leakage on reconnect.
- **M-a**: `cleanupOnStartFail(ctx, eng, logger)` helper added to `starter.go`. All four failure paths in `startModularGame` (Send fail, duplicate session, startReply error, ctx.Done) now call `eng.Stop` before returning, preventing module timer/pubsub leaks.
- **M-e**: Ending flow analysed — `KindStop` is never auto-triggered by `AdvancePhase` reaching the last phase. `EndingModule` publishes `ending.*` events only; session termination is always explicit by host. No code change required; `refs/ending-flow.md` documents the finding.
- **L-2**: `persistSnapshot`/`deleteSnapshot`/`sendSnapshotFromCache` now use `s.Ctx()` with timeout instead of `context.Background()`, so Redis ops are cancelled when the session stops.
- **L-6**: `hub.go` panic dumps changed from `Interface("panic", r)` to `Str("panic", fmt.Sprint(r))` with stack emitted separately at debug level to avoid file-path leakage in production logs.
- **L-7**: `startModularGame` `BuildModules` error now exposes generic `"failed to initialise game modules"` to host; detailed error remains in server log only.

## Files changed

| File | Change |
|------|--------|
| `internal/session/snapshot.go` | M-7 per-player persist + L-2 ctx, split to 133 lines |
| `internal/session/snapshot_send.go` | SendSnapshot / sendSnapshotFromCache / sendSnapshotForActor (split from snapshot.go) |
| `internal/session/snapshot_serialize.go` | Added `playerSnapshotKey()` helper |
| `internal/session/starter.go` | M-a `cleanupOnStartFail` + L-7 generic error |
| `internal/ws/hub.go` | L-6 panic dump fix |
| `internal/session/snapshot_test.go` | Updated for per-player key format |
| `internal/session/snapshot_lifecycle_test.go` | Updated for per-player key format |
| `internal/session/snapshot_pr0_test.go` | New: M-7/M-a/L-2 unit tests |
| `internal/session/snapshot_pr0_helpers_test.go` | New: fakeCache extensions |
| `docs/plans/.../refs/ending-flow.md` | M-e analysis document |

## Test plan

- [x] `go test -race ./internal/session/... ./internal/engine/... ./internal/module/... ./internal/ws/...` — all pass
- [x] `go build ./...` — clean
- [x] `go vet ./internal/session/...` — clean
- [x] Pre-existing `internal/config` test failure confirmed pre-existing on `main` (env var issue, unrelated)
- [x] All files in scope ≤200 lines
- [x] No debug code left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)