### PR TITLE
docs(phase-18.8): initial plan — E2E skip recovery

### DIFF
--- a/.claude/active-plan.json
+++ b/.claude/active-plan.json
@@ -1,0 +1,116 @@
+{
+  "active": {
+    "id": "phase-18.8-e2e-skip-recovery",
+    "name": "Phase 18.8 — E2E Skip Recovery",
+    "dir": "docs/plans/2026-04-16-e2e-skip-recovery",
+    "design": "docs/plans/2026-04-16-e2e-skip-recovery/design.md",
+    "plan": "docs/plans/2026-04-16-e2e-skip-recovery/plan.md",
+    "checklist": "docs/plans/2026-04-16-e2e-skip-recovery/checklist.md",
+    "progress_memory": "memory/project_phase188_progress.md",
+    "scope": [
+      "apps/server/internal/domain/room/**",
+      "apps/web/src/mocks/**",
+      "apps/web/e2e/helpers/**",
+      "apps/web/e2e/game-redaction-stubbed.spec.ts",
+      "apps/web/e2e/clue-relation-stubbed.spec.ts",
+      "apps/web/playwright.config.ts",
+      "apps/web/package.json",
+      ".github/workflows/phase-18.1-real-backend.yml",
+      ".github/workflows/e2e-stubbed.yml"
+    ],
+    "started_at": "2026-04-16",
+    "started_commit": null,
+    "current_wave": "W1",
+    "current_pr": "PR-1",
+    "current_task": "계획 승인 대기",
+    "status": "pending",
+    "blockers": [],
+    "waves": [
+      {
+        "id": "W1",
+        "name": "foundation",
+        "mode": "parallel",
+        "prs": ["PR-1", "PR-2"]
+      },
+      {
+        "id": "W2",
+        "name": "stub-expansion",
+        "mode": "parallel",
+        "prs": ["PR-3", "PR-4"]
+      },
+      {
+        "id": "W3",
+        "name": "ci-promotion",
+        "mode": "sequential",
+        "prs": ["PR-5"]
+      }
+    ],
+    "prs": {
+      "PR-1": {
+        "title": "fix(rooms): MaxPlayers optional + theme fallback",
+        "depends_on": [],
+        "scope": ["apps/server/internal/domain/room/**"],
+        "tasks_total": 5,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "fix/rooms-maxplayers-optional",
+        "commit": null
+      },
+      "PR-2": {
+        "title": "test(e2e): MSW foundation + party helper",
+        "depends_on": [],
+        "scope": [
+          "apps/web/src/mocks/**",
+          "apps/web/e2e/helpers/**",
+          "apps/web/playwright.config.ts",
+          "apps/web/package.json"
+        ],
+        "tasks_total": 7,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "test/e2e-msw-helpers",
+        "commit": null
+      },
+      "PR-3": {
+        "title": "test(e2e): game-redaction stubbed 복제본",
+        "depends_on": ["PR-1", "PR-2"],
+        "scope": [
+          "apps/web/e2e/game-redaction-stubbed.spec.ts",
+          "apps/web/src/mocks/handlers/game-ws.ts"
+        ],
+        "tasks_total": 4,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "test/e2e-redaction-stubbed",
+        "commit": null
+      },
+      "PR-4": {
+        "title": "test(e2e): clue-relation stubbed 복제본",
+        "depends_on": ["PR-1", "PR-2"],
+        "scope": [
+          "apps/web/e2e/clue-relation-stubbed.spec.ts",
+          "apps/web/src/mocks/handlers/clue.ts"
+        ],
+        "tasks_total": 4,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "test/e2e-clue-relation-stubbed",
+        "commit": null
+      },
+      "PR-5": {
+        "title": "ci(e2e): real-backend main push + workflow_dispatch",
+        "depends_on": ["PR-3", "PR-4"],
+        "scope": [
+          ".github/workflows/phase-18.1-real-backend.yml",
+          ".github/workflows/e2e-stubbed.yml"
+        ],
+        "tasks_total": 4,
+        "tasks_done": 0,
+        "status": "pending",
+        "branch": "ci/e2e-real-backend-gate",
+        "commit": null
+      }
+    }
+  },
+  "history": []
+}

--- a/docs/plans/2026-04-16-e2e-skip-recovery/checklist.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/checklist.md
@@ -1,0 +1,93 @@
+<!-- STATUS-START -->
+**Active**: Phase 18.8 E2E Skip Recovery — Wave 1/3
+**PR**: PR-1 (0%)
+**Task**: 계획 승인 대기
+**State**: pending
+**Blockers**: (none)
+**Last updated**: 2026-04-16
+<!-- STATUS-END -->
+
+# Phase 18.8 — E2E Skip Recovery 체크리스트
+
+> 부모: [design.md](design.md) | 실행: [plan.md](plan.md)
+> STATUS 마커는 hook/스크립트가 파싱하므로 수정 시 형식 유지.
+
+---
+
+## Wave 1 — Foundation (parallel)
+
+### PR-1: fix(rooms): MaxPlayers optional + theme fallback
+- [ ] Task 1 — `CreateRoomRequest.MaxPlayers`를 `*int32` + `validate:"omitempty,min=2,max=12"`로 변경
+- [ ] Task 2 — `service.go:CreateRoom`에서 nil 시 theme 조회 → `theme.MaxPlayers` fallback + 범위 재검증
+- [ ] Task 3 — handler_test.go에 optional 시나리오 + theme fallback 케이스 추가
+- [ ] Task 4 — service_test.go에 min/max 범위 검증 테이블 테스트 추가
+- [ ] Task 5 — Run after_task pipeline (go fmt + scope test + go test -race)
+
+### PR-2: test(e2e): MSW foundation + party helper
+- [ ] Task 1 — MSW v2 설치 + `apps/web/src/mocks/{browser,server}.ts` 셋업
+- [ ] Task 2 — handlers/{auth,theme,room,clue}.ts 초기 핸들러 작성
+- [ ] Task 3 — `apps/web/e2e/helpers/msw-route.ts` MSW→page.route 어댑터
+- [ ] Task 4 — `apps/web/e2e/helpers/common.ts` — login/createRoom/createPartyOfN/waitForGamePage
+- [ ] Task 5 — playwright.config.ts fixtures 확장 (authenticatedPage, multiPartyContext)
+- [ ] Task 6 — 기존 game-session.spec.ts 1건 helper로 리팩터 + pass 확인
+- [ ] Task 7 — helper 단위 테스트(Vitest) + after_task pipeline
+
+**Wave 1 gate**:
+- [ ] PR-1 all tasks ✅
+- [ ] PR-2 all tasks ✅
+- [ ] Parallel 4-reviewer pass
+- [ ] Fix-loop < 3 iterations
+- [ ] `go test -race ./apps/server/...` + `pnpm --filter @mmp/web test` pass
+- [ ] Both PRs merged to main
+- [ ] User confirmed Wave 2 진입
+
+---
+
+## Wave 2 — Stub Expansion (parallel)
+
+### PR-3: test(e2e): game-redaction stubbed 복제본
+- [ ] Task 1 — `apps/web/src/mocks/handlers/game-ws.ts` — role별 payload 4종 (normal/murderer/detective/whisper)
+- [ ] Task 2 — `apps/web/e2e/game-redaction-stubbed.spec.ts` 신규 (4 시나리오)
+- [ ] Task 3 — 기존 game-redaction.spec.ts에 주석으로 stubbed 대응 관계 표기
+- [ ] Task 4 — stubbed CI에서 4 시나리오 pass + after_task pipeline
+
+### PR-4: test(e2e): clue-relation stubbed 복제본
+- [ ] Task 1 — `apps/web/src/mocks/handlers/clue.ts` clue-relation API 핸들러 확장
+- [ ] Task 2 — `apps/web/e2e/clue-relation-stubbed.spec.ts` 신규 (3 시나리오)
+- [ ] Task 3 — React Flow 그래프 assertion 패턴 확인
+- [ ] Task 4 — stubbed CI에서 3 시나리오 pass + after_task pipeline
+
+**Wave 2 gate**:
+- [ ] PR-3, PR-4 all tasks ✅
+- [ ] Parallel 4-reviewer pass
+- [ ] stubbed CI 전체 skip 수 ≤3
+- [ ] Both merged
+- [ ] User confirmed Wave 3 진입
+
+---
+
+## Wave 3 — CI Promotion (sequential)
+
+### PR-5: ci(e2e): real-backend main push + workflow_dispatch
+- [ ] Task 1 — `phase-18.1-real-backend.yml`에 `push: [main]` 추가 (required 아님)
+- [ ] Task 2 — 실패 시 Slack/Discord 알림 step (staging 채널) 추가
+- [ ] Task 3 — `e2e-stubbed.yml`에 `workflow_dispatch` 추가
+- [ ] Task 4 — `refs/ci-promotion.md`에 3일 green 후 required 승격 후속 PR 예약 기록
+
+**Wave 3 gate**:
+- [ ] PR-5 merged
+- [ ] main push 후 real-backend workflow 자동 실행 확인
+- [ ] 의도적 실패 커밋으로 알림 도달 확인 후 revert
+- [ ] 3일 연속 nightly green
+
+---
+
+## Phase completion gate
+
+- [ ] All waves ✅
+- [ ] E2E stubbed CI: `13+ pass / ≤3 skip / 0 fail`
+- [ ] `memory/project_phase188_progress.md` 최종
+- [ ] `MEMORY.md` 인덱스 업데이트 (Phase 18.8 완료 링크)
+- [ ] Root checklist "Phase 18.8 ✅"
+- [ ] `/plan-finish` executed
+- [ ] Phase 18.9 (required 승격) 예약 메모 기록

--- a/docs/plans/2026-04-16-e2e-skip-recovery/design.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/design.md
@@ -1,0 +1,113 @@
+# Phase 18.8 — E2E Skip Recovery 설계 (index)
+
+> **상태**: 확정
+> **시작**: 2026-04-16
+> **다음 단계**: plan.md → wave 기반 실행
+> **상위 참조**: Phase 18.6 (E2E Recovery) + Phase 18.7 (CI Hardening)
+> **MD 200줄 제한**: 모든 문서 <200줄. 상세는 `refs/` 분할.
+
+---
+
+## 목적
+
+현재 E2E 테스트는 `4 pass / 11 skip / 0 fail`. skip 11건은 세 뿌리에서 비롯됨: (1) H7 `MaxPlayers` 계약 drift로 `createRoom` 400 실패, (2) `PLAYWRIGHT_BACKEND` env gate로 live spec 3종 전체 skip, (3) single-context 한계로 멀티플레이 시나리오 미검증. 이 Phase는 세 원인을 전부 해소해 `game_runtime_v2` 런타임 전반에 회귀 방지망을 깐다.
+
+---
+
+## Scope
+
+| 카테고리 | 항목 |
+|---------|------|
+| Backend | `CreateRoomRequest.MaxPlayers` optional + theme fallback |
+| E2E 인프라 | MSW v2 foundation + Playwright fixtures + common helpers |
+| 멀티플레이 | `createPartyOfN` 4-context helper + Investigation 단서 수신 검증 |
+| Stub 복제 | `game-redaction-stubbed`, `clue-relation-stubbed` 신규 spec |
+| CI | real-backend main push post-merge gate (알림 전용) + `workflow_dispatch` |
+
+**Out of scope**: Voting/엔딩 페이즈 커버리지 (Phase 19), real-backend required 승격 (Phase 18.9), MSW-Storybook 공유.
+
+상세는 [refs/scope-and-decisions.md](refs/scope-and-decisions.md).
+
+---
+
+## 7대 결정 (변경 금지)
+
+| # | 결정 | 선택 | 근거 |
+|---|------|------|------|
+| 1 | Scope | C (최대) | H7+live 3종+multi-context+CI 승격까지 포함해 회귀망 두텁게 |
+| 2 | H7 아키텍처 | 서버 optional + theme fallback | FE는 이미 `theme_id`만 전송 — 서버 변경이 계약의 진실 |
+| 3 | Multi-user lifecycle | P1 단일 테스트 N-context | pw.dev 권장 패턴, flaky 위험 예측 가능 |
+| 4 | Stub 기술 | 혼합 (HTTP MSW + WS page.route) | HTTP SSOT로 drift 방지, WS는 Playwright 안정성 우선 |
+| 5 | Persistence | e2e-themes.sql 기존 4인 테마 재사용 | 별도 seed 추가 불필요 |
+| 6 | 운영 안전성 | 점진적 CI gate (관측 → 3일 green → required) | 베타 단계 flaky 리스크 완화 |
+| 7 | 도입 전략 | 3 Wave / 5 PR / worktree 병렬 | W1 foundation → W2 stub → W3 CI |
+
+상세는 [refs/scope-and-decisions.md](refs/scope-and-decisions.md).
+
+---
+
+## 문서 맵 (refs/)
+
+| 파일 | 내용 |
+|------|------|
+| [refs/scope-and-decisions.md](refs/scope-and-decisions.md) | 7대 결정 상세 + 옵션 분석 |
+| [refs/architecture.md](refs/architecture.md) | 컴포넌트 + MSW/page.route 경계 |
+| [refs/execution-model.md](refs/execution-model.md) | **Wave DAG + 파일 구조 설계** |
+| [refs/observability-testing.md](refs/observability-testing.md) | 검증 시나리오 + 메트릭 + flaky 가드 |
+| refs/pr-1-maxplayers-optional.md | PR-1 상세 |
+| refs/pr-2-msw-party-helper.md | PR-2 상세 |
+| refs/pr-3-redaction-stubbed.md | PR-3 상세 |
+| refs/pr-4-clue-relation-stubbed.md | PR-4 상세 |
+| refs/pr-5-ci-promotion.md | PR-5 상세 |
+
+---
+
+## 전체 구조 요약
+
+```
+E2E stubbed CI (PR + main)      E2E real-backend (nightly + main post-merge)
+  ├─ MSW handlers (HTTP SSOT)     ├─ docker-compose backend
+  ├─ page.route (WS)              ├─ seed user + theme
+  ├─ common helpers               └─ game-session-live + webkit
+  │   ├─ login()
+  │   ├─ createRoom()
+  │   └─ createPartyOfN(n=4)
+  └─ stubbed specs
+      ├─ game-redaction-stubbed
+      └─ clue-relation-stubbed
+```
+
+---
+
+## 실행 전략 요약
+
+| Wave | PRs | 모드 | 의존 |
+|------|-----|------|------|
+| W1 | PR-1, PR-2 | parallel | - |
+| W2 | PR-3, PR-4 | parallel | W1 |
+| W3 | PR-5 | sequential | W2 |
+
+상세는 [refs/execution-model.md](refs/execution-model.md).
+
+**속도 이득**: 순차 5T → 병렬 3T (40% 단축)
+
+---
+
+## 종료 조건
+
+- [ ] 5개 PR main 머지 (3 waves 완료)
+- [ ] E2E stubbed CI: `13+ pass / ≤3 skip / 0 fail`
+- [ ] 4인 party flow Investigation 단서 수신까지 검증
+- [ ] real-backend workflow main push 트리거 + 알림 채널 도달 확인
+- [ ] 3일 연속 nightly green 관측
+- [ ] `memory/project_phase188_progress.md` 최종 갱신
+- [ ] `MEMORY.md` 인덱스 업데이트
+
+---
+
+## 다음 단계
+
+1. plan.md 작성 완료 — PR별 task breakdown 위치 `refs/pr-N-*.md`
+2. checklist.md 작성 완료 — STATUS 마커 포함
+3. `/plan-start docs/plans/2026-04-16-e2e-skip-recovery` 실행
+4. `/plan-go` 실행 → Wave 1부터 자동 진행

--- a/docs/plans/2026-04-16-e2e-skip-recovery/plan.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/plan.md
@@ -1,0 +1,82 @@
+# Phase 18.8 — E2E Skip Recovery 실행 계획 (index)
+
+> 부모: [design.md](design.md)
+> MD 200줄 제한: 각 PR 상세는 `refs/pr-N-*.md`
+
+---
+
+## Overview
+
+E2E 11 skip 복구 + real-backend CI 점진 승격. H7 루트 제거, MSW+party helper 인프라 구축, redaction/clue-relation stubbed 복제본, main push post-merge 관측 gate.
+
+---
+
+## Wave 구조
+
+```
+Wave 1 (parallel): PR-1, PR-2
+  ↓
+Wave 2 (parallel): PR-3, PR-4
+  ↓
+Wave 3 (sequential): PR-5
+```
+
+| Wave | Mode | PRs | 의존 | 예상 단위 |
+|------|------|-----|------|----------|
+| W1 | parallel | PR-1, PR-2 | - | 2T |
+| W2 | parallel | PR-3, PR-4 | W1 | 2T |
+| W3 | sequential | PR-5 | W2 | 1T |
+
+---
+
+## PR 목록
+
+| PR | Wave | Title | 의존 | Scope | Tasks | 상세 |
+|----|------|-------|------|-------|-------|------|
+| PR-1 | W1 | fix(rooms): MaxPlayers optional + theme fallback | - | `apps/server/internal/domain/room/**` | 5 | [refs/pr-1-maxplayers-optional.md](refs/pr-1-maxplayers-optional.md) |
+| PR-2 | W1 | test(e2e): MSW foundation + party helper | - | `apps/web/src/mocks/**`, `apps/web/e2e/helpers/**` | 7 | [refs/pr-2-msw-party-helper.md](refs/pr-2-msw-party-helper.md) |
+| PR-3 | W2 | test(e2e): game-redaction stubbed 복제본 | PR-1, PR-2 | `apps/web/e2e/game-redaction-stubbed.spec.ts`, `apps/web/src/mocks/handlers/**` | 4 | [refs/pr-3-redaction-stubbed.md](refs/pr-3-redaction-stubbed.md) |
+| PR-4 | W2 | test(e2e): clue-relation stubbed 복제본 | PR-1, PR-2 | `apps/web/e2e/clue-relation-stubbed.spec.ts`, `apps/web/src/mocks/handlers/clue.ts` | 4 | [refs/pr-4-clue-relation-stubbed.md](refs/pr-4-clue-relation-stubbed.md) |
+| PR-5 | W3 | ci(e2e): real-backend main push + workflow_dispatch | PR-3, PR-4 | `.github/workflows/phase-18.1-real-backend.yml`, `.github/workflows/e2e-stubbed.yml` | 4 | [refs/pr-5-ci-promotion.md](refs/pr-5-ci-promotion.md) |
+
+---
+
+## Merge 전략
+
+- Wave 내 병렬 PR은 `isolation: worktree`
+- 머지는 항상 **PR 번호 순** sequential
+- 각 머지 후 `go test -race -count=1 ./apps/server/...` + `pnpm --filter @mmp/web test` gate
+- Wave 종료 시 user 확인 1회
+- 충돌 발생 시 executor 서브에이전트에 해결 위임
+- 4-parallel review (security / code-reviewer / test-engineer / docs-navigator) per PR
+- Fix-loop 최대 3회 → 초과 시 user 개입
+
+---
+
+## Feature flag
+
+환경변수: `PLAYWRIGHT_STUBBED_EXPANSION` (default: `false`)
+
+- PR-1 ~ PR-2: 기존 테스트 영향 없음 — flag 불필요
+- PR-3 ~ PR-4: stubbed spec은 기본 비활성, CI에서만 flag=true
+- PR-5: main push post-merge 관측 — required 아님
+
+prod/stage 환경 영향 없음 (테스트 인프라 전용).
+
+---
+
+## 알려진 위험
+
+| 위험 | 완화 |
+|------|------|
+| MSW 셋업과 기존 page.route() 패턴 충돌 | PR-2에서 어댑터(`msw-route.ts`) 경계 명확화, 기존 editor-golden-path-fixtures는 유지 |
+| 4-context party flaky (WS handshake race) | `waitForGamePage` 전원 동기 대기 + 3 retry + timeout 30s |
+| real-backend alerting spam | 최초 3일은 알림 채널 staging에만, 안정화 후 main 채널로 |
+| 서버 optional 전환으로 기존 클라이언트 regression | 기존 handler 테스트 유지 + new 테스트만 추가 (subtractive 변경 없음) |
+
+---
+
+## 후속 phase
+
+- **Phase 18.9**: real-backend workflow `required` 승격 (branch protection 설정 변경)
+- **Phase 19.0**: Voting/엔딩 페이즈 커버리지 + MSW-Storybook 공유 (SSOT 확장)

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/architecture.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/architecture.md
@@ -1,0 +1,122 @@
+# Phase 18.8 — Architecture
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## 컴포넌트 맵
+
+```
+Backend (변경 최소)
+  └─ room/service.go
+     ├─ CreateRoomRequest { ThemeID, MaxPlayers *int32 (optional), IsPrivate }
+     └─ CreateRoom(): nil → theme.MaxPlayers fallback + 범위 재검증
+
+Frontend mocks (신규)
+  apps/web/src/mocks/
+    ├─ browser.ts          (setupWorker, dev/스토리북 사용 가능)
+    ├─ server.ts           (setupServer, Vitest 사용)
+    └─ handlers/
+        ├─ auth.ts         (POST /v1/auth/login, GET /v1/auth/me)
+        ├─ theme.ts        (GET /v1/themes, GET /v1/themes/:id)
+        ├─ room.ts         (POST /v1/rooms, GET /v1/rooms/:id)
+        ├─ clue.ts         (GET /v1/clues, GET /v1/clue-relations)
+        └─ game-ws.ts      (WS payload factory — role별 redacted)
+
+E2E helpers (신규 + 기존 재배치)
+  apps/web/e2e/helpers/
+    ├─ common.ts           (login, createRoom, createPartyOfN, waitForGamePage)
+    ├─ msw-route.ts        (MSW handler → Playwright page.route 어댑터)
+    └─ editor-golden-path-fixtures.ts  (기존 유지)
+
+E2E specs (신규)
+  apps/web/e2e/
+    ├─ game-redaction-stubbed.spec.ts  (신규, MSW+page.route 기반)
+    └─ clue-relation-stubbed.spec.ts   (신규, MSW 기반)
+
+CI (트리거 확장)
+  .github/workflows/
+    ├─ e2e-stubbed.yml                (+ workflow_dispatch)
+    └─ phase-18.1-real-backend.yml    (+ push: [main] 관측 모드)
+```
+
+---
+
+## 데이터 경로
+
+### HTTP 경로 (MSW 주도)
+
+```
+Playwright test
+  → page.goto('/login')
+  → fetch('/api/v1/auth/login')  ─┐
+                                  │
+               MSW Service Worker ◂ handlers/auth.ts
+                                  │
+  ← 200 { accessToken, user } ◂───┘
+```
+
+테스트에서는 `page.addInitScript(msw.start)` 또는 어댑터를 통해 `page.route()`로 등록.
+
+### WS 경로 (page.route 주도)
+
+```
+Test WS client
+  → new WebSocket('ws://.../session')
+          │
+  Playwright routeWebSocket intercept
+          │
+  game-ws.ts handler에서 role별 payload 생성:
+    • murderer  → { ... role:"murderer", secret_card:{...} }
+    • detective → { ... role:"detective", secret_card:"???" }
+    • normal    → { ... role:"normal",    secret_card:"???" }
+    • whisper   → 수신자 일치 시 전송, 불일치 시 필터
+```
+
+---
+
+## MSW handler 책임 경계
+
+| 핸들러 | 담당 | 사용처 |
+|--------|------|--------|
+| `auth.ts` | 로그인/토큰 갱신/me | stubbed spec 전부 |
+| `theme.ts` | 테마 목록/상세 | createRoom 플로우 |
+| `room.ts` | 방 생성/조회/join | party helper |
+| `clue.ts` | 단서 목록/관계 | `clue-relation-stubbed` |
+| `game-ws.ts` | WS payload factory (role-based redaction) | `game-redaction-stubbed` |
+
+**SSOT 원칙**: 응답 shape 변경 시 handler 한 곳만 수정. FE 컴포넌트와 spec이 모두 이 shape을 따름.
+
+---
+
+## party helper 설계
+
+```ts
+// apps/web/e2e/helpers/common.ts (개념)
+export async function createPartyOfN(
+  browser: Browser,
+  n: number,
+): Promise<{
+  host: Page;
+  guests: Page[];
+  roomId: string;
+}> {
+  // 1. n개 context 병렬 생성
+  // 2. 각 context에서 login (e2e@test.com ~ e2e+3@test.com)
+  // 3. host가 createRoom → roomId 반환
+  // 4. guests가 join(roomId) 병렬 실행
+  // 5. 전원 LobbyRoom 진입 대기 (Promise.all)
+}
+
+export async function waitForGamePage(pages: Page[], timeout = 30_000) {
+  // 전원 GamePage 진입 동기 대기. 하나라도 실패 시 throw.
+}
+```
+
+---
+
+## 결정 근거 (요약)
+
+- **왜 MSW를 도입하나**: H6(ThemeCard), H7(MaxPlayers) 둘 다 계약 drift. `page.route()`는 spec마다 분산되어 SSOT 부재. MSW handler를 한 곳에 두면 FE·E2E·Storybook·Vitest 모두 같은 계약 참조.
+- **왜 WS는 page.route인가**: MSW v2의 WS 지원은 실험 단계. Playwright 1.48+ `routeWebSocket`이 안정 + role별 redaction 테스트에 충분.
+- **왜 혼합인가**: 최대 재사용 + 최소 리스크. HTTP는 SSOT, WS는 안정성 우선.

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/execution-model.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/execution-model.md
@@ -1,0 +1,134 @@
+# Phase 18.8 — Execution Model (Wave DAG + 파일 구조)
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## Wave DAG
+
+```
+┌─────────────────────────────────────────────┐
+│ Wave 1 — Foundation (parallel, 2 worktree)  │
+│                                             │
+│   PR-1 fix/rooms-maxplayers-optional        │
+│       (Go backend, scope: room/**)          │
+│                                             │
+│   PR-2 test/e2e-msw-helpers                 │
+│       (FE infra, scope: mocks/** + e2e/**)  │
+│                                             │
+│   gate: 4-reviewer + tests pass → merge     │
+└─────────────────────────────────────────────┘
+                    │
+                    ▼
+┌─────────────────────────────────────────────┐
+│ Wave 2 — Stub Expansion (parallel, 2 wt)    │
+│                                             │
+│   PR-3 test/e2e-redaction-stubbed           │
+│       (scope: game-redaction-stubbed.spec)  │
+│                                             │
+│   PR-4 test/e2e-clue-relation-stubbed       │
+│       (scope: clue-relation-stubbed.spec)   │
+│                                             │
+│   gate: stubbed CI ≤3 skip + review → merge │
+└─────────────────────────────────────────────┘
+                    │
+                    ▼
+┌─────────────────────────────────────────────┐
+│ Wave 3 — CI Promotion (sequential, 1 wt)    │
+│                                             │
+│   PR-5 ci/e2e-real-backend-gate             │
+│       (scope: .github/workflows/**)         │
+│                                             │
+│   gate: main push trigger 확인 + 알림 도달  │
+└─────────────────────────────────────────────┘
+                    │
+                    ▼
+         3일 nightly green 관측
+                    │
+                    ▼
+              /plan-finish
+```
+
+---
+
+## 의존성 분석
+
+| PR | 직접 의존 | 간접 의존 |
+|----|----------|----------|
+| PR-1 | - | - |
+| PR-2 | - | - |
+| PR-3 | PR-1 (API optional), PR-2 (MSW foundation) | - |
+| PR-4 | PR-1 (관계 없음 but MSW), PR-2 (MSW foundation) | - |
+| PR-5 | PR-3, PR-4 (stubbed CI 안정화 후) | PR-1, PR-2 |
+
+**topological sort**: [PR-1, PR-2] → [PR-3, PR-4] → [PR-5]
+
+---
+
+## Scope globs (per PR)
+
+```yaml
+PR-1:
+  - apps/server/internal/domain/room/**
+  - apps/server/internal/domain/room/**_test.go
+  # 제외: db/migrations/** (컬럼 변경 없음)
+
+PR-2:
+  - apps/web/src/mocks/**
+  - apps/web/e2e/helpers/**
+  - apps/web/playwright.config.ts
+  - apps/web/e2e/game-session.spec.ts  # helper 리팩터 대상
+  - apps/web/package.json              # msw dep 추가
+
+PR-3:
+  - apps/web/e2e/game-redaction-stubbed.spec.ts
+  - apps/web/src/mocks/handlers/game-ws.ts
+  - apps/web/src/mocks/handlers/index.ts
+
+PR-4:
+  - apps/web/e2e/clue-relation-stubbed.spec.ts
+  - apps/web/src/mocks/handlers/clue.ts
+
+PR-5:
+  - .github/workflows/phase-18.1-real-backend.yml
+  - .github/workflows/e2e-stubbed.yml
+  - docs/plans/2026-04-16-e2e-skip-recovery/refs/ci-promotion.md
+```
+
+**충돌 분석**: W1의 PR-1과 PR-2는 디렉토리 disjoint. W2의 PR-3, PR-4는 `handlers/` 공유하지만 서로 다른 파일(`game-ws.ts` vs `clue.ts`) → 충돌 없음.
+
+---
+
+## 브랜치 / 워크트리 네이밍
+
+```
+fix/rooms-maxplayers-optional     (PR-1)
+test/e2e-msw-helpers              (PR-2)
+test/e2e-redaction-stubbed        (PR-3)
+test/e2e-clue-relation-stubbed    (PR-4)
+ci/e2e-real-backend-gate          (PR-5)
+```
+
+워크트리 경로: `/tmp/phase-18.8/{PR-N}` 또는 플러그인 기본값.
+
+---
+
+## 속도 계산
+
+- 순차 실행: 5T (PR-1 → PR-2 → PR-3 → PR-4 → PR-5)
+- 병렬 실행: 3T (W1: 1T, W2: 1T, W3: 1T)
+- 단축률: (5-3)/5 = **40%**
+
+---
+
+## 실행 단위 (T) 추정
+
+| PR | 예상 단위 | 근거 |
+|----|----------|------|
+| PR-1 | 1T | Go 3~4 파일, 기존 테스트 확장. 소규모 |
+| PR-2 | 1.5T | MSW 셋업 + helper + config + spec 리팩터. 가장 큼 |
+| PR-3 | 0.8T | MSW handler 1 + spec 1. 중간 |
+| PR-4 | 0.8T | 동등 |
+| PR-5 | 0.5T | workflow YAML 2개 |
+
+W1 최대(PR-2) = 1.5T, W2 최대(PR-3) = 0.8T, W3 = 0.5T → 총 2.8T 병렬 (여유 0.2T)

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/observability-testing.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/observability-testing.md
@@ -1,0 +1,99 @@
+# Phase 18.8 — Observability & Testing
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## 검증 시나리오
+
+### PR-1 — 서버 optional 수용
+
+| # | 시나리오 | 기대 |
+|---|---------|------|
+| 1 | `POST /v1/rooms { theme_id: T }` (MaxPlayers 생략) | 201 + `response.max_players = theme.max_players` (=8) |
+| 2 | `POST /v1/rooms { theme_id: T, max_players: 6 }` (범위 내) | 201 + `response.max_players = 6` |
+| 3 | `POST /v1/rooms { theme_id: T, max_players: 1 }` (테마 min 미달) | 400 VALIDATION_ERROR |
+| 4 | `POST /v1/rooms { theme_id: T, max_players: 99 }` (테마 max 초과) | 400 VALIDATION_ERROR |
+
+### PR-2 — MSW foundation 동작
+
+| # | 시나리오 | 기대 |
+|---|---------|------|
+| 1 | Vitest에서 `setupServer(auth)` → `login()` 호출 | MSW가 가로채 200 반환 |
+| 2 | Playwright에서 `msw-route(auth+theme)` 후 `login()` → lobby 렌더 | 성공 |
+| 3 | `createPartyOfN(browser, 4)` | 4 context 병렬 LobbyRoom 도달 |
+| 4 | helper 없이 기존 `game-session.spec`이 여전히 pass | 회귀 없음 |
+
+### PR-3 — redaction 검증
+
+| # | 시나리오 | 기대 |
+|---|---------|------|
+| 1 | 범인 역할 수신 시 | `secret_card.contents != "???"` |
+| 2 | 일반/탐정 역할 수신 시 | `secret_card.contents == "???"` |
+| 3 | whisper 발신자≠수신자 | 해당 메시지 DOM 미출현 |
+| 4 | 역할 카드 영역 role-scoped 데이터만 표시 | PASS |
+
+### PR-4 — clue-relation 검증
+
+| # | 시나리오 | 기대 |
+|---|---------|------|
+| 1 | 단서 2개 이상 시 노드 렌더 | React Flow node count ≥2 |
+| 2 | 엣지 있으면 edge 렌더 | edge count ≥1 |
+| 3 | 노드 클릭 → 관련 엣지 하이라이트 | class 변경 |
+
+### PR-5 — CI gate
+
+| # | 시나리오 | 기대 |
+|---|---------|------|
+| 1 | main push 후 real-backend workflow 자동 실행 | run 생성 |
+| 2 | 의도적 실패 커밋 후 revert | 실패 run + 알림 도달 (staging 채널) |
+| 3 | `workflow_dispatch`로 PR에서 수동 실행 | run 생성 가능 |
+
+---
+
+## 메트릭
+
+| 지표 | 시작 | 목표 | 측정 방법 |
+|------|------|------|----------|
+| E2E pass 수 | 4 | ≥13 | Playwright JSON report 파싱 |
+| E2E skip 수 | 11 | ≤3 | 동일 |
+| E2E fail 수 | 0 | 0 | 동일 |
+| stubbed CI 소요 | ~8분 | ≤10분 (MSW 로드로 소폭 증가 허용) | workflow run duration |
+| real-backend nightly green streak | 0 | ≥3 | run history |
+
+---
+
+## Flaky 가드
+
+| 패턴 | 대책 |
+|------|------|
+| WS handshake race (party helper) | 전원 LobbyRoom 진입 `Promise.all` + timeout 30s + retry 3 |
+| MSW worker register 타이밍 | `page.waitForLoadState("networkidle")` 후 fetch |
+| React Flow layout race | `graph.react-flow__node` 개수 expect + toHaveCount |
+| real-backend Postgres startup | healthcheck `pg_isready` 루프 (기존 유지) |
+
+---
+
+## 로깅
+
+- 서버 PR-1: theme fallback 발생 시 `info` 로그 `room.create theme-fallback theme_id=<...> max_players=<...>`
+- Playwright: `trace: "retain-on-failure"` (CI) — trace.zip 업로드
+- real-backend workflow: server stdout 전체를 artifact (기존 유지)
+
+---
+
+## 에러 분류
+
+| 코드 | 상황 |
+|------|------|
+| `VALIDATION_ERROR` | PR-1 범위 벗어남 |
+| `ROOM_THEME_NOT_FOUND` | theme_id 존재 안 함 |
+| (e2e) `PartyTimeout` | party helper 내 guest 중 1명 LobbyRoom 미도달 |
+| (e2e) `PhaseTimeout` | GamePage 페이즈 전환 타임아웃 |
+
+---
+
+## 알림
+
+- staging Slack `#e2e-staging` (3일 관측 기간)
+- 3일 green 이후 `#ci-alerts` main 채널 이관 (Phase 18.9에서)

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-1-maxplayers-optional.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-1-maxplayers-optional.md
@@ -1,0 +1,89 @@
+# PR-1 — fix(rooms): MaxPlayers optional + theme fallback
+
+> 부모: [../plan.md](../plan.md)
+> Wave: 1 (parallel) | 의존: - | 브랜치: `fix/rooms-maxplayers-optional`
+
+---
+
+## 목적
+
+H7 해결: `CreateRoomRequest.MaxPlayers`가 `validate:"required"`라 FE가 생략하면 400. FE는 이미 `theme_id`만 보내도록 설계되어 있으므로 서버에서 optional 수용 + theme 기본값 fallback으로 정렬.
+
+---
+
+## Scope
+
+```yaml
+scope_globs:
+  - apps/server/internal/domain/room/service.go
+  - apps/server/internal/domain/room/handler.go
+  - apps/server/internal/domain/room/handler_test.go
+  - apps/server/internal/domain/room/service_test.go  # 신규
+```
+
+**변경 없음**: `db/migrations/**`, `db/queries/**`, FE 전부.
+
+---
+
+## Tasks
+
+### Task 1 — Request 구조 변경
+- `service.go:19-24` `CreateRoomRequest.MaxPlayers`를 `*int32`로 변경
+- validate 태그 `required,min=2,max=12` → `omitempty,min=2,max=12`
+- JSON 직렬화 확인: nil이면 `"max_players"` 필드 자체가 omit되도록 (or 안 보내면 nil)
+
+### Task 2 — Service fallback 로직
+- `service.go:129-187 CreateRoom`:
+  1. `theme, err := s.themeRepo.GetByID(ctx, req.ThemeID)` 호출 (기존 있으면 재사용, 없으면 신규)
+  2. `maxPlayers := theme.MaxPlayers` 기본값
+  3. `if req.MaxPlayers != nil` → `maxPlayers = *req.MaxPlayers`
+  4. 범위 검증: `theme.MinPlayers ≤ maxPlayers ≤ theme.MaxPlayers`
+  5. 범위 밖이면 `AppError` VALIDATION_ERROR 반환
+  6. `CreateRoomParams.MaxPlayers = maxPlayers`로 저장
+
+### Task 3 — handler_test 확장
+- 기존 케이스 유지
+- 추가:
+  - optional 생략 → 201 + fallback 적용 확인
+  - 범위 밖 → 400 VALIDATION_ERROR
+
+### Task 4 — service_test 테이블 테스트
+- 신규 `service_test.go`:
+  - min-1 → error
+  - min → OK
+  - max → OK
+  - max+1 → error
+  - nil → theme default
+
+### Task 5 — after_task pipeline
+- `go fmt ./apps/server/...`
+- `go test -race -count=1 ./apps/server/internal/domain/room/...`
+- scope 내 변경 파일 `wc -l` 500줄 이하 확인
+
+---
+
+## 핵심 파일 참조
+
+| 파일 | 역할 |
+|------|------|
+| `service.go:19-24` | CreateRoomRequest struct |
+| `service.go:129-187` | CreateRoom impl (theme 조회 추가) |
+| `handler.go:28-47` | ReadJSON + validation (변경 없음) |
+| `httputil/json.go:26-41` | validator 체인 (자동 omitempty 처리) |
+| `db/migrations/00004_rooms.sql:8` | max_players NOT NULL (변경 없음) |
+
+---
+
+## 검증
+
+- `curl -X POST localhost:8080/api/v1/rooms -H "Auth..." -d '{"theme_id":"<uuid>"}'` → 201 + `response.max_players == 8`
+- `curl -X POST localhost:8080/api/v1/rooms -H "Auth..." -d '{"theme_id":"<uuid>", "max_players": 1}'` → 400
+- 기존 E2E `game-session.spec.ts`에서 `NO_THEMES` 관련 skip 감소 확인 (수동)
+
+---
+
+## 리뷰 포인트
+
+- 서버 로그에 `theme-fallback` info log 남기는지
+- `room.max_players`는 여전히 NOT NULL (저장 시점엔 always 값)
+- 기존 테스트 전부 green (subtractive 변경 없음)

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-2-msw-party-helper.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-2-msw-party-helper.md
@@ -1,0 +1,97 @@
+# PR-2 — test(e2e): MSW foundation + party helper
+
+> 부모: [../plan.md](../plan.md)
+> Wave: 1 (parallel) | 의존: - | 브랜치: `test/e2e-msw-helpers`
+
+---
+
+## 목적
+
+(1) HTTP 계약 SSOT를 MSW v2로 확립 — Vitest·Playwright·(장래)Storybook이 동일 handler 공유. (2) 7개 spec에 중복된 `login()`과 없었던 `createPartyOfN` 공용 헬퍼 제공.
+
+---
+
+## Scope
+
+```yaml
+scope_globs:
+  - apps/web/src/mocks/**
+  - apps/web/e2e/helpers/common.ts
+  - apps/web/e2e/helpers/msw-route.ts
+  - apps/web/playwright.config.ts
+  - apps/web/e2e/game-session.spec.ts  # 리팩터 대상
+  - apps/web/package.json
+```
+
+---
+
+## Tasks
+
+### Task 1 — MSW v2 설치 + 셋업
+- `pnpm --filter @mmp/web add -D msw@^2`
+- `apps/web/src/mocks/browser.ts`: `setupWorker(...handlers)`
+- `apps/web/src/mocks/server.ts`: `setupServer(...handlers)` (Vitest용)
+- `apps/web/src/mocks/handlers/index.ts`: 모든 handler 배럴 export
+
+### Task 2 — 초기 handler 4종
+- `handlers/auth.ts`: POST /v1/auth/login, GET /v1/auth/me, POST /v1/auth/refresh
+- `handlers/theme.ts`: GET /v1/themes (seed 4인 테마 1건), GET /v1/themes/:id
+- `handlers/room.ts`: POST /v1/rooms (theme_id만 받아도 PR-1 기준으로 201), GET /v1/rooms/:id
+- `handlers/clue.ts`: GET /v1/clues, GET /v1/clue-relations (빈 배열 기본)
+
+### Task 3 — msw-route 어댑터
+- `apps/web/e2e/helpers/msw-route.ts`:
+  ```ts
+  // MSW handler → Playwright page.route 변환
+  export async function installMswRoutes(page: Page, handlers: RequestHandler[])
+  ```
+- MSW Service Worker 대신 Playwright가 request 인터셉트
+
+### Task 4 — common.ts helper
+- `login(page, email?, password?)` — 7개 spec의 중복 통합
+- `createRoom(page): Promise<roomId>` — createRoom modal 열기 → 테마 선택 → 제출
+- `createPartyOfN(browser, n): Promise<{host, guests, roomId}>` — n context × login + join
+- `waitForGamePage(pages: Page[], timeout?)` — 전원 동기 대기
+
+### Task 5 — playwright.config.ts fixtures
+- `test.extend<Fixtures>({ authenticatedPage, multiPartyContext })`
+- fixtures는 `common.ts` helper를 자동 주입
+
+### Task 6 — 기존 spec 리팩터
+- `game-session.spec.ts` 1건을 `login()` 공용 helper로 교체
+- 테스트 pass 확인 (회귀 없음)
+
+### Task 7 — helper 단위 테스트 + pipeline
+- `apps/web/src/mocks/handlers/*.test.ts` (Vitest) — handler shape validation
+- `pnpm --filter @mmp/web test` pass
+- `pnpm --filter @mmp/web test:e2e game-session.spec` pass
+- after_task: format + scope test
+
+---
+
+## 핵심 파일 참조
+
+| 파일 | 역할 |
+|------|------|
+| `CreateRoomModal.tsx:36-37` | 페이로드 구조 (MSW room.ts 기준) |
+| `features/lobby/api.ts:158-165` | createRoom client (MSW가 가로챌 엔드포인트) |
+| `editor-golden-path-fixtures.ts:268-281` | 기존 login helper 패턴 |
+| `e2e-themes.sql:19-25` | MSW theme.ts 기본 응답 shape 참조 |
+
+---
+
+## 검증
+
+- `pnpm --filter @mmp/web test -- mocks/handlers` pass
+- `pnpm --filter @mmp/web test:e2e game-session.spec` pass (리팩터 후)
+- `wc -l apps/web/e2e/helpers/common.ts` ≤ 400줄
+- 각 handler 파일 ≤ 200줄
+
+---
+
+## 리뷰 포인트
+
+- MSW v2 API 정확성 (http.post / http.get 최신)
+- handler 응답 shape이 서버 실제 응답과 일치 (drift 방지)
+- Playwright fixtures가 기존 spec 영향 없는지 (opt-in)
+- `party` helper의 n=4 기본값, n=1~8 범위 허용

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-3-redaction-stubbed.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-3-redaction-stubbed.md
@@ -1,0 +1,85 @@
+# PR-3 — test(e2e): game-redaction stubbed 복제본
+
+> 부모: [../plan.md](../plan.md)
+> Wave: 2 (parallel) | 의존: PR-1, PR-2 | 브랜치: `test/e2e-redaction-stubbed`
+
+---
+
+## 목적
+
+`game-redaction.spec.ts`는 `PLAYWRIGHT_BACKEND` env gate로 stubbed CI에서 전체 skip. 본질은 "role에 따라 서버 payload에서 민감 정보가 가려지는지"로, 이는 FE 렌더링 로직 검증 → MSW HTTP + Playwright WS route 조합으로 재현 가능. 실제 backend 없이 stubbed CI에서 pass하는 복제본 spec 신규.
+
+---
+
+## Scope
+
+```yaml
+scope_globs:
+  - apps/web/e2e/game-redaction-stubbed.spec.ts
+  - apps/web/src/mocks/handlers/game-ws.ts
+  - apps/web/src/mocks/handlers/index.ts
+```
+
+---
+
+## Tasks
+
+### Task 1 — game-ws handler factory
+- `handlers/game-ws.ts`:
+  ```ts
+  export function createGameWsRoute(role: "murderer"|"detective"|"normal")
+  export function createWhisperRoute(senderId: string, receiverId: string)
+  ```
+- Role별 payload 4종:
+  - `normal`: `secret_card: "???"`, 역할 카드 일반
+  - `murderer`: `secret_card: {...full...}`, 역할 카드에 범인 정보
+  - `detective`: `secret_card: "???"`, 탐정 전용 단서 표시
+  - `whisper`: sender/receiver 매칭 시에만 DOM 출현
+
+### Task 2 — game-redaction-stubbed.spec.ts
+- 구조는 `game-redaction.spec.ts` 참조
+- `test.beforeEach`에서 `installMswRoutes(page, [auth, theme, room])` + `page.routeWebSocket` 등록
+- 4 시나리오 전부 stubbed에서 수행:
+  1. 범인 역할 payload 검증 — `secret_card.contents` 실제 값 노출
+  2. 일반/탐정 역할 payload 검증 — `"???"` 마스킹
+  3. whisper 수신자 매칭 — DOM 노출
+  4. whisper 수신자 비매칭 — DOM 미노출
+
+### Task 3 — 기존 spec 주석 연동
+- `game-redaction.spec.ts` 파일 최상단에 코멘트:
+  ```
+  // Stubbed 복제본: game-redaction-stubbed.spec.ts
+  // 이 spec은 PLAYWRIGHT_BACKEND 환경에서만 실행. stubbed CI는 복제본으로 검증.
+  ```
+
+### Task 4 — after_task pipeline
+- `pnpm --filter @mmp/web test:e2e game-redaction-stubbed` 로컬 pass
+- stubbed CI에서 4 시나리오 pass 확인
+- `game-redaction-stubbed.spec.ts` 250줄 이내 (helper 활용으로)
+
+---
+
+## 핵심 파일 참조
+
+| 파일 | 역할 |
+|------|------|
+| `game-redaction.spec.ts` | 시나리오 원본 참조 |
+| `handlers/game-ws.ts` (PR-2에서 shell 생성) | role factory 구현 |
+| `common.ts:createPartyOfN` | 4인 컨텍스트 구성 (수신자 ID 부여용) |
+| Playwright `page.routeWebSocket` (1.48+) | WS intercept |
+
+---
+
+## 검증
+
+- 로컬: `pnpm test:e2e game-redaction-stubbed` 4/4 pass
+- CI: `e2e-stubbed.yml` 실행 시 4 시나리오 pass
+- 기존 `game-redaction.spec.ts`는 여전히 nightly에서 real backend로 실행
+
+---
+
+## 리뷰 포인트
+
+- `routeWebSocket` 패턴 정확성 (Playwright 버전 체크)
+- role 매핑 로직이 서버 실제 redaction과 일치 (drift 방지 — `snapshot redaction` 스펙 참조)
+- flaky 위험: WS 연결 타이밍 → `page.waitForEvent("websocket")` + route 먼저 설치

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-4-clue-relation-stubbed.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-4-clue-relation-stubbed.md
@@ -1,0 +1,76 @@
+# PR-4 — test(e2e): clue-relation stubbed 복제본
+
+> 부모: [../plan.md](../plan.md)
+> Wave: 2 (parallel) | 의존: PR-1, PR-2 | 브랜치: `test/e2e-clue-relation-stubbed`
+
+---
+
+## 목적
+
+`clue-relation-live.spec.ts`는 real backend 전용으로 stubbed CI에서 skip. 본질은 "서버가 주는 단서 그래프가 React Flow로 올바르게 렌더되는지"로, 서버 로직 검증이 아니라 **FE 렌더링 검증**. MSW clue handler로 노드/엣지 응답을 만들어 stubbed CI에서 pass하는 복제본 신규.
+
+---
+
+## Scope
+
+```yaml
+scope_globs:
+  - apps/web/e2e/clue-relation-stubbed.spec.ts
+  - apps/web/src/mocks/handlers/clue.ts
+```
+
+---
+
+## Tasks
+
+### Task 1 — clue handler 확장
+- PR-2에서 shell만 있는 `handlers/clue.ts`를 확장:
+  ```ts
+  GET /v1/clue-relations   → 기본 { nodes: [...], edges: [...] }
+  GET /v1/clues            → 단서 배열 (ID 기반)
+  POST /v1/clue-relations  → 신규 엣지 생성 (stub echo)
+  DELETE /v1/clue-relations/:id → 204
+  ```
+- 기본 fixture: 단서 3개 + 엣지 2개 (시나리오 2~3 커버)
+
+### Task 2 — clue-relation-stubbed.spec.ts
+- 구조는 `clue-relation-live.spec.ts` 참조
+- `test.beforeEach`에서 `installMswRoutes(page, [auth, theme, clue])`
+- 3 시나리오:
+  1. 단서 2개 이상 시 React Flow `.react-flow__node` 렌더 (count ≥2)
+  2. 엣지 있으면 `.react-flow__edge` 렌더 (count ≥1)
+  3. 노드 클릭 → 관련 엣지 하이라이트 (class 변경 확인)
+
+### Task 3 — 원본 spec 주석 연동
+- `clue-relation-live.spec.ts` 최상단 코멘트로 복제본 존재 표기 + PLAYWRIGHT_BACKEND 전용임을 재확인
+
+### Task 4 — after_task pipeline
+- `pnpm --filter @mmp/web test:e2e clue-relation-stubbed` 로컬 pass
+- stubbed CI pass
+- `clue-relation-stubbed.spec.ts` 200줄 이내
+
+---
+
+## 핵심 파일 참조
+
+| 파일 | 역할 |
+|------|------|
+| `clue-relation-live.spec.ts` | 원본 시나리오 참조 |
+| React Flow `.react-flow__node` 셀렉터 | assertion 대상 |
+| `handlers/clue.ts` (PR-2 shell) | 확장 대상 |
+
+---
+
+## 검증
+
+- 로컬: `pnpm test:e2e clue-relation-stubbed` 3/3 pass
+- CI: stubbed workflow 3 시나리오 pass
+- 기존 `clue-relation-live.spec.ts`는 nightly 전용
+
+---
+
+## 리뷰 포인트
+
+- React Flow layout 비동기 race — `await expect(nodes).toHaveCount(n)` 사용
+- 엣지 클릭 인터랙션 assertion이 layout 완료 이후인지
+- fixture의 노드 id가 edges와 정합 (orphan edge 없음)

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-5-ci-promotion.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/pr-5-ci-promotion.md
@@ -1,0 +1,98 @@
+# PR-5 — ci(e2e): real-backend main push + workflow_dispatch
+
+> 부모: [../plan.md](../plan.md)
+> Wave: 3 (sequential) | 의존: PR-3, PR-4 | 브랜치: `ci/e2e-real-backend-gate`
+
+---
+
+## 목적
+
+`phase-18.1-real-backend.yml`을 `main` push에 post-merge 관측 모드로 연결 (required 아님) + `e2e-stubbed.yml`에 `workflow_dispatch` 추가. 3일 연속 green 달성 시 Phase 18.9에서 required로 승격하는 **점진적 승격 패턴**의 1단계.
+
+---
+
+## Scope
+
+```yaml
+scope_globs:
+  - .github/workflows/phase-18.1-real-backend.yml
+  - .github/workflows/e2e-stubbed.yml
+  - docs/plans/2026-04-16-e2e-skip-recovery/refs/ci-promotion.md
+```
+
+---
+
+## Tasks
+
+### Task 1 — real-backend trigger 확장
+- `phase-18.1-real-backend.yml:8-18` 트리거 블록:
+  ```yaml
+  on:
+    schedule:
+      - cron: "0 2 * * *"
+    push:
+      branches: [main]
+    workflow_dispatch:
+  ```
+- 기존 schedule·workflow_dispatch 유지
+
+### Task 2 — 알림 step 추가
+- job 마지막에 failure 조건부 step:
+  ```yaml
+  - name: Notify staging channel on failure
+    if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
+    uses: slackapi/slack-github-action@<SHA>
+    with:
+      channel-id: ${{ secrets.E2E_STAGING_CHANNEL }}
+      slack-message: "real-backend E2E failed on ${{ github.sha }}"
+  ```
+- Discord 대체도 허용 (사용자 선호)
+- **required 체크 아님** — main에 failing run 남아도 merge 차단 X
+
+### Task 3 — e2e-stubbed dispatch
+- `e2e-stubbed.yml:16-20` 트리거에 `workflow_dispatch` 추가
+- PR에서 필요 시 수동으로 stubbed CI 재실행 가능
+
+### Task 4 — ci-promotion.md 문서화
+- `refs/ci-promotion.md` 신규:
+  - 3일 green 관측 조건
+  - Phase 18.9에서 수행할 후속 작업 (branch protection 설정, required 승격)
+  - 알림 채널 staging → main 이관 타이밍
+
+---
+
+## 핵심 파일 참조
+
+| 파일 | 역할 |
+|------|------|
+| `phase-18.1-real-backend.yml:8-18` | 기존 trigger 블록 |
+| `e2e-stubbed.yml:16-20` | 기존 PR CI trigger |
+| GitHub docs: branch protection | 후속 PR 참조 |
+
+---
+
+## 검증
+
+- PR 머지 후 main에 커밋 push → real-backend workflow `Actions` 탭에서 자동 실행 확인
+- 의도적 failing 커밋(예: 임시로 Playwright 1건 `expect(false)`) push → 알림 staging 채널 도달 확인 → revert
+- `e2e-stubbed.yml`을 PR에서 workflow_dispatch 버튼으로 수동 실행 가능 확인
+- 기존 nightly schedule은 변경 없이 동작
+
+---
+
+## 리뷰 포인트
+
+- action SHA pinning 준수 (Phase 18.7 규약)
+- `if: failure()` 조건이 success 케이스 알림 누락 방지
+- required 아님을 명시적으로 기록 (branch protection 변경 없음)
+- 알림 spam 방지: staging 채널 사용
+- secrets: `E2E_STAGING_CHANNEL` 저장소 secret에 추가 필요 (사용자 수동 작업)
+
+---
+
+## 완료 후 관측 단계 (Phase 종료 조건)
+
+- main push trigger 3회 이상 성공
+- nightly 3회 연속 green
+- 실패 알림 도달 1회 이상 관측 (의도적 테스트 또는 자연 발생)
+- 이상 확인 시 `/plan-finish` 실행 → Phase 18.9 예약

--- a/docs/plans/2026-04-16-e2e-skip-recovery/refs/scope-and-decisions.md
+++ b/docs/plans/2026-04-16-e2e-skip-recovery/refs/scope-and-decisions.md
@@ -1,0 +1,78 @@
+# Phase 18.8 — Scope & 7대 결정 상세
+
+> 부모: [../design.md](../design.md)
+
+---
+
+## 1. Scope
+
+### In scope
+
+| 카테고리 | 항목 | 근거 |
+|---------|------|------|
+| Backend | `CreateRoomRequest.MaxPlayers` optional + theme fallback | H7 루트. Phase 18.6→18.7 이관 후 미해결 |
+| E2E 인프라 | MSW v2 foundation (HTTP SSOT) | 계약 drift 예방 (H6/H7 재발 방지) |
+| E2E 인프라 | Playwright fixtures + common helpers | 7개 spec login 중복 제거 |
+| 멀티플레이 | `createPartyOfN(n=4)` | 머더미스터리 본질 시나리오 |
+| 검증 깊이 | Investigation 단서 수신까지 | redaction spec과 시너지, Voting은 후속 |
+| Stub 복제 | `game-redaction-stubbed`, `clue-relation-stubbed` | stubbed CI에서 redaction/clue 회귀 감지 |
+| CI | real-backend main push post-merge 관측 | 3일 green 축적 → required 승격 전 단계 |
+| CI | `workflow_dispatch` 확장 | PR 필요 시 수동 real-backend 검증 |
+
+### Out of scope
+
+- Voting/엔딩 페이즈 커버리지 → Phase 19.0
+- real-backend `required` 승격 → Phase 18.9 (3일 green 달성 후)
+- MSW 핸들러를 Storybook/Vitest와 공유 → Phase 19.0 SSOT 확장
+- `PLAYWRIGHT_BACKEND` env gate 3 spec 원본 수정 (nightly 유지)
+
+---
+
+## 2. 7대 결정 상세
+
+### 결정 1 — Scope: **C (최대)**
+- A (H7만) / B (H7+stub) / **C (H7+stub+multi-context+CI)**
+- 선택: C. 이유: 회귀 방지망을 런타임 전반으로 확장. 머더미스터리 특성상 멀티플레이 검증은 필수.
+
+### 결정 2 — H7 아키텍처: **서버 optional + theme fallback**
+- 탐색 결과: FE `CreateRoomModal`은 이미 `theme_id`만 전송 → FE 변경 불필요
+- 서버: `MaxPlayers *int32` + `omitempty` + nil 시 `theme.MaxPlayers` 사용
+- 범위 검증은 `theme.MinPlayers` ~ `theme.MaxPlayers`로 theme-relative
+- `rooms.max_players` 컬럼은 NOT NULL 유지 (저장 시점엔 항상 값)
+
+### 결정 3 — Multi-user lifecycle: **P1 단일 테스트 N-context**
+- P1 / P2 (fixture) / P3 (solo 1인 테마)
+- 선택: P1. `browser.newContext()` × 4 → host/guest 분리 제어
+- `createPartyOfN(browser, 4)` helper로 길이 문제 관리 (각 spec 150줄 이내)
+
+### 결정 4 — Stub 기술: **혼합 (HTTP MSW + WS page.route)**
+- MSW v2는 HTTP의 SSOT. Vitest·Playwright·dev 공유 가능
+- WS는 MSW v2 지원 불안정 → Playwright `page.route()`/`page.routeWebSocket()` 사용
+- 기존 `editor-golden-path-fixtures.ts` (page.route) 패턴과 공존
+- 어댑터 `msw-route.ts`로 MSW handler를 page.route로 변환 가능하게
+
+### 결정 5 — Persistence: **기존 `e2e-themes.sql` 재사용**
+- 이미 min=4, max=8, PUBLISHED, 4 캐릭터 — 요구 충족
+- 추가 seed 파일 불필요
+
+### 결정 6 — 운영 안전성: **점진적 CI gate**
+- main push post-merge 관측 (알림 전용, required 아님)
+- 3일 연속 green → 별도 후속 PR(Phase 18.9)에서 required 승격
+- 최초 3일 알림은 staging 채널, 안정화 후 main 채널로
+
+### 결정 7 — 도입 전략: **3 Wave / 5 PR / worktree 병렬**
+- W1 Foundation (PR-1, PR-2) parallel — 서로 독립
+- W2 Stub (PR-3, PR-4) parallel — W1 완료 후
+- W3 CI (PR-5) sequential — 전체 완료 후 관측 시작
+
+---
+
+## 기각된 대안
+
+| 대안 | 기각 사유 |
+|------|----------|
+| A (H7만) | 회귀 방지망 확장 목표 미달 |
+| ①FE가 MaxPlayers 전송 | UI 변경 필요, 테마 min/max 조정 UI 논쟁 유발 |
+| γ 3 spec 모두 stubbed + real 중복 | 유지비 2배, 가치 중복 |
+| R2 main push required gate | flaky 1건이 팀 전체 차단 — 베타 단계 과도 |
+| P2 fixture | WS 세션 race + lifecycle 복잡, 단일 테스트 N-context가 명확 |


### PR DESCRIPTION
## Summary
- Phase 18.8 설계·계획·체크리스트 스펙 정립 (5 PR / 3 Wave)
- MSW v2 foundation 도입, `createPartyOfN` 멀티 컨텍스트 helper, stubbed 복제 spec 2종, real-backend 점진 승격 gate
- H7 루트(`MaxPlayers` 계약 drift) + live 3종 skip + multi-context 미검증을 모두 해소

## Wave 구조
| Wave | Mode | PRs |
|------|------|-----|
| W1 | parallel | PR-1 MaxPlayers optional / PR-2 MSW + party helper |
| W2 | parallel | PR-3 redaction stubbed / PR-4 clue-relation stubbed |
| W3 | sequential | PR-5 real-backend main push gate |

## 7대 결정
C 스코프 / H7 서버 optional / MSW+page.route 혼합 / P1 N-context / 기존 seed / 점진 CI 승격 / worktree 병렬. 상세는 `refs/scope-and-decisions.md`.

## Test plan
- [x] 12개 MD 파일 200줄 이하 (최대 134줄)
- [x] STATUS marker 포함
- [x] active-plan.json JSON valid
- [ ] `/plan-start docs/plans/2026-04-16-e2e-skip-recovery` 활성화
- [ ] `/plan-go`로 Wave 1 병렬 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)