### PR TITLE
feat(phase-19): PR-3 HTTP Error Standardization (F-sec-1 P0)

### DIFF
--- a/apps/server/.golangci.yml
+++ b/apps/server/.golangci.yml
@@ -4,10 +4,19 @@ linters:
   default: none
   enable:
     - errcheck
+    - forbidigo
     - govet
     - ineffassign
     - staticcheck
     - unused
+  settings:
+    forbidigo:
+      forbid:
+        # Phase 19 PR-3 — http.Error 직접 호출 금지. apperror.WriteError 사용.
+        # RFC 9457 Problem Details 일관성 + F-sec-1 재발 방지.
+        - pattern: '^http\.Error$'
+          msg: 'use apperror.WriteError instead of http.Error (Phase 19 F-sec-1 / RFC 9457)'
+      exclude-godoc-examples: true
   exclusions:
     generated: lax
     presets:

--- a/apps/server/internal/apperror/apperror.go
+++ b/apps/server/internal/apperror/apperror.go
@@ -102,6 +102,11 @@ func Timeout(detail string) *AppError {
 	return New(ErrTimeout, http.StatusRequestTimeout, detail)
 }
 
+// MethodNotAllowed creates a 405 Method Not Allowed error.
+func MethodNotAllowed(detail string) *AppError {
+	return New(ErrMethodNotAllowed, http.StatusMethodNotAllowed, detail)
+}
+
 // Unwrap supports errors.Is/As chain traversal.
 func (e *AppError) Unwrap() error {
 	return e.Internal

--- a/apps/server/internal/apperror/codes.go
+++ b/apps/server/internal/apperror/codes.go
@@ -13,6 +13,7 @@ const (
 	ErrValidation         = "VALIDATION_ERROR"
 	ErrTimeout            = "TIMEOUT"
 	ErrServiceUnavailable = "SERVICE_UNAVAILABLE"
+	ErrMethodNotAllowed   = "METHOD_NOT_ALLOWED"
 
 	// Auth errors
 	ErrAuthTokenExpired = "AUTH_TOKEN_EXPIRED"

--- a/apps/server/internal/infra/storage/local.go
+++ b/apps/server/internal/infra/storage/local.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/rs/zerolog"
 )
 
@@ -115,7 +116,7 @@ func (l *LocalProvider) DeleteObjects(ctx context.Context, keys []string) error 
 func (l *LocalProvider) UploadHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			apperror.WriteError(w, r, apperror.MethodNotAllowed("method not allowed"))
 			return
 		}
 
@@ -130,7 +131,7 @@ func (l *LocalProvider) UploadHandler() http.HandlerFunc {
 			}
 		}
 		if key == "" {
-			http.Error(w, "missing key", http.StatusBadRequest)
+			apperror.WriteError(w, r, apperror.BadRequest("missing key"))
 			return
 		}
 
@@ -140,20 +141,20 @@ func (l *LocalProvider) UploadHandler() http.HandlerFunc {
 		absBase, _ := filepath.Abs(l.baseDir)
 		absDest, _ := filepath.Abs(destPath)
 		if !strings.HasPrefix(absDest, absBase+string(os.PathSeparator)) {
-			http.Error(w, "invalid path", http.StatusBadRequest)
+			apperror.WriteError(w, r, apperror.BadRequest("invalid path"))
 			return
 		}
 
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			l.log.Error().Err(err).Str("path", destPath).Msg("failed to create upload directory")
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			apperror.WriteError(w, r, apperror.Internal("failed to create upload directory").Wrap(err))
 			return
 		}
 
 		f, err := os.Create(destPath)
 		if err != nil {
 			l.log.Error().Err(err).Str("path", destPath).Msg("failed to create upload file")
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			apperror.WriteError(w, r, apperror.Internal("failed to create upload file").Wrap(err))
 			return
 		}
 		defer f.Close()
@@ -161,7 +162,7 @@ func (l *LocalProvider) UploadHandler() http.HandlerFunc {
 		r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10MB hard cap
 		if _, err := io.Copy(f, r.Body); err != nil {
 			l.log.Error().Err(err).Str("path", destPath).Msg("failed to write upload file")
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			apperror.WriteError(w, r, apperror.Internal("failed to write upload file").Wrap(err))
 			return
 		}
 
@@ -181,7 +182,7 @@ func (l *LocalProvider) ServeHandler() http.HandlerFunc {
 			}
 		}
 		if key == "" {
-			http.Error(w, "missing key", http.StatusBadRequest)
+			apperror.WriteError(w, r, apperror.BadRequest("missing key"))
 			return
 		}
 
@@ -191,7 +192,7 @@ func (l *LocalProvider) ServeHandler() http.HandlerFunc {
 		absBase, _ := filepath.Abs(l.baseDir)
 		absDest, _ := filepath.Abs(filePath)
 		if !strings.HasPrefix(absDest, absBase+string(os.PathSeparator)) {
-			http.Error(w, "invalid path", http.StatusBadRequest)
+			apperror.WriteError(w, r, apperror.BadRequest("invalid path"))
 			return
 		}
 

--- a/apps/server/internal/seo/handler.go
+++ b/apps/server/internal/seo/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/rs/zerolog"
 )
 
@@ -118,7 +119,7 @@ func (h *Handler) ThemePage(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.theme.ExecuteTemplate(w, "layout", data); err != nil {
 		h.logger.Error().Err(err).Str("slug", slug).Msg("failed to render theme page")
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		apperror.WriteError(w, r, apperror.Internal("failed to render theme page").Wrap(err))
 	}
 }
 
@@ -133,7 +134,7 @@ func (h *Handler) PrivacyPage(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.privacy.ExecuteTemplate(w, "layout", data); err != nil {
 		h.logger.Error().Err(err).Msg("failed to render privacy page")
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		apperror.WriteError(w, r, apperror.Internal("failed to render privacy page").Wrap(err))
 	}
 }
 
@@ -148,7 +149,7 @@ func (h *Handler) TermsPage(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.terms.ExecuteTemplate(w, "layout", data); err != nil {
 		h.logger.Error().Err(err).Msg("failed to render terms page")
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		apperror.WriteError(w, r, apperror.Internal("failed to render terms page").Wrap(err))
 	}
 }
 

--- a/apps/server/internal/ws/upgrade.go
+++ b/apps/server/internal/ws/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/rs/zerolog"
 )
 
@@ -113,7 +114,7 @@ func UpgradeHandler(hub ClientHub, extractPlayerID PlayerIDExtractor, cfg Upgrad
 		playerID, err := extractPlayerID(r)
 		if err != nil {
 			log.Warn().Err(err).Msg("invalid player ID on upgrade")
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			apperror.WriteError(w, r, apperror.Unauthorized("unauthorized").Wrap(err))
 			return
 		}
 


### PR DESCRIPTION
## Summary
Phase 19 W1 PR-3 — **F-sec-1 P0 해소**. \`http.Error\` 직접 호출 12건을 \`apperror.WriteError\` 로 교체하고 forbidigo linter rule로 재발 방지.

## 배경
- Phase 19 F-sec-1 (**P0**): RFC 9457 Problem Details 우회 12건
- 오늘 delta audit(PR #82) **GI-2**에서 구조적 증거 확인 (\`WriteError\`/\`writeJSON\` 272 edges 병존)
- priority-update.md에서 W1 내 **우선순위 1위**로 상향

## Changes (6 파일, +30/-12)

### apperror 패키지 확장
- \`codes.go\`: \`ErrMethodNotAllowed = "METHOD_NOT_ALLOWED"\` 추가
- \`apperror.go\`: \`MethodNotAllowed(detail)\` helper 추가 (405)

### 12 호출 교체
| 파일 | 건 | Helper |
|------|----|--------|
| \`internal/infra/storage/local.go\` UploadHandler | 6 | MethodNotAllowed × 1 / BadRequest × 2 / Internal × 3 (Wrap(err)) |
| \`internal/infra/storage/local.go\` ServeHandler | 2 | BadRequest × 2 |
| \`internal/seo/handler.go\` | 3 | Internal × 3 (Wrap(err), Theme/Privacy/Terms) |
| \`internal/ws/upgrade.go\` | 1 | Unauthorized × 1 (Wrap(err)) |

모든 응답은 이제 \`application/problem+json\` RFC 9457 형식.

### 재발 방지 — forbidigo linter
\`apps/server/.golangci.yml\`:
\`\`\`yaml
linters:
  enable:
    - forbidigo
  settings:
    forbidigo:
      forbid:
        - pattern: '^http\\.Error$'
          msg: 'use apperror.WriteError instead of http.Error (Phase 19 F-sec-1 / RFC 9457)'
      exclude-godoc-examples: true
\`\`\`

## Test plan
- [x] \`grep -rn 'http.Error(' apps/server/\` = **0건**
- [x] \`go build ./...\` OK
- [x] \`go test ./internal/{apperror,seo,infra/storage,ws}/...\` 전부 **pass** (storage는 원래 no test files)
- [ ] forbidigo rule 실제 작동 — 로컬 \`golangci-lint run\` 시 http.Error 재도입 시도하면 fail (CI admin-skip이라 주로 로컬 확인)

## 교차 영향 (graphify GI-2)
- \`writeJSON()\` 119 edges는 별도 경로(\`apps/server/cmd/server/routes_*.go\` 등)라 이 PR scope 밖
- 후속으로 \`writeJSON\` 경로도 점검 가능하지만 Phase 19 backlog에 명시적 항목 아직 없음

## Phase 19 진행
- W0 PR-0 ✅ (MEMORY migration, #84)
- **W1 PR-3 ← 현재 PR** (F-sec-1 P0 해소)
- W1 PR-1 WS Contract SSOT · PR-6 Auditlog Expansion 미착수

## Merge 정책
CI admin-skip (2026-05-01까지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)