### PR TITLE
docs(repo): main 직접 push 금지 + feature branch + PR 워크플로우 규칙

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,58 @@
 - Semantic Versioning, Conventional Commits (feat/fix/perf/docs/test/chore)
 - 브랜치: main, feat/*, fix/*
 
+## 🔴 Git 워크플로우 (main 브랜치 보호)
+
+> **main 직접 push 금지.** 이 레포는 GitHub branch protection으로 PR 필수 + 15개 status check 필수가 걸려있다. bypass 권한이 있어도 사용하지 않는다.
+
+### 필수 규칙
+1. **모든 변경은 feature 브랜치 + PR** — 문서·계획·설정 파일이라도 예외 없음. Phase 19 감사 shadow plan, CLAUDE.md 규칙 업데이트, memory/ 편집 전부 포함.
+2. **`git push origin main` 금지** — 사용자가 명시적으로 "bypass 해라"라고 지시할 때만 예외.
+3. **실수로 main에 직접 커밋했다면** — 즉시 사용자에게 보고하고 `git revert` + PR 재작업 여부를 확인. 임의 push 금지.
+4. **PR 생성 전에 사용자 확인** — 브랜치 이름·커밋 범위를 먼저 보여주고 승인 받은 뒤 `gh pr create`.
+
+### 브랜치 네이밍 (Conventional Commit prefix + 슬러그)
+- `feat/<scope>-<slug>` · `fix/<scope>-<slug>` · `docs/<scope>-<slug>`
+- `chore/<scope>-<slug>` · `test/<scope>-<slug>` · `ci/<scope>-<slug>` · `perf/<scope>-<slug>`
+- scope 예: `phase-19`, `phase-18.8`, `rooms`, `editor`, `ws`, `ci-workflow`
+
+### 워크플로우
+```bash
+# 1. 작업 시작 전 브랜치 생성
+git checkout -b <type>/<scope>-<slug>
+
+# 2. 커밋 (Conventional Commits, 한글 허용, 기존 스타일)
+git add <선택 파일>
+git commit -m "<type>(<scope>): <한글 요약>"
+
+# 3. 푸시
+git push -u origin <branch>
+
+# 4. PR 생성 (사용자 승인 후)
+gh pr create --title "<type>(<scope>): <요약>" --body "$(cat <<'EOF'
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+EOF
+)"
+
+# 5. status check 15/15 통과 확인 후 사용자에게 머지 요청
+gh pr checks <N>  # 대기
+# 사용자 승인 시: gh pr merge <N> --squash (또는 사용자 지정 방식)
+```
+
+### 제외 대상 (커밋 스코프)
+다음 파일은 작업 스테이징에서 명시적으로 제외한다 (runtime artifact):
+- `.claude/active-plan.json` — autopilot 런타임 state
+- `.claude/run-lock.json` — 실행 lock
+- `.claude/runs/**` — run artifact
+- `.claude/plans/**` — 임시 plan 파일
+
+### 오염된 기록 (참고용)
+- `d1262a7` (2026-04-17, chore(phase-19): shadow plan 초안) — 이 규칙 수립 전 main 직접 push (bypass 경고 발생). revert 여부는 사용자 결정.
+
 ## 🔴 QMD 필수 사용 규칙
 
 > `docs/plans/`, `memory/`, `docs/superpowers/` 경로의 문서는 **반드시 QMD MCP 먼저** 사용.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,12 +71,12 @@
 - **검증**: PR 리뷰 시 변경 파일 `wc -l` + 큰 함수 스캔
 
 ### 버전 관리
-- Semantic Versioning, Conventional Commits (feat/fix/perf/docs/test/chore)
-- 브랜치: main, feat/*, fix/*
+- Semantic Versioning, Conventional Commits (feat/fix/perf/docs/test/chore/ci)
+- 브랜치: main + feat/*, fix/*, docs/*, chore/*, test/*, ci/*, perf/* (상세는 § Git 워크플로우)
 
 ## 🔴 Git 워크플로우 (main 브랜치 보호)
 
-> **main 직접 push 금지.** 이 레포는 GitHub branch protection으로 PR 필수 + 15개 status check 필수가 걸려있다. bypass 권한이 있어도 사용하지 않는다.
+> **main 직접 push 금지.** 이 레포는 GitHub branch protection으로 PR 필수 + required status checks 필수가 걸려있다. bypass 권한이 있어도 사용하지 않는다. (현재 required 목록은 `gh api repos/<owner>/<repo>/branches/main/protection` 로 확인)
 
 ### 필수 규칙
 1. **모든 변경은 feature 브랜치 + PR** — 문서·계획·설정 파일이라도 예외 없음. Phase 19 감사 shadow plan, CLAUDE.md 규칙 업데이트, memory/ 편집 전부 포함.
@@ -99,7 +99,7 @@ git add <선택 파일>
 git commit -m "<type>(<scope>): <한글 요약>"
 
 # 3. 푸시
-git push -u origin <branch>
+git push -u origin <type>/<scope>-<slug>
 
 # 4. PR 생성 (사용자 승인 후)
 gh pr create --title "<type>(<scope>): <요약>" --body "$(cat <<'EOF'
@@ -111,17 +111,22 @@ gh pr create --title "<type>(<scope>): <요약>" --body "$(cat <<'EOF'
 EOF
 )"
 
-# 5. status check 15/15 통과 확인 후 사용자에게 머지 요청
+# 5. 모든 required status checks 통과 확인 후 사용자에게 머지 요청
 gh pr checks <N>  # 대기
 # 사용자 승인 시: gh pr merge <N> --squash (또는 사용자 지정 방식)
 ```
 
 ### 제외 대상 (커밋 스코프)
-다음 파일은 작업 스테이징에서 명시적으로 제외한다 (runtime artifact):
-- `.claude/active-plan.json` — autopilot 런타임 state
+
+**git이 추적하지만 런타임 변경은 커밋 금지** (plan-autopilot / mmp-pilot artifact):
+- `.claude/active-plan.json` — 현재 active plan 포인터
 - `.claude/run-lock.json` — 실행 lock
 - `.claude/runs/**` — run artifact
-- `.claude/plans/**` — 임시 plan 파일
+
+**`.gitignore`에 이미 포함됨** (참고, 실수로 `-f` 추가 금지):
+- `.claude/worktrees/`, `.worktrees/` — worktree 메타데이터·디렉터리
+- `.claude/autopilot-state.json` — autopilot 상태
+- `.pr-body.tmp` — PR 본문 임시
 
 ### 오염된 기록 (참고용)
 - `d1262a7` (2026-04-17, chore(phase-19): shadow plan 초안) — 이 규칙 수립 전 main 직접 push (bypass 경고 발생). revert 여부는 사용자 결정.


### PR DESCRIPTION
## Summary
- `CLAUDE.md`에 **🔴 Git 워크플로우 (main 브랜치 보호)** 섹션 추가
- main 직접 push 금지 (bypass 권한 있어도 미사용), 문서·계획·설정 포함 예외 없음
- 브랜치 네이밍, 표준 워크플로우 커맨드, 스테이징 제외 고정 목록 문서화

## Context
- 계기: `d1262a7` (chore(phase-19): shadow plan 초안) main 직접 push 시 GitHub가 반환한 경고
  > `Bypassed rule violations for refs/heads/main:` `Changes must be made through a pull request.` `15 of 15 required status checks are expected.`
- 사용자가 "다음부터는 별도 브랜치 + PR 워크플로우" 명시 지시 (2026-04-17)

## Test plan
- [ ] 섹션 존재: \`grep -n "🔴 Git 워크플로우" CLAUDE.md\` → line 77 hit
- [ ] 파일 크기: \`wc -l CLAUDE.md\` ≤ 200 (현재 199)
- [ ] 15개 required status check 통과
- [ ] 이 PR 자체가 규칙의 첫 적용 사례 — 본 PR 승인·머지 흐름으로 워크플로우 검증

## Notes
- `~/.claude/projects/.../memory/feedback_branch_pr_workflow.md` + `MEMORY.md` 인덱스는 로컬 auto memory (레포 밖)로 별도 기록 — 다음 세션부터 Claude 자동 로딩

🤖 Generated with [Claude Code](https://claude.com/claude-code)