### PR TITLE
feat(phase-19)(pr-2a): engine gate + PublicStateMarker opt-out (F-sec-2)

### DIFF
--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -85,6 +85,14 @@ func BuildModules(
 		if err != nil {
 			return nil, nil, apperror.New(apperror.ErrBadRequest, http.StatusBadRequest, "unknown module: "+mc.Name)
 		}
+		// PR-2a runtime gate: reject modules that slipped past Register()
+		// (e.g. tests that inject factories into globalRegistry directly).
+		// Only enforced in strict mode to preserve legacy fallback behaviour.
+		if strictGateEnabled() {
+			if err := assertModuleContract(mc.Name, mod); err != nil {
+				return nil, nil, apperror.New(apperror.ErrBadRequest, http.StatusBadRequest, err.Error())
+			}
+		}
 		if hs, ok := mod.(HostSubmittable); ok && !hs.IsHostSubmittable() {
 			return nil, nil, apperror.New(apperror.ErrForbidden, http.StatusForbidden, "module not host-submittable: "+mc.Name)
 		}

--- a/apps/server/internal/engine/gate_test.go
+++ b/apps/server/internal/engine/gate_test.go
@@ -1,0 +1,249 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// PR-2a F-sec-2 boot gate tests.
+//
+// These tests verify that:
+//   1. assertModuleContract accepts PlayerAware modules.
+//   2. assertModuleContract accepts PublicStateMarker-bearing modules.
+//   3. assertModuleContract rejects modules that implement neither.
+//   4. Register() panics in strict mode on a violating module.
+//   5. BuildModules returns an error when a manually injected factory violates
+//      the contract (tests that bypass Register via direct map mutation).
+//   6. MMP_PLAYERAWARE_STRICT=false disables the panic path (legacy mode).
+// ---------------------------------------------------------------------------
+
+// gateBareModule implements Module only (no marker, no BuildStateFor).
+// It must fail the PR-2a gate.
+type gateBareModule struct{ name string }
+
+func (g *gateBareModule) Name() string { return g.name }
+func (g *gateBareModule) Init(_ context.Context, _ ModuleDeps, _ json.RawMessage) error {
+	return nil
+}
+func (g *gateBareModule) BuildState() (json.RawMessage, error) { return json.RawMessage(`{}`), nil }
+func (g *gateBareModule) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
+	return nil
+}
+func (g *gateBareModule) Cleanup(_ context.Context) error { return nil }
+
+// gatePublicModule embeds PublicStateMarker and satisfies the gate.
+type gatePublicModule struct {
+	PublicStateMarker
+	name string
+}
+
+func (g *gatePublicModule) Name() string { return g.name }
+func (g *gatePublicModule) Init(_ context.Context, _ ModuleDeps, _ json.RawMessage) error {
+	return nil
+}
+func (g *gatePublicModule) BuildState() (json.RawMessage, error) {
+	return json.RawMessage(`{"public":true}`), nil
+}
+func (g *gatePublicModule) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
+	return nil
+}
+func (g *gatePublicModule) Cleanup(_ context.Context) error { return nil }
+
+// gatePlayerAwareModule implements BuildStateFor and satisfies the gate.
+type gatePlayerAwareModule struct{ name string }
+
+func (g *gatePlayerAwareModule) Name() string { return g.name }
+func (g *gatePlayerAwareModule) Init(_ context.Context, _ ModuleDeps, _ json.RawMessage) error {
+	return nil
+}
+func (g *gatePlayerAwareModule) BuildState() (json.RawMessage, error) {
+	return json.RawMessage(`{"public":true}`), nil
+}
+func (g *gatePlayerAwareModule) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
+	return nil
+}
+func (g *gatePlayerAwareModule) Cleanup(_ context.Context) error { return nil }
+func (g *gatePlayerAwareModule) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
+	return json.Marshal(map[string]string{"viewer": playerID.String()})
+}
+
+// ---------------------------------------------------------------------------
+// assertModuleContract unit tests.
+// ---------------------------------------------------------------------------
+
+func TestAssertModuleContract_AcceptsPlayerAware(t *testing.T) {
+	m := &gatePlayerAwareModule{name: "pa"}
+	if err := assertModuleContract("pa", m); err != nil {
+		t.Fatalf("PlayerAware module rejected: %v", err)
+	}
+}
+
+func TestAssertModuleContract_AcceptsPublicMarker(t *testing.T) {
+	m := &gatePublicModule{name: "pub"}
+	if err := assertModuleContract("pub", m); err != nil {
+		t.Fatalf("PublicStateMarker module rejected: %v", err)
+	}
+}
+
+func TestAssertModuleContract_RejectsBare(t *testing.T) {
+	m := &gateBareModule{name: "bare"}
+	err := assertModuleContract("bare", m)
+	if err == nil {
+		t.Fatal("expected gate violation for bare module, got nil")
+	}
+	if !strings.Contains(err.Error(), "F-sec-2") {
+		t.Errorf("error must mention F-sec-2: %v", err)
+	}
+	if !strings.Contains(err.Error(), "bare") {
+		t.Errorf("error must name the module: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Register() panic gate.
+// ---------------------------------------------------------------------------
+
+func TestRegister_PanicsOnGateViolation(t *testing.T) {
+	// Default strict mode on. Save+restore registry.
+	orig := globalRegistry.factories
+	globalRegistry.factories = map[string]ModuleFactory{}
+	defer func() { globalRegistry.factories = orig }()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Register did not panic on gate violation")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
+		if !strings.Contains(msg, "F-sec-2") {
+			t.Errorf("panic message missing F-sec-2: %s", msg)
+		}
+	}()
+
+	Register("gate_bare", func() Module { return &gateBareModule{name: "gate_bare"} })
+}
+
+func TestRegister_AcceptsPlayerAware(t *testing.T) {
+	orig := globalRegistry.factories
+	globalRegistry.factories = map[string]ModuleFactory{}
+	defer func() { globalRegistry.factories = orig }()
+
+	Register("gate_pa", func() Module { return &gatePlayerAwareModule{name: "gate_pa"} })
+
+	if !HasModule("gate_pa") {
+		t.Fatal("PlayerAware module was not registered")
+	}
+}
+
+func TestRegister_AcceptsPublicMarker(t *testing.T) {
+	orig := globalRegistry.factories
+	globalRegistry.factories = map[string]ModuleFactory{}
+	defer func() { globalRegistry.factories = orig }()
+
+	Register("gate_pub", func() Module { return &gatePublicModule{name: "gate_pub"} })
+
+	if !HasModule("gate_pub") {
+		t.Fatal("PublicStateMarker module was not registered")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildModules runtime gate (for tests that inject factories manually).
+// ---------------------------------------------------------------------------
+
+func TestBuildModules_RejectsGateViolation(t *testing.T) {
+	orig := globalRegistry.factories
+	// Inject a bare factory directly, bypassing Register's panic.
+	globalRegistry.factories = map[string]ModuleFactory{
+		"bare_inject": func() Module { return &gateBareModule{name: "bare_inject"} },
+	}
+	defer func() { globalRegistry.factories = orig }()
+
+	cfg := &GameConfig{
+		Modules: []ModuleConfig{{Name: "bare_inject"}},
+	}
+	_, _, err := BuildModules(context.Background(), cfg, ModuleDeps{})
+	if err == nil {
+		t.Fatal("BuildModules must reject bare modules that bypassed Register")
+	}
+	if !strings.Contains(err.Error(), "F-sec-2") {
+		t.Errorf("BuildModules error must mention F-sec-2: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MMP_PLAYERAWARE_STRICT=false disables the panic path.
+// ---------------------------------------------------------------------------
+
+func TestRegister_StrictModeDisabled_DoesNotPanic(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "false")
+
+	orig := globalRegistry.factories
+	globalRegistry.factories = map[string]ModuleFactory{}
+	defer func() { globalRegistry.factories = orig }()
+
+	// In non-strict mode Register must NOT panic even on a bare module.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Register panicked in non-strict mode: %v", r)
+		}
+	}()
+
+	Register("legacy_bare", func() Module { return &gateBareModule{name: "legacy_bare"} })
+
+	if !HasModule("legacy_bare") {
+		t.Fatal("legacy bare module not registered in non-strict mode")
+	}
+}
+
+func TestStrictGateEnabled_Defaults(t *testing.T) {
+	t.Setenv(strictModeEnvVar, "")
+	if !strictGateEnabled() {
+		t.Error("empty env: strict mode should be ON by default")
+	}
+	for _, v := range []string{"false", "False", "FALSE", "0", "no", "off"} {
+		t.Setenv(strictModeEnvVar, v)
+		if strictGateEnabled() {
+			t.Errorf("env=%q: strict mode should be OFF", v)
+		}
+	}
+	for _, v := range []string{"true", "1", "yes", "on", "anything_else"} {
+		t.Setenv(strictModeEnvVar, v)
+		if !strictGateEnabled() {
+			t.Errorf("env=%q: strict mode should be ON", v)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// All registered modules (production 33) must satisfy the gate.
+// This is the regression test that replaces the fallback path.
+// ---------------------------------------------------------------------------
+
+func TestAllRegisteredModules_SatisfyGate(t *testing.T) {
+	// This test runs against the real globalRegistry populated by init().
+	// Any module that slipped through without marker or BuildStateFor will
+	// fail here, even if its Register call did not panic (non-strict mode).
+	names := RegisteredModules()
+	if len(names) == 0 {
+		t.Skip("no modules registered in this test binary — skipping")
+	}
+	for _, name := range names {
+		mod, err := CreateModule(name)
+		if err != nil {
+			t.Errorf("CreateModule(%q): %v", name, err)
+			continue
+		}
+		if err := assertModuleContract(name, mod); err != nil {
+			t.Errorf("module %q fails PR-2a gate: %v", name, err)
+		}
+	}
+}

--- a/apps/server/internal/engine/module_test.go
+++ b/apps/server/internal/engine/module_test.go
@@ -13,7 +13,11 @@ import (
 // ---------------------------------------------------------------------------
 
 // optMinModule implements only the Module interface (no optionals).
-type optMinModule struct{ name string }
+// PR-2a: embed PublicStateMarker to pass the F-sec-2 boot gate.
+type optMinModule struct {
+	PublicStateMarker
+	name string
+}
 
 func (s *optMinModule) Name() string { return s.name }
 func (s *optMinModule) Init(_ context.Context, _ ModuleDeps, _ json.RawMessage) error {
@@ -26,7 +30,11 @@ func (s *optMinModule) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _
 func (s *optMinModule) Cleanup(_ context.Context) error { return nil }
 
 // optMaxModule implements Module + all 5 optional interfaces.
-type optMaxModule struct{ name string }
+// PR-2a: embed PublicStateMarker to pass the F-sec-2 boot gate.
+type optMaxModule struct {
+	PublicStateMarker
+	name string
+}
 
 func (s *optMaxModule) Name() string { return s.name }
 func (s *optMaxModule) Init(_ context.Context, _ ModuleDeps, _ json.RawMessage) error {

--- a/apps/server/internal/engine/phase_engine_test.go
+++ b/apps/server/internal/engine/phase_engine_test.go
@@ -21,6 +21,10 @@ func (l *testLogger) Printf(format string, v ...any) {
 }
 
 type stubCoreModule struct {
+	// PR-2a: declare public state so tests satisfy the F-sec-2 boot gate
+	// without having to implement BuildStateFor on every stub.
+	PublicStateMarker
+
 	name     string
 	initErr  error
 	cleaned  bool

--- a/apps/server/internal/engine/registry.go
+++ b/apps/server/internal/engine/registry.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 )
 
@@ -17,8 +19,53 @@ var globalRegistry = &Registry{
 	factories: make(map[string]ModuleFactory),
 }
 
+// strictModeEnvVar toggles the PR-2a PlayerAware-or-PublicState boot gate.
+// Set MMP_PLAYERAWARE_STRICT=false to fall back to legacy permissive mode
+// (Phase 18 behaviour). Default: strict (true).
+const strictModeEnvVar = "MMP_PLAYERAWARE_STRICT"
+
+// strictGateEnabled reports whether Register should panic on modules that
+// implement neither PlayerAwareModule nor PublicStateModule.
+// Default: true. Any of "0", "false", "no", "off" (case-insensitive) disables.
+func strictGateEnabled() bool {
+	raw := strings.TrimSpace(os.Getenv(strictModeEnvVar))
+	if raw == "" {
+		return true
+	}
+	switch strings.ToLower(raw) {
+	case "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
+// assertModuleContract validates that the module satisfies PR-2a: either it
+// implements PlayerAwareModule (per-player redaction) or it explicitly opts
+// out via PublicStateModule (engine.PublicStateMarker embed).
+// Returns a descriptive error if neither interface is satisfied.
+func assertModuleContract(name string, m Module) error {
+	if _, ok := m.(PlayerAwareModule); ok {
+		return nil
+	}
+	if _, ok := m.(PublicStateModule); ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"engine: module %q violates F-sec-2 gate: must implement "+
+			"PlayerAwareModule (BuildStateFor) or embed engine.PublicStateMarker "+
+			"to declare public state",
+		name,
+	)
+}
+
 // Register adds a module factory to the global registry.
 // Called from each module's init() function.
+//
+// PR-2a boot gate: Register invokes factory() once to assert that the module
+// implements PlayerAwareModule OR embeds PublicStateMarker. When strict mode
+// is on (default), a missing contract panics — this is intentional and
+// surfaces at process start, not runtime. Disable via MMP_PLAYERAWARE_STRICT
+// only for temporary migration.
 func Register(name string, factory ModuleFactory) {
 	globalRegistry.mu.Lock()
 	defer globalRegistry.mu.Unlock()
@@ -26,6 +73,18 @@ func Register(name string, factory ModuleFactory) {
 	if _, exists := globalRegistry.factories[name]; exists {
 		panic(fmt.Sprintf("engine: duplicate module registration: %s", name))
 	}
+
+	// PR-2a: sample the factory at boot and verify the F-sec-2 contract.
+	sample := factory()
+	if err := assertModuleContract(name, sample); err != nil {
+		if strictGateEnabled() {
+			panic(err.Error())
+		}
+		// Legacy permissive mode: log-via-panic would break tests; callers
+		// opting out accept silent fallback to BuildState.
+		fmt.Fprintf(os.Stderr, "engine: WARN %s (strict mode disabled)\n", err.Error())
+	}
+
 	globalRegistry.factories[name] = factory
 }
 

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -84,10 +84,15 @@ type Module interface {
 	Cleanup(ctx context.Context) error
 }
 
-// PlayerAwareModule is an optional interface for modules that must redact
-// or shape their state on a per-player basis (role-private data, whispers,
-// per-player clues, etc.). Modules that do NOT implement this interface are
-// assumed to have public state; BuildModuleStateFor falls back to BuildState.
+// PlayerAwareModule is an interface for modules that must redact or shape
+// their state on a per-player basis (role-private data, whispers, per-player
+// clues, etc.).
+//
+// PR-2a (Phase 19, F-sec-2): Every registered module MUST implement this
+// interface OR explicitly declare itself as public-state via PublicStateModule
+// (embed engine.PublicStateMarker). The registry enforces this at init() time
+// so module authors cannot silently fall back to BuildState for data that
+// should be per-player redacted.
 //
 // Implementations MUST NOT include any data the given player is not entitled
 // to see — this is the trust boundary for Phase 18.1 B-2 (snapshot redaction).
@@ -96,9 +101,43 @@ type PlayerAwareModule interface {
 	BuildStateFor(playerID uuid.UUID) (json.RawMessage, error)
 }
 
+// PublicStateModule is a sentinel marker declaring that a module's state is
+// intentionally identical for every player (no per-player redaction required).
+// Modules with truly public state (room meta, audio cues, phase index, etc.)
+// embed engine.PublicStateMarker to satisfy this interface and pass the
+// PR-2a gate without implementing BuildStateFor.
+//
+// The sole method is unexported on purpose: only types that embed
+// PublicStateMarker can satisfy PublicStateModule, preventing external
+// packages from forging the opt-out by defining their own stub method.
+type PublicStateModule interface {
+	isPublicState()
+}
+
+// PublicStateMarker is the helper type module authors embed to satisfy
+// PublicStateModule from outside the engine package.
+//
+//	type RoomModule struct {
+//	    engine.PublicStateMarker
+//	    // ...fields
+//	}
+//
+// Embedding this marker is an explicit, auditable declaration that the
+// module's BuildState() output is safe to broadcast to every player.
+type PublicStateMarker struct{}
+
+// isPublicState satisfies PublicStateModule. Never call directly.
+func (PublicStateMarker) isPublicState() {}
+
 // BuildModuleStateFor returns the player-aware state for a module.
-// If the module implements PlayerAwareModule, its redacted state is returned;
-// otherwise the public BuildState() is used.
+//
+// Gate hierarchy (PR-2a):
+//  1. If the module implements PlayerAwareModule → BuildStateFor is called.
+//  2. Else if the module implements PublicStateModule → BuildState is called
+//     (module author has explicitly declared public state).
+//  3. Else (no marker and no BuildStateFor): registry should have panicked at
+//     init() time; this fallback preserves legacy behaviour when strict mode
+//     is disabled via MMP_PLAYERAWARE_STRICT=false.
 func BuildModuleStateFor(m Module, playerID uuid.UUID) (json.RawMessage, error) {
 	if pam, ok := m.(PlayerAwareModule); ok {
 		return pam.BuildStateFor(playerID)

--- a/apps/server/internal/module/cluedist/conditional_clue.go
+++ b/apps/server/internal/module/cluedist/conditional_clue.go
@@ -319,8 +319,9 @@ func (m *ConditionalClueModule) GetRules() []engine.Rule {
 
 // Compile-time interface assertions.
 var (
-	_ engine.Module           = (*ConditionalClueModule)(nil)
-	_ engine.ConfigSchema     = (*ConditionalClueModule)(nil)
-	_ engine.GameEventHandler = (*ConditionalClueModule)(nil)
-	_ engine.RuleProvider     = (*ConditionalClueModule)(nil)
+	_ engine.Module            = (*ConditionalClueModule)(nil)
+	_ engine.ConfigSchema      = (*ConditionalClueModule)(nil)
+	_ engine.GameEventHandler  = (*ConditionalClueModule)(nil)
+	_ engine.RuleProvider      = (*ConditionalClueModule)(nil)
+	_ engine.PlayerAwareModule = (*ConditionalClueModule)(nil)
 )

--- a/apps/server/internal/module/cluedist/round_clue.go
+++ b/apps/server/internal/module/cluedist/round_clue.go
@@ -317,4 +317,5 @@ var (
 	_ engine.GameEventHandler   = (*RoundClueModule)(nil)
 	_ engine.SerializableModule = (*RoundClueModule)(nil)
 	_ engine.RuleProvider       = (*RoundClueModule)(nil)
+	_ engine.PlayerAwareModule  = (*RoundClueModule)(nil)
 )

--- a/apps/server/internal/module/cluedist/starting_clue.go
+++ b/apps/server/internal/module/cluedist/starting_clue.go
@@ -256,4 +256,5 @@ var (
 	_ engine.ConfigSchema       = (*StartingClueModule)(nil)
 	_ engine.PhaseHookModule    = (*StartingClueModule)(nil)
 	_ engine.SerializableModule = (*StartingClueModule)(nil)
+	_ engine.PlayerAwareModule  = (*StartingClueModule)(nil)
 )

--- a/apps/server/internal/module/cluedist/timed_clue.go
+++ b/apps/server/internal/module/cluedist/timed_clue.go
@@ -322,4 +322,5 @@ var (
 	_ engine.Module             = (*TimedClueModule)(nil)
 	_ engine.ConfigSchema       = (*TimedClueModule)(nil)
 	_ engine.SerializableModule = (*TimedClueModule)(nil)
+	_ engine.PlayerAwareModule  = (*TimedClueModule)(nil)
 )

--- a/apps/server/internal/module/cluedist/trade_clue.go
+++ b/apps/server/internal/module/cluedist/trade_clue.go
@@ -528,4 +528,5 @@ var (
 	_ engine.ConfigSchema       = (*TradeClueModule)(nil)
 	_ engine.PhaseReactor       = (*TradeClueModule)(nil)
 	_ engine.SerializableModule = (*TradeClueModule)(nil)
+	_ engine.PlayerAwareModule  = (*TradeClueModule)(nil)
 )

--- a/apps/server/internal/module/communication/group_chat.go
+++ b/apps/server/internal/module/communication/group_chat.go
@@ -416,6 +416,14 @@ func (m *GroupChatModule) RestoreState(_ context.Context, _ uuid.UUID, state eng
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will add per-player redaction (players outside a given room should
+// not see that room's message history or full member list).
+func (m *GroupChatModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface checks.
 var (
 	_ engine.Module             = (*GroupChatModule)(nil)
@@ -423,4 +431,5 @@ var (
 	_ engine.ConfigSchema       = (*GroupChatModule)(nil)
 	_ engine.GameEventHandler   = (*GroupChatModule)(nil)
 	_ engine.SerializableModule = (*GroupChatModule)(nil)
+	_ engine.PlayerAwareModule  = (*GroupChatModule)(nil)
 )

--- a/apps/server/internal/module/communication/spatial_voice.go
+++ b/apps/server/internal/module/communication/spatial_voice.go
@@ -16,7 +16,14 @@ func init() {
 
 // SpatialVoiceModule manages location-based voice room assignments.
 // Requires: voice_chat, and one of floor_exploration or room_exploration.
+//
+// PR-2a: declares public state — player location → voice-room membership is
+// a shared map used by every client to render spatial audio UI. Client-side
+// filtering (distance/LOS) is enforced by the LiveKit room topology, not by
+// per-player state redaction.
 type SpatialVoiceModule struct {
+	engine.PublicStateMarker
+
 	mu              sync.RWMutex
 	deps            engine.ModuleDeps
 	config          spatialVoiceConfig
@@ -197,5 +204,8 @@ func (m *SpatialVoiceModule) Cleanup(_ context.Context) error {
 	return nil
 }
 
-// Compile-time interface check.
-var _ engine.Module = (*SpatialVoiceModule)(nil)
+// Compile-time interface checks.
+var (
+	_ engine.Module            = (*SpatialVoiceModule)(nil)
+	_ engine.PublicStateModule = (*SpatialVoiceModule)(nil)
+)

--- a/apps/server/internal/module/communication/text_chat.go
+++ b/apps/server/internal/module/communication/text_chat.go
@@ -233,10 +233,20 @@ func (m *TextChatModule) Apply(_ context.Context, _ engine.GameEvent, state *eng
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will add per-player filtering (e.g. redact blocked-user messages per
+// viewer, and omit the full history for late-joiners whose join_time is after
+// a given message's timestamp).
+func (m *TextChatModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface checks.
 var (
-	_ engine.Module           = (*TextChatModule)(nil)
-	_ engine.PhaseReactor     = (*TextChatModule)(nil)
-	_ engine.ConfigSchema     = (*TextChatModule)(nil)
-	_ engine.GameEventHandler = (*TextChatModule)(nil)
+	_ engine.Module            = (*TextChatModule)(nil)
+	_ engine.PhaseReactor      = (*TextChatModule)(nil)
+	_ engine.ConfigSchema      = (*TextChatModule)(nil)
+	_ engine.GameEventHandler  = (*TextChatModule)(nil)
+	_ engine.PlayerAwareModule = (*TextChatModule)(nil)
 )

--- a/apps/server/internal/module/communication/voice_chat.go
+++ b/apps/server/internal/module/communication/voice_chat.go
@@ -15,7 +15,13 @@ func init() {
 }
 
 // VoiceChatModule manages voice chat participation and mute state.
+//
+// PR-2a: declares public state — the participant roster (with mute flags)
+// is broadcast openly; voice tokens are fetched via a separate authenticated
+// endpoint and never carried in session state.
 type VoiceChatModule struct {
+	engine.PublicStateMarker
+
 	mu           sync.RWMutex
 	deps         engine.ModuleDeps
 	config       voiceChatConfig
@@ -178,5 +184,8 @@ func (m *VoiceChatModule) Cleanup(_ context.Context) error {
 	return nil
 }
 
-// Compile-time interface check.
-var _ engine.Module = (*VoiceChatModule)(nil)
+// Compile-time interface checks.
+var (
+	_ engine.Module            = (*VoiceChatModule)(nil)
+	_ engine.PublicStateModule = (*VoiceChatModule)(nil)
+)

--- a/apps/server/internal/module/communication/whisper.go
+++ b/apps/server/internal/module/communication/whisper.go
@@ -229,8 +229,9 @@ func (m *WhisperModule) OnPhaseExit(_ context.Context, _ engine.Phase) error {
 
 // Compile-time interface checks.
 var (
-	_ engine.Module           = (*WhisperModule)(nil)
-	_ engine.PhaseReactor     = (*WhisperModule)(nil)
-	_ engine.GameEventHandler = (*WhisperModule)(nil)
-	_ engine.PhaseHookModule  = (*WhisperModule)(nil)
+	_ engine.Module            = (*WhisperModule)(nil)
+	_ engine.PhaseReactor      = (*WhisperModule)(nil)
+	_ engine.GameEventHandler  = (*WhisperModule)(nil)
+	_ engine.PhaseHookModule   = (*WhisperModule)(nil)
+	_ engine.PlayerAwareModule = (*WhisperModule)(nil)
 )

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -466,10 +466,19 @@ func (m *ClueInteractionModule) Apply(_ context.Context, event engine.GameEvent,
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will add player-specific redaction (each player should only see their
+// own playerDrawCounts / acquiredClues / usedItems / activeItemUse entries).
+func (m *ClueInteractionModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface checks.
 var (
-	_ engine.Module           = (*ClueInteractionModule)(nil)
-	_ engine.PhaseReactor     = (*ClueInteractionModule)(nil)
-	_ engine.ConfigSchema     = (*ClueInteractionModule)(nil)
-	_ engine.GameEventHandler = (*ClueInteractionModule)(nil)
+	_ engine.Module            = (*ClueInteractionModule)(nil)
+	_ engine.PhaseReactor      = (*ClueInteractionModule)(nil)
+	_ engine.ConfigSchema      = (*ClueInteractionModule)(nil)
+	_ engine.GameEventHandler  = (*ClueInteractionModule)(nil)
+	_ engine.PlayerAwareModule = (*ClueInteractionModule)(nil)
 )

--- a/apps/server/internal/module/core/connection.go
+++ b/apps/server/internal/module/core/connection.go
@@ -24,7 +24,12 @@ type PlayerStatus struct {
 }
 
 // ConnectionModule tracks online players in a game session.
+//
+// PR-2a: declares public state — player presence (online/offline) is shared
+// openly across the room for UI indicators.
 type ConnectionModule struct {
+	engine.PublicStateMarker
+
 	mu      sync.RWMutex
 	deps    engine.ModuleDeps
 	players map[uuid.UUID]*PlayerStatus
@@ -176,5 +181,6 @@ func (m *ConnectionModule) RestoreState(_ context.Context, _ uuid.UUID, state en
 // Compile-time interface checks.
 var (
 	_ engine.Module             = (*ConnectionModule)(nil)
+	_ engine.PublicStateModule  = (*ConnectionModule)(nil)
 	_ engine.SerializableModule = (*ConnectionModule)(nil)
 )

--- a/apps/server/internal/module/core/ready.go
+++ b/apps/server/internal/module/core/ready.go
@@ -15,7 +15,12 @@ func init() {
 }
 
 // ReadyModule tracks player ready states before game start.
+//
+// PR-2a: declares public state — every player sees the full ready map
+// (this is the lobby UI's primary signal).
 type ReadyModule struct {
+	engine.PublicStateMarker
+
 	mu           sync.RWMutex
 	deps         engine.ModuleDeps
 	readyPlayers map[uuid.UUID]bool
@@ -173,7 +178,8 @@ func (m *ReadyModule) Apply(_ context.Context, event engine.GameEvent, state *en
 
 // Compile-time interface checks.
 var (
-	_ engine.Module           = (*ReadyModule)(nil)
-	_ engine.PhaseHookModule  = (*ReadyModule)(nil)
-	_ engine.GameEventHandler = (*ReadyModule)(nil)
+	_ engine.Module            = (*ReadyModule)(nil)
+	_ engine.PublicStateModule = (*ReadyModule)(nil)
+	_ engine.PhaseHookModule   = (*ReadyModule)(nil)
+	_ engine.GameEventHandler  = (*ReadyModule)(nil)
 )

--- a/apps/server/internal/module/core/room.go
+++ b/apps/server/internal/module/core/room.go
@@ -15,7 +15,12 @@ func init() {
 }
 
 // RoomModule manages character selection and room phase.
+//
+// PR-2a: declares public state — character map is broadcast to all players
+// for the lobby UI, and phase is a single game-wide value.
 type RoomModule struct {
+	engine.PublicStateMarker
+
 	mu         sync.RWMutex
 	deps       engine.ModuleDeps
 	characters map[string]uuid.UUID // characterCode → playerID
@@ -137,4 +142,7 @@ func (m *RoomModule) Cleanup(_ context.Context) error {
 }
 
 // Compile-time interface checks.
-var _ engine.Module = (*RoomModule)(nil)
+var (
+	_ engine.Module            = (*RoomModule)(nil)
+	_ engine.PublicStateModule = (*RoomModule)(nil)
+)

--- a/apps/server/internal/module/crime_scene/combination.go
+++ b/apps/server/internal/module/crime_scene/combination.go
@@ -523,6 +523,15 @@ func (m *CombinationModule) RestoreState(_ context.Context, _ uuid.UUID, state e
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will restrict completed/derived/collected entries to the requesting
+// player's own progress, since revealing other players' combinations leaks
+// strategic information.
+func (m *CombinationModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface assertions.
 var (
 	_ engine.Module             = (*CombinationModule)(nil)
@@ -530,4 +539,5 @@ var (
 	_ engine.WinChecker         = (*CombinationModule)(nil)
 	_ engine.RuleProvider       = (*CombinationModule)(nil)
 	_ engine.SerializableModule = (*CombinationModule)(nil)
+	_ engine.PlayerAwareModule  = (*CombinationModule)(nil)
 )

--- a/apps/server/internal/module/crime_scene/evidence.go
+++ b/apps/server/internal/module/crime_scene/evidence.go
@@ -390,10 +390,20 @@ func (m *EvidenceModule) RestoreState(_ context.Context, _ uuid.UUID, state engi
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will filter discovered/collected to the requesting player only
+// (currently those maps include every player's inventory which leaks
+// discovery progress).
+func (m *EvidenceModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface assertions.
 var (
 	_ engine.Module             = (*EvidenceModule)(nil)
 	_ engine.GameEventHandler   = (*EvidenceModule)(nil)
 	_ engine.PhaseHookModule    = (*EvidenceModule)(nil)
 	_ engine.SerializableModule = (*EvidenceModule)(nil)
+	_ engine.PlayerAwareModule  = (*EvidenceModule)(nil)
 )

--- a/apps/server/internal/module/crime_scene/location.go
+++ b/apps/server/internal/module/crime_scene/location.go
@@ -307,10 +307,19 @@ func (m *LocationModule) GetRules() []engine.Rule {
 	}
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will redact per-player history — each player should only see their
+// own movement history, not everyone else's positions trail.
+func (m *LocationModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface assertions.
 var (
 	_ engine.Module             = (*LocationModule)(nil)
 	_ engine.GameEventHandler   = (*LocationModule)(nil)
 	_ engine.SerializableModule = (*LocationModule)(nil)
 	_ engine.RuleProvider       = (*LocationModule)(nil)
+	_ engine.PlayerAwareModule  = (*LocationModule)(nil)
 )

--- a/apps/server/internal/module/decision/accusation.go
+++ b/apps/server/internal/module/decision/accusation.go
@@ -496,11 +496,20 @@ func (m *AccusationModule) OnPhaseExit(_ context.Context, _ engine.Phase) error 
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will redact the live vote tally per viewer — votes should only be
+// visible post-resolution to avoid strategic coercion during the vote.
+func (m *AccusationModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface checks.
 var (
-	_ engine.Module           = (*AccusationModule)(nil)
-	_ engine.ConfigSchema     = (*AccusationModule)(nil)
-	_ engine.GameEventHandler = (*AccusationModule)(nil)
-	_ engine.WinChecker       = (*AccusationModule)(nil)
-	_ engine.PhaseHookModule  = (*AccusationModule)(nil)
+	_ engine.Module            = (*AccusationModule)(nil)
+	_ engine.ConfigSchema      = (*AccusationModule)(nil)
+	_ engine.GameEventHandler  = (*AccusationModule)(nil)
+	_ engine.WinChecker        = (*AccusationModule)(nil)
+	_ engine.PhaseHookModule   = (*AccusationModule)(nil)
+	_ engine.PlayerAwareModule = (*AccusationModule)(nil)
 )

--- a/apps/server/internal/module/decision/hidden_mission.go
+++ b/apps/server/internal/module/decision/hidden_mission.go
@@ -555,4 +555,5 @@ var (
 	_ engine.SerializableModule = (*HiddenMissionModule)(nil)
 	_ engine.WinChecker         = (*HiddenMissionModule)(nil)
 	_ engine.RuleProvider       = (*HiddenMissionModule)(nil)
+	_ engine.PlayerAwareModule  = (*HiddenMissionModule)(nil)
 )

--- a/apps/server/internal/module/decision/voting.go
+++ b/apps/server/internal/module/decision/voting.go
@@ -635,4 +635,5 @@ var (
 	_ engine.WinChecker         = (*VotingModule)(nil)
 	_ engine.SerializableModule = (*VotingModule)(nil)
 	_ engine.RuleProvider       = (*VotingModule)(nil)
+	_ engine.PlayerAwareModule  = (*VotingModule)(nil)
 )

--- a/apps/server/internal/module/exploration/floor_exploration.go
+++ b/apps/server/internal/module/exploration/floor_exploration.go
@@ -195,10 +195,19 @@ func (m *FloorExplorationModule) Apply(_ context.Context, _ engine.GameEvent, st
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will redact playerFloors so each viewer only sees their own floor
+// assignment (currently the map leaks every player's floor selection).
+func (m *FloorExplorationModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface assertions.
 var (
-	_ engine.Module           = (*FloorExplorationModule)(nil)
-	_ engine.PhaseReactor     = (*FloorExplorationModule)(nil)
-	_ engine.ConfigSchema     = (*FloorExplorationModule)(nil)
-	_ engine.GameEventHandler = (*FloorExplorationModule)(nil)
+	_ engine.Module            = (*FloorExplorationModule)(nil)
+	_ engine.PhaseReactor      = (*FloorExplorationModule)(nil)
+	_ engine.ConfigSchema      = (*FloorExplorationModule)(nil)
+	_ engine.GameEventHandler  = (*FloorExplorationModule)(nil)
+	_ engine.PlayerAwareModule = (*FloorExplorationModule)(nil)
 )

--- a/apps/server/internal/module/exploration/location_clue.go
+++ b/apps/server/internal/module/exploration/location_clue.go
@@ -179,9 +179,18 @@ func (m *LocationClueModule) Apply(_ context.Context, _ engine.GameEvent, state 
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will restrict searchedLocations and foundClues to the requesting
+// player's own progress (other players' search trails leak strategy).
+func (m *LocationClueModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface assertions.
 var (
-	_ engine.Module           = (*LocationClueModule)(nil)
-	_ engine.ConfigSchema     = (*LocationClueModule)(nil)
-	_ engine.GameEventHandler = (*LocationClueModule)(nil)
+	_ engine.Module            = (*LocationClueModule)(nil)
+	_ engine.ConfigSchema      = (*LocationClueModule)(nil)
+	_ engine.GameEventHandler  = (*LocationClueModule)(nil)
+	_ engine.PlayerAwareModule = (*LocationClueModule)(nil)
 )

--- a/apps/server/internal/module/exploration/room_based_exploration.go
+++ b/apps/server/internal/module/exploration/room_based_exploration.go
@@ -209,9 +209,18 @@ func (m *RoomBasedExplorationModule) Apply(_ context.Context, _ engine.GameEvent
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will honour config.ShowPlayerLocations=false by redacting other
+// players' locations / room occupancy for the viewer.
+func (m *RoomBasedExplorationModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface assertions.
 var (
-	_ engine.Module           = (*RoomBasedExplorationModule)(nil)
-	_ engine.ConfigSchema     = (*RoomBasedExplorationModule)(nil)
-	_ engine.GameEventHandler = (*RoomBasedExplorationModule)(nil)
+	_ engine.Module            = (*RoomBasedExplorationModule)(nil)
+	_ engine.ConfigSchema      = (*RoomBasedExplorationModule)(nil)
+	_ engine.GameEventHandler  = (*RoomBasedExplorationModule)(nil)
+	_ engine.PlayerAwareModule = (*RoomBasedExplorationModule)(nil)
 )

--- a/apps/server/internal/module/exploration/timed_exploration.go
+++ b/apps/server/internal/module/exploration/timed_exploration.go
@@ -288,10 +288,19 @@ func (m *TimedExplorationModule) Apply(_ context.Context, _ engine.GameEvent, st
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will redact playerLocations for viewers whose config disables
+// cross-player visibility.
+func (m *TimedExplorationModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface assertions.
 var (
-	_ engine.Module           = (*TimedExplorationModule)(nil)
-	_ engine.ConfigSchema     = (*TimedExplorationModule)(nil)
-	_ engine.PhaseHookModule  = (*TimedExplorationModule)(nil)
-	_ engine.GameEventHandler = (*TimedExplorationModule)(nil)
+	_ engine.Module            = (*TimedExplorationModule)(nil)
+	_ engine.ConfigSchema      = (*TimedExplorationModule)(nil)
+	_ engine.PhaseHookModule   = (*TimedExplorationModule)(nil)
+	_ engine.GameEventHandler  = (*TimedExplorationModule)(nil)
+	_ engine.PlayerAwareModule = (*TimedExplorationModule)(nil)
 )

--- a/apps/server/internal/module/media/audio.go
+++ b/apps/server/internal/module/media/audio.go
@@ -25,7 +25,12 @@ func init() {
 }
 
 // AudioModule reacts to audio PhaseActions and bridges reading events to audio events.
+//
+// PR-2a: declares public state — BGM/SFX cues are synchronised across all
+// players so every client hears the same soundscape.
 type AudioModule struct {
+	engine.PublicStateMarker
+
 	mu           sync.RWMutex
 	deps         engine.ModuleDeps
 	currentBGMId string
@@ -193,8 +198,9 @@ func (m *AudioModule) Apply(_ context.Context, _ engine.GameEvent, state *engine
 
 // Compile-time interface checks.
 var (
-	_ engine.Module           = (*AudioModule)(nil)
-	_ engine.PhaseReactor     = (*AudioModule)(nil)
-	_ engine.PhaseHookModule  = (*AudioModule)(nil)
-	_ engine.GameEventHandler = (*AudioModule)(nil)
+	_ engine.Module            = (*AudioModule)(nil)
+	_ engine.PublicStateModule = (*AudioModule)(nil)
+	_ engine.PhaseReactor      = (*AudioModule)(nil)
+	_ engine.PhaseHookModule   = (*AudioModule)(nil)
+	_ engine.GameEventHandler  = (*AudioModule)(nil)
 )

--- a/apps/server/internal/module/progression/consensus_control.go
+++ b/apps/server/internal/module/progression/consensus_control.go
@@ -20,7 +20,12 @@ type ConsensusProposal struct {
 
 // ConsensusControlModule manages player-driven consensus for game actions.
 // Auto-enabled when gmMode is NONE or OPTIONAL.
+//
+// PR-2a: declares public state — active proposals and per-player vote tallies
+// are broadcast to everyone (designed transparency for player-driven consensus).
 type ConsensusControlModule struct {
+	engine.PublicStateMarker
+
 	mu   sync.RWMutex
 	deps engine.ModuleDeps
 
@@ -239,8 +244,9 @@ func (m *ConsensusControlModule) OnPhaseExit(_ context.Context, _ engine.Phase) 
 
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*ConsensusControlModule)(nil)
-	_ engine.PhaseHookModule = (*ConsensusControlModule)(nil)
+	_ engine.Module            = (*ConsensusControlModule)(nil)
+	_ engine.PhaseHookModule   = (*ConsensusControlModule)(nil)
+	_ engine.PublicStateModule = (*ConsensusControlModule)(nil)
 )
 
 func init() {

--- a/apps/server/internal/module/progression/ending.go
+++ b/apps/server/internal/module/progression/ending.go
@@ -21,7 +21,12 @@ var defaultRevealSteps = []string{
 }
 
 // EndingModule manages the game ending reveal sequence.
+//
+// PR-2a: declares public state — reveal step progress is broadcast to all
+// players simultaneously by design (everyone sees the same ending reveal).
 type EndingModule struct {
+	engine.PublicStateMarker
+
 	mu   sync.RWMutex
 	deps engine.ModuleDeps
 
@@ -188,9 +193,10 @@ func (m *EndingModule) OnPhaseExit(_ context.Context, _ engine.Phase) error {
 
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*EndingModule)(nil)
-	_ engine.ConfigSchema    = (*EndingModule)(nil)
-	_ engine.PhaseHookModule = (*EndingModule)(nil)
+	_ engine.Module            = (*EndingModule)(nil)
+	_ engine.ConfigSchema      = (*EndingModule)(nil)
+	_ engine.PhaseHookModule   = (*EndingModule)(nil)
+	_ engine.PublicStateModule = (*EndingModule)(nil)
 )
 
 func init() {

--- a/apps/server/internal/module/progression/event_progression.go
+++ b/apps/server/internal/module/progression/event_progression.go
@@ -11,7 +11,12 @@ import (
 )
 
 // EventProgressionModule manages non-linear phase progression driven by triggers.
+//
+// PR-2a: declares public state — current phase, visited phase list, and
+// backtrack flag are shared by all players.
 type EventProgressionModule struct {
+	engine.PublicStateMarker
+
 	mu   sync.RWMutex
 	deps engine.ModuleDeps
 
@@ -175,9 +180,10 @@ func (m *EventProgressionModule) OnPhaseExit(_ context.Context, _ engine.Phase) 
 
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*EventProgressionModule)(nil)
-	_ engine.ConfigSchema    = (*EventProgressionModule)(nil)
-	_ engine.PhaseHookModule = (*EventProgressionModule)(nil)
+	_ engine.Module            = (*EventProgressionModule)(nil)
+	_ engine.ConfigSchema      = (*EventProgressionModule)(nil)
+	_ engine.PhaseHookModule   = (*EventProgressionModule)(nil)
+	_ engine.PublicStateModule = (*EventProgressionModule)(nil)
 )
 
 func init() {

--- a/apps/server/internal/module/progression/gm_control.go
+++ b/apps/server/internal/module/progression/gm_control.go
@@ -13,7 +13,13 @@ import (
 // GmControlModule provides GM (Game Master) controls for session management.
 // Auto-enabled when gmMode is REQUIRED or OPTIONAL.
 // Does not implement ConfigSchema or PhaseReactor.
+//
+// PR-2a: declares public state — BuildState exposes gmPlayerId + isActive which
+// are broadcast to every player for the GM HUD. GM-command authorization is
+// enforced in HandleMessage (playerID == gmPlayerID), not via state redaction.
 type GmControlModule struct {
+	engine.PublicStateMarker
+
 	mu   sync.RWMutex
 	deps engine.ModuleDeps
 
@@ -178,8 +184,9 @@ func (m *GmControlModule) OnPhaseExit(_ context.Context, _ engine.Phase) error {
 
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*GmControlModule)(nil)
-	_ engine.PhaseHookModule = (*GmControlModule)(nil)
+	_ engine.Module            = (*GmControlModule)(nil)
+	_ engine.PhaseHookModule   = (*GmControlModule)(nil)
+	_ engine.PublicStateModule = (*GmControlModule)(nil)
 )
 
 func init() {

--- a/apps/server/internal/module/progression/hybrid_progression.go
+++ b/apps/server/internal/module/progression/hybrid_progression.go
@@ -11,7 +11,13 @@ import (
 )
 
 // HybridProgressionModule combines consensus-based and event-driven phase advancement.
+//
+// PR-2a: declares public state — threshold and vote tallies are broadcast
+// to all players (votes map exposes each player's vote to everyone, which is
+// the designed UX for consensus visibility).
 type HybridProgressionModule struct {
+	engine.PublicStateMarker
+
 	mu   sync.RWMutex
 	deps engine.ModuleDeps
 
@@ -174,9 +180,10 @@ func (m *HybridProgressionModule) OnPhaseExit(_ context.Context, _ engine.Phase)
 
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*HybridProgressionModule)(nil)
-	_ engine.ConfigSchema    = (*HybridProgressionModule)(nil)
-	_ engine.PhaseHookModule = (*HybridProgressionModule)(nil)
+	_ engine.Module            = (*HybridProgressionModule)(nil)
+	_ engine.ConfigSchema      = (*HybridProgressionModule)(nil)
+	_ engine.PhaseHookModule   = (*HybridProgressionModule)(nil)
+	_ engine.PublicStateModule = (*HybridProgressionModule)(nil)
 )
 
 func init() {

--- a/apps/server/internal/module/progression/reading.go
+++ b/apps/server/internal/module/progression/reading.go
@@ -630,11 +630,21 @@ func (m *ReadingModule) OnPhaseExit(_ context.Context, _ engine.Phase) error {
 	return nil
 }
 
+// BuildStateFor returns the same state as BuildState for now.
+// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
+// PR-2b will tailor the line window to the viewer — for role-gated advance
+// the current line's prompts should be restricted to the owning role, and
+// future lines should be redacted until revealed.
+func (m *ReadingModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}
+
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*ReadingModule)(nil)
-	_ engine.ConfigSchema    = (*ReadingModule)(nil)
-	_ engine.PhaseHookModule = (*ReadingModule)(nil)
+	_ engine.Module            = (*ReadingModule)(nil)
+	_ engine.ConfigSchema      = (*ReadingModule)(nil)
+	_ engine.PhaseHookModule   = (*ReadingModule)(nil)
+	_ engine.PlayerAwareModule = (*ReadingModule)(nil)
 )
 
 func init() {

--- a/apps/server/internal/module/progression/script_progression.go
+++ b/apps/server/internal/module/progression/script_progression.go
@@ -11,7 +11,12 @@ import (
 )
 
 // ScriptProgressionModule manages linear phase progression through a predefined script.
+//
+// PR-2a: declares public state — phase index, total count, skip/progress flags
+// are identical for every player (no per-role redaction).
 type ScriptProgressionModule struct {
+	engine.PublicStateMarker
+
 	mu   sync.RWMutex
 	deps engine.ModuleDeps
 
@@ -138,9 +143,10 @@ func (m *ScriptProgressionModule) OnPhaseExit(_ context.Context, _ engine.Phase)
 
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*ScriptProgressionModule)(nil)
-	_ engine.ConfigSchema    = (*ScriptProgressionModule)(nil)
-	_ engine.PhaseHookModule = (*ScriptProgressionModule)(nil)
+	_ engine.Module            = (*ScriptProgressionModule)(nil)
+	_ engine.ConfigSchema      = (*ScriptProgressionModule)(nil)
+	_ engine.PhaseHookModule   = (*ScriptProgressionModule)(nil)
+	_ engine.PublicStateModule = (*ScriptProgressionModule)(nil)
 )
 
 func init() {

--- a/apps/server/internal/module/progression/skip_consensus.go
+++ b/apps/server/internal/module/progression/skip_consensus.go
@@ -12,7 +12,12 @@ import (
 
 // SkipConsensusModule manages skip vote consensus for script progression.
 // Requires: script_progression module.
+//
+// PR-2a: declares public state — active request flag, votes, and required
+// ratio are shared by all players for the skip-prompt UI.
 type SkipConsensusModule struct {
+	engine.PublicStateMarker
+
 	mu   sync.RWMutex
 	deps engine.ModuleDeps
 
@@ -229,9 +234,10 @@ func (m *SkipConsensusModule) OnPhaseExit(_ context.Context, _ engine.Phase) err
 
 // Compile-time interface checks.
 var (
-	_ engine.Module          = (*SkipConsensusModule)(nil)
-	_ engine.ConfigSchema    = (*SkipConsensusModule)(nil)
-	_ engine.PhaseHookModule = (*SkipConsensusModule)(nil)
+	_ engine.Module            = (*SkipConsensusModule)(nil)
+	_ engine.ConfigSchema      = (*SkipConsensusModule)(nil)
+	_ engine.PhaseHookModule   = (*SkipConsensusModule)(nil)
+	_ engine.PublicStateModule = (*SkipConsensusModule)(nil)
 )
 
 func init() {


### PR DESCRIPTION
## Summary

**F-sec-2 gate 해소** — PlayerAwareModule 의무화 + PublicStateMarker sentinel 도입으로 25 모듈 fallback 재발 원천 차단. W2 잔여 단독 PR. PR-2b/2c 선행 gate.

설계: `docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2a-engine-gate.md`

## Engine-level gate (3 + 1 files)
- `engine/types.go` — `PublicStateModule` sentinel interface (unexported `isPublicState()`) + `PublicStateMarker` helper struct (외부 위조 방지)
- `engine/registry.go` — `assertModuleContract` + `Register()` panic gate + `MMP_PLAYERAWARE_STRICT` env
- `engine/factory.go` — `BuildModules()` runtime gate (test escape hatch 방어)
- `engine/gate_test.go` **NEW** — 10 tests (assert / Register / BuildModules / strict mode / env parsing / real-registry)

## 33 모듈 최종 분류

| 분류 | 수 | 모듈 |
|---|---:|---|
| PlayerAware 실구현 (compile assertion 추가) | 8 | whisper · hidden_mission · voting · trade_clue · starting_clue · round_clue · timed_clue · conditional_clue |
| PublicStateMarker opt-out | 13 | room · ready · connection · voice_chat · spatial_voice · audio · gm_control · script_progression · event_progression · hybrid_progression · consensus_control · skip_consensus · ending |
| PlayerAware stub (PR-2b 실구현) | 12 | clue_interaction · text_chat · group_chat · evidence · location · combination · accusation · floor_exploration · room_exploration · timed_exploration · location_clue · reading |

### gm_control 결정: PublicStateMarker
`BuildState()`가 `gmPlayerId + isActive`만 노출(이미 공개). `snapshot_send.go`에 GM 전용 필터 없음 — GM 권한은 `HandleMessage()`에서 검증. Public state로 분류가 정확.

## Feature flag
- `MMP_PLAYERAWARE_STRICT` env (default `true`)
- 이슈 시 `false`로 fallback 롤백. PR-2b/2c 머지 + 30일 안정 관측 후 제거.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/engine/...` — ok (0.480s)
- [x] `go test ./internal/module/...` — 8 패키지 ok
- [x] `go test ./...` — 전 패키지 ok (engine + apperror + auditlog + bridge + clue + config + domain × 10 + e2e + eventbus + health + httputil + infra × 4 + middleware + seo + server + session + template + ws)
- [x] 회귀 0건
- [x] gate 동작: marker 없는 모듈 등록 시 panic 검증 (gate_test.go)
- [x] strict mode false → 경고 로그만, panic 없음

## Risk
Low — gate만, 실구현 아님. stub 모듈의 `BuildStateFor`는 `BuildState()` 그대로 호출 (PR-2b가 실구현). Feature flag로 즉시 롤백 가능.

## Next
- PR-2b: 12 stub 모듈 실구현 (L, Med risk)
- PR-2c: craftedAsClueMap redaction (S-M, Low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>