### PR TITLE
chore(phase-19-residual): preflight 스킬 경로/인라인 훅 처리 수정

### DIFF
--- a/.claude/scripts/plan-preflight.sh
+++ b/.claude/scripts/plan-preflight.sh
@@ -14,7 +14,9 @@ set -u  # -e would abort the script; we want to complete and print a summary
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 SETTINGS="$PROJECT_DIR/.claude/settings.json"
 SCRIPTS_DIR="$PROJECT_DIR/.claude/scripts"
-SKILL_DIR="$HOME/.claude/skills/plan-autopilot"
+# M3 cutover(2026-04-15) 이후 canonical 스킬 경로 = 프로젝트 로컬 mmp-pilot.
+# 레거시 ~/.claude/skills/plan-autopilot 은 M3 에서 제거됨.
+SKILL_DIR="$PROJECT_DIR/.claude/skills/mmp-pilot"
 
 print_recovery() {
     cat <<EOF
@@ -116,6 +118,13 @@ while IFS= read -r cmd; do
     if [[ "$expanded" == .claude/scripts/* ]] || [[ "$expanded" == ./.claude/scripts/* ]]; then
         expanded="$PROJECT_DIR/${expanded#./}"
     fi
+
+    # Skip inline shell constructs (e.g. `[ -f x ] && touch y`, subshells).
+    # 이 preflight 는 파일 기반 훅만 검증; 쉘 빌트인/복합 커맨드는 대상 아님.
+    case "$expanded" in
+        /*|./*|../*|*/*) : ;;
+        *) continue ;;
+    esac
 
     if [ ! -e "$expanded" ]; then
         echo "❌ PRE-FLIGHT: hook script not found"


### PR DESCRIPTION
## Summary
- M3 cutover(2026-04-15) 이후 canonical 경로가 프로젝트 로컬 `mmp-pilot`으로 이동했으나 `plan-preflight.sh:17`은 레거시 `~/.claude/skills/plan-autopilot`을 그대로 검사해 `/plan-go`·`/plan-resume`이 ❌ false negative로 중단되던 문제 수정.
- `settings.json`의 인라인 bash hook (`[ -f x ] && touch y` 등)을 파일 경로로 오해석하던 두 번째 결함 동반 수정 — 경로 형태가 아닌 항목은 validation 대상에서 제외.

## Test plan
- [x] `CLAUDE_PROJECT_DIR=. bash .claude/scripts/plan-preflight.sh` → `✓ PRE-FLIGHT OK: 6/6 hooks verified | active: Phase 19 Residual (W0 PR-0)` 확인
- [x] 변경 diff 11줄 (3 insert, 1 delete + 7줄 guard 블록), 다른 스크립트·설정 무영향
- [ ] Phase 19 Residual 실제 /plan-go 실행 시 PR-0 착수까지 gate 통과 (머지 직후 확인)

## Scope
- `.claude/scripts/plan-preflight.sh` 단일 파일 (10 insertions, 1 deletion)
- 현 Phase 19 Residual plan scope 밖이지만 /plan-go 파이프라인을 차단하는 인프라 결함이라 별도 chore로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)