### PR TITLE
plan(phase-18.6): E2E Recovery — login timeout + theme seed

### DIFF
--- a/.claude/active-plan.json
+++ b/.claude/active-plan.json
@@ -1,0 +1,97 @@
+{
+  "active": {
+    "id": "phase-18.6",
+    "name": "E2E Recovery",
+    "dir": "docs/plans/2026-04-16-e2e-recovery",
+    "design": "docs/plans/2026-04-16-e2e-recovery/design.md",
+    "plan": "docs/plans/2026-04-16-e2e-recovery/plan.md",
+    "checklist": "docs/plans/2026-04-16-e2e-recovery/checklist.md",
+    "progress_memory": "memory/project_phase186_progress.md",
+    "scope": [
+      "apps/web/e2e/**",
+      "apps/server/db/seed/**",
+      ".github/workflows/e2e-stubbed.yml"
+    ],
+    "started_at": "2026-04-16",
+    "started_commit": "191b37b",
+    "current_wave": "W0",
+    "current_pr": "PR-1",
+    "current_task": "W0 PR-1: Playwright trace + artifact 조사로 login timeout 원인 확정",
+    "status": "pending",
+    "blockers": [],
+    "waves": [
+      {
+        "id": "W0",
+        "name": "investigate",
+        "mode": "sequential",
+        "prs": ["PR-1"]
+      },
+      {
+        "id": "W1",
+        "name": "fix-parallel",
+        "mode": "parallel",
+        "prs": ["PR-2", "PR-3"]
+      },
+      {
+        "id": "W2",
+        "name": "regression-merge",
+        "mode": "sequential",
+        "prs": ["PR-4"]
+      }
+    ],
+    "prs": {
+      "PR-1": {
+        "title": "Investigate login timeout (trace + repro)",
+        "depends_on": [],
+        "scope": ["docs/plans/2026-04-16-e2e-recovery/refs/findings.md"],
+        "tasks_total": 4,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "investigate/phase-18.6/login-timeout",
+        "commit": null
+      },
+      "PR-2": {
+        "title": "login helper 공용화 + fix",
+        "depends_on": ["PR-1"],
+        "scope": [
+          "apps/web/e2e/helpers/auth.ts",
+          "apps/web/e2e/game-session.spec.ts",
+          "apps/web/e2e/game-reconnect.spec.ts",
+          "apps/web/e2e/game-redaction.spec.ts"
+        ],
+        "tasks_total": 5,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "fix/phase-18.6/login-helper",
+        "commit": null
+      },
+      "PR-3": {
+        "title": "theme seed SQL + workflow step",
+        "depends_on": [],
+        "scope": [
+          "apps/server/db/seed/e2e-themes.sql",
+          ".github/workflows/e2e-stubbed.yml"
+        ],
+        "tasks_total": 4,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "fix/phase-18.6/theme-seed",
+        "commit": null
+      },
+      "PR-4": {
+        "title": "Full regression + E2E green gate",
+        "depends_on": ["PR-2", "PR-3"],
+        "scope": [
+          "memory/project_phase186_progress.md",
+          "memory/MEMORY.md"
+        ],
+        "tasks_total": 6,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "test/phase-18.6/green-gate",
+        "commit": null
+      }
+    }
+  },
+  "history": []
+}

--- a/docs/plans/2026-04-16-e2e-recovery/checklist.md
+++ b/docs/plans/2026-04-16-e2e-recovery/checklist.md
@@ -1,0 +1,43 @@
+# Phase 18.6 — E2E Recovery 체크리스트
+
+> 부모: [design.md](design.md), [plan.md](plan.md)
+> 시작: 2026-04-16
+
+---
+
+## W0 — PR-1: Investigate login timeout
+
+- [ ] Task 1 — PR #48 머지 후 trigger된 latest `e2e-stubbed` run 아티팩트 다운로드
+- [ ] Task 2 — `playwright-e2e-stubbed-report/` trace 로컬 뷰어로 분석
+- [ ] Task 3 — fill 실패 원인 확정 (placeholder 텍스트, 리다이렉트, hydration, 네트워크 등)
+- [ ] Task 4 — findings.md 에 증거(스크린샷/네트워크 타임라인) 정리
+
+## W1 — PR-2: Login helper 공용화 + 수정
+
+- [ ] Task 1 — `apps/web/e2e/helpers/auth.ts` 신규 — `loginWithForm(page, email, password)` export
+- [ ] Task 2 — game-session/reconnect/redaction 3파일이 새 헬퍼 import 하도록 치환
+- [ ] Task 3 — PR-1 원인 반영: placeholder/selector/waitFor 수정
+- [ ] Task 4 — Vitest + lint 그린 유지
+- [ ] Task 5 — 변경 파일 ≤400줄 / 함수 ≤60줄 확인
+
+## W1 — PR-3: Theme seed SQL + workflow step
+
+- [ ] Task 1 — `apps/server/db/seed/e2e-themes.sql` 신규 (published theme 1건 + characters/clues 최소 fixture)
+- [ ] Task 2 — `.github/workflows/e2e-stubbed.yml` 에 `Seed E2E theme` step 추가 (Seed user 다음, Start server 전)
+- [ ] Task 3 — seed SQL idempotent 확인 (ON CONFLICT, 재실행 안전)
+- [ ] Task 4 — `go build ./...` 그린 (관련 파일 없지만 회귀 체크)
+
+## W2 — PR-4: 회귀 + green gate
+
+- [ ] Task 1 — main에 PR-2, PR-3 머지 후 `e2e-stubbed` 재실행
+- [ ] Task 2 — 3 E2E jobs (방 생성/재접속/Redaction) 전부 green 확인
+- [ ] Task 3 — memory/project_phase186_progress.md 작성
+- [ ] Task 4 — MEMORY.md 인덱스 업데이트
+- [ ] Task 5 — Issue #46 close
+- [ ] Task 6 — `/plan-finish` 실행
+
+## 회귀/게이트
+
+- [ ] editor vitest 437+ 유지
+- [ ] Go build + testcontainers 그린
+- [ ] CI 4/4 green (TS + Go + Docker + E2E)

--- a/docs/plans/2026-04-16-e2e-recovery/design.md
+++ b/docs/plans/2026-04-16-e2e-recovery/design.md
@@ -1,0 +1,44 @@
+# Phase 18.6 — E2E Recovery 설계 (index)
+
+> **상태**: 초안
+> **시작**: 2026-04-16
+> **선행**: Phase 18.4 (완료), PR #48 (CI seed/migrate/build 복구 머지됨)
+> **목표**: `e2e-stubbed` job의 남은 E2E 실패 해소 — login timeout + theme seed.
+
+---
+
+## 배경
+
+PR #48로 CI의 치명적 infra 3건 복구:
+- `e2e@test.com` user seed
+- goose migrations 실행
+- `@mmp/game-logic` workspace build
+
+이제 실제 테스트 실행까지 진입하지만 **game-session.spec.ts 6 tests 모두 beforeEach login 30s 타임아웃**으로 fail.
+
+## 남은 실패 매트릭스
+
+| # | 증상 | 추정 원인 | Severity |
+|---|------|-----------|----------|
+| 1 | `locator.fill("이메일")` 30s 타임아웃 | SPA /login 렌더 이슈 (placeholder 변경, 리다이렉트, or hydration 지연) | High |
+| 2 | createRoom 시나리오 테마 미존재 | theme seed 누락 (`test.skip(roomId === "NO_THEMES")` 방어만) | Medium |
+| 3 | game-reconnect/game-redaction 연쇄 실패 | #1 동일 로그인 헬퍼 공유 | High |
+
+상세: [refs/findings.md](refs/findings.md)
+
+## 5대 결정
+
+| # | 결정 | 선택 | 근거 |
+|---|------|------|------|
+| 1 | login 헬퍼 방식 | localStorage 주입 대신 **실제 폼 통과** | 실제 backend 모드 유지 시 token 정합성 — 직접 주입은 API 호출 시 401 |
+| 2 | 타임아웃 원인 파악 | Playwright trace + console log | 로컬 재현 어려움 → artifact 기반 분석 |
+| 3 | theme seed 방법 | E2E seed 전용 SQL 파일 + psql 실행 | register API 없음, SQL INSERT가 최단 |
+| 4 | login helper 공용화 | `apps/web/e2e/helpers/auth.ts`에 단일 헬퍼 추출 | game-session/reconnect/redaction 3곳에 동일 로직 |
+| 5 | Feature flag 게이트 | 해당 없음 — 테스트 인프라만 수정 | - |
+
+---
+
+## Out of scope
+- Playwright config 개편 (project별 분리)
+- 새 E2E 시나리오 추가
+- 프로덕션 auth flow 변경

--- a/docs/plans/2026-04-16-e2e-recovery/plan.md
+++ b/docs/plans/2026-04-16-e2e-recovery/plan.md
@@ -1,0 +1,70 @@
+# Phase 18.6 — E2E Recovery 실행 계획
+
+> 부모: [design.md](design.md)
+
+---
+
+## Overview
+
+W0 Playwright trace 수집 → W1 login 헬퍼 수정 + theme seed 병렬 → W2 회귀 + merge.
+
+---
+
+## Wave 구조
+
+```
+W0 (sequential):
+  PR-1 — Playwright trace + artifact 조사 → 원인 확정
+
+W1 (parallel ×2):
+  PR-2 — Login 헬퍼 공용화 + 타임아웃 원인 수정    ← test-engineer
+  PR-3 — Theme seed SQL + workflow step           ← go-backend
+
+W2 (sequential):
+  PR-4 — E2E green 검증 + PR 생성 + main 머지
+```
+
+---
+
+## PR 목록
+
+| PR | Wave | Title | 의존 | 도메인 |
+|----|------|-------|------|--------|
+| PR-1 | W0 | Investigate login timeout (trace + repro) | - | test |
+| PR-2 | W1 | login helper 공용화 + fix | PR-1 | frontend/test |
+| PR-3 | W1 | theme seed SQL + workflow step | - | backend/ci |
+| PR-4 | W2 | Full regression + E2E green gate | PR-2,3 | test |
+
+---
+
+## Merge 전략
+
+- W0 PR-1: 조사만 — worktree 불필요, 직접 main 기준 branch
+- W1 PR-2/PR-3 worktree isolation (file 겹침 없음: apps/web/e2e/helpers vs .github/workflows + db/seed)
+- 각 merge 후 CI `e2e-stubbed` 재실행, 이전 6 failures 중 최소 `방 생성` 1건 green 확인
+- Wave 종료 시 user 확인 1회
+
+---
+
+## Feature flag
+
+해당 없음 — 테스트 인프라만 수정.
+
+---
+
+## 알려진 위험
+
+| 위험 | 완화 |
+|------|------|
+| Trace artifact 용량 제한 | `--trace=on-first-retry` 유지, 실패 1건만 분석 |
+| theme seed SQL이 스키마 drift에 깨짐 | fixture seed 파일 버전화 + migrations 이후 실행 |
+| login helper 변경이 editor-golden-path에 영향 | 단일 헬퍼로 통합 시 양쪽 테스트 모두 회귀 확인 |
+
+---
+
+## 테스트 전략
+
+- PR-1: trace.zip artifact 다운로드 → Playwright viewer 로컬 분석. 증거 기반 원인 결정.
+- PR-2: `vitest` 회귀 (editor 437 유지), Playwright local + CI 재실행
+- PR-3: `psql` dry-run + server startup 이후 seed step 순서 검증
+- PR-4: 3 E2E jobs 모두 green (방 생성·재접속·Redaction)

--- a/docs/plans/2026-04-16-e2e-recovery/refs/findings.md
+++ b/docs/plans/2026-04-16-e2e-recovery/refs/findings.md
@@ -1,0 +1,47 @@
+# Phase 18.6 — 초기 조사 findings
+
+## CI 최근 실행 (PR #48 브랜치 — `22135d3`)
+
+- TS/Go/Docker: pass
+- E2E: 6/6 tests in `game-session.spec.ts` fail
+- 에러 패턴:
+  ```
+  Test timeout of 30000ms exceeded while running "beforeEach" hook.
+  Error: locator.fill: Test timeout of 30000ms exceeded.
+  ```
+- 스택: `login()` → `page.getByPlaceholder("이메일").fill(LOGIN_EMAIL)`
+
+## 세션 컨텍스트
+
+- `e2e@test.com` user seed → 201 OK
+- migrations 22개 전부 OK
+- `@mmp/game-logic` workspace build OK
+- frontend `pnpm dev` 실행 완료 (vite HMR 준비)
+
+## 가설 (증거 수집 필요)
+
+### H1: placeholder 불일치
+- `apps/web/src/features/auth/LoginPage.tsx:119` — `placeholder="이메일"` 유지 확인됨
+- 반론: 로컬 `pnpm dev`로 재현 어려움. 혹시 `@jittda/ui` TextField가 placeholder 렌더를 wrapping 하는지?
+
+### H2: 리다이렉트 레이스
+- `auth_token` 없는 상태에서 `/login` 접근 시 정상. 그러나 SPA 초기화 중 `useAuthStore` rehydrate가 끝나기 전에 form fill 시도 → element invisible 가능.
+
+### H3: hydration 지연
+- React 19 + Vite dev → HMR/SSR 오버헤드. fill 전 `waitForLoadState("networkidle")` 필요?
+
+### H4: 네트워크 실패
+- register 직후 seed user로 login은 가능해야 함. 하지만 서버가 restart/reload 중이면 API 거부.
+
+## 다음 probe
+
+1. Playwright trace artifact 다운로드 (PR #48 run id — 통합 후 main의 가장 최근 run 사용)
+2. trace viewer로 login 페이지 DOM snapshot 확인 (fill 실패 시점의 HTML)
+3. 네트워크 timeline에서 `/api/v1/auth/login` 요청 여부 확인
+4. console log에 hydration 에러 있는지
+
+## Seed 필요 자산 (PR-3)
+
+- `themes` 테이블에 published=true 테마 최소 1건
+- 연관: `characters`, `clues`, `locations`, `theme_modules` fixture (createRoom 내부에서 요구)
+- 현재 migrations 중 `00008_payment.sql`, `00011_editor_tables.sql`까지 스키마 정의됨 — seed SQL은 그 schema 에 부합


### PR DESCRIPTION
## Summary
- Phase 18.6 E2E Recovery 플랜 문서 추가 (design/plan/checklist/findings)
- 3 Wave / 4 PR 구조, login timeout + theme seed 복구 스코프
- 구현 코드 변경 없음 — docs/plans + active-plan 포인터만

## Test plan
- [ ] 구현 PR은 이후 W0~W2 wave별로 별도 생성