### PR TITLE
chore(phase-19.1)(pr-b): coverage lint AST 재작성 — BuildStateFor 회귀 4 패턴 차단

### DIFF
--- a/apps/server/cmd/playeraware-lint/main.go
+++ b/apps/server/cmd/playeraware-lint/main.go
@@ -1,0 +1,221 @@
+// playeraware-lint enforces the PR-2a / Phase 19 F-sec-2 boot-gate invariant at
+// source level: every engine.Module's BuildStateFor implementation must do
+// real per-player redaction — it may NOT delegate to BuildState() or snapshot
+// the whole-player map.
+//
+// Ran once per CI build against apps/server/internal/module/..., this linter
+// walks the Go AST and rejects four known regression patterns:
+//
+//  1. `return m.BuildState()`                               — direct delegate
+//  2. `data, err := m.BuildState(); return data, err`       — variable capture
+//  3. `return json.Marshal(m.snapshot())`                   — whole-state marshal
+//  4. `m.BuildState()` anywhere else in a BuildStateFor body (3-line stubs, etc.)
+//
+// Patterns 1 & 4 collapse into "any call on the receiver to BuildState" —
+// the AST walker catches that independent of surrounding syntax. Pattern 3
+// collapses into "any call on the receiver to snapshot()". Pattern 2 is
+// structurally identical to 1 once we stop caring about the return path.
+//
+// The previous awk+grep implementation at scripts/check-playeraware-coverage.sh
+// missed patterns 2 through 4 because they spanned more than -A2 lines or
+// used intermediate variables. This tool is a drop-in replacement.
+//
+// Usage:
+//
+//	go run ./cmd/playeraware-lint ./internal/module/...
+//	go run ./cmd/playeraware-lint --allow path/to/exempt ./internal/module/...
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type violation struct {
+	file    string
+	line    int
+	module  string // receiver type name (e.g. "CombinationModule")
+	pattern string
+	snippet string // trimmed source excerpt
+}
+
+func main() {
+	allowFlag := flag.String("allow", "", "comma-separated directory paths to exempt (deprecated — should normally be empty)")
+	flag.Usage = usage
+	flag.Parse()
+
+	roots := flag.Args()
+	if len(roots) == 0 {
+		usage()
+		os.Exit(2)
+	}
+
+	allow := parseAllowList(*allowFlag)
+
+	var all []violation
+	for _, root := range roots {
+		root = strings.TrimSuffix(root, "/...")
+		if err := walk(root, allow, &all); err != nil {
+			fmt.Fprintf(os.Stderr, "playeraware-lint: walk %s: %v\n", root, err)
+			os.Exit(2)
+		}
+	}
+
+	if len(all) == 0 {
+		fmt.Println("✅ playeraware-lint: no BuildStateFor delegates to BuildState/snapshot.")
+		return
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].file != all[j].file {
+			return all[i].file < all[j].file
+		}
+		return all[i].line < all[j].line
+	})
+
+	fmt.Fprintln(os.Stderr, "❌ playeraware-lint: BuildStateFor must do real per-player redaction:")
+	fmt.Fprintln(os.Stderr, "")
+	for _, v := range all {
+		fmt.Fprintf(os.Stderr, "  %s:%d  (*%s).BuildStateFor — %s\n", v.file, v.line, v.module, v.pattern)
+		if v.snippet != "" {
+			fmt.Fprintf(os.Stderr, "    > %s\n", v.snippet)
+		}
+	}
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Fix: implement real per-player redaction (e.g. snapshotFor(playerID)),")
+	fmt.Fprintln(os.Stderr, "or switch the module to engine.PublicStateMarker + drop BuildStateFor.")
+	os.Exit(1)
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: playeraware-lint [--allow pkg1,pkg2] <dir>[/...]...")
+}
+
+func parseAllowList(raw string) map[string]struct{} {
+	out := map[string]struct{}{}
+	if raw == "" {
+		return out
+	}
+	for _, p := range strings.Split(raw, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out[filepath.Clean(p)] = struct{}{}
+		}
+	}
+	return out
+}
+
+func walk(root string, allow map[string]struct{}, out *[]violation) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if _, skip := allow[filepath.Clean(path)]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		vs, err := inspectFile(path)
+		if err != nil {
+			return err
+		}
+		*out = append(*out, vs...)
+		return nil
+	})
+}
+
+// inspectFile parses a single Go source file and returns any violations in
+// its BuildStateFor method bodies. Pure AST — no type resolution required.
+func inspectFile(path string) ([]violation, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	return inspectAST(fset, file, path), nil
+}
+
+// inspectAST is the analyser used by both the filesystem walker and the
+// in-memory test fixtures.
+func inspectAST(fset *token.FileSet, file *ast.File, path string) []violation {
+	var violations []violation
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "BuildStateFor" {
+			continue
+		}
+		if fn.Recv == nil || len(fn.Recv.List) == 0 || fn.Body == nil {
+			continue
+		}
+		recvName := receiverIdentName(fn.Recv.List[0])
+		if recvName == "" {
+			continue // anonymous receiver — cannot match method calls reliably
+		}
+		typeName := receiverTypeName(fn.Recv.List[0])
+
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != recvName {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "BuildState":
+				violations = append(violations, violation{
+					file:    path,
+					line:    fset.Position(call.Pos()).Line,
+					module:  typeName,
+					pattern: "delegates to BuildState() — reveals every player's state",
+					snippet: fmt.Sprintf("%s.BuildState()", recvName),
+				})
+			case "snapshot":
+				violations = append(violations, violation{
+					file:    path,
+					line:    fset.Position(call.Pos()).Line,
+					module:  typeName,
+					pattern: "calls whole-map snapshot() from within per-player BuildStateFor",
+					snippet: fmt.Sprintf("%s.snapshot()", recvName),
+				})
+			}
+			return true
+		})
+	}
+	return violations
+}
+
+func receiverIdentName(field *ast.Field) string {
+	if len(field.Names) == 0 {
+		return ""
+	}
+	return field.Names[0].Name
+}
+
+func receiverTypeName(field *ast.Field) string {
+	expr := field.Type
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return "<unknown>"
+}

--- a/apps/server/cmd/playeraware-lint/main_test.go
+++ b/apps/server/cmd/playeraware-lint/main_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// Each fixture exercises one known regression shape. `want` indicates whether
+// inspectAST must return at least one violation from the module's
+// BuildStateFor body. The linter deliberately accepts some legitimate patterns
+// (direct map access, snapshotFor dispatch) as negatives.
+var fixtures = []struct {
+	name         string
+	src          string
+	wantAnyMatch bool
+	wantPattern  string // substring the reported pattern must contain (only for positives)
+}{
+	{
+		name: "ok_snapshotFor_dispatch",
+		src: `package combination
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+)
+type M struct{}
+func (m *M) snapshotFor(uuid.UUID) map[string][]string { return map[string][]string{} }
+func (m *M) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
+	return json.Marshal(m.snapshotFor(playerID))
+}`,
+		wantAnyMatch: false,
+	},
+	{
+		name: "ok_direct_field_access",
+		src: `package combination
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+)
+type M struct{ completed map[string][]string }
+func (m *M) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
+	key := playerID.String()
+	_ = key
+	return json.Marshal(m.completed[key])
+}`,
+		wantAnyMatch: false,
+	},
+	{
+		name: "bad_direct_delegate",
+		src: `package combination
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+)
+type M struct{}
+func (m *M) BuildState() (json.RawMessage, error) { return nil, nil }
+func (m *M) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return m.BuildState()
+}`,
+		wantAnyMatch: true,
+		wantPattern:  "BuildState()",
+	},
+	{
+		name: "bad_two_line_capture",
+		src: `package combination
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+)
+type M struct{}
+func (m *M) BuildState() (json.RawMessage, error) { return nil, nil }
+func (m *M) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	data, err := m.BuildState()
+	return data, err
+}`,
+		wantAnyMatch: true,
+		wantPattern:  "BuildState()",
+	},
+	{
+		name: "bad_marshal_whole_snapshot",
+		src: `package combination
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+)
+type M struct{}
+func (m *M) snapshot() any { return nil }
+func (m *M) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	return json.Marshal(m.snapshot())
+}`,
+		wantAnyMatch: true,
+		wantPattern:  "snapshot()",
+	},
+	{
+		name: "bad_three_line_stub",
+		src: `package combination
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+)
+type M struct{}
+func (m *M) BuildState() (json.RawMessage, error) { return nil, nil }
+func (m *M) BuildStateFor(_ uuid.UUID) (json.RawMessage, error) {
+	// noop
+	_ = 1
+	return m.BuildState()
+}`,
+		wantAnyMatch: true,
+		wantPattern:  "BuildState()",
+	},
+}
+
+func TestInspectAST_Fixtures(t *testing.T) {
+	for _, tc := range fixtures {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, tc.name+".go", tc.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			got := inspectAST(fset, file, tc.name+".go")
+
+			if tc.wantAnyMatch && len(got) == 0 {
+				t.Fatalf("expected violations for %q, got none", tc.name)
+			}
+			if !tc.wantAnyMatch && len(got) != 0 {
+				t.Fatalf("expected NO violations for %q, got %d: %v", tc.name, len(got), got)
+			}
+			if !tc.wantAnyMatch {
+				return
+			}
+			found := false
+			for _, v := range got {
+				if strings.Contains(v.snippet, tc.wantPattern) || strings.Contains(v.pattern, tc.wantPattern) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected pattern containing %q, got %+v", tc.wantPattern, got)
+			}
+		})
+	}
+}
+
+// TestParseAllowList_TrimsAndClean ensures the CLI flag parser is robust
+// against whitespace and trailing slashes.
+func TestParseAllowList_TrimsAndClean(t *testing.T) {
+	m := parseAllowList(" foo/bar , baz/ ,,  ")
+	if _, ok := m["foo/bar"]; !ok {
+		t.Errorf("expected foo/bar in allow list: %v", m)
+	}
+	if _, ok := m["baz"]; !ok {
+		t.Errorf("expected baz (trailing slash trimmed by filepath.Clean) in allow list: %v", m)
+	}
+	if len(m) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(m), m)
+	}
+}
+
+// TestReceiverIdentName covers the two shapes the tool must handle.
+func TestReceiverHelpers(t *testing.T) {
+	src := `package x
+type M struct{}
+func (m *M) A() {}
+func (*M) B() {}`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "x.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := map[string]struct {
+		name string
+		typ  string
+	}{}
+	for _, d := range file.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil {
+			continue
+		}
+		got[fn.Name.Name] = struct {
+			name string
+			typ  string
+		}{
+			name: receiverIdentName(fn.Recv.List[0]),
+			typ:  receiverTypeName(fn.Recv.List[0]),
+		}
+	}
+	if got["A"].name != "m" || got["A"].typ != "M" {
+		t.Errorf("A receiver: got %+v, want {m M}", got["A"])
+	}
+	if got["B"].name != "" || got["B"].typ != "M" {
+		t.Errorf("B receiver: got %+v, want {\"\" M}", got["B"])
+	}
+}

--- a/scripts/check-playeraware-coverage.sh
+++ b/scripts/check-playeraware-coverage.sh
@@ -1,74 +1,27 @@
 #!/usr/bin/env bash
 #
-# PR-2b coverage lint: BuildStateFor must not be a stub.
+# Phase 19 F-sec-2 gate — BuildStateFor coverage lint.
 #
-# Rationale
-# ---------
-# Phase 19 F-sec-2 gate forces every engine.Module to either
-#   (a) implement PlayerAwareModule.BuildStateFor with real per-player
-#       redaction, or
-#   (b) embed engine.PublicStateMarker (and therefore not implement
-#       BuildStateFor at all).
+# Since Phase 19.1 PR-B this script is a thin wrapper around the Go-based AST
+# linter at apps/server/cmd/playeraware-lint. The AST walker catches four
+# regression patterns the original awk/grep implementation missed:
 #
-# A module that does implement BuildStateFor but delegates straight back to
-# m.BuildState() has opted neither in nor out — it reintroduces the pre-PR-2a
-# permissive fallback. This lint flags that single regression pattern.
+#   1. return m.BuildState()                                  (direct delegate)
+#   2. data, err := m.BuildState(); return data, err          (variable capture)
+#   3. return json.Marshal(m.snapshot())                      (whole-state marshal)
+#   4. m.BuildState() anywhere in a multi-line BuildStateFor body
 #
-# The regex is deliberately narrow:
-#   - grep -A2 after a BuildStateFor signature
-#   - require the literal `return m.BuildState()` on one of the next lines
-#   - one-line stubs (`{ return m.BuildState() }`) are also matched
-#
-# Legitimate patterns (independent snapshot, even if semantically identical
-# to BuildState) pass because the body references module fields instead of
-# re-calling BuildState.
+# Empty ALLOW list as of PR-2c (2026-04-18): crime_scene/combination now
+# implements real per-player redaction (D-MO-1). Add a new `--allow` entry
+# below only when introducing a deliberate, time-boxed stub tracked by a
+# follow-up PR.
 
 set -euo pipefail
 
-ROOT="${1:-apps/server/internal/module}"
+ROOT="${1:-./internal/module/...}"
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
-if [ ! -d "$ROOT" ]; then
-    echo "scripts/check-playeraware-coverage.sh: directory not found: $ROOT" >&2
-    exit 2
-fi
+cd "$REPO_ROOT/apps/server"
 
-# Allowed exceptions (tracked as their own PR). Each path must be removed
-# from this list when the corresponding real-redaction PR lands.
-#
-# Empty as of PR-2c (2026-04-18): crime_scene/combination now implements real
-# per-player redaction (D-MO-1). Add a new entry here only when introducing a
-# deliberate, time-boxed stub that is tracked by a follow-up PR.
-ALLOW_STUB=()
-
-allow_filter=""
-for p in "${ALLOW_STUB[@]}"; do
-    if [ -z "$allow_filter" ]; then
-        allow_filter="$p"
-    else
-        allow_filter="$allow_filter|$p"
-    fi
-done
-
-# Collect BuildStateFor-signature lines with 2 lines of trailing context, then
-# surface only the blocks that contain `return m.BuildState()`.
-match_blocks=$(grep -rn --include='*.go' -A2 -E 'func \([a-zA-Z_]+ \*?[A-Z][a-zA-Z0-9_]*\) BuildStateFor\(' "$ROOT" 2>/dev/null | \
-    (if [ -n "$allow_filter" ]; then grep -vE "$allow_filter"; else cat; fi) || true)
-
-violations=$(echo "$match_blocks" | awk '
-    /BuildStateFor\(/ { sig=$0; armed=1; next }
-    armed==1 && /return[[:space:]]+m\.BuildState\(\)/ { print sig; print $0; armed=0; next }
-    /^--$/ { armed=0 }
-')
-
-if [ -n "$violations" ]; then
-    echo "❌ PR-2b coverage lint — BuildStateFor delegates to m.BuildState() (stub pattern banned):" >&2
-    echo "" >&2
-    echo "$violations" >&2
-    echo "" >&2
-    echo "Fix: either implement real per-player redaction, or switch the" >&2
-    echo "module to PublicStateMarker (remove BuildStateFor, embed" >&2
-    echo "engine.PublicStateMarker)." >&2
-    exit 1
-fi
-
-echo "✅ PR-2b coverage clean — no BuildStateFor → m.BuildState() stubs under $ROOT."
+# shellcheck disable=SC2086  # intentional word-splitting of $ROOT
+go run ./cmd/playeraware-lint $ROOT


### PR DESCRIPTION
## Summary

Phase 19.1 W1 두 번째 PR. PR-2c 4-agent 리뷰 MEDIUM "coverage lint 우회 가능" 해소. awk+grep 기반 lint 는 `return m.BuildState()` literal 만 탐지했으나 AST 기반 재작성으로 4 우회 패턴 모두 차단.

### 4 패턴
1. `return m.BuildState()` — literal (기존 catch)
2. `data, err := m.BuildState(); return data, err` — 2줄 캡처
3. `return json.Marshal(m.snapshot())` — whole-state marshal
4. `m.BuildState()` anywhere in 3+ line body

### 변경
- **신규** `apps/server/cmd/playeraware-lint/main.go` (+220 LOC) — `go/parser` + `go/ast` 기반 walker
- **신규** `apps/server/cmd/playeraware-lint/main_test.go` — 인라인 fixture 6 case (ok 2 + bad 4) + 보조 테스트 2
- **교체** `scripts/check-playeraware-coverage.sh` (+17 / -64) — `go run ./cmd/playeraware-lint` 호출로 변경
- CI workflow 수정 불필요 (동일 shell wrapper 경로)

**Diff: 3 files · +436 / -64**

## Test plan

- [x] `go test -race -count=1 ./cmd/playeraware-lint/...` — 8/8 pass (fixtures + allow-list + receiver helpers)
- [x] `go run ./cmd/playeraware-lint ./internal/module/...` — exit 0, clean (33 모듈)
- [x] `bash scripts/check-playeraware-coverage.sh` — exit 0, clean (repo root 외 동작)
- [x] `go vet ./...` + `go build ./...` — exit 0
- [x] `go test -race -count=1 ./internal/engine/...` — 회귀 없음

## 영향

- 외부 API 불변. 33 모듈 현재 clean.
- CI step 변경 없음 — 단일 shell wrapper 호출 경로 유지.
- 신규 모듈이 4 우회 패턴 중 하나를 사용하면 이제 CI 가 잡는다 (awk 시절 sneak-through 방지).

## 참조

- 설계: `docs/plans/2026-04-18-phase-19-1-audit-followups/refs/pr-b.md`
- 선행 PR-A (#111, strict env 제거): main 이미 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)