### PR TITLE
feat(phase-19)(pr-2c): combination BuildStateFor real per-player redaction (D-MO-1)

### DIFF
--- a/apps/server/internal/module/crime_scene/combination/combination_test.go
+++ b/apps/server/internal/module/crime_scene/combination/combination_test.go
@@ -3,6 +3,7 @@ package combination
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -306,6 +307,159 @@ func TestCombinationModule_BuildState(t *testing.T) {
 	if err := json.Unmarshal(data, &s); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+}
+
+// Phase 19 PR-2c (D-MO-1): BuildStateFor must expose only the caller's own
+// completed/derived sets, never peer progress.
+func TestCombinationModule_BuildStateFor_OnlyCallerVisible(t *testing.T) {
+	m := NewCombinationModule()
+	if err := m.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	bob := uuid.New()
+
+	m.mu.Lock()
+	m.completed[alice] = []string{"combo1"}
+	m.derived[alice] = []string{"weapon_set"}
+	m.completed[bob] = []string{"combo2"}
+	m.derived[bob] = []string{"motive"}
+	m.mu.Unlock()
+
+	raw, err := m.BuildStateFor(alice)
+	if err != nil {
+		t.Fatalf("BuildStateFor(alice): %v", err)
+	}
+	var s combinationState
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	aliceKey := alice.String()
+	bobKey := bob.String()
+
+	if got := s.Completed[aliceKey]; len(got) != 1 || got[0] != "combo1" {
+		t.Errorf("alice completed: got %v, want [combo1]", got)
+	}
+	if got := s.Derived[aliceKey]; len(got) != 1 || got[0] != "weapon_set" {
+		t.Errorf("alice derived: got %v, want [weapon_set]", got)
+	}
+	if _, ok := s.Completed[bobKey]; ok {
+		t.Errorf("alice snapshot leaked bob completed: %v", s.Completed)
+	}
+	if _, ok := s.Derived[bobKey]; ok {
+		t.Errorf("alice snapshot leaked bob derived: %v", s.Derived)
+	}
+}
+
+// Phase 19 PR-2c: a player with no combination progress must get empty (non-nil)
+// maps so the JSON shape stays `{}` — never `null` — and never mirrors peers.
+func TestCombinationModule_BuildStateFor_EmptyForNewPlayer(t *testing.T) {
+	m := NewCombinationModule()
+	if err := m.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	newbie := uuid.New()
+
+	m.mu.Lock()
+	m.completed[alice] = []string{"combo1"}
+	m.derived[alice] = []string{"weapon_set"}
+	m.collected[alice] = map[string]bool{"knife": true, "glove": true}
+	m.mu.Unlock()
+
+	raw, err := m.BuildStateFor(newbie)
+	if err != nil {
+		t.Fatalf("BuildStateFor(newbie): %v", err)
+	}
+
+	// Root keys must exist and decode to empty objects, not null.
+	var probe struct {
+		Completed map[string][]string `json:"completed"`
+		Derived   map[string][]string `json:"derived"`
+		Collected map[string][]string `json:"collected"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if probe.Completed == nil || probe.Derived == nil || probe.Collected == nil {
+		t.Fatalf("expected non-nil maps, got %q", raw)
+	}
+	if len(probe.Completed) != 0 || len(probe.Derived) != 0 || len(probe.Collected) != 0 {
+		t.Fatalf("newbie snapshot not empty: %q", raw)
+	}
+
+	// And no trace of alice may appear in the newbie's view.
+	if got := string(raw); got != "{}" && !jsonIsEmptyShape(got) {
+		// Smoke-check: alice's uuid must never show up.
+		if strings.Contains(got, alice.String()) {
+			t.Errorf("newbie snapshot leaked alice id: %s", got)
+		}
+	}
+}
+
+// Phase 19 PR-2c: collected evidence mirrored from the event bus must be
+// per-player-scoped in the snapshot, so bob's collected inventory stays
+// invisible to alice even when both players are active.
+func TestCombinationModule_BuildStateFor_CollectedMirror(t *testing.T) {
+	m := NewCombinationModule()
+	deps := newTestDeps()
+	if err := m.Init(context.Background(), deps, combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	bob := uuid.New()
+
+	// Drive the event bus exactly like the evidence module would.
+	deps.EventBus.Publish(engine.Event{
+		Type: "evidence.collected",
+		Payload: map[string]any{
+			"playerID":   alice,
+			"evidenceID": "knife",
+		},
+	})
+	deps.EventBus.Publish(engine.Event{
+		Type: "evidence.collected",
+		Payload: map[string]any{
+			"playerID":   bob,
+			"evidenceID": "note",
+		},
+	})
+
+	raw, err := m.BuildStateFor(alice)
+	if err != nil {
+		t.Fatalf("BuildStateFor(alice): %v", err)
+	}
+	var s combinationState
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	aliceKey := alice.String()
+	bobKey := bob.String()
+
+	if got := s.Collected[aliceKey]; len(got) != 1 || got[0] != "knife" {
+		t.Errorf("alice collected: got %v, want [knife]", got)
+	}
+	if _, ok := s.Collected[bobKey]; ok {
+		t.Errorf("alice snapshot leaked bob collected: %v", s.Collected)
+	}
+	if strings.Contains(string(raw), "note") {
+		t.Errorf("alice snapshot leaked bob evidence id 'note': %s", raw)
+	}
+}
+
+// jsonIsEmptyShape allows for any of `{"completed":{},"derived":{},"collected":{}}` orderings.
+func jsonIsEmptyShape(s string) bool {
+	var probe struct {
+		Completed map[string][]string `json:"completed"`
+		Derived   map[string][]string `json:"derived"`
+		Collected map[string][]string `json:"collected"`
+	}
+	if err := json.Unmarshal([]byte(s), &probe); err != nil {
+		return false
+	}
+	return len(probe.Completed) == 0 && len(probe.Derived) == 0 && len(probe.Collected) == 0
 }
 
 // Phase 20 PR-5: GroupID shortcut — clients can pass `group_id` to match

--- a/apps/server/internal/module/crime_scene/combination/state.go
+++ b/apps/server/internal/module/crime_scene/combination/state.go
@@ -40,7 +40,41 @@ func (m *CombinationModule) snapshot() combinationState {
 	return combinationState{Completed: completed, Derived: derived, Collected: collected}
 }
 
-// BuildState returns the module's current state for client sync.
+// snapshotFor returns a combinationState disclosing only the calling player's
+// completed combinations, derived ("crafted") clues, and collected evidence.
+// Other players' entries are elided to uphold the D-MO-1 redaction boundary:
+// revealing that peer X has already crafted a clue leaks strategic intel.
+func (m *CombinationModule) snapshotFor(playerID uuid.UUID) combinationState {
+	s := combinationState{
+		Completed: map[string][]string{},
+		Derived:   map[string][]string{},
+		Collected: map[string][]string{},
+	}
+	key := playerID.String()
+	if ids := m.completed[playerID]; len(ids) > 0 {
+		cp := make([]string, len(ids))
+		copy(cp, ids)
+		s.Completed[key] = cp
+	}
+	if ids := m.derived[playerID]; len(ids) > 0 {
+		cp := make([]string, len(ids))
+		copy(cp, ids)
+		s.Derived[key] = cp
+	}
+	if evMap := m.collected[playerID]; len(evMap) > 0 {
+		ids := make([]string, 0, len(evMap))
+		for id := range evMap {
+			ids = append(ids, id)
+		}
+		s.Collected[key] = ids
+	}
+	return s
+}
+
+// BuildState returns the combination module state combining every player's
+// progress. Reserved for persistence (SaveState) and admin/test fixtures —
+// the runtime broadcast path goes through BuildStateFor via the PR-2a engine
+// gate, so this payload never reaches clients.
 func (m *CombinationModule) BuildState() (json.RawMessage, error) {
 	m.mu.RLock()
 	s := m.snapshot()
@@ -48,13 +82,15 @@ func (m *CombinationModule) BuildState() (json.RawMessage, error) {
 	return json.Marshal(s)
 }
 
-// BuildStateFor returns the same state as BuildState for now.
-// PR-2a (F-sec-2 gate): satisfies engine.PlayerAwareModule interface.
-// PR-2b will restrict completed/derived/collected entries to the requesting
-// player's own progress, since revealing other players' combinations leaks
-// strategic information.
-func (m *CombinationModule) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
-	return m.BuildState()
+// BuildStateFor implements engine.PlayerAwareModule with per-player redaction
+// (D-MO-1): only the caller's completed, derived, and collected sets are
+// disclosed. Solves Phase 18.1 B-2 where the combination snapshot leaked
+// every player's crafted clue map to every client.
+func (m *CombinationModule) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
+	m.mu.RLock()
+	s := m.snapshotFor(playerID)
+	m.mu.RUnlock()
+	return json.Marshal(s)
 }
 
 // --- SerializableModule ---

--- a/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/current-state.md
+++ b/docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/current-state.md
@@ -23,7 +23,7 @@
 | 14 | spatial_voice | communication | - | - | - | 위치 기반 필터는 클라이언트 |
 | 15 | **evidence** | crime_scene | O | - | **O** | `discovered[pid]` `collected[pid]` 전체맵 노출 — **F-03 핵심** |
 | 16 | **location** | crime_scene | O | - | **O** | `positions[pid]` `history[pid]` 전체맵 노출 — **F-03 핵심** |
-| 17 | **combination** | crime_scene | O | - | **O** | `completed[pid]` `derived[pid]` `collected[pid]` — **F-03 핵심 + D-MO-1** |
+| 17 | **combination** | crime_scene | O | **O** | - | `completed[pid]` `derived[pid]` `collected[pid]` — **F-03 + D-MO-1, PR-2c 완료 (2026-04-18)** |
 | 18 | accusation | decision | O | - | **O** | `activeAccusation.Votes[pid]` 투표 분포 누설 |
 | 19 | voting | decision | O | **O** | - | 구현됨 (secret mode redaction) |
 | 20 | hidden_mission | decision | O | **O** | - | 구현됨 (타인 미션 redact) |
@@ -68,13 +68,13 @@ lastMove  map[uuid.UUID]time.Time
 ```
 → BuildStateFor: `positions[caller]` 만 + `history[caller]` 만. 룸 전체 위치 공유는 별도 public state 분리 설계가 이상적이나 PR-2b 범위에서는 단순 redact.
 
-### combination (crime_scene) — PR-2c 분리
+### combination (crime_scene) — PR-2c 완료 (2026-04-18)
 ```go
 completed map[uuid.UUID][]string
 derived   map[uuid.UUID][]string
 collected map[uuid.UUID]map[string]bool
 ```
-→ PR-2b 에서는 BuildStateFor 를 추가하되, redaction 은 PR-2c 로 분리. 즉 PR-2b 커밋에서는 `BuildStateFor` 가 현재 `BuildState` 와 동일 결과를 반환하는 **stub** 으로 두고, PR-2c 에서 실제 per-player filter 적용.
+→ PR-2b 단계에서는 stub(`BuildStateFor = BuildState`)으로 두고, **PR-2c** 에서 `snapshotFor(playerID)` helper + `BuildStateFor` 를 real per-player filter 로 승격. caller 의 `completed`/`derived`/`collected` 엔트리만 노출, 타 플레이어 키는 엘라이드. `craftedAsClueMap` 경로(CRAFT 트리거 graph.Resolve) 는 내부 heuristic 으로만 사용되며 스냅샷에 반영되지 않음. 검증: `TestCombinationModule_BuildStateFor_{OnlyCallerVisible,EmptyForNewPlayer,CollectedMirror}` + coverage lint ALLOW_STUB 비움.
 
 ### accusation (decision)
 ```go

--- a/scripts/check-playeraware-coverage.sh
+++ b/scripts/check-playeraware-coverage.sh
@@ -34,10 +34,11 @@ fi
 
 # Allowed exceptions (tracked as their own PR). Each path must be removed
 # from this list when the corresponding real-redaction PR lands.
-#   - crime_scene/combination : PR-2c (D-MO-1 craftedAsClueMap redaction)
-ALLOW_STUB=(
-    "apps/server/internal/module/crime_scene/combination/"
-)
+#
+# Empty as of PR-2c (2026-04-18): crime_scene/combination now implements real
+# per-player redaction (D-MO-1). Add a new entry here only when introducing a
+# deliberate, time-boxed stub that is tracked by a follow-up PR.
+ALLOW_STUB=()
 
 allow_filter=""
 for p in "${ALLOW_STUB[@]}"; do


### PR DESCRIPTION
## Summary

Phase 19 F-03 + F-sec-2 잔여분 해소. PR-2b(#104) 에서 `ALLOW_STUB` 예외로 남겨둔 `crime_scene/combination` 의 `BuildStateFor` 를 real per-player redaction 으로 승격. **P0 해소율: 6/7 → 7/7 (100%)**.

- `combination/state.go` — `snapshotFor(playerID)` helper 신규 + `BuildStateFor` 가 `m.BuildState()` 로 delegate 하던 stub 제거. RLock 아래 caller 의 `completed`/`derived`/`collected` 엔트리만 담는 `{}` 를 반환 (null 아님). `BuildState` 는 persistence/fixture 전용 docstring 경계.
- `combination/combination_test.go` — 3 테스트 신규:
  - `OnlyCallerVisible` — alice snapshot 에 bob 키 엘라이드.
  - `EmptyForNewPlayer` — 진행 0 플레이어는 non-nil 빈 `{}` 3 map.
  - `CollectedMirror` — `evidence.collected` 이벤트 경로로 모인 bob 의 evidence ID(`note`) 가 alice 스냅샷에 누설되지 않음.
- `scripts/check-playeraware-coverage.sh` — `ALLOW_STUB` 배열에서 `crime_scene/combination/` 제거 (현재 예외 0건 명시 코멘트).
- `docs/plans/.../refs/pr-2/current-state.md` — combination 행 BuildStateFor `O`, 비고 \"PR-2c 완료\" + 민감 필드 상세 섹션 업데이트.

## Test plan

- [x] `go fmt ./internal/module/crime_scene/combination/...`
- [x] `go vet ./...` (exit 0)
- [x] `go build ./...` (exit 0)
- [x] `go test -race -count=1 ./internal/engine/... ./internal/module/... ./internal/session/...` — 전 패키지 pass
- [x] `go test -race -run 'TestCombination.*BuildStateFor' -v` — 3/3 PASS
- [x] `bash scripts/check-playeraware-coverage.sh` — ✅ clean (ALLOW_STUB 비움에도 위반 0)

## 영향

- F-sec-2: 12/12 모듈 real per-player redaction 완료.
- F-03: crime_scene 3/3 (evidence · location · combination) 완결.
- D-MO-1 (craftedAsClueMap 누설): combination snapshot 이 caller 엔트리만 노출.
- 외부 API 불변 — 클라이언트는 기존 `combination.derived[myPlayerId]` 패턴이라 렌더 영향 없음.

## 참조

- 설계: `docs/plans/2026-04-17-platform-deep-audit/refs/pr-2/pr-2c-crafted-redaction.md`
- 선행 머지: PR #97 (PR-2a gate), PR #104 (PR-2b 12 모듈 backfill)
- Progress memory: `memory/project_phase19_implementation_progress.md` (별도 sync 커밋 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)