### PR TITLE
chore(tooling): graphify D 정책 — Phase 종료 시점 fresh rebuild만 repo 커밋

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,12 +72,16 @@ claude_skill_create.pdf
 .playwright-mcp/
 
 # ─── Graphify (knowledge graph artifacts) ────────────
-# graph.json / GRAPH_REPORT.md / manifest.json 은 선택적으로 커밋 가능
-# (주기 스냅샷 전용 — PR마다 갱신은 지양, repo 비대화 방지)
+# 정책 (D, 2026-04-18~): graph.json / GRAPH_REPORT.md / manifest.json 은
+#   Phase 종료 시점에만 fresh rebuild 결과를 PR로 커밋.
+#   일상 자동 재빌드(post-commit/watch/update) 결과는 개인 로컬 전용 — 커밋 금지.
 graphify-out/cache/
 graphify-out/.graphify_python
 graphify-out/.needs_update
+graphify-out/needs_update
 graphify-out/cost.json
+graphify-out/graph.html
+graphify-out/obsidian/
 .graphify-cache/
 
 # ─── Claude backup snapshots (local safety nets) ─────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,10 +253,26 @@ gh pr checks <N>  # 대기
 - `cache/` — AST/semantic 캐시 (재인덱싱 시 재사용)
 - `cost.json` — 토큰 누적
 
+### 🔴 repo graph.json 갱신 정책 (D, 2026-04-18~)
+
+**핵심:**
+- **repo의 `graphify-out/graph.json`은 Phase 종료 시점에만 수동 fresh rebuild → PR**
+- 일상 자동 재빌드(`post-commit` / `graphify watch` / `graphify update`)는 **개인 로컬 전용**이며 **결과물 repo 커밋 금지**
+- **이유:** `graphify.watch._rebuild_code`가 기존 `file_type="code"` 노드를 전부 삭제하고 AST로 재생성 → semantic 추출로 만든 "확장자 없는 개념 경로"(예: `apps/server/internal/domain/editor`, `packages/shared`) 노드 **~6% 영구 손실** (upstream 버그, 2026-04-18 확인)
+
 ### 팀 공유 Makefile target
 | 커맨드 | 용도 |
 |--------|------|
-| `make graphify-setup` | clone 직후 1회 — `pipx install graphifyy` + `graphify hook install` (post-commit/post-checkout) |
-| `make graphify-watch` | 코드 변경 실시간 감지 + AST 재빌드 (LLM 토큰 0). tmux/screen 안에서 실행 권장 |
-| `make graphify-update` | 마지막 커밋 이후 변경 코드만 증분 재추출 (AST, 토큰 0). hook 미설치 환경용 |
-- `.git/hooks/`는 gitignore이므로 **각 개발자/worktree가 `make graphify-setup`을 1회 직접 실행**해야 post-commit 자동 동기화가 활성화된다.
+| `make graphify-setup` | clone 직후 1회 — pipx로 CLI만 설치 (**hook 자동 설치 안 함**) |
+| `make graphify-install-hooks` | (선택) post-commit/post-checkout hook 설치 — **개인 로컬 전용**, 결과물 커밋 금지 |
+| `make graphify-uninstall-hooks` | 기존 hook 제거 |
+| `make graphify-watch` | 코드 변경 실시간 감지 + AST 재빌드 (tmux 권장). **결과물 커밋 금지** |
+| `make graphify-update` | 변경 코드만 증분 재추출 (수동). **결과물 커밋 금지** |
+| `make graphify-refresh` | **Phase 종료 시** Claude Code에서 `/graphify .` 실행 안내 (실제 fresh rebuild는 Claude Code 세션 필요) |
+
+**Phase 종료 fresh rebuild 워크플로우:**
+1. `make graphify-refresh` (안내 출력)
+2. 새 Claude Code 세션에서 `/graphify .` 실행 — 캐시 적중으로 변경 MD만 재추출 (Phase당 ~$0.15–2)
+3. `graph.json` / `GRAPH_REPORT.md` / `manifest.json` 만 PR로 커밋 (`cache/`는 `.gitignore`)
+
+**일반 PR에서 graph.json 변경은 reviewer가 즉시 revert 요구 대상.** 예외는 graphify 툴링 자체 PR.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: up down build build-no-cache logs ps lint lint-go lint-web test migrate seed ci-local graphify-setup graphify-watch graphify-update
+.PHONY: up down build build-no-cache logs ps lint lint-go lint-web test migrate seed ci-local \
+        graphify-setup graphify-install-hooks graphify-uninstall-hooks \
+        graphify-watch graphify-update graphify-refresh
 
 # ---------------------------------------------------------------------------
 # Core commands
@@ -97,27 +99,57 @@ dev prod:
 	@true
 
 # ---------------------------------------------------------------------------
-# Graphify (knowledge graph tooling)
+# Graphify (knowledge graph tooling) — D 정책 (2026-04-18~)
+#   repo graphify-out/graph.json 은 Phase 종료 시점에만 수동 fresh rebuild + PR.
+#   일상 post-commit / watch / update 는 "개인 로컬 전용" — 결과물 커밋 금지.
+#   이유: AST-only 재빌드가 semantic 개념 노드 ~6% 영구 손실 (upstream 버그).
 # ---------------------------------------------------------------------------
 
-## graphify-setup — graphify CLI + git hooks 설치 (clone 직후 1회)
-##                  pipx install graphifyy → graphify hook install
-##                  post-commit / post-checkout hook으로 `graphify update` 자동 실행
+## graphify-setup — graphify CLI 설치 (clone 직후 1회, hook 자동 설치 아님)
+##                  개인용 자동 동기화 원하면 make graphify-install-hooks 별도 실행
 graphify-setup:
 	@command -v graphify >/dev/null 2>&1 || { \
 		command -v pipx >/dev/null 2>&1 || { echo "pipx 필요: brew install pipx" >&2; exit 1; }; \
 		pipx install graphifyy; \
 	}
-	graphify hook install
-	@echo "✓ graphify CLI + git hooks 설치 완료"
+	@echo "✓ graphify CLI 설치 완료"
+	@echo "ℹ  post-commit hook은 기본 설치 안 함 (개인 선택: make graphify-install-hooks)"
+	@echo "ℹ  repo graph.json은 Phase 종료 시에만 fresh rebuild — make graphify-refresh"
 
-## graphify-watch — 코드 변경 감지 + AST 자동 재빌드 (LLM 토큰 0)
-##                  tmux/screen 안에서 백그라운드 실행 권장
-##                  MD/PDF 변경은 알림만 — 문서 대량 변경 시 `/graphify . --update` 권장
+## graphify-install-hooks — (선택) post-commit/post-checkout hook 설치 — 개인 로컬 전용
+##                          ⚠ AST 증분이 semantic 개념 노드 덮어쓰므로 결과 repo 커밋 금지
+graphify-install-hooks:
+	graphify hook install
+	@echo "⚠  hook 설치됨 (개인 로컬용). graph.json/REPORT를 repo에 커밋하지 말 것."
+
+## graphify-uninstall-hooks — post-commit/post-checkout hook 제거
+graphify-uninstall-hooks:
+	graphify hook uninstall
+
+## graphify-watch — 코드 변경 감지 + AST 재빌드 (LLM 토큰 0, 로컬 전용)
+##                  tmux/screen 권장. ⚠ 결과물 repo 커밋 금지
 graphify-watch:
 	graphify watch .
 
-## graphify-update — 마지막 커밋 이후 변경된 코드만 증분 재추출 (AST, 토큰 0)
-##                   post-commit hook 미설치 환경에서 수동 동기화용
+## graphify-update — 변경 코드만 증분 재추출 (AST, 토큰 0, 로컬 전용)
+##                   ⚠ 결과물 repo 커밋 금지
 graphify-update:
 	graphify update .
+
+## graphify-refresh — Phase 종료 시점 fresh rebuild 안내 (실제 실행은 Claude Code에서)
+graphify-refresh:
+	@echo "========================================================================"
+	@echo " Phase 종료 시점 fresh rebuild 워크플로우"
+	@echo "========================================================================"
+	@echo ""
+	@echo "1. Claude Code 세션을 새로 열고 다음을 입력:"
+	@echo "     /graphify ."
+	@echo ""
+	@echo "2. detect 경고가 뜨면 '전체 진행'으로 응답"
+	@echo "3. 결과를 PR로 커밋:"
+	@echo "     graphify-out/graph.json"
+	@echo "     graphify-out/GRAPH_REPORT.md"
+	@echo "     graphify-out/manifest.json"
+	@echo "   (cache/는 gitignore로 커밋 제외됨)"
+	@echo ""
+	@echo "캐시 적중으로 변경된 MD만 재추출됩니다 (Phase당 ~\$$0.15–2)."


### PR DESCRIPTION
## Summary
PR #80 후속 — graphify 자동 재빌드(post-commit / watch / update)가 semantic 개념 노드를 ~6% 영구 손실시키는 upstream 버그 확인 후 정책 재설정.

## 핵심 정책 (D)
- **repo의 \`graphify-out/graph.json\` / \`GRAPH_REPORT.md\` / \`manifest.json\`은 Phase 종료 시점에만 fresh rebuild → PR로 커밋**
- 일상 자동 재빌드는 **개인 로컬 전용** — 결과물 repo 커밋 금지
- \`graphify-setup\`은 hook 자동 설치 **제거** — 원하면 \`graphify-install-hooks\` 별도 실행

## Changes
- \`Makefile\` — graphify 섹션 재구성
  - \`graphify-setup\` — hook 자동 설치 제거
  - \`graphify-install-hooks\` / \`-uninstall-hooks\` — 개인 로컬 hook 선택 관리
  - \`graphify-refresh\` — Phase 종료 시점 워크플로우 안내 출력
  - \`watch\` / \`update\` — 로컬 전용, 커밋 금지 주석
- \`CLAUDE.md\` — "🔴 repo graph.json 갱신 정책 (D)" 섹션 신설, Makefile target 테이블 교체
- \`.gitignore\` — \`graphify-out/graph.html\`, \`graphify-out/obsidian/\` 상시 차단

## 배경 — Upstream 버그
\`graphify.watch._rebuild_code\` (pipx venv \`graphify/watch.py:46-47\`)가 기존 그래프의 \`file_type="code"\` 노드를 **전부 삭제**하고 AST extract로 재생성. 하지만 초기 semantic extraction이 만든 **확장자 없는 개념 경로 노드**(예: \`apps/server/internal/domain/editor\`, \`packages/shared\`, \`apps/server/internal/clue/\`)는 AST가 재생성 불가 → 영구 손실.

**실측:** MAIN 852 source_file → post-commit 결과 799 source_file (**-53개, 6.2%**). document/image/struct 손실 0.

## Test plan
- [x] \`make -n graphify-setup\` / \`-install-hooks\` / \`-refresh\` dry-run OK
- [x] \`git check-ignore graphify-out/graph.html graphify-out/obsidian/test.md\` 양쪽 차단 확인
- [x] post-commit hook 제거 후 graph.json 원본(6700 nodes) 상태 유지 확인
- [ ] 2026-04-18 이후 첫 Phase 종료 시 \`make graphify-refresh\` → \`/graphify .\` fresh rebuild 실전 검증 (별도 Phase archive PR에서)

## 영향
- 신규 clone 개발자: \`make graphify-setup\` → CLI만 설치. hook 원하면 \`make graphify-install-hooks\` 추가 1회.
- 기존 개발자: 현재 .git/hooks에 graphify hook이 있다면 \`make graphify-uninstall-hooks\` 권장 (품질 저하 방지)
- repo graph.json 품질: Phase 단위 fresh rebuild로 **semantic 풀 추출 유지**

🤖 Generated with [Claude Code](https://claude.com/claude-code)