### PR TITLE
fix(phase-19)(pr-2c-hotfix): combination deadlock + redaction edge cases

### DIFF
--- a/apps/server/internal/module/crime_scene/combination/combination_test.go
+++ b/apps/server/internal/module/crime_scene/combination/combination_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/mmp-platform/server/internal/engine"
@@ -460,6 +462,170 @@ func jsonIsEmptyShape(s string) bool {
 		return false
 	}
 	return len(probe.Completed) == 0 && len(probe.Derived) == 0 && len(probe.Collected) == 0
+}
+
+// Phase 19 PR-2c hotfix: uuid.Nil must return an empty shape even when peers
+// have state. Protects against stray zero-value playerIDs ever aliasing a
+// real entry at the redaction layer.
+func TestCombinationModule_BuildStateFor_NilUUIDEmpty(t *testing.T) {
+	m := NewCombinationModule()
+	if err := m.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	m.mu.Lock()
+	m.completed[alice] = []string{"combo1"}
+	m.derived[alice] = []string{"weapon_set"}
+	m.collected[alice] = map[string]bool{"knife": true}
+	m.mu.Unlock()
+
+	raw, err := m.BuildStateFor(uuid.Nil)
+	if err != nil {
+		t.Fatalf("BuildStateFor(uuid.Nil): %v", err)
+	}
+	if !jsonIsEmptyShape(string(raw)) {
+		t.Errorf("uuid.Nil snapshot must be empty shape, got %s", raw)
+	}
+	if strings.Contains(string(raw), alice.String()) {
+		t.Errorf("uuid.Nil snapshot leaked alice id: %s", raw)
+	}
+}
+
+// Phase 19 PR-2c hotfix: Collected slice must be sorted for deterministic
+// JSON — map iteration order is non-deterministic in Go, causing spurious
+// diffs between otherwise identical snapshots on reconnect / diff paths.
+func TestCombinationModule_BuildStateFor_CollectedSortedStable(t *testing.T) {
+	m := NewCombinationModule()
+	if err := m.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	m.mu.Lock()
+	m.collected[alice] = map[string]bool{"zeta": true, "alpha": true, "mike": true, "bravo": true}
+	m.mu.Unlock()
+
+	// Marshal twice and ensure byte identity — the fix must survive map
+	// iteration randomisation across calls.
+	r1, err := m.BuildStateFor(alice)
+	if err != nil {
+		t.Fatalf("BuildStateFor first call: %v", err)
+	}
+	r2, err := m.BuildStateFor(alice)
+	if err != nil {
+		t.Fatalf("BuildStateFor second call: %v", err)
+	}
+	if string(r1) != string(r2) {
+		t.Errorf("BuildStateFor not deterministic between calls:\n  %s\n  %s", r1, r2)
+	}
+
+	// And the collected slice must be in ascending ASCII order.
+	var s combinationState
+	if err := json.Unmarshal(r1, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := s.Collected[alice.String()]
+	want := []string{"alpha", "bravo", "mike", "zeta"}
+	if len(got) != len(want) {
+		t.Fatalf("collected length: got %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("collected[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// Phase 19 PR-2c hotfix (HIGH): handleCombine must not publish events while
+// holding m.mu.Lock. Any subscriber calling a method that takes m.mu
+// (legitimate now that BuildStateFor is a live broadcast path) would
+// deadlock. This test plants such a subscriber and asserts that the combine
+// call + the callback both complete promptly.
+func TestCombinationModule_HandleCombine_NoDeadlockDuringPublish(t *testing.T) {
+	m := NewCombinationModule()
+	deps := newTestDeps()
+	if err := m.Init(context.Background(), deps, combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	playerID := uuid.New()
+	m.mu.Lock()
+	m.collected[playerID] = map[string]bool{"knife": true, "glove": true}
+	m.mu.Unlock()
+
+	callbackDone := make(chan error, 1)
+	deps.EventBus.Subscribe("combination.completed", func(_ engine.Event) {
+		// Re-enter the module through a BuildStateFor call. This takes
+		// m.mu.RLock internally; if handleCombine still held m.mu.Lock it
+		// would block forever.
+		_, err := m.BuildStateFor(playerID)
+		callbackDone <- err
+	})
+
+	combineDone := make(chan error, 1)
+	go func() {
+		combineDone <- m.HandleMessage(context.Background(), playerID,
+			"combine", json.RawMessage(`{"evidence_ids":["knife","glove"]}`))
+	}()
+
+	select {
+	case err := <-combineDone:
+		if err != nil {
+			t.Fatalf("HandleMessage combine: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleMessage deadlocked — likely holding m.mu across Publish")
+	}
+
+	select {
+	case err := <-callbackDone:
+		if err != nil {
+			t.Fatalf("subscriber BuildStateFor: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("combination.completed subscriber never reached BuildStateFor — deadlock or missed publish")
+	}
+}
+
+// Phase 19 PR-2c hotfix: concurrent BuildStateFor fan-out (broadcast to N
+// players in parallel) must not race with handleCombine writes. go test
+// -race will flag any missed lock or unsynchronised map access.
+func TestCombinationModule_BuildStateFor_ConcurrentBroadcast(t *testing.T) {
+	m := NewCombinationModule()
+	deps := newTestDeps()
+	if err := m.Init(context.Background(), deps, combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	const n = 16
+	players := make([]uuid.UUID, n)
+	m.mu.Lock()
+	for i := range players {
+		players[i] = uuid.New()
+		m.collected[players[i]] = map[string]bool{"knife": true, "glove": true}
+	}
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	// Fan out BuildStateFor across all players while one player actively
+	// triggers a combine. The combine writes to m.completed / m.derived
+	// under Lock; the readers take RLock in snapshotFor.
+	wg.Add(n + 1)
+	go func() {
+		defer wg.Done()
+		_ = m.HandleMessage(context.Background(), players[0],
+			"combine", json.RawMessage(`{"evidence_ids":["knife","glove"]}`))
+	}()
+	for i := 0; i < n; i++ {
+		go func(pid uuid.UUID) {
+			defer wg.Done()
+			for j := 0; j < 32; j++ {
+				if _, err := m.BuildStateFor(pid); err != nil {
+					t.Errorf("BuildStateFor: %v", err)
+					return
+				}
+			}
+		}(players[i])
+	}
+	wg.Wait()
 }
 
 // Phase 20 PR-5: GroupID shortcut — clients can pass `group_id` to match

--- a/apps/server/internal/module/crime_scene/combination/handlers.go
+++ b/apps/server/internal/module/crime_scene/combination/handlers.go
@@ -37,29 +37,36 @@ func (m *CombinationModule) handleCombine(_ context.Context, playerID uuid.UUID,
 		return fmt.Errorf("combination: combine requires at least one evidence_id")
 	}
 
+	// Mutate state under lock, then release BEFORE publishing events. Holding
+	// m.mu while invoking a synchronous EventBus is a deadlock hazard — any
+	// subscriber that calls back into a module method acquiring m.mu (now
+	// realistic via BuildStateFor on the broadcast path) would block forever.
+	var (
+		combo    CombinationDef
+		produced bool
+	)
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Find a matching combination def.
 	combo, err := m.findCombo(p)
 	if err != nil {
+		m.mu.Unlock()
 		return err
 	}
-
-	// Verify player has all input evidence.
 	for _, inputID := range combo.InputIDs {
 		if !m.collected[playerID][inputID] {
+			m.mu.Unlock()
 			return fmt.Errorf("combination: invalid combine: missing evidence %q", inputID)
 		}
 	}
-
-	// Check not already completed.
-	if m.hasCompleted(playerID, combo.ID) {
-		return nil // idempotent
+	if !m.hasCompleted(playerID, combo.ID) {
+		m.completed[playerID] = append(m.completed[playerID], combo.ID)
+		m.derived[playerID] = append(m.derived[playerID], combo.OutputClueID)
+		produced = true
 	}
+	m.mu.Unlock()
 
-	m.completed[playerID] = append(m.completed[playerID], combo.ID)
-	m.derived[playerID] = append(m.derived[playerID], combo.OutputClueID)
+	if !produced {
+		return nil // idempotent replay
+	}
 
 	m.deps.EventBus.Publish(engine.Event{
 		Type: "combination.completed",

--- a/apps/server/internal/module/crime_scene/combination/state.go
+++ b/apps/server/internal/module/crime_scene/combination/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/google/uuid"
 	"github.com/mmp-platform/server/internal/engine"
@@ -35,6 +36,7 @@ func (m *CombinationModule) snapshot() combinationState {
 		for id := range evMap {
 			ids = append(ids, id)
 		}
+		sort.Strings(ids) // deterministic JSON for snapshot diffing
 		collected[pid.String()] = ids
 	}
 	return combinationState{Completed: completed, Derived: derived, Collected: collected}
@@ -44,11 +46,20 @@ func (m *CombinationModule) snapshot() combinationState {
 // completed combinations, derived ("crafted") clues, and collected evidence.
 // Other players' entries are elided to uphold the D-MO-1 redaction boundary:
 // revealing that peer X has already crafted a clue leaks strategic intel.
+//
+// When playerID is uuid.Nil the function returns an empty (non-nil) shape.
+// uuid.Nil is an ambiguous identity that could accidentally alias a stray
+// map entry if a peer module ever publishes evidence.collected with a
+// zero-value playerID — returning empty here closes that vector at the
+// redaction layer, independently of upstream input validation.
 func (m *CombinationModule) snapshotFor(playerID uuid.UUID) combinationState {
 	s := combinationState{
 		Completed: map[string][]string{},
 		Derived:   map[string][]string{},
 		Collected: map[string][]string{},
+	}
+	if playerID == uuid.Nil {
+		return s
 	}
 	key := playerID.String()
 	if ids := m.completed[playerID]; len(ids) > 0 {
@@ -66,6 +77,7 @@ func (m *CombinationModule) snapshotFor(playerID uuid.UUID) combinationState {
 		for id := range evMap {
 			ids = append(ids, id)
 		}
+		sort.Strings(ids) // deterministic JSON regardless of map iteration
 		s.Collected[key] = ids
 	}
 	return s


### PR DESCRIPTION
## Summary

PR-2c(#107) 사후 4-agent 병렬 코드리뷰 결과(HIGH 1 + MEDIUM 2) 반영 hotfix.

**HIGH** — `handlers.handleCombine` 이 `m.mu.Lock` 을 홀드한 채 `combination.completed` / `combination.clue_unlocked` 를 synchronous Publish. PR-2c 로 `BuildStateFor` 가 session broadcast live path 가 된 이후 구독자가 모듈 메서드(RLock 포함) 재진입 시 deadlock. Fix: state mutation 은 Lock 아래, Publish 는 Unlock 이후.

**MEDIUM #1** — `snapshotFor` uuid.Nil guard 부재. zero-value UUID 가 어떤 경로로든 유입되면 `collected[uuid.Nil]` 슬롯 전체 유출. Fix: redaction 레이어 자체 방어로 빈 shape 즉시 반환.

**MEDIUM #2** — Collected slice 비결정적 순서. `map[string]bool` 순회가 언어 사양상 비결정적이라 스냅샷 diff / 관측 파이프라인이 spurious diff. Fix: `sort.Strings(ids)` 로 deterministic ASCII 정렬. `snapshot()` / `snapshotFor()` 양쪽.

## Test plan

- [x] 신규 4 테스트 추가:
  - `BuildStateFor_NilUUIDEmpty` — uuid.Nil 빈 shape + 타 플레이어 id 누설 없음
  - `BuildStateFor_CollectedSortedStable` — 2회 Marshal 바이트 동등 + ASCII 오름차순
  - `HandleCombine_NoDeadlockDuringPublish` — 구독자 `BuildStateFor` 재진입 2s 안에 완료
  - `BuildStateFor_ConcurrentBroadcast` — 16 goroutine × 32 round + combine writer, race detector green
- [x] `go fmt` + `go vet ./...` exit 0
- [x] `go build ./...` exit 0
- [x] `go test -race -count=1 ./internal/engine/... ./internal/module/... ./internal/session/...` — 전 패키지 pass
- [x] `bash scripts/check-playeraware-coverage.sh` — clean

## 영향

외부 API 불변. PR-2c 의 D-MO-1 해소 상태 유지. Phase 19 P0 7/7 (100%) 그대로.

## 참조

- 원 PR: #107 (0b31271)
- 4-agent 리뷰 결과 요약(세션 로그): HIGH 1 + MEDIUM 4 + LOW 5+
- 남은 follow-up: MEDIUM 나머지(`BuildState` godoc 강화 / coverage lint AST 전환 / `MMP_PLAYERAWARE_STRICT` env 제거) + LOW 통합 테스트(`TestSnapshot_Redaction_CombinationCrafted`) 는 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)