### PR TITLE
chore(phase-19): pr-2a skill + CLAUDE.md — PlayerAware 의무 규약 반영

### DIFF
--- a/.claude/skills/mmp-module-factory/SKILL.md
+++ b/.claude/skills/mmp-module-factory/SKILL.md
@@ -70,6 +70,25 @@ func (m *Module) OnPhase(ctx context.Context, a phase.Action) error { ... }
 ### 5. 이벤트 relay
 `EventBus.SubscribeAll` + prefix 기반. 임시 채널 생성 금지.
 
+### 6. 🔴 PlayerAware 게이트 (PR-2a 이후 의무, F-sec-2)
+모든 `engine.Module` 구현체는 **둘 중 하나**를 반드시 충족. registry 가 `init()` 시점 panic 으로 강제 (`MMP_PLAYERAWARE_STRICT=false` 로 일시 롤백 가능, default true).
+
+- **A. Per-player redaction 모듈** — `BuildStateFor(playerID)` 구현 + compile assertion
+  ```go
+  func (m *Module) BuildStateFor(pid uuid.UUID) (json.RawMessage, error) { /* redact */ }
+  var _ engine.PlayerAwareModule = (*Module)(nil)
+  ```
+- **B. 전원 공개 state 모듈** — `engine.PublicStateMarker` 임베드 + compile assertion
+  ```go
+  type Module struct {
+      engine.PublicStateMarker
+      // ...
+  }
+  var ( _ engine.Module; _ engine.PublicStateModule = (*Module)(nil) )
+  ```
+
+`isPublicState()` 는 unexported 라 외부 패키지에서 직접 구현 불가. 반드시 `engine.PublicStateMarker` 임베드로 opt-out 명시.
+
 ## 테스트 요구
 - Factory 독립성: 동일 sessionID 두 번 호출해도 서로 다른 인스턴스.
 - ConfigSchema 검증: 잘못된 cfg에 `ErrInvalidConfig` 반환.
@@ -87,4 +106,6 @@ func (m *Module) OnPhase(ctx context.Context, a phase.Action) error { ... }
 - [ ] ConfigSchema 단일 소스 + 검증 함수
 - [ ] `init() { Register(...) }` + blank import 추가
 - [ ] PhaseReactor는 필요할 때만 구현
+- [ ] **🔴 PlayerAware gate (PR-2a)**: `BuildStateFor` 구현 **OR** `engine.PublicStateMarker` 임베드 중 하나 + `var _ engine.PlayerAwareModule | PublicStateModule = (*X)(nil)` compile assertion
+- [ ] `go test ./internal/engine/... -run Gate` — registry boot gate 통과 확인 (strict mode default)
 - [ ] 모듈 추가 후 `docs/plans/2026-04-05-rebuild/module-spec.md` 갱신 알림

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 |------|----------|------|------|
 | 2026-04-15 | 초기 구성 | 전체 | harness 플러그인 기반 전프로젝트 범용 팀 구축 |
 | 2026-04-15 | mmp-pilot M0-M2 | `/plan-go`, mmp-pilot 스킬, run-*.sh, m3-cutover.sh, m4-plan.md | plan-autopilot↔하네스 통합 (M3 대기, M4 계획만 문서화). 상세: `.claude/designs/mmp-pilot/` |
+| 2026-04-18 | PR-2a PlayerAware 게이트 의무화 | `§ 모듈 시스템`, `.claude/skills/mmp-module-factory/SKILL.md` | F-sec-2 대응: 모든 `engine.Module` 은 `PlayerAwareModule.BuildStateFor` 구현 또는 `engine.PublicStateMarker` 임베드 opt-out 중 하나 필수. registry boot panic + `MMP_PLAYERAWARE_STRICT` 롤백 스위치. PR #97 (phase-19 PR-2a). |
 
 ## 프로젝트 개요
 다중 테마 실시간 멀티플레이어 머더미스터리 게임 플랫폼 v3 리빌드.
@@ -59,6 +60,7 @@
 - PhaseReactor(선택적): PhaseAction에 반응하는 모듈만 구현
 - Factory 패턴: 세션별 독립 인스턴스 (싱글턴 금지)
 - init() + blank import 등록
+- **🔴 PlayerAware (의무, PR-2a 이후)**: 모든 `engine.Module` 은 `PlayerAwareModule.BuildStateFor` 구현 **또는** `engine.PublicStateMarker` 임베드로 `PublicStateModule` 명시적 opt-out 중 하나를 충족해야 함. registry boot 시점 panic 으로 강제 (F-sec-2 게이트). 롤백용 env: `MMP_PLAYERAWARE_STRICT=false` (default true). 상세 템플릿: `.claude/skills/mmp-module-factory/SKILL.md`
 
 ### 🔴 파일/함수 크기 제한 (유형별 티어)
 


### PR DESCRIPTION
## Summary
PR-2a (#97) 머지로 `PlayerAwareModule 의무 + PublicStateMarker opt-out` gate 강제됨 → skill 템플릿 + 프로젝트 규칙 동기화.

## Changes
- `.claude/skills/mmp-module-factory/SKILL.md` (+21) — §6 PlayerAware 게이트 추가 (2분기 템플릿 + compile assertion + `MMP_PLAYERAWARE_STRICT` 롤백 + 체크리스트 2항목)
- `CLAUDE.md` (+2) — § 모듈 시스템 불릿 + § 하네스 변경 이력 2026-04-18 행

## Test plan
- [x] 파일 2개만 변경 (코드 영향 無)
- [x] SKILL.md는 skill description 유지, 기존 체크리스트에 gate 항목 추가
- [x] CLAUDE.md는 +2줄 (신규 하드리밋 위반 無)

## Refs
- SSOT: `docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2a-engine-gate.md`
- 실측 API: `apps/server/internal/engine/types.go` + `registry.go` + `gate_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>