### PR TITLE
fix(phase-19)(pr-8): module cache isolation — sessionId namespace + resetGame

### DIFF
--- a/apps/web/src/hooks/useGameSync.ts
+++ b/apps/web/src/hooks/useGameSync.ts
@@ -4,7 +4,7 @@ import { syncServerTime } from "@mmp/game-logic";
 
 import { useAuthStore } from "@/stores/authStore";
 import { useGameSessionStore as useGameStore } from "@/stores/gameSessionStore";
-import { getModuleStore, clearModuleStores } from "@/stores/moduleStoreFactory";
+import { getModuleStore } from "@/stores/moduleStoreFactory";
 import { useWsEvent } from "@/hooks/useWsEvent";
 
 // ---------------------------------------------------------------------------
@@ -68,6 +68,9 @@ interface PlayerLeftPayload {
  * 이전에 병행 존재하던 `gameMessageHandlers.ts`와
  * `features/game/hooks/useGameSession.ts`는 실제 호출처가 없는
  * dead code였기에 같은 PR에서 삭제되었다.
+ *
+ * Phase 19 PR-8 (F-react-6): 모듈 스토어 접근 시 sessionId namespace를
+ * 함께 전달해 세션 전환 시 이전 모듈 state가 유출되지 않도록 한다.
  */
 export function useGameSync(): void {
   const hydrateFromSnapshot = useGameStore((s) => s.hydrateFromSnapshot);
@@ -76,6 +79,7 @@ export function useGameSync(): void {
   const resetGame = useGameStore((s) => s.resetGame);
   const addPlayer = useGameStore((s) => s.addPlayer);
   const removePlayer = useGameStore((s) => s.removePlayer);
+  const sessionId = useGameStore((s) => s.sessionId);
   const myId = useAuthStore((s) => s.user?.id ?? null);
 
   // session:state — 재접속 시 서버 스냅샷으로 전체 상태 복원
@@ -99,10 +103,11 @@ export function useGameSync(): void {
   });
 
   // game:end — 게임 종료, 전체 상태 리셋
+  // resetGame이 내부에서 clearBySessionId를 호출하므로 중복 clearModuleStores는
+  // 제거. 로그아웃 등 전역 teardown은 별도 경로에서 clearModuleStores 사용.
   useWsEvent<GameEndPayload>("game", WsEventType.GAME_END, (payload) => {
     syncServerTime(payload.ts);
     resetGame();
-    clearModuleStores();
   });
 
   // player.joined — 플레이어 입장
@@ -118,16 +123,17 @@ export function useGameSync(): void {
   });
 
   // module:state — 모듈 전체 상태 교체
-  // Factory의 store.getState()는 PR-8 Module Cache Isolation에서 sessionId
-  // namespace 도입과 함께 최적화될 예정이므로 이번 PR에서는 유지한다.
+  // PR-8: sessionId namespace로 store를 조회해 세션별 격리를 보장한다.
+  // store.getState() 호출은 factory 내부 action invocation이므로 selector
+  // bind 대상이 아니다 (action은 id가 동적).
   useWsEvent<ModuleStatePayload>("game", WsEventType.MODULE_STATE, (payload) => {
     syncServerTime(payload.ts);
-    getModuleStore(payload.moduleId).getState().setData(payload.data);
+    getModuleStore(payload.moduleId, sessionId).getState().setData(payload.data);
   });
 
   // module:event — 모듈 부분 상태 병합
   useWsEvent<ModuleEventPayload>("game", WsEventType.MODULE_EVENT, (payload) => {
     syncServerTime(payload.ts);
-    getModuleStore(payload.moduleId).getState().mergeData(payload.data);
+    getModuleStore(payload.moduleId, sessionId).getState().mergeData(payload.data);
   });
 }

--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -10,7 +10,6 @@ import { useWsClient } from "@/hooks/useWsClient";
 import { useGameSync } from "@/hooks/useGameSync";
 import { useGameSessionStore as useGameStore } from "@/stores/gameSessionStore";
 import { selectPhase, selectIsGameActive } from "@/stores/gameSelectors";
-import { clearModuleStores } from "@/stores/moduleStoreFactory";
 
 import {
   VotingPanel,
@@ -84,10 +83,11 @@ function GamePageInner({ sessionId, isChatOpen, setIsChatOpen }: GamePageInnerPr
   const [isMissionOpen, setIsMissionOpen] = useState(false);
 
   // unmount 시 게임/모듈 스토어 정리
+  // PR-8 (F-react-6): resetGame이 내부에서 clearBySessionId를 호출하므로
+  // 모듈 스토어는 자동 정리된다. 별도 clearModuleStores 호출 불필요.
   useEffect(() => {
     return () => {
       useGameStore.getState().resetGame();
-      clearModuleStores();
     };
   }, [sessionId]);
 

--- a/apps/web/src/stores/__tests__/moduleStoreFactory.test.ts
+++ b/apps/web/src/stores/__tests__/moduleStoreFactory.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import {
   getModuleStore,
   useModuleStore,
   clearModuleStores,
+  clearBySessionId,
 } from "../moduleStoreFactory";
+import { useGameSessionStore } from "../gameSessionStore";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -13,6 +15,17 @@ import {
 describe("moduleStoreFactory", () => {
   beforeEach(() => {
     clearModuleStores();
+    useGameSessionStore.setState({
+      sessionId: null,
+      phase: null,
+      players: [],
+      modules: [],
+      round: 0,
+      phaseDeadline: null,
+      isGameActive: false,
+      myPlayerId: null,
+      myRole: null,
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -21,138 +34,233 @@ describe("moduleStoreFactory", () => {
 
   describe("getModuleStore", () => {
     it("새 스토어를 생성한다", () => {
-      const store = getModuleStore("mod-a");
+      const store = getModuleStore("mod-a", "sess-1");
       expect(store).toBeDefined();
       expect(store.getState().moduleId).toBe("mod-a");
+      expect(store.getState().sessionId).toBe("sess-1");
     });
 
-    it("같은 ID면 캐시된 인스턴스를 반환한다", () => {
-      const a = getModuleStore("mod-a");
-      const b = getModuleStore("mod-a");
+    it("같은 (moduleId, sessionId) 조합은 캐시된 인스턴스를 반환한다", () => {
+      const a = getModuleStore("mod-a", "sess-1");
+      const b = getModuleStore("mod-a", "sess-1");
       expect(a).toBe(b);
     });
 
-    it("다른 ID면 다른 인스턴스를 반환한다", () => {
-      const a = getModuleStore("mod-a");
-      const b = getModuleStore("mod-b");
+    it("다른 moduleId는 다른 인스턴스를 반환한다", () => {
+      const a = getModuleStore("mod-a", "sess-1");
+      const b = getModuleStore("mod-b", "sess-1");
       expect(a).not.toBe(b);
     });
 
+    it("같은 moduleId라도 sessionId가 다르면 다른 인스턴스를 반환한다 (F-react-6)", () => {
+      const a = getModuleStore("mod-a", "sess-1");
+      const b = getModuleStore("mod-a", "sess-2");
+      expect(a).not.toBe(b);
+    });
+
+    it("세션 격리 — 한 세션 변경은 다른 세션에 영향 없다", () => {
+      const a = getModuleStore("mod-a", "sess-1");
+      const b = getModuleStore("mod-a", "sess-2");
+      a.getState().setData({ secret: "sess-1" });
+      expect(a.getState().data).toEqual({ secret: "sess-1" });
+      expect(b.getState().data).toEqual({});
+    });
+
     it("초기 상태가 올바르다", () => {
-      const store = getModuleStore("mod-x");
+      const store = getModuleStore("mod-x", "sess-1");
       const s = store.getState();
       expect(s.moduleId).toBe("mod-x");
+      expect(s.sessionId).toBe("sess-1");
       expect(s.data).toEqual({});
       expect(s.isActive).toBe(false);
     });
   });
 
   // -------------------------------------------------------------------------
-  // setData
+  // dev warning (sessionId 없이 호출)
   // -------------------------------------------------------------------------
 
-  describe("setData", () => {
-    it("data를 교체한다", () => {
-      const store = getModuleStore("mod-a");
-      store.getState().setData({ key: "value" });
-      expect(store.getState().data).toEqual({ key: "value" });
+  describe("dev warning", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     });
 
-    it("이전 data를 완전히 교체한다", () => {
-      const store = getModuleStore("mod-a");
-      store.getState().setData({ a: 1, b: 2 });
-      store.getState().setData({ c: 3 });
-      expect(store.getState().data).toEqual({ c: 3 });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("sessionId 없이 호출 시 DEV에서 console.warn을 호출한다", () => {
+      getModuleStore("mod-nowarn");
+      // vitest 기본은 DEV=true (import.meta.env.DEV)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("getModuleStore(\"mod-nowarn\") called without sessionId"),
+      );
+    });
+
+    it("sessionId 전달 시 warn을 호출하지 않는다", () => {
+      getModuleStore("mod-nowarn", "sess-1");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("sessionId=null (명시적 null)도 legacy로 간주하고 warn한다", () => {
+      getModuleStore("mod-null-sess", null);
+      expect(warnSpy).toHaveBeenCalled();
     });
   });
 
   // -------------------------------------------------------------------------
-  // mergeData
+  // setData / mergeData / reset / setActive (기존 계약 유지)
   // -------------------------------------------------------------------------
 
-  describe("mergeData", () => {
-    it("data를 부분 병합한다", () => {
-      const store = getModuleStore("mod-a");
+  describe("actions", () => {
+    it("setData는 data를 교체한다", () => {
+      const store = getModuleStore("mod-a", "sess-1");
+      store.getState().setData({ key: "value" });
+      expect(store.getState().data).toEqual({ key: "value" });
+
+      store.getState().setData({ next: 1 });
+      expect(store.getState().data).toEqual({ next: 1 });
+    });
+
+    it("mergeData는 부분 병합한다", () => {
+      const store = getModuleStore("mod-a", "sess-1");
       store.getState().setData({ a: 1 });
       store.getState().mergeData({ b: 2 });
       expect(store.getState().data).toEqual({ a: 1, b: 2 });
     });
 
-    it("기존 키를 덮어쓴다", () => {
-      const store = getModuleStore("mod-a");
+    it("mergeData는 기존 키를 덮어쓴다", () => {
+      const store = getModuleStore("mod-a", "sess-1");
       store.getState().setData({ a: 1, b: 2 });
       store.getState().mergeData({ a: 99 });
       expect(store.getState().data).toEqual({ a: 99, b: 2 });
     });
-  });
 
-  // -------------------------------------------------------------------------
-  // reset
-  // -------------------------------------------------------------------------
-
-  describe("reset", () => {
-    it("초기 상태로 복원한다", () => {
-      const store = getModuleStore("mod-a");
+    it("reset은 초기 상태로 복원한다", () => {
+      const store = getModuleStore("mod-a", "sess-1");
       store.getState().setData({ a: 1 });
       store.getState().setActive(true);
-
       store.getState().reset();
 
       const s = store.getState();
       expect(s.data).toEqual({});
       expect(s.isActive).toBe(false);
       expect(s.moduleId).toBe("mod-a");
+      expect(s.sessionId).toBe("sess-1");
     });
-  });
 
-  // -------------------------------------------------------------------------
-  // setActive
-  // -------------------------------------------------------------------------
-
-  describe("setActive", () => {
-    it("isActive를 true로 변경한다", () => {
-      const store = getModuleStore("mod-a");
+    it("setActive는 isActive를 토글한다", () => {
+      const store = getModuleStore("mod-a", "sess-1");
       store.getState().setActive(true);
       expect(store.getState().isActive).toBe(true);
-    });
-
-    it("isActive를 false로 변경한다", () => {
-      const store = getModuleStore("mod-a");
-      store.getState().setActive(true);
       store.getState().setActive(false);
       expect(store.getState().isActive).toBe(false);
     });
   });
 
   // -------------------------------------------------------------------------
-  // clearModuleStores
+  // clearBySessionId
+  // -------------------------------------------------------------------------
+
+  describe("clearBySessionId", () => {
+    it("지정한 sessionId의 스토어만 reset하고 캐시에서 제거한다", () => {
+      const a1 = getModuleStore("mod-a", "sess-1");
+      const a2 = getModuleStore("mod-a", "sess-2");
+      a1.getState().setData({ v: 1 });
+      a2.getState().setData({ v: 2 });
+
+      clearBySessionId("sess-1");
+
+      // sess-1 스토어는 reset됨
+      expect(a1.getState().data).toEqual({});
+
+      // sess-2 스토어는 보존됨
+      expect(a2.getState().data).toEqual({ v: 2 });
+
+      // sess-1 재조회 시 새 인스턴스
+      const a1New = getModuleStore("mod-a", "sess-1");
+      expect(a1New).not.toBe(a1);
+
+      // sess-2 재조회 시 같은 인스턴스
+      const a2Same = getModuleStore("mod-a", "sess-2");
+      expect(a2Same).toBe(a2);
+    });
+
+    it("sessionId가 null이면 no-op", () => {
+      const store = getModuleStore("mod-a", "sess-1");
+      store.getState().setData({ v: 1 });
+
+      clearBySessionId(null);
+
+      expect(store.getState().data).toEqual({ v: 1 });
+    });
+
+    it("같은 sessionId에 속한 여러 모듈을 모두 정리한다", () => {
+      const a = getModuleStore("mod-a", "sess-1");
+      const b = getModuleStore("mod-b", "sess-1");
+      a.getState().setData({ v: 1 });
+      b.getState().setData({ v: 2 });
+
+      clearBySessionId("sess-1");
+
+      expect(a.getState().data).toEqual({});
+      expect(b.getState().data).toEqual({});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // clearModuleStores (전역 teardown)
   // -------------------------------------------------------------------------
 
   describe("clearModuleStores", () => {
-    it("모든 스토어를 reset하고 캐시를 비운다", () => {
-      const storeA = getModuleStore("mod-a");
-      const storeB = getModuleStore("mod-b");
-      storeA.getState().setData({ a: 1 });
-      storeB.getState().setActive(true);
+    it("모든 세션의 스토어를 reset하고 캐시를 비운다", () => {
+      const a = getModuleStore("mod-a", "sess-1");
+      const b = getModuleStore("mod-b", "sess-2");
+      a.getState().setData({ v: 1 });
+      b.getState().setActive(true);
 
       clearModuleStores();
 
-      // 캐시가 비워졌으므로 새 인스턴스가 생성됨
-      const storeA2 = getModuleStore("mod-a");
-      expect(storeA2).not.toBe(storeA);
-      expect(storeA2.getState().data).toEqual({});
+      // 재조회 시 새 인스턴스
+      const a2 = getModuleStore("mod-a", "sess-1");
+      expect(a2).not.toBe(a);
+      expect(a2.getState().data).toEqual({});
     });
 
-    it("정리 후 기존 스토어는 reset된 상태이다", () => {
-      const store = getModuleStore("mod-a");
+    it("정리 후 기존 참조의 상태도 reset된다", () => {
+      const store = getModuleStore("mod-a", "sess-1");
       store.getState().setData({ key: "val" });
       store.getState().setActive(true);
 
       clearModuleStores();
 
-      // 기존 참조의 상태도 reset됨
       expect(store.getState().data).toEqual({});
       expect(store.getState().isActive).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // resetGame 연계 (F-react-6 핵심)
+  // -------------------------------------------------------------------------
+
+  describe("gameSessionStore.resetGame 연계", () => {
+    it("resetGame 시 해당 sessionId의 모듈 스토어만 정리된다", () => {
+      const a = getModuleStore("mod-a", "sess-active");
+      const b = getModuleStore("mod-a", "sess-other");
+      a.getState().setData({ v: 1 });
+      b.getState().setData({ v: 2 });
+
+      // 현재 게임 세션을 sess-active로 설정
+      useGameSessionStore.setState({ sessionId: "sess-active" });
+      useGameSessionStore.getState().resetGame();
+
+      // sess-active 스토어는 reset됨
+      expect(a.getState().data).toEqual({});
+
+      // sess-other 스토어는 보존됨
+      expect(b.getState().data).toEqual({ v: 2 });
     });
   });
 
@@ -161,16 +269,31 @@ describe("moduleStoreFactory", () => {
   // -------------------------------------------------------------------------
 
   describe("useModuleStore", () => {
-    it("모듈 스토어의 전체 상태를 반환한다", () => {
+    let hookWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // hook은 자동으로 useGameSessionStore.sessionId를 읽는다
+      useGameSessionStore.setState({ sessionId: "sess-hook" });
+      // renderHook cleanup 중에 이전 테스트의 hook이 다시 평가되며 sessionId=null
+      // 상태에서 warn이 날 수 있어 이 block에서는 console.warn을 silent 처리.
+      hookWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      hookWarnSpy.mockRestore();
+    });
+
+    it("현재 세션의 모듈 스토어의 전체 상태를 반환한다", () => {
       const { result } = renderHook(() => useModuleStore("mod-hook"));
 
       expect(result.current.moduleId).toBe("mod-hook");
+      expect(result.current.sessionId).toBe("sess-hook");
       expect(result.current.data).toEqual({});
       expect(result.current.isActive).toBe(false);
     });
 
     it("selector로 특정 값만 반환한다", () => {
-      const store = getModuleStore("mod-sel");
+      const store = getModuleStore("mod-sel", "sess-hook");
       store.getState().setData({ x: 42 });
 
       const { result } = renderHook(() => useModuleStore("mod-sel", (s) => s.data));
@@ -179,7 +302,7 @@ describe("moduleStoreFactory", () => {
     });
 
     it("스토어 변경이 hook에 반영된다", () => {
-      const store = getModuleStore("mod-react");
+      const store = getModuleStore("mod-react", "sess-hook");
       const { result } = renderHook(() => useModuleStore("mod-react"));
 
       act(() => {
@@ -194,11 +317,22 @@ describe("moduleStoreFactory", () => {
       const { result: r2 } = renderHook(() => useModuleStore("mod-same"));
 
       act(() => {
-        getModuleStore("mod-same").getState().setData({ shared: true });
+        getModuleStore("mod-same", "sess-hook").getState().setData({ shared: true });
       });
 
       expect(r1.current.data).toEqual({ shared: true });
       expect(r2.current.data).toEqual({ shared: true });
+    });
+
+    it("sessionId override가 명시되면 해당 세션 스토어를 구독한다", () => {
+      const explicit = getModuleStore("mod-override", "sess-explicit");
+      explicit.getState().setData({ tag: "explicit" });
+
+      const { result } = renderHook(() =>
+        useModuleStore("mod-override", (s) => s.data, "sess-explicit"),
+      );
+
+      expect(result.current).toEqual({ tag: "explicit" });
     });
   });
 });

--- a/apps/web/src/stores/gameSessionStore.ts
+++ b/apps/web/src/stores/gameSessionStore.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import type { GamePhase, GameState, ModuleConfig, Player, PlayerRole } from "@mmp/shared";
 import { syncServerTime } from "@mmp/game-logic";
 
+import { clearBySessionId } from "./moduleStoreFactory";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -85,6 +87,10 @@ export const useGameSessionStore = create<GameSessionState & GameSessionActions>
     },
 
     resetGame: () => {
+      // 세션 종료 시 해당 sessionId에 속한 모듈 스토어만 정리한다.
+      // 다른 세션 (동시 관전 등) 스토어는 보존된다.
+      const { sessionId } = get();
+      clearBySessionId(sessionId);
       set({ ...INITIAL_STATE });
     },
 

--- a/apps/web/src/stores/moduleStoreFactory.ts
+++ b/apps/web/src/stores/moduleStoreFactory.ts
@@ -1,12 +1,15 @@
 import { createStore, type StoreApi } from "zustand";
 import { useStore } from "zustand";
 
+import { useGameSessionStore } from "./gameSessionStore";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export interface ModuleStoreState {
   moduleId: string;
+  sessionId: string;
   data: Record<string, unknown>;
   isActive: boolean;
 }
@@ -24,28 +27,60 @@ type ModuleStore = ModuleStoreState & ModuleStoreActions;
 // Factory
 // ---------------------------------------------------------------------------
 
-/** 모듈 ID별 스토어 인스턴스 캐시 */
+/**
+ * sessionId 없이 호출된 스토어의 fallback 네임스페이스.
+ * 테스트·legacy 호출 호환성을 위해 유지하되, DEV 환경에서는 경고한다.
+ */
+const GLOBAL_NAMESPACE = "__global__";
+
+/**
+ * 캐시 key 포맷: `${sessionId}:${moduleId}`.
+ * 세션 전환 시 이전 세션의 모듈 state가 유출되지 않도록 namespace 분리.
+ */
 const moduleStores = new Map<string, StoreApi<ModuleStore>>();
 
+function makeCacheKey(sessionId: string, moduleId: string): string {
+  return `${sessionId}:${moduleId}`;
+}
+
 /** 모듈 스토어의 초기 상태 생성 */
-function createInitialState(moduleId: string): ModuleStoreState {
+function createInitialState(moduleId: string, sessionId: string): ModuleStoreState {
   return {
     moduleId,
+    sessionId,
     data: {},
     isActive: false,
   };
 }
 
 /**
- * 모듈 ID에 해당하는 vanilla 스토어를 반환한다.
- * 같은 moduleId면 캐시된 인스턴스를 돌려준다.
+ * 모듈 ID + sessionId에 해당하는 vanilla 스토어를 반환한다.
+ * 같은 (sessionId, moduleId) 조합이면 캐시된 인스턴스를 돌려준다.
+ *
+ * Phase 19 PR-8 (F-react-6): sessionId namespace 도입으로 세션 전환 시
+ * 이전 세션 모듈 state 유출을 방지한다. sessionId 없이 호출하면 DEV 경고 +
+ * `__global__` 네임스페이스로 fallback (legacy/test 호환).
  */
-export function getModuleStore(moduleId: string): StoreApi<ModuleStore> {
-  const existing = moduleStores.get(moduleId);
+export function getModuleStore(
+  moduleId: string,
+  sessionId?: string | null,
+): StoreApi<ModuleStore> {
+  const namespace = sessionId ?? GLOBAL_NAMESPACE;
+  if (!sessionId && import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[moduleStoreFactory] getModuleStore("${moduleId}") called without sessionId — ` +
+        `falling back to "${GLOBAL_NAMESPACE}" namespace. Pass sessionId to isolate ` +
+        `per-session module state (F-react-6).`,
+    );
+  }
+
+  const key = makeCacheKey(namespace, moduleId);
+  const existing = moduleStores.get(key);
   if (existing) return existing;
 
   const store = createStore<ModuleStore>()((set) => ({
-    ...createInitialState(moduleId),
+    ...createInitialState(moduleId, namespace),
 
     setData: (data) => {
       set({ data });
@@ -56,7 +91,7 @@ export function getModuleStore(moduleId: string): StoreApi<ModuleStore> {
     },
 
     reset: () => {
-      set(createInitialState(moduleId));
+      set(createInitialState(moduleId, namespace));
     },
 
     setActive: (active) => {
@@ -64,28 +99,54 @@ export function getModuleStore(moduleId: string): StoreApi<ModuleStore> {
     },
   }));
 
-  moduleStores.set(moduleId, store);
+  moduleStores.set(key, store);
   return store;
 }
 
 /**
  * React 컴포넌트에서 모듈 스토어를 구독하는 hook.
- * moduleId가 바뀌면 해당 모듈의 스토어로 자동 전환된다.
+ * sessionId는 명시 인자가 없으면 `useGameSessionStore`에서 자동으로 읽는다.
+ * 세션이 바뀌면 다른 namespace의 스토어로 자동 전환된다.
  */
 export function useModuleStore(moduleId: string): ModuleStore;
 export function useModuleStore<T>(moduleId: string, selector: (s: ModuleStore) => T): T;
 export function useModuleStore<T>(
   moduleId: string,
+  selector: (s: ModuleStore) => T,
+  sessionIdOverride: string | null,
+): T;
+export function useModuleStore<T>(
+  moduleId: string,
   selector?: (s: ModuleStore) => T,
+  sessionIdOverride?: string | null,
 ): T | ModuleStore {
-  const store = getModuleStore(moduleId);
+  // sessionId override가 명시되면 그 값을, 아니면 현재 게임 세션 id를 사용
+  const activeSessionId = useGameSessionStore((s) => s.sessionId);
+  const sessionId = sessionIdOverride !== undefined ? sessionIdOverride : activeSessionId;
+  const store = getModuleStore(moduleId, sessionId);
   // selector가 없으면 전체 상태 반환
   return useStore(store, selector ?? ((s) => s as unknown as T));
 }
 
 /**
- * 게임 종료 시 모든 모듈 스토어를 정리한다.
- * 각 스토어를 reset 후 캐시에서 제거한다.
+ * 지정한 sessionId에 속한 모든 모듈 스토어를 reset 후 캐시에서 제거한다.
+ * 다른 세션의 스토어는 보존된다. resetGame 직전 호출해 이전 세션의
+ * 모듈 state가 유출되지 않도록 한다.
+ */
+export function clearBySessionId(sessionId: string | null | undefined): void {
+  if (!sessionId) return;
+  const prefix = `${sessionId}:`;
+  for (const [key, store] of moduleStores.entries()) {
+    if (key.startsWith(prefix)) {
+      store.getState().reset();
+      moduleStores.delete(key);
+    }
+  }
+}
+
+/**
+ * 전역 정리: 모든 세션의 모듈 스토어를 제거한다.
+ * 로그아웃이나 앱 종료 등 명시적 teardown 상황에서만 호출.
  */
 export function clearModuleStores(): void {
   for (const store of moduleStores.values()) {
@@ -101,3 +162,4 @@ export function clearModuleStores(): void {
 export const selectModuleData = (s: ModuleStoreState) => s.data;
 export const selectModuleIsActive = (s: ModuleStoreState) => s.isActive;
 export const selectModuleId = (s: ModuleStoreState) => s.moduleId;
+export const selectModuleSessionId = (s: ModuleStoreState) => s.sessionId;


### PR DESCRIPTION
## Summary

Phase 19 PR-8 — **F-react-6 (P1) 해소**. moduleStoreFactory cache 키를 sessionId namespace로 분리하여 세션 전환 시 이전 모듈 state 유출 방지.

- cache key: `moduleId` → `${sessionId}:${moduleId}` (sessionId 없으면 `__global__` fallback + DEV warn)
- `clearBySessionId(sessionId)` 추가 — `resetGame` 훅업으로 세션 종료 시 해당 세션 모듈 store만 teardown
- `useModuleStore` 자동 sessionId 구독 (gameSessionStore); optional `sessionIdOverride` 3-인자 지원
- `useGameSync` MODULE_STATE/MODULE_EVENT 핸들러에 sessionId 전달
- `clearModuleStores` 전역 teardown용 API 유지 (로그아웃 등)

## 변경 파일
- `apps/web/src/stores/moduleStoreFactory.ts` (165줄)
- `apps/web/src/stores/gameSessionStore.ts` (157줄)
- `apps/web/src/hooks/useGameSync.ts` (139줄)
- `apps/web/src/pages/GamePage.tsx` (311줄)
- `apps/web/src/stores/__tests__/moduleStoreFactory.test.ts` (338줄, 25 tests)

모든 파일 TS 400줄 한도 내.

## Test plan
- [x] `pnpm -C apps/web test -- --run moduleStoreFactory` — 25/25 pass
- [x] `pnpm -C apps/web test -- --run` — 1047/1047 pass (109 files)
- [x] `pnpm -C apps/web exec tsc --noEmit` — 0 errors
- [x] session-A → exit → session-B 세션 전환 시 모듈 state 격리 (unit test 검증)
- [x] DEV-only console.warn on missing sessionId (tree-shaken in production)

## 코드리뷰 결과: APPROVE-WITH-NITS
- Circular import (moduleStoreFactory ↔ gameSessionStore) — ESM live binding으로 런타임 안전, **follow-up PR로 cleanup 함수 추출 권장**
- `.getState()` 잔존 건은 WS 동적 moduleId dispatch + unmount cleanup 용도로 Zustand 허용 패턴
- useWsEvent이 `useRef + handlerRef.current` 사용 — stale closure 무관

## F-react-6 해소
세션 전환 시 이전 세션의 `trade_clue/voting/hidden_mission` 등 module state가 다음 세션 렌더에 유출되는 P1 이슈 해소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>