### PR TITLE
chore(phase-19.1)(pr-a): MMP_PLAYERAWARE_STRICT env 제거 + PhaseEngine.BuildState() godoc 강화

### DIFF
--- a/.claude/skills/mmp-module-factory/SKILL.md
+++ b/.claude/skills/mmp-module-factory/SKILL.md
@@ -71,7 +71,7 @@ func (m *Module) OnPhase(ctx context.Context, a phase.Action) error { ... }
 `EventBus.SubscribeAll` + prefix 기반. 임시 채널 생성 금지.
 
 ### 6. 🔴 PlayerAware 게이트 (PR-2a 이후 의무, F-sec-2)
-모든 `engine.Module` 구현체는 **둘 중 하나**를 반드시 충족. registry 가 `init()` 시점 panic 으로 강제 (`MMP_PLAYERAWARE_STRICT=false` 로 일시 롤백 가능, default true).
+모든 `engine.Module` 구현체는 **둘 중 하나**를 반드시 충족. registry 가 `init()` 시점 panic 으로 강제. rollback env(`MMP_PLAYERAWARE_STRICT`) 는 Phase 19.1 PR-A 에서 제거되어 gate 는 항상 활성.
 
 - **A. Per-player redaction 모듈** — `BuildStateFor(playerID)` 구현 + compile assertion
   ```go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 | 2026-04-15 | 초기 구성 | 전체 | harness 플러그인 기반 전프로젝트 범용 팀 구축 |
 | 2026-04-15 | mmp-pilot M0-M2 | `/plan-go`, mmp-pilot 스킬, run-*.sh, m3-cutover.sh, m4-plan.md | plan-autopilot↔하네스 통합 (M3 대기, M4 계획만 문서화). 상세: `.claude/designs/mmp-pilot/` |
 | 2026-04-18 | PR-2a PlayerAware 게이트 의무화 | `§ 모듈 시스템`, `.claude/skills/mmp-module-factory/SKILL.md` | F-sec-2 대응: 모든 `engine.Module` 은 `PlayerAwareModule.BuildStateFor` 구현 또는 `engine.PublicStateMarker` 임베드 opt-out 중 하나 필수. registry boot panic + `MMP_PLAYERAWARE_STRICT` 롤백 스위치. PR #97 (phase-19 PR-2a). |
+| 2026-04-18 | Phase 19.1 PR-A — PlayerAware 게이트 rollback env 제거 | `§ 모듈 시스템`, `.claude/skills/mmp-module-factory/SKILL.md`, `apps/server/internal/engine/registry.go`, `factory.go`, `types.go`, `phase_engine.go`, `gate_test.go` | 33/33 gate 충족 후 `MMP_PLAYERAWARE_STRICT` escape hatch 제거. `PhaseEngine.BuildState()` godoc 으로 internal/persistence-only 경계 강화. PR #(TBD) (phase-19.1 PR-A). |
 
 ## 프로젝트 개요
 다중 테마 실시간 멀티플레이어 머더미스터리 게임 플랫폼 v3 리빌드.
@@ -60,7 +61,7 @@
 - PhaseReactor(선택적): PhaseAction에 반응하는 모듈만 구현
 - Factory 패턴: 세션별 독립 인스턴스 (싱글턴 금지)
 - init() + blank import 등록
-- **🔴 PlayerAware (의무, PR-2a 이후)**: 모든 `engine.Module` 은 `PlayerAwareModule.BuildStateFor` 구현 **또는** `engine.PublicStateMarker` 임베드로 `PublicStateModule` 명시적 opt-out 중 하나를 충족해야 함. registry boot 시점 panic 으로 강제 (F-sec-2 게이트). 롤백용 env: `MMP_PLAYERAWARE_STRICT=false` (default true). 상세 템플릿: `.claude/skills/mmp-module-factory/SKILL.md`
+- **🔴 PlayerAware (의무, PR-2a 이후)**: 모든 `engine.Module` 은 `PlayerAwareModule.BuildStateFor` 구현 **또는** `engine.PublicStateMarker` 임베드로 `PublicStateModule` 명시적 opt-out 중 하나를 충족해야 함. registry boot 시점 panic 으로 강제 (F-sec-2 게이트). rollback env 는 33/33 gate 충족 후 Phase 19.1 PR-A 에서 제거됨 — 이제 gate 는 항상 활성. 상세 템플릿: `.claude/skills/mmp-module-factory/SKILL.md`
 
 ### 🔴 파일/함수 크기 제한 (유형별 티어)
 

--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -85,13 +85,12 @@ func BuildModules(
 		if err != nil {
 			return nil, nil, apperror.New(apperror.ErrBadRequest, http.StatusBadRequest, "unknown module: "+mc.Name)
 		}
-		// PR-2a runtime gate: reject modules that slipped past Register()
-		// (e.g. tests that inject factories into globalRegistry directly).
-		// Only enforced in strict mode to preserve legacy fallback behaviour.
-		if strictGateEnabled() {
-			if err := assertModuleContract(mc.Name, mod); err != nil {
-				return nil, nil, apperror.New(apperror.ErrBadRequest, http.StatusBadRequest, err.Error())
-			}
+		// PR-2a / Phase 19.1 PR-A runtime gate: reject modules that slipped
+		// past Register() (e.g. tests that inject factories into
+		// globalRegistry directly). Always enforced — the env-driven fallback
+		// was retired once all modules achieved compliance.
+		if err := assertModuleContract(mc.Name, mod); err != nil {
+			return nil, nil, apperror.New(apperror.ErrBadRequest, http.StatusBadRequest, err.Error())
 		}
 		if hs, ok := mod.(HostSubmittable); ok && !hs.IsHostSubmittable() {
 			return nil, nil, apperror.New(apperror.ErrForbidden, http.StatusForbidden, "module not host-submittable: "+mc.Name)

--- a/apps/server/internal/engine/gate_test.go
+++ b/apps/server/internal/engine/gate_test.go
@@ -10,16 +10,18 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// PR-2a F-sec-2 boot gate tests.
+// PR-2a / Phase 19.1 PR-A — F-sec-2 boot gate tests.
 //
 // These tests verify that:
 //   1. assertModuleContract accepts PlayerAware modules.
 //   2. assertModuleContract accepts PublicStateMarker-bearing modules.
 //   3. assertModuleContract rejects modules that implement neither.
-//   4. Register() panics in strict mode on a violating module.
+//   4. Register() panics on a violating module — the gate is always on; the
+//      Phase 18/19 env-driven escape hatch (MMP_PLAYERAWARE_STRICT) was
+//      retired in Phase 19.1 PR-A.
 //   5. BuildModules returns an error when a manually injected factory violates
 //      the contract (tests that bypass Register via direct map mutation).
-//   6. MMP_PLAYERAWARE_STRICT=false disables the panic path (legacy mode).
+//   6. Every currently-registered module satisfies the gate (regression).
 // ---------------------------------------------------------------------------
 
 // gateBareModule implements Module only (no marker, no BuildStateFor).
@@ -180,52 +182,10 @@ func TestBuildModules_RejectsGateViolation(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// MMP_PLAYERAWARE_STRICT=false disables the panic path.
-// ---------------------------------------------------------------------------
-
-func TestRegister_StrictModeDisabled_DoesNotPanic(t *testing.T) {
-	t.Setenv(strictModeEnvVar, "false")
-
-	orig := globalRegistry.factories
-	globalRegistry.factories = map[string]ModuleFactory{}
-	defer func() { globalRegistry.factories = orig }()
-
-	// In non-strict mode Register must NOT panic even on a bare module.
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("Register panicked in non-strict mode: %v", r)
-		}
-	}()
-
-	Register("legacy_bare", func() Module { return &gateBareModule{name: "legacy_bare"} })
-
-	if !HasModule("legacy_bare") {
-		t.Fatal("legacy bare module not registered in non-strict mode")
-	}
-}
-
-func TestStrictGateEnabled_Defaults(t *testing.T) {
-	t.Setenv(strictModeEnvVar, "")
-	if !strictGateEnabled() {
-		t.Error("empty env: strict mode should be ON by default")
-	}
-	for _, v := range []string{"false", "False", "FALSE", "0", "no", "off"} {
-		t.Setenv(strictModeEnvVar, v)
-		if strictGateEnabled() {
-			t.Errorf("env=%q: strict mode should be OFF", v)
-		}
-	}
-	for _, v := range []string{"true", "1", "yes", "on", "anything_else"} {
-		t.Setenv(strictModeEnvVar, v)
-		if !strictGateEnabled() {
-			t.Errorf("env=%q: strict mode should be ON", v)
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
-// All registered modules (production 33) must satisfy the gate.
-// This is the regression test that replaces the fallback path.
+// All registered modules (production 33) must satisfy the gate — regression
+// test. With the env-driven escape hatch retired in Phase 19.1 PR-A, any new
+// non-compliant module would panic at init(). This test still runs so that
+// future refactors of the gate logic itself are caught.
 // ---------------------------------------------------------------------------
 
 func TestAllRegisteredModules_SatisfyGate(t *testing.T) {

--- a/apps/server/internal/engine/phase_engine.go
+++ b/apps/server/internal/engine/phase_engine.go
@@ -282,7 +282,23 @@ func (e *PhaseEngine) DispatchAction(ctx context.Context, action PhaseActionPayl
 	return nil
 }
 
-// BuildState returns the full engine state for client synchronization.
+// BuildState returns the full engine state with every module's all-player
+// output combined into a single envelope.
+//
+// SECURITY — internal/persistence only. This method invokes Module.BuildState
+// directly, bypassing the PR-2a PlayerAware gate. The resulting payload may
+// contain role-private data for EVERY player (e.g. hidden missions, per-player
+// clue draws, whispered messages) and MUST NEVER be broadcast to clients.
+//
+// Runtime broadcasts and reconnect envelopes MUST flow through BuildStateFor
+// below. The only legitimate callers are:
+//   - SaveState for session persistence (mirrored by RestoreState).
+//   - Admin / fixture / debug tooling that explicitly surfaces the
+//     all-player view.
+//
+// Adding a new caller that hands this payload to a WebSocket, HTTP handler,
+// or user-visible log is a per-player data leakage hazard and requires a
+// security review before merging.
 func (e *PhaseEngine) BuildState() (json.RawMessage, error) {
 	state := map[string]any{
 		"sessionId": e.sessionID,

--- a/apps/server/internal/engine/registry.go
+++ b/apps/server/internal/engine/registry.go
@@ -2,8 +2,6 @@ package engine
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"sync"
 )
 
@@ -17,26 +15,6 @@ type Registry struct {
 // globalRegistry is the package-level registry populated by init() calls.
 var globalRegistry = &Registry{
 	factories: make(map[string]ModuleFactory),
-}
-
-// strictModeEnvVar toggles the PR-2a PlayerAware-or-PublicState boot gate.
-// Set MMP_PLAYERAWARE_STRICT=false to fall back to legacy permissive mode
-// (Phase 18 behaviour). Default: strict (true).
-const strictModeEnvVar = "MMP_PLAYERAWARE_STRICT"
-
-// strictGateEnabled reports whether Register should panic on modules that
-// implement neither PlayerAwareModule nor PublicStateModule.
-// Default: true. Any of "0", "false", "no", "off" (case-insensitive) disables.
-func strictGateEnabled() bool {
-	raw := strings.TrimSpace(os.Getenv(strictModeEnvVar))
-	if raw == "" {
-		return true
-	}
-	switch strings.ToLower(raw) {
-	case "0", "false", "no", "off":
-		return false
-	}
-	return true
 }
 
 // assertModuleContract validates that the module satisfies PR-2a: either it
@@ -58,14 +36,16 @@ func assertModuleContract(name string, m Module) error {
 	)
 }
 
-// Register adds a module factory to the global registry.
-// Called from each module's init() function.
+// Register adds a module factory to the global registry. Called from each
+// module's init() function.
 //
-// PR-2a boot gate: Register invokes factory() once to assert that the module
-// implements PlayerAwareModule OR embeds PublicStateMarker. When strict mode
-// is on (default), a missing contract panics — this is intentional and
-// surfaces at process start, not runtime. Disable via MMP_PLAYERAWARE_STRICT
-// only for temporary migration.
+// PR-2a / Phase 19.1 PR-A: Register invokes factory() once to assert that
+// the module implements PlayerAwareModule OR embeds PublicStateMarker, and
+// panics if neither is satisfied. The env-driven escape hatch
+// (MMP_PLAYERAWARE_STRICT) was retired after all 33 modules achieved
+// compliance — the gate is now always on and a failure here is intended to
+// stop the process at init time, surfacing configuration mistakes before
+// they reach production.
 func Register(name string, factory ModuleFactory) {
 	globalRegistry.mu.Lock()
 	defer globalRegistry.mu.Unlock()
@@ -74,15 +54,9 @@ func Register(name string, factory ModuleFactory) {
 		panic(fmt.Sprintf("engine: duplicate module registration: %s", name))
 	}
 
-	// PR-2a: sample the factory at boot and verify the F-sec-2 contract.
 	sample := factory()
 	if err := assertModuleContract(name, sample); err != nil {
-		if strictGateEnabled() {
-			panic(err.Error())
-		}
-		// Legacy permissive mode: log-via-panic would break tests; callers
-		// opting out accept silent fallback to BuildState.
-		fmt.Fprintf(os.Stderr, "engine: WARN %s (strict mode disabled)\n", err.Error())
+		panic(err.Error())
 	}
 
 	globalRegistry.factories[name] = factory

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -131,13 +131,17 @@ func (PublicStateMarker) isPublicState() {}
 
 // BuildModuleStateFor returns the player-aware state for a module.
 //
-// Gate hierarchy (PR-2a):
+// Gate hierarchy (PR-2a / Phase 19.1 PR-A):
 //  1. If the module implements PlayerAwareModule → BuildStateFor is called.
-//  2. Else if the module implements PublicStateModule → BuildState is called
-//     (module author has explicitly declared public state).
-//  3. Else (no marker and no BuildStateFor): registry should have panicked at
-//     init() time; this fallback preserves legacy behaviour when strict mode
-//     is disabled via MMP_PLAYERAWARE_STRICT=false.
+//  2. Else the module MUST implement PublicStateModule (engine.PublicStateMarker
+//     embed) — BuildState is called because the author has explicitly declared
+//     that the state is identical for every player.
+//
+// The env-driven escape hatch (MMP_PLAYERAWARE_STRICT) has been retired: any
+// module that satisfies neither interface would have been rejected by
+// Register() at init time. The BuildState() fallback below therefore runs
+// only against explicitly-public modules; it is NOT a safety net for
+// accidental leakage.
 func BuildModuleStateFor(m Module, playerID uuid.UUID) (json.RawMessage, error) {
 	if pam, ok := m.(PlayerAwareModule); ok {
 		return pam.BuildStateFor(playerID)


### PR DESCRIPTION
## Summary

Phase 19.1 W1 의 첫 PR. PR-2c 4-agent 사후 리뷰 MEDIUM 2건 번들:
1. **`MMP_PLAYERAWARE_STRICT` env escape hatch 제거** — PR-2a 도입 당시 rollout 안전판이었으나 PR-2c 로 33/33 gate 충족 후 negative-only 가치만 남음.
2. **`PhaseEngine.BuildState()` godoc 강화** — pub 메서드가 실수로 broadcast 경로에 유입되면 전-플레이어 데이터 유출. internal/persistence-only 경계를 godoc 으로 명시.

## 변경 요약

- `registry.go` · `factory.go` — strict env/함수 삭제, gate 상시 활성
- `types.go` — `BuildModuleStateFor` godoc 업데이트 (fallback 은 public 전용)
- `phase_engine.go` — `BuildState()` godoc 에 SECURITY 블록 추가
- `gate_test.go` — env-dependent 테스트 2개 제거
- `CLAUDE.md` — 변경 이력 + §모듈 시스템 갱신
- `.claude/skills/mmp-module-factory/SKILL.md` — §6 게이트 문구 갱신

**Diff: 7 files · +55 / -101 (net -46 LOC)**

## Test plan

- [x] `go fmt` + `go vet ./...` (exit 0)
- [x] `go build ./...` (exit 0)
- [x] `go test -race -count=1 ./internal/engine/... ./internal/module/... ./internal/session/...` — 전 패키지 green
- [x] `bash scripts/check-playeraware-coverage.sh` — clean
- [x] 런타임 경로 `MMP_PLAYERAWARE_STRICT` 참조 0건 (historical 문서만 잔존)
- [x] gate_test.go `TestAllRegisteredModules_SatisfyGate` 33/33 pass

## 영향

외부 API 불변. Production 에서 현재 env=false 설정 환경이 없음을 확인 — boot panic 회귀 없음.

## 참조

- 설계: `docs/plans/2026-04-18-phase-19-1-audit-followups/refs/pr-a.md`
- 상위 plan: `docs/plans/2026-04-18-phase-19-1-audit-followups/design.md`
- 선행 Phase 19: #97 (PR-2a gate 도입) → #104 (PR-2b) → #107 (PR-2c) → #108 (hotfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)