### PR TITLE
chore(tooling): graphify watch/hook/setup Makefile target 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,3 +252,11 @@ gh pr checks <N>  # 대기
 - `manifest.json` — 증분 업데이트용
 - `cache/` — AST/semantic 캐시 (재인덱싱 시 재사용)
 - `cost.json` — 토큰 누적
+
+### 팀 공유 Makefile target
+| 커맨드 | 용도 |
+|--------|------|
+| `make graphify-setup` | clone 직후 1회 — `pipx install graphifyy` + `graphify hook install` (post-commit/post-checkout) |
+| `make graphify-watch` | 코드 변경 실시간 감지 + AST 재빌드 (LLM 토큰 0). tmux/screen 안에서 실행 권장 |
+| `make graphify-update` | 마지막 커밋 이후 변경 코드만 증분 재추출 (AST, 토큰 0). hook 미설치 환경용 |
+- `.git/hooks/`는 gitignore이므로 **각 개발자/worktree가 `make graphify-setup`을 1회 직접 실행**해야 post-commit 자동 동기화가 활성화된다.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down build build-no-cache logs ps lint lint-go lint-web test migrate seed ci-local
+.PHONY: up down build build-no-cache logs ps lint lint-go lint-web test migrate seed ci-local graphify-setup graphify-watch graphify-update
 
 # ---------------------------------------------------------------------------
 # Core commands
@@ -95,3 +95,29 @@ ci-local: lint-go lint-web typecheck test build-server build-web
 # Prevent make from treating 'dev'/'prod' as file targets
 dev prod:
 	@true
+
+# ---------------------------------------------------------------------------
+# Graphify (knowledge graph tooling)
+# ---------------------------------------------------------------------------
+
+## graphify-setup — graphify CLI + git hooks 설치 (clone 직후 1회)
+##                  pipx install graphifyy → graphify hook install
+##                  post-commit / post-checkout hook으로 `graphify update` 자동 실행
+graphify-setup:
+	@command -v graphify >/dev/null 2>&1 || { \
+		command -v pipx >/dev/null 2>&1 || { echo "pipx 필요: brew install pipx" >&2; exit 1; }; \
+		pipx install graphifyy; \
+	}
+	graphify hook install
+	@echo "✓ graphify CLI + git hooks 설치 완료"
+
+## graphify-watch — 코드 변경 감지 + AST 자동 재빌드 (LLM 토큰 0)
+##                  tmux/screen 안에서 백그라운드 실행 권장
+##                  MD/PDF 변경은 알림만 — 문서 대량 변경 시 `/graphify . --update` 권장
+graphify-watch:
+	graphify watch .
+
+## graphify-update — 마지막 커밋 이후 변경된 코드만 증분 재추출 (AST, 토큰 0)
+##                   post-commit hook 미설치 환경에서 수동 동기화용
+graphify-update:
+	graphify update .


### PR DESCRIPTION
## Summary
PR #79 후속 — graphify 사용을 팀에 공유할 수 있도록 Makefile target 3개 + CLAUDE.md 가이드 추가.

## Changes
- `Makefile` (+28/-1)
  - `graphify-setup` — clone 직후 1회: `pipx install graphifyy` + `graphify hook install`
  - `graphify-watch` — tmux 백그라운드 실시간 코드 AST 재빌드 (LLM 토큰 0)
  - `graphify-update` — hook 미설치 환경용 수동 증분 재추출
  - `.PHONY`에 3 target 등록
- `CLAUDE.md` (+8) — 🔴 graphify 섹션 하단에 "팀 공유 Makefile target" 표 추가. `.git/hooks/`가 gitignore이라 각 개발자/worktree가 \`make graphify-setup\` 1회 직접 실행 필요 명시

## Test plan
- [x] \`make -n graphify-setup\` dry-run OK
- [x] \`make -n graphify-watch\` dry-run OK
- [x] \`make -n graphify-update\` dry-run OK
- [x] PR 커밋 직후 post-commit hook **자동 트리거 검증** (`[graphify watch] Rebuilt: 4931 nodes, 11326 edges, 459 communities`)
- [ ] worktree 신규 환경에서 \`make graphify-setup\` 실행 → hook 정상 설치 확인 (머지 후 수동 검증)

## 후속 이슈
post-commit hook의 AST-only 증분이 기존 semantic 노드를 일부 씻어버린 흔적(6700 → 4931 nodes, warning 202건). 다음 PR에서 조사:
- \`graphify update\`의 manifest merge 로직이 semantic 노드를 보존하는지
- 또는 \`-\-mode deep\` 유지 옵션 필요한지

🤖 Generated with [Claude Code](https://claude.com/claude-code)