### PR TITLE
perf(ci): pnpm + buildx GHA cache for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-
-      - name: Enable corepack
-        run: corepack enable
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -103,5 +104,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
-        run: docker build -f apps/server/Dockerfile apps/server
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/server
+          file: apps/server/Dockerfile
+          push: false
+          load: true
+          tags: ghcr.io/sabyunrepo/mmp-server:ci-${{ github.sha }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,scope=server,mode=max

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -2,9 +2,13 @@
 FROM golang:1.25-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app ./cmd/server
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app ./cmd/server
 
 # Stage 2: Runtime (distroless ~20MB, non-root + signal handling)
 FROM gcr.io/distroless/static-debian12:nonroot


### PR DESCRIPTION
## Summary
Wave 1 PR-1 of Phase 18.7 — PR CI latency 단축을 위해 pnpm store + buildx GHA 캐시 적용.

## Changes
- `ci.yml ts-check`: corepack → `pnpm/action-setup@v5` + `setup-node cache: 'pnpm'`
- `ci.yml docker-build`: buildx + `docker/build-push-action@v6` + GHA cache scope=server
- `apps/server/Dockerfile`: BuildKit cache mounts (`/go/pkg/mod`, `/root/.cache/go-build`) for `go mod download` + `go build`

## Test plan
- [ ] CI green
- [ ] 2회차 push에서 pnpm install ≤20s 확인
- [ ] docker build 로그에 `CACHED` 레이어 5개+ 확인

## Context
Part of [Phase 18.7 plan](../blob/main/docs/plans/2026-04-16-phase-18.7-ci-hardening/plan.md#pr-1-perfci-pnpm--go--docker-%EC%BA%90%EC%8B%9C-%EC%9E%AC%EC%A0%95%EB%A0%AC).

Verified locally: `docker buildx build` succeeded with new Dockerfile cache mounts (go build 13.6s, image exported clean).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>