### PR TITLE
fix(voice): remove mock token plaintext log (F-sec-3 P0)

### DIFF
--- a/apps/server/internal/domain/voice/provider.go
+++ b/apps/server/internal/domain/voice/provider.go
@@ -100,12 +100,15 @@ func NewMockProvider(logger zerolog.Logger) VoiceProvider {
 }
 
 // GenerateToken returns a deterministic mock token for testing.
+//
+// SECURITY: do not log the token value itself — even mock tokens mirror the
+// real LiveKit JWT shape, and leaking them here would normalize the pattern
+// for production providers. player_id + room uniquely identify the request.
 func (m *mockProvider) GenerateToken(_ context.Context, params TokenParams) (string, error) {
 	token := fmt.Sprintf("mock-token-%s", params.PlayerID.String())
 	m.logger.Debug().
 		Str("room", params.RoomName).
 		Str("player_id", params.PlayerID.String()).
-		Str("token", token).
 		Msg("mock: generated token")
 	return token, nil
 }


### PR DESCRIPTION
## Summary
Phase 19 F-sec-3 P0 해소 — mockProvider.GenerateToken 의 \`Str(\"token\", token)\` 로그 삭제.

## 배경
- Phase 19 Platform Deep Audit(PR #69) 에서 P0로 플래그됨
- 오늘 delta audit(PR #82)에서 **여전히 미해소** 확인
- mock token은 \`mock-token-<uuid>\` 형태지만 실제 LiveKit provider 도입 시 동일 패턴이 JWT 원문 로깅으로 이어질 위험
- player_id + room만으로 디버깅 요청 식별 충분

## Changes
- \`apps/server/internal/domain/voice/provider.go:108\` — token 필드 로깅 제거
- SECURITY 주석 3줄 추가 (future regression 방어)

## Test plan
- [x] \`go build ./...\` 성공
- [x] \`grep -rn 'Str(\"token\"' apps/server/\` → 0건 (잔여 패턴 없음 확인)
- [x] voice 패키지 \`go test\` → no test files (기존 상태 유지, F-04 coverage 갭은 별도 PR-5 scope)

## 추가 고려 (후속)
- production LiveKit provider 구현 시 동일 규약 강제할 linter rule 검토 (PR #82 priority-update 의 **PR-10 D-DEV-RULE** 후보 참조)

## Merge 정책
CI admin-skip 적용 (2026-05-01까지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)