### PR TITLE
docs(module-spec): crime_scene + media 카테고리 신설 (33 모듈 동기화)

### DIFF
--- a/docs/plans/2026-04-05-rebuild/module-spec.md
+++ b/docs/plans/2026-04-05-rebuild/module-spec.md
@@ -1,6 +1,7 @@
 # MMP v3 모듈 스펙 인덱스
 
-> 29개 모듈 상세는 `refs/modules/` 참조. 이 파일은 전체 목록 + 핵심 원칙만.
+> 33개 모듈 상세는 `refs/modules/` 참조. 이 파일은 전체 목록 + 핵심 원칙만.
+> (스펙 원본 29개 + Phase 11~12에서 승격된 CrimeScene 3 + Media 1 = 33)
 
 ## 핵심 원칙
 
@@ -8,6 +9,7 @@
 2. **콘텐츠 = 고정형 + 자율형** — 고정: 모듈/캐릭터 추가 시 자동. 자율: 제작자 임의 생성
 3. **gmMode 연동** — REQUIRED→GmControl, NONE→ConsensusControl, OPTIONAL→둘 다
 4. **PhaseAction 12종** — 모듈 상태 변경 부수효과 (ActionDispatcher → PhaseReactor)
+5. **🔴 PlayerAware 게이트 (F-sec-2, Phase 19.1 PR-A 이후 필수)** — 모든 `engine.Module`은 `BuildStateFor(playerID)` 구현(per-player redaction) **또는** `engine.PublicStateMarker` 임베드(전원 공개) 둘 중 하나 충족. registry boot panic으로 강제, escape hatch 없음.
 
 ## PhaseAction 전체 목록
 
@@ -18,13 +20,13 @@
 | SET_CLUE_LEVEL | ClueInteraction |
 | OPEN_VOTING / CLOSE_VOTING | Voting |
 | ALLOW_EXCHANGE | TradeClue |
-| BROADCAST_MESSAGE / PLAY_SOUND | (모듈 무관) |
-| PLAY_MEDIA / SET_BGM | (모듈 무관) |
+| PLAY_SOUND / PLAY_MEDIA / SET_BGM / STOP_AUDIO | **Audio** (Phase 11+ 승격) |
+| BROADCAST_MESSAGE | (모듈 무관) |
 | MUTE_CHAT / UNMUTE_CHAT | TextChat, Whisper, GroupChat |
 | OPEN_GROUP_CHAT / CLOSE_GROUP_CHAT | GroupChat |
 | LOCK_MODULE / UNLOCK_MODULE | 대상 모듈 |
 
-## 전체 모듈 목록 (29개)
+## 전체 모듈 목록 (33개)
 
 ### A. Core (항상 활성) → [refs/modules/core.md](refs/modules/core.md)
 | # | 모듈 | 역할 |
@@ -68,7 +70,7 @@
 | 21 | FloorExploration | 층 이동 (택1) |
 | 22 | RoomBasedExploration | 방 이동 (택1) |
 | 23 | TimedExploration | 시간 제한 (택1) |
-| 24 | LocationClue | 장소 단서 배치 (독립) |
+| 24 | LocationClue | 장소 단서 배치 (독립, 공용 풀) |
 
 ### F. Clue Distribution → [refs/modules/clue-distribution.md](refs/modules/clue-distribution.md)
 | # | 모듈 | 역할 |
@@ -79,8 +81,39 @@
 | 28 | TimedClue | 시간 경과 자동 배포 |
 | 29 | TradeClue | 교환 + 보여주기 |
 
+### G. Crime Scene (Phase 11+ 승격) → [refs/modules/crime_scene.md](refs/modules/crime_scene.md)
+| # | 모듈 | 역할 |
+|---|------|------|
+| 30 | Location | 플레이어 이동·검사 (per-player 위치) |
+| 31 | Evidence | 증거 발견·수집 (장소 연계, autoDiscover) |
+| 32 | Combination | 증거 조합 → 파생 단서 (CRAFT trigger) |
+
+### H. Media (Phase 11+ 승격) → [refs/modules/media.md](refs/modules/media.md)
+| # | 모듈 | 역할 |
+|---|------|------|
+| 33 | Audio | 오디오 PhaseAction 브리지 + Reading 음성 자동화 |
+
 ## 호환성 매트릭스
 
 **상호 배타:** script ↔ hybrid ↔ event / floor ↔ room ↔ timed
 **의존:** skip-consensus → script / spatial-voice → voice-chat + (floor OR room)
 **gmMode:** REQUIRED→gm-control / NONE→consensus / OPTIONAL→둘 다
+**권장 세트:** crime_scene/{location, evidence, combination} — 수사 루프 3종
+**독립:** audio, location-clue (다른 모듈과 자유 조합)
+
+## 네이밍 혼동 주의
+
+| 축 | LocationClueModule (#24) | LocationModule (#30) |
+|----|-------------------------|----------------------|
+| 카테고리 | Exploration | CrimeScene |
+| 역할 | 탐색 위 단서 배치 (공용 풀) | 플레이어 이동·검사 (per-player) |
+| 타입 문자열 | `location-clue` | `location` |
+
+## PlayerAware 게이트 분포 (33개 기준)
+
+| 분류 | 모듈 (예) |
+|------|----------|
+| **per-player redaction** (`BuildStateFor`) | ClueInteraction, Whisper, GroupChat, TextChat, Reading, Voting, Accusation, HiddenMission, Evidence, Location, Combination |
+| **public state** (`PublicStateMarker`) | Room, Audio, VoiceChat, SpatialVoice, Script/Hybrid/EventProgression, GmControl, SkipConsensus, ConsensusControl, Ending |
+
+registry boot panic + `go test ./internal/engine/... -run Gate`로 33/33 충족 검증.

--- a/docs/plans/2026-04-05-rebuild/refs/modules/crime_scene.md
+++ b/docs/plans/2026-04-05-rebuild/refs/modules/crime_scene.md
@@ -1,0 +1,159 @@
+# Crime Scene 모듈 (3개) — 수사 메커니즘
+
+> Phase 11.0(2026-04-13) 단서 아이템 + 메타포 템플릿 도입으로 승격된 신규 카테고리.
+> 스펙 #24 `LocationClueModule`(탐색 위 단서 배치)과 달리, **crime_scene은 장소 이동·증거 수집·조합의 구체 수사 루프**를 담당. 독립 카테고리로 분리해 혼동 방지.
+
+## 이벤트 체인
+
+```
+location.examine → location.examined
+                    ↓ (autoDiscover=true)
+                 evidence.discovered → evidence.collected
+                                        ↓ (구독)
+                                     combination.completed / clue_unlocked / available
+```
+
+---
+
+## 30. LocationModule
+
+```
+타입: location | 카테고리: CRIME_SCENE | 인증: CHARACTER
+PhaseReactor: 아님
+인터페이스: Module + GameEventHandler + SerializableModule + RuleProvider + PlayerAwareModule
+```
+
+**ConfigSchema:**
+| Key | Label | Type | Default |
+|-----|-------|------|---------|
+| locations | 장소 목록 | LocationDef[] | [] |
+| startingLocation | 시작 장소 | string | "" |
+| moveCooldownSec | 이동 쿨다운 (초) | number | 0 (무제한) |
+
+**LocationDef:** `{ id, name, description, accessRules[] }`
+
+**WS 이벤트:**
+- `→ location:move { location_id }` → `← location.moved { playerID, locationID }`
+- `→ location:examine { location_id }` → `← location.examined { playerID, locationID }`
+
+**State (per-player):** `positions[playerID]` / `history[playerID]` / `lastMove[playerID]`
+
+**PlayerAware 경계 (F-sec-2 / Phase 18.1 B-2):**
+- `BuildStateFor(alice)` → 본인 위치 + 이동 히스토리만 공개
+- Peer 위치는 기본 **비공개** (공개 맵 필요 시 `engine.PublicStateMarker` 임베드로 opt-out 권장)
+
+**핵심:**
+- 이동 시 쿨다운 검증 (`moveCooldownSec > 0` 설정 시)
+- `startingLocation`은 Init 시점 존재 검증
+- `evidence.autoDiscover=true`일 때 `location.examined` 발행 → evidence 모듈이 구독
+
+---
+
+## 31. EvidenceModule
+
+```
+타입: evidence | 카테고리: CRIME_SCENE | 인증: CHARACTER
+PhaseReactor: 아님
+인터페이스: Module + GameEventHandler + SerializableModule + PlayerAwareModule
+```
+
+**ConfigSchema:**
+| Key | Label | Type | Default |
+|-----|-------|------|---------|
+| evidence | 증거 목록 | EvidenceDef[] | [] |
+| autoDiscover | 장소 검사 시 자동 발견 | boolean | false |
+
+**EvidenceDef:** `{ id, name, locationId, availableAtPhase, hidden }`
+- `availableAtPhase=""` → 시작부터 해금
+- `hidden=true` → autoDiscover 대상에서 제외 (명시적 discover 메시지 필요)
+
+**WS 이벤트:**
+- `→ evidence:discover { evidence_id, location_id? }` → `← evidence.discovered`
+- `→ evidence:collect { evidence_id }` → `← evidence.collected`
+- (자동) `location.examined` 구독 시 `autoDiscover` 실행
+
+**핵심 불변식:**
+1. collect는 discovered 이후에만 가능
+2. 같은 증거 중복 discover/collect는 idempotent (무시)
+3. `hidden=true` 증거는 autoDiscover 건너뜀 → 플레이어가 명시적으로 찾아야 함
+4. phase 게이트: `availableAtPhase` 미도달 증거는 `unlockedByID=false`
+
+**State (per-player):** `discovered[playerID][]` / `collected[playerID][]`
+
+**PlayerAware:** 본인 발견/수집만 공개. Peer 진행 상황 누출 차단.
+
+**EventBus 발행:** `evidence.discovered`, `evidence.collected` → combination 모듈이 수신
+
+---
+
+## 32. CombinationModule
+
+```
+타입: combination | 카테고리: CRIME_SCENE | 인증: CHARACTER
+PhaseReactor: 아님
+인터페이스: Module + GameEventHandler + WinChecker + RuleProvider
+            + SerializableModule + PlayerAwareModule (5종 — 레포 최다)
+파일 구조: 4-file 분할 (module/handlers/state/events)
+```
+
+**ConfigSchema:**
+| Key | Label | Type | Default |
+|-----|-------|------|---------|
+| combinations | 조합 레시피 | CombinationDef[] | [] |
+| winCombination | 승리 조건 증거 ID | string[] | [] |
+
+**CombinationDef:** `{ id, inputIds[], outputClueId, description }`
+
+**Phase 20 PR-5 단일 소스:** `id` 필드가 `clue_edge_groups.id`와 일치 → 에디터가 CRAFT-트리거 그룹을 만들면 ID 공유. 클라이언트는 `combine` payload에 `group_id`를 직접 넘길 수 있음 (O(1) 매칭). 미전달 시 `inputIds` 집합 동등성으로 fallback.
+
+**WS 이벤트:**
+- `→ combination:combine { evidence_ids[], group_id? }`
+- `← combination.completed { playerID, combinationID }`
+- `← combination.clue_unlocked { playerID, outputClueID }`
+- `← combination.available { playerID, clueID }` (재료 확보 시 자동 발행)
+
+**핵심 보안 — CRAFT Trigger (Phase 20 PR-5):**
+- `clue.Graph`에 `Trigger: clue.TriggerCRAFT`로 등록 → 재료만 모여도 자동 해금 **금지**
+- `handleCombine`가 명시적으로 성공해야 output clue가 `crafted` 집합에 진입
+- `graph.Resolve(discovered, crafted)` — CRAFT output은 crafted 진입 전까지 reveal 차단
+
+**핵심 불변식:**
+1. `HasCycle()` Init 시점 검증 — 순환 의존 거부
+2. 모든 input이 `collected`에 있어야 combine 성공
+3. 같은 combo 중복 완료는 idempotent (early return)
+4. **Deadlock 방지 (hotfix #108, 2026-04-18)**: EventBus publish는 `m.mu.Unlock()` 이후에만 수행 — BuildStateFor가 broadcast 경로에서 다시 m.mu를 잡을 수 있음
+
+**PlayerAware 경계 (D-MO-1):**
+- `BuildStateFor(alice)` → 본인 `completed` / `derived` / `collected`만 반환
+- Peer가 무엇을 크래프팅했는지는 전략적 정보 → 절대 누출 금지
+- `uuid.Nil` 방어: zero-value playerID로 호출 시 빈 shape 반환 (redaction layer에서 차단)
+
+**State:**
+- `completed[playerID][]` — 완료된 combination ID
+- `derived[playerID][]` — 조합으로 획득한 output clue ID
+- `collected[playerID]{evidenceID: bool}` — evidence 모듈 이벤트 미러
+
+**WinChecker:** `winCombination` 전량 수집 시 해당 플레이어 승리 판정.
+
+**RuleProvider:** `has_combination` 규칙 노출 (조건 빌더용).
+
+---
+
+## 호환성
+
+- **independent** — 다른 모듈과 conflict 없음
+- **권장 조합**: `location` + `evidence` + `combination` 3종 세트로 수사 루프 완성
+- **연계 모듈**:
+  - `ClueInteraction` — 단서 교환·양도
+  - `ConditionalClue` — `evidence.collected` 이벤트 구독해 파생 단서 해금
+  - `LocationClue` (스펙 #24) — 층/방 단위 추상 단서 분배 (crime_scene과 병행 가능)
+
+## 구분: LocationClue vs crime_scene/location
+
+| 축 | LocationClueModule (#24) | LocationModule (#30) |
+|----|-------------------------|----------------------|
+| 카테고리 | Exploration | CrimeScene |
+| 역할 | "ThemeLocation에 단서 배치" | "플레이어 이동·검사" |
+| State | 공용 단서 풀 | per-player 위치/히스토리 |
+| PlayerAware | public | per-player redaction |
+| 타입 문자열 | `location-clue` | `location` |

--- a/docs/plans/2026-04-05-rebuild/refs/modules/media.md
+++ b/docs/plans/2026-04-05-rebuild/refs/modules/media.md
@@ -1,0 +1,85 @@
+# Media 모듈 (1개) — 오디오 브리지
+
+> Phase 11~12(2026-04-13) 메타포 + 라운드 음성 피드백 도입 시 독립 카테고리로 분리.
+> 스펙 `PhaseAction 12종` 테이블에서 "모듈 무관"으로 분류됐던 `PLAY_SOUND / PLAY_MEDIA / SET_BGM` 등 오디오 계열 액션을 **WebSocket 브로드캐스트 가능한 이벤트로 변환**할 전담 PhaseReactor가 필요해서 승격.
+
+---
+
+## 33. AudioModule
+
+```
+타입: audio | 카테고리: MEDIA | 인증: SESSION
+PhaseReactor: ReactsTo [PLAY_SOUND, PLAY_MEDIA, SET_BGM, STOP_AUDIO]
+인터페이스: Module + PublicStateModule + PhaseReactor + PhaseHookModule + GameEventHandler
+ConfigSchema: 없음 (PhaseAction + EventBus 전구동)
+State 공개성: public (PublicStateMarker 임베드 — 전원 동일한 사운드스케이프)
+```
+
+**State Shape:**
+```json
+{ "currentBGMId": "...", "phaseBGMId": "..." }
+```
+- `currentBGMId` — 현재 재생 중 BGM
+- `phaseBGMId` — 페이즈 진입 시 `SET_BGM`으로 고정된 BGM (reading 중 override되어도 복원 기준점)
+
+---
+
+## PhaseAction → EventBus 매핑
+
+| PhaseAction | 발행 이벤트 | 비고 |
+|-------------|----------|------|
+| `PLAY_SOUND` | `audio.play_sound` | 일회성 SFX |
+| `PLAY_MEDIA` | `audio.play_media` | 비디오/장시간 오디오 |
+| `SET_BGM` | `audio.set_bgm` | `currentBGMId` + `phaseBGMId` 동시 갱신 |
+| `STOP_AUDIO` | `audio.stop` | 전체 정지 |
+
+`ReactTo`는 `action.Params`(JSON)를 그대로 event payload로 전달. 클라이언트 계약은 WS layer에서 확정.
+
+---
+
+## Reading 모듈 이벤트 브리지
+
+`Init`에서 EventBus 두 개 구독:
+
+```
+reading.line_changed → (voiceId 존재 시) audio.play_voice { voiceId }
+reading.completed    → (phaseBGMId 존재 시) audio.set_bgm { mediaId: phaseBGMId, fadeMs: 1500 }
+```
+
+**의도:**
+- 대사 라인별 자동 음성 재생 (voiceId는 ReadingModule의 `configJson.phases[].readingSection.lines[].voiceId`)
+- 리딩 중 SET_BGM으로 BGM이 일시 override되어도 `reading.completed` 시 페이즈 BGM 자동 복원
+- `SET_BGM` 액션 수신 시 `currentBGMId`와 `phaseBGMId`를 동시 갱신 → reading override는 EventBus `audio.set_bgm`을 **직접** 발행해야 phaseBGMId가 안 바뀜 (이중 경로 분리)
+
+---
+
+## GameEventHandler
+
+`Validate` — `audio:play / pause / resume / stop` 이벤트 타입 허용
+`Apply` — `BuildState()` 결과를 `state.Modules["audio"]`에 스냅샷
+
+이벤트 소싱 모드에서 AudioModule 상태를 `GameState.Modules["audio"]`에 실어 보낼 수 있게 함.
+
+---
+
+## 왜 PublicStateMarker (opt-out) 인가
+
+- BGM/SFX는 **플레이 경험의 공통 무대 장치** — 모든 플레이어가 동시에 같은 소리를 들어야 함
+- per-player redaction은 의미 없음 (개인 voice 라인도 `voiceId`만 브로드캐스트, 실제 재생 권한은 클라이언트 로직이 판단)
+- F-sec-2 게이트 통과 방식: `engine.PublicStateMarker` 임베드
+
+```go
+type AudioModule struct {
+    engine.PublicStateMarker
+    // ...
+}
+var _ engine.PublicStateModule = (*AudioModule)(nil)
+```
+
+---
+
+## 호환성 / 의존
+
+- **independent** — conflict 없음
+- **선택 연계**: `Reading` — line_changed / completed 이벤트 구독 시 자동 음성·BGM 전환
+- **클라이언트**: WS layer에서 `audio.*` 이벤트를 받아 `<audio>` / `<video>` 엘리먼트 제어 (실 재생은 프런트 책임)


### PR DESCRIPTION
## Summary
- Phase 11~12에서 등록만 되고 스펙에 미반영이던 **crime_scene 3종 + media 1종** 문서화
- `module-spec.md`를 29 → 33 모듈로 동기화, PlayerAware 게이트 분포 표·LocationClue vs Location 혼동 주의표 추가
- 스펙 drift 해소: registry 등록 33개 ↔ 문서 기재 29개 격차 제거

## 변경 파일
| 파일 | 줄수 | 종류 |
|------|------|------|
| `docs/plans/2026-04-05-rebuild/module-spec.md` | 119 | 수정 |
| `docs/plans/2026-04-05-rebuild/refs/modules/crime_scene.md` | 159 | 신규 |
| `docs/plans/2026-04-05-rebuild/refs/modules/media.md` | 85 | 신규 |

전원 MD 200줄 하드 리밋 내.

## 문서화 핵심
### crime_scene (Phase 11.0 도입)
- **#30 Location** — per-player 위치·히스토리, `moveCooldownSec`, `location.examined` 발행
- **#31 Evidence** — `autoDiscover`(location 구독), `availableAtPhase` 게이트, `hidden` 플래그
- **#32 Combination** — 4-file 분할, `clue.Graph` + CRAFT trigger(Phase 20 PR-5), D-MO-1 per-player redaction, deadlock 방지(hotfix #108)

### media (Phase 11~12 도입)
- **#33 Audio** — PhaseAction(`PLAY_SOUND/PLAY_MEDIA/SET_BGM/STOP_AUDIO`) → EventBus 브리지, Reading line_changed/completed 구독해 자동 음성·BGM 복원

### spec 업데이트 요점
- 핵심 원칙 5번 신설: PlayerAware 게이트(F-sec-2, Phase 19.1 PR-A) 명문화
- PhaseAction 표에서 오디오 계열 4종을 `(모듈 무관)` → `Audio`로 교정
- LocationClue(#24, exploration/공용 풀) vs Location(#30, crime_scene/per-player) 구분 표

## Test plan
- [ ] refs/modules 링크 경로 확인 (`module-spec.md` 의 crime_scene/media 앵커)
- [ ] PlayerAware 게이트 분포 표에 기재된 모듈 구분이 실제 코드와 일치하는지 spot-check
- [ ] 33 모듈 카운트가 `apps/server/internal/module/` 디렉터리 구조와 일치 (core 4 + progression 8 + communication 5 + decision 3 + exploration 4 + cluedist 5 + crime_scene 3 + media 1 = 33)

## 비고
- 코드 변경 없음 — 순수 문서 drift 해소
- `memory/project_module_system.md`의 "29개 모듈" 기재는 다음 세션에서 별도 업데이트 (memory 파일은 이 PR 스코프 밖)