### PR TITLE
chore(phase-19): pr-2 3분할 설계 문서 + inventory 교정 + backlog 재기입

### DIFF
--- a/docs/plans/2026-04-17-platform-deep-audit/refs/phase19-backlog.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/phase19-backlog.md
@@ -34,12 +34,38 @@
   - **D2 = D (AUTH catalog stub)**: `auth.*` 이벤트는 Catalog에 stub entry만 등록. 서버 핸들러·프론트 sendAuth는 미구현(쿼리 토큰 정책 유지). 정식 protocol은 **PR-9**로 분리.
   - **D3 = v1.5 opt α (tygo)**: `// wsgen:payload` 주석이 있는 Go struct만 `packages/shared/src/ws/types.generated.ts`에 TS interface로 전환. 런타임 zod 검증은 **PR-10**으로 분리. dynamic payload(`json.RawMessage`)는 `unknown` 유지.
 
-### PR-2: PlayerAwareModule Mandatory — 엔진 레벨 강제 + crime_scene 3 구현 + 테스트 백필
-- **Scope**: `apps/server/internal/module/crime_scene/{evidence,location,combination}/**`, `apps/server/internal/module/decision/{accusation,hidden_mission,voting}/**`, `apps/server/internal/engine/types.go`, `apps/server/internal/engine/snapshot_redaction_test.go`
-- **Depends on**: 없음 (병렬 가능)
-- **Rationale**: C-2 / F-module-1 P0 + F-sec-2 P0. Phase 18.1 B-2 redaction 반쪽 상태 해소. 25 모듈 fallback → 필수 구현 + 컴파일 타임 assertion + boot-fail gate.
-- **Size**: L (>2d)
-- **Risk**: Med (서버만, 테스트 확장)
+### PR-2 3분할 (2026-04-18 재설계) — design: `refs/pr-2-split-design.md`
+
+> **분할 근거**: W1 draft "PlayerAware 0/33" → 실측 **8/33 (24%)**. 잔여 25 fallback 중 공개 state 모듈 12개는 `PublicStateMarker` sentinel로 opt-out, 민감 state 13개만 실구현 필요. 3분할 실행 순서: **PR-2a → PR-2b → PR-2c** (순차).
+
+#### PR-2a: Engine Gate + PublicStateMarker — design: `refs/pr-2/pr-2a-engine-gate.md`
+- **Scope**: `apps/server/internal/engine/types.go`, `engine/factory.go`, `engine/registry.go`, 33 모듈 `module.go` (marker/stub 부착)
+- **Depends on**: 없음 (W2 잔여, 단독)
+- **Rationale**: F-sec-2 gate 설치. `PlayerAwareModule OR PublicStateMarker` 중 하나 필수 → compile-time assertion + boot-fail gate + `MMP_PLAYERAWARE_STRICT` env flag (default true).
+- **Size**: S (~170 LOC)
+- **Risk**: Low (gate만, 실구현 아님)
+
+#### PR-2b: 13 모듈 BuildStateFor 백필 — design: `refs/pr-2/pr-2b-module-backfill.md`
+- **Scope**: 13 민감 모듈 `BuildStateFor` 실구현 + `snapshot_redaction_test.go` 확장 (`combination` 제외, PR-2c 담당)
+- **Depends on**: **PR-2a** (gate 통과)
+- **Rationale**: F-03 + F-sec-2 실구현. crime_scene/{evidence,location} · decision/accusation · cluedist 일부 · 기타 단서 개인화 대상.
+- **Size**: L (~520 LOC)
+- **Risk**: Med (13 모듈 동시 변경, 카테고리별 커밋 granularity 확보)
+
+#### PR-2c: craftedAsClueMap redaction (D-MO-1) — design: `refs/pr-2/pr-2c-crafted-redaction.md`
+- **Scope**: `apps/server/internal/module/crime_scene/combination/**` (`snapshotFor` + `BuildStateFor` + 테스트 4건)
+- **Depends on**: **PR-2a** (gate) + **PR-2b** (combination stub → real 전환 전제)
+- **Rationale**: D-MO-1 delta finding 단독 해소. `craftedAsClueMap`이 `BuildState`에 반영 안 되는 문제.
+- **Size**: S-M (~180 LOC)
+- **Risk**: Low (combination 파일 단일 집중)
+
+**의존성 그래프**:
+```
+PR-2a ──┬──→ PR-2b
+        └──→ PR-2c  (PR-2b 선 머지 권장 — combination.go 충돌 회피)
+```
+
+**Feature flag**: `MMP_PLAYERAWARE_STRICT` env (default `true`). 프로덕션 이슈 시 `false`로 즉시 fallback 롤백. PR-2b/2c 머지 + 30일 안정 관측 후 제거.
 
 ### PR-3: HTTP Error Standardization — http.Error → apperror + linter
 - **Scope**: `apps/server/internal/seo/**`, `apps/server/internal/infra/storage/local/**`, `apps/server/internal/ws/upgrade*`, `apps/server/internal/apperror/**`, `.golangci.yml` (depguard 룰)

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2-split-design.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2-split-design.md
@@ -1,0 +1,72 @@
+# PR-2 PlayerAwareModule Mandatory — 3분할 설계 (index)
+
+> Author: module-architect (Phase 19 W3)
+> 대상 Finding: F-03 (P0, crime_scene PlayerAware 누락) · F-sec-2 (P0, 25/33 fallback) · D-MO-1 (P0 delta, craftedAsClueMap redaction)
+> Baseline: main @ 858a1fa (2026-04-17). 실측 PlayerAware 구현 **8/33** (W2 audit 03-module-architect §Metrics 확정, W1 인벤토리 0/33 는 drift).
+
+## 결론
+
+원래 PR-2 (XL, Med risk) 를 **3개 PR** 로 분할. 각 PR 모두 독립 mergeable, 순차 실행 권장 (PR-2a → PR-2b → PR-2c), 중간에 feature flag 불요. 분할 후 PR별 재추정:
+
+| PR | Scope | Size | Risk | Finding |
+|----|-------|------|------|---------|
+| **PR-2a** | Engine gate + mandatory 인터페이스 전환 + sentinel helper | **S** | **Low** | F-sec-2 인프라 |
+| **PR-2b** | 25 모듈 `BuildStateFor` 백필 + redaction 테스트 확장 | **L** | **Med** | F-03 + F-sec-2 실구현 |
+| **PR-2c** | `CombinationModule` craftedAsClueMap redaction | **S-M** | **Low** | D-MO-1 단독 해소 |
+
+원 PR-2 XL 단일 머지 시 git conflict·리뷰 병목·롤백 granularity 손실이 예상되어 분할한다.
+
+## 문서 맵
+
+- [refs/pr-2/current-state.md](pr-2/current-state.md) — 33 모듈 PlayerAware 구현 현황 실측표 + 민감 필드 매핑
+- [refs/pr-2/pr-2a-engine-gate.md](pr-2/pr-2a-engine-gate.md) — Engine 인터페이스 mandatory 전환 + boot-fail gate
+- [refs/pr-2/pr-2b-module-backfill.md](pr-2/pr-2b-module-backfill.md) — 25 모듈 구현 계획 + pattern catalog
+- [refs/pr-2/pr-2c-crafted-redaction.md](pr-2/pr-2c-crafted-redaction.md) — `combination.derived/completed/collected` per-player redaction
+- [refs/pr-2/execution-plan.md](pr-2/execution-plan.md) — Wave 배치 + 병렬/순차 판정 + 리스크·완화
+
+## 3분할 근거 (요약)
+
+1. **경계가 다름**: PR-2a 는 *engine 규약 변경* (interface + factory validation), PR-2b 는 *모듈 구현부 백필* (각 모듈 `BuildStateFor` 작성), PR-2c 는 *기존 PlayerAware 모듈 1개의 internal state 재설계* (crafted/derived 맵 redaction). 코드 소유자·테스트 레벨·검토 심도가 달라 단일 PR 에 섞이면 리뷰 granularity 손상.
+2. **롤백 단위**: PR-2a 만 머지하면 registry 가 PlayerAware 미구현 모듈을 `init()` 에서 **boot fail** 로 거절하므로, 임시로 *모든 모듈이 no-op `BuildStateFor() { return m.BuildState() }` 를 가지는 stub 단계* 가 필요. 이 stub 을 포함한 PR-2a 를 먼저 머지해야 PR-2b 가 25 파일을 점진 교체 가능. 단일 XL 로 하면 stub 과 real 구현이 혼재 diff 로 섞여 리뷰 불가.
+3. **Testability 격리**: PR-2a 의 검증은 `factory.go` + `registry.go` 단위 테스트. PR-2b 는 `snapshot_redaction_test.go` 확장 + 모듈별 redaction assert. PR-2c 는 `combination_test.go` 확장. 각 PR 이 독립된 테스트 수트를 가지므로 CI signal 도 분리된다.
+4. **Risk surface**: PR-2b 가 25 파일 변경으로 가장 크지만, PR-2a 의 gate 가 먼저 머지되어 있으면 "stub → real" 교체는 컴파일 보장 아래에서 진행된다. PR-2a 단독 위험은 build break 1건 (모든 모듈이 gate 통과해야 함) 으로 한정 가능.
+
+## Finding → PR 매핑
+
+| Finding | PR-2a | PR-2b | PR-2c | 비고 |
+|---------|:----:|:----:|:----:|----|
+| **F-03 crime_scene PlayerAware 미구현** (P0) | 게이트만 | 실구현 | - | PR-2b 가 evidence/location/combination 3개 포함 |
+| **F-sec-2 25/33 fallback** (P0) | 게이트만 | 실구현 | - | PR-2b 가 나머지 22 모듈 백필 |
+| **D-MO-1 craftedAsClueMap redaction** (P0 delta) | - | - | 단독 | `combination.derived/completed/collected` per-player filter — 이미 PlayerAware 구현된 모듈의 internal state 변경이므로 PR-2b 범위 밖 |
+
+## 실행 순서 요약
+
+```
+W2 잔여  → PR-2a (S, Low)     단독 머지 [stub 25 모듈 포함]
+W3 전반  → PR-2b (L, Med)     PR-2a 머지 후 착수 (stub → real)
+W3 후반  → PR-2c (S-M, Low)   PR-2b 병렬 가능하지만 conflict 최소화 위해 sequential 권장
+```
+
+Feature flag: **불요**. PR-2a 는 compile-time 강제로 boot fail 안전장치가 내장되고, PR-2b/2c 는 state shape 변경이 아니라 *추가* 경로(`BuildStateFor`) 구현이라 기존 클라이언트 미영향.
+
+## 주요 리스크 TOP 3
+
+1. **PR-2a 머지 직후 모든 모듈이 stub BuildStateFor 로 동작** → public BuildState 와 동일한 값을 반환하므로 *기능적으론* 현재와 같지만, 테스트는 "PlayerAware 구현됨" 으로 표시되어 fallback path 가 사라진다. snapshot_redaction_test 가 stub 을 real 과 구분할 수 있어야 한다. **완화**: stub 에 `// TODO(pr-2b): redact per-player state` 주석 + `var _ engine.PlayerAwareModule = (*X)(nil)` 컴파일 assertion 만 추가, 실제 `BuildStateFor` 는 `return m.BuildState()` 만 호출 (lint rule 로 PR-2b 에서 제거 강제).
+2. **PR-2b 25 파일 동시 변경 → 다른 PR 과 git conflict** — Phase 20 이후 에디터·CI PR 이 같은 파일을 건드릴 확률 높음. **완화**: PR-2b 를 Wave 경계 머지 직후 착수 + subagent-driven-development 로 카테고리별(crime_scene/decision/communication/core/progression) 커밋 분리해 cherry-pick rebase 용이하도록.
+3. **PR-2c 는 `combination.derived/completed/collected` 의 *per-player* 맵을 *calling-player only* 로 좁히는데, 기존 `evidence.collected` 구독 로직이 전 플레이어 맵을 공유한다는 가정에 의존** → redaction 하면서도 graph.Resolve 입력에 자기 플레이어 collected 만 넣는 현재 구조는 유지. **완화**: PR-2c 는 state *외부 노출* 레이어만 redact 하고 internal `m.derived[otherPlayerID]` 는 서버 내부 계산용으로 유지. BuildStateFor 는 `playerID` 키만 snapshot 에 포함.
+
+## 다음 단계 (PR-2a 착수 전 확인 필요)
+
+1. **W3 advisor 승인**: advisor-consultations.md 에 "PlayerAwareModule 의무화를 boot-fail gate 로 강제할지, 점진 migration 으로 둘지" 의사결정 확정(05-security F-sec-2 Advisor-Ask §1 미해결).
+2. **`engine.SerializableModule` 과의 의무화 정책 일관성**: 현재 선택 인터페이스 중 `PlayerAwareModule` 만 의무화하면 코드 규약이 비대칭. 문서(project_module_system.md) 업데이트 범위 확정.
+3. **Phase 19 backlog 기존 PR-2 엔트리 업데이트**: phase19-backlog.md 에서 PR-2 → PR-2a/2b/2c 재기입 + 각 PR 의존성 그래프 명시.
+4. **module-inventory.md 수정 선행**: W1 인벤토리의 "PlayerAwareModule 0/33" 수치를 실측 8/33 으로 교정(F-module-6 요청). PR-2a diff 에서 reviewer 가 ground truth 로 참조할 문서.
+
+## 참조
+
+- W2 audit: `refs/audits/03-module-architect.md` (F-module-1, F-module-6, §Metrics)
+- W2 audit: `refs/audits/05-security.md` (F-sec-2)
+- W1 shared: `refs/shared/module-inventory.md` (33 모듈 표)
+- Engine 규약: `apps/server/internal/engine/types.go:70-139`
+- Redaction boundary: `apps/server/internal/session/snapshot_send.go:86-111`
+- 기존 PlayerAware 구현 8종: whisper · hidden_mission · voting · trade_clue · starting_clue · round_clue · timed_clue · conditional_clue

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/current-state.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/current-state.md
@@ -1,0 +1,106 @@
+# PR-2 Split — 현재 상태 실측 (33 모듈)
+
+> Source: W2 audit 03-module-architect §Metrics (2026-04-17) + main HEAD grep 재검증
+> 기준: `BuildStateFor(playerID uuid.UUID) (json.RawMessage, error)` 메서드 존재 여부
+
+## PlayerAware 구현 현황 (33 모듈)
+
+| # | 모듈 | 카테고리 | 민감 필드 보유 | BuildStateFor | PR-2b 대상 | 비고 |
+|---|------|---------|:-:|:-:|:-:|------|
+| 01 | room | core | - | - | - | 공개 state (참가자 code 만) |
+| 02 | ready | core | - | - | - | ready flag map - 전원 공개 의도 |
+| 03 | connection | core | - | - | - | 연결 상태 메타, 플레이어별 필드 없음 |
+| 04 | clue_interaction | core | O | - | **O** | `drawCount[playerID]` · `clueLevel[playerID]` 개인 상태 |
+| 05 | starting_clue | cluedist | O | **O** | - | 구현됨 |
+| 06 | round_clue | cluedist | O | **O** | - | 구현됨 |
+| 07 | timed_clue | cluedist | O | **O** | - | 구현됨 |
+| 08 | conditional_clue | cluedist | O | **O** | - | 구현됨 |
+| 09 | trade_clue | cluedist | O | **O** | - | 구현됨 |
+| 10 | text_chat | communication | O | - | **O** | DM 기록이 room-wide log 에 섞임 — 확인 필요 |
+| 11 | whisper | communication | O | **O** | - | 구현됨 |
+| 12 | group_chat | communication | O | - | **O** | `memberships[playerID]` 타 그룹 소속 누설 가능 |
+| 13 | voice_chat | communication | - | - | - | LiveKit room 메타만, token 은 별도 endpoint |
+| 14 | spatial_voice | communication | - | - | - | 위치 기반 필터는 클라이언트 |
+| 15 | **evidence** | crime_scene | O | - | **O** | `discovered[pid]` `collected[pid]` 전체맵 노출 — **F-03 핵심** |
+| 16 | **location** | crime_scene | O | - | **O** | `positions[pid]` `history[pid]` 전체맵 노출 — **F-03 핵심** |
+| 17 | **combination** | crime_scene | O | - | **O** | `completed[pid]` `derived[pid]` `collected[pid]` — **F-03 핵심 + D-MO-1** |
+| 18 | accusation | decision | O | - | **O** | `activeAccusation.Votes[pid]` 투표 분포 누설 |
+| 19 | voting | decision | O | **O** | - | 구현됨 (secret mode redaction) |
+| 20 | hidden_mission | decision | O | **O** | - | 구현됨 (타인 미션 redact) |
+| 21 | floor_exploration | exploration | O | - | **O** | `floorSelection[pid]` 개인 선택 |
+| 22 | room_exploration | exploration | O | - | **O** | 개인별 방문 기록 |
+| 23 | timed_exploration | exploration | O | - | **O** | 개인 타이머 상태 |
+| 24 | location_clue | exploration | O | - | **O** | 개인 노출 단서 맵 |
+| 25 | audio | media | - | - | - | BGM/SFX 전원 동기화 |
+| 26 | script_progression | progression | - | - | - | Phase 인덱스 공개 |
+| 27 | event_progression | progression | - | - | - | 이벤트 큐 공개 |
+| 28 | hybrid_progression | progression | - | - | - | script+event 합성 |
+| 29 | reading | progression | O | - | **O** | 개인 읽기 진행 위치 |
+| 30 | gm_control | progression | - | - | - | GM 전용 state, GM 만 수신 가정 (확인 필요) |
+| 31 | consensus_control | progression | - | - | - | 제안 목록 공개 |
+| 32 | skip_consensus | progression | - | - | - | 스킵 투표 공개 |
+| 33 | ending | progression | - | - | - | 엔딩 분기 공개 |
+
+## 요약
+
+- **PlayerAware 구현 완료**: 8개 (cluedist 5 + whisper + hidden_mission + voting)
+- **PR-2b 백필 필요**: 13개 (crime_scene 3 + decision 1 + communication 2 + core 1 + exploration 4 + progression 1 + clue_interaction 1 — **clue_interaction 은 core 중복 카운트**)
+- **공개 state 확정** (PlayerAware 불요): 12개 (room · ready · connection · voice_chat · spatial_voice · audio · script_progression · event_progression · hybrid_progression · consensus_control · skip_consensus · ending)
+- **확인 필요** (민감성 모호): text_chat(로그 구조), gm_control(GM-only 전달 채널 확인 필요)
+
+실측 **8/33 (24%)** 구현, PR-2b 가 **13 모듈** 백필 → 목표 **21/33 (64%)**. 나머지 12 모듈은 공개 state 로 *명시적으로 opt-out* 하기 위해 PR-2a 에서 `var _ engine.PublicStateModule = ...` (네이밍 TBD) sentinel marker 도입 검토 — 아래 PR-2a 섹션 참조.
+
+## 민감 필드 상세 (PR-2b 구현 가이드용)
+
+### evidence (crime_scene)
+```go
+discovered   map[uuid.UUID][]string   // playerID → discovered evidenceIDs
+collected    map[uuid.UUID][]string   // playerID → collected evidenceIDs
+unlockedByID map[string]bool          // 전역, 공개 OK
+```
+→ BuildStateFor: `discovered[caller]` + `collected[caller]` 만 포함. 타 플레이어 키 제거.
+
+### location (crime_scene)
+```go
+positions map[uuid.UUID]string
+history   map[uuid.UUID][]string
+lastMove  map[uuid.UUID]time.Time
+```
+→ BuildStateFor: `positions[caller]` 만 + `history[caller]` 만. 룸 전체 위치 공유는 별도 public state 분리 설계가 이상적이나 PR-2b 범위에서는 단순 redact.
+
+### combination (crime_scene) — PR-2c 분리
+```go
+completed map[uuid.UUID][]string
+derived   map[uuid.UUID][]string
+collected map[uuid.UUID]map[string]bool
+```
+→ PR-2b 에서는 BuildStateFor 를 추가하되, redaction 은 PR-2c 로 분리. 즉 PR-2b 커밋에서는 `BuildStateFor` 가 현재 `BuildState` 와 동일 결과를 반환하는 **stub** 으로 두고, PR-2c 에서 실제 per-player filter 적용.
+
+### accusation (decision)
+```go
+activeAccusation *Accusation  // Votes map[uuid.UUID]bool
+```
+→ `Votes` 는 결과 공개 전까지 hidden (accusation 완료 후에만 reveal). PR-2b 에서는 config 의 `VoteThreshold`/`DefenseTime` 등 공개 필드와 분리한 `activeAccusation` 을 "DefenseDeadline 전이면 Votes 비움, 이후 전원 공개" 정책 고정.
+
+### clue_interaction (core)
+```go
+drawCount map[uuid.UUID]int
+clueLevel map[uuid.UUID]int   // 개별 단서 난이도 단계
+```
+→ BuildStateFor: caller 만. 타 플레이어의 draw 상태는 공개하지 않음.
+
+### group_chat (communication)
+```go
+memberships map[uuid.UUID][]string   // playerID → groupIDs
+messages    map[string][]Message     // groupID → messages
+```
+→ BuildStateFor: `memberships[caller]` + `messages[g]` (g ∈ caller 가 속한 groups). 타 그룹 메시지는 엄격히 제외.
+
+### reading (progression)
+```go
+progress map[uuid.UUID]int   // playerID → 현재 라인 인덱스
+```
+→ BuildStateFor: caller progress 만.
+
+### exploration 4종 (floor/room/timed/location_clue)
+- 각각 개인별 선택/방문/타이머/노출 단서 맵. 동일 패턴으로 caller 만 유지.

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/execution-plan.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/execution-plan.md
@@ -1,0 +1,109 @@
+# PR-2 Split — 실행 계획 + Wave 배치
+
+> PR-2a · PR-2b · PR-2c 머지 순서, 병렬성, feature flag, 리스크 완화 전략.
+
+## Wave 배치
+
+Phase 19 backlog (`phase19-backlog.md`) 의 wave 구조를 기준으로 다음 배치 권장:
+
+```
+W2 잔여
+  └─ PR-2a (S, Low) ─── engine gate + stub + 33 모듈 marker  [단독, 의존 없음]
+
+W3 전반
+  └─ PR-2b (L, Med) ─── 12 모듈 real 구현 (combination 제외)  [PR-2a 의존]
+
+W3 후반
+  └─ PR-2c (S-M, Low) ─ combination crafted redaction        [PR-2a 의존, PR-2b 선 머지 권장]
+```
+
+**합산**: 원 PR-2 XL 분량은 유지하되 wave 2개에 분할. W3 부담이 크므로 다른 W3 PR 과 밸런싱 필요 — phase19-backlog.md 업데이트 시 W3 총량 재확인.
+
+## 병렬 / 순차 판정
+
+| 쌍 | 판정 | 근거 |
+|----|-----|------|
+| PR-2a ↔ PR-2b | **순차 필수** | PR-2a 의 gate 가 PR-2b stub 교체의 안전판. PR-2a 없이 PR-2b 만 머지하면 PR-2b 브랜치에 33 모듈 marker 까지 포함 → PR 거대화. |
+| PR-2a ↔ PR-2c | **순차 필수** | 동일 근거. |
+| PR-2b ↔ PR-2c | **순차 권장** (병렬 가능) | 다른 파일 touch (PR-2c 는 combination.go 만, PR-2b 는 combination 제외). 이론상 병렬 가능하나 리뷰 부하와 merge conflict (combination.go 가 PR-2b 카테고리 커밋에서 실수로 포함될 위험) 완화 위해 순차. |
+
+## Feature Flag 전략
+
+| PR | Flag | 기본값 | 목적 |
+|----|------|-------|------|
+| PR-2a | 없음 | - | compile-time gate 이므로 flag 불요 |
+| PR-2b | `MMP_PLAYERAWARE_STRICT` | true | 프로덕션 이슈 시 false → 각 BuildStateFor 가 `m.BuildState()` fallback. 30일 후 제거. |
+| PR-2c | (PR-2b flag 재사용) | true | 동일 flag 로 combination 도 제어 |
+
+**구현**: `engine/factory.go` 또는 `engine/build_state_for.go` 에 전역 config 읽어 `BuildModuleStateFor` 내부에서 flag false 시 `m.BuildState()` 강제 호출. 모듈 내부 `BuildStateFor` 는 무조건 real 구현이되, 호출 경로에서 단일 스위치로 우회.
+
+```go
+// engine/types.go 개정 (PR-2b 시점)
+var strictRedaction = os.Getenv("MMP_PLAYERAWARE_STRICT") != "false"
+
+func BuildModuleStateFor(m Module, playerID uuid.UUID) (json.RawMessage, error) {
+    if !strictRedaction {
+        return m.BuildState()
+    }
+    if pam, ok := m.(PlayerAwareModule); ok {
+        return pam.BuildStateFor(playerID)
+    }
+    return m.BuildState() // PublicStateModule path
+}
+```
+
+## 리스크 + 완화
+
+### R1. 25개 모듈 동시 구현 시 git conflict
+- **영향**: 다른 진행 중 PR (에디터·CI·phase 20 후속) 과 충돌 확률 높음. 특히 crime_scene/evidence/location, communication/group_chat 은 Phase 20 개방 이후 에디터 연동 작업이 잦음.
+- **완화**:
+  - PR-2a 는 marker 추가만이라 conflict 표면적 작음. 우선 머지.
+  - PR-2b 커밋을 카테고리별로 분리(crime_scene · decision · communication · exploration · progression). 각 카테고리 커밋을 PR 내부에서 독립 commit 유지 → rebase 시 cherry-pick 가능.
+  - PR-2b 브랜치를 open 단계에서 최대 3일 내 머지 목표. 그 이상 시 cherry-pick 재베이스 부담.
+
+### R2. 모듈 author 다양성 (PR-2b 25 모듈을 누가 리뷰하나)
+- **영향**: 각 모듈 도메인 지식이 분산 (crime_scene 저자 ≠ decision 저자). 단일 리뷰어가 13 모듈 변경을 전부 검토하기 어렵다.
+- **완화**:
+  - `requesting-code-review` skill 로 카테고리별 review 분할 요청.
+  - 리뷰 체크리스트 표준화: "민감 필드 리스트 명시 / helper 사용 / 단위 테스트 3케이스". `refs/pr-2/current-state.md` 의 민감 필드 섹션을 리뷰어 체크리스트 소스로 사용.
+
+### R3. Redaction coverage 측정 방법
+- **영향**: PR-2b 머지 후 "정말로 25 → 0 fallback" 이 된 것을 측정하지 않으면 재발 가능.
+- **완화**:
+  - PR-2a 가 제공하는 registry gate 가 영구 불변식 (신규 모듈도 자동 검증).
+  - CI lint: `scripts/check-playeraware-coverage.sh` — engine 패키지 interface assertion 블록 수 + module 패키지 BuildStateFor 구현 수 cross-check.
+  - 정기 감사: Phase 20 이후 half-yearly 감사에 PlayerAware coverage 메트릭 포함.
+
+### R4. 게임 디자인 의도 충돌 (F-03 특유)
+- **영향**: evidence/location 이 "전원 공유" 인지 "개인 수첩" 인지 제품 결정 필요. 구현을 완료했는데 디자인이 "전원 공유" 로 확정되면 rollback.
+- **완화**:
+  - PR-2a 착수 전 W3 advisor 승인 필수 (03-module-architect Advisor-Ask §1).
+  - Feature flag 로 staging 에서 A/B 실험 가능.
+  - PublicStateMarker 로 재분류하는 것만으로 rollback 가능 (BuildStateFor 메서드는 남아도 호출 안됨).
+
+## 측정 지표 (Before → After 목표)
+
+| Metric | Baseline (main) | PR-2a 직후 | PR-2b 직후 | PR-2c 직후 |
+|--------|----------------:|----------:|----------:|----------:|
+| PlayerAware real impl | 8/33 | 8/33 (+ 13 stub) | 20/33 | 21/33 |
+| PublicState marker | 0/33 | 12/33 | 12/33 | 12/33 |
+| Registry gate coverage | 0% | 100% | 100% | 100% |
+| snapshot_redaction_test 케이스 | 3 | 3 | 3+3 = 6 | 6+1 = 7 |
+| F-sec-2 잔여 P0 | Open | Open | Resolved | - |
+| F-03 잔여 P0 | Open | Open | Resolved | - |
+| D-MO-1 잔여 P0 | Open | Open | Open | Resolved |
+
+## 외부 의존성
+
+- **advisor-consultations.md**: PR-2a 착수 전 결정 항목 — "PlayerAware 의무화 boot-fail 방식 승인", "evidence/location 게임 디자인 정책", "gm_control PublicState 재분류 여부".
+- **module-inventory.md**: W1 drift 수치 (PlayerAware 0/33 → 8/33, ConfigSchema 22/33 → 21/33) 를 **PR-2a 머지 전** 교정. Reviewer 가 참조하는 ground truth.
+- **project_module_system.md** (memory): PR-2a 머지 후 "PlayerAwareModule 은 **선택** 이 아니라 **의무** (PublicStateMarker 로 opt-out 가능)" 로 규약 기술 업데이트.
+
+## 완료 정의 (Definition of Done)
+
+- [ ] PR-2a · 2b · 2c 전부 main 머지
+- [ ] Phase 19 backlog 에서 PR-2 엔트리 resolved 표시
+- [ ] memory/MEMORY.md 에 Phase 19 PR-2 entry 업데이트
+- [ ] `CLAUDE.md` 의 "모듈 시스템" 섹션에 PlayerAware mandatory 룰 반영 (mmp-module-factory 스킬도 업데이트)
+- [ ] `scripts/check-playeraware-coverage.sh` 가 CI required check 로 승격
+- [ ] staging 에서 `MMP_PLAYERAWARE_STRICT=true` 로 1주간 운영 후 flag 제거 티켓 생성

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2a-engine-gate.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2a-engine-gate.md
@@ -1,0 +1,143 @@
+# PR-2a — Engine Gate + Mandatory Interface
+
+> Size: **S** · Risk: **Low** · Dependency: 없음 (단독 mergeable)
+> Finding: F-sec-2 인프라 (게이트만, 실구현은 PR-2b)
+
+## 목표
+
+`engine.PlayerAwareModule` 을 선택(optional) → *규약상* 의무로 승격. 단 의무화 방식은 **compile-time assertion + registry boot-fail** 이중 게이트로 enforce 한다. 실제 redaction 로직은 모듈마다 다르므로 PR-2a 는 *인프라* 만 깔고, PR-2b 가 real 구현을 채운다.
+
+## Scope
+
+| 파일 | 변경 | 책임 |
+|------|------|------|
+| `apps/server/internal/engine/types.go` | 수정 | `PlayerAwareModule` 문서 업데이트 ("mandatory") + `PublicStateModule` sentinel 추가 |
+| `apps/server/internal/engine/factory.go` | 수정 | `Create(name)` 가 반환 모듈에 대해 PlayerAware **OR** PublicState 중 하나 구현 검증, 둘 다 미구현이면 error |
+| `apps/server/internal/engine/registry.go` | 수정 | `Register(name, factory)` 가 첫 호출 시 (init() 시점) factory 를 **한 번 실행해 interface 검증** → 미충족 시 panic (boot fail) |
+| `apps/server/internal/module/**/*.go` | 수정 | 모든 33 모듈에 `BuildStateFor` **stub** 또는 `var _ engine.PublicStateModule = ...` marker 추가 |
+| `apps/server/internal/engine/build_state_for_test.go` | 수정 | 기존 fallback test 제거 → "모든 등록 모듈이 PlayerAware OR PublicState 구현" gate test 로 교체 |
+| `apps/server/internal/engine/factory_test.go` | 신규 | 가상 모듈(미구현) 팩토리 등록 시 `Create` 가 error 리턴 확인 |
+
+## 변경 내용
+
+### 1. types.go — sentinel marker + 문서 업데이트
+
+```go
+// PlayerAwareModule는 per-player redaction 이 필요한 모듈이 구현한다.
+// PR-2 이후로 Module 구현체는 PlayerAwareModule 또는 PublicStateModule
+// 둘 중 하나를 반드시 만족해야 한다. registry 가 boot 시점에 검증한다.
+type PlayerAwareModule interface {
+    BuildStateFor(playerID uuid.UUID) (json.RawMessage, error)
+}
+
+// PublicStateModule 은 state 가 전 플레이어에게 동일하게 공개됨을 선언하는
+// sentinel marker. 메서드는 의도적으로 비움 — compile-time marker 용도.
+// 이 marker 를 달면 registry 의 mandatory 게이트를 통과한다.
+// 예: room, ready, audio, consensus_control 등.
+type PublicStateModule interface {
+    isPublicState()   // 패키지 외부 구현 금지 — engine 패키지 내부 타입만 임베드 가능
+}
+```
+
+> 대안: sentinel 대신 `BuildStateFor` 를 public state 모듈도 구현(그냥 `BuildState` 호출). 장점: 타입 하나. 단점: "공개 state" 라는 설계 의도가 코드에 안 드러남 → F-sec-2 재발 위험. **sentinel marker 채택 권장.**
+
+### 2. factory.go — Create 검증
+
+```go
+func (f *Factory) Create(name string) (Module, error) {
+    factory, ok := f.registry.Get(name)
+    if !ok {
+        return nil, fmt.Errorf("module %q not registered", name)
+    }
+    m := factory()
+
+    // PR-2 mandatory gate: PlayerAware OR PublicState 중 하나 구현 필수.
+    _, isPlayerAware := m.(PlayerAwareModule)
+    _, isPublic := m.(PublicStateModule)
+    if !isPlayerAware && !isPublic {
+        return nil, fmt.Errorf(
+            "module %q violates F-sec-2: must implement PlayerAwareModule "+
+                "or declare PublicStateModule", name)
+    }
+    return m, nil
+}
+```
+
+### 3. registry.go — 첫 등록 시 sanity check
+
+```go
+func Register(name string, factory ModuleFactory) {
+    // PR-2a: init() 시점 factory 시험 호출로 interface 게이트 강제.
+    sample := factory()
+    _, isPA := sample.(PlayerAwareModule)
+    _, isPS := sample.(PublicStateModule)
+    if !isPA && !isPS {
+        panic(fmt.Sprintf(
+            "module %q F-sec-2 violation: "+
+                "implement BuildStateFor or embed engine.PublicStateMarker",
+            name))
+    }
+    defaultRegistry.register(name, factory)
+}
+```
+
+### 4. 모듈 33개 업데이트
+
+각 모듈 파일 상단에 **둘 중 하나만** 추가:
+
+- **PlayerAware 모듈** (21개, PR-2b 대상 13 + 이미 구현된 8): stub 추가 (13개) — `func (m *X) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) { return m.BuildState() }` + `var _ engine.PlayerAwareModule = (*X)(nil)`. PR-2b 에서 real 구현으로 교체.
+- **Public 모듈** (12개): embed `engine.PublicStateMarker` 익명 임베드 또는 `func (*X) isPublicState() {}` 구현 + `var _ engine.PublicStateModule = (*X)(nil)`.
+
+> **주의**: `isPublicState()` 는 unexported method 이므로 외부 패키지에서는 구현 불가. engine 패키지가 helper type 을 export 해야 한다.
+
+```go
+// engine/types.go 추가
+// PublicStateMarker embeds to satisfy PublicStateModule from outside packages.
+type PublicStateMarker struct{}
+func (PublicStateMarker) isPublicState() {}
+```
+
+모듈 쪽:
+```go
+type RoomModule struct {
+    engine.PublicStateMarker
+    // ...
+}
+```
+
+### 5. 테스트
+
+- `engine/build_state_for_test.go`: 기존 "PlayerAware 미구현 → fallback to BuildState" 케이스 제거 (이제 gate 가 그 상태를 막음). 대신 "PlayerAware 구현 모듈 → 해당 메서드 호출", "Public 모듈 → BuildState 호출" 두 분기.
+- `engine/factory_test.go` (신규): 가상 모듈 3종 — (a) PlayerAware 만 (b) Public 만 (c) 둘 다 미구현 — 각각 Create 결과 검증. (c) 는 error 반환 확인.
+- `engine/registry_test.go`: 현재 `TestRegister`/`TestAllNames` 가 있다면 그대로. 신규로 미구현 factory 가 `Register` 에 들어오면 panic 확인 (defer recover).
+
+## 의존성
+
+- **상류**: 없음. main HEAD 에서 바로 착수.
+- **하류**: PR-2b 는 이 PR 머지 후 stub 을 real 구현으로 교체. PR-2c 도 이 PR 머지 전제.
+
+## Size · Risk 재추정
+
+- **Size S**: types.go +20 LOC · factory.go +10 · registry.go +8 · 모듈 33개 평균 +4 LOC (stub or marker) ≈ **170 LOC 변경**, 33 파일. XL 우려는 모듈 개수 때문이지만 변경은 모두 boilerplate.
+- **Risk Low**:
+  - Panic 경로는 `init()` 시점 — 시작 시점에 즉시 발현되어 숨겨진 regression 없음.
+  - Stub 의 `BuildStateFor` 는 `BuildState` 호출 → 동작 동일. 사용자 체감 0.
+  - Rollback: PR revert 로 인터페이스 게이트 제거, stub 메서드는 남아도 무해.
+- **CI risk**: build_state_for_test.go 기존 fallback 테스트를 삭제·재작성해야 함. 이 재작성이 빠지면 PR-2b 머지 시 test drift 로 빨간불.
+
+## 검수 체크리스트
+
+- [ ] `go build ./...` 성공 (33 모듈 전부 인터페이스 충족)
+- [ ] `go test ./internal/engine/...` 통과
+- [ ] `go test ./internal/module/... -run Build` — 각 모듈의 BuildState / BuildStateFor 테스트 그대로 통과 (stub 이므로 동일 결과)
+- [ ] `go test ./internal/session/... -run Redaction` — 기존 snapshot_redaction_test 그대로 통과
+- [ ] 가상 "미구현 모듈" 을 한 번 registry 에 넣어보고 panic 출력 육안 확인 (테스트 내부)
+- [ ] `module-inventory.md` 의 PlayerAware 수치 업데이트 (33/33 실구현은 PR-2b 완료 후, PR-2a 시점은 "21 real + 12 public" 로 표기)
+
+## 예상 PR 구성
+
+- 커밋 1: engine types.go + factory.go + registry.go + PublicStateMarker 헬퍼 타입
+- 커밋 2: 12 public 모듈에 marker 추가 (카테고리별 묶음)
+- 커밋 3: 13 pending PlayerAware 모듈에 stub 추가
+- 커밋 4: 기존 8 PlayerAware 모듈에 `var _ engine.PlayerAwareModule = (*X)(nil)` assertion 추가 (누락된 곳만)
+- 커밋 5: engine 테스트 업데이트 + factory_test.go 신규

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2b-module-backfill.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2b-module-backfill.md
@@ -1,0 +1,135 @@
+# PR-2b — 모듈 구현 백필 (13 모듈 실구현)
+
+> Size: **L** · Risk: **Med** · Dependency: **PR-2a 머지 선행 필수**
+> Finding: F-03 + F-sec-2 실구현
+
+## 목표
+
+PR-2a 가 깔아둔 stub `BuildStateFor` 를 13개 모듈에서 **real per-player redaction** 으로 교체. 각 모듈의 민감 필드를 식별해 caller 만 포함한 state 반환. snapshot_redaction_test 확장으로 회귀 방지.
+
+## Scope (13 모듈)
+
+| # | 모듈 | 파일 | 민감 필드 | 구현 난이도 |
+|---|------|------|---------|:-:|
+| 1 | clue_interaction | `core/clue_interaction.go` | `drawCount` `clueLevel` | 중 |
+| 2 | evidence | `crime_scene/evidence.go` | `discovered` `collected` | 중 (F-03) |
+| 3 | location | `crime_scene/location.go` | `positions` `history` `lastMove` | 중 (F-03) |
+| 4 | combination | `crime_scene/combination.go` | `completed` `derived` `collected` | **PR-2c 분리** |
+| 5 | accusation | `decision/accusation.go` | `activeAccusation.Votes` | 상 (시점 정책) |
+| 6 | text_chat | `communication/text_chat.go` | DM 채널 | 중 (구조 확인) |
+| 7 | group_chat | `communication/group_chat.go` | `memberships` `messages` | 중 |
+| 8 | floor_exploration | `exploration/floor_exploration.go` | `floorSelection` | 하 |
+| 9 | room_exploration | `exploration/room_based_exploration.go` | 방문 기록 | 하 |
+| 10 | timed_exploration | `exploration/timed_exploration.go` | 개인 타이머 | 하 |
+| 11 | location_clue | `exploration/location_clue.go` | 노출 단서 | 하 |
+| 12 | reading | `progression/reading.go` | `progress` | 하 |
+| 13 | gm_control | `progression/gm_control.go` | GM-only 판정 필요 | 상 (사전 조사) |
+
+**combination 은 PR-2c 로 이관**, gm_control 은 "GM 플레이어만 state 수신" 정책이 이미 상위 레이어에 있는지 먼저 조사 (snapshot_send.go gm 필터). 결과에 따라 PR-2b 에 포함 또는 PublicStateMarker 로 재분류.
+
+## 공통 구현 패턴
+
+### Pattern A: simple per-player map filter
+
+```go
+func (m *EvidenceModule) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
+    m.mu.RLock()
+    defer m.mu.RUnlock()
+
+    s := evidenceState{
+        Evidence:     m.config.Evidence,              // 공개 OK (id/name/locationId)
+        UnlockedByID: m.unlockedByID,                  // 전역 unlock 상태 공개 OK
+        Discovered:   filterByPlayer(m.discovered, playerID),
+        Collected:    filterByPlayer(m.collected, playerID),
+    }
+    return json.Marshal(s)
+}
+
+// engine/helpers 또는 module/common 에 helper 두기
+func filterByPlayer[V any](m map[uuid.UUID]V, pid uuid.UUID) map[uuid.UUID]V {
+    if v, ok := m[pid]; ok {
+        return map[uuid.UUID]V{pid: v}
+    }
+    return map[uuid.UUID]V{}
+}
+```
+
+### Pattern B: 조건부 공개 (accusation, voting-like)
+
+`activeAccusation.Votes` 는 투표 종료 전에는 빈 맵, 종료 후에는 공개. `voting.go:400-` 에 이미 확립된 패턴이 있으므로 동일 구조 차용.
+
+### Pattern C: 복합 redaction (group_chat)
+
+`memberships[caller]` 로 caller 그룹 목록을 얻은 뒤, `messages` 를 그룹 ID 집합으로 필터. helper 필요.
+
+## 테스트 전략
+
+### 1. `session/snapshot_redaction_test.go` 확장
+
+기존 3개 테스트 (TwoPlayersEachGetEnvelope · PayloadContainsSessionID · NoPlayerIDCrossLeak) 에 다음 추가:
+
+```go
+// TestSnapshot_Redaction_EvidenceDiscovered 
+// Alice 만 evidence e1 을 collected. Bob 스냅샷에 e1 이 없어야.
+func TestSnapshot_Redaction_EvidenceDiscovered(t *testing.T) { ... }
+
+// TestSnapshot_Redaction_AccusationVotesHidden
+// Defense 진행중인 accusation 의 Votes 가 어느 플레이어 스냅샷에도 없어야.
+func TestSnapshot_Redaction_AccusationVotesHidden(t *testing.T) { ... }
+
+// TestSnapshot_Redaction_GroupChatIsolation
+// Alice 가 그룹 g1, Bob 이 그룹 g2. 서로 다른 그룹 메시지가 교차 유출되지 않아야.
+func TestSnapshot_Redaction_GroupChatIsolation(t *testing.T) { ... }
+```
+
+### 2. 모듈 단위 테스트
+
+각 모듈 `*_test.go` 에 `TestBuildStateFor_*` 시리즈 추가. 최소 3 케이스:
+- caller 가 state 를 가진 경우 → 자기 필드만
+- caller 가 state 없는 경우 → 빈 맵 (nil 아님)
+- 타 플레이어 상태 존재 시 → caller 응답에 포함되지 않음
+
+### 3. redaction coverage 회귀 게이트
+
+신규 CI 스크립트 `scripts/check-playeraware-coverage.sh` 를 PR-2a 에서 먼저 넣고, PR-2b 에서 "13 모듈 모두 real 구현 (stub 패턴 `return m.BuildState()` 금지)" lint 추가. `forbidigo` 또는 `rg` 기반.
+
+## 구현 순서 (커밋 granularity)
+
+단일 PR 내 카테고리별 커밋 분리:
+
+1. 커밋 1: helpers (`filterByPlayer`) 추가 + util test
+2. 커밋 2: crime_scene/evidence + crime_scene/location (F-03 핵심 2)
+3. 커밋 3: decision/accusation
+4. 커밋 4: communication/text_chat + communication/group_chat
+5. 커밋 5: exploration 4종 + progression/reading
+6. 커밋 6: core/clue_interaction
+7. 커밋 7: gm_control 정책 확정 결과 반영 (PlayerAware or PublicState 재분류)
+8. 커밋 8: snapshot_redaction_test 확장 + coverage lint
+
+Cherry-pick rebase 가능하도록 각 커밋은 독립 compilable.
+
+## Size · Risk 재추정
+
+- **Size L**: 13 모듈 × 평균 +40 LOC (BuildStateFor + 단위 테스트) ≈ **520 LOC**. 기존 원 PR-2 의 XL 중 모듈 구현 부분 거의 전부.
+- **Risk Med**:
+  - 각 모듈의 state shape 변경 없음 (필드 삭제 아닌 필터). 클라이언트 호환성 유지.
+  - but: 25 모듈 중 11개가 이미 PlayerAware 미구현이라 실제 운영 중 fallback 으로 전 플레이어 공개되고 있었음 → PR-2b 머지 직후 **기능 변화** 체감 가능 (예: "다른 플레이어가 어떤 증거를 수집했는지" 가 안 보이게 됨). 이 기능이 게임플레이 의도인지 체크 필요.
+- **Mitigation**:
+  - **feature flag**: 개별 모듈마다 `BuildStateFor` 가 `m.BuildState()` 로 rollback 하는 `MMP_PLAYERAWARE_STRICT` env toggle (default true). 프로덕션 이슈 시 false 로 즉시 롤백. **채택 권장** — PR-2b 만 적용, PR-2a 는 flag 없음.
+  - Advisor 확인: evidence/location 이 "전 플레이어 위치 공개" 인지 "본인만 보이는 개인 탐색" 인지 게임 디자인 결정 (03-module-architect Advisor-Ask §1 미해결).
+
+## 검수 체크리스트
+
+- [ ] 13 모듈 각각 `BuildStateFor` 가 `m.BuildState()` 를 호출하지 않음 (grep lint)
+- [ ] `snapshot_redaction_test.go` 신규 케이스 3+ 통과
+- [ ] 각 모듈 `TestBuildStateFor_*` 3 케이스 통과
+- [ ] E2E 회귀 (pnpm test:e2e) — 기존 12 flow 영향 없음
+- [ ] `scripts/check-playeraware-coverage.sh` green
+- [ ] `module-inventory.md` PlayerAware coverage 24% → 64% (21/33)
+- [ ] `MMP_PLAYERAWARE_STRICT=false` 환경에서 종전 public state 로 복귀하는 smoke test (feature flag 채택 시)
+
+## 의존성 요약
+
+- 상류 필수: PR-2a (gate + stub)
+- 상류 권장: module-inventory.md 의 W1 drift 교정 PR (별도, phase19 backlog 참조)
+- 하류: PR-2c 와 병렬 가능하지만 순차 권장 (combination.go 동일 파일 touch 시 conflict 가능)

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2c-crafted-redaction.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2c-crafted-redaction.md
@@ -1,0 +1,140 @@
+# PR-2c — craftedAsClueMap redaction (D-MO-1)
+
+> Size: **S-M** · Risk: **Low** · Dependency: **PR-2a 머지 선행 필수**, PR-2b 와 동일 파일 touch 주의
+> Finding: D-MO-1 단독 해소 (Phase 18.1 B-2 반쪽 상태 해소)
+
+## 목표
+
+`CombinationModule` 의 `completed / derived / collected` 세 map 이 현재 `BuildState` 에서 **전 플레이어 결합 결과** 를 그대로 직렬화한다(`combination.go:325-355`). 이 때문에 "다른 플레이어가 이미 어떤 단서를 조합했는지" 가 스냅샷으로 유출된다. `craftedAsClueMap(playerID)` helper 는 이미 존재 (line 185-194) 하지만 내부 `checkNewCombos` 에서만 사용, 외부 스냅샷에는 반영되지 않는다.
+
+PR-2c 는 **`BuildStateFor(playerID)` 를 real 구현** 으로 교체해 caller 의 combined 결과만 노출한다. PR-2b 가 combination 모듈에 stub 을 두고 지나가는 것을 PR-2c 가 real 로 승격한다.
+
+## Scope
+
+| 파일 | 변경 |
+|------|------|
+| `apps/server/internal/module/crime_scene/combination.go` | `BuildStateFor` real 구현 + `snapshotFor(playerID)` helper 추가 |
+| `apps/server/internal/module/crime_scene/combination_test.go` | `TestCombination_BuildStateFor_*` 3 케이스 추가 |
+| `apps/server/internal/session/snapshot_redaction_test.go` | `TestSnapshot_Redaction_CombinationCrafted` 1 케이스 추가 |
+
+## 변경 내용
+
+### 1. combination.go — snapshot 함수 per-player 변형
+
+```go
+// snapshotFor returns the combination state from the given player's view.
+// Other players' completed/derived/collected are elided — preserves
+// Phase 18.1 B-2 per-player snapshot redaction boundary (D-MO-1).
+func (m *CombinationModule) snapshotFor(playerID uuid.UUID) combinationState {
+    s := combinationState{
+        Completed: map[string][]string{},
+        Derived:   map[string][]string{},
+        Collected: map[string][]string{},
+    }
+    if ids := m.completed[playerID]; len(ids) > 0 {
+        cp := make([]string, len(ids))
+        copy(cp, ids)
+        s.Completed[playerID.String()] = cp
+    }
+    if ids := m.derived[playerID]; len(ids) > 0 {
+        cp := make([]string, len(ids))
+        copy(cp, ids)
+        s.Derived[playerID.String()] = cp
+    }
+    if evMap := m.collected[playerID]; len(evMap) > 0 {
+        ids := make([]string, 0, len(evMap))
+        for id := range evMap {
+            ids = append(ids, id)
+        }
+        s.Collected[playerID.String()] = ids
+    }
+    return s
+}
+
+// BuildStateFor implements engine.PlayerAwareModule — per D-MO-1
+// only the caller's crafted/discovered clue sets are disclosed.
+func (m *CombinationModule) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
+    m.mu.RLock()
+    s := m.snapshotFor(playerID)
+    m.mu.RUnlock()
+    return json.Marshal(s)
+}
+```
+
+### 2. BuildState() 정책 결정
+
+`BuildState` (공개) 는 3가지 선택지:
+- (A) **현재 유지** — 관리 콘솔·E2E fixture 용 디버그 경로. 런타임에선 `BuildStateFor` 가 우선 호출되어 공개로 빠지지 않음.
+- (B) **빈 snapshot 리턴** — 실수로라도 `BuildState()` 가 브로드캐스트 경로에 끼면 유출이므로 안전판.
+- (C) **삭제** — 인터페이스에서 Module.BuildState() 는 필수라 삭제 불가, (B) 와 동일 효과.
+
+**권장: (A)** 유지. 이유: PR-2a 의 registry 게이트가 public fallback 을 원천 차단(모든 모듈이 PlayerAware OR PublicState). 즉 engine.BuildModuleStateFor 가 PlayerAware 구현을 반드시 호출한다. `BuildState()` 는 serializable/snapshot 내부 저장용·테스트용으로 남는다. 다만 docstring 에 "internal/test only — do NOT feed to clients directly" 주석 강제.
+
+### 3. 테스트
+
+#### combination_test.go 신규 케이스
+
+```go
+func TestCombination_BuildStateFor_OnlyCallerVisible(t *testing.T) {
+    m := NewCombinationModule()
+    // setup config with 1 combo
+    ...
+    alice := uuid.New()
+    bob := uuid.New()
+    // alice combines (e1+e2 → derived=d1), bob combines (e3+e4 → derived=d2)
+    m.completed[alice] = []string{"c1"}
+    m.derived[alice]   = []string{"d1"}
+    m.completed[bob]   = []string{"c2"}
+    m.derived[bob]     = []string{"d2"}
+
+    raw, err := m.BuildStateFor(alice)
+    // assert: derived has alice.String() key with ["d1"], no bob key.
+    // assert: completed has alice.String() with ["c1"], no bob key.
+}
+
+func TestCombination_BuildStateFor_EmptyForNewPlayer(t *testing.T) { ... }
+
+func TestCombination_BuildStateFor_CollectedMirror(t *testing.T) {
+    // evidence.collected event 로 m.collected[alice][e1]=true 설정 후
+    // alice 스냅샷에만 collected["alice-uuid"] = ["e1"] 나타나는지.
+}
+```
+
+#### snapshot_redaction_test.go 신규 케이스
+
+```go
+func TestSnapshot_Redaction_CombinationCrafted(t *testing.T) {
+    // 2-player session with combination module configured.
+    // Alice triggers combine (evidence_ids e1+e2) → derived d1.
+    // Request snapshot for Bob. Bob's payload must NOT contain "d1"
+    // in any combination.derived field.
+}
+```
+
+## PR-2b 와의 관계
+
+PR-2b 의 커밋 granularity 제안에서 combination 은 **stub 유지** (PR-2b 가 real 구현으로 교체하지 않음). PR-2b 의 lint "BuildStateFor real 구현 필수" 는 combination 을 예외 리스트에 두고, PR-2c 머지 시 예외 제거. 이유: PR-2b 리뷰어가 combination 의 `derived/collected/completed` 3-way map 교차 필터를 별도 검증하기 쉽도록 분리.
+
+**병렬 가능 여부**: combination.go 파일 하나만 touch 하므로 PR-2b 와 **동일 파일 수정 없음** 조건 하에 병렬 가능. 단 PR-2b 의 카테고리 커밋에서 crime_scene 묶음에 combination.go 가 들어가면 conflict → PR-2b 를 evidence/location 만 포함하도록 조정 + combination 은 PR-2c 전담. **순차 권장**: PR-2b 머지 → PR-2c rebase.
+
+## Size · Risk 재추정
+
+- **Size S-M**: combination.go +60 LOC (snapshotFor + BuildStateFor + 주석), combination_test.go +80 LOC, snapshot_redaction_test.go +40 LOC ≈ **180 LOC**.
+- **Risk Low**:
+  - 기존 `craftedAsClueMap(playerID)` helper 가 이미 per-player 필터를 올바르게 수행하는 패턴을 확립. `snapshotFor` 는 같은 패턴을 3 map 에 확장할 뿐.
+  - `BuildState()` 정책 (A) 유지로 기존 테스트 (`TestCombination_*`) 영향 없음.
+  - 클라이언트 소비 측면: Phase 18.1 B-2 이후 클라이언트는 이미 `combination.derived[myPlayerId]` 만 읽는 패턴이므로 재렌더링 영향 없음 (확인 필요: `apps/web/src/features/game/runtime/modules/combination.ts` 가 있다면 grep).
+
+## 검수 체크리스트
+
+- [ ] `TestCombination_BuildStateFor_*` 3개 통과
+- [ ] `TestSnapshot_Redaction_CombinationCrafted` 통과
+- [ ] `TestCombination_Integration` 기존 테스트 무회귀
+- [ ] `module-inventory.md` 의 combination 라인 PlayerAware O 로 업데이트
+- [ ] E2E 회귀 (recovery 시나리오에서 combination 재조합 플로우 영향 없음)
+- [ ] `docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/current-state.md` 의 combination 라인 "PlayerAware 구현 완료" 로 업데이트
+
+## PR-2b 와의 충돌 방지 운영
+
+- PR-2b 브랜치가 open 인 동안 PR-2c 는 `main + PR-2a` 기반으로 분기.
+- PR-2b 머지 후 PR-2c 는 1회 rebase — combination.go 가 stub 에서 real 로 변할 가능성이 없으므로 (PR-2b 는 combination 을 안 건드림) conflict 없음.

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/shared/module-inventory.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/shared/module-inventory.md
@@ -1,7 +1,8 @@
-# Module Inventory & Compliance Matrix — Phase 19 W1
+# Module Inventory & Compliance Matrix — Phase 19 W1 (2026-04-18 교정)
 
-> 실측: `apps/server/internal/module/**` · `apps/server/internal/engine/**` (2026-04-17)
+> 실측: `apps/server/internal/module/**` · `apps/server/internal/engine/**` (2026-04-17 W1 draft → **2026-04-18 교정**)
 > 설계 문서 "29개 모듈" vs 실측 **33개** → **+4개 차이**. 상세는 §Drift.
+> **2026-04-18 교정 사항**: W1 draft "PlayerAwareModule 0/33" → 실측 **8/33 (24%)**. 05-security / 03-module-architect 공동 검증. ConfigSchema는 W1 실측 22/33 유지 (pr-2/current-state.md 실측 재검증 결과 22/33). 상세는 `refs/pr-2/current-state.md`.
 
 ## 규약 요약 (engine/types.go 기준)
 
@@ -57,7 +58,7 @@
 | 32 | skip_consensus | progression | O | O | O | - | - | 239 |
 | 33 | ending | progression | O | O | O | - | - | 198 |
 
-> Extra 약어: **GEH**=GameEventHandler · **SER**=SerializableModule · **WIN**=WinChecker. **PlayerAwareModule 실측 0건.**
+> Extra 약어: **GEH**=GameEventHandler · **SER**=SerializableModule · **WIN**=WinChecker. **PlayerAwareModule 실측 8/33 (24%)**: whisper · hidden_mission · voting · trade_clue · starting_clue · round_clue · timed_clue · conditional_clue. 잔여 25건이 fallback — F-sec-2 대상. 상세 분류는 `refs/pr-2/current-state.md`.
 
 ## 총계
 
@@ -71,7 +72,7 @@
 | GameEventHandler (선택) | 17 | 33 | 52% |
 | SerializableModule (선택) | 11 | 33 | 33% |
 | WinChecker (선택) | 4 | 33 | 12% |
-| PlayerAwareModule (선택) | 0 | 33 | **0%** |
+| PlayerAwareModule (의무화 예정, PR-2a) | 8 | 33 | **24%** |
 | LOC 합계 (non-test) | 10,057 | - | - |
 | 500줄 초과 파일 | 6 | 33 | 18% |
 
@@ -81,7 +82,7 @@
 
 실측상 **필수 규약 (Module + Factory + init) 33/33 전원 충족**. 비준수는 "선택적이어야 할 자리에 미구현으로 기능 공백이 생긴 케이스"로 재정의.
 
-1. **PlayerAwareModule 0/33** — Phase 18.1 B-2 redaction boundary 인터페이스인데 아무도 구현하지 않음. `hidden_mission.go`(role-private), `whisper.go`(1:1 메시지), `starting_clue.go`(플레이어별 시작 단서)는 명백한 private state 보유. `module_types.go:94-97` 인터페이스만 존재, 호출처는 `BuildModuleStateFor`에서 fallback만 타는 중. → **W2 `05-security` cross-ref 대상**.
+1. **PlayerAwareModule 8/33 (25 fallback)** — Phase 18.1 B-2 redaction boundary 인터페이스. 2026-04-18 실측 교정 결과 8개 모듈(whisper · hidden_mission · voting · trade_clue · starting_clue · round_clue · timed_clue · conditional_clue)은 이미 구현, **잔여 25개가 fallback**. 명백한 public state 모듈(예: room · ready · connection · text_chat · progression 계열)은 의도적 opt-out이 맞지만, **crime_scene 3(evidence/location/combination) + decision/accusation + cluedist 일부는 민감 state를 fallback 중**. → **F-sec-2 P0 대상, PR-2a(gate + PublicStateMarker) + PR-2b(백필) + PR-2c(craftedAsClueMap redaction)**로 3분할.
 2. **communication/voice_chat.go:182 · spatial_voice.go:201 · core/room.go:140** — ConfigSchema 미구현. 에디터에서 설정 불가능 → 하드코딩 의존. voice_chat은 `maxChannels`·`codec`·LiveKit opts, spatial_voice는 `radius`·`attenuation` 등 명백한 튜닝 노브가 있는데 노출 경로 없음.
 3. **progression/gm_control.go:15 주석 "Does not implement ConfigSchema or PhaseReactor"** — 자체 주석으로 선언적 스키마 부재를 공식화함. GM 제어는 호스트가 타임라인에서 직접 조작하는 축이라 Phase action 매핑이 자연스러운 후보(`ActionLockModule`·`ActionUnlockModule`이 types.go:30-31에 이미 정의). 현재 gm_control은 이 action들의 reactor가 아님.
 


### PR DESCRIPTION
## Summary

PR-2 (PlayerAwareModule Mandatory, XL) → **PR-2a/2b/2c 3분할 설계 확정**. PR-2a 착수를 위한 사전 문서 정리.

## 신규 설계 문서 (6건, 705줄)
- `refs/pr-2-split-design.md` (index, 72줄) — 3분할 근거 + Finding→PR 매핑
- `refs/pr-2/current-state.md` (106줄) — 33 모듈 실측표 + 민감 필드
- `refs/pr-2/pr-2a-engine-gate.md` (143줄) — engine gate + PublicStateMarker
- `refs/pr-2/pr-2b-module-backfill.md` (135줄) — 13 모듈 실구현
- `refs/pr-2/pr-2c-crafted-redaction.md` (140줄) — D-MO-1 combination 전용
- `refs/pr-2/execution-plan.md` (109줄) — Wave 배치 + feature flag + 리스크

모두 MD 200줄 한도 내.

## Inventory 교정 (W1 drift → 2026-04-18 실측)
- **PlayerAwareModule 0/33 → 8/33 (24%)** — whisper / hidden_mission / voting / trade_clue / starting_clue / round_clue / timed_clue / conditional_clue
- F-sec-2 재정의: 잔여 25 fallback 중 공개 state **12개 opt-out (PublicStateMarker)**, 민감 state **13개 백필 대상**

## Backlog 재기입

PR-2 단일 XL 엔트리 → 3엔트리:

| PR | Size | Depends | Rationale |
|---|---|---|---|
| **PR-2a** Engine Gate + PublicStateMarker | S | - | F-sec-2 gate (compile+boot-fail) |
| **PR-2b** 13 모듈 BuildStateFor 백필 | L | PR-2a | F-03 + F-sec-2 실구현 |
| **PR-2c** craftedAsClueMap redaction | S-M | PR-2a + PR-2b 권장 | D-MO-1 단독 |

**의존성 그래프**:
```
PR-2a ──┬──→ PR-2b
        └──→ PR-2c  (PR-2b 선 머지 권장 — combination.go 충돌 회피)
```

**Feature flag**: `MMP_PLAYERAWARE_STRICT` env (default `true`), 프로덕션 롤백 스위치.

## Test plan
- [x] MD 파일만 변경 (코드 영향 無)
- [x] 모든 MD 200줄 한도 내
- [x] Deadlink 없음 (모든 refs/pr-2/* 경로 실재)

## Risk
None — 문서만. 코드 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>