### PR TITLE
fix(phase-19)(a11y): focus-visible outline ring (WCAG 2.4.7)

### DIFF
--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -111,7 +111,7 @@ function LoginPage() {
               required
               minLength={2}
               maxLength={30}
-              className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus:outline-none"
+              className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
             />
           )}
           <input
@@ -120,7 +120,7 @@ function LoginPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-            className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus:outline-none"
+            className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           <input
             type="password"
@@ -129,7 +129,7 @@ function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             required
             minLength={4}
-            className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus:outline-none"
+            className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           {error && (
             <p className="text-sm text-red-400">{error}</p>

--- a/apps/web/src/features/editor/components/AdvancedTab.tsx
+++ b/apps/web/src/features/editor/components/AdvancedTab.tsx
@@ -203,7 +203,7 @@ export function AdvancedTab({ themeId, theme }: AdvancedTabProps) {
               if (parseError) setParseError(null);
             }}
             spellCheck={false}
-            className="flex-1 bg-slate-950 py-3 pl-3 pr-4 font-mono text-sm leading-5 text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus:outline-none resize-none min-h-[400px]"
+            className="flex-1 bg-slate-950 py-3 pl-3 pr-4 font-mono text-sm leading-5 text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset resize-none min-h-[400px]"
           />
         </div>
 

--- a/apps/web/src/features/editor/components/CharacterCard.tsx
+++ b/apps/web/src/features/editor/components/CharacterCard.tsx
@@ -32,7 +32,7 @@ export function CharacterCard({ character, index, onEdit, onDelete }: CharacterC
       tabIndex={0}
       onClick={() => onEdit(character)}
       onKeyDown={(e) => e.key === 'Enter' && onEdit(character)}
-      className="group rounded-sm border border-slate-800 bg-slate-900 p-3 hover:border-slate-700 transition-all cursor-pointer focus:outline-none focus:border-amber-500/50"
+      className="group rounded-sm border border-slate-800 bg-slate-900 p-3 hover:border-slate-700 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950 focus:border-amber-500/50"
     >
       <div className="flex items-start gap-3">
         <div

--- a/apps/web/src/features/editor/components/CharacterForm.tsx
+++ b/apps/web/src/features/editor/components/CharacterForm.tsx
@@ -157,7 +157,7 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
             placeholder="캐릭터에 대한 설명"
             maxLength={2000}
             rows={3}
-            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           {errors.description && (
             <p className="text-sm text-red-400">{errors.description}</p>

--- a/apps/web/src/features/editor/components/ClueCard.tsx
+++ b/apps/web/src/features/editor/components/ClueCard.tsx
@@ -58,7 +58,7 @@ export function ClueCard({ clue, themeId, onEdit, onDelete, onImageUploaded }: C
         tabIndex={0}
         onClick={() => onEdit(clue)}
         onKeyDown={(e) => e.key === 'Enter' && onEdit(clue)}
-        className="flex cursor-pointer items-start justify-between gap-2 p-3 focus:outline-none"
+        className="flex cursor-pointer items-start justify-between gap-2 p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
       >
         <div className="min-w-0 flex-1">
           {/* Compact placeholder when no image */}

--- a/apps/web/src/features/editor/components/ClueForm.tsx
+++ b/apps/web/src/features/editor/components/ClueForm.tsx
@@ -214,7 +214,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
             placeholder="단서에 대한 설명"
             maxLength={2000}
             rows={3}
-            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           {errors.description && (
             <p className="text-sm text-red-400">{errors.description}</p>

--- a/apps/web/src/features/editor/components/ClueFormAdvancedFields.tsx
+++ b/apps/web/src/features/editor/components/ClueFormAdvancedFields.tsx
@@ -125,7 +125,7 @@ export function ClueFormAdvancedFields({
                   placeholder="1부터"
                   value={revealRound ?? ''}
                   onChange={(e) => onRevealRoundChange(parseRoundInput(e.target.value))}
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                 />
               </div>
               <div className="flex flex-1 flex-col gap-1">
@@ -143,7 +143,7 @@ export function ClueFormAdvancedFields({
                   placeholder="끝까지"
                   value={hideRound ?? ''}
                   onChange={(e) => onHideRoundChange(parseRoundInput(e.target.value))}
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                 />
               </div>
             </div>
@@ -185,7 +185,7 @@ export function ClueFormAdvancedFields({
                     id="clue-use-effect"
                     value={useEffect_}
                     onChange={(e) => onUseEffectChange(e.target.value)}
-                    className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                    className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                   >
                     <option value="peek">엿보기 (Peek)</option>
                     <option value="steal">강탈 (Steal)</option>
@@ -206,7 +206,7 @@ export function ClueFormAdvancedFields({
                     id="clue-use-target"
                     value={useTarget}
                     onChange={(e) => onUseTargetChange(e.target.value)}
-                    className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                    className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                   >
                     <option value="player">플레이어</option>
                     <option value="clue">단서</option>

--- a/apps/web/src/features/editor/components/ClueListRow.tsx
+++ b/apps/web/src/features/editor/components/ClueListRow.tsx
@@ -21,7 +21,7 @@ export function ClueListRow({ clue, onEdit, onDelete }: ClueListRowProps) {
       tabIndex={0}
       onClick={() => onEdit(clue)}
       onKeyDown={(e) => e.key === 'Enter' && onEdit(clue)}
-      className="group flex cursor-pointer items-center gap-3 rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 transition-all hover:border-slate-700 focus:outline-none"
+      className="group flex cursor-pointer items-center gap-3 rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 transition-all hover:border-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
     >
       {/* Name */}
       <span className="flex-1 truncate text-sm font-medium text-slate-200">{clue.name}</span>

--- a/apps/web/src/features/editor/components/ConfigJsonTab.tsx
+++ b/apps/web/src/features/editor/components/ConfigJsonTab.tsx
@@ -82,7 +82,7 @@ export function ConfigJsonTab({ themeId, theme }: ConfigJsonTabProps) {
           if (parseError) setParseError(null);
         }}
         spellCheck={false}
-        className="min-h-[400px] w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500 font-mono"
+        className="min-h-[400px] w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 font-mono"
       />
 
       {/* Validation error */}

--- a/apps/web/src/features/editor/components/EditorDashboard.tsx
+++ b/apps/web/src/features/editor/components/EditorDashboard.tsx
@@ -90,7 +90,7 @@ function CreateThemeForm({ onSubmit, isLoading, onCancel }: CreateThemeFormProps
       <div className="flex flex-col gap-1.5">
         <label className="text-sm font-medium text-slate-300">설명</label>
         <textarea
-          className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500"
+          className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           rows={3}
           placeholder="테마에 대한 간단한 설명"
           value={description}

--- a/apps/web/src/features/editor/components/OverviewTab.tsx
+++ b/apps/web/src/features/editor/components/OverviewTab.tsx
@@ -36,7 +36,7 @@ function SpecField({ label, unit, value, onChange, min, max, error }: SpecFieldP
           min={min}
           max={max}
           onChange={(e) => onChange(Number(e.target.value))}
-          className="w-full bg-transparent text-2xl font-mono font-bold text-slate-200 focus:outline-none focus:text-amber-400 transition-colors"
+          className="w-full bg-transparent text-2xl font-mono font-bold text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 focus:text-amber-400 transition-colors"
         />
         <span className="text-xs text-slate-600">{unit}</span>
       </div>
@@ -72,7 +72,7 @@ function PriceField({ label, unit, value, onChange, min, max, error }: PriceFiel
           min={min}
           max={max}
           onChange={(e) => onChange(Number(e.target.value))}
-          className="w-full bg-transparent text-xl font-mono font-bold text-slate-200 focus:outline-none focus:text-amber-400 transition-colors"
+          className="w-full bg-transparent text-xl font-mono font-bold text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 focus:text-amber-400 transition-colors"
         />
         <span className="text-xs text-slate-600">{unit}</span>
       </div>
@@ -180,7 +180,7 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
               onChange={(e) => setTitle(e.target.value)}
               placeholder="테마 제목"
               maxLength={100}
-              className="w-full rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-700 focus:border-amber-500/50 focus:outline-none focus:ring-1 focus:ring-amber-500/30 transition-colors"
+              className="w-full rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-700 focus:border-amber-500/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 transition-colors"
             />
             {errors.title && <p className="mt-1 text-xs text-red-400">{errors.title}</p>}
           </div>
@@ -196,7 +196,7 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
               placeholder="테마에 대한 세부 설명을 입력하세요"
               maxLength={2000}
               rows={3}
-              className="w-full rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-700 focus:border-amber-500/50 focus:outline-none focus:ring-1 focus:ring-amber-500/30 transition-colors resize-none"
+              className="w-full rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-700 focus:border-amber-500/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 transition-colors resize-none"
             />
             {errors.description && <p className="mt-1 text-xs text-red-400">{errors.description}</p>}
           </div>

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -125,7 +125,7 @@ export function StoryTab({ themeId }: StoryTabProps) {
               onChange={(e) => setMarkdown(e.target.value)}
               placeholder="마크다운으로 스토리를 작성하세요..."
               spellCheck={false}
-              className="flex-1 resize-none bg-slate-950 px-5 py-4 font-mono text-sm leading-relaxed text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus:outline-none"
+              className="flex-1 resize-none bg-slate-950 px-5 py-4 font-mono text-sm leading-relaxed text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
             />
           </div>
         )}

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -75,7 +75,7 @@ export function ActionListEditor({
           <select
             value={action.type}
             onChange={(e) => handleTypeChange(idx, e.target.value)}
-            className="flex-1 bg-transparent text-xs text-slate-300 focus:outline-none"
+            className="flex-1 bg-transparent text-xs text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
           >
             {ACTION_TYPES.map((at) => (
               <option key={at.value} value={at.value}>

--- a/apps/web/src/features/editor/components/design/AddNameInput.tsx
+++ b/apps/web/src/features/editor/components/design/AddNameInput.tsx
@@ -29,7 +29,7 @@ export function AddNameInput({ placeholder, onAdd, onCancel, isPending }: AddNam
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         disabled={isPending}
-        className="flex-1 min-w-0 rounded-sm bg-slate-800 px-2 py-1 text-xs text-slate-200 placeholder-slate-600 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
+        className="flex-1 min-w-0 rounded-sm bg-slate-800 px-2 py-1 text-xs text-slate-200 placeholder-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
       />
       <button
         type="button"

--- a/apps/web/src/features/editor/components/design/BranchNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/BranchNodePanel.tsx
@@ -51,7 +51,7 @@ export function BranchNodePanel({
       <div className="flex flex-col gap-1">
         <label className="text-[11px] text-slate-400">라벨</label>
         <input
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
           value={nodeData.label ?? ""}
           onChange={(e) => onUpdate(node.id, { label: e.target.value })}
           placeholder="분기 이름"
@@ -65,7 +65,7 @@ export function BranchNodePanel({
             기본 경로 (조건 없이 통과)
           </label>
           <select
-            className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-300 focus:border-amber-500 focus:outline-none"
+            className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-300 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
             value={nodeData.default_edge_id ?? ""}
             onChange={(e) =>
               onUpdate(node.id, { default_edge_id: e.target.value })

--- a/apps/web/src/features/editor/components/design/CluePlacementPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CluePlacementPanel.tsx
@@ -142,7 +142,7 @@ export function CluePlacementPanel({ themeId, theme }: CluePlacementPanelProps) 
                   onChange={(e) => {
                     if (e.target.value) handleAssign(clue.id, e.target.value);
                   }}
-                  className="w-full rounded-sm bg-slate-800 px-2 py-1 text-xs text-slate-300 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
+                  className="w-full rounded-sm bg-slate-800 px-2 py-1 text-xs text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                 >
                   <option value="" disabled>
                     장소 선택…

--- a/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
@@ -57,7 +57,7 @@ export function EndingNodePanel({
           value={data.label ?? ""}
           onChange={(e) => handleChange({ label: e.target.value })}
           placeholder="엔딩 이름"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus:outline-none"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>
 
@@ -69,7 +69,7 @@ export function EndingNodePanel({
           onChange={(e) => handleChange({ description: e.target.value })}
           placeholder="엔딩 설명"
           rows={3}
-          className="resize-none rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus:outline-none"
+          className="resize-none rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>
 
@@ -89,7 +89,7 @@ export function EndingNodePanel({
             })
           }
           placeholder="1.0"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus:outline-none"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>
     </div>

--- a/apps/web/src/features/editor/components/design/LocationRow.tsx
+++ b/apps/web/src/features/editor/components/design/LocationRow.tsx
@@ -100,7 +100,7 @@ export function LocationRow({ themeId, location, onDelete }: LocationRowProps) {
           onKeyDown={(e) => {
             if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
           }}
-          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
         />
         <span>~</span>
         <label
@@ -122,7 +122,7 @@ export function LocationRow({ themeId, location, onDelete }: LocationRowProps) {
           onKeyDown={(e) => {
             if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
           }}
-          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
         />
       </div>
       <button

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -166,7 +166,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
                         aria-checked={isEnabled}
                         aria-label={`${mod.name} ${isEnabled ? '비활성화' : '활성화'}`}
                         onClick={() => handleToggle(mod.id)}
-                        className={`relative shrink-0 h-5 w-9 rounded-full transition-colors focus:outline-none ${
+                        className={`relative shrink-0 h-5 w-9 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                           isEnabled ? 'bg-amber-500' : 'bg-slate-700'
                         }`}
                       >

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -128,7 +128,7 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
           onChange={(e) => handleChange({ label: e.target.value })}
           onBlur={flush}
           placeholder="페이즈 이름"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus:outline-none"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>
 
@@ -139,7 +139,7 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
           value={data.phase_type ?? ""}
           onChange={(e) => handleChange({ phase_type: e.target.value })}
           onBlur={flush}
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         >
           <option value="">선택 안 함</option>
           {PHASE_TYPES.map((pt) => (
@@ -162,7 +162,7 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
           }
           onBlur={flush}
           placeholder="0"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus:outline-none"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>
 
@@ -178,7 +178,7 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
           }
           onBlur={flush}
           placeholder="1"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus:outline-none"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>
 
@@ -215,7 +215,7 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
             }
             onBlur={flush}
             placeholder="30"
-            className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus:outline-none"
+            className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
           />
         </div>
       )}

--- a/apps/web/src/features/editor/components/design/condition/ConditionRule.tsx
+++ b/apps/web/src/features/editor/components/design/condition/ConditionRule.tsx
@@ -28,7 +28,7 @@ interface ConditionRuleProps {
 // ---------------------------------------------------------------------------
 
 const selectCls =
-  "rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-300 focus:border-amber-500 focus:outline-none";
+  "rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-300 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950";
 
 // ---------------------------------------------------------------------------
 // ConditionRuleRow

--- a/apps/web/src/features/editor/components/media/MediaCard.tsx
+++ b/apps/web/src/features/editor/components/media/MediaCard.tsx
@@ -86,7 +86,7 @@ export function MediaCard({
         }
       }}
       aria-pressed={selected}
-      className={`group relative flex cursor-pointer flex-col overflow-hidden rounded-sm border text-left transition-colors focus:outline-none focus:ring-1 focus:ring-amber-500 ${
+      className={`group relative flex cursor-pointer flex-col overflow-hidden rounded-sm border text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950 ${
         selected
           ? "border-amber-500 bg-slate-900"
           : "border-slate-800 bg-slate-900/50 hover:border-slate-600"

--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -127,7 +127,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+            className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
           />
         </label>
 
@@ -140,7 +140,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
             value={tagsText}
             onChange={(e) => setTagsText(e.target.value)}
             placeholder="전투, 긴장감"
-            className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+            className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
           />
         </label>
 
@@ -153,7 +153,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
               type="number"
               value={sortOrder}
               onChange={(e) => setSortOrder(Number(e.target.value))}
-              className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+              className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
             />
           </label>
           <label className="flex flex-col gap-1">
@@ -166,7 +166,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
               step="0.1"
               value={duration}
               onChange={(e) => setDuration(e.target.value)}
-              className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus:outline-none"
+              className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
             />
           </label>
         </div>

--- a/apps/web/src/features/editor/components/media/MediaPicker.tsx
+++ b/apps/web/src/features/editor/components/media/MediaPicker.tsx
@@ -121,7 +121,7 @@ export function MediaPicker({
           <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
           <input
             type="text"
-            className="w-full rounded border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-100 focus:border-amber-500 focus:outline-none"
+            className="w-full rounded border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-100 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
             placeholder="이름으로 검색"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/web/src/features/game/components/AccusationPanel.tsx
+++ b/apps/web/src/features/game/components/AccusationPanel.tsx
@@ -112,7 +112,7 @@ export function AccusationPanel({ send, moduleId }: AccusationPanelProps) {
             </label>
             <textarea
               id="accuse-reason"
-              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 resize-none"
+              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 resize-none"
               rows={3}
               placeholder="이 플레이어가 범인이라고 생각하는 이유를 작성하세요..."
               value={reason}

--- a/apps/web/src/features/game/components/ChatInput.tsx
+++ b/apps/web/src/features/game/components/ChatInput.tsx
@@ -36,7 +36,7 @@ export function ChatInput({
   return (
     <div className="flex items-center gap-2 border-t border-slate-800 p-3">
       <input
-        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-200 placeholder-slate-500 outline-none focus:border-amber-500"
+        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-200 placeholder-slate-500 outline-none focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}

--- a/apps/web/src/features/game/components/GameChat.tsx
+++ b/apps/web/src/features/game/components/GameChat.tsx
@@ -268,7 +268,7 @@ export function GameChat({ send, fullWidth = false }: GameChatProps) {
       {activeTab === "whisper" && (
         <div className="border-b border-slate-800 px-3 py-2">
           <select
-            className="w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-200 outline-none focus:border-purple-500"
+            className="w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-200 outline-none focus:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
             value={whisperTarget}
             onChange={(e) => setWhisperTarget(e.target.value)}
           >

--- a/apps/web/src/features/game/components/WhisperTargetPicker.tsx
+++ b/apps/web/src/features/game/components/WhisperTargetPicker.tsx
@@ -27,7 +27,7 @@ export function WhisperTargetPicker({
     <div className="flex items-center gap-2 border-b border-slate-800 px-3 py-2">
       <UserCheck className="h-4 w-4 shrink-0 text-purple-400" />
       <select
-        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-2 py-1.5 text-sm text-slate-200 outline-none focus:border-purple-500"
+        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-2 py-1.5 text-sm text-slate-200 outline-none focus:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
         value={selected}
         onChange={(e) => onSelect(e.target.value)}
         aria-label="귓속말 대상 선택"

--- a/apps/web/src/features/profile/components/DeleteAccountModal.tsx
+++ b/apps/web/src/features/profile/components/DeleteAccountModal.tsx
@@ -113,7 +113,7 @@ export function DeleteAccountModal({ onClose }: DeleteAccountModalProps) {
               value={nicknameInput}
               onChange={(e) => setNicknameInput(e.target.value)}
               placeholder={user?.nickname ?? ""}
-              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
             />
           </div>
 
@@ -128,7 +128,7 @@ export function DeleteAccountModal({ onClose }: DeleteAccountModalProps) {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="비밀번호"
-                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
               />
             </div>
           )}

--- a/apps/web/src/features/social/components/ChatRoom.tsx
+++ b/apps/web/src/features/social/components/ChatRoom.tsx
@@ -257,7 +257,7 @@ export function ChatRoom({ roomId }: ChatRoomProps) {
           <div className="relative flex-1">
             <textarea
               ref={textareaRef}
-              className="w-full resize-none rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500"
+              className="w-full resize-none rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
               rows={1}
               placeholder="메시지를 입력하세요..."
               value={text}

--- a/apps/web/src/features/social/components/FriendsList.tsx
+++ b/apps/web/src/features/social/components/FriendsList.tsx
@@ -333,7 +333,7 @@ export function FriendsList() {
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
               <input
                 type="text"
-                className="w-full rounded-lg border border-slate-700 bg-slate-800 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500"
+                className="w-full rounded-lg border border-slate-700 bg-slate-800 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                 placeholder="닉네임으로 검색..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/web/src/pages/AdminReviewPage.tsx
+++ b/apps/web/src/pages/AdminReviewPage.tsx
@@ -266,7 +266,7 @@ export default function AdminReviewPage() {
             onChange={(e) => setRejectNote(e.target.value)}
             placeholder="반려 사유를 입력하세요..."
             rows={4}
-            className="w-full resize-none rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+            className="w-full resize-none rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
         </div>
       </Modal>

--- a/apps/web/src/shared/components/ui/Input.tsx
+++ b/apps/web/src/shared/components/ui/Input.tsx
@@ -31,7 +31,7 @@ export function Input({
         )}
         <input
           id={inputId}
-          className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors ${leftIcon ? 'pl-10' : ''} ${className}`}
+          className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 ${leftIcon ? 'pl-10' : ''} ${className}`}
           aria-invalid={error ? true : undefined}
           aria-describedby={error && inputId ? `${inputId}-error` : undefined}
           {...rest}

--- a/apps/web/src/shared/components/ui/Select.tsx
+++ b/apps/web/src/shared/components/ui/Select.tsx
@@ -27,7 +27,7 @@ export function Select({
       )}
       <select
         id={selectId}
-        className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 outline-none transition-colors ${className}`}
+        className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 outline-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 ${className}`}
         aria-invalid={error ? true : undefined}
         aria-describedby={error && selectId ? `${selectId}-error` : undefined}
         {...rest}


### PR DESCRIPTION
## Summary

Phase 19 **F-a11y-3 (P0) 해소**. `outline-none` 60 occurrence 전수 수정 → WCAG 2.4.7 Focus Visible (Level AA) 준수.

- 34 files changed, 54 insertions(+), 54 deletions(-)
- 키보드 사용자 focus 시각 가시성 복원 (인풋/버튼/카드/토글 스위치/textarea)
- 마우스 클릭 시 ring 미노출 (`focus-visible:` 사용)

## 적용 패턴

**Before (WCAG 실패)**: `focus:outline-none` (ring 없거나 `:focus` 기반)
**After (WCAG AA)**:
```
focus-visible:outline-none
focus-visible:ring-2
focus-visible:ring-amber-500/60
focus-visible:ring-offset-1
focus-visible:ring-offset-slate-900
```

**변형 (의도적)**:
- 폼 인풋: 기존 `focus:border-amber-500` 유지 + ring 추가 (이중 단서)
- WhisperTargetPicker/GameChat select: `focus-visible:ring-purple-500/60` (purple 테마)
- 전면 textarea (StoryTab/AdvancedTab/ActionListEditor): `focus-visible:ring-inset`
- 토글 스위치 (ModulesSubTab): `ring-offset-2`

## 제외 파일 (이미 정합 상태 4개)
- `shared/components/ui/Button.tsx`
- `components/profile/AvatarPresetGrid.tsx`
- `features/editor/components/ImageCropUpload.tsx`
- `features/profile/components/NotificationSettings.tsx`

## Test plan
- [x] `pnpm -C apps/web exec tsc --noEmit` — 0 errors
- [x] `pnpm -C apps/web lint` — 0 errors (42 pre-existing warnings 무관)
- [x] `pnpm -C apps/web test -- --run` — 109 files, 1039 tests pass, regression 0
- [x] `pnpm -C apps/web build` — Vite 7.91s 성공

수동 QA (권장):
- [ ] Tab 키 순차 이동 — LoginPage/EditorDashboard/GameChat focus ring 확인
- [ ] 마우스 클릭 시 ring 미노출 검증
- [ ] amber-500/60 on slate-900 대비 ≥ 3:1 검증

## 코드리뷰 결과: APPROVE
- Residual bare `outline-none` 7건 — dead CSS, WCAG 영향 無 (follow-up 정리)
- 체크박스 `focus:ring-amber-500` 미변환 — 범위 외 (follow-up)

## 정책 준수
- [x] `@jittda/ui` import 추가 없음 (MMP v3 정책 — Tailwind 4 직접 사용)
- [x] 네이티브 HTML 요소 교체 없음 (className 추가만)
- [x] 하드코딩 색상 없음 (amber/slate/purple 토큰만)
- [x] TS/TSX 400줄 / 컴포넌트 150줄 한도 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>