### PR TITLE
test(phase-19.1)(pr-c): session-level 통합 테스트 + 3+ players table + PeerLeakAssert helper

### DIFF
--- a/apps/server/internal/engine/testutil/redaction.go
+++ b/apps/server/internal/engine/testutil/redaction.go
@@ -1,0 +1,53 @@
+// Package testutil provides shared helpers for engine module redaction tests.
+// Lives outside the engine package so callers in module/ and session/ can
+// import it without creating cycles.
+package testutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// PeerLeakAssert verifies that a per-player snapshot payload (`raw`) contains
+// no reference to any peer's UUID string. This is the canonical cross-package
+// assertion for the PR-2a / Phase 19 F-sec-2 per-player redaction contract.
+//
+// The check is a substring match: simple, strict, and catches the common
+// module authoring bug where peer UUIDs end up as map keys in the serialised
+// snapshot. False positives are possible only if a peer UUID legitimately
+// matches some non-key field in the payload — no such collision exists in
+// current modules, and the risk is outweighed by the cost of a full JSON
+// walk that would know nothing about module-specific field semantics.
+//
+// Usage:
+//
+//	raw, _ := mod.BuildStateFor(alice)
+//	testutil.PeerLeakAssert(t, raw, alice, bob, charlie)
+//
+// The `caller` argument is only used for error messages — it does not have to
+// be present in the payload (a player with no state yet yields an empty
+// snapshot, which is also a valid passing case).
+func PeerLeakAssert(t *testing.T, raw []byte, caller uuid.UUID, peers ...uuid.UUID) {
+	t.Helper()
+	s := string(raw)
+	for _, p := range peers {
+		if strings.Contains(s, p.String()) {
+			t.Errorf(
+				"peer uuid %s leaked into caller %s snapshot:\n  payload=%s",
+				p, caller, s,
+			)
+		}
+	}
+}
+
+// AssertContainsCaller asserts that the snapshot DOES carry the caller's UUID
+// when state exists for them. Useful alongside PeerLeakAssert to confirm that
+// redaction is not over-zealous (stripping the caller's own entry).
+func AssertContainsCaller(t *testing.T, raw []byte, caller uuid.UUID) {
+	t.Helper()
+	if !strings.Contains(string(raw), caller.String()) {
+		t.Errorf("caller %s missing from own snapshot: %s", caller, raw)
+	}
+}

--- a/apps/server/internal/engine/testutil/redaction_test.go
+++ b/apps/server/internal/engine/testutil/redaction_test.go
@@ -1,0 +1,64 @@
+package testutil_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine/testutil"
+)
+
+// TestPeerLeakAssert_FlagsPeerPresence — a peer UUID anywhere in the raw
+// payload must be reported.
+func TestPeerLeakAssert_FlagsPeerPresence(t *testing.T) {
+	alice := uuid.New()
+	bob := uuid.New()
+
+	payload := []byte(`{"completed":{"` + alice.String() + `":["c1"],"` + bob.String() + `":["c2"]}}`)
+
+	// Subtest isolates the inner t.Errorf so we can observe a failing
+	// PeerLeakAssert without failing the outer test.
+	spy := &testing.T{}
+	testutil.PeerLeakAssert(spy, payload, alice, bob)
+	if !spy.Failed() {
+		t.Error("expected PeerLeakAssert to flag bob leak, but spy reported no failure")
+	}
+}
+
+// TestPeerLeakAssert_PassesOnCleanPayload — a payload with only the caller's
+// UUID must not trip the assertion.
+func TestPeerLeakAssert_PassesOnCleanPayload(t *testing.T) {
+	alice := uuid.New()
+	bob := uuid.New()
+
+	payload := []byte(`{"completed":{"` + alice.String() + `":["c1"]}}`)
+
+	spy := &testing.T{}
+	testutil.PeerLeakAssert(spy, payload, alice, bob)
+	if spy.Failed() {
+		t.Errorf("PeerLeakAssert should have passed a clean payload, but spy reported failure")
+	}
+}
+
+// TestAssertContainsCaller_RequiresCallerWhenStateExists — the caller's UUID
+// must be present in their own payload when state is non-empty.
+func TestAssertContainsCaller_RequiresCallerWhenStateExists(t *testing.T) {
+	alice := uuid.New()
+	payload := []byte(`{"completed":{}}`) // empty — no caller UUID
+
+	spy := &testing.T{}
+	testutil.AssertContainsCaller(spy, payload, alice)
+	if !spy.Failed() {
+		t.Error("expected AssertContainsCaller to flag missing caller, but spy reported no failure")
+	}
+}
+
+func TestAssertContainsCaller_Passes(t *testing.T) {
+	alice := uuid.New()
+	payload := []byte(`{"completed":{"` + alice.String() + `":["c1"]}}`)
+
+	spy := &testing.T{}
+	testutil.AssertContainsCaller(spy, payload, alice)
+	if spy.Failed() {
+		t.Errorf("AssertContainsCaller should have passed, but spy reported failure")
+	}
+}

--- a/apps/server/internal/module/crime_scene/combination/combination_test.go
+++ b/apps/server/internal/module/crime_scene/combination/combination_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mmp-platform/server/internal/engine"
+	"github.com/mmp-platform/server/internal/engine/testutil"
 )
 
 func newTestDeps() engine.ModuleDeps {
@@ -716,4 +717,148 @@ func TestCombinationModule_Cleanup(t *testing.T) {
 		t.Fatal("expected nil comboByID after cleanup")
 	}
 	m.mu.RUnlock()
+}
+
+// Phase 19.1 PR-C: multi-player (3+) redaction matrix using the shared
+// PeerLeakAssert helper from engine/testutil. Each player in a 3-player
+// session has distinct completed/derived sets; iterating the caller guarantees
+// no peer UUID leaks into anyone's snapshot.
+func TestCombinationModule_BuildStateFor_ThreePlayersTable_NoPeerLeak(t *testing.T) {
+	m := NewCombinationModule()
+	if err := m.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	bob := uuid.New()
+	charlie := uuid.New()
+
+	m.mu.Lock()
+	m.completed[alice] = []string{"combo1"}
+	m.derived[alice] = []string{"weapon_set"}
+	m.collected[alice] = map[string]bool{"knife": true, "glove": true}
+	m.completed[bob] = []string{"combo2"}
+	m.derived[bob] = []string{"motive"}
+	m.collected[bob] = map[string]bool{"note": true}
+	// charlie: no progress — must receive an empty but well-formed shape.
+	m.mu.Unlock()
+
+	cases := []struct {
+		name       string
+		caller     uuid.UUID
+		peers      []uuid.UUID
+		wantCaller bool // expect caller.String() to appear in raw (false for zero-state)
+	}{
+		{"alice", alice, []uuid.UUID{bob, charlie}, true},
+		{"bob", bob, []uuid.UUID{alice, charlie}, true},
+		{"charlie_zero_state", charlie, []uuid.UUID{alice, bob}, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := m.BuildStateFor(tc.caller)
+			if err != nil {
+				t.Fatalf("BuildStateFor(%s): %v", tc.name, err)
+			}
+			testutil.PeerLeakAssert(t, raw, tc.caller, tc.peers...)
+			if tc.wantCaller {
+				testutil.AssertContainsCaller(t, raw, tc.caller)
+			}
+		})
+	}
+}
+
+// Phase 19.1 PR-C: after SaveState / RestoreState round-trip, BuildStateFor
+// must continue to emit only the caller's entries. Regression against a drift
+// where Restore reconstitutes maps under different keys and the per-player
+// filter silently fails to match.
+func TestCombinationModule_BuildStateFor_AfterRestoreState_PreservesRedaction(t *testing.T) {
+	src := NewCombinationModule()
+	if err := src.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init src: %v", err)
+	}
+	alice := uuid.New()
+	bob := uuid.New()
+	src.mu.Lock()
+	src.completed[alice] = []string{"combo1"}
+	src.derived[alice] = []string{"weapon_set"}
+	src.completed[bob] = []string{"combo2"}
+	src.derived[bob] = []string{"motive"}
+	src.mu.Unlock()
+
+	gs, err := src.SaveState(context.Background())
+	if err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	dst := NewCombinationModule()
+	if err := dst.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init dst: %v", err)
+	}
+	if err := dst.RestoreState(context.Background(), uuid.New(), gs); err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+
+	rawAlice, err := dst.BuildStateFor(alice)
+	if err != nil {
+		t.Fatalf("BuildStateFor(alice): %v", err)
+	}
+	testutil.AssertContainsCaller(t, rawAlice, alice)
+	testutil.PeerLeakAssert(t, rawAlice, alice, bob)
+
+	rawBob, err := dst.BuildStateFor(bob)
+	if err != nil {
+		t.Fatalf("BuildStateFor(bob): %v", err)
+	}
+	testutil.AssertContainsCaller(t, rawBob, bob)
+	testutil.PeerLeakAssert(t, rawBob, bob, alice)
+}
+
+// Phase 19.1 PR-C: verify that engine.BuildModuleStateFor correctly dispatches
+// to CombinationModule.BuildStateFor (PlayerAware path, not BuildState
+// fallback). This pins the engine-level wiring that PR-2a installed.
+func TestCombinationModule_BuildStateFor_ViaEngineDispatch(t *testing.T) {
+	m := NewCombinationModule()
+	if err := m.Init(context.Background(), newTestDeps(), combinationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	bob := uuid.New()
+	m.mu.Lock()
+	m.completed[alice] = []string{"combo1"}
+	m.derived[alice] = []string{"weapon_set"}
+	m.completed[bob] = []string{"combo2"}
+	m.derived[bob] = []string{"motive"}
+	m.mu.Unlock()
+
+	// engine.BuildModuleStateFor dispatches to PlayerAwareModule.BuildStateFor
+	// when the module satisfies the interface. If this ever regresses to
+	// m.BuildState() fallback (e.g. through a refactor removing the
+	// PlayerAwareModule interface assertion), the assert below will catch it
+	// because bob's UUID would leak into alice's payload.
+	raw, err := engine.BuildModuleStateFor(m, alice)
+	if err != nil {
+		t.Fatalf("BuildModuleStateFor(alice): %v", err)
+	}
+	testutil.AssertContainsCaller(t, raw, alice)
+	testutil.PeerLeakAssert(t, raw, alice, bob)
+
+	// Second player — same assertion flipped.
+	raw2, err := engine.BuildModuleStateFor(m, bob)
+	if err != nil {
+		t.Fatalf("BuildModuleStateFor(bob): %v", err)
+	}
+	testutil.AssertContainsCaller(t, raw2, bob)
+	testutil.PeerLeakAssert(t, raw2, bob, alice)
+
+	// Sanity: BuildState() DOES contain both (reserved for persistence).
+	// This is not a security failure — it confirms the internal path exists
+	// and why the pub method needs the godoc boundary added in PR-A.
+	all, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if !strings.Contains(string(all), alice.String()) || !strings.Contains(string(all), bob.String()) {
+		t.Errorf("BuildState should include both players (persistence view), got %s", all)
+	}
 }


### PR DESCRIPTION
## Summary

Phase 19.1 W1 마지막 PR. PR-2c 4-agent 리뷰 LOW "통합 테스트 부재" + PR-C 설계의 helper export / 3+ players table / RestoreState 회귀 3 축 처리.

### 신규 `apps/server/internal/engine/testutil` 패키지
- `PeerLeakAssert(t, raw, caller, peers...)` — per-player 스냅샷 redaction 계약의 canonical cross-package assertion
- `AssertContainsCaller(t, raw, caller)` — over-redaction 방지용
- 4 self-test (testing.T spy 기법)

### `combination/combination_test.go` — 3 통합 테스트
1. **`ThreePlayersTable_NoPeerLeak`** — alice/bob/charlie table-driven, zero-state 포함
2. **`AfterRestoreState_PreservesRedaction`** — SaveState (persistence-view) → Restore → BuildStateFor 회귀 방지
3. **`ViaEngineDispatch`** — `engine.BuildModuleStateFor` 경로 pinning

### Diff
- 3 files · +262 / -0

### 설계 차이
session layer `TestSnapshot_Redaction_CombinationCrafted` 는 `SessionManager.Start` 가 nil module list 로 PhaseEngine 만들어 real CombinationModule 주입 불가 → session API 확장 없이 `engine.BuildModuleStateFor` 레벨에서 등가 회귀 테스트로 달성. `session/snapshot_test.go::TestSnapshot_TwoReconnectsBothViaActor` 가 기존에 actor path 커버.

## Test plan

- [x] `go test -race -count=1 ./internal/engine/testutil/...` — 4/4 pass
- [x] `go test -race -count=1 ./internal/module/crime_scene/combination/... -run ThreePlayers|AfterRestore|ViaEngine` — 3/3 pass
- [x] `go test -race -count=1 ./internal/engine/... ./internal/module/... ./internal/session/...` — 17 패키지 green
- [x] `go vet ./...` + `go build ./...` — exit 0
- [x] `bash scripts/check-playeraware-coverage.sh` — clean (PR-B AST lint)

## 영향

외부 API 불변. 신규 `testutil` 패키지는 test-only import path — production 바이너리 미포함.

## 참조

- 설계: `docs/plans/2026-04-18-phase-19-1-audit-followups/refs/pr-c.md`
- 선행 PR-A #111 (strict env 제거) + PR-B #112 (AST lint) — main 이미 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)