### PR TITLE
chore(phase-19): pr-4 파일 분할 설계 문서 + backlog 재기입

### DIFF
--- a/docs/plans/2026-04-17-platform-deep-audit/refs/phase19-backlog.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/phase19-backlog.md
@@ -74,12 +74,41 @@ PR-2a ──┬──→ PR-2b
 - **Size**: M (≤2d)
 - **Risk**: Low
 
-### PR-4: File Size Refactor Wave — Go 10 + TS 3 파일 분할
-- **Scope**: `apps/server/internal/domain/social/service.go` (759→분할), `apps/server/internal/editor/handler.go` (26 endpoint 분할), `apps/server/internal/ws/hub.go` (lifecycle/broadcast 분리), `apps/server/internal/module/{progression/reading,decision/voting,decision/hidden_mission,cluedist/trade_clue,decision/accusation,crime_scene/combination}/**`, `apps/web/src/features/game/components/GameChat.tsx`, `apps/web/src/features/editor/api.ts`, `apps/web/src/features/social/components/FriendsList.tsx`
-- **Depends on**: PR-1 (WS envelope 영향받는 파일)
-- **Rationale**: C-4 / F-go-3·4 + F-react-1·3·4. CLAUDE.md hard limit 누적 위반 10+ 건.
-- **Size**: L (>2d)
+### PR-4 분할 (2026-04-18 재설계) — design: `refs/pr-4-split-design.md`
+
+> **분할 근거**: Go 9 파일(6 모듈 + 3 인프라) + TS 3 파일은 파일셋 disjoint + 언어 경계 명확 → 병렬 실행 가능. Git conflict 0. 리뷰어 분리로 부담 감소.
+
+#### PR-4a: Go 파일 분할 — design: `refs/pr-4/pr-4a-go-split.md`
+- **Scope**:
+  - 6 모듈 디렉터리 승격: `progression/reading` (652) · `decision/voting` (639) · `decision/hidden_mission` (559) · `crime_scene/combination` (543) · `cluedist/trade_clue` (532) · `decision/accusation` (515) → `module/<cat>/<module>/` 내부 `module.go / config.go / state.go / handlers.go / reactor.go / events.go`
+  - 3 인프라 파일 분할 (package 유지): `domain/social/service.go` (759) · `ws/hub.go` (649) · `domain/editor/service.go` (505)
+  - F-go-4 `accusation.handleAccusationVote` 101줄 → `tally.go` 수학 로직 추출
+  - 카테고리 내 `register.go` 신설 (blank import 안전)
+- **Depends on**: 없음 (PR-2a 이후로 gate 안정)
+- **Rationale**: C-4 / F-go-3·4. CLAUDE.md hard limit (Go 500/함수 80) 위반 해소. Factory 서명 불변.
+- **Size**: L
 - **Risk**: Med (import 경로 대량 변경)
+- **Gate**: `go test ./... -race` + `TestRegistry_AllCoreModulesRegistered` 신규
+
+#### PR-4b: TS 파일 분할 — design: `refs/pr-4/pr-4b-ts-split.md`
+- **Scope**:
+  - `editor/api.ts` (428) → `api/` 배럴 + `types.ts/keys.ts/themes.ts/characters.ts/content.ts/validation.ts/moduleSchemas.ts`
+  - `GameChat.tsx` (423) → `GameChat/` 디렉터리 + 탭별 컴포넌트 (state 모델은 PR-7 범위, 본 PR은 파일 분할만)
+  - `FriendsList.tsx` (415) → `FriendsList/` 디렉터리 + 탭별 컴포넌트
+- **Depends on**: 없음 (PR-4a와 disjoint 병렬)
+- **Rationale**: C-4 / F-react-3·4. CLAUDE.md hard limit (TS 400) 해소. 배럴 type-only + 명시 re-export로 tree-shake 보장.
+- **Size**: M
+- **Risk**: Low
+- **Gate**: `pnpm build` bundle size baseline ≤ +3%
+
+**의존성 그래프**:
+```
+PR-4a ──(독립)──> main
+PR-4b ──(독립)──> main   (PR-4a와 병렬)
+
+PR-2b ── requires ──> PR-4a (combination/reading/accusation 500+ 해소 필요)
+PR-2c ── requires ──> PR-4a (combination 충돌 회피)
+```
 
 ### PR-5: Coverage Gate + mockgen 재도입 + 0% 패키지 전략
 - **Scope**: `.github/workflows/ci.yml`, `apps/web/vitest.config.ts`, `apps/server/internal/infra/otel/**` (테스트 추가), `apps/server/internal/infra/sentry/**`, `apps/server/internal/infra/storage/**`, `apps/server/cmd/server/**`, `apps/server/internal/db/**`, `codecov.yml`, 모든 Service 인터페이스 `//go:generate mockgen` 디렉티브 추가

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4-split-design.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4-split-design.md
@@ -1,0 +1,104 @@
+# PR-4 File Size Refactor Wave — 분할 설계 (index)
+
+> Author: module-architect (Phase 19 W3 → Wave 3 준비)
+> 대상 Finding: F-go-3 (P1, 500+ 초과 10건) · F-go-4 (P1, 함수 80+ 6건) · F-react-1 (P1, GameChat state 이중) · F-react-3 (P1, editor/api.ts 423) · F-react-4 (P1, FriendsList 415)
+> Baseline: main @ 858a1fa (2026-04-17). baseline.md 수치와 실측(`wc -l`) 일치 확인 (reading 652, voting 639, hidden_mission 559, combination 543, trade_clue 532, accusation 515, social/service 759, ws/hub 649, editor/domain/service 505, GameChat 423, editor/api 428, FriendsList 415).
+
+## 결론
+
+원래 PR-4 (L, Med) 를 **2개 PR** 로 분할. 병렬 가능 (PR-4a/PR-4b 상이 파일 집합, import 경로 독립). Wave 3 내 동시 진행 가능.
+
+| PR | Scope | 파일 수 | Size | Risk | Finding |
+|----|-------|--------|------|------|---------|
+| **PR-4a** | Go 모듈 6개 + social/ws/editor/domain 3개 분할 | 9 | **L** | **Med** | F-go-3·4 |
+| **PR-4b** | TS editor/api.ts + GameChat + FriendsList 분할 | 3 | **M** | **Low** | F-react-1·3·4 |
+
+원 PR-4 L 단일 머지 시 Go/TS 양 도메인 리뷰어 동시 요구 + cross-stack rebase 충돌 확률 증가 → 언어 경계로 먼저 가르고, Go 내부는 **모듈 분할 vs 도메인 인프라 분할**로 커밋을 나눈다.
+
+## 문서 맵
+
+- [refs/pr-4/current-state.md](pr-4/current-state.md) — 13 파일 실측 크기 + 섹션별 책임 맵
+- [refs/pr-4/pr-4a-go-split.md](pr-4/pr-4a-go-split.md) — Go 9 파일 하위 패키지 분할 설계 (factory · 등록 패턴 유지)
+- [refs/pr-4/pr-4b-ts-split.md](pr-4/pr-4b-ts-split.md) — TS 3 파일 배럴 re-export + 도메인 sub-files
+- [refs/pr-4/execution-plan.md](pr-4/execution-plan.md) — 실행 순서 · 리스크 · 테스트 · 후속
+
+## 분할 철학
+
+### Go 모듈 (6개: reading · voting · hidden_mission · combination · trade_clue · accusation)
+
+모든 모듈이 **`package xxx` 단일 파일 → `package xxx/` 디렉터리**로 승격.
+
+**공통 레이아웃** (PR-2 split-design 의 "pr-2/" 서브디렉터리 패턴과 일치):
+
+```
+apps/server/internal/module/<category>/<module>/
+├── module.go       # Module 인터페이스(Name/Init/Cleanup/HandleMessage dispatcher) + Factory + init() register + 컴파일 타임 assertion
+├── config.go       # Config struct + Schema() (ConfigSchema 선언적 SSOT)
+├── state.go        # internal state struct + BuildState / BuildStateFor / Save/Restore
+├── handlers.go     # HandleMessage 분기 함수들 (handleX 각각)
+├── reactor.go      # ReactTo / SupportedActions / OnPhaseEnter / OnPhaseExit (구현 모듈만)
+└── events.go       # EventBus subscribe 콜백 (onX 핸들러, 해당 모듈만)
+```
+
+**Factory 서명 불변**: `engine.Register("<name>", func() engine.Module { return New<Name>Module() })` — blank import 경로만 `_ "github.com/.../module/<category>/<module>"` 로 1레벨 깊어진다. 기존 `_ "…/module/decision"` 단일 블랭크 import 가 session package 에서 사용되고 있는지 확인 필요(상위 패키지 init chain 확인 — pr-4/pr-4a-go-split.md §Blank Imports).
+
+**싱글턴 금지 유지**: 모든 모듈은 여전히 `sync.RWMutex` + 세션별 Factory 생성. 디렉터리 분할은 파일 경계만 바꾸고 런타임 불변식(PhaseReactor 이벤트 순서, EventBus subscribe 타이밍) 은 100% 보존.
+
+### Go 인프라 (3개: social/service.go 759 · ws/hub.go 649 · editor/domain/service.go 505)
+
+각 파일은 **도메인 경계로 분할**하되 package 구조는 유지한다.
+
+- `internal/domain/social/` → `friend_service.go` + `chat_service.go` + `types.go` + `helpers.go` (현재 2개 struct + helpers 혼재)
+- `internal/ws/hub.go` → `hub.go` (struct + lifecycle) + `hub_broadcast.go` (Broadcast/Send/Whisper) + `hub_route.go` (Route dispatcher) + `hub_listeners.go` (notifyX / gc)
+- `internal/domain/editor/service.go` → 이미 분할된 sibling (maps / clues / content / media) 와 동일 패턴으로 `service_theme.go` (Theme ops) + `service.go` (interface + constructor + shared helpers)
+
+### TS 프론트 (3개)
+
+- `features/editor/api.ts` → **배럴 re-export index** + `api/themes.ts` · `api/characters.ts` · `api/validation.ts` · `api/content.ts` · `api/module-schemas.ts` · `api/types.ts` 분할. sibling 파일 (editorClueApi / editorMapApi / flowApi / readingApi / mediaApi) 을 같은 `api/` 디렉터리로 흡수할지 여부는 **이번 PR 범위 외** (F-react-3 단독 해소만 목표).
+- `features/game/components/GameChat.tsx` → `GameChat/` 디렉터리 + `index.tsx` (shell) + `GroupTab.tsx` + `WhisperTab.tsx` + `CreateGroupForm.tsx` + 공통 `useChatMessages.ts` (F-react-1: 로컬 state → **Zustand Domain layer 이동 후보** 지만, 상태 이동은 **PR-7 Zustand Action Unification** 와 conflict 가능 → PR-4b 는 파일 분할만 수행하고 state 모델 변경은 out-of-scope).
+- `features/social/components/FriendsList.tsx` → `FriendsList/` 디렉터리 + `index.tsx` (shell + 탭 상태) + `FriendRow.tsx` + `PendingRow.tsx` + `AddFriendModal.tsx` + 공통 `constants.ts` (탭 타입).
+
+## Finding → PR 매핑
+
+| Finding | PR-4a | PR-4b | 비고 |
+|---------|:----:|:----:|----|
+| **F-go-3 500+ 10건** (P1) | 전체 | - | 10건 중 sqlc gen 없는 수동 파일만 대상 (6모듈 + 3인프라 = 9) |
+| **F-go-4 함수 80+ 6건** (P1) | 2건 | - | `accusation.handleAccusationVote` (101) 는 PR-4a 안에서 `handlers.go/vote_tally.go` 로 분리 가능. `editor/RequestUpload·ConfirmUpload` 는 media sibling 이므로 **별도 follow-up** (이미 routes_editor_media.go 분할됨 → 재확인 필요). `coin/Purchase·Refund` · `room/CreateRoom` 은 **out of PR-4 scope** (domain 별 PR). |
+| **F-react-1 GameChat state 이중** (P1) | - | 파일 분할만 | state 모델은 PR-7 범위. 여기선 컴포넌트 150줄 한도만 해소. |
+| **F-react-3 editor/api.ts** (P1) | - | 전체 | 배럴 패턴으로 import 경로 무파괴 (`@/features/editor/api` 유지). |
+| **F-react-4 FriendsList 415** (P1) | - | 전체 | 150줄 한도 초과 3 컴포넌트 합본 → 디렉터리 분할. |
+
+## 실행 순서 요약
+
+```
+Wave 3 전반  → PR-4a (L, Med)   Go 9 파일, 단일 sweeping 커밋 지양, 카테고리별 3~4 커밋
+Wave 3 전반  → PR-4b (M, Low)   TS 3 파일, Go 와 파일셋 disjoint 이므로 병렬 가능
+Wave 3 후반  → PR-8 Module Cache Isolation (S) — PR-7 의존, PR-4 와 독립
+```
+
+Feature flag: **불요**. 파일 분할은 외부 공개 API / 패키지 경로 불변을 원칙으로 하며, Factory 서명·init() 등록·배럴 re-export 으로 caller 영향을 0 으로 만든다. blank import 경로만 1 case 추가 변경 (서버 main 에서 `_ "…/module/decision"` → `_ "…/module/decision/accusation" _ "…/module/decision/voting" _ "…/module/decision/hidden_mission"` 3줄로 확장) — `current-state.md` 에 exhaustive 리스트 첨부.
+
+## 주요 리스크 TOP 3
+
+1. **Go 모듈 디렉터리 승격 시 test 파일 package 재배치 누락** — 각 모듈은 `*_test.go` 를 10~20개 동반. `package decision` → `package voting` 전환 시 기존 "decision_test" 가 참조하던 private 심볼(예: `AccusationModule.timeNow`, `votingSavedState`) 접근이 깨질 수 있음. **완화**: 테스트는 `*_internal_test.go` 로 유지하고 package 를 새 이름으로 동반 변경. PR-4a 는 **test 파일 포함 diff** 로 단일 커밋 단위를 구성.
+
+2. **blank import 누락으로 engine.Register 미호출 → 런타임 "unknown module" 500 에러** — 새 sub-package 를 서버 main 에서 import 하지 않으면 `init()` 이 돌지 않는다. **완화**: `cmd/server/main.go` (또는 `internal/module/register.go` 배럴) 에 **모든** 신규 경로를 한 번에 추가하는 커밋을 PR-4a 에 묶고, CI 에 `go test ./apps/server/internal/module/... -run TestRegistry_AllModulesRegistered` gate 추가 (PR-5 Coverage Gate 이후 활용).
+
+3. **React 배럴 re-export 가 Vite tree-shake 을 저해** — `features/editor/api.ts` 가 18개 hook을 전부 re-export 하면 번들러가 사용 안 하는 훅을 drop 못할 위험. **완화**: 새 구조에서 배럴은 **types 전용 + 명시적 named re-export** 로 제한. 각 페이지는 `@/features/editor/api/themes` 처럼 **sub-path import** 를 권장. 단, 점진 migration 을 위해 레거시 `@/features/editor/api` 는 하위 호환 보존. 번들 크기는 `vite build --mode analyze` 로 PR-4b 전후 비교 필수(test plan 에 포함).
+
+## 다음 단계 (PR-4 착수 전 확인 필요)
+
+1. **phase_engine_test.go (580줄, 테스트 파일)** — 500줄 초과이지만 table-driven 테스트 + 16개 TestPhaseEngine_* 함수로 응집. CLAUDE.md "자동 생성 코드 예외 / 테스트 table-driven 데이터 제외" 규정에 따라 **예외 허용** (pr-4/current-state.md §3 에 예외 승인 기록).
+2. **sqlc gen 5건(회계·에디터·소셜·방·단서 query 생성물)** 은 500 초과여도 리팩터 대상 아님. baseline §1 각주 확인 후 PR-4 scope 에서 제외 명시.
+3. **`apps/server/cmd/server/routes_editor.go`** (backlog 언급 "editor/handler.go" 실체) 는 Phase 18.5 에서 이미 분할됨 (`routes_editor_flow/themes/media.go`). PR-4 는 이 파일 재확인만 하고 스킵.
+4. **react-frontend-engineer 와 PR-7 conflict 조정**: PR-7 (Zustand Action Unification) 이 먼저 머지되면 GameChat 로컬 state 3개(`messages/whisperMessages/groupMessages`) 가 Domain store 로 이동된다. PR-4b 는 PR-7 머지 후 착수하여 이동된 state 기준으로 컴포넌트 분할.
+5. **go-backend-engineer 에게 blank import 배럴 (internal/module/register.go) 존재 여부** 조회 → 없으면 PR-4a 에 신설 제안.
+
+## 참조
+
+- baseline: `refs/shared/baseline.md` §1 (Go 500+) §2 (TS 400+) §3 (함수 80+/60+)
+- audit: `refs/audits/01-go-backend.md` F-go-3, F-go-4
+- audit: `refs/audits/02-react-frontend.md` F-react-1, F-react-3, F-react-4
+- 선행 분할 사례: `apps/server/cmd/server/routes_editor.go` → `routes_editor_{flow,themes,media}.go` (Phase 18.5, commit `1bc1f23`)
+- Factory 패턴 SSOT: `apps/server/internal/engine/registry.go`, `apps/server/internal/engine/factory.go`
+- 유사 PR split 사례: `refs/pr-2-split-design.md`

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/current-state.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/current-state.md
@@ -1,0 +1,100 @@
+# PR-4 Current State — 13 파일 실측 + 섹션 맵
+
+> 모든 수치는 `wc -l` 직접 측정 (2026-04-18 main @ 858a1fa). baseline.md 대비 드리프트 ≤ 2줄 이내.
+
+## 1. Go 모듈 (6건, 평균 573줄)
+
+| 파일 | LOC | Interfaces 구현 | 주요 섹션 (함수 경계) | Handler 분기 수 |
+|------|----:|-----------------|---------------------|:---:|
+| `module/progression/reading.go` | **652** | Module · ConfigSchema · **PhaseHookModule** · PlayerAwareModule | Config + State (L1-102) / HandleVoiceEnded (L104-184) / HandleAdvance (L186-267) / Factory+Init (L269-332) / HandleMessage (L342-419) / PlayerLeft · PlayerRejoined (L421-514) / GetState · Wire (L516-578) / BuildState · Cleanup · Schema (L580-621) / PhaseHook stubs (L623-652) | 3 (advance/voice_ended/jump) |
+| `module/decision/voting.go` | **639** | Module · **PhaseReactor** · ConfigSchema · GameEventHandler · WinChecker · SerializableModule · RuleProvider · PlayerAwareModule | Config + Factory (L1-103) / HandleMessage (L104-196) / ReactTo · SupportedActions (L197-251) / open·closeVoting (L217-271) / tallyResults (L273-339) / Schema (L341-360) / BuildState · BuildStateFor (L362-432) / Cleanup (L434-442) / Validate · Apply (L446-517) / CheckWin (L521-541) / Save·RestoreState (L543-605) / GetRules (L607-639) | 2 (cast/change) |
+| `module/decision/hidden_mission.go` | **559** | Module · ConfigSchema · SerializableModule · WinChecker · RuleProvider · PlayerAwareModule | Config · Factory · Init + subscribe (L1-119) / HandleMessage (L121-222) / completeMission (L225-247) / onClueAcquired · onVoteCast · onClueTransferred (L249-323) / Schema · BuildState · BuildStateFor · Cleanup (L325-403) / Save·RestoreState (L405-485) / CheckWin (L487-527) / GetRules (L529-559) | 3 (report/verify/check) + 3 event subscribers |
+| `module/crime_scene/combination.go` | **543** | Module · GameEventHandler · WinChecker · RuleProvider · SerializableModule · PlayerAwareModule | Config · Init + graph build (L1-147) / checkNewCombos + clue map helpers (L149-195) / HandleMessage (L197-262) / findCombo · inputIDsMatch · hasCompleted (L264-316) / snapshot · BuildState · Cleanup (L318-368) / Validate · Apply (L370-408) / CheckWin (L410-439) / GetRules (L441-458) / Save·RestoreState · BuildStateFor (L460-533) | 1 (combine) + evidence.collected subscriber |
+| `module/cluedist/trade_clue.go` | **532** | Module · ConfigSchema · **PhaseReactor** · SerializableModule · PlayerAwareModule | Config + Factory (L1-99) / HandleMessage + payloads (L100-138) / handleTradePropose/Accept/Decline (L140-253) / handleShowRequest/Accept/Decline (L255-367) / ReactTo · SupportedActions (L369-395) / Schema · BuildState · BuildStateFor · Cleanup (L397-477) / Save·RestoreState (L479-533) | 6 (trade × 3 + show × 3) |
+| `module/decision/accusation.go` | **515** | Module · ConfigSchema · GameEventHandler · WinChecker · **PhaseHookModule** · PlayerAwareModule | Config + Factory (L1-98) / HandleMessage (L100-120) / handleAccuse · handleAccusationVote (L122-262, 함수 한 개 101줄 — **F-go-4**) / handleReset (L264-275) / Schema · BuildState · Cleanup (L277-327) / Validate · Apply (L329-451) / CheckWin (L453-476) / PhaseHook + BuildStateFor (L478-515) | 3 (accuse/vote/reset) |
+
+## 2. Go 도메인 인프라 (3건)
+
+| 파일 | LOC | 주요 섹션 | Struct/Export 수 |
+|------|----:|---------|---:|
+| `domain/social/service.go` | **759** | validMessageTypes · interfaces (L1-53) / friendService impl (L55-329, 10 메서드) / chatService impl (L331-703, 9 메서드 + advisory lock helper) / requireMembership · buildChatRoomResponse · mapMembers · textToString (L705-759) | 2 services + 2 interfaces |
+| `ws/hub.go` | **649** | Constants + Hub struct (L1-95) / SetRegistry · SetSessionSender (L97-107) / run event loop (L109-147) / removeClientLocked · Register · Unregister (L149-192) / JoinSession · isReconnectLocked · gcRecentLeftLocked · LeaveSession (L194-301) / Broadcast × 3 wrappers + core (L303-352) / ReplayToClient (L354-379) / SendToPlayer · Whisper (L381-416) / Route + isSystemType (L418-482) / 5 query helpers (L484-531) / RegisterLifecycleListener + notifyPlayerLeft/Rejoined (L533-610) / gcAllRecentLeft · Stop (L612-649) | 1 Hub + 1 listener pattern |
+| `domain/editor/service.go` | **505** | Request/Response types (L26-111) / Service interface 22 메서드 (L113-163) / service struct + constructor (L165-180) / Theme ops 7 메서드 (L182-398) / shared helpers (getOwnedTheme · text/ptr converters · slugCleanRe · generateSlug · isUniqueViolation · toThemeResponse) (L400-505) | 1 interface + 1 impl + ≥7 helpers |
+
+## 3. TS Frontend (3건)
+
+| 파일 | LOC | 현재 구조 | 주요 책임 |
+|------|----:|---------|---------|
+| `features/editor/api.ts` | **428** | Types (L1-199) + Query Keys (L201-216) + Theme Q/M 8 hooks (L220-341) + Character Q/M 4 hooks (L345-412) + Module Schemas (L374-383) + sibling re-exports (L415-428) | React Query hooks 단일 진입점. Maps/Locations/Clues 는 이미 sibling 파일로 분리되어 배럴만 re-export. |
+| `features/game/components/GameChat.tsx` | **423** | Types (L17-62) + sanitize helpers (L64-83) + GameChat component (L89-423, JSX 200+ 라인 포함) | 3 탭(all/whisper/group) + 3 로컬 state(messages/whisper/group) + WS subscribe × 3 + group 생성 inline UI. **컴포넌트 150줄 한도 2.8배** — 실제 JSX 렌더 영역 L225-421 = 196줄. |
+| `features/social/components/FriendsList.tsx` | **415** | FriendRow sub-component (L46-112) + PendingRow (L126-167) + AddFriendModal (L178-223) + FriendsList main (L229-415, JSX 140줄) | 이미 3개 sub-component 존재하지만 **동일 파일 내 선언** → 150줄 한도 실제 위반은 `FriendsList` 컴포넌트 자체. |
+
+## 4. 예외 판정 (분할 대상 아님)
+
+| 파일 | LOC | 판정 근거 |
+|------|----:|---------|
+| `engine/phase_engine_test.go` | 580 | **테스트 파일** — CLAUDE.md "테스트 table-driven 데이터 카운트에서 제외" 규정 해당. 16개 TestPhaseEngine_* 함수 응집, 분할 시 helper 중복 발생. PR-4 scope 제외. |
+| `db/sqlc/*.sql.go` 5건 (accounts · editor · social · rooms · clues) | 각 500~900 | **자동 생성** — 수정 대상 아님. baseline §1 각주 참조. |
+| `cmd/server/routes_editor.go` | 253 (Phase 18.5 분할 후) | Phase 18.5 에서 `routes_editor_flow/themes/media.go` 로 이미 분할됨. 현재 500 미만. PR-4 scope 제외. |
+
+## 5. 함수 80줄 초과 (F-go-4) — PR-4 내 다룰 범위
+
+| 함수 | 파일 | LOC | PR-4 처리 |
+|------|------|---:|---------|
+| `handleAccusationVote` | `module/decision/accusation.go` | 101 (L164-262) | **PR-4a 포함** — accusation 모듈 분할 시 `tally.go` 로 수학 판정 로직(L203-239) 추출 → `handleAccusationVote` 60줄 이하로 축소 |
+| `editor/RequestUpload` 89 · `editor/ConfirmUpload` 85 | `domain/editor/media_service.go` | - | **PR-4 scope 외** — 이미 별도 파일, 함수 내부 단순화는 에디터 follow-up PR 로 이관 |
+| `coin/PurchaseTheme` 156 · `RefundTheme` 115 | `domain/coin/service.go` | - | **PR-4 scope 외** — domain 별 PR, backlog 재분류 |
+| `room/CreateRoom` 83 | `domain/rooms/service.go` | - | **PR-4 scope 외** — 동일 |
+
+## 6. Blank Import 영향 범위 (확인 완료 — `internal/module/register.go`)
+
+현재 진입점: `apps/server/internal/module/register.go` — **카테고리 패키지만 blank-import** (8 카테고리):
+
+```go
+package module
+import (
+    _ "…/module/cluedist"
+    _ "…/module/communication"
+    _ "…/module/core"
+    _ "…/module/crime_scene"
+    _ "…/module/decision"
+    _ "…/module/exploration"
+    _ "…/module/media"
+    _ "…/module/progression"
+)
+```
+
+각 카테고리 패키지 파일들(`voting.go`, `accusation.go`, ...)이 같은 `package decision` 에 속해 있으므로 **단일 import 로 모든 모듈 init() 이 호출**되는 구조.
+
+### 분할 후 유지 전략: **카테고리 내부 register.go 패턴**
+
+모듈을 sub-package 로 승격하면 `package decision` 이 더 이상 init() 을 소유하지 않는다. 해결책 두 가지:
+
+**A. 카테고리 패키지에 `register.go` 신설 (권장)**:
+
+```go
+// apps/server/internal/module/decision/register.go
+package decision
+import (
+    _ "…/module/decision/accusation"
+    _ "…/module/decision/voting"
+    _ "…/module/decision/hidden_mission"
+)
+```
+
+`internal/module/register.go` 는 **변경 없음**. 카테고리 경계는 현재 8건 그대로 유지, 내부만 2층 구조로 확장. 단일 PR diff minimal.
+
+**B. 최상위 register.go 확장**: 모든 모듈을 개별 경로로 import. 8줄 → 29줄. diff 가 크고 새 모듈 추가 시마다 최상위 편집 강제.
+
+**결정**: **A 패턴 채택**. PR-4a 각 모듈 디렉터리 승격 커밋 다음에 카테고리별 `register.go` 신설 커밋 1건씩 추가 (커밋 단위는 그대로 유지).
+
+### PR-4a 영향 대상 카테고리 (6 모듈 → 4 카테고리)
+
+| 카테고리 | 승격 대상 모듈 | 카테고리 내부 register.go 필요 | 기타 같은 카테고리 파일 (미승격) |
+|----------|--------------|:---:|-----|
+| `decision` | accusation · voting · hidden_mission | **필수** | (기타 decision 모듈 — 확인 필요) |
+| `progression` | reading | **필수** | (기타 progression 모듈 — 확인 필요) |
+| `crime_scene` | combination | **필수** | evidence · location (이미 sub-files 일 수 있음, pr-4a 착수 시 재확인) |
+| `cluedist` | trade_clue | **필수** | starting_clue · round_clue · timed_clue · conditional_clue (동일 카테고리 다수, **함께 승격 여부 판단 필요** — 미승격 시 category 내 혼재 발생) |
+
+**추가 판단 필요 (PR-4a 착수 전 go-backend-engineer 에게 질의)**: cluedist 에 5+ 모듈이 있다면 trade_clue 만 디렉터리 승격하면 **파일 1개 + 디렉터리 1개** 혼재 구조가 된다. 일관성을 위해 cluedist 전체 모듈을 같이 승격할지 결정. 시간 상 PR-4a 한 번에 몰지, 후속 PR 로 점진 이행할지도 같이 결정.

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/execution-plan.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/execution-plan.md
@@ -1,0 +1,99 @@
+# PR-4 Execution Plan — Wave 3 착수 순서 · 리스크 · 테스트
+
+## 1. Wave 배치 (backlog 확정)
+
+```
+Wave 0 → PR-0 (memory migration)
+Wave 1 → PR-1 (WS Contract SSOT) + PR-3 (HTTP Error Standard) + PR-6 (Auditlog)
+Wave 2 → PR-2a/2b/2c (PlayerAware) + PR-5 (Coverage Gate) + PR-7 (Zustand Unification)
+Wave 3 → PR-4a (Go split) ∥ PR-4b (TS split) + PR-8 (Module Cache Isolation)
+```
+
+PR-4a 와 PR-4b 는 파일셋 disjoint 이므로 Wave 3 내 **병렬 실행**. PR-7 머지 후 PR-4b 착수하면 GameChat 상태 이동이 smooth.
+
+## 2. PR-4a vs PR-4b 선후 판단
+
+| 선행 후보 | 근거 |
+|-----------|------|
+| **PR-4a 먼저** (Go) | Wave 2 PR-2 의 module 파일을 직접 건드림. PR-2a 머지 후 diff noise 최소화 위해 빠르게 이어 착수. |
+| **PR-4b 먼저** (TS) | PR-7 (Zustand Action Unification) 완료 후 GameChat 상태 이동 반영 용이. 단 PR-7 이 Wave 2 에 머지된다면 Wave 3 초입엔 이미 준비 완료. |
+
+**권장**: Wave 3 시작일에 PR-4a 와 PR-4b 를 **동시 병렬 실행** (worktree 분리). 일정상 작업자 1명이면 PR-4a 선행 (리뷰어 Go domain 우선 확보 용이).
+
+## 3. Git 워크플로우
+
+- 브랜치: `refactor/phase-19-pr-4a-go-split`, `refactor/phase-19-pr-4b-ts-split`
+- 커밋 단위: pr-4a-go-split.md §5 (11 커밋) + pr-4b-ts-split.md §5 (4 커밋)
+- PR 제목:
+  - `refactor(phase-19): PR-4a — Go 모듈·인프라 9 파일 분할 (F-go-3/4)`
+  - `refactor(phase-19): PR-4b — TS editor/api · GameChat · FriendsList 분할 (F-react-1/3/4)`
+- 하나의 PR 당 main 머지 전 **사용자 확인 1회** 필수 (Wave 3 Gate 에 포함).
+
+## 4. 테스트 전략
+
+### 4.1 PR-4a (Go)
+
+| 수준 | 스위트 | Gate |
+|------|-------|------|
+| Unit | `go test ./apps/server/internal/module/...` | 전 모듈 기존 테스트 100% pass (리팩터 불변식) |
+| Unit | `go test ./apps/server/internal/ws/...` | Hub broadcast / lifecycle / reconnect 기존 테스트 pass |
+| Unit | `go test ./apps/server/internal/domain/social/...` + `domain/editor/...` | 기존 service test 분할 후 pass |
+| Integration | `go test -tags=integration ./apps/server/...` (testcontainers) | registry.Register 호출 검증 |
+| Lint | `golangci-lint run ./apps/server/...` | file size rule (있다면) 통과 |
+| 신규 테스트 | `registry_test.go`: `TestRegistry_AllCoreModulesRegistered` — 29개 모듈 이름이 registry 에 등록되었는지 검증 (blank import 누락 탐지) | 신규 추가, **PR-4a 필수** |
+
+### 4.2 PR-4b (TS)
+
+| 수준 | 스위트 | Gate |
+|------|-------|------|
+| Unit | `pnpm test` (Vitest) | 기존 GameChat/FriendsList/api 테스트 pass |
+| Type | `pnpm typecheck` | import path 변경 반영 |
+| Lint | `pnpm lint` | no-unused-imports / no-cycle 통과 |
+| Build | `pnpm build` | tree-shake 후 bundle size ≤ baseline+3% |
+| E2E | `pnpm test:e2e` (Playwright, 에디터 + 게임 + 소셜 플로우) | 기존 시나리오 pass |
+
+### 4.3 mmp-test-strategy 반영
+
+- mockgen / testcontainers-go 기존 패턴 유지 (PR-4a 는 package 경로 변경만)
+- MSW handler 경로 변경 없음 (PR-4b 배럴 유지)
+- 커버리지 리포트: PR-4 전후 `go tool cover` 동일성 ± 0.5%p 유지
+
+## 5. 리스크 · 완화 매트릭스
+
+| ID | 리스크 | 영향 | 완화 |
+|----|-------|------|------|
+| R1 | 모듈 디렉터리 승격 시 `package xxx_test` black-box 테스트 package 이름 누락 | CI 빨강 | 각 sub-package 생성 시 test 파일 package 선언 grep 으로 사전 확인 |
+| R2 | blank import 경로 갱신 누락 → 런타임 `engine.Register` 미호출 → "unknown module" 500 | 프로덕션 장애 | `registry_test.go` TestRegistry_AllCoreModulesRegistered 신규 추가. cmd/server/main.go 변경 시 `go vet` import 경로 전수 검증 |
+| R3 | TS 배럴로 tree-shake 저해, bundle size 증가 | 번들 크기 | vite build analyze 전후 비교. 배럴은 hook re-export 만, type-only re-export 사용 |
+| R4 | accusation tally.go 함수 추출 시 lock 경계 누락 → 데이터 레이스 | 게임 로직 버그 | `handleAccusationVote` 의 mu.Lock 보유 범위를 tallyVotes 호출 이전으로 한정. race detector `go test -race` 필수 |
+| R5 | GameChat 파일 분할로 `useWsEvent` 구독이 탭 컴포넌트 unmount 시 leak | 메모리 누수 | useChatMessages hook 을 shell(index.tsx) 에서만 사용. 탭 컴포넌트는 구독 없음 |
+| R6 | Phase 20 또는 다른 feature PR 과 git conflict | 리뷰 지연 | Wave 3 시작 직후 PR 생성, conflict 발생 시 rebase + 커밋 단위 cherry-pick |
+
+## 6. Finding 해소 매핑 (최종)
+
+| Finding | PR | 해소 방식 | Acceptance |
+|---------|:--:|---------|-----------|
+| **F-go-3 500+ 10건 (P1)** | PR-4a | 6 모듈 디렉터리 승격 + 3 인프라 분할. 수동 500+ 파일 0건 수렴 (sqlc · 테스트 파일 제외) | `find apps/server -name '*.go' -not -name '*_test.go' -not -path '*/db/sqlc/*' | xargs wc -l | awk '$1>500'` empty |
+| **F-go-4 함수 80+ 6건 중 1건 (P1)** | PR-4a | `accusation.handleAccusationVote` 101줄 → 60줄 + `tallyVotes` 40줄 (tally.go) | gocyclo / funlen ≤ 80 linter pass |
+| **F-react-1 GameChat state 이중 (P1)** | PR-4b (partial) | 파일 분할만 이번 PR, state 모델은 PR-7 에서 완결 | GameChat shell 150줄 이하 |
+| **F-react-3 editor/api.ts 423 (P1)** | PR-4b | api/ 디렉터리 + 배럴 + sub-files | 파일 400+ 0건 |
+| **F-react-4 FriendsList 415 (P1)** | PR-4b | FriendsList/ 디렉터리 + 탭 컴포넌트 추출 | 파일 400+ 0건, 컴포넌트 150+ 0건 |
+
+## 7. 후속 작업 (PR-4 merge 후)
+
+1. **ESLint rule 활성화**: file-size · function-size (Biome 기반), 400/150/60 한도 강제 → CI gate 로 재발 방지. 별도 PR.
+2. **sibling 파일 통합** (features/editor/): `editorClueApi`, `editorMapApi`, `flowApi`, `readingApi`, `mediaApi`, `templateApi`, `imageApi`, `editorConfigApi`, `clueEdgeApi` 를 `api/` 디렉터리로 마이그레이션 → F-react-3 완전 해소. Phase 20 이후 기술 부채 PR 로.
+3. **module-architect 리뷰**: 각 모듈 디렉터리 승격 후 `Factory 독립성 테스트` + `PhaseReactor 순서 테스트` 확장 (mmp-test-strategy 스킬 → test-engineer 요청). Phase 20 착수 전 1회.
+4. **docs-navigator 인덱싱**: `docs/plans/2026-04-05-rebuild/module-spec.md` 의 모듈 경로 예시 업데이트 필요 여부 확인 (module-spec 은 이름 기반이므로 영향 low 예상). 갱신 시 QMD reindex.
+
+## 8. 진척도 tracker (체크리스트)
+
+- [ ] PR-4a Wave 3 착수 가능 시점: Wave 2 (PR-2a/b/c + PR-7) 전부 main 머지 후
+- [ ] Go-backend-engineer 에 Factory 서명 리뷰 요청 완료 (module-architect → go-backend-engineer)
+- [ ] Test-engineer 에 "모듈 Factory 독립성 테스트 + PhaseReactor 순서 테스트" 요청 완료
+- [ ] React-frontend-engineer 에 "ConfigSchema → 에디터 UI 매핑" 영향도 조회 완료 (schema 파일 이동 여부)
+- [ ] `registry_test.go` TestRegistry_AllCoreModulesRegistered 작성
+- [ ] bundle size baseline 측정 (PR-4b 착수 전)
+- [ ] PR-4a / PR-4b PR 생성 + 사용자 승인
+- [ ] main 머지 후 `find ... | awk '$1>500'` / `awk '$1>400'` 0건 확인
+- [ ] MEMORY.md `project_phase19_audit_progress.md` 에 Finding 해소 기록

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/pr-4a-go-split.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/pr-4a-go-split.md
@@ -1,0 +1,149 @@
+# PR-4a Go Split — 9 파일 하위 패키지 분할
+
+> Scope: Go 6 모듈 + 3 인프라 파일. Size L. Risk Med.
+> 선행 의존: 없음 (PR-7 Zustand 와 무관). PR-2/PR-3/PR-6 Wave 1·2 결과 반영 후 Wave 3 에서 착수.
+
+## 1. 공통 분할 레이아웃 (6 모듈 공통)
+
+기존 `apps/server/internal/module/<category>/<module>.go` (단일 파일) →
+`apps/server/internal/module/<category>/<module>/` (디렉터리, package 이름 `<module>`).
+
+```
+<module>/
+├── module.go        # Factory + init() + Name · Init · Cleanup · HandleMessage 스위치 + interface assertions
+├── config.go        # Config struct + Schema() (ConfigSchema SSOT — 에디터가 읽는 단일 원본)
+├── state.go         # 내부 state struct + BuildState · BuildStateFor · Save · RestoreState
+├── handlers.go      # HandleMessage dispatch → handleX 함수들 (action 단위 분리)
+├── reactor.go       # ReactTo · SupportedActions · OnPhaseEnter · OnPhaseExit (해당 인터페이스 구현 모듈만)
+└── events.go        # EventBus Subscribe 콜백 (onClueAcquired 등, 해당 모듈만)
+```
+
+**패키지 경로 변경**: 상위 category (`decision`, `progression`, ...) 는 유지. 단, category 패키지가 다중 모듈을 담았던 기존 구조는 각 서브디렉터리로 쪼개진다.
+
+**Factory 서명 불변**: `engine.Register("<name>", func() engine.Module { return New<Name>Module() })` 와 `var _ engine.Module = (*<Name>Module)(nil)` 컴파일 타임 assertion 유지. 리뷰어가 Factory 무파괴를 한눈에 확인할 수 있도록 `module.go` 최상단/최하단에 배치.
+
+## 2. 모듈별 세부 맵
+
+### 2.1 `reading.go` (652 → 6 파일)
+
+| 파일 | 라인 예상 | 내용 (현재 라인 범위) |
+|------|----:|---------|
+| `module.go` | ~140 | Factory + Init (L269-332) + HandleMessage 라우팅 (L342-350, L415-418) + interface assertions (L642-648) + `init()` (L650-652) |
+| `config.go` | ~80 | `readingConfig` · `readingLineConfig` (L55-70) + `Schema()` (L602-621) + `validAdvanceBy` · `resolveAdvanceBy` · `resolveVoiceID` (L72-102, L334-340) |
+| `state.go` | ~170 | `readingStatus` const (L37-43) + `ReadingState` + `ReadingStateWire` (L45-53, L547-557) + `GetState` · `GetReadingStateWire` · `BuildState` · `BuildStateFor` · `Cleanup` (L516-599, L633-640) |
+| `handlers.go` | ~140 | `HandleAdvance` (L186-267) + `HandleVoiceEnded` (L104-184) + legacy `HandleMessage` jump 분기 (L370-413) |
+| `reactor.go` | ~70 | `OnPhaseEnter` · `OnPhaseExit` (L623-631) + `HandlePlayerLeft` · `HandlePlayerRejoined` (L421-514) |
+| `events.go` | (없음) | reading 은 EventBus Subscribe 콜백 없음 → 파일 생성 스킵 |
+
+### 2.2 `voting.go` (639 → 6 파일)
+
+| 파일 | 라인 예상 | 내용 |
+|------|----:|---------|
+| `module.go` | ~70 | Factory + Init + HandleMessage dispatch (L52-117) + init() + assertions (L629-639) |
+| `config.go` | ~60 | `VotingConfig` + `VoteResult` (L19-36) + `Schema` (L343-360) |
+| `state.go` | ~180 | `votingState` · `votingSavedState` (L362-370, L545-552) + `BuildState` · `BuildStateFor` · `Cleanup` (L372-442) + `SaveState` · `RestoreState` (L554-605) |
+| `handlers.go` | ~100 | `handleVoteCast` · `handleVoteChange` (L119-195) + payload types (L104-106) |
+| `reactor.go` | ~130 | `ReactTo` · `SupportedActions` · `openVoting` · `closeVoting` · `tallyResults` (L199-339) |
+| `events.go` | (없음) | voting 은 EventBus Subscribe 콜백 없음 |
+| `rules.go` | ~30 | `GetRules` (L609-627) + `Validate` · `Apply` (GameEventHandler) (L446-517) — rules + game event handler 분리 |
+
+> 예외: voting 은 WinChecker + RuleProvider + GameEventHandler 추가 인터페이스 때문에 7개 파일. 리뷰어 혼란 방지를 위해 `module.go` 상단 주석에 "7-file layout (has rules.go due to WinChecker/RuleProvider)" 명시.
+
+### 2.3 `hidden_mission.go` (559 → 6 파일)
+
+| 파일 | 라인 예상 | 주요 내용 |
+|------|----:|---------|
+| `module.go` | ~90 | Factory + Init (EventBus subscribe × 3) + HandleMessage dispatch + init + assertions |
+| `config.go` | ~40 | `HiddenMissionConfig` · `Mission` + `Schema` |
+| `state.go` | ~200 | `hiddenMissionState` · `hiddenMissionSavedState` + `BuildState` · `BuildStateFor` · `Save·RestoreState` · `Cleanup` |
+| `handlers.go` | ~100 | `handleReport` · `handleVerify` · `handleCheck` · `completeMission` |
+| `events.go` | ~100 | `onClueAcquired` · `onVoteCast` · `onClueTransferred` (L249-323) |
+| `rules.go` | ~40 | `CheckWin` + `GetRules` |
+
+### 2.4 `combination.go` (543 → 6 파일)
+
+| 파일 | 라인 예상 | 주요 내용 |
+|------|----:|---------|
+| `module.go` | ~90 | Factory + Init(graph build) + HandleMessage dispatch + init + assertions |
+| `config.go` | ~40 | `CombinationDef` · `CombinationConfig` (no Schema — 현재 없음, 필요시 추가) |
+| `state.go` | ~180 | `combinationState` + `snapshot` + `BuildState` · `BuildStateFor` · `Save·RestoreState` · `Cleanup` |
+| `handlers.go` | ~130 | `handleCombine` · `findCombo` · `inputIDsMatch` · `hasCompleted` + `checkNewCombos` + clue map helpers |
+| `events.go` | ~30 | `evidence.collected` subscriber (현재 Init 인라인 lambda L122-144 → 이름 있는 메서드로 추출) |
+| `rules.go` | ~70 | `Validate` · `Apply` · `CheckWin` · `GetRules` |
+
+### 2.5 `trade_clue.go` (532 → 5 파일)
+
+| 파일 | 라인 예상 | 주요 내용 |
+|------|----:|---------|
+| `module.go` | ~80 | Factory + Init + HandleMessage dispatch + init + assertions |
+| `config.go` | ~50 | `TradeClueConfig` + `Schema` + `TradeProposal` · `ShowSession` types |
+| `state.go` | ~150 | `tradeClueState` + `BuildState` · `BuildStateFor` · `Save·RestoreState` · `Cleanup` |
+| `handlers.go` | ~230 | 6 handler 함수 (trade × 3 + show × 3) — 가장 큰 파일이지만 80줄 이하 함수들 모음이므로 수용 가능 |
+| `reactor.go` | ~30 | `ReactTo` (ALLOW_EXCHANGE) + `SupportedActions` |
+
+### 2.6 `accusation.go` (515 → 6 파일 + 함수 축소)
+
+| 파일 | 라인 예상 | 주요 내용 |
+|------|----:|---------|
+| `module.go` | ~80 | Factory + Init + HandleMessage dispatch + init + assertions |
+| `config.go` | ~50 | `AccusationConfig` · `Accusation` + `Schema` |
+| `state.go` | ~70 | `accusationState` + `BuildState` · `BuildStateFor` · `Cleanup` |
+| `handlers.go` | ~100 | `handleAccuse` · `handleAccusationVote` (50줄) · `handleReset` |
+| `tally.go` | ~80 | **NEW** — `handleAccusationVote` 의 수학 판정 부분(L203-239) 을 `tallyVotes(counts, eligibleVoters) (expelled bool, guiltyPct int)` 로 추출 → **F-go-4 해소** |
+| `reactor.go` | ~20 | `OnPhaseEnter` · `OnPhaseExit` |
+| `rules.go` | ~110 | `Validate` · `Apply` · `CheckWin` |
+
+## 3. 인프라 파일 분할 (3건)
+
+### 3.1 `domain/social/service.go` (759 → 4 파일)
+
+- `service.go` — interface 선언 + `validMessageTypes` + package doc (~80줄)
+- `friend_service.go` — `friendService` struct + `NewFriendService` + 10 메서드 (SendRequest/Accept/Reject/RemoveFriend/ListFriends/ListPendingRequests/BlockUser/UnblockUser/ListBlocks) (~300줄)
+- `chat_service.go` — `chatService` struct + `NewChatService` + 9 메서드 + `dmLockKey` (~320줄)
+- `helpers.go` — `requireMembership` · `buildChatRoomResponse` · `mapMembers` · `textToString` (~60줄)
+
+Package 경로 불변 (`internal/domain/social`). 외부 caller (route wiring) 영향 0. 기존 테스트는 `service_test.go` 유지하되, friend/chat 분리 원한다면 `friend_service_test.go` · `chat_service_test.go` 신설 (선택, 본 PR 범위).
+
+### 3.2 `ws/hub.go` (649 → 4 파일)
+
+- `hub.go` — constants + Hub struct + NewHub + SetRegistry/SetSessionSender + run event loop + removeClientLocked + Register/Unregister + Stop (~220줄, 핵심 lifecycle)
+- `hub_session.go` — JoinSession · isReconnectLocked · gcRecentLeftLocked · gcAllRecentLeft · LeaveSession (~120줄)
+- `hub_broadcast.go` — BroadcastToSession × 3 wrappers + broadcastToSession core + ReplayToClient + SendToPlayer + Whisper (~130줄)
+- `hub_route.go` — Route + isSystemType + 5 query helpers (SessionClients/ClientCount/SessionCount/HasSession/SessionBuffer) (~100줄)
+- `hub_listeners.go` — RegisterLifecycleListener + notifyPlayerLeft + notifyPlayerRejoined (~80줄)
+
+모두 package `ws` 유지. `var _ ClientHub = (*Hub)(nil)` assertion 은 `hub.go` 에 유지.
+
+### 3.3 `domain/editor/service.go` (505 → 3 파일)
+
+- `service.go` — Service interface + service struct + NewService + 공유 helpers (getOwnedTheme · text/ptr converters · slugCleanRe · generateSlug · isUniqueViolation · toThemeResponse) (~170줄)
+- `service_theme.go` — Theme ops 7 메서드 (CreateTheme/UpdateTheme/DeleteTheme/ListMyThemes/GetTheme/PublishTheme/UnpublishTheme/SubmitForReview) (~220줄)
+- `types.go` — Request / Response struct 들 (CreateThemeRequest · UpdateThemeRequest · ThemeResponse · ThemeSummary · Character types) (~115줄)
+
+이미 sibling 파일(`map_service.go`, `clue_service.go`, `location_service.go`, `media_service.go`, `content_service.go`, `flow_service.go`) 이 존재하는 패턴과 일치. **reviewer 는 "Theme ops 만 별도 파일로 뺌" 1줄로 diff 요약 가능**.
+
+## 4. 테스트 영향
+
+- 모든 `*_test.go` 는 해당 모듈의 신규 sub-package 로 이동. 예: `module/decision/voting_test.go` → `module/decision/voting/voting_test.go` (package `voting`).
+- 기존 `package decision_test` black-box 테스트가 있으면 `package voting_test` 로 rename. 참조하는 internal 심볼이 있다면 `package voting` (white-box) 로 전환.
+- `engine.Register` 가 test setup 에서 호출되는 케이스는 없음 확인 (SessionManager 가 registry lookup). PR-4a 는 main blank import 조정만.
+
+## 5. 커밋 granularity 제안
+
+> blank import 진입점은 이미 `apps/server/internal/module/register.go` 에 존재 (8 카테고리). 각 카테고리 내부에 **`register.go` 신설** (category-local blank imports) 하여 최상위 register.go 는 무변경.
+
+1. `chore(phase-19): module/decision 내부 register.go + voting 디렉터리 승격 + Factory 불변 assertion`
+2. `chore(phase-19): module/decision/hidden_mission 디렉터리 승격 + register.go 추가 import`
+3. `chore(phase-19): module/decision/accusation 디렉터리 승격 + tally.go 함수 추출 (F-go-4)`
+4. `chore(phase-19): module/progression 내부 register.go + reading 디렉터리 승격`
+5. `chore(phase-19): module/crime_scene 내부 register.go + combination 디렉터리 승격`
+6. `chore(phase-19): module/cluedist 내부 register.go + trade_clue 디렉터리 승격` (cluedist 타 모듈 일관성 판단은 current-state §6 결정 반영)
+7. `refactor(phase-19): ws/hub 4파일 분할`
+8. `refactor(phase-19): domain/social/service 4파일 분할`
+9. `refactor(phase-19): domain/editor/service 3파일 분할 (sibling 패턴 일치 — service_theme.go 추가)`
+10. `test(phase-19): registry_test.go — TestRegistry_AllCoreModulesRegistered (blank import 누락 탐지)`
+11. `chore(phase-19): PR-4a 최종 wc -l 검증 + CLAUDE.md 한도 복귀 확인`
+
+각 커밋은 `go build ./...` + `go test ./apps/server/internal/...` green. `gofmt`/`goimports`/`golangci-lint run` 통과. Wave 3 머지 전 Linear 하게 push → PR 1건.
+
+**caveat**: editor 도메인은 **이미 sibling 분할된 상태**(`service.go` + `service_character.go` + `service_clue.go` + `service_config.go` + `service_location.go` + `service_validation.go` + `media_service.go` + `image_service.go` + `reading_service.go` + `clue_edge_service.go` + `types.go`). PR-4a §9 는 Theme ops 만 `service_theme.go` 로 분리하는 1-step 작업.

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/pr-4b-ts-split.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-4/pr-4b-ts-split.md
@@ -1,0 +1,128 @@
+# PR-4b TS Split — 3 파일 배럴 + 컴포넌트 분할
+
+> Scope: 3 TS/TSX 파일 (`features/editor/api.ts` 428 · `features/game/components/GameChat.tsx` 423 · `features/social/components/FriendsList.tsx` 415). Size M. Risk Low.
+> 선행 의존: PR-7 Zustand Action Unification 권장 (GameChat 로컬 state → Domain store 이동). PR-7 미완이면 PR-4b 는 **파일 분할만** 수행하고 state 모델 변경은 out-of-scope.
+
+## 1. `features/editor/api.ts` → 배럴 + sub-files
+
+### 1.1 제안 구조
+
+```
+features/editor/api/
+├── index.ts            # 배럴 re-export (하위 호환)
+├── types.ts            # 공용 Request/Response types (ThemeResponse · CharacterResponse · ...)
+├── keys.ts             # editorKeys 객체 (Query Keys SSOT)
+├── themes.ts           # Theme Q/M 8 hooks (useEditorThemes/useEditorTheme/useCreateTheme/.../useSubmitForReview/useUpdateConfigJson)
+├── characters.ts       # Character Q/M 4 hooks
+├── content.ts          # Content Q/M (useEditorContent · useUpsertContent)
+├── validation.ts       # useValidateTheme
+└── moduleSchemas.ts    # useModuleSchemas + ModuleSchemasResponse type
+```
+
+기존 sibling(`editorClueApi.ts` · `editorMapApi.ts` · `flowApi.ts` · `readingApi.ts` · `mediaApi.ts` · `templateApi.ts` · `imageApi.ts` · `editorConfigApi.ts` · `clueEdgeApi.ts`) 은 **이번 PR 에서 이동하지 않는다**. F-react-3 의 핵심은 `api.ts` 단일 파일 423줄 해소이므로 sibling 통합은 후속 PR로.
+
+### 1.2 배럴 (index.ts) 예시
+
+```typescript
+// features/editor/api/index.ts (30줄 이내)
+export * from "./types";
+export { editorKeys } from "./keys";
+export * from "./themes";
+export * from "./characters";
+export * from "./content";
+export * from "./validation";
+export * from "./moduleSchemas";
+
+// 레거시 sibling re-exports (기존 유지)
+export { useEditorClues, useCreateClue, useUpdateClue, useDeleteClue } from "../editorClueApi";
+export type { UpdateMapRequest, CreateLocationRequest, UpdateLocationRequest } from "../editorMapApi";
+export {
+  useEditorMaps, useCreateMap, useUpdateMap, useDeleteMap,
+  useEditorLocations, useCreateLocation, useUpdateLocation, useDeleteLocation,
+} from "../editorMapApi";
+```
+
+**Import path 하위호환**: 기존 `import { useEditorThemes } from "@/features/editor/api"` 가 그대로 동작. 점진 migration 을 위해 새 페이지는 `@/features/editor/api/themes` 처럼 sub-path import 권장. 단, ESLint rule "no-barrel-import" 활성화는 **이번 PR 범위 외**.
+
+### 1.3 Tree-shake 검증
+
+PR-4b 머지 전후 `vite build --mode analyze` 실행하여 bundle size delta 비교. 배럴로 인해 번들이 5% 이상 증가하면 배럴을 **type-only re-export + 명시적 hook re-export** 로 제한. Test plan 에 포함.
+
+## 2. `features/game/components/GameChat.tsx` → 디렉터리 분할
+
+### 2.1 제안 구조
+
+```
+features/game/components/GameChat/
+├── index.tsx                 # 최상위 shell. 탭 state + 레이아웃 + 현재 탭 렌더링 (~150줄)
+├── AllChatPanel.tsx          # 전체 채팅 탭 (~60줄)
+├── WhisperPanel.tsx          # 귓속말 탭 (대상 selector + 메시지 리스트) (~90줄)
+├── GroupPanel.tsx            # 그룹 탭 (그룹 목록 + 선택된 그룹 메시지) (~100줄)
+├── CreateGroupForm.tsx       # 그룹 생성 inline UI (멤버 체크박스 + 제출) (~80줄)
+├── ChatInput.tsx             # Input + Send 버튼 (탭별 placeholder + disabled 로직) (~50줄)
+├── useChatMessages.ts        # 3 useWsEvent 구독 + appendMessage 로직 모음 (~80줄)
+└── types.ts                  # ChatPayload · WhisperPayload · GroupMessagePayload · GroupChatData · TabType (~40줄)
+```
+
+**공유 utilities**:
+- `sanitizeChat` · `appendMessage` · `MAX_*` 상수 → `types.ts` 또는 `utils.ts` (별도 파일 대신 types.ts 하단에 두어 파일 수 최소화)
+
+### 2.2 State 모델 — PR-7 과의 경계
+
+현재 GameChat 은 `messages`/`whisperMessages`/`groupMessages` 3개 로컬 state 를 사용하며, 이는 **Domain 계층에서 관리되어야 할 상태**(F-react-1). PR-7 (Zustand Action Unification) 이 먼저 머지되어 `useChatStore` (Domain) 가 생기면 PR-4b 는 `useChatMessages.ts` hook 이 `useChatStore` 를 subscribe 하도록 설계. PR-7 이 나중이면 PR-4b 는 **로컬 state 그대로 유지** 하고 F-react-1 은 PR-7 범위로 이관.
+
+### 2.3 Import path 하위호환
+
+기존 `import { GameChat } from "@/features/game/components/GameChat"` 은 TypeScript 의 `moduleResolution: "bundler"` 덕분에 자동으로 `GameChat/index.tsx` 로 resolve. **호출자 변경 없음**.
+
+## 3. `features/social/components/FriendsList.tsx` → 디렉터리 분할
+
+### 3.1 제안 구조
+
+```
+features/social/components/FriendsList/
+├── index.tsx              # 최상위 shell. 탭 state + 검색 + 목록 렌더링 (~150줄)
+├── FriendRow.tsx          # 친구 row + 삭제 확인 Modal (~90줄, 기존 L46-112)
+├── PendingRow.tsx         # 대기 중인 요청 row (~50줄, 기존 L126-167)
+├── AddFriendModal.tsx     # 친구 추가 Modal (~70줄, 기존 L178-223)
+├── FriendsTab.tsx         # 친구 목록 탭 (검색 + EmptyState + 리스트) (~70줄)
+├── PendingTab.tsx         # 대기 요청 탭 (~50줄)
+└── useFriendActions.ts    # handleRemove · handleAccept · handleReject (toast 포함) (~60줄)
+```
+
+### 3.2 변경점 요약
+
+- 현재 이미 파일 내부에 `FriendRow` · `PendingRow` · `AddFriendModal` sub-component 선언 → 각각 별도 파일로 승격.
+- 메인 `FriendsList` 컴포넌트(L229-415, 186줄)를 탭 분리 + 핸들러 훅 추출로 150줄 이하로 축소.
+- 공용 `getNicknameColor` import 는 그대로 유지 (`@/shared/utils/nickname`).
+
+### 3.3 Import path 하위호환
+
+디렉터리 승격 + `index.tsx` 패턴이므로 `import { FriendsList } from "@/features/social/components/FriendsList"` 그대로 동작.
+
+## 4. 테스트 영향
+
+| 대상 | 현재 테스트 | 분할 후 |
+|------|------|---------|
+| editor/api | `editorConfigApi.test.ts` · `mediaApi.test.ts` · `readingApi.test.ts` (sibling) | 기존 테스트 유지. 새 `api/themes.test.ts` · `api/characters.test.ts` 작성 권장 (PR-4b scope 포함) |
+| GameChat | 확인 필요 — `GameChat.test.tsx` 있다면 import path 만 수정 | 탭별 단위 테스트 추가 가능 (별도 PR) |
+| FriendsList | 확인 필요 | 동일 |
+
+MSW handler 는 현 파일 (`apps/web/src/mocks/handlers/editor.ts` 등) 구조 무파괴. `@/features/editor/api` 배럴이 유지되므로 handler 가 참조하는 type 경로 변경 없음.
+
+## 5. 커밋 granularity 제안
+
+1. `refactor(phase-19): editor/api 배럴 + sub-files 분할 (F-react-3)`
+2. `refactor(phase-19): GameChat 디렉터리 분할 + 탭 컴포넌트 추출 (F-react-1 partial — 파일 분할만)`
+3. `refactor(phase-19): FriendsList 디렉터리 분할 + 탭 컴포넌트 추출 (F-react-4)`
+4. `chore(phase-19): PR-4b bundle size 검증 + `wc -l` 한도 복귀 확인`
+
+각 커밋은 `pnpm lint` + `pnpm typecheck` + `pnpm test` + `pnpm build` green.
+
+## 6. 번들 분석 체크리스트 (PR-4b Merge Gate)
+
+- [ ] `pnpm build --mode analyze` 전후 비교 스크린샷 첨부 (PR 설명)
+- [ ] `features/editor/api` import 사이트 grep 결과 (현재 vs PR-4b 후) — 외부 페이지 경로 변경 없음 확인
+- [ ] `features/game/components/GameChat` 호출 사이트 grep — `import` 경로 불변 확인
+- [ ] `features/social/components/FriendsList` 동일
+- [ ] Storybook (있다면) 경로 업데이트


### PR DESCRIPTION
## Summary
PR-4 (File Size Refactor) → **PR-4a (Go, L) ∥ PR-4b (TS, M) 병렬 분할 설계**. 6 파일 / 580줄 docs.

## Split
| PR | Lang | Size | Risk | Scope |
|---|---|---|---|---|
| PR-4a | Go | L | Med | 6 모듈 디렉터리 승격 + 3 인프라 분할 + F-go-4 1건 |
| PR-4b | TS | M | Low | editor/api.ts + GameChat.tsx + FriendsList.tsx |

**의존성**: PR-4a ∥ PR-4b 병렬 (disjoint). PR-2b/2c는 PR-4a 선행 권장.

## Test plan
- [x] MD 6개 파일 변경 (코드 영향 無)
- [x] 모든 MD 200줄 한도 내
- [x] Deadlink 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>