### PR TITLE
fix(phase-19)(a11y): f-a11y-4 residual outline-none + checkbox focus-visible

### DIFF
--- a/apps/web/src/features/admin/components/AdminPackages.tsx
+++ b/apps/web/src/features/admin/components/AdminPackages.tsx
@@ -363,7 +363,7 @@ export function AdminPackages() {
               type="checkbox"
               checked={form.is_active}
               onChange={(e) => updateField("is_active", e.target.checked)}
-              className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus:ring-amber-500"
+              className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
             />
             활성 상태
           </label>

--- a/apps/web/src/features/editor/components/CharacterForm.tsx
+++ b/apps/web/src/features/editor/components/CharacterForm.tsx
@@ -190,7 +190,7 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
             type="checkbox"
             checked={isCulprit}
             onChange={(e) => setIsCulprit(e.target.checked)}
-            className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-slate-900"
+            className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           <label htmlFor="character-is-culprit" className="text-sm font-medium text-slate-300">
             범인 여부

--- a/apps/web/src/features/editor/components/ClueFormAdvancedFields.tsx
+++ b/apps/web/src/features/editor/components/ClueFormAdvancedFields.tsx
@@ -94,7 +94,7 @@ export function ClueFormAdvancedFields({
               type="checkbox"
               checked={isCommon}
               onChange={(e) => onIsCommonChange(e.target.checked)}
-              className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-slate-900"
+              className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
             />
             <label
               htmlFor="clue-is-common"
@@ -162,7 +162,7 @@ export function ClueFormAdvancedFields({
                 type="checkbox"
                 checked={isUsable}
                 onChange={(e) => onIsUsableChange(e.target.checked)}
-                className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-slate-900"
+                className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
               />
               <label
                 htmlFor="clue-is-usable"
@@ -220,7 +220,7 @@ export function ClueFormAdvancedFields({
                     type="checkbox"
                     checked={useConsumed}
                     onChange={(e) => onUseConsumedChange(e.target.checked)}
-                    className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-slate-900"
+                    className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                   />
                   <label
                     htmlFor="clue-use-consumed"

--- a/apps/web/src/features/editor/components/EditorDashboard.tsx
+++ b/apps/web/src/features/editor/components/EditorDashboard.tsx
@@ -90,7 +90,7 @@ function CreateThemeForm({ onSubmit, isLoading, onCancel }: CreateThemeFormProps
       <div className="flex flex-col gap-1.5">
         <label className="text-sm font-medium text-slate-300">설명</label>
         <textarea
-          className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+          className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           rows={3}
           placeholder="테마에 대한 간단한 설명"
           value={description}

--- a/apps/web/src/features/editor/components/ModulesTab.tsx
+++ b/apps/web/src/features/editor/components/ModulesTab.tsx
@@ -112,7 +112,7 @@ function CategorySection({
                     checked={isRequired ? true : checked}
                     disabled={isDisabled}
                     onChange={() => onToggle(mod.id)}
-                    className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus:ring-amber-500"
+                    className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                   />
                   <div className="min-w-0">
                     <span className="block text-sm font-medium text-slate-200">

--- a/apps/web/src/features/editor/components/SchemaField.tsx
+++ b/apps/web/src/features/editor/components/SchemaField.tsx
@@ -101,7 +101,7 @@ export function SchemaField({ schema, path, value, onChange }: SchemaFieldProps)
             type="checkbox"
             checked={typeof resolved === "boolean" ? resolved : false}
             onChange={(e) => onChange(path, e.target.checked)}
-            className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus:ring-amber-500"
+            className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           {labelEl}
         </label>

--- a/apps/web/src/features/game/components/AccusationPanel.tsx
+++ b/apps/web/src/features/game/components/AccusationPanel.tsx
@@ -112,7 +112,7 @@ export function AccusationPanel({ send, moduleId }: AccusationPanelProps) {
             </label>
             <textarea
               id="accuse-reason"
-              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 resize-none"
+              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 resize-none"
               rows={3}
               placeholder="이 플레이어가 범인이라고 생각하는 이유를 작성하세요..."
               value={reason}

--- a/apps/web/src/features/game/components/ChatInput.tsx
+++ b/apps/web/src/features/game/components/ChatInput.tsx
@@ -36,7 +36,7 @@ export function ChatInput({
   return (
     <div className="flex items-center gap-2 border-t border-slate-800 p-3">
       <input
-        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-200 placeholder-slate-500 outline-none focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}

--- a/apps/web/src/features/game/components/GameChat.tsx
+++ b/apps/web/src/features/game/components/GameChat.tsx
@@ -268,7 +268,7 @@ export function GameChat({ send, fullWidth = false }: GameChatProps) {
       {activeTab === "whisper" && (
         <div className="border-b border-slate-800 px-3 py-2">
           <select
-            className="w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-200 outline-none focus:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+            className="w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-200 focus:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
             value={whisperTarget}
             onChange={(e) => setWhisperTarget(e.target.value)}
           >

--- a/apps/web/src/features/game/components/WhisperTargetPicker.tsx
+++ b/apps/web/src/features/game/components/WhisperTargetPicker.tsx
@@ -27,7 +27,7 @@ export function WhisperTargetPicker({
     <div className="flex items-center gap-2 border-b border-slate-800 px-3 py-2">
       <UserCheck className="h-4 w-4 shrink-0 text-purple-400" />
       <select
-        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-2 py-1.5 text-sm text-slate-200 outline-none focus:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+        className="flex-1 rounded-md border border-slate-700 bg-slate-800 px-2 py-1.5 text-sm text-slate-200 focus:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
         value={selected}
         onChange={(e) => onSelect(e.target.value)}
         aria-label="귓속말 대상 선택"

--- a/apps/web/src/features/social/components/ChatRoom.tsx
+++ b/apps/web/src/features/social/components/ChatRoom.tsx
@@ -257,7 +257,7 @@ export function ChatRoom({ roomId }: ChatRoomProps) {
           <div className="relative flex-1">
             <textarea
               ref={textareaRef}
-              className="w-full resize-none rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+              className="w-full resize-none rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
               rows={1}
               placeholder="메시지를 입력하세요..."
               value={text}

--- a/apps/web/src/features/social/components/FriendsList.tsx
+++ b/apps/web/src/features/social/components/FriendsList.tsx
@@ -333,7 +333,7 @@ export function FriendsList() {
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
               <input
                 type="text"
-                className="w-full rounded-lg border border-slate-700 bg-slate-800 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+                className="w-full rounded-lg border border-slate-700 bg-slate-800 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 transition-colors focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
                 placeholder="닉네임으로 검색..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/web/src/shared/components/ui/Input.tsx
+++ b/apps/web/src/shared/components/ui/Input.tsx
@@ -31,7 +31,7 @@ export function Input({
         )}
         <input
           id={inputId}
-          className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 outline-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 ${leftIcon ? 'pl-10' : ''} ${className}`}
+          className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 ${leftIcon ? 'pl-10' : ''} ${className}`}
           aria-invalid={error ? true : undefined}
           aria-describedby={error && inputId ? `${inputId}-error` : undefined}
           {...rest}

--- a/apps/web/src/shared/components/ui/Select.tsx
+++ b/apps/web/src/shared/components/ui/Select.tsx
@@ -27,7 +27,7 @@ export function Select({
       )}
       <select
         id={selectId}
-        className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 outline-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 ${className}`}
+        className={`w-full rounded-lg bg-slate-800 ${borderClass} border px-3 py-2 text-sm text-slate-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 ${className}`}
         aria-invalid={error ? true : undefined}
         aria-describedby={error && selectId ? `${selectId}-error` : undefined}
         {...rest}


### PR DESCRIPTION
## Summary
F-a11y-3 (#92) 코드리뷰 MEDIUM 2건 해소.

- **Bare `outline-none` 9건 제거** (dead CSS) — focus-visible:outline-none이 이미 붙은 곳 앞쪽 중복 제거. 리뷰어 지목 7건 + 동일 패턴 `WhisperTargetPicker.tsx` / `GameChat.tsx` 2건 추가 발견.
- **체크박스 `focus:ring-amber-500` → `focus-visible:` 변환 7건** — 마우스 클릭 시에도 ring이 노출되던 문제 해소. 키보드 포커스에만 ring + offset 적용.

## Scope
- 14 파일, +16 / -16 lines
- className 교체만, 컴포넌트 구조 변경 없음
- 하드코딩 색상 없음 (amber-*/slate-* 토큰 유지)

## Test plan
- [x] `grep` bare `outline-none` → 0건
- [x] `grep` `focus:ring-amber-500` → 0건
- [x] `pnpm -C apps/web exec tsc --noEmit` → 0 errors
- [x] `pnpm -C apps/web test -- --run` → 1047 tests pass
- [x] `pnpm -C apps/web lint` → 0 errors (42 warnings pre-existing)
- [x] `pnpm -C apps/web build` → success

## Risk
None — Tailwind 유틸리티 문자열 교체, 런타임 동작 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>