### PR TITLE
feat(phase-20): W2 PR-3 — 단서 카드·리스트 라운드 배지

### DIFF
--- a/apps/web/src/features/editor/components/ClueCard.tsx
+++ b/apps/web/src/features/editor/components/ClueCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Trash2, Image } from 'lucide-react';
 import type { ClueResponse } from '@/features/editor/api';
+import { formatRoundRange } from '@/features/editor/utils/roundFormat';
 import { ImageUpload } from './ImageUpload';
 
 // ---------------------------------------------------------------------------
@@ -17,6 +18,7 @@ interface ClueCardProps {
 
 export function ClueCard({ clue, themeId, onEdit, onDelete, onImageUploaded }: ClueCardProps) {
   const [showImageUpload, setShowImageUpload] = useState(false);
+  const roundLabel = formatRoundRange(clue.reveal_round, clue.hide_round);
 
   return (
     <div className="group rounded-sm border border-slate-800 bg-slate-900 transition-all hover:border-slate-700">
@@ -77,9 +79,16 @@ export function ClueCard({ clue, themeId, onEdit, onDelete, onImageUploaded }: C
               </span>
             )}
           </div>
-          <div className="mt-0.5 flex items-center gap-2">
-            <span className="text-[11px] text-slate-600">Lv.{clue.level}</span>
-          </div>
+          {roundLabel && (
+            <div className="mt-0.5 flex items-center gap-2">
+              <span
+                aria-label="라운드 범위"
+                className="inline-flex items-center rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-300"
+              >
+                {roundLabel}
+              </span>
+            </div>
+          )}
           {clue.description && (
             <p className="mt-1 line-clamp-2 text-xs text-slate-500">{clue.description}</p>
           )}

--- a/apps/web/src/features/editor/components/ClueListRow.tsx
+++ b/apps/web/src/features/editor/components/ClueListRow.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from 'lucide-react';
 import type { ClueResponse } from '@/features/editor/api';
+import { formatRoundRange } from '@/features/editor/utils/roundFormat';
 
 // ---------------------------------------------------------------------------
 // ClueListRow
@@ -12,6 +13,8 @@ interface ClueListRowProps {
 }
 
 export function ClueListRow({ clue, onEdit, onDelete }: ClueListRowProps) {
+  const roundLabel = formatRoundRange(clue.reveal_round, clue.hide_round);
+
   return (
     <div
       role="button"
@@ -23,8 +26,15 @@ export function ClueListRow({ clue, onEdit, onDelete }: ClueListRowProps) {
       {/* Name */}
       <span className="flex-1 truncate text-sm font-medium text-slate-200">{clue.name}</span>
 
-      {/* Level */}
-      <span className="shrink-0 text-[11px] text-slate-600">Lv.{clue.level}</span>
+      {/* Round range badge — hidden when unbounded on both sides */}
+      {roundLabel && (
+        <span
+          aria-label="라운드 범위"
+          className="shrink-0 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-300"
+        >
+          {roundLabel}
+        </span>
+      )}
 
       {/* Common badge */}
       {clue.is_common && (

--- a/apps/web/src/features/editor/components/__tests__/ClueCard.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueCard.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+vi.mock('../ImageUpload', () => ({
+  ImageUpload: () => <div data-testid="image-upload" />,
+}));
+
+import { ClueCard } from '../ClueCard';
+import type { ClueResponse } from '@/features/editor/api';
+
+function baseClue(overrides: Partial<ClueResponse> = {}): ClueResponse {
+  return {
+    id: 'c1',
+    theme_id: 't1',
+    location_id: null,
+    name: '단검',
+    description: null,
+    image_url: null,
+    is_common: false,
+    level: 1,
+    sort_order: 0,
+    created_at: '2026-04-17T00:00:00Z',
+    is_usable: false,
+    use_effect: null,
+    use_target: null,
+    use_consumed: false,
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe('ClueCard round badge', () => {
+  const noop = vi.fn();
+
+  it('closed range (2~5) 배지를 표시한다', () => {
+    render(
+      <ClueCard
+        clue={baseClue({ reveal_round: 2, hide_round: 5 })}
+        themeId="t1"
+        onEdit={noop}
+        onDelete={noop}
+        onImageUploaded={noop}
+      />,
+    );
+    expect(screen.getByLabelText('라운드 범위').textContent).toBe('R2~5');
+  });
+
+  it('open upper bound (~R4) 배지', () => {
+    render(
+      <ClueCard
+        clue={baseClue({ reveal_round: null, hide_round: 4 })}
+        themeId="t1"
+        onEdit={noop}
+        onDelete={noop}
+        onImageUploaded={noop}
+      />,
+    );
+    expect(screen.getByLabelText('라운드 범위').textContent).toBe('~R4');
+  });
+
+  it('round 필드가 없으면 배지를 전혀 렌더하지 않는다 (Lv 텍스트도 없음)', () => {
+    render(
+      <ClueCard
+        clue={baseClue()}
+        themeId="t1"
+        onEdit={noop}
+        onDelete={noop}
+        onImageUploaded={noop}
+      />,
+    );
+    expect(screen.queryByLabelText('라운드 범위')).toBeNull();
+    expect(screen.queryByText(/Lv\./)).toBeNull();
+  });
+});

--- a/apps/web/src/features/editor/components/__tests__/ClueListRow.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueListRow.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { ClueListRow } from '../ClueListRow';
+import type { ClueResponse } from '@/features/editor/api';
+
+function baseClue(overrides: Partial<ClueResponse> = {}): ClueResponse {
+  return {
+    id: 'c1',
+    theme_id: 't1',
+    location_id: null,
+    name: '독병',
+    description: null,
+    image_url: null,
+    is_common: false,
+    level: 1,
+    sort_order: 0,
+    created_at: '2026-04-17T00:00:00Z',
+    is_usable: false,
+    use_effect: null,
+    use_target: null,
+    use_consumed: false,
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe('ClueListRow round badge', () => {
+  const noop = vi.fn();
+
+  it('single-round (R3) 배지를 표시한다', () => {
+    render(
+      <ClueListRow
+        clue={baseClue({ reveal_round: 3, hide_round: 3 })}
+        onEdit={noop}
+        onDelete={noop}
+      />,
+    );
+    expect(screen.getByLabelText('라운드 범위').textContent).toBe('R3');
+  });
+
+  it('open lower bound (R2~) 배지', () => {
+    render(
+      <ClueListRow
+        clue={baseClue({ reveal_round: 2, hide_round: null })}
+        onEdit={noop}
+        onDelete={noop}
+      />,
+    );
+    expect(screen.getByLabelText('라운드 범위').textContent).toBe('R2~');
+  });
+
+  it('round 없으면 Lv 텍스트와 배지 모두 생략된다', () => {
+    render(
+      <ClueListRow
+        clue={baseClue()}
+        onEdit={noop}
+        onDelete={noop}
+      />,
+    );
+    expect(screen.queryByLabelText('라운드 범위')).toBeNull();
+    expect(screen.queryByText(/Lv\./)).toBeNull();
+  });
+
+  it('공통 배지와 라운드 배지가 함께 렌더된다', () => {
+    render(
+      <ClueListRow
+        clue={baseClue({ reveal_round: 1, hide_round: 4, is_common: true })}
+        onEdit={noop}
+        onDelete={noop}
+      />,
+    );
+    expect(screen.getByLabelText('라운드 범위').textContent).toBe('R1~4');
+    expect(screen.getByText('공통')).toBeDefined();
+  });
+});

--- a/apps/web/src/features/editor/utils/__tests__/roundFormat.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/roundFormat.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { formatRoundRange } from '../roundFormat';
+
+describe('formatRoundRange', () => {
+  it('returns null when both bounds are absent', () => {
+    expect(formatRoundRange(null, null)).toBeNull();
+    expect(formatRoundRange(undefined, undefined)).toBeNull();
+    expect(formatRoundRange(null, undefined)).toBeNull();
+  });
+
+  it('formats open lower bound (reveal only / from only)', () => {
+    expect(formatRoundRange(2, null)).toBe('R2~');
+    expect(formatRoundRange(5, undefined)).toBe('R5~');
+  });
+
+  it('formats open upper bound (hide only / until only)', () => {
+    expect(formatRoundRange(null, 4)).toBe('~R4');
+    expect(formatRoundRange(undefined, 7)).toBe('~R7');
+  });
+
+  it('formats closed range', () => {
+    expect(formatRoundRange(2, 5)).toBe('R2~5');
+    expect(formatRoundRange(1, 10)).toBe('R1~10');
+  });
+
+  it('collapses single-round range', () => {
+    expect(formatRoundRange(3, 3)).toBe('R3');
+  });
+});

--- a/apps/web/src/features/editor/utils/roundFormat.ts
+++ b/apps/web/src/features/editor/utils/roundFormat.ts
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------------
+// roundFormat — shared helpers for rendering clue/location round schedules.
+//
+// Rounds are stored as nullable INT columns:
+//   - `null` on the lower bound → visible from round 1
+//   - `null` on the upper bound → stays visible forever
+//
+// formatRoundRange returns a short human label. When both bounds are null it
+// returns null so callers can skip rendering entirely (no badge).
+// ---------------------------------------------------------------------------
+
+export function formatRoundRange(
+  from: number | null | undefined,
+  to: number | null | undefined,
+): string | null {
+  const f = from ?? null;
+  const t = to ?? null;
+  if (f == null && t == null) return null;
+  if (f != null && t != null) {
+    if (f === t) return `R${f}`;
+    return `R${f}~${t}`;
+  }
+  if (f != null) return `R${f}~`;
+  return `~R${t}`;
+}

--- a/docs/plans/2026-04-17-clue-edges-unified/checklist.md
+++ b/docs/plans/2026-04-17-clue-edges-unified/checklist.md
@@ -47,10 +47,11 @@
 **Branch**: `feat/phase-20/PR-3-round-badge`
 **Depends**: PR-1
 
-- [ ] `apps/web/src/features/editor/utils/roundFormat.ts` 신규 (formatRoundRange)
-- [ ] ClueCard.tsx: 기존 clue_type/Lv 줄 → 라운드 배지 (없으면 생략)
-- [ ] ClueListRow.tsx: 타입 텍스트 → 라운드 배지
-- [ ] 단위 테스트: ClueCard/ClueListRow 렌더 스냅샷
+- [x] `apps/web/src/features/editor/utils/roundFormat.ts` 신규 (formatRoundRange: null/단일/열림/닫힘 4종)
+- [x] ClueCard.tsx: Lv.x 줄 → roundLabel 배지 (없으면 row 전체 생략)
+- [x] ClueListRow.tsx: Lv.x → 라운드 배지 span (없으면 생략, 공통 배지와 공존)
+- [x] 단위 테스트: roundFormat 5 + ClueCard 3 + ClueListRow 4 = 12 신규 (aria-label="라운드 범위" 기반)
+- [x] `make ci-local` 통과 (lint + typecheck + 1050+ tests + build)
 - [ ] PR 생성 → 머지 (PR-2 payload 타입에 의존하므로 PR-2 선행 merged 후 brown-bag)
 
 ## W3 — PR-4 통합 엣지 스키마


### PR DESCRIPTION
## Summary

Phase 20 W2 PR-3. PR-2에서 추가된 `reveal_round/hide_round`를 에디터 단서 카드·리스트에 배지로 노출한다.

- **`utils/roundFormat.ts`** 신규: `formatRoundRange(from, to)` 공통 포맷터 (null → null, 단일/열림/닫힘 처리)
- **ClueCard**: 기존 `Lv.{level}` 서브라인을 라운드 배지로 교체 (라운드 없으면 row 생략)
- **ClueListRow**: `Lv.{level}` 텍스트를 라운드 배지 span으로 교체 (공통 배지와 공존)
- **접근성**: `aria-label="라운드 범위"` 부착
- **테스트**: roundFormat 5 + ClueCard 3 + ClueListRow 4 = 12 신규

## Scope (7 파일, +235/-9)

- `apps/web/src/features/editor/utils/roundFormat.ts` (신규)
- `apps/web/src/features/editor/utils/__tests__/roundFormat.test.ts` (신규)
- `apps/web/src/features/editor/components/ClueCard.tsx`
- `apps/web/src/features/editor/components/ClueListRow.tsx`
- `apps/web/src/features/editor/components/__tests__/ClueCard.test.tsx` (신규)
- `apps/web/src/features/editor/components/__tests__/ClueListRow.test.tsx` (신규)
- `docs/plans/2026-04-17-clue-edges-unified/checklist.md`

## Test plan

- [x] `make ci-local` (lint + typecheck + 1050+ tests + build) — 로컬 통과
- [ ] 에디터 단서 카드 뷰에서 reveal_round=2/hide_round=5 단서가 `R2~5` 배지로 표시
- [ ] 단서 리스트 뷰에서 동일 단서가 배지로 표시, 라운드 없는 단서는 배지 없음
- [ ] 공통 단서 + 라운드 단서 → 두 배지 모두 표시

## 의존성

PR #73 (PR-2) merged 후 진행. `ClueResponse.reveal_round/hide_round` 필드에 의존.

## Blocker

GitHub Actions 계정 레벨 disable (5월 1일 자동 리셋). admin bypass merge + 로컬 CI 검증으로 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)