### PR TITLE
chore(phase-18.3): low hygiene — L-3/L-4/L-5

### DIFF
--- a/apps/server/internal/session/snapshot_lifecycle_test.go
+++ b/apps/server/internal/session/snapshot_lifecycle_test.go
@@ -15,7 +15,7 @@ func TestSnapshot_KindStopDeletesSnapshot(t *testing.T) {
 	cache := newFakeCache()
 	sender := &fakeSender{}
 	sessionID, s, _ := startWithSnapshot(t, cache, sender)
-	key := "session:" + sessionID.String() + ":snapshot"
+	key := "mmp:session:" + sessionID.String() + ":snapshot"
 
 	// Populate a snapshot first via KindCriticalSnapshot.
 	reply := make(chan error, 1)
@@ -61,5 +61,45 @@ func TestSnapshot_KindStopDeletesSnapshot(t *testing.T) {
 	// The snapshot key must be gone.
 	if cache.hasKey(key) {
 		t.Errorf("snapshot key %q still present after KindStop (expected delete)", key)
+	}
+}
+
+// TestSnapshot_KeyHasMmpNamespacePrefix verifies that snapshots are written
+// under the "mmp:session:{id}:snapshot" key (L-4 fix). Old "session:{id}:snapshot"
+// keys auto-expire via 24h TTL.
+func TestSnapshot_KeyHasMmpNamespacePrefix(t *testing.T) {
+	cache := newFakeCache()
+	sender := &fakeSender{}
+	sessionID, s, m := startWithSnapshot(t, cache, sender)
+	t.Cleanup(func() { m.Stop(sessionID) }) //nolint:errcheck
+
+	reply := make(chan error, 1)
+	if err := s.Send(session.SessionMessage{
+		Kind: session.KindCriticalSnapshot, Reply: reply, Ctx: context.Background(),
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	select {
+	case err := <-reply:
+		if err != nil {
+			t.Fatalf("KindCriticalSnapshot: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for KindCriticalSnapshot reply")
+	}
+
+	newKey := "mmp:session:" + sessionID.String() + ":snapshot"
+	oldKey := "session:" + sessionID.String() + ":snapshot"
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && !cache.hasKey(newKey) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if !cache.hasKey(newKey) {
+		t.Errorf("snapshot not found at namespaced key %q", newKey)
+	}
+	if cache.hasKey(oldKey) {
+		t.Errorf("snapshot written to legacy key %q; should use mmp: prefix", oldKey)
 	}
 }

--- a/apps/server/internal/session/snapshot_serialize.go
+++ b/apps/server/internal/session/snapshot_serialize.go
@@ -12,7 +12,9 @@ import (
 const snapshotTTL = 24 * time.Hour
 
 // snapshotKeyPrefix is the Redis key prefix for session snapshots.
-const snapshotKeyPrefix = "session:"
+// The "mmp:" namespace prevents collisions with other Redis tenants (L-4 fix).
+// Old keys ("session:{id}:snapshot") auto-expire via snapshotTTL (24h).
+const snapshotKeyPrefix = "mmp:session:"
 
 // snapshotKeySuffix is the Redis key suffix for session snapshots.
 const snapshotKeySuffix = ":snapshot"

--- a/apps/server/internal/session/snapshot_test.go
+++ b/apps/server/internal/session/snapshot_test.go
@@ -158,7 +158,7 @@ func TestSnapshot_CriticalSnapshotPersistsToRedis(t *testing.T) {
 	// Allow the actor goroutine time to execute persistSnapshot.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		expectedKey := "session:" + sessionID.String() + ":snapshot"
+		expectedKey := "mmp:session:" + sessionID.String() + ":snapshot"
 		if cache.hasKey(expectedKey) {
 			return
 		}
@@ -179,7 +179,7 @@ func TestSnapshot_Roundtrip(t *testing.T) {
 	_ = s.Send(session.SessionMessage{Kind: session.KindCriticalSnapshot, Reply: reply, Ctx: context.Background()})
 	<-reply
 
-	key := "session:" + sessionID.String() + ":snapshot"
+	key := "mmp:session:" + sessionID.String() + ":snapshot"
 	deadline := time.Now().Add(500 * time.Millisecond)
 	var raw []byte
 	for time.Now().Before(deadline) {
@@ -226,7 +226,7 @@ func TestSnapshot_SendSnapshotOnReconnect(t *testing.T) {
 	<-reply
 
 	// Wait for Redis write.
-	key := "session:" + sessionID.String() + ":snapshot"
+	key := "mmp:session:" + sessionID.String() + ":snapshot"
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if fc.hasKey(key) {

--- a/apps/server/internal/ws/hub.go
+++ b/apps/server/internal/ws/hub.go
@@ -3,6 +3,7 @@ package ws
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -58,11 +59,16 @@ type Hub struct {
 	lifecycleMu        sync.RWMutex
 	lifecycleListeners []SessionLifecycleListener
 
-	// recentLeftAt tracks when each (sessionID, playerID) pair last disconnected
+	// recentLeftAt tracks when each playerID last disconnected per session,
 	// so that JoinSession can detect reconnects within reconnectWindow.
-	// Key format: sessionID.String() + "/" + playerID.String()
+	// Structure: sessionID → playerID → disconnect time.
+	// O(1) lookup per (session, player) pair — no prefix scan needed.
 	// Protected by mu (same lock as sessions map).
-	recentLeftAt map[string]time.Time
+	recentLeftAt map[uuid.UUID]map[uuid.UUID]time.Time
+
+	// closing is set to true when Stop() is called. broadcastToSession checks
+	// this flag so it does not write to maps that Stop() is clearing (L-5 fix).
+	closing atomic.Bool
 }
 
 // NewHub creates a Hub and starts its event loop.
@@ -74,7 +80,7 @@ func NewHub(router *Router, pubsub PubSub, logger zerolog.Logger) *Hub {
 		lobby:        make(map[uuid.UUID]*Client),
 		players:      make(map[uuid.UUID]*Client),
 		buffers:      make(map[uuid.UUID]*ReconnectBuffer),
-		recentLeftAt: make(map[string]time.Time),
+		recentLeftAt: make(map[uuid.UUID]map[uuid.UUID]time.Time),
 		register:     make(chan *Client, 64),
 		unregister:   make(chan *Client, 64),
 		router:       router,
@@ -155,16 +161,14 @@ func (h *Hub) removeClientLocked(c *Client, recordLeave bool) {
 		}
 		if recordLeave {
 			// Record departure for reconnect window tracking.
-			h.recentLeftAt[recentLeftKey(c.SessionID, c.ID)] = time.Now()
+			if h.recentLeftAt[c.SessionID] == nil {
+				h.recentLeftAt[c.SessionID] = make(map[uuid.UUID]time.Time)
+			}
+			h.recentLeftAt[c.SessionID][c.ID] = time.Now()
 		}
 	} else {
 		delete(h.lobby, c.ID)
 	}
-}
-
-// recentLeftKey builds the map key for recentLeftAt.
-func recentLeftKey(sessionID, playerID uuid.UUID) string {
-	return sessionID.String() + "/" + playerID.String()
 }
 
 // Register queues a client for registration. Safe to call after Stop().
@@ -220,7 +224,12 @@ func (h *Hub) JoinSession(c *Client, sessionID uuid.UUID) {
 
 	// Clear the recentLeftAt entry now that the player has rejoined.
 	if isReconnect {
-		delete(h.recentLeftAt, recentLeftKey(sessionID, c.ID))
+		if sub := h.recentLeftAt[sessionID]; sub != nil {
+			delete(sub, c.ID)
+			if len(sub) == 0 {
+				delete(h.recentLeftAt, sessionID)
+			}
+		}
 	}
 
 	h.mu.Unlock()
@@ -239,7 +248,11 @@ func (h *Hub) JoinSession(c *Client, sessionID uuid.UUID) {
 // isReconnectLocked returns true if the player disconnected from sessionID within
 // reconnectWindow. Caller must hold h.mu (read or write).
 func (h *Hub) isReconnectLocked(sessionID, playerID uuid.UUID) bool {
-	leftAt, ok := h.recentLeftAt[recentLeftKey(sessionID, playerID)]
+	sub, ok := h.recentLeftAt[sessionID]
+	if !ok {
+		return false
+	}
+	leftAt, ok := sub[playerID]
 	if !ok {
 		return false
 	}
@@ -247,17 +260,21 @@ func (h *Hub) isReconnectLocked(sessionID, playerID uuid.UUID) bool {
 }
 
 // gcRecentLeftLocked removes stale entries (older than reconnectWindow) from
-// recentLeftAt for the given session. Caller must hold h.mu (write lock).
+// recentLeftAt for the given session. O(P) where P = players in session.
+// Caller must hold h.mu (write lock).
 func (h *Hub) gcRecentLeftLocked(sessionID uuid.UUID) {
-	prefix := sessionID.String() + "/"
+	sub, ok := h.recentLeftAt[sessionID]
+	if !ok {
+		return
+	}
 	now := time.Now()
-	for key, leftAt := range h.recentLeftAt {
-		// Only GC entries for this session to keep the loop bounded.
-		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
-			if now.Sub(leftAt) > reconnectWindow {
-				delete(h.recentLeftAt, key)
-			}
+	for playerID, leftAt := range sub {
+		if now.Sub(leftAt) > reconnectWindow {
+			delete(sub, playerID)
 		}
+	}
+	if len(sub) == 0 {
+		delete(h.recentLeftAt, sessionID)
 	}
 }
 
@@ -301,6 +318,10 @@ func (h *Hub) BroadcastToSessionEphemeral(sessionID uuid.UUID, env *Envelope) {
 }
 
 func (h *Hub) broadcastToSession(sessionID uuid.UUID, env *Envelope, excludeID uuid.UUID, buffer bool) {
+	// L-5: if Stop() is in progress, the maps are being cleared — bail early.
+	if h.closing.Load() {
+		return
+	}
 	h.mu.RLock()
 	sess, ok := h.sessions[sessionID]
 	if !ok {
@@ -582,16 +603,25 @@ func (h *Hub) notifyPlayerRejoined(sessionID, playerID uuid.UUID) {
 func (h *Hub) gcAllRecentLeft() {
 	now := time.Now()
 	h.mu.Lock()
-	for key, leftAt := range h.recentLeftAt {
-		if now.Sub(leftAt) > reconnectWindow {
-			delete(h.recentLeftAt, key)
+	for sessionID, sub := range h.recentLeftAt {
+		for playerID, leftAt := range sub {
+			if now.Sub(leftAt) > reconnectWindow {
+				delete(sub, playerID)
+			}
+		}
+		if len(sub) == 0 {
+			delete(h.recentLeftAt, sessionID)
 		}
 	}
 	h.mu.Unlock()
 }
 
 // Stop shuts down the hub event loop and closes all connected clients.
+// It sets closing=true before acquiring the lock so concurrent broadcastToSession
+// calls bail out before touching the maps being cleared (L-5 fix).
 func (h *Hub) Stop() {
+	// Signal broadcast loops to stop before we wipe the maps.
+	h.closing.Store(true)
 	close(h.done)
 
 	// Close all connected clients to prevent goroutine leaks.

--- a/apps/server/internal/ws/hub_lifecycle_test.go
+++ b/apps/server/internal/ws/hub_lifecycle_test.go
@@ -11,9 +11,9 @@ import (
 
 // fakeLifecycleListener records all OnPlayerLeft / OnPlayerRejoined calls.
 type fakeLifecycleListener struct {
-	mu       sync.Mutex
-	leftCalls     []lifecycleCall
-	rejoinCalls   []lifecycleCall
+	mu          sync.Mutex
+	leftCalls   []lifecycleCall
+	rejoinCalls []lifecycleCall
 }
 
 type lifecycleCall struct {
@@ -161,7 +161,9 @@ func TestLifecycle_NoRejoined_AfterWindowExpired(t *testing.T) {
 
 	// Manually insert a stale entry (disconnected > reconnectWindow ago).
 	h.mu.Lock()
-	h.recentLeftAt[recentLeftKey(sessionID, playerID)] = time.Now().Add(-(reconnectWindow + time.Second))
+	h.recentLeftAt[sessionID] = map[uuid.UUID]time.Time{
+		playerID: time.Now().Add(-(reconnectWindow + time.Second)),
+	}
 	h.mu.Unlock()
 
 	// JoinSession should NOT see this as a reconnect.
@@ -300,30 +302,47 @@ func TestLifecycle_GlobalGCSweeper(t *testing.T) {
 	fresh := time.Now().Add(-time.Second) // well within window
 
 	h.mu.Lock()
-	h.recentLeftAt[recentLeftKey(sid1, pid1)] = stale // should be swept
-	h.recentLeftAt[recentLeftKey(sid2, pid2)] = stale // should be swept
-	h.recentLeftAt[recentLeftKey(sid1, pid3)] = fresh // must survive
+	h.recentLeftAt[sid1] = map[uuid.UUID]time.Time{
+		pid1: stale, // should be swept
+		pid3: fresh, // must survive
+	}
+	h.recentLeftAt[sid2] = map[uuid.UUID]time.Time{
+		pid2: stale, // should be swept
+	}
 	h.mu.Unlock()
 
 	h.gcAllRecentLeft()
 
 	h.mu.Lock()
-	remaining := len(h.recentLeftAt)
-	_, pid3Alive := h.recentLeftAt[recentLeftKey(sid1, pid3)]
-	_, pid1Gone := h.recentLeftAt[recentLeftKey(sid1, pid1)]
-	_, pid2Gone := h.recentLeftAt[recentLeftKey(sid2, pid2)]
+	// After GC: sid2 sub-map is empty (deleted), sid1 has only pid3.
+	// Total session keys = 1 (sid1 only).
+	remainingSessions := len(h.recentLeftAt)
+	var pid3Alive, pid1Gone, pid2Gone bool
+	if sub1, ok := h.recentLeftAt[sid1]; ok {
+		_, pid3Alive = sub1[pid3]
+		_, hasPid1 := sub1[pid1]
+		pid1Gone = !hasPid1
+	} else {
+		pid1Gone = true
+	}
+	if sub2, ok := h.recentLeftAt[sid2]; ok {
+		_, hasPid2 := sub2[pid2]
+		pid2Gone = !hasPid2
+	} else {
+		pid2Gone = true
+	}
 	h.mu.Unlock()
 
-	if remaining != 1 {
-		t.Errorf("recentLeftAt len = %d after gcAllRecentLeft, want 1", remaining)
+	if remainingSessions != 1 {
+		t.Errorf("recentLeftAt session count = %d after gcAllRecentLeft, want 1", remainingSessions)
 	}
 	if !pid3Alive {
 		t.Error("fresh entry was incorrectly swept")
 	}
-	if pid1Gone {
+	if !pid1Gone {
 		t.Error("stale entry sid1/pid1 should have been swept but survives")
 	}
-	if pid2Gone {
+	if !pid2Gone {
 		t.Error("stale entry sid2/pid2 should have been swept but survives")
 	}
 }
@@ -366,4 +385,70 @@ func TestLifecycle_Race(t *testing.T) {
 	wg.Wait()
 	// Allow goroutines spawned by notify to finish.
 	time.Sleep(100 * time.Millisecond)
+}
+
+// TestHub_Stop_ClosingFlagBlocksBroadcast verifies that after Stop() sets the
+// closing flag, subsequent BroadcastToSession calls return immediately without
+// touching the session maps (L-5 fix: closing atomic.Bool).
+func TestHub_Stop_ClosingFlagBlocksBroadcast(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHub(nil)
+	sessionID := uuid.New()
+
+	// Register and join a client so a session entry exists.
+	c := newTestClient(h, uuid.New())
+	registerAndWait(h, c)
+	h.JoinSession(c, sessionID)
+
+	env := MustEnvelope("game:event", nil)
+
+	// Drain the send buffer so we know the baseline.
+	initialCount := len(c.send)
+
+	// Set closing flag directly (same as Stop does) and verify broadcast is a no-op.
+	h.closing.Store(true)
+
+	h.BroadcastToSession(sessionID, env)
+	h.BroadcastToSessionExcept(sessionID, env, uuid.New())
+	h.BroadcastToSessionEphemeral(sessionID, env)
+
+	// No new messages should have reached the client.
+	if got := len(c.send); got != initialCount {
+		t.Errorf("closing flag did not block broadcast: send queue grew by %d", got-initialCount)
+	}
+}
+
+// TestHub_RecentLeftAt_PerSessionCleanup verifies that rejoining a session
+// removes the per-session sub-map entry and cleans up the session key when
+// empty — confirming O(1) sub-map GC (L-3 fix).
+func TestHub_RecentLeftAt_PerSessionCleanup(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHub(nil)
+	defer h.Stop()
+
+	sessionID := uuid.New()
+	playerID := uuid.New()
+
+	// Seed a recentLeftAt entry directly (simulates a prior disconnect).
+	h.mu.Lock()
+	h.recentLeftAt[sessionID] = map[uuid.UUID]time.Time{
+		playerID: time.Now(), // fresh — within reconnect window
+	}
+	h.mu.Unlock()
+
+	// JoinSession should detect reconnect and delete the entry.
+	c := newTestClient(h, playerID)
+	registerAndWait(h, c)
+	h.JoinSession(c, sessionID)
+
+	h.mu.Lock()
+	sub := h.recentLeftAt[sessionID]
+	h.mu.Unlock()
+
+	// After rejoining, sub-map for the session must be nil or empty.
+	if sub != nil && len(sub) > 0 {
+		t.Errorf("recentLeftAt[sessionID] has %d entries after rejoin, want 0", len(sub))
+	}
 }


### PR DESCRIPTION
## Summary
- **L-3** `recentLeftAt` O(N) prefix scan → per-session sub-map `map[uuid.UUID]map[uuid.UUID]time.Time`. O(1) lookup/GC, removes `recentLeftKey` string helper.
- **L-4** Redis snapshot key namespace: `session:{id}:snapshot` → `mmp:session:{id}:snapshot`. Old keys auto-expire via existing 24h TTL.
- **L-5** `Hub.closing atomic.Bool` added. `broadcastToSession` checks flag and returns early before reading session maps, preventing a stale-map reference race during `Stop()`.

## Files changed
- `apps/server/internal/ws/hub.go` — L-3 sub-map, L-5 closing flag + Stop ordering
- `apps/server/internal/session/snapshot_serialize.go` — L-4 key prefix
- `apps/server/internal/session/snapshot_test.go` — key updated
- `apps/server/internal/session/snapshot_lifecycle_test.go` — key updated + namespace regression test
- `apps/server/internal/ws/hub_lifecycle_test.go` — sub-map test helpers updated + 2 regression tests

## Test plan
- [x] `go test -race -count=1 ./internal/ws/... ./internal/session/...` — pass
- [x] `go test -race -count=1 ./...` — pass (pre-existing `TestLoad_Defaults` config failure unrelated to PR-2, confirmed failing before changes)
- [x] `TestHub_Stop_ClosingFlagBlocksBroadcast` — verifies closing flag stops broadcasts
- [x] `TestHub_RecentLeftAt_PerSessionCleanup` — verifies sub-map GC after rejoin
- [x] `TestSnapshot_KeyHasMmpNamespacePrefix` — verifies new key format, rejects old

🤖 Generated with [Claude Code](https://claude.com/claude-code)