### PR TITLE
feat(phase-20): W2 PR-2 — 단서·장소 라운드 스케줄 컬럼·API·폼

### DIFF
--- a/apps/server/db/migrations/00025_round_schedule.sql
+++ b/apps/server/db/migrations/00025_round_schedule.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- Phase 20 PR-2: 단서·장소 라운드 스케줄 컬럼.
+-- 라운드 번호는 1 이상의 정수 (NULL 허용 = 범위 무제한).
+-- reveal_round/hide_round, from_round/until_round 모두 NULL 가능.
+
+ALTER TABLE theme_clues
+  ADD COLUMN reveal_round INT,
+  ADD COLUMN hide_round   INT,
+  ADD CONSTRAINT theme_clues_reveal_round_positive
+    CHECK (reveal_round IS NULL OR reveal_round >= 1),
+  ADD CONSTRAINT theme_clues_hide_round_positive
+    CHECK (hide_round IS NULL OR hide_round >= 1),
+  ADD CONSTRAINT theme_clues_round_order
+    CHECK (reveal_round IS NULL OR hide_round IS NULL OR reveal_round <= hide_round);
+
+ALTER TABLE theme_locations
+  ADD COLUMN from_round  INT,
+  ADD COLUMN until_round INT,
+  ADD CONSTRAINT theme_locations_from_round_positive
+    CHECK (from_round IS NULL OR from_round >= 1),
+  ADD CONSTRAINT theme_locations_until_round_positive
+    CHECK (until_round IS NULL OR until_round >= 1),
+  ADD CONSTRAINT theme_locations_round_order
+    CHECK (from_round IS NULL OR until_round IS NULL OR from_round <= until_round);
+
+-- +goose Down
+ALTER TABLE theme_locations
+  DROP CONSTRAINT IF EXISTS theme_locations_round_order,
+  DROP CONSTRAINT IF EXISTS theme_locations_until_round_positive,
+  DROP CONSTRAINT IF EXISTS theme_locations_from_round_positive,
+  DROP COLUMN IF EXISTS until_round,
+  DROP COLUMN IF EXISTS from_round;
+
+ALTER TABLE theme_clues
+  DROP CONSTRAINT IF EXISTS theme_clues_round_order,
+  DROP CONSTRAINT IF EXISTS theme_clues_hide_round_positive,
+  DROP CONSTRAINT IF EXISTS theme_clues_reveal_round_positive,
+  DROP COLUMN IF EXISTS hide_round,
+  DROP COLUMN IF EXISTS reveal_round;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -38,12 +38,13 @@ SELECT * FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
 SELECT * FROM theme_locations WHERE id = $1;
 
 -- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING *;
 
 -- name: UpdateLocation :one
-UPDATE theme_locations SET name = $2, restricted_characters = $3, sort_order = $4
+UPDATE theme_locations
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6
 WHERE id = $1
 RETURNING *;
 
@@ -67,12 +68,13 @@ SELECT * FROM theme_clues WHERE location_id = $1 ORDER BY sort_order;
 SELECT * FROM theme_clues WHERE id = $1;
 
 -- name: CreateClue :one
-INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 RETURNING *;
 
 -- name: UpdateClue :one
-UPDATE theme_clues SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, sort_order = $8, is_usable = $9, use_effect = $10, use_target = $11, use_consumed = $12
+UPDATE theme_clues
+SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, sort_order = $8, is_usable = $9, use_effect = $10, use_target = $11, use_consumed = $12, reveal_round = $13, hide_round = $14
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -46,9 +46,9 @@ func (q *Queries) CountMapsByTheme(ctx context.Context, themeID uuid.UUID) (int6
 }
 
 const createClue = `-- name: CreateClue :one
-INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed
+INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round
 `
 
 type CreateClueParams struct {
@@ -64,6 +64,8 @@ type CreateClueParams struct {
 	UseEffect   pgtype.Text `json:"use_effect"`
 	UseTarget   pgtype.Text `json:"use_target"`
 	UseConsumed bool        `json:"use_consumed"`
+	RevealRound pgtype.Int4 `json:"reveal_round"`
+	HideRound   pgtype.Int4 `json:"hide_round"`
 }
 
 func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeClue, error) {
@@ -80,6 +82,8 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 		arg.UseEffect,
 		arg.UseTarget,
 		arg.UseConsumed,
+		arg.RevealRound,
+		arg.HideRound,
 	)
 	var i ThemeClue
 	err := row.Scan(
@@ -97,14 +101,16 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 		&i.UseEffect,
 		&i.UseTarget,
 		&i.UseConsumed,
+		&i.RevealRound,
+		&i.HideRound,
 	)
 	return i, err
 }
 
 const createLocation = `-- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order)
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round
 `
 
 type CreateLocationParams struct {
@@ -113,6 +119,8 @@ type CreateLocationParams struct {
 	Name                 string      `json:"name"`
 	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
 	SortOrder            int32       `json:"sort_order"`
+	FromRound            pgtype.Int4 `json:"from_round"`
+	UntilRound           pgtype.Int4 `json:"until_round"`
 }
 
 func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) (ThemeLocation, error) {
@@ -122,6 +130,8 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		arg.Name,
 		arg.RestrictedCharacters,
 		arg.SortOrder,
+		arg.FromRound,
+		arg.UntilRound,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -132,6 +142,8 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.FromRound,
+		&i.UntilRound,
 	)
 	return i, err
 }
@@ -264,7 +276,7 @@ func (q *Queries) DeleteMapWithOwner(ctx context.Context, arg DeleteMapWithOwner
 }
 
 const getClue = `-- name: GetClue :one
-SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed FROM theme_clues WHERE id = $1
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round FROM theme_clues WHERE id = $1
 `
 
 func (q *Queries) GetClue(ctx context.Context, id uuid.UUID) (ThemeClue, error) {
@@ -285,12 +297,14 @@ func (q *Queries) GetClue(ctx context.Context, id uuid.UUID) (ThemeClue, error) 
 		&i.UseEffect,
 		&i.UseTarget,
 		&i.UseConsumed,
+		&i.RevealRound,
+		&i.HideRound,
 	)
 	return i, err
 }
 
 const getClueWithOwner = `-- name: GetClueWithOwner :one
-SELECT c.id, c.theme_id, c.location_id, c.name, c.description, c.image_url, c.is_common, c.level, c.sort_order, c.created_at, c.is_usable, c.use_effect, c.use_target, c.use_consumed FROM theme_clues c
+SELECT c.id, c.theme_id, c.location_id, c.name, c.description, c.image_url, c.is_common, c.level, c.sort_order, c.created_at, c.is_usable, c.use_effect, c.use_target, c.use_consumed, c.reveal_round, c.hide_round FROM theme_clues c
 JOIN themes t ON c.theme_id = t.id
 WHERE c.id = $1 AND t.creator_id = $2
 `
@@ -318,6 +332,8 @@ func (q *Queries) GetClueWithOwner(ctx context.Context, arg GetClueWithOwnerPara
 		&i.UseEffect,
 		&i.UseTarget,
 		&i.UseConsumed,
+		&i.RevealRound,
+		&i.HideRound,
 	)
 	return i, err
 }
@@ -349,7 +365,7 @@ func (q *Queries) GetContent(ctx context.Context, arg GetContentParams) (ThemeCo
 }
 
 const getLocation = `-- name: GetLocation :one
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at FROM theme_locations WHERE id = $1
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round FROM theme_locations WHERE id = $1
 `
 
 func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation, error) {
@@ -363,12 +379,14 @@ func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation,
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.FromRound,
+		&i.UntilRound,
 	)
 	return i, err
 }
 
 const getLocationWithOwner = `-- name: GetLocationWithOwner :one
-SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at FROM theme_locations l
+SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round FROM theme_locations l
 JOIN themes t ON l.theme_id = t.id
 WHERE l.id = $1 AND t.creator_id = $2
 `
@@ -389,6 +407,8 @@ func (q *Queries) GetLocationWithOwner(ctx context.Context, arg GetLocationWithO
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.FromRound,
+		&i.UntilRound,
 	)
 	return i, err
 }
@@ -441,7 +461,7 @@ func (q *Queries) GetMapWithOwner(ctx context.Context, arg GetMapWithOwnerParams
 }
 
 const listCluesByLocation = `-- name: ListCluesByLocation :many
-SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed FROM theme_clues WHERE location_id = $1 ORDER BY sort_order
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round FROM theme_clues WHERE location_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) ListCluesByLocation(ctx context.Context, locationID pgtype.UUID) ([]ThemeClue, error) {
@@ -468,6 +488,8 @@ func (q *Queries) ListCluesByLocation(ctx context.Context, locationID pgtype.UUI
 			&i.UseEffect,
 			&i.UseTarget,
 			&i.UseConsumed,
+			&i.RevealRound,
+			&i.HideRound,
 		); err != nil {
 			return nil, err
 		}
@@ -481,7 +503,7 @@ func (q *Queries) ListCluesByLocation(ctx context.Context, locationID pgtype.UUI
 
 const listCluesByTheme = `-- name: ListCluesByTheme :many
 
-SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed FROM theme_clues WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round FROM theme_clues WHERE theme_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -511,6 +533,8 @@ func (q *Queries) ListCluesByTheme(ctx context.Context, themeID uuid.UUID) ([]Th
 			&i.UseEffect,
 			&i.UseTarget,
 			&i.UseConsumed,
+			&i.RevealRound,
+			&i.HideRound,
 		); err != nil {
 			return nil, err
 		}
@@ -554,7 +578,7 @@ func (q *Queries) ListContentsByTheme(ctx context.Context, themeID uuid.UUID) ([
 
 const listLocationsByMap = `-- name: ListLocationsByMap :many
 
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -577,6 +601,8 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 			&i.RestrictedCharacters,
 			&i.SortOrder,
 			&i.CreatedAt,
+			&i.FromRound,
+			&i.UntilRound,
 		); err != nil {
 			return nil, err
 		}
@@ -589,7 +615,7 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 }
 
 const listLocationsByTheme = `-- name: ListLocationsByTheme :many
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeLocation, error) {
@@ -609,6 +635,8 @@ func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) (
 			&i.RestrictedCharacters,
 			&i.SortOrder,
 			&i.CreatedAt,
+			&i.FromRound,
+			&i.UntilRound,
 		); err != nil {
 			return nil, err
 		}
@@ -656,9 +684,10 @@ func (q *Queries) ListMapsByTheme(ctx context.Context, themeID uuid.UUID) ([]The
 }
 
 const updateClue = `-- name: UpdateClue :one
-UPDATE theme_clues SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, sort_order = $8, is_usable = $9, use_effect = $10, use_target = $11, use_consumed = $12
+UPDATE theme_clues
+SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, sort_order = $8, is_usable = $9, use_effect = $10, use_target = $11, use_consumed = $12, reveal_round = $13, hide_round = $14
 WHERE id = $1
-RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed
+RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round
 `
 
 type UpdateClueParams struct {
@@ -674,6 +703,8 @@ type UpdateClueParams struct {
 	UseEffect   pgtype.Text `json:"use_effect"`
 	UseTarget   pgtype.Text `json:"use_target"`
 	UseConsumed bool        `json:"use_consumed"`
+	RevealRound pgtype.Int4 `json:"reveal_round"`
+	HideRound   pgtype.Int4 `json:"hide_round"`
 }
 
 func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeClue, error) {
@@ -690,6 +721,8 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 		arg.UseEffect,
 		arg.UseTarget,
 		arg.UseConsumed,
+		arg.RevealRound,
+		arg.HideRound,
 	)
 	var i ThemeClue
 	err := row.Scan(
@@ -707,14 +740,17 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 		&i.UseEffect,
 		&i.UseTarget,
 		&i.UseConsumed,
+		&i.RevealRound,
+		&i.HideRound,
 	)
 	return i, err
 }
 
 const updateLocation = `-- name: UpdateLocation :one
-UPDATE theme_locations SET name = $2, restricted_characters = $3, sort_order = $4
+UPDATE theme_locations
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6
 WHERE id = $1
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round
 `
 
 type UpdateLocationParams struct {
@@ -722,6 +758,8 @@ type UpdateLocationParams struct {
 	Name                 string      `json:"name"`
 	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
 	SortOrder            int32       `json:"sort_order"`
+	FromRound            pgtype.Int4 `json:"from_round"`
+	UntilRound           pgtype.Int4 `json:"until_round"`
 }
 
 func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) (ThemeLocation, error) {
@@ -730,6 +768,8 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		arg.Name,
 		arg.RestrictedCharacters,
 		arg.SortOrder,
+		arg.FromRound,
+		arg.UntilRound,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -740,6 +780,8 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.FromRound,
+		&i.UntilRound,
 	)
 	return i, err
 }

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -282,6 +282,8 @@ type ThemeClue struct {
 	UseEffect   pgtype.Text `json:"use_effect"`
 	UseTarget   pgtype.Text `json:"use_target"`
 	UseConsumed bool        `json:"use_consumed"`
+	RevealRound pgtype.Int4 `json:"reveal_round"`
+	HideRound   pgtype.Int4 `json:"hide_round"`
 }
 
 type ThemeContent struct {
@@ -300,6 +302,8 @@ type ThemeLocation struct {
 	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
 	SortOrder            int32       `json:"sort_order"`
 	CreatedAt            time.Time   `json:"created_at"`
+	FromRound            pgtype.Int4 `json:"from_round"`
+	UntilRound           pgtype.Int4 `json:"until_round"`
 }
 
 type ThemeMap struct {

--- a/apps/server/internal/domain/editor/round_validation_test.go
+++ b/apps/server/internal/domain/editor/round_validation_test.go
@@ -1,0 +1,78 @@
+package editor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mmp-platform/server/internal/apperror"
+)
+
+func p(v int32) *int32 { return &v }
+
+func TestValidateClueRoundOrder(t *testing.T) {
+	cases := []struct {
+		name    string
+		reveal  *int32
+		hide    *int32
+		wantErr bool
+	}{
+		{"both nil", nil, nil, false},
+		{"only reveal", p(2), nil, false},
+		{"only hide", nil, p(5), false},
+		{"reveal < hide", p(2), p(5), false},
+		{"reveal == hide", p(3), p(3), false},
+		{"reveal > hide", p(5), p(2), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateClueRoundOrder(tc.reveal, tc.hide)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "reveal_round") {
+					t.Fatalf("expected reveal_round in error, got %v", err)
+				}
+				ae, ok := err.(*apperror.AppError)
+				if !ok || ae.Status != 400 {
+					t.Fatalf("expected 400 AppError, got %T %v", err, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateLocationRoundOrder(t *testing.T) {
+	cases := []struct {
+		name    string
+		from    *int32
+		until   *int32
+		wantErr bool
+	}{
+		{"both nil", nil, nil, false},
+		{"only from", p(1), nil, false},
+		{"only until", nil, p(4), false},
+		{"from < until", p(1), p(4), false},
+		{"from == until", p(2), p(2), false},
+		{"from > until", p(5), p(2), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLocationRoundOrder(tc.from, tc.until)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "from_round") {
+					t.Fatalf("expected from_round in error, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -429,6 +429,21 @@ func ptrToText(s *string) pgtype.Text {
 	return pgtype.Text{String: *s, Valid: true}
 }
 
+func int32PtrToPgtype(i *int32) pgtype.Int4 {
+	if i == nil {
+		return pgtype.Int4{}
+	}
+	return pgtype.Int4{Int32: *i, Valid: true}
+}
+
+func pgtypeInt4ToPtr(i pgtype.Int4) *int32 {
+	if !i.Valid {
+		return nil
+	}
+	v := i.Int32
+	return &v
+}
+
 var slugCleanRe = regexp.MustCompile(`[^a-z0-9-]+`)
 
 func generateSlug(title string) string {

--- a/apps/server/internal/domain/editor/service_clue.go
+++ b/apps/server/internal/domain/editor/service_clue.go
@@ -38,6 +38,9 @@ func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, 
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
 		return nil, err
 	}
+	if err := validateClueRoundOrder(req.RevealRound, req.HideRound); err != nil {
+		return nil, err
+	}
 	count, err := s.q.CountCluesByTheme(ctx, themeID)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to count clues")
@@ -59,6 +62,8 @@ func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, 
 		UseEffect:   ptrToText(req.UseEffect),
 		UseTarget:   ptrToText(req.UseTarget),
 		UseConsumed: req.UseConsumed,
+		RevealRound: int32PtrToPgtype(req.RevealRound),
+		HideRound:   int32PtrToPgtype(req.HideRound),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create clue")
@@ -69,6 +74,9 @@ func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, 
 }
 
 func (s *service) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, req UpdateClueRequest) (*ClueResponse, error) {
+	if err := validateClueRoundOrder(req.RevealRound, req.HideRound); err != nil {
+		return nil, err
+	}
 	c, err := s.q.GetClueWithOwner(ctx, db.GetClueWithOwnerParams{ID: clueID, CreatorID: creatorID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -90,6 +98,8 @@ func (s *service) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, r
 		UseEffect:   ptrToText(req.UseEffect),
 		UseTarget:   ptrToText(req.UseTarget),
 		UseConsumed: req.UseConsumed,
+		RevealRound: int32PtrToPgtype(req.RevealRound),
+		HideRound:   int32PtrToPgtype(req.HideRound),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update clue")
@@ -97,6 +107,16 @@ func (s *service) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, r
 	}
 	resp := toClueResponse(updated)
 	return &resp, nil
+}
+
+// validateClueRoundOrder ensures reveal_round <= hide_round when both are set.
+// Matches the DB CHECK in migration 00025 but returns a friendly 400 instead
+// of letting the constraint fire as a 500.
+func validateClueRoundOrder(reveal, hide *int32) error {
+	if reveal != nil && hide != nil && *reveal > *hide {
+		return apperror.BadRequest("reveal_round must not be greater than hide_round")
+	}
+	return nil
 }
 
 func (s *service) DeleteClue(ctx context.Context, creatorID, clueID uuid.UUID) error {
@@ -170,6 +190,8 @@ func toClueResponse(c db.ThemeClue) ClueResponse {
 		UseEffect:   textToPtr(c.UseEffect),
 		UseTarget:   textToPtr(c.UseTarget),
 		UseConsumed: c.UseConsumed,
+		RevealRound: pgtypeInt4ToPtr(c.RevealRound),
+		HideRound:   pgtypeInt4ToPtr(c.HideRound),
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -113,6 +113,9 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
 		return nil, err
 	}
+	if err := validateLocationRoundOrder(req.FromRound, req.UntilRound); err != nil {
+		return nil, err
+	}
 	// verify map belongs to the theme via ownership check
 	_, err := s.q.GetMapWithOwner(ctx, db.GetMapWithOwnerParams{ID: mapID, CreatorID: creatorID})
 	if err != nil {
@@ -136,6 +139,8 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 		Name:                 req.Name,
 		RestrictedCharacters: ptrToText(req.RestrictedCharacters),
 		SortOrder:            req.SortOrder,
+		FromRound:            int32PtrToPgtype(req.FromRound),
+		UntilRound:           int32PtrToPgtype(req.UntilRound),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create location")
@@ -146,6 +151,9 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 }
 
 func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID, req UpdateLocationRequest) (*LocationResponse, error) {
+	if err := validateLocationRoundOrder(req.FromRound, req.UntilRound); err != nil {
+		return nil, err
+	}
 	l, err := s.q.GetLocationWithOwner(ctx, db.GetLocationWithOwnerParams{ID: locID, CreatorID: creatorID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -159,6 +167,8 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		Name:                 req.Name,
 		RestrictedCharacters: ptrToText(req.RestrictedCharacters),
 		SortOrder:            req.SortOrder,
+		FromRound:            int32PtrToPgtype(req.FromRound),
+		UntilRound:           int32PtrToPgtype(req.UntilRound),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update location")
@@ -166,6 +176,14 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 	}
 	resp := toLocationResponse(updated)
 	return &resp, nil
+}
+
+// validateLocationRoundOrder enforces from_round <= until_round when both set.
+func validateLocationRoundOrder(from, until *int32) error {
+	if from != nil && until != nil && *from > *until {
+		return apperror.BadRequest("from_round must not be greater than until_round")
+	}
+	return nil
 }
 
 func (s *service) DeleteLocation(ctx context.Context, creatorID, locID uuid.UUID) error {
@@ -202,5 +220,7 @@ func toLocationResponse(l db.ThemeLocation) LocationResponse {
 		RestrictedCharacters: textToPtr(l.RestrictedCharacters),
 		SortOrder:            l.SortOrder,
 		CreatedAt:            l.CreatedAt,
+		FromRound:            pgtypeInt4ToPtr(l.FromRound),
+		UntilRound:           pgtypeInt4ToPtr(l.UntilRound),
 	}
 }

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -35,12 +35,16 @@ type CreateLocationRequest struct {
 	Name                 string  `json:"name" validate:"required,min=1,max=100"`
 	RestrictedCharacters *string `json:"restricted_characters"`
 	SortOrder            int32   `json:"sort_order" validate:"min=0"`
+	FromRound            *int32  `json:"from_round" validate:"omitempty,min=1"`
+	UntilRound           *int32  `json:"until_round" validate:"omitempty,min=1"`
 }
 
 type UpdateLocationRequest struct {
 	Name                 string  `json:"name" validate:"required,min=1,max=100"`
 	RestrictedCharacters *string `json:"restricted_characters"`
 	SortOrder            int32   `json:"sort_order" validate:"min=0"`
+	FromRound            *int32  `json:"from_round" validate:"omitempty,min=1"`
+	UntilRound           *int32  `json:"until_round" validate:"omitempty,min=1"`
 }
 
 type LocationResponse struct {
@@ -51,6 +55,8 @@ type LocationResponse struct {
 	RestrictedCharacters *string   `json:"restricted_characters,omitempty"`
 	SortOrder            int32     `json:"sort_order"`
 	CreatedAt            time.Time `json:"created_at"`
+	FromRound            *int32    `json:"from_round,omitempty"`
+	UntilRound           *int32    `json:"until_round,omitempty"`
 }
 
 // --- Clue types ---
@@ -67,6 +73,8 @@ type CreateClueRequest struct {
 	UseEffect   *string    `json:"use_effect" validate:"omitempty,oneof=peek steal reveal block swap"`
 	UseTarget   *string    `json:"use_target" validate:"omitempty,oneof=player clue self"`
 	UseConsumed bool       `json:"use_consumed"`
+	RevealRound *int32     `json:"reveal_round" validate:"omitempty,min=1"`
+	HideRound   *int32     `json:"hide_round" validate:"omitempty,min=1"`
 }
 
 type UpdateClueRequest struct {
@@ -81,6 +89,8 @@ type UpdateClueRequest struct {
 	UseEffect   *string    `json:"use_effect" validate:"omitempty,oneof=peek steal reveal block swap"`
 	UseTarget   *string    `json:"use_target" validate:"omitempty,oneof=player clue self"`
 	UseConsumed bool       `json:"use_consumed"`
+	RevealRound *int32     `json:"reveal_round" validate:"omitempty,min=1"`
+	HideRound   *int32     `json:"hide_round" validate:"omitempty,min=1"`
 }
 
 type ClueResponse struct {
@@ -98,6 +108,8 @@ type ClueResponse struct {
 	UseEffect   *string    `json:"use_effect,omitempty"`
 	UseTarget   *string    `json:"use_target,omitempty"`
 	UseConsumed bool       `json:"use_consumed"`
+	RevealRound *int32     `json:"reveal_round,omitempty"`
+	HideRound   *int32     `json:"hide_round,omitempty"`
 }
 
 // --- Clue relation types ---

--- a/apps/web/src/features/editor/api.ts
+++ b/apps/web/src/features/editor/api.ts
@@ -99,6 +99,8 @@ export interface CreateClueRequest {
   use_effect?: string;
   use_target?: string;
   use_consumed?: boolean;
+  reveal_round?: number | null;
+  hide_round?: number | null;
 }
 
 export interface UpdateClueRequest {
@@ -113,6 +115,8 @@ export interface UpdateClueRequest {
   use_effect?: string;
   use_target?: string;
   use_consumed?: boolean;
+  reveal_round?: number | null;
+  hide_round?: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -142,6 +146,8 @@ export interface LocationResponse {
   restricted_characters: string | null;
   sort_order: number;
   created_at: string;
+  from_round?: number | null;
+  until_round?: number | null;
 }
 
 export interface ClueResponse {
@@ -159,6 +165,8 @@ export interface ClueResponse {
   use_effect: string | null;
   use_target: string | null;
   use_consumed: boolean;
+  reveal_round?: number | null;
+  hide_round?: number | null;
 }
 
 export interface ContentResponse {

--- a/apps/web/src/features/editor/components/ClueForm.tsx
+++ b/apps/web/src/features/editor/components/ClueForm.tsx
@@ -52,6 +52,10 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
   const [useTarget, setUseTarget] = useState('player');
   const [useConsumed, setUseConsumed] = useState(true);
 
+  // Round schedule (null = unbounded on that side)
+  const [revealRound, setRevealRound] = useState<number | null>(null);
+  const [hideRound, setHideRound] = useState<number | null>(null);
+
   // Pending image for new clue (staged upload)
   const [pendingImage, setPendingImage] = useState<File | null>(null);
   const [pendingPreview, setPendingPreview] = useState<string | null>(null);
@@ -76,6 +80,8 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
       setUseEffect(clue.use_effect ?? 'peek');
       setUseTarget(clue.use_target ?? 'player');
       setUseConsumed(clue.use_consumed ?? true);
+      setRevealRound(clue.reveal_round ?? null);
+      setHideRound(clue.hide_round ?? null);
     } else {
       setName('');
       setDescription('');
@@ -87,6 +93,8 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
       setUseEffect('peek');
       setUseTarget('player');
       setUseConsumed(true);
+      setRevealRound(null);
+      setHideRound(null);
     }
     setPendingImage(null);
     setPendingPreview(null);
@@ -104,6 +112,13 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
     }
     if (description.length > 2000) {
       next.description = '설명은 2000자 이하여야 합니다';
+    }
+    if (
+      revealRound != null &&
+      hideRound != null &&
+      revealRound > hideRound
+    ) {
+      next.round = '공개 라운드는 사라짐 라운드보다 클 수 없습니다';
     }
     return next;
   }
@@ -138,6 +153,8 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
         use_effect: isUsable ? useEffect_ : undefined,
         use_target: isUsable ? useTarget : undefined,
         use_consumed: isUsable ? useConsumed : undefined,
+        reveal_round: revealRound,
+        hide_round: hideRound,
       },
       pendingImage,
     );
@@ -217,6 +234,11 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
           onUseTargetChange={setUseTarget}
           useConsumed={useConsumed}
           onUseConsumedChange={setUseConsumed}
+          revealRound={revealRound}
+          onRevealRoundChange={setRevealRound}
+          hideRound={hideRound}
+          onHideRoundChange={setHideRound}
+          roundError={errors.round}
         />
       </form>
     </Modal>

--- a/apps/web/src/features/editor/components/ClueFormAdvancedFields.tsx
+++ b/apps/web/src/features/editor/components/ClueFormAdvancedFields.tsx
@@ -30,6 +30,25 @@ export interface ClueFormAdvancedFieldsProps {
 
   useConsumed: boolean;
   onUseConsumedChange: (value: boolean) => void;
+
+  /** Round at which the clue becomes visible (null = from round 1). */
+  revealRound: number | null;
+  onRevealRoundChange: (value: number | null) => void;
+
+  /** Round at which the clue is hidden (null = stays visible forever). */
+  hideRound: number | null;
+  onHideRoundChange: (value: number | null) => void;
+
+  /** Optional error banner (e.g. reveal > hide). */
+  roundError?: string;
+}
+
+function parseRoundInput(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return Math.floor(n);
 }
 
 export function ClueFormAdvancedFields({
@@ -45,6 +64,11 @@ export function ClueFormAdvancedFields({
   onUseTargetChange,
   useConsumed,
   onUseConsumedChange,
+  revealRound,
+  onRevealRoundChange,
+  hideRound,
+  onHideRoundChange,
+  roundError,
 }: ClueFormAdvancedFieldsProps) {
   return (
     <div className="space-y-3">
@@ -78,6 +102,56 @@ export function ClueFormAdvancedFields({
             >
               공개 단서 (모든 플레이어 공유)
             </label>
+          </div>
+
+          {/* Round schedule */}
+          <div className="space-y-1.5 border-t border-slate-800 pt-3">
+            <div className="text-xs font-semibold uppercase tracking-widest text-slate-500">
+              라운드 스케줄
+            </div>
+            <div className="flex gap-2">
+              <div className="flex flex-1 flex-col gap-1">
+                <label
+                  htmlFor="clue-reveal-round"
+                  className="text-xs text-slate-400"
+                >
+                  공개 라운드
+                </label>
+                <input
+                  id="clue-reveal-round"
+                  type="number"
+                  min={1}
+                  step={1}
+                  placeholder="1부터"
+                  value={revealRound ?? ''}
+                  onChange={(e) => onRevealRoundChange(parseRoundInput(e.target.value))}
+                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-1">
+                <label
+                  htmlFor="clue-hide-round"
+                  className="text-xs text-slate-400"
+                >
+                  사라짐 라운드
+                </label>
+                <input
+                  id="clue-hide-round"
+                  type="number"
+                  min={1}
+                  step={1}
+                  placeholder="끝까지"
+                  value={hideRound ?? ''}
+                  onChange={(e) => onHideRoundChange(parseRoundInput(e.target.value))}
+                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                />
+              </div>
+            </div>
+            {roundError && (
+              <p className="text-xs text-red-400" role="alert">
+                {roundError}
+              </p>
+            )}
           </div>
 
           {/* Item usage */}

--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -243,4 +243,84 @@ describe('ClueForm', () => {
     expect(screen.getByRole('alert').textContent).toContain('이름은 필수');
     expect(createMutate).not.toHaveBeenCalled();
   });
+
+  it('고급 설정의 공개/사라짐 라운드 입력이 payload에 포함된다', () => {
+    const onClose = vi.fn();
+    render(<ClueForm themeId="theme-1" isOpen onClose={onClose} />);
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '라운드 단서' },
+    });
+    fireEvent.click(screen.getByText('고급 설정'));
+    fireEvent.change(screen.getByLabelText('공개 라운드'), {
+      target: { value: '2' },
+    });
+    fireEvent.change(screen.getByLabelText('사라짐 라운드'), {
+      target: { value: '4' },
+    });
+
+    fireEvent.submit(document.getElementById('clue-form')!);
+
+    expect(createMutate).toHaveBeenCalledTimes(1);
+    const [body] = createMutate.mock.calls[0];
+    expect(body.reveal_round).toBe(2);
+    expect(body.hide_round).toBe(4);
+  });
+
+  it('공개 > 사라짐 라운드 조합은 에러를 표시하고 mutate를 막는다', () => {
+    const onClose = vi.fn();
+    render(<ClueForm themeId="theme-1" isOpen onClose={onClose} />);
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '역전 단서' },
+    });
+    fireEvent.click(screen.getByText('고급 설정'));
+    fireEvent.change(screen.getByLabelText('공개 라운드'), {
+      target: { value: '5' },
+    });
+    fireEvent.change(screen.getByLabelText('사라짐 라운드'), {
+      target: { value: '2' },
+    });
+
+    fireEvent.submit(document.getElementById('clue-form')!);
+
+    expect(
+      screen.getByText('공개 라운드는 사라짐 라운드보다 클 수 없습니다'),
+    ).toBeDefined();
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it('edit 모드에서 기존 reveal_round/hide_round가 초기값으로 로드된다', () => {
+    const onClose = vi.fn();
+    const existing = {
+      id: 'clue-rr',
+      theme_id: 'theme-1',
+      location_id: null,
+      name: '기존 단서',
+      description: null,
+      image_url: null,
+      is_common: false,
+      level: 1,
+      sort_order: 0,
+      created_at: '2026-04-17T00:00:00Z',
+      is_usable: false,
+      use_effect: null,
+      use_target: null,
+      use_consumed: false,
+      reveal_round: 3,
+      hide_round: 7,
+    };
+
+    render(
+      <ClueForm themeId="theme-1" clue={existing} isOpen onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByText('고급 설정'));
+
+    expect(
+      (screen.getByLabelText('공개 라운드') as HTMLInputElement).value,
+    ).toBe('3');
+    expect(
+      (screen.getByLabelText('사라짐 라운드') as HTMLInputElement).value,
+    ).toBe('7');
+  });
 });

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -10,6 +10,7 @@ import { LocationRow } from './LocationRow';
 // ---------------------------------------------------------------------------
 
 interface LocationDetailPanelProps {
+  themeId: string;
   selectedMap: MapResponse | null;
   mapLocations: LocationResponse[];
   addingLocation: boolean;
@@ -25,6 +26,7 @@ interface LocationDetailPanelProps {
 // ---------------------------------------------------------------------------
 
 export function LocationDetailPanel({
+  themeId,
   selectedMap,
   mapLocations,
   addingLocation,
@@ -82,6 +84,7 @@ export function LocationDetailPanel({
           {mapLocations.map((loc) => (
             <LocationRow
               key={loc.id}
+              themeId={themeId}
               location={loc}
               onDelete={onDeleteLocation}
             />

--- a/apps/web/src/features/editor/components/design/LocationRow.tsx
+++ b/apps/web/src/features/editor/components/design/LocationRow.tsx
@@ -1,21 +1,129 @@
+import { useEffect, useState } from 'react';
 import { MapPin, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 import type { LocationResponse } from '@/features/editor/api';
+import { useUpdateLocation } from '@/features/editor/api';
 
 // ---------------------------------------------------------------------------
-// LocationRow — single location row with delete button
+// LocationRow — name + inline round schedule editor + delete.
+// Round inputs commit on blur (and on Enter) via useUpdateLocation. Local
+// state mirrors the server value so optimistic re-rendering is avoided —
+// react-query invalidation handles the refresh.
 // ---------------------------------------------------------------------------
 
 interface LocationRowProps {
+  themeId: string;
   location: LocationResponse;
   onDelete: (id: string) => void;
 }
 
-export function LocationRow({ location, onDelete }: LocationRowProps) {
+function parseRound(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return Math.floor(n);
+}
+
+export function LocationRow({ themeId, location, onDelete }: LocationRowProps) {
+  const updateLocation = useUpdateLocation(themeId);
+
+  const [fromRound, setFromRound] = useState<number | null>(
+    location.from_round ?? null,
+  );
+  const [untilRound, setUntilRound] = useState<number | null>(
+    location.until_round ?? null,
+  );
+
+  // Keep local state in sync when server data refreshes (e.g. after PATCH).
+  useEffect(() => {
+    setFromRound(location.from_round ?? null);
+    setUntilRound(location.until_round ?? null);
+  }, [location.from_round, location.until_round]);
+
+  function commitRounds(nextFrom: number | null, nextUntil: number | null) {
+    if (
+      nextFrom === (location.from_round ?? null) &&
+      nextUntil === (location.until_round ?? null)
+    ) {
+      return;
+    }
+    if (nextFrom != null && nextUntil != null && nextFrom > nextUntil) {
+      toast.error('등장 라운드는 퇴장 라운드보다 클 수 없습니다');
+      setFromRound(location.from_round ?? null);
+      setUntilRound(location.until_round ?? null);
+      return;
+    }
+    updateLocation.mutate(
+      {
+        locationId: location.id,
+        body: {
+          name: location.name,
+          sort_order: location.sort_order,
+          from_round: nextFrom,
+          until_round: nextUntil,
+        },
+      },
+      {
+        onError: () => {
+          toast.error('라운드 저장에 실패했습니다');
+          setFromRound(location.from_round ?? null);
+          setUntilRound(location.until_round ?? null);
+        },
+      },
+    );
+  }
+
   return (
-    <div className="group flex items-start gap-2 rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 hover:border-slate-700">
-      <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-600" />
-      <div className="flex-1 min-w-0">
-        <span className="text-xs font-medium text-slate-300">{location.name}</span>
+    <div className="group flex items-center gap-2 rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 hover:border-slate-700">
+      <MapPin className="h-3.5 w-3.5 shrink-0 text-slate-600" />
+      <span className="flex-1 truncate text-xs font-medium text-slate-300">
+        {location.name}
+      </span>
+      <div className="flex items-center gap-1 text-[10px] text-slate-500">
+        <label
+          htmlFor={`location-${location.id}-from`}
+          className="sr-only"
+        >
+          {location.name} 등장 라운드
+        </label>
+        <input
+          id={`location-${location.id}-from`}
+          type="number"
+          min={1}
+          step={1}
+          placeholder="시작"
+          aria-label={`${location.name} 등장 라운드`}
+          value={fromRound ?? ''}
+          onChange={(e) => setFromRound(parseRound(e.target.value))}
+          onBlur={() => commitRounds(fromRound, untilRound)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          }}
+          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+        />
+        <span>~</span>
+        <label
+          htmlFor={`location-${location.id}-until`}
+          className="sr-only"
+        >
+          {location.name} 퇴장 라운드
+        </label>
+        <input
+          id={`location-${location.id}-until`}
+          type="number"
+          min={1}
+          step={1}
+          placeholder="끝"
+          aria-label={`${location.name} 퇴장 라운드`}
+          value={untilRound ?? ''}
+          onChange={(e) => setUntilRound(parseRound(e.target.value))}
+          onBlur={() => commitRounds(fromRound, untilRound)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          }}
+          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+        />
       </div>
       <button
         type="button"

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -179,6 +179,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
       {/* ── Location detail ── */}
       <div className="flex-1 overflow-y-auto px-5 py-5">
         <LocationDetailPanel
+          themeId={themeId}
           selectedMap={selectedMap}
           mapLocations={mapLocations}
           addingLocation={addingLocation}

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -10,12 +10,14 @@ const {
   toastError,
   mutateMock,
   updateConfigMutateMock,
+  updateLocationMutateMock,
   useEditorMapsMock,
   useCreateMapMock,
   useDeleteMapMock,
   useEditorLocationsMock,
   useCreateLocationMock,
   useDeleteLocationMock,
+  useUpdateLocationMock,
   useEditorCluesMock,
   useUpdateConfigJsonMock,
 } = vi.hoisted(() => ({
@@ -23,12 +25,14 @@ const {
   toastError: vi.fn(),
   mutateMock: vi.fn(),
   updateConfigMutateMock: vi.fn(),
+  updateLocationMutateMock: vi.fn(),
   useEditorMapsMock: vi.fn(),
   useCreateMapMock: vi.fn(),
   useDeleteMapMock: vi.fn(),
   useEditorLocationsMock: vi.fn(),
   useCreateLocationMock: vi.fn(),
   useDeleteLocationMock: vi.fn(),
+  useUpdateLocationMock: vi.fn(),
   useEditorCluesMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
 }));
@@ -52,6 +56,7 @@ vi.mock("@/features/editor/api", () => ({
   useEditorLocations: () => useEditorLocationsMock(),
   useCreateLocation: () => useCreateLocationMock(),
   useDeleteLocation: () => useDeleteLocationMock(),
+  useUpdateLocation: () => useUpdateLocationMock(),
   useEditorClues: () => useEditorCluesMock(),
   useUpdateConfigJson: () => useUpdateConfigJsonMock(),
   editorKeys: {
@@ -147,6 +152,10 @@ function setupDefaultMocks() {
   useDeleteMapMock.mockReturnValue(defaultMutation());
   useCreateLocationMock.mockReturnValue(defaultMutation());
   useDeleteLocationMock.mockReturnValue(defaultMutation());
+  useUpdateLocationMock.mockReturnValue({
+    mutate: updateLocationMutateMock,
+    isPending: false,
+  });
   useEditorCluesMock.mockReturnValue({ data: mockClues, isLoading: false });
   useUpdateConfigJsonMock.mockReturnValue({
     mutate: updateConfigMutateMock,
@@ -176,6 +185,10 @@ describe("LocationsSubTab", () => {
       useDeleteMapMock.mockReturnValue(defaultMutation());
       useCreateLocationMock.mockReturnValue(defaultMutation());
       useDeleteLocationMock.mockReturnValue(defaultMutation());
+      useUpdateLocationMock.mockReturnValue({
+        mutate: updateLocationMutateMock,
+        isPending: false,
+      });
       useEditorCluesMock.mockReturnValue({ data: [], isLoading: false });
       useUpdateConfigJsonMock.mockReturnValue({
         mutate: updateConfigMutateMock,
@@ -351,6 +364,69 @@ describe("LocationsSubTab", () => {
     it("맵 미선택 상태에서는 단서 배정 picker 가 표시되지 않는다", () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       expect(screen.queryByText(/단서 배정 — 장소 선택/)).toBeNull();
+    });
+  });
+
+  describe("LocationRow 라운드 편집", () => {
+    beforeEach(setupDefaultMocks);
+
+    it("등장/퇴장 라운드 입력이 각 장소 행마다 존재한다", () => {
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+      fireEvent.click(screen.getByText("저택 1층"));
+      expect(screen.getByLabelText("거실 등장 라운드")).toBeDefined();
+      expect(screen.getByLabelText("거실 퇴장 라운드")).toBeDefined();
+    });
+
+    it("라운드 값 입력 후 blur 하면 useUpdateLocation.mutate 가 호출된다", () => {
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+      fireEvent.click(screen.getByText("저택 1층"));
+      const fromInput = screen.getByLabelText("거실 등장 라운드") as HTMLInputElement;
+      fireEvent.change(fromInput, { target: { value: "2" } });
+      fireEvent.blur(fromInput);
+      expect(updateLocationMutateMock).toHaveBeenCalledOnce();
+      const [payload] = updateLocationMutateMock.mock.calls[0] as [
+        { locationId: string; body: Record<string, unknown> },
+      ];
+      expect(payload.locationId).toBe("loc-1");
+      expect(payload.body.from_round).toBe(2);
+      expect(payload.body.name).toBe("거실");
+    });
+
+    it("등장 > 퇴장 조합은 에러 토스트 후 저장되지 않는다", () => {
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+      fireEvent.click(screen.getByText("저택 1층"));
+      const fromInput = screen.getByLabelText("거실 등장 라운드") as HTMLInputElement;
+      const untilInput = screen.getByLabelText("거실 퇴장 라운드") as HTMLInputElement;
+      fireEvent.change(untilInput, { target: { value: "2" } });
+      fireEvent.blur(untilInput);
+      updateLocationMutateMock.mockClear();
+      fireEvent.change(fromInput, { target: { value: "5" } });
+      fireEvent.blur(fromInput);
+      expect(updateLocationMutateMock).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith(
+        "등장 라운드는 퇴장 라운드보다 클 수 없습니다",
+      );
+    });
+
+    it("값을 비우면 from_round 가 null 로 저장된다", () => {
+      useEditorLocationsMock.mockReturnValue({
+        data: [
+          { ...mockLocations[0], from_round: 2, until_round: 5 },
+          ...mockLocations.slice(1),
+        ],
+        isLoading: false,
+      });
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+      fireEvent.click(screen.getByText("저택 1층"));
+      const fromInput = screen.getByLabelText("거실 등장 라운드") as HTMLInputElement;
+      fireEvent.change(fromInput, { target: { value: "" } });
+      fireEvent.blur(fromInput);
+      expect(updateLocationMutateMock).toHaveBeenCalledOnce();
+      const [payload] = updateLocationMutateMock.mock.calls[0] as [
+        { body: Record<string, unknown> },
+      ];
+      expect(payload.body.from_round).toBeNull();
+      expect(payload.body.until_round).toBe(5);
     });
   });
 });

--- a/apps/web/src/features/editor/editorMapApi.ts
+++ b/apps/web/src/features/editor/editorMapApi.ts
@@ -17,12 +17,17 @@ export interface CreateLocationRequest {
   name: string;
   description?: string;
   restricted_characters?: string[];
+  from_round?: number | null;
+  until_round?: number | null;
 }
 
 export interface UpdateLocationRequest {
   name?: string;
   description?: string;
   restricted_characters?: string[];
+  sort_order?: number;
+  from_round?: number | null;
+  until_round?: number | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/editor/hooks/useClueFormSubmit.ts
+++ b/apps/web/src/features/editor/hooks/useClueFormSubmit.ts
@@ -30,6 +30,8 @@ export interface ClueSubmitBody {
   use_effect?: string;
   use_target?: string;
   use_consumed?: boolean;
+  reveal_round?: number | null;
+  hide_round?: number | null;
 }
 
 export interface UseClueFormSubmitOptions {

--- a/docs/plans/2026-04-17-clue-edges-unified/checklist.md
+++ b/docs/plans/2026-04-17-clue-edges-unified/checklist.md
@@ -29,17 +29,17 @@
 **Branch**: `feat/phase-20/PR-2-round-schedule`
 **Depends**: PR-1
 
-- [ ] migration 00025 (theme_clues.reveal_round/hide_round + theme_locations.from_round/until_round)
-- [ ] sqlc 재생성
-- [ ] types.go: 단서·장소 DTO에 round 필드 추가 (pointer nullable)
-- [ ] service_clue.go, service_location.go: round 필드 매핑
-- [ ] 프론트 api.ts: 단서·장소 응답 타입 확장, PATCH/POST payload에 round 포함
-- [ ] ClueForm.tsx: revealRound/hideRound state + AdvancedFields 폼
-- [ ] ClueFormAdvancedFields.tsx: localStorage 기반 PoC 제거, 부모 controlled 전환
-- [ ] LocationRow.tsx: localStorage 제거, useUpdateLocation 으로 저장
-- [ ] 서비스 레이어 의미적 검증: `reveal_round > hide_round` 거부
-- [ ] 테스트: clue/location handler round 필드 왕복, UI 입력→PATCH 연동
-- [ ] `make lint` + `make test` 통과
+- [x] migration 00025 (theme_clues.reveal_round/hide_round + theme_locations.from_round/until_round, CHECK constraints)
+- [x] sqlc 재생성 (pgtype.Int4 round 필드 확인)
+- [x] types.go: 단서·장소 DTO에 round 필드 추가 (pointer nullable, validate:min=1)
+- [x] service_clue.go, service_location.go: round 필드 매핑 + int32PtrToPgtype/pgtypeInt4ToPtr helper
+- [x] 프론트 api.ts + editorMapApi.ts: 응답 타입 + PATCH/POST payload round 포함
+- [x] ClueForm.tsx: revealRound/hideRound state + 편집 모드 로드 + submit 포함
+- [x] ClueFormAdvancedFields.tsx: parseRoundInput + 두 number input (controlled, 부모 state)
+- [x] LocationRow.tsx: useUpdateLocation 인라인 편집 (blur/Enter commit, 에러시 롤백)
+- [x] 서비스 레이어 검증: validateClueRoundOrder + validateLocationRoundOrder (400 AppError)
+- [x] 테스트: round_validation_test (12 서브케이스), ClueForm.test 3 신규, LocationsSubTab.test 4 신규
+- [x] `make ci-local` 통과 (lint + typecheck + test + build)
 - [ ] PR 생성 → 머지
 
 ## W2 — PR-3 라운드 배지 노출 (병렬)


### PR DESCRIPTION
## Summary

Phase 20 W2 PR-2. 단서·장소에 라운드 스케줄 컬럼 + API + 에디터 폼을 도입한다.

- **DB**: migration 00025 — `theme_clues.reveal_round/hide_round`, `theme_locations.from_round/until_round` (nullable INT, CHECK 제약 positive × 4 + order × 2)
- **백엔드**: DTO + service 매핑 + `validateClueRoundOrder` / `validateLocationRoundOrder` (역순 시 400)
- **프론트**: ClueForm 고급 설정에 공개/사라짐 라운드, LocationRow 인라인 편집 (blur/Enter commit, 역순 롤백 + toast)
- **테스트**: `round_validation_test` 12 서브케이스, `ClueForm.test` +3, `LocationsSubTab.test` +4
- **CI**: `make ci-local` 통과 (lint + typecheck + 1040+ tests + build)

## 결정 근거

- 라운드 저장 방식: **정규 INT NULL 컬럼** (design.md 결정 2) — JSONB 대비 쿼리·정렬 용이.
- CHECK 제약은 DB에 두되, service 레이어에서 역순을 400으로 먼저 잡아 500이 새는 것을 방지.
- LocationRow: 기존 display-only를 인라인 편집으로 변환. `onBlur` commit + 서버 실패 시 `location.from/until_round`로 롤백.
- `ClueFormAdvancedFields`는 부모 controlled 유지 — PoC localStorage는 이 레포 현 상태에 존재하지 않으므로 도입 없음 (PR-6에서 edges UI PoC와 함께 정리 예정).

## Scope 요약 (20 파일, +654/-41)

**Backend**
- `apps/server/db/migrations/00025_round_schedule.sql` (신규)
- `apps/server/db/queries/editor.sql` + sqlc 재생성 (`editor.sql.go`, `models.go`)
- `apps/server/internal/domain/editor/types.go`, `service.go` (헬퍼), `service_clue.go`, `service_location.go`
- `apps/server/internal/domain/editor/round_validation_test.go` (신규)

**Frontend**
- `apps/web/src/features/editor/api.ts`, `editorMapApi.ts`, `hooks/useClueFormSubmit.ts`
- `components/ClueForm.tsx`, `components/ClueFormAdvancedFields.tsx`
- `components/design/LocationRow.tsx`, `LocationDetailPanel.tsx`, `LocationsSubTab.tsx`
- tests: `components/__tests__/ClueForm.test.tsx`, `components/design/__tests__/LocationsSubTab.test.tsx`

**Docs**
- `docs/plans/2026-04-17-clue-edges-unified/checklist.md` (W2 PR-2 체크)

## Test plan

- [x] `make ci-local` (lint + typecheck + test + build) — 로컬 통과
- [x] `go test -race ./internal/domain/editor/...` green (validate 12 서브케이스 포함)
- [x] Vitest: `ClueForm.test` 7, `LocationsSubTab.test` 23
- [ ] Staging DB에 migration 00025 적용 후 `psql \d theme_clues` / `\d theme_locations`로 CHECK 제약 확인
- [ ] 에디터에서 단서 라운드 편집 → 새로고침 → 값 복원
- [ ] 장소 행 라운드 편집 → 새로고침 → 값 복원

## Blocker

GitHub Actions 계정 레벨 disable (무료 2000분 초과). 5월 1일 자동 리셋 전까지 admin bypass merge + 로컬 CI로 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)