### PR TITLE
fix(ci): seed e2e@test.com in stubbed E2E workflow (#46)

### DIFF
--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -70,6 +70,16 @@ jobs:
         working-directory: apps/server
         run: go build -o /tmp/mmp-server ./cmd/server
 
+      - name: Install goose
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+
+      - name: Run migrations
+        working-directory: apps/server
+        run: |
+          goose -dir db/migrations postgres \
+            "host=localhost port=5432 user=mmp password=mmp_e2e dbname=mmp_e2e sslmode=disable" \
+            up
+
       - name: Start server
         run: |
           /tmp/mmp-server &

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -82,6 +82,24 @@ jobs:
             sleep 1
           done
 
+      # ── Seed E2E user (Issue #46) ──────────────────────────────────────────
+      # game-session/reconnect/redaction specs log in as e2e@test.com.
+      # Without this seed, login() times out at 30s and all scenarios fail.
+
+      - name: Seed E2E user
+        run: |
+          http_code=$(curl -s -o /tmp/seed.out -w "%{http_code}" \
+            -X POST http://localhost:8080/api/v1/auth/register \
+            -H "Content-Type: application/json" \
+            -d '{"email":"e2e@test.com","password":"e2etest1234","nickname":"E2E Tester"}')
+          if [ "$http_code" = "201" ] || [ "$http_code" = "409" ]; then
+            echo "Seed OK (http=$http_code)"
+          else
+            echo "Seed failed (http=$http_code):"
+            cat /tmp/seed.out
+            exit 1
+          fi
+
       # ── Node / pnpm ────────────────────────────────────────────────────────
 
       - name: Setup Node.js

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -127,6 +127,9 @@ jobs:
         working-directory: apps/web
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Build workspace packages
+        run: pnpm --filter "@mmp/game-logic" --filter "@mmp/shared" build
+
       # ── Frontend dev server ────────────────────────────────────────────────
 
       - name: Start frontend


### PR DESCRIPTION
## Summary
CI workflow `e2e-stubbed.yml` (실제로는 real Postgres+Redis+Go) 가 로그인 전 `e2e@test.com` 계정을 seed 하지 않아 `game-session/reconnect/redaction` specs 의 `login()` 이 30s 타임아웃으로 실패.

## 변경
- `Start server` 이후 `Seed E2E user` step 추가
- `POST /api/v1/auth/register` 로 e2e@test.com/e2etest1234 등록
- 201 (첫 seed) 또는 409 (재실행 시 중복) 둘 다 성공 처리
- 그 외 HTTP code 는 body 로그 후 fast fail

## Closes
- Fixes #46

## Test plan
- [ ] CI `E2E Stubbed Backend (Chromium)` green
- [ ] game-session.spec.ts 6 tests 이전 timeout 해소
- [ ] 재접속/Redaction specs 도 동일하게 복구

🤖 Generated with [Claude Code](https://claude.com/claude-code)