### PR TITLE
feat(phase-19): PR-6 Auditlog Expansion — schema + auth/admin/review/editor 배선

### DIFF
--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 	"github.com/mmp-platform/server/internal/config"
 	"github.com/mmp-platform/server/internal/db"
 	"github.com/mmp-platform/server/internal/domain/admin"
@@ -139,8 +140,18 @@ func main() {
 	// inject snapshot deps after Hub is ready).
 	sessionMgr := session.NewSessionManager(logger)
 
-	// 8. Domain Services
-	authSvc := auth.NewService(queries, redisCache.Client(), []byte(cfg.JWTSecret), logger)
+	// 8. Audit log pipeline (Phase 19 PR-6 — F-sec-4).
+	// DBLogger writes asynchronously; Start spawns the flush goroutine,
+	// Stop drains the queue at shutdown. Services that need to record
+	// identity-bound audit events accept the Logger as a dependency.
+	auditStore := auditlog.NewStore(pool)
+	auditLog := auditlog.NewDBLogger(auditStore, logger)
+	auditLog.Start()
+	defer auditLog.Stop()
+	logger.Info().Msg("auditlog started")
+
+	// 9. Domain Services
+	authSvc := auth.NewService(queries, redisCache.Client(), []byte(cfg.JWTSecret), auditLog, logger)
 	profileSvc := profile.NewService(queries, logger)
 	themeSvc := theme.NewService(queries, logger)
 	editorSvc := editor.NewService(queries, pool, logger)
@@ -216,14 +227,14 @@ func main() {
 	authHandler := auth.NewHandler(authSvc)
 	profileHandler := profile.NewHandler(profileSvc)
 	themeHandler := theme.NewHandler(themeSvc)
-	editorHandler := editor.NewHandler(editorSvc)
-	adminHandler := admin.NewHandler(adminSvc)
+	editorHandler := editor.NewHandler(editorSvc, auditLog, logger)
+	adminHandler := admin.NewHandler(adminSvc, auditLog, logger)
 	socialHandler := social.NewHandler(friendSvc, chatSvc)
 	paymentHandler := payment.NewHandler(paymentSvc, paymentProvider)
 	coinHandler := coin.NewHandler(coinSvc)
 	creatorHandler := creator.NewHandler(creatorSvc)
 	creatorAdminHandler := creator.NewAdminHandler(queries, pool, settlementPipeline, logger)
-	reviewHandler := admin.NewReviewHandler(queries, logger)
+	reviewHandler := admin.NewReviewHandler(queries, auditLog, logger)
 
 	// Template loader + handler (Phase 18.4 W0 PR-1: expose preset templates).
 	templateLoader := template.NewLoader()

--- a/apps/server/db/migrations/00026_auditlog_expansion.sql
+++ b/apps/server/db/migrations/00026_auditlog_expansion.sql
@@ -1,0 +1,66 @@
+-- +goose Up
+-- Phase 19 PR-6 — Auditlog Expansion (F-sec-4 P0, delta D-SEC-1).
+--
+-- Motivation: the original audit_events schema (00018) required a non-null
+-- session_id, so auth/admin/review/editor events — which occur outside any
+-- game session — could not be written. Phase 19 audit F-sec-4 flagged this
+-- as a P0 because a full class of security-relevant actions (login,
+-- logout, ban, review approval, clue-edge edits) goes unrecorded.
+--
+-- This migration loosens the schema to support both game-bound events
+-- (session_id, seq) and identity-bound events (user_id, seq=NULL), while
+-- guaranteeing every row carries at least one identity:
+--
+--   1. session_id and seq become NULLABLE.
+--   2. A user_id column is added (NULLABLE) so auth/admin actions can be
+--      attributed to the acting account without fabricating a session.
+--   3. The legacy per-session UNIQUE(session_id, seq) is replaced with a
+--      partial unique index active only when session_id IS NOT NULL, so
+--      user-only rows never collide on a synthetic seq.
+--   4. An IDENTITY CHECK constraint forbids rows that have neither
+--      session_id nor user_id, preserving the "every audit row is
+--      attributable" invariant.
+--   5. A descending index on (user_id, created_at) keeps admin-dashboard
+--      lookups ("show last N actions by user X") fast.
+
+ALTER TABLE audit_events
+    ALTER COLUMN session_id DROP NOT NULL,
+    ALTER COLUMN seq DROP NOT NULL,
+    ADD COLUMN user_id UUID;
+
+ALTER TABLE audit_events
+    DROP CONSTRAINT IF EXISTS audit_events_session_id_seq_key;
+
+CREATE UNIQUE INDEX audit_events_session_seq_key
+    ON audit_events (session_id, seq)
+    WHERE session_id IS NOT NULL;
+
+CREATE INDEX idx_audit_events_user
+    ON audit_events (user_id, created_at DESC)
+    WHERE user_id IS NOT NULL;
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT audit_events_identity_required
+    CHECK (session_id IS NOT NULL OR user_id IS NOT NULL);
+
+-- +goose Down
+-- Reverts the schema to the 00018 shape. Session-less rows (user-only) are
+-- evicted before restoring NOT NULL; the down path is only expected to
+-- run when rolling back an aborted migration and losing those rows is
+-- acceptable in that recovery scenario.
+
+ALTER TABLE audit_events
+    DROP CONSTRAINT IF EXISTS audit_events_identity_required;
+
+DROP INDEX IF EXISTS idx_audit_events_user;
+DROP INDEX IF EXISTS audit_events_session_seq_key;
+
+DELETE FROM audit_events WHERE session_id IS NULL;
+
+ALTER TABLE audit_events
+    ALTER COLUMN session_id SET NOT NULL,
+    ALTER COLUMN seq SET NOT NULL,
+    DROP COLUMN user_id;
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT audit_events_session_id_seq_key UNIQUE (session_id, seq);

--- a/apps/server/db/queries/audit_events.sql
+++ b/apps/server/db/queries/audit_events.sql
@@ -1,12 +1,31 @@
 -- name: AppendAuditEvent :one
-INSERT INTO audit_events (session_id, seq, actor_id, action, module_id, payload)
-VALUES ($1, $2, $3, $4, $5, $6)
+-- Game-bound audit row. session_id + seq are required; user_id is optional
+-- but commonly set for player-triggered events so dashboards can correlate
+-- by both axes.
+INSERT INTO audit_events (session_id, seq, actor_id, user_id, action, module_id, payload)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING *;
+
+-- name: AppendUserAuditEvent :one
+-- Identity-bound audit row (Phase 19 PR-6). Used for auth/admin/review/
+-- editor actions that occur outside any game session; session_id and seq
+-- stay NULL and the partial UNIQUE index is not engaged.
+INSERT INTO audit_events (session_id, seq, actor_id, user_id, action, module_id, payload)
+VALUES (NULL, NULL, $1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: ListBySession :many
 SELECT * FROM audit_events
 WHERE session_id = $1
 ORDER BY seq;
+
+-- name: ListByUser :many
+-- Newest-first lookup for admin dashboards. user_id is the target user
+-- (may equal actor_id for self-initiated events like login).
+SELECT * FROM audit_events
+WHERE user_id = $1
+ORDER BY created_at DESC
+LIMIT $2;
 
 -- name: LatestSeq :one
 SELECT COALESCE(MAX(seq), 0)::bigint AS seq

--- a/apps/server/internal/auditlog/event.go
+++ b/apps/server/internal/auditlog/event.go
@@ -8,27 +8,83 @@ import (
 	"github.com/google/uuid"
 )
 
-// AuditAction identifies the type of game event being audited.
+// AuditAction identifies the type of event being audited.
+//
+// Constants are grouped by domain. The Phase 19 PR-6 expansion introduced
+// the auth/admin/review/editor groups so that F-sec-4 (no audit coverage
+// outside game sessions) is addressed: prior to PR-6 only the Game group
+// existed and write attempts for session-less events were rejected by
+// AuditEvent.Validate().
 type AuditAction string
 
 const (
+	// --- Game (original 00018 taxonomy) ---
 	ActionPlayerAction AuditAction = "player.action"
 	ActionPhaseEnter   AuditAction = "phase.enter"
 	ActionPhaseExit    AuditAction = "phase.exit"
 	ActionWinDecision  AuditAction = "win.decision"
 	ActionModulePanic  AuditAction = "module.panic"
 	ActionRuleEval     AuditAction = "rule.eval"
+
+	// --- Auth (Phase 19 PR-6) ---
+	ActionUserRegister       AuditAction = "user.register"
+	ActionUserLogin          AuditAction = "user.login"
+	ActionUserLoginFail      AuditAction = "user.login_fail"
+	ActionUserLogout         AuditAction = "user.logout"
+	ActionUserPasswordChange AuditAction = "user.password_change"
+	ActionUserDeleteAccount  AuditAction = "user.delete_account"
+
+	// --- Admin (Phase 19 PR-6) ---
+	ActionAdminBan                 AuditAction = "admin.ban"
+	ActionAdminUnban               AuditAction = "admin.unban"
+	ActionAdminRoleChange          AuditAction = "admin.role_change"
+	ActionAdminForceUnpublishTheme AuditAction = "admin.theme.force_unpublish"
+	ActionAdminForceCloseRoom      AuditAction = "admin.room.force_close"
+	ActionAdminTrustedCreator      AuditAction = "admin.trusted_creator"
+
+	// --- Review (Phase 19 PR-6) ---
+	ActionReviewSubmit  AuditAction = "review.submit"
+	ActionReviewApprove AuditAction = "review.approve"
+	ActionReviewReject  AuditAction = "review.reject"
+	ActionReviewSuspend AuditAction = "review.suspend"
+
+	// --- Editor — delta D-SEC-1 (Phase 19 PR-6) ---
+	ActionEditorClueEdgesReplace   AuditAction = "editor.clue_edges.replace"
+	ActionEditorClueEdgeCreate     AuditAction = "editor.clue_edge.create"
+	ActionEditorClueEdgeDelete     AuditAction = "editor.clue_edge.delete"
+	ActionEditorClueRelationCreate AuditAction = "editor.clue_relation.create"
+	ActionEditorClueRelationDelete AuditAction = "editor.clue_relation.delete"
 )
 
 // AuditEvent is the domain representation of a single audit log entry.
 // It mirrors the audit_events DB row but uses Go-native nullable types.
+//
+// Two shapes are supported (Phase 19 PR-6):
+//
+//   - Game-bound: SessionID != uuid.Nil AND Seq > 0.
+//     Persisted via the transactional per-session Append path; protected by
+//     the partial UNIQUE(session_id, seq) index.
+//
+//   - Identity-bound: UserID != nil, SessionID == uuid.Nil, Seq == 0.
+//     Persisted via AppendUserAuditEvent; used for auth/admin/review/editor
+//     actions that occur outside any game session.
+//
+// Validate() rejects rows that carry neither identity.
 type AuditEvent struct {
 	// ID is set after persistence; zero value before insertion.
-	ID        int64
+	ID int64
+	// SessionID is uuid.Nil when the event is not tied to a game session.
 	SessionID uuid.UUID
-	Seq       int64
-	// ActorID is nil for system-generated events.
-	ActorID  *uuid.UUID
+	// Seq is 0 when SessionID == uuid.Nil.
+	Seq int64
+	// ActorID is the user/bot that triggered the event; nil for system-
+	// generated events (e.g. ActionModulePanic).
+	ActorID *uuid.UUID
+	// UserID is the user the audit entry is filed against. For self-
+	// initiated events (login, password change) this typically equals
+	// ActorID; for admin actions (ban) it is the target account.
+	UserID *uuid.UUID
+	// Action is one of the AuditAction constants above.
 	Action   AuditAction
 	ModuleID string
 	Payload  json.RawMessage
@@ -36,10 +92,20 @@ type AuditEvent struct {
 	CreatedAt time.Time
 }
 
+// HasSession reports whether the event is tied to a game session.
+func (e AuditEvent) HasSession() bool { return e.SessionID != uuid.Nil }
+
+// HasUser reports whether the event carries an identity-bound user_id.
+func (e AuditEvent) HasUser() bool { return e.UserID != nil }
+
 // Validate returns an error if the event is structurally invalid.
+// Every row MUST carry either a SessionID or a UserID (or both); this
+// invariant is enforced in the DB via CHECK audit_events_identity_required
+// but is also asserted here so violations fail fast in the caller rather
+// than round-tripping to postgres.
 func (e AuditEvent) Validate() error {
-	if e.SessionID == uuid.Nil {
-		return fmt.Errorf("auditlog: session_id must not be zero")
+	if !e.HasSession() && !e.HasUser() {
+		return fmt.Errorf("auditlog: session_id or user_id required")
 	}
 	if e.Action == "" {
 		return fmt.Errorf("auditlog: action must not be empty")

--- a/apps/server/internal/auditlog/logger_test.go
+++ b/apps/server/internal/auditlog/logger_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/db"
@@ -362,14 +363,14 @@ func TestDBLogger_RealPersistPath(t *testing.T) {
 	// Build a Store with a mock TxRunner instead of a real pgxpool.
 	var called atomic.Bool
 	sq := &stubQuerier{
-		latestSeqFn: func(_ context.Context, _ uuid.UUID) (int64, error) {
+		latestSeqFn: func(_ context.Context, _ pgtype.UUID) (int64, error) {
 			return 0, nil
 		},
 		appendAuditEventFn: func(_ context.Context, _ db.AppendAuditEventParams) (db.AuditEvent, error) {
 			called.Store(true)
 			return db.AuditEvent{}, nil
 		},
-		listBySessionFn: func(_ context.Context, _ uuid.UUID) ([]db.AuditEvent, error) {
+		listBySessionFn: func(_ context.Context, _ pgtype.UUID) ([]db.AuditEvent, error) {
 			return nil, nil
 		},
 	}

--- a/apps/server/internal/auditlog/store.go
+++ b/apps/server/internal/auditlog/store.go
@@ -21,13 +21,17 @@ var ErrBufferFull = errors.New("auditlog: buffer full")
 // ErrStopped is returned by DBLogger.Append when Stop has already been called.
 var ErrStopped = errors.New("auditlog: logger stopped")
 
-// Querier is the subset of db.Queries used inside the Append transaction.
+// Querier is the subset of db.Queries used inside audit transactions.
 // Keeping this as an interface is what makes TxRunner injectable for unit
 // tests: a fake runner calls its own stub Querier without touching postgres.
+//
+// The pgtype-typed session_id / seq / user_id reflect the Phase 19 PR-6
+// schema where those columns are NULLABLE.
 type Querier interface {
 	AppendAuditEvent(ctx context.Context, arg db.AppendAuditEventParams) (db.AuditEvent, error)
-	ListBySession(ctx context.Context, sessionID uuid.UUID) ([]db.AuditEvent, error)
-	LatestSeq(ctx context.Context, sessionID uuid.UUID) (int64, error)
+	AppendUserAuditEvent(ctx context.Context, arg db.AppendUserAuditEventParams) (db.AuditEvent, error)
+	ListBySession(ctx context.Context, sessionID pgtype.UUID) ([]db.AuditEvent, error)
+	LatestSeq(ctx context.Context, sessionID pgtype.UUID) (int64, error)
 }
 
 // TxRunner is a minimal seam for executing a read/write transaction against
@@ -44,7 +48,7 @@ type TxRunner interface {
 // to avoid lost-update races under concurrent writers.
 type Store struct {
 	runner TxRunner
-	pool   *pgxpool.Pool // retained for non-tx reads (ListBySession, LatestSeq)
+	pool   *pgxpool.Pool // retained for non-tx reads (ListBySession, LatestSeq, user path)
 }
 
 // NewStore constructs a Store backed by the given pgxpool. pool must not be nil.
@@ -61,7 +65,7 @@ func NewStore(pool *pgxpool.Pool) *Store {
 // NewStoreWithRunner constructs a Store with a custom TxRunner. Intended for
 // unit tests that need to drive error-classification paths without spinning up
 // a testcontainer. pool may be nil when the caller does not exercise
-// ListBySession / LatestSeq.
+// ListBySession / LatestSeq / the user-event path.
 func NewStoreWithRunner(runner TxRunner, pool *pgxpool.Pool) *Store {
 	if runner == nil {
 		panic("auditlog: runner must not be nil")
@@ -69,48 +73,64 @@ func NewStoreWithRunner(runner TxRunner, pool *pgxpool.Pool) *Store {
 	return &Store{runner: runner, pool: pool}
 }
 
-// Append persists evt to the database, assigning the next seq atomically.
-// An advisory lock keyed on the session_id ensures only one writer at a time
-// increments the per-session sequence counter, preventing duplicate-key races
-// under concurrent load without requiring retry logic in the caller. The lock
-// is transaction-scoped (pg_advisory_xact_lock), so it's released automatically
-// on commit or rollback. Cross-session writers do not contend with each other.
+// Append persists evt to the database. The write path is chosen by evt
+// shape (Phase 19 PR-6):
+//
+//   - SessionID non-zero ⇒ per-session Tx + seq assignment + AppendAuditEvent
+//     (preserves the original 00018 behaviour: advisory lock, seq race-free).
+//   - SessionID zero && UserID set ⇒ AppendUserAuditEvent (identity-bound
+//     row, no seq, no Tx — the DB CHECK constraint asserts at least one
+//     identity is present).
 func (s *Store) Append(ctx context.Context, evt AuditEvent) error {
 	if err := evt.Validate(); err != nil {
 		return err
 	}
+	if evt.HasSession() {
+		return s.appendSessionEvent(ctx, evt)
+	}
+	return s.appendUserEvent(ctx, evt)
+}
 
+// appendSessionEvent implements the game-bound write path. An advisory lock
+// keyed on the session_id ensures only one writer at a time increments the
+// per-session sequence counter, preventing duplicate-key races without
+// requiring retry logic in the caller. The lock is transaction-scoped
+// (pg_advisory_xact_lock), released on commit/rollback. Cross-session
+// writers do not contend.
+func (s *Store) appendSessionEvent(ctx context.Context, evt AuditEvent) error {
 	err := s.runner.RunTx(ctx, evt.SessionID, func(q Querier) error {
-		seq, err := q.LatestSeq(ctx, evt.SessionID)
+		sessPG := toPgUUID(evt.SessionID)
+		seq, err := q.LatestSeq(ctx, sessPG)
 		if err != nil {
 			return err
 		}
-		seq++ // next sequence number
-
-		payload := evt.Payload
-		if len(payload) == 0 {
-			payload = json.RawMessage(`{}`)
-		}
-
-		var actorID pgtype.UUID
-		if evt.ActorID != nil {
-			actorID = pgtype.UUID{Bytes: *evt.ActorID, Valid: true}
-		}
-
-		var moduleID pgtype.Text
-		if evt.ModuleID != "" {
-			moduleID = pgtype.Text{String: evt.ModuleID, Valid: true}
-		}
+		seq++
 
 		_, err = q.AppendAuditEvent(ctx, db.AppendAuditEventParams{
-			SessionID: evt.SessionID,
-			Seq:       seq,
-			ActorID:   actorID,
+			SessionID: sessPG,
+			Seq:       pgtype.Int8{Int64: seq, Valid: true},
+			ActorID:   ptrToPgUUID(evt.ActorID),
+			UserID:    ptrToPgUUID(evt.UserID),
 			Action:    string(evt.Action),
-			ModuleID:  moduleID,
-			Payload:   payload,
+			ModuleID:  stringToPgText(evt.ModuleID),
+			Payload:   payloadOrEmpty(evt.Payload),
 		})
 		return err
+	})
+	return wrapDBError(err)
+}
+
+// appendUserEvent implements the identity-bound write path for auth/admin/
+// review/editor events. No Tx or seq is required because the partial
+// UNIQUE(session_id, seq) index is not engaged when session_id IS NULL.
+func (s *Store) appendUserEvent(ctx context.Context, evt AuditEvent) error {
+	q := db.New(s.pool)
+	_, err := q.AppendUserAuditEvent(ctx, db.AppendUserAuditEventParams{
+		ActorID:  ptrToPgUUID(evt.ActorID),
+		UserID:   ptrToPgUUID(evt.UserID),
+		Action:   string(evt.Action),
+		ModuleID: stringToPgText(evt.ModuleID),
+		Payload:  payloadOrEmpty(evt.Payload),
 	})
 	return wrapDBError(err)
 }
@@ -141,7 +161,7 @@ func (r *pgxTxRunner) RunTx(ctx context.Context, sessionID uuid.UUID, fn func(q 
 // ListBySession returns all audit events for the given session ordered by seq.
 func (s *Store) ListBySession(ctx context.Context, sessionID uuid.UUID) ([]AuditEvent, error) {
 	q := db.New(s.pool)
-	rows, err := q.ListBySession(ctx, sessionID)
+	rows, err := q.ListBySession(ctx, toPgUUID(sessionID))
 	if err != nil {
 		return nil, wrapDBError(err)
 	}
@@ -155,11 +175,41 @@ func (s *Store) ListBySession(ctx context.Context, sessionID uuid.UUID) ([]Audit
 // LatestSeq returns the highest seq stored for the session, or 0 if none.
 func (s *Store) LatestSeq(ctx context.Context, sessionID uuid.UUID) (int64, error) {
 	q := db.New(s.pool)
-	seq, err := q.LatestSeq(ctx, sessionID)
+	seq, err := q.LatestSeq(ctx, toPgUUID(sessionID))
 	if err != nil {
 		return 0, wrapDBError(err)
 	}
 	return seq, nil
+}
+
+// --- pgtype <-> domain conversion helpers ---
+
+func toPgUUID(u uuid.UUID) pgtype.UUID {
+	if u == uuid.Nil {
+		return pgtype.UUID{}
+	}
+	return pgtype.UUID{Bytes: u, Valid: true}
+}
+
+func ptrToPgUUID(p *uuid.UUID) pgtype.UUID {
+	if p == nil {
+		return pgtype.UUID{}
+	}
+	return pgtype.UUID{Bytes: *p, Valid: true}
+}
+
+func stringToPgText(s string) pgtype.Text {
+	if s == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: s, Valid: true}
+}
+
+func payloadOrEmpty(p json.RawMessage) json.RawMessage {
+	if len(p) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return p
 }
 
 // wrapDBError classifies a raw database error into the appropriate AppError
@@ -169,25 +219,23 @@ func wrapDBError(err error) error {
 	if err == nil {
 		return nil
 	}
-	// Context errors pass through unchanged.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
-	// pgx no-rows → NotFound.
 	if errors.Is(err, pgx.ErrNoRows) {
 		return apperror.NotFound("auditlog: no events for session").Wrap(err)
 	}
-	// Postgres-specific error codes.
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
 		switch pgErr.Code {
 		case "23505": // unique_violation
 			return apperror.Conflict("auditlog: duplicate seq for session").Wrap(err)
 		case "23503": // foreign_key_violation
-			return apperror.BadRequest("auditlog: invalid session_id reference").Wrap(err)
+			return apperror.BadRequest("auditlog: invalid session_id or user_id reference").Wrap(err)
+		case "23514": // check_violation (e.g. identity_required)
+			return apperror.BadRequest("auditlog: identity constraint violated").Wrap(err)
 		}
 	}
-	// Catch-all: internal database error.
 	return apperror.Internal("auditlog: database error").Wrap(err)
 }
 
@@ -195,15 +243,23 @@ func wrapDBError(err error) error {
 func rowToEvent(r db.AuditEvent) AuditEvent {
 	evt := AuditEvent{
 		ID:        r.ID,
-		SessionID: r.SessionID,
-		Seq:       r.Seq,
 		Action:    AuditAction(r.Action),
 		Payload:   r.Payload,
 		CreatedAt: r.CreatedAt,
 	}
+	if r.SessionID.Valid {
+		evt.SessionID = uuid.UUID(r.SessionID.Bytes)
+	}
+	if r.Seq.Valid {
+		evt.Seq = r.Seq.Int64
+	}
 	if r.ActorID.Valid {
 		id := uuid.UUID(r.ActorID.Bytes)
 		evt.ActorID = &id
+	}
+	if r.UserID.Valid {
+		id := uuid.UUID(r.UserID.Bytes)
+		evt.UserID = &id
 	}
 	if r.ModuleID.Valid {
 		evt.ModuleID = r.ModuleID.String

--- a/apps/server/internal/auditlog/store_test.go
+++ b/apps/server/internal/auditlog/store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx stdlib driver for database/sql used by goose
 	"github.com/pressly/goose/v3"
@@ -130,18 +131,25 @@ func TestAuditEvent_Validate_Errors(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 type stubQuerier struct {
-	latestSeqFn        func(ctx context.Context, sessionID uuid.UUID) (int64, error)
-	appendAuditEventFn func(ctx context.Context, arg db.AppendAuditEventParams) (db.AuditEvent, error)
-	listBySessionFn    func(ctx context.Context, sessionID uuid.UUID) ([]db.AuditEvent, error)
+	latestSeqFn            func(ctx context.Context, sessionID pgtype.UUID) (int64, error)
+	appendAuditEventFn     func(ctx context.Context, arg db.AppendAuditEventParams) (db.AuditEvent, error)
+	appendUserAuditEventFn func(ctx context.Context, arg db.AppendUserAuditEventParams) (db.AuditEvent, error)
+	listBySessionFn        func(ctx context.Context, sessionID pgtype.UUID) ([]db.AuditEvent, error)
 }
 
-func (sq *stubQuerier) LatestSeq(ctx context.Context, sessionID uuid.UUID) (int64, error) {
+func (sq *stubQuerier) LatestSeq(ctx context.Context, sessionID pgtype.UUID) (int64, error) {
 	return sq.latestSeqFn(ctx, sessionID)
 }
 func (sq *stubQuerier) AppendAuditEvent(ctx context.Context, arg db.AppendAuditEventParams) (db.AuditEvent, error) {
 	return sq.appendAuditEventFn(ctx, arg)
 }
-func (sq *stubQuerier) ListBySession(ctx context.Context, sessionID uuid.UUID) ([]db.AuditEvent, error) {
+func (sq *stubQuerier) AppendUserAuditEvent(ctx context.Context, arg db.AppendUserAuditEventParams) (db.AuditEvent, error) {
+	if sq.appendUserAuditEventFn == nil {
+		return db.AuditEvent{}, nil
+	}
+	return sq.appendUserAuditEventFn(ctx, arg)
+}
+func (sq *stubQuerier) ListBySession(ctx context.Context, sessionID pgtype.UUID) ([]db.AuditEvent, error) {
 	return sq.listBySessionFn(ctx, sessionID)
 }
 
@@ -206,7 +214,7 @@ func TestStore_Append_ErrorClassification(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			sq := &stubQuerier{
-				latestSeqFn: func(_ context.Context, _ uuid.UUID) (int64, error) {
+				latestSeqFn: func(_ context.Context, _ pgtype.UUID) (int64, error) {
 					if tc.latestErr != nil {
 						return 0, tc.latestErr
 					}

--- a/apps/server/internal/db/audit_events.sql.go
+++ b/apps/server/internal/db/audit_events.sql.go
@@ -9,30 +9,34 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const appendAuditEvent = `-- name: AppendAuditEvent :one
-INSERT INTO audit_events (session_id, seq, actor_id, action, module_id, payload)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, session_id, seq, actor_id, action, module_id, payload, created_at
+INSERT INTO audit_events (session_id, seq, actor_id, user_id, action, module_id, payload)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, session_id, seq, actor_id, action, module_id, payload, created_at, user_id
 `
 
 type AppendAuditEventParams struct {
-	SessionID uuid.UUID       `json:"session_id"`
-	Seq       int64           `json:"seq"`
+	SessionID pgtype.UUID     `json:"session_id"`
+	Seq       pgtype.Int8     `json:"seq"`
 	ActorID   pgtype.UUID     `json:"actor_id"`
+	UserID    pgtype.UUID     `json:"user_id"`
 	Action    string          `json:"action"`
 	ModuleID  pgtype.Text     `json:"module_id"`
 	Payload   json.RawMessage `json:"payload"`
 }
 
+// Game-bound audit row. session_id + seq are required; user_id is optional
+// but commonly set for player-triggered events so dashboards can correlate
+// by both axes.
 func (q *Queries) AppendAuditEvent(ctx context.Context, arg AppendAuditEventParams) (AuditEvent, error) {
 	row := q.db.QueryRow(ctx, appendAuditEvent,
 		arg.SessionID,
 		arg.Seq,
 		arg.ActorID,
+		arg.UserID,
 		arg.Action,
 		arg.ModuleID,
 		arg.Payload,
@@ -47,6 +51,47 @@ func (q *Queries) AppendAuditEvent(ctx context.Context, arg AppendAuditEventPara
 		&i.ModuleID,
 		&i.Payload,
 		&i.CreatedAt,
+		&i.UserID,
+	)
+	return i, err
+}
+
+const appendUserAuditEvent = `-- name: AppendUserAuditEvent :one
+INSERT INTO audit_events (session_id, seq, actor_id, user_id, action, module_id, payload)
+VALUES (NULL, NULL, $1, $2, $3, $4, $5)
+RETURNING id, session_id, seq, actor_id, action, module_id, payload, created_at, user_id
+`
+
+type AppendUserAuditEventParams struct {
+	ActorID  pgtype.UUID     `json:"actor_id"`
+	UserID   pgtype.UUID     `json:"user_id"`
+	Action   string          `json:"action"`
+	ModuleID pgtype.Text     `json:"module_id"`
+	Payload  json.RawMessage `json:"payload"`
+}
+
+// Identity-bound audit row (Phase 19 PR-6). Used for auth/admin/review/
+// editor actions that occur outside any game session; session_id and seq
+// stay NULL and the partial UNIQUE index is not engaged.
+func (q *Queries) AppendUserAuditEvent(ctx context.Context, arg AppendUserAuditEventParams) (AuditEvent, error) {
+	row := q.db.QueryRow(ctx, appendUserAuditEvent,
+		arg.ActorID,
+		arg.UserID,
+		arg.Action,
+		arg.ModuleID,
+		arg.Payload,
+	)
+	var i AuditEvent
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.Seq,
+		&i.ActorID,
+		&i.Action,
+		&i.ModuleID,
+		&i.Payload,
+		&i.CreatedAt,
+		&i.UserID,
 	)
 	return i, err
 }
@@ -57,7 +102,7 @@ FROM audit_events
 WHERE session_id = $1
 `
 
-func (q *Queries) LatestSeq(ctx context.Context, sessionID uuid.UUID) (int64, error) {
+func (q *Queries) LatestSeq(ctx context.Context, sessionID pgtype.UUID) (int64, error) {
 	row := q.db.QueryRow(ctx, latestSeq, sessionID)
 	var seq int64
 	err := row.Scan(&seq)
@@ -65,12 +110,12 @@ func (q *Queries) LatestSeq(ctx context.Context, sessionID uuid.UUID) (int64, er
 }
 
 const listBySession = `-- name: ListBySession :many
-SELECT id, session_id, seq, actor_id, action, module_id, payload, created_at FROM audit_events
+SELECT id, session_id, seq, actor_id, action, module_id, payload, created_at, user_id FROM audit_events
 WHERE session_id = $1
 ORDER BY seq
 `
 
-func (q *Queries) ListBySession(ctx context.Context, sessionID uuid.UUID) ([]AuditEvent, error) {
+func (q *Queries) ListBySession(ctx context.Context, sessionID pgtype.UUID) ([]AuditEvent, error) {
 	rows, err := q.db.Query(ctx, listBySession, sessionID)
 	if err != nil {
 		return nil, err
@@ -88,6 +133,51 @@ func (q *Queries) ListBySession(ctx context.Context, sessionID uuid.UUID) ([]Aud
 			&i.ModuleID,
 			&i.Payload,
 			&i.CreatedAt,
+			&i.UserID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listByUser = `-- name: ListByUser :many
+SELECT id, session_id, seq, actor_id, action, module_id, payload, created_at, user_id FROM audit_events
+WHERE user_id = $1
+ORDER BY created_at DESC
+LIMIT $2
+`
+
+type ListByUserParams struct {
+	UserID pgtype.UUID `json:"user_id"`
+	Limit  int32       `json:"limit"`
+}
+
+// Newest-first lookup for admin dashboards. user_id is the target user
+// (may equal actor_id for self-initiated events like login).
+func (q *Queries) ListByUser(ctx context.Context, arg ListByUserParams) ([]AuditEvent, error) {
+	rows, err := q.db.Query(ctx, listByUser, arg.UserID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AuditEvent{}
+	for rows.Next() {
+		var i AuditEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.SessionID,
+			&i.Seq,
+			&i.ActorID,
+			&i.Action,
+			&i.ModuleID,
+			&i.Payload,
+			&i.CreatedAt,
+			&i.UserID,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -14,13 +14,14 @@ import (
 
 type AuditEvent struct {
 	ID        int64           `json:"id"`
-	SessionID uuid.UUID       `json:"session_id"`
-	Seq       int64           `json:"seq"`
+	SessionID pgtype.UUID     `json:"session_id"`
+	Seq       pgtype.Int8     `json:"seq"`
 	ActorID   pgtype.UUID     `json:"actor_id"`
 	Action    string          `json:"action"`
 	ModuleID  pgtype.Text     `json:"module_id"`
 	Payload   json.RawMessage `json:"payload"`
 	CreatedAt time.Time       `json:"created_at"`
+	UserID    pgtype.UUID     `json:"user_id"`
 }
 
 type ChatMessage struct {

--- a/apps/server/internal/domain/admin/handler.go
+++ b/apps/server/internal/domain/admin/handler.go
@@ -1,23 +1,80 @@
 package admin
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 	"github.com/mmp-platform/server/internal/httputil"
+	"github.com/mmp-platform/server/internal/middleware"
 )
 
 // Handler handles admin HTTP endpoints.
+//
+// Phase 19 PR-6: writes to auditlog.Logger on mutating endpoints
+// (role change, theme force-unpublish, room force-close) so that each
+// moderator action leaves an identity-bound audit trail attributable
+// to the admin's user_id (actor) and the affected user/theme/room.
 type Handler struct {
-	svc Service
+	svc    Service
+	audit  auditlog.Logger
+	logger zerolog.Logger
 }
 
-// NewHandler creates a new admin handler.
-func NewHandler(svc Service) *Handler {
-	return &Handler{svc: svc}
+// NewHandler creates a new admin handler. If audit is nil the handler
+// silently substitutes auditlog.NoOpLogger{} so tests without a DB can
+// still exercise the HTTP path.
+func NewHandler(svc Service, audit auditlog.Logger, logger zerolog.Logger) *Handler {
+	if audit == nil {
+		audit = auditlog.NoOpLogger{}
+	}
+	return &Handler{
+		svc:    svc,
+		audit:  audit,
+		logger: logger.With().Str("handler", "admin").Logger(),
+	}
+}
+
+// recordAudit appends an admin audit entry. actor is the moderator; target
+// (optional) is the affected user UUID. payload is marshalled to JSON and
+// kept small — only the fields a reviewer genuinely needs later.
+func (h *Handler) recordAudit(ctx context.Context, action auditlog.AuditAction, actor, target *uuid.UUID, payload map[string]any) {
+	var raw json.RawMessage
+	if len(payload) > 0 {
+		if b, err := json.Marshal(payload); err == nil {
+			raw = b
+		} else {
+			h.logger.Warn().Err(err).Str("action", string(action)).Msg("auditlog payload marshal failed")
+		}
+	}
+	evt := auditlog.AuditEvent{
+		ActorID: actor,
+		UserID:  target,
+		Action:  action,
+		Payload: raw,
+	}
+	if err := h.audit.Append(ctx, evt); err != nil {
+		h.logger.Warn().Err(err).Str("action", string(action)).Msg("auditlog append failed")
+	}
+}
+
+// actor extracts the moderator's user id from the request context.
+// Returns nil when the context lacks an auth UUID — the audit entry then
+// records a system-level actor (admin routes are middleware-guarded, so
+// this should not occur in production, but the fallback avoids panics in
+// unit tests that skip the middleware).
+func actor(ctx context.Context) *uuid.UUID {
+	uid := middleware.UserIDFrom(ctx)
+	if uid == uuid.Nil {
+		return nil
+	}
+	return &uid
 }
 
 // ListUsers handles GET /admin/users.
@@ -69,6 +126,8 @@ func (h *Handler) UpdateUserRole(w http.ResponseWriter, r *http.Request) {
 		apperror.WriteError(w, r, err)
 		return
 	}
+	h.recordAudit(r.Context(), auditlog.ActionAdminRoleChange, actor(r.Context()), &userID,
+		map[string]any{"new_role": req.Role})
 	httputil.WriteJSON(w, http.StatusOK, user)
 }
 
@@ -98,6 +157,8 @@ func (h *Handler) ForceUnpublishTheme(w http.ResponseWriter, r *http.Request) {
 		apperror.WriteError(w, r, err)
 		return
 	}
+	h.recordAudit(r.Context(), auditlog.ActionAdminForceUnpublishTheme, actor(r.Context()), nil,
+		map[string]any{"theme_id": themeID.String()})
 	httputil.WriteJSON(w, http.StatusOK, theme)
 }
 
@@ -126,5 +187,7 @@ func (h *Handler) ForceCloseRoom(w http.ResponseWriter, r *http.Request) {
 		apperror.WriteError(w, r, err)
 		return
 	}
+	h.recordAudit(r.Context(), auditlog.ActionAdminForceCloseRoom, actor(r.Context()), nil,
+		map[string]any{"room_id": roomID.String()})
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/apps/server/internal/domain/admin/handler_test.go
+++ b/apps/server/internal/domain/admin/handler_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 )
 
 // mockService implements Service for testing.
@@ -71,7 +73,7 @@ func TestListUsers_Success(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	req := httptest.NewRequest(http.MethodGet, "/admin/users?limit=10&offset=0", nil)
 	rec := httptest.NewRecorder()
@@ -110,7 +112,7 @@ func TestGetUser_Success(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	req := httptest.NewRequest(http.MethodGet, "/admin/users/"+userID.String(), nil)
 	req = withChiParam(req, "id", userID.String())
@@ -143,7 +145,7 @@ func TestGetUser_NotFound(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	req := httptest.NewRequest(http.MethodGet, "/admin/users/"+userID.String(), nil)
 	req = withChiParam(req, "id", userID.String())
@@ -175,7 +177,7 @@ func TestUpdateUserRole_Success(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body, _ := json.Marshal(UpdateRoleRequest{Role: "ADMIN"})
 	req := httptest.NewRequest(http.MethodPut, "/admin/users/"+userID.String()+"/role", bytes.NewReader(body))
@@ -202,7 +204,7 @@ func TestUpdateUserRole_InvalidBody(t *testing.T) {
 	userID := uuid.New()
 
 	mock := &mockService{}
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	// Send invalid role value.
 	body := []byte(`{"role": "SUPERADMIN"}`)
@@ -228,7 +230,7 @@ func TestListAllThemes_Success(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	req := httptest.NewRequest(http.MethodGet, "/admin/themes?limit=10&offset=0", nil)
 	rec := httptest.NewRecorder()
@@ -263,7 +265,7 @@ func TestForceUnpublishTheme_Success(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/themes/"+themeID.String()+"/unpublish", nil)
 	req = withChiParam(req, "id", themeID.String())
@@ -294,7 +296,7 @@ func TestListAllRooms_Success(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	req := httptest.NewRequest(http.MethodGet, "/admin/rooms?limit=10&offset=0", nil)
 	rec := httptest.NewRecorder()
@@ -325,7 +327,7 @@ func TestForceCloseRoom_Success(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(mock)
+	h := NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/rooms/"+roomID.String()+"/close", nil)
 	req = withChiParam(req, "id", roomID.String())

--- a/apps/server/internal/domain/admin/review_handler.go
+++ b/apps/server/internal/domain/admin/review_handler.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -9,21 +11,31 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 	"github.com/mmp-platform/server/internal/db"
 	"github.com/mmp-platform/server/internal/httputil"
 	"github.com/mmp-platform/server/internal/middleware"
 )
 
 // ReviewHandler handles admin theme review endpoints.
+//
+// Phase 19 PR-6: mutating endpoints (approve / reject / suspend / trusted
+// creator) emit auditlog entries so moderation activity is attributable.
 type ReviewHandler struct {
 	q      *db.Queries
+	audit  auditlog.Logger
 	logger zerolog.Logger
 }
 
-// NewReviewHandler creates a new ReviewHandler.
-func NewReviewHandler(q *db.Queries, logger zerolog.Logger) *ReviewHandler {
+// NewReviewHandler creates a new ReviewHandler. nil audit falls back to
+// auditlog.NoOpLogger{} for tests.
+func NewReviewHandler(q *db.Queries, audit auditlog.Logger, logger zerolog.Logger) *ReviewHandler {
+	if audit == nil {
+		audit = auditlog.NoOpLogger{}
+	}
 	return &ReviewHandler{
 		q:      q,
+		audit:  audit,
 		logger: logger.With().Str("handler", "admin.review").Logger(),
 	}
 }
@@ -36,6 +48,31 @@ type ReviewActionRequest struct {
 // SetTrustedCreatorRequest is the request body for setting trusted creator status.
 type SetTrustedCreatorRequest struct {
 	Trusted bool `json:"trusted"`
+}
+
+func (h *ReviewHandler) recordAudit(ctx context.Context, action auditlog.AuditAction, actor, target *uuid.UUID, payload map[string]any) {
+	var raw json.RawMessage
+	if len(payload) > 0 {
+		if b, err := json.Marshal(payload); err == nil {
+			raw = b
+		} else {
+			h.logger.Warn().Err(err).Str("action", string(action)).Msg("auditlog payload marshal failed")
+		}
+	}
+	// If no explicit target and the actor is known, pin both to the actor so
+	// the row has at least one identity (matches the identity CHECK).
+	if target == nil && actor != nil {
+		target = actor
+	}
+	evt := auditlog.AuditEvent{
+		ActorID: actor,
+		UserID:  target,
+		Action:  action,
+		Payload: raw,
+	}
+	if err := h.audit.Append(ctx, evt); err != nil {
+		h.logger.Warn().Err(err).Str("action", string(action)).Msg("auditlog append failed")
+	}
 }
 
 // ListPendingReviews handles GET /admin/reviews.
@@ -73,6 +110,8 @@ func (h *ReviewHandler) ApproveTheme(w http.ResponseWriter, r *http.Request) {
 		apperror.WriteError(w, r, err)
 		return
 	}
+	h.recordAudit(r.Context(), auditlog.ActionReviewApprove, actorPtr(adminID), nil,
+		map[string]any{"theme_id": themeID.String(), "note": req.Note})
 	httputil.WriteJSON(w, http.StatusOK, theme)
 }
 
@@ -106,6 +145,8 @@ func (h *ReviewHandler) RejectTheme(w http.ResponseWriter, r *http.Request) {
 		apperror.WriteError(w, r, err)
 		return
 	}
+	h.recordAudit(r.Context(), auditlog.ActionReviewReject, actorPtr(adminID), nil,
+		map[string]any{"theme_id": themeID.String(), "note": req.Note})
 	httputil.WriteJSON(w, http.StatusOK, theme)
 }
 
@@ -139,6 +180,8 @@ func (h *ReviewHandler) SuspendTheme(w http.ResponseWriter, r *http.Request) {
 		apperror.WriteError(w, r, err)
 		return
 	}
+	h.recordAudit(r.Context(), auditlog.ActionReviewSuspend, actorPtr(adminID), nil,
+		map[string]any{"theme_id": themeID.String(), "note": req.Note})
 	httputil.WriteJSON(w, http.StatusOK, theme)
 }
 
@@ -165,6 +208,9 @@ func (h *ReviewHandler) SetTrustedCreator(w http.ResponseWriter, r *http.Request
 		apperror.WriteError(w, r, err)
 		return
 	}
+	adminID := middleware.UserIDFrom(r.Context())
+	h.recordAudit(r.Context(), auditlog.ActionAdminTrustedCreator, actorPtr(adminID), &userID,
+		map[string]any{"trusted": req.Trusted})
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -184,4 +230,14 @@ func toPgtypeText(s string) pgtype.Text {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: s, Valid: true}
+}
+
+// actorPtr returns a pointer to uid, or nil when uid is the zero UUID.
+// Shared by the handler package so audit entries consistently collapse
+// the "no authenticated actor" case to nil rather than the zero UUID.
+func actorPtr(uid uuid.UUID) *uuid.UUID {
+	if uid == uuid.Nil {
+		return nil
+	}
+	return &uid
 }

--- a/apps/server/internal/domain/auth/service.go
+++ b/apps/server/internal/domain/auth/service.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -14,6 +15,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 	"github.com/mmp-platform/server/internal/db"
 )
 
@@ -54,15 +56,32 @@ type service struct {
 	redis     *redis.Client
 	jwtSecret []byte
 	logger    zerolog.Logger
+	audit     auditlog.Logger
 }
 
 // NewService creates a new auth service.
-func NewService(queries *db.Queries, redisClient *redis.Client, jwtSecret []byte, logger zerolog.Logger) Service {
+//
+// Phase 19 PR-6: `audit` is optional — pass auditlog.NoOpLogger{} (or nil;
+// the constructor falls back to NoOp) when running in a test or bootstrap
+// context that does not wire the audit pipeline. In production the caller
+// is expected to inject a running auditlog.DBLogger so that login,
+// register, logout, and account-deletion events are captured.
+func NewService(
+	queries *db.Queries,
+	redisClient *redis.Client,
+	jwtSecret []byte,
+	audit auditlog.Logger,
+	logger zerolog.Logger,
+) Service {
+	if audit == nil {
+		audit = auditlog.NoOpLogger{}
+	}
 	return &service{
 		queries:   queries,
 		redis:     redisClient,
 		jwtSecret: jwtSecret,
 		logger:    logger.With().Str("domain", "auth").Logger(),
+		audit:     audit,
 	}
 }
 
@@ -74,6 +93,33 @@ func refreshKeyPrefix(userID string) string {
 // refreshKey returns the full Redis key for a specific refresh token.
 func refreshKey(userID, jti string) string {
 	return fmt.Sprintf("refresh:%s:%s", userID, jti)
+}
+
+// recordAudit persists a self-initiated (actor == user) auth event. The
+// payload map is marshalled to JSON; on marshal error the entry is logged
+// but the caller flow is not disturbed — auditlog is additive, never
+// blocks primary auth behaviour.
+func (s *service) recordAudit(ctx context.Context, action auditlog.AuditAction, userID uuid.UUID, payload map[string]any) {
+	var raw json.RawMessage
+	if len(payload) > 0 {
+		if b, err := json.Marshal(payload); err == nil {
+			raw = b
+		} else {
+			s.logger.Warn().Err(err).Str("action", string(action)).
+				Msg("auditlog payload marshal failed")
+		}
+	}
+	uid := userID
+	evt := auditlog.AuditEvent{
+		ActorID: &uid,
+		UserID:  &uid,
+		Action:  action,
+		Payload: raw,
+	}
+	if err := s.audit.Append(ctx, evt); err != nil {
+		s.logger.Warn().Err(err).Str("action", string(action)).
+			Str("user_id", uid.String()).Msg("auditlog append failed")
+	}
 }
 
 // OAuthCallback handles the OAuth callback flow.
@@ -88,6 +134,7 @@ func (s *service) OAuthCallback(ctx context.Context, provider, code, nickname st
 		Provider:   provider,
 		ProviderID: code,
 	})
+	created := false
 	if err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			s.logger.Error().Err(err).Str("provider", provider).Msg("failed to look up user by provider")
@@ -106,6 +153,7 @@ func (s *service) OAuthCallback(ctx context.Context, provider, code, nickname st
 			s.logger.Error().Err(err).Str("provider", provider).Msg("failed to create user")
 			return nil, apperror.Internal("failed to create user")
 		}
+		created = true
 		s.logger.Info().Str("user_id", user.ID.String()).Msg("new user created via OAuth")
 	}
 
@@ -113,6 +161,12 @@ func (s *service) OAuthCallback(ctx context.Context, provider, code, nickname st
 	if err != nil {
 		return nil, err
 	}
+
+	action := auditlog.ActionUserLogin
+	if created {
+		action = auditlog.ActionUserRegister
+	}
+	s.recordAudit(ctx, action, user.ID, map[string]any{"provider": provider})
 
 	return pair, nil
 }
@@ -199,6 +253,7 @@ func (s *service) RefreshToken(ctx context.Context, refreshTokenStr string) (*To
 func (s *service) Logout(ctx context.Context, userID uuid.UUID) error {
 	s.revokeAllTokens(ctx, userID.String())
 	s.logger.Info().Str("user_id", userID.String()).Msg("user logged out, all refresh tokens revoked")
+	s.recordAudit(ctx, auditlog.ActionUserLogout, userID, nil)
 	return nil
 }
 
@@ -296,6 +351,10 @@ func (s *service) Register(ctx context.Context, email, password, nickname string
 	}
 
 	s.logger.Info().Str("user_id", user.ID.String()).Msg("new user registered with password")
+	s.recordAudit(ctx, auditlog.ActionUserRegister, user.ID, map[string]any{
+		"method":   "password",
+		"nickname": user.Nickname,
+	})
 	return s.generateTokenPair(ctx, user.ID, user.Role)
 }
 
@@ -308,6 +367,8 @@ func (s *service) Login(ctx context.Context, email, password string) (*TokenPair
 	user, err := s.queries.GetUserByEmail(ctx, pgtype.Text{String: email, Valid: true})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			// No audit write — no identifiable user to attribute to.
+			// Rate limiting / WAF handles anonymous password guessing.
 			return nil, apperror.Unauthorized("invalid email or password")
 		}
 		s.logger.Error().Err(err).Msg("failed to look up user by email")
@@ -315,13 +376,19 @@ func (s *service) Login(ctx context.Context, email, password string) (*TokenPair
 	}
 
 	if !user.PasswordHash.Valid {
+		s.recordAudit(ctx, auditlog.ActionUserLoginFail, user.ID,
+			map[string]any{"reason": "no_password_set"})
 		return nil, apperror.Unauthorized("invalid email or password")
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash.String), []byte(password)); err != nil {
+		s.recordAudit(ctx, auditlog.ActionUserLoginFail, user.ID,
+			map[string]any{"reason": "bad_password"})
 		return nil, apperror.Unauthorized("invalid email or password")
 	}
 
+	s.recordAudit(ctx, auditlog.ActionUserLogin, user.ID,
+		map[string]any{"method": "password"})
 	return s.generateTokenPair(ctx, user.ID, user.Role)
 }
 
@@ -351,6 +418,7 @@ func (s *service) DeleteAccount(ctx context.Context, userID uuid.UUID, req Delet
 
 	s.revokeAllTokens(ctx, userID.String())
 	s.logger.Info().Str("user_id", userID.String()).Msg("user account soft deleted")
+	s.recordAudit(ctx, auditlog.ActionUserDeleteAccount, userID, nil)
 	return nil
 }
 

--- a/apps/server/internal/domain/editor/clue_edge_handler.go
+++ b/apps/server/internal/domain/editor/clue_edge_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 	"github.com/mmp-platform/server/internal/httputil"
 	"github.com/mmp-platform/server/internal/middleware"
 )
@@ -47,5 +48,14 @@ func (h *Handler) ReplaceClueEdges(w http.ResponseWriter, r *http.Request) {
 		apperror.WriteError(w, r, err)
 		return
 	}
+	// D-SEC-1 audit: record which creator rewrote which theme's clue graph
+	// and how many edge groups were persisted (not the payload itself — the
+	// graph snapshot lives in theme versioning).
+	h.recordAudit(r.Context(), auditlog.ActionEditorClueEdgesReplace, creatorID,
+		map[string]any{
+			"theme_id":     themeID.String(),
+			"group_count":  len(reqs),
+			"result_count": len(edges),
+		})
 	httputil.WriteJSON(w, http.StatusOK, edges)
 }

--- a/apps/server/internal/domain/editor/clue_edge_handler_test.go
+++ b/apps/server/internal/domain/editor/clue_edge_handler_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 )
 
 func TestGetClueEdges_Empty(t *testing.T) {
@@ -19,7 +21,7 @@ func TestGetClueEdges_Empty(t *testing.T) {
 			return []ClueEdgeGroupResponse{}, nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodGet, "/editor/themes/"+testThemeID.String()+"/clue-edges", nil)
 	r = withAuth(r)
@@ -55,7 +57,7 @@ func TestGetClueEdges_OK(t *testing.T) {
 			}}, nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodGet, "/editor/themes/"+testThemeID.String()+"/clue-edges", nil)
 	r = withAuth(r)
@@ -92,7 +94,7 @@ func TestReplaceClueEdges_OK(t *testing.T) {
 			}}, nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body, _ := json.Marshal([]ClueEdgeGroupRequest{{
 		TargetID: uuid.New(),
@@ -122,7 +124,7 @@ func TestReplaceClueEdges_OK(t *testing.T) {
 
 func TestReplaceClueEdges_InvalidJSON(t *testing.T) {
 	ms := &mockService{}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodPut, "/editor/themes/"+testThemeID.String()+"/clue-edges", bytes.NewReader([]byte("not json")))
 	r.Header.Set("Content-Type", "application/json")
@@ -143,7 +145,7 @@ func TestReplaceClueEdges_CycleDetected(t *testing.T) {
 			return nil, apperror.New("EDGE_CYCLE_DETECTED", 400, "clue edge graph contains a cycle")
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body, _ := json.Marshal([]ClueEdgeGroupRequest{{
 		TargetID: uuid.New(),
@@ -173,7 +175,7 @@ func TestReplaceClueEdges_InvalidCraftOR(t *testing.T) {
 			return nil, apperror.New("EDGE_INVALID_CRAFT_OR", 400, "edge[0]: CRAFT trigger does not allow OR mode")
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body, _ := json.Marshal([]ClueEdgeGroupRequest{{
 		TargetID: uuid.New(),

--- a/apps/server/internal/domain/editor/handler.go
+++ b/apps/server/internal/domain/editor/handler.go
@@ -1,26 +1,74 @@
 package editor
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 	"github.com/mmp-platform/server/internal/httputil"
 	"github.com/mmp-platform/server/internal/middleware"
 )
 
 // Handler handles editor HTTP endpoints for theme creators.
+//
+// Phase 19 PR-6 (D-SEC-1): mutating clue-graph endpoints
+// (ReplaceClueEdges, …) record audit entries so edits to the canonical
+// clue graph — a frequent target for unauthorised modification — leave a
+// trail attributed to the acting creator.
 type Handler struct {
-	svc Service
+	svc    Service
+	audit  auditlog.Logger
+	logger zerolog.Logger
 }
 
-// NewHandler creates a new editor handler.
-func NewHandler(svc Service) *Handler {
-	return &Handler{svc: svc}
+// NewHandler creates a new editor handler. A nil audit falls back to
+// auditlog.NoOpLogger{} so bootstrap and unit tests that do not wire the
+// audit pipeline still compile and run.
+func NewHandler(svc Service, audit auditlog.Logger, logger zerolog.Logger) *Handler {
+	if audit == nil {
+		audit = auditlog.NoOpLogger{}
+	}
+	return &Handler{
+		svc:    svc,
+		audit:  audit,
+		logger: logger.With().Str("handler", "editor").Logger(),
+	}
+}
+
+// recordAudit appends an editor audit entry. actor is the creator; target
+// is the theme owner (for clue-graph edits we pass actor as both — the
+// creator is editing their own theme per RBAC). payload carries the
+// minimum identifiers needed to reproduce the action.
+func (h *Handler) recordAudit(ctx context.Context, action auditlog.AuditAction, actor uuid.UUID, payload map[string]any) {
+	var raw json.RawMessage
+	if len(payload) > 0 {
+		if b, err := json.Marshal(payload); err == nil {
+			raw = b
+		} else {
+			h.logger.Warn().Err(err).Str("action", string(action)).Msg("auditlog payload marshal failed")
+		}
+	}
+	if actor == uuid.Nil {
+		// No attributable actor — skip rather than persist an anonymous row.
+		return
+	}
+	uid := actor
+	evt := auditlog.AuditEvent{
+		ActorID: &uid,
+		UserID:  &uid,
+		Action:  action,
+		Payload: raw,
+	}
+	if err := h.audit.Append(ctx, evt); err != nil {
+		h.logger.Warn().Err(err).Str("action", string(action)).Msg("auditlog append failed")
+	}
 }
 
 // ListMyThemes handles GET /editor/themes.

--- a/apps/server/internal/domain/editor/handler_test.go
+++ b/apps/server/internal/domain/editor/handler_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/auditlog"
 	"github.com/mmp-platform/server/internal/middleware"
 )
 
@@ -213,7 +215,7 @@ func TestListMyThemes(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodGet, "/editor/themes", nil)
 	r = withAuth(r)
@@ -232,7 +234,7 @@ func TestCreateTheme_Success(t *testing.T) {
 			return sampleThemeResponse(), nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body := `{"title":"Test Theme","min_players":4,"max_players":8,"duration_min":60,"price":0}`
 	r := httptest.NewRequest(http.MethodPost, "/editor/themes", bytes.NewBufferString(body))
@@ -249,7 +251,7 @@ func TestCreateTheme_Success(t *testing.T) {
 
 func TestCreateTheme_InvalidBody(t *testing.T) {
 	ms := &mockService{}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	// missing required fields
 	body := `{"title":"X"}`
@@ -271,7 +273,7 @@ func TestUpdateTheme_Success(t *testing.T) {
 			return sampleThemeResponse(), nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body := `{"title":"Updated Theme","min_players":4,"max_players":8,"duration_min":60,"price":0}`
 	r := httptest.NewRequest(http.MethodPut, "/editor/themes/"+testThemeID.String(), bytes.NewBufferString(body))
@@ -293,7 +295,7 @@ func TestDeleteTheme_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodDelete, "/editor/themes/"+testThemeID.String(), nil)
 	r = withAuth(r)
@@ -313,7 +315,7 @@ func TestDeleteTheme_Forbidden(t *testing.T) {
 			return apperror.Forbidden("you do not own this theme")
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodDelete, "/editor/themes/"+testThemeID.String(), nil)
 	r = withAuth(r)
@@ -335,7 +337,7 @@ func TestPublishTheme_Success(t *testing.T) {
 			return resp, nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodPost, "/editor/themes/"+testThemeID.String()+"/publish", nil)
 	r = withAuth(r)
@@ -355,7 +357,7 @@ func TestUnpublishTheme_Success(t *testing.T) {
 			return sampleThemeResponse(), nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodPost, "/editor/themes/"+testThemeID.String()+"/unpublish", nil)
 	r = withAuth(r)
@@ -375,7 +377,7 @@ func TestCreateCharacter_Success(t *testing.T) {
 			return sampleCharResponse(), nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body := `{"name":"Detective","description":"A detective","is_culprit":false,"sort_order":0}`
 	r := httptest.NewRequest(http.MethodPost, "/editor/themes/"+testThemeID.String()+"/characters", bytes.NewBufferString(body))
@@ -397,7 +399,7 @@ func TestUpdateCharacter_Success(t *testing.T) {
 			return sampleCharResponse(), nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body := `{"name":"Detective Updated","is_culprit":false,"sort_order":1}`
 	r := httptest.NewRequest(http.MethodPut, "/editor/characters/"+testCharID.String(), bytes.NewBufferString(body))
@@ -419,7 +421,7 @@ func TestDeleteCharacter_Success(t *testing.T) {
 			return nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	r := httptest.NewRequest(http.MethodDelete, "/editor/characters/"+testCharID.String(), nil)
 	r = withAuth(r)
@@ -441,7 +443,7 @@ func TestUpdateConfigJson_Success(t *testing.T) {
 			return resp, nil
 		},
 	}
-	h := NewHandler(ms)
+	h := NewHandler(ms, auditlog.NoOpLogger{}, zerolog.Nop())
 
 	body := `{"phases":["intro","discussion"]}`
 	r := httptest.NewRequest(http.MethodPut, "/editor/themes/"+testThemeID.String()+"/config", bytes.NewBufferString(body))

--- a/memory/project_phase19_implementation_progress.md
+++ b/memory/project_phase19_implementation_progress.md
@@ -30,6 +30,26 @@ type: project
   - `ErrMethodNotAllowed` + `MethodNotAllowed(detail)` helper 추가
   - **Phase 19 F-05 P0 1건 해소 (F-sec-1)**
 
+- **PR-1 WS Contract SSOT** ✅ #86 (2026-04-18, `feat/phase-19-pr-1-ws-ssot` squash-merged)
+  - Go Catalog 130 events SSOT + wsgen codegen (v1.5 α tygo-like)
+  - packages/shared/src/ws/types.generated.ts 자동 생성
+  - ws-client AUTH 제거 (쿼리 토큰 정책), 프론트 enum 정합
+  - CI WS contract drift gate
+  - PR-9 (WS Auth) + PR-10 (Runtime validation) 신설
+
+- **PR-6 Auditlog Expansion** ✅ (진행 중, `feat/phase-19-pr-6-auditlog`)
+  - 00026_auditlog_expansion.sql — session_id/seq NULLABLE + user_id + CHECK identity_required
+  - sqlc: AppendAuditEvent + AppendUserAuditEvent + ListByUser
+  - auditlog.AuditEvent에 UserID + HasSession/HasUser + Validate 확장
+  - Store.Append 분기(session vs user), pgtype 변환 헬퍼
+  - auth service.go: Register/Login(succ+fail)/Logout/DeleteAccount/OAuthCallback 배선
+  - admin handler: UpdateUserRole/ForceUnpublishTheme/ForceCloseRoom
+  - admin review_handler: Approve/Reject/Suspend/SetTrustedCreator
+  - editor clue_edge_handler: ReplaceClueEdges (D-SEC-1)
+  - main.go: auditlog.DBLogger 정식 wiring (Start/Stop)
+  - 새 AuditAction 상수 14종 추가
+  - **Phase 19 F-05 P0 F-sec-4 해소**
+
 ## 남은 PR
 
 ### W1 잔여 (병렬 가능)


### PR DESCRIPTION
## Summary
audit_events 스키마를 확장해 세션 바깥 이벤트(로그인·관리·리뷰·단서 그래프 편집)도 기록하도록 하고, `auditlog.DBLogger`를 보안 관련 도메인에 전면 배선한다. **Phase 19 audit F-sec-4 (P0) 해소**.

### 스키마 (00026)
- `session_id` / `seq` → NULLABLE
- `user_id UUID` 칼럼 추가 + 부분 유니크 인덱스 + CHECK `identity_required`
- Down: NULL 행 삭제 후 원복

### sqlc 확장
- `AppendAuditEvent` 파라미터에 `user_id`
- 신규 `AppendUserAuditEvent` (session-less identity-bound)
- 신규 `ListByUser` (admin 대시보드 최신 N건)

### auditlog 코어
- `AuditEvent.UserID *uuid.UUID` + `HasSession/HasUser`
- `Validate`: session OR user 필수
- `Store.Append` 분기 — 세션 기반 vs 사용자 기반
- pgtype ↔ 도메인 uuid 변환 헬퍼
- `23514` CHECK 위반 분류기 추가
- 새 `AuditAction` 상수 14종 (auth / admin / review / editor)

### 배선
- `auth/service.go`: Register / Login(성공+실패) / Logout / DeleteAccount / OAuthCallback
- `admin/handler.go`: UpdateUserRole / ForceUnpublishTheme / ForceCloseRoom
- `admin/review_handler.go`: Approve / Reject / Suspend / SetTrustedCreator
- `editor/clue_edge_handler.go`: ReplaceClueEdges (**D-SEC-1**)
- `cmd/server/main.go`: `auditlog.NewDBLogger` 정식 wiring (Start/Stop)

### 익명 password guess 정책
서버는 존재하지 않는 이메일의 로그인 실패는 **기록하지 않음** — 귀속 가능한 actor/user가 없으면 CHECK 위반이고, 익명 brute-force는 rate limit/WAF 책임.

## Test plan
- [x] `go build ./...` OK
- [x] `go test -race -count=1 ./...` 전 패키지 통과
- [x] auditlog + auth + admin + editor 기존 testcontainer 테스트 그린
- [x] migration up/down 스모크 (`store_test` `goose.Up` 자동 실행)
- [ ] CI 종합 그린 (PR 생성 후)

## Phase 19 P0 해소
- **F-sec-4** auditlog 부재 → 해소 (본 PR)
- 누계: 4/6 해소 (F-sec-1 / F-sec-3 / F-a11y-3 대기 / F-03 F-sec-2 D-MO-1은 PR-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)