### PR TITLE
chore(plan): /plan-* 커맨드 slim + QMD 전환 + Sonnet 4.6 기준

### DIFF
--- a/.claude/commands/plan-go.md
+++ b/.claude/commands/plan-go.md
@@ -1,5 +1,5 @@
 ---
-description: (mmp-pilot) 통합 진입점 — wave 자동 실행 + 단일 task + 재개. plan-autopilot 후계 (M1 dual-write 단계)
+description: (mmp-pilot) 통합 진입점 — wave 자동 실행 + 단일 task + 재개. plan-autopilot 후계 (M3 cutover 완료)
 argument-hint: [--wave W2] [--task "id"] [--until WN] [--only PR-N] [--dry-run] [--resume] [--force-unlock] [--ab exp-id]
 allowed-tools: Read Write Edit Bash Task
 ---
@@ -10,93 +10,43 @@ allowed-tools: Read Write Edit Bash Task
 
 프리플라이트 ❌/🛑 시 중단. `jq . .claude/settings.json`으로 검증 후 재시도.
 
-## 실행 단계
+## 실행
 
-1. **락 확인** — `.claude/scripts/run-lock.sh check` 로 `.claude/run-lock.json` 상태 조회.
-   - `owner != null` 이고 `last_heartbeat < 60min` → "다른 run 진행 중" 에러.
-   - stale(≥60min) → `--force-unlock` 있어야 강제 해제.
-2. **active-plan.json 로드** — schema_version 1/2 양쪽 지원. `current_run_id` 없으면 신규 `r-YYYYMMDD-HHMMSS-xxx` 생성.
-3. **manifest 생성** — `.claude/runs/{run-id}/manifest.json`.
-   - 기본: `current_wave`부터 순차. `--wave`/`--until`/`--only`로 범위 축소. `--task` 단일 실행.
-4. **락 획득** — `run-lock.sh acquire <run-id> <wave> <pr> <task>`.
-5. **모드 분기**:
-   - `--dry-run` → manifest만 출력 후 종료.
-   - `--ab <exp>` → `references/ab-runner.md` 참조 (M4 이후 활성, 현재는 스텁 메시지).
-   - 일반 실행 → wave 루프 (§실행 루프).
-6. **종료 시** — FINAL_SUMMARY 생성 + `run-lock.sh release`.
+**상세 Phase 로직·팀 편성 규칙·에러 핸들링은 `.claude/skills/mmp-pilot/SKILL.md`가 단일 소스.** 이 커맨드는 entry point + 락 관리 + 재개 옵션만 담당.
 
-## 실행 루프
+핵심 시퀀스:
 
-각 wave마다:
+1. **락 확인** — `.claude/scripts/run-lock.sh check`. owner≠null 이고 heartbeat<60min 이면 차단. stale(≥60min)은 `--force-unlock` 필요.
+2. **active-plan.json 로드** — schema_version 1/2 지원. `current_run_id` 없으면 신규 `r-YYYYMMDD-HHMMSS-xxx`.
+3. **manifest 생성** — `.claude/runs/{run-id}/manifest.json`. 기본 `current_wave`부터 순차. 플래그:
+   - `--wave W2` / `--until WN` / `--only PR-N` — 범위
+   - `--task "M-7"` — 단일 실행 (worktree 없음, in-place)
+   - `--dry-run` — manifest 출력 후 종료
+   - `--resume` — current_run_id 이어받기 → 미완료 task부터
+   - `--ab <exp>` — M4 이후 활성 (현재 스텁)
+4. **락 획득** → mmp-pilot Phase 2~5 루프 → FINAL_SUMMARY → 락 release
 
-```bash
-# 1. 의존성 / scope 오버랩 검증
-$HOME/.claude/skills/plan-autopilot/scripts/plan-wave.sh validate <wave-id>
+## 서브에이전트 모델 지정
 
-# 2. PR마다 worktree 생성 (parallel wave)
-.claude/scripts/run-wave.sh create-worktrees <run-id> <wave-id>
+mmp-pilot이 Layer 2 팀원 spawn 시 **일반 구현·리뷰는 `claude-sonnet-4-6`**, **security / architecture 판단은 `claude-opus-4-7`**. 4.5는 사용 금지(4.6 출시 이후).
 
-# 3. task 루프 — mmp-pilot 스킬이 팀 편성·실행
-#    각 task는 .claude/runs/{run-id}/{wave}/{pr}/{task}/ 하위에 산출
-#    - 01_docs_context.md ~ 04_security_report.md
-#    - SUMMARY.md (frontmatter 필수)
-#    - logs/{team,hooks}.jsonl
+## 에러·산출물 경로
 
-# 4. SUMMARY 파싱 → checklist + progress 갱신
-.claude/scripts/summary-parse.sh <run-id> <wave-id>
-
-# 5. worktree 머지 (fast-forward)
-.claude/scripts/run-wave.sh merge <run-id> <wave-id>
-
-# 6. heartbeat 갱신
-.claude/scripts/run-lock.sh heartbeat
-```
-
-## 팀 편성 규칙 (Layer 2)
-
-task 성격에 따라 동적으로 2~6명 선정.
-
-| task 키워드/패턴 | 편성 |
-|------------------|------|
-| security / redaction / token / auth | docs-navigator + go-backend + test + **security-reviewer** (4명) |
-| module / genre / phase-reactor | docs-navigator + **module-architect** + go-backend + test (4명) |
-| ws / session / engine 구현 | docs-navigator + go-backend + test (3명) |
-| frontend / editor / canvas | docs-navigator + react-frontend + test (3명) |
-| 풀스택 | docs-navigator + go-backend + react-frontend + test + security (5명) |
-| 단순 조회/설계 질문 | docs-navigator 단독 |
-
-팀 크기 상한은 `--team N` 플래그로 덮어쓰기. 기본: auto.
-
-## M1 단계의 현재 동작 (dual-write)
-
-- `/plan-go`는 신규 `.claude/runs/{run-id}/` 경로로 산출.
-- 내부적으로 **기존 plan-autopilot 엔진**($HOME/.claude/skills/plan-autopilot/scripts/)을 재사용하여 wave/worktree 실행.
-- 기존 `.claude/runs/{run-id}/` 경로는 더 이상 쓰지 않는다(하네스 통합분만 해당). autopilot 기존 산출물은 그대로 유지.
-- `/plan-autopilot`은 여전히 동작(M2 deprecation 경고만). Phase 18.3 무중단.
-
-## 에러 핸들링
-
-- 락 획득 실패 → "run-lock.json에 소유자 있음" 상세 출력 + `--force-unlock` 안내.
-- task 실패(SUMMARY.status=failed) → wave 내 후속 task 보류, 사용자에게 에스컬레이트.
-- SUMMARY 누락 → `summary-require` hook이 재실행 요청.
-- worktree 충돌 → `run-wave.sh abort <run-id>` 로 정리.
-
-## 출력
-
-- 진행 로그: `stdout` 요약 + `.claude/runs/{run-id}/stdout.log` 전문
-- 최종: `runs/{run-id}/FINAL_SUMMARY.md` (wave별 SUMMARY 집계)
+- 산출물: `.claude/runs/{run-id}/{wave}/{pr}/{task}/NN_agent_artifact.md` + `SUMMARY.md`
+- 로그: `stdout` 요약 + `.claude/runs/{run-id}/stdout.log` 전문
 - 메트릭: `memory/mmp-pilot-metrics.jsonl` append
+
+상세 에러 분류·scope enforcement·팀 크기 가이드는 mmp-pilot/SKILL.md §팀 크기 + §에러 핸들링 참조.
 
 ## 보조 커맨드
 
-- 상태: `/plan-status` (run_id + heartbeat 경과 분 포함)
-- 중단: `/plan-stop` → partial SUMMARY + 락 해제
-- 재개: `/plan-go --resume` (current_run_id 이어받기)
-- 단일 task: `/plan-go --task "M-7"` (in-place, worktree 없음)
+- 상태: `/plan-status` — run_id + heartbeat 경과 포함
+- 중단: `/plan-stop` — partial SUMMARY + 락 해제
+- 재개: `/plan-go --resume`
+- 단일 task: `/plan-go --task "M-7"`
 
 ## 참조
 
-- 오케스트레이터 상세: `.claude/skills/mmp-pilot/SKILL.md`
+- 오케스트레이터: `.claude/skills/mmp-pilot/SKILL.md`
 - wave 엔진: `.claude/skills/mmp-pilot/references/wave-engine.md`
-- A/B 러너(M4): `.claude/skills/mmp-pilot/references/ab-runner.md`
-- 마이그레이션 상태: `.claude/designs/mmp-pilot/` + `m3-cutover.sh`
+- A/B(M4): `.claude/skills/mmp-pilot/references/ab-runner.md`

--- a/.claude/commands/plan-go.md
+++ b/.claude/commands/plan-go.md
@@ -6,7 +6,7 @@ allowed-tools: Read Write Edit Bash Task
 
 ## 프리플라이트
 
-!`$HOME/.claude/skills/plan-autopilot/scripts/plan-preflight.sh`
+!`$HOME/.claude/skills/plan-go/scripts/plan-preflight.sh`
 
 프리플라이트 ❌/🛑 시 중단. `jq . .claude/settings.json`으로 검증 후 재시도.
 

--- a/.claude/commands/plan-resume.md
+++ b/.claude/commands/plan-resume.md
@@ -1,91 +1,77 @@
 ---
-description: (sabyun) /clear 후 전체 컨텍스트 복원 — design + plan + checklist + progress + git 한번에 로드
+description: (sabyun) /clear 후 컨텍스트 복원 — QMD 기반 최소 로드. design/plan은 스킵 (편집 직전 PreToolUse가 강제 읽기)
 allowed-tools: Read Bash(jq*) Bash(git*) Bash(cat*) Bash(*/plan-preflight.sh)
 ---
 
-Full context restore — read all plan files and summarize current state.
+QMD 우선 복원 — 현재 PR spec + checklist만 로드. 전체 Read는 컨텍스트 낭비 (프로젝트 CLAUDE.md § QMD 강제 규칙).
 
-## Pre-flight check
+## Pre-flight
 
 !`$HOME/.claude/skills/plan-go/scripts/plan-preflight.sh`
 
-**If pre-flight shows ❌, the first thing to do after restore is fix settings.json.**
-Continue reading plan files even if pre-flight fails — the context is still useful.
+❌ 시 복원 계속 진행, 단 settings.json 수정이 첫 과제.
 
-## Preload live data
+## Preload
 
 ### Active plan pointer
 !`cat .claude/active-plan.json 2>/dev/null || echo "(no active plan)"`
 
 ### Git state
-!`git log --oneline -10`
+!`git log --oneline -5`
 !`git status --short`
 !`git branch --show-current`
-
-### Autopilot state (if paused)
-!`[ -f .claude/autopilot-state.json ] && cat .claude/autopilot-state.json || echo "(no paused state)"`
 
 ---
 
 ## Steps
 
-1. Read these files (all — this is the source of truth restore):
-   - `<plan.design>` (from active-plan.json)
-   - `<plan.plan>`
-   - `<plan.checklist>`
-   - `<plan.progress_memory>`
-   - `.claude/post-task-pipeline.json`
-2. Also load current PR's detailed file if it exists:
-   - `<plan.dir>/refs/pr-<current_pr>-*.md`
-3. Summarize:
+1. **active-plan.json에서 필드 추출** — `active.dir`, `active.current_pr`, `active.current_wave`, `active.current_task`, `active.status`, `active.checklist`, `active.scope[]`
+
+2. **QMD 우선 로드 (이 순서대로, 절대 Read 금지)**:
+   - 🔴 `qmd get "<active.dir>/refs/pr-<current_pr>-*.md"` — 현재 PR spec (다음 편집의 실제 소스)
+   - 🔴 `qmd get "<active.checklist>"` — STATUS marker + 현재 PR 체크리스트 위치 파악
+   - 조건부 — **blocker 플래그가 있거나 사용자가 명시 요청 시만**:
+     - `qmd get "<active.progress_memory>"` (기본 스킵)
+   - **절대 로드 금지** (PreToolUse guard가 편집 직전 자동 강제):
+     - `design.md` — scope 편집 시 hook이 BLOCK → 그때 qmd get
+     - `plan.md` — checklist와 정보 중복, 불필요
+     - 전체 `refs/*` — 현재 PR 외 다른 PR은 편집 전까지 불필요
+
+3. **요약 — 아래 템플릿에 맞춰 한 화면으로 보고**:
 
 ```
 ═══════════════════════════════════════════
- Plan Context Restored
+ Plan Context Restored (QMD mode)
 ═══════════════════════════════════════════
 
-Phase: <name>
-Started: <date> (<commit>)
-
---- Current Position ---
-Wave: <current>/<total>
-PR: <current_pr> — <title>
-Task: <current_task>
-Status: <status>
+Phase: <active.name>
 Branch: <git current branch>
 
---- Completed ---
-<list of ✅ tasks in current PR>
-<list of completed PRs>
+--- Current Position ---
+Wave: <current_wave>
+PR: <current_pr> — <title from PR spec>
+Task: <current_task>
+Status: <status>
 
---- Next ---
-<next uncompleted task with file paths>
-<next PR in wave if any>
-<next wave if current complete>
-
---- Blockers ---
-<list from active-plan.json>
+--- Current PR Tasks (from checklist STATUS section) ---
+<체크된 task + 미완료 task 구분해서 3~5개만>
 
 --- Recent Commits ---
-<from git log above>
+<git log -5 그대로>
 
 --- Uncommitted ---
-<from git status above>
-
---- Files Reminder ---
-Design: <plan.design>
-Plan: <plan.plan>
-Checklist: <plan.checklist>
-Progress: <plan.progress_memory>
+<git status --short 그대로>
 
 --- Scope ---
-<list of scope globs>
+<active.scope 3개 정도만 + 총개수>
 
 --- Next Actions ---
-1. Continue current task manually
-2. /plan-go — resume automated execution
-3. /plan-tasks — visual progress
-4. /plan-status — quick check
+1. Continue current task — 편집 시 PreToolUse가 design/checklist 자동 요구
+2. /plan-go --resume — 파일럿 재개
+3. /plan-tasks — 진행률 시각화
+4. blocker 있으면 progress_memory 추가 로드 필요
 ```
 
-**Note**: The act of reading design + checklist above **satisfies the PreToolUse guard** for the next 30 minutes — edits in scope will proceed immediately.
+**중요**:
+- QMD `get` 실패 시 파일 경로 한 번 더 확인. Read 폴백 금지 (qmd-enforcer hook이 차단).
+- design/plan 내용이 필요한 순간은 편집 직전 — PreToolUse가 자동으로 read 요구하므로 지금 미리 읽지 말 것. 토큰 5~10K 절감.

--- a/.claude/commands/plan-status.md
+++ b/.claude/commands/plan-status.md
@@ -19,9 +19,6 @@ allowed-tools: Bash(jq*) Bash(git*) Bash(cat*) Bash(sed*) Bash(*/plan-preflight.
 ## Uncommitted changes
 !`git status --short`
 
-## Autopilot state (if paused)
-!`[ -f .claude/autopilot-state.json ] && cat .claude/autopilot-state.json || echo "(no paused state)"`
-
 ---
 
 Based on the above, summarize:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,15 +227,26 @@ gh pr checks <N>  # 대기
 
 > Anthropic advisor tool 패턴의 Claude Code 응용 — Opus는 판단·지시·종합, Sonnet은 실제 실행.
 
-- **Opus 메인의 책임**: 문제 정의, 플랜 수립, 에이전트 결과 종합, 중요한 판단 승인
-- **Sonnet 서브에이전트 위임 대상**:
-  - **탐색·검색**: `Explore`, `oh-my-claudecode:explore` — 대량 파일 grep/find
-  - **MD 작성**: `oh-my-claudecode:writer`, `oh-my-claudecode:executor` — README·refs·progress
-  - **테스트·빌드 실행**: `general-purpose`, `oh-my-claudecode:qa-tester` — verbose 출력은 서브에서 소화
-  - **단일 도메인 구현**: `go-backend-engineer`, `react-frontend-engineer` 등 프로젝트 전문 agent
-- **위임 시 필수**:
-  - 프롬프트에 **"결과만 ≤200 단어로 보고"** 명시 (raw 로그 메인 유입 차단)
-  - 병렬 가능한 독립 task는 `Task tool` 다중 호출 한 메시지에 묶기
-  - 파일 크기·함수 한도 프롬프트에 재명시 (서브는 CLAUDE.md 자동 로드 안 될 수 있음)
-- **Opus 직접 수행 유지**: 보안 판단, 아키텍처 결정, PR 생성 승인, user-facing 답변
-- **참고**: advisor tool(Anthropic API beta)은 Claude Code CLI에서 직접 사용 불가 — 위 패턴이 기능적 등가
+### 모델 기준 (2026-04-19 이후)
+- **메인**: `claude-opus-4-7` (Opus 4.7 1M context)
+- **서브에이전트 기본**: `claude-sonnet-4-6` — **Sonnet 4.5 사용 금지** (4.6 출시 이후 구버전)
+- **간단 검색·요약**: `claude-haiku-4-5-20251001`
+- **복잡 판단 재위임**: `claude-opus-4-7` (security / architecture / 설계)
+
+### 위임 대상
+- **탐색·검색** (sonnet): `Explore`, `oh-my-claudecode:explore` — 대량 파일 grep/find
+- **MD 작성** (sonnet): `oh-my-claudecode:writer`, `oh-my-claudecode:executor` — README·refs·progress
+- **테스트·빌드 실행** (sonnet): `general-purpose`, `oh-my-claudecode:qa-tester` — verbose 출력은 서브에서 소화
+- **단일 도메인 구현** (sonnet): `go-backend-engineer`, `react-frontend-engineer` 프로젝트 전문 agent
+- **보안·아키텍처 판단** (opus): `security-reviewer`, `oh-my-claudecode:critic`, `oh-my-claudecode:security-reviewer`
+
+### 위임 시 필수
+- 프롬프트에 **"결과만 ≤200 단어로 보고"** 명시 (raw 로그 메인 유입 차단)
+- Agent tool `model` 파라미터로 `claude-sonnet-4-6` 명시 (기본 inherit 대신)
+- 병렬 가능한 독립 task는 `Task tool` 다중 호출 한 메시지에 묶기
+- 파일 크기·함수 한도 프롬프트에 재명시 (서브는 CLAUDE.md 자동 로드 안 될 수 있음)
+
+### Opus 직접 수행 유지
+보안 판단, 아키텍처 결정, PR 생성 승인, user-facing 답변, 여러 서브에이전트 결과 종합.
+
+**참고**: advisor tool(Anthropic API beta)은 Claude Code CLI에서 직접 사용 불가 — 위 패턴이 기능적 등가.


### PR DESCRIPTION
## Summary

/plan-* 커맨드 전체 감사 후 토큰 효율 최적화. 예상 절감 세션당 ~13K 토큰 (plan-resume 1회 + plan-go 2회 기준).

## 변경 파일

| 파일 | 변경 |
|------|------|
| `.claude/commands/plan-status.md` | deprecated `autopilot-state.json` cat 제거 |
| `.claude/commands/plan-resume.md` | Read 5 files → QMD get 2개 (현재 PR spec + checklist). git log -10 → -5. deprecated state cat 제거 |
| `.claude/commands/plan-go.md` | Phase/팀/에러 상세 → mmp-pilot/SKILL.md 단일 소스 참조. 103 → 52줄 |
| `CLAUDE.md` | Sonnet 4.6 모델 기준 섹션 추가 (서브에이전트 4.5 금지) |

## 근거 — /plan-* 감사 요점

### `/plan-resume` (기존 ~15K/호출)
- "Read these files (all)" 지시로 design/plan/checklist/progress/PR-refs 전부 full read
- 프로젝트 CLAUDE.md § QMD 규칙은 "plan-resume 시 QMD get으로 현재 PR spec만" 지시하지만 커맨드 본문은 위반
- 전환: `qmd get` 2개만 로드, design/plan은 PreToolUse hook이 편집 직전 강제하므로 선로드 금지

### `/plan-go` (기존 ~5.5K/호출)
- 프로젝트 `plan-go.md` (103줄) + `mmp-pilot/SKILL.md` (130줄)에 Phase·팀 편성·에러 로직 중복
- 프로젝트 커맨드는 entry point + 락 + 재개 옵션만 남기고 상세는 mmp-pilot 단일 소스

### `/plan-status` (마이너)
- `autopilot-state.json` cat — M3 cutover 이후 사용 안 함, 매 호출 `(no paused state)` 출력

### Sonnet 4.6 반영
- 서브에이전트 spawn 시 `model: "claude-sonnet-4-6"` 명시 규칙 CLAUDE.md에 추가
- 모델 ID 테이블 (Opus 4.7 / Sonnet 4.6 / Haiku 4.5) 고정
- 메모리 `feedback_sonnet_46_default.md` 신규 (repo 외, 별도 적용됨)

## Test plan

- [x] 모든 .md 파일 200줄 하드 리밋 내 (최대 86줄, plan-new.md)
- [x] qmd-enforcer hook이 Read 폴백을 차단하는지 확인 — plan-resume.md에 주석 추가
- [ ] 실제 `/plan-resume` 호출 시 qmd get 2개만 발동하고 design/plan은 로드되지 않는지 검증
- [ ] `/plan-go` 호출 시 mmp-pilot/SKILL.md 만 주입되는지 확인 (중복 제거)

## 관련 작업 (이 PR 범위 밖)

- 글로벌 `~/.claude/skills/plan-autopilot/` archive — M3 cutover 이후 deprecated, 중복 SKILL.md 제거 (별도 적용 예정)
- 글로벌 `~/.claude/skills/plan-go/SKILL.md` Anti-patterns/Red flags refs/ 분리 (별도 적용 예정)