### PR TITLE
supply-chain(ci): SBOM + build provenance attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,10 @@ jobs:
     name: Docker Build Check
     runs-on: ubuntu-latest
     needs: [go-check, ts-check]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -123,6 +127,7 @@ jobs:
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Build Docker image
+        id: docker-build
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: apps/server
@@ -132,3 +137,20 @@ jobs:
           tags: ghcr.io/sabyunrepo/mmp-server:ci-${{ github.sha }}
           cache-from: type=gha,scope=server
           cache-to: type=gha,scope=server,mode=max
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/sabyunrepo/mmp-server:ci-${{ github.sha }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: true
+          artifact-name: sbom-cyclonedx
+
+      - name: Attest build provenance
+        # Only on main pushes — PR runs skip this to avoid sigstore noise.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/sabyunrepo/mmp-server
+          subject-digest: ${{ steps.docker-build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+# Tag-triggered release pipeline.
+# Builds and pushes the server image to GHCR, generates a CycloneDX SBOM,
+# and produces a signed build provenance attestation.
+#
+# NOTE: This workflow is structurally in place but untested end-to-end because
+# no `v*` tag has been cut yet. Activation is deferred to a dedicated release
+# Phase. Until then, pushing to main or opening PRs will NOT trigger it.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build, Push, SBOM, Attest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: docker-push
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: apps/server
+          file: apps/server/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/sabyunrepo/mmp-server:${{ github.ref_name }}
+            ghcr.io/sabyunrepo/mmp-server:latest
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,scope=server,mode=max
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/sabyunrepo/mmp-server:${{ github.ref_name }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/sabyunrepo/mmp-server
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-${{ github.ref_name }}
+          path: sbom.cdx.json
+          if-no-files-found: error
+          retention-days: 90


### PR DESCRIPTION
## Summary
- `ci.yml` docker-build: adds `anchore/sbom-action` (CycloneDX JSON) as artifact on every build (PR + main). Adds `actions/attest-build-provenance` guarded by `github.event_name == 'push' && github.ref == 'refs/heads/main'` so PR runs skip sigstore/OIDC signing.
- New `release.yml`: tag-triggered (`v*`) workflow that pushes server image to GHCR, generates CycloneDX SBOM, produces build provenance attestation, and uploads SBOM artifact. **Structural only** — no `v*` tag exists yet, so this workflow is inactive until a dedicated release Phase exercises it end-to-end.
- Job-scoped permissions (`id-token: write`, `attestations: write`) instead of repo-wide.
- All new action references SHA-pinned (anchore/sbom-action `e22c389...` v0.24.0, actions/attest-build-provenance `a2bbfa2...` v4.1.0, docker/login-action `4907a6d...` v4.1.0, actions/upload-artifact `043fb46...` v7.0.1).

## Test plan
- [ ] CI green on this PR (go-check, ts-check, docker-build)
- [ ] Verify `sbom-cyclonedx` artifact appears in PR run Artifacts tab (`sbom.cdx.json`)
- [ ] Confirm `Attest build provenance` step is **skipped** on PR run (expected: `github.event_name == 'push' && github.ref == 'refs/heads/main'` is false)
- [ ] After merge: main push should exercise attestation step; follow-up verification via `gh attestation verify --owner sabyunrepo oci://ghcr.io/sabyunrepo/mmp-server:ci-<sha>` (deferred — PR verifies SBOM generation only)
- [ ] `release.yml` activation deferred — no behavior change until a `v*` tag is cut

## Scope
Phase 18.7 Wave 2 PR-5. Merge-gated; do not auto-merge.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>