### PR TITLE
chore(phase-19-residual): PR-0 MEMORY Canonical Migration (user home → repo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,9 +157,12 @@ gh pr checks <N>  # 대기
 | `multi_get` | 즉시 | glob/리스트로 다중 문서 배치 조회 |
 
 ### 컬렉션
-- `mmp-plans` (97 docs) — 설계 문서, PR 스펙, 체크리스트, 아키텍처
-- `mmp-memory` (18 docs) — 프로젝트 메모리, 피드백, 코딩 규칙
+- `mmp-plans` (290 docs) — 설계 문서, PR 스펙, 체크리스트, 아키텍처
+- `mmp-memory` (64 docs, **canonical = repo `memory/`**) — 프로젝트 메모리, 피드백, 코딩 규칙. 2026-04-21 Phase 19 Residual PR-0에서 user home → repo 이전 (이전 user home 경로는 archival 스냅샷).
 - `mmp-specs` (9 docs) — 브레인스토밍 결과, 엔진 재설계 스펙
+- `mmp-v2-docs` (98 docs) — MMP v2 머더미스터리 호텔 UX 이식 원본 (base 브랜치)
+
+> **🔴 쓰기 규칙**: 신규 memory 파일은 `memory/<name>.md` (repo 상대)로만 작성. user home `~/.claude/projects/.../memory/`는 auto-memory 시스템 기본값이지만 이 프로젝트에서는 **읽지 않음, 쓰지 않음** — drift 누적 방지. 상세: `memory/feedback_memory_canonical_repo.md`.
 
 ### 🔴 강제 규칙
 1. **Grep on docs/plans/ 절대 금지** — Hook이 차단함. QMD search 사용

--- a/docs/plans/2026-04-21-phase-19-residual/checklist.md
+++ b/docs/plans/2026-04-21-phase-19-residual/checklist.md
@@ -2,24 +2,26 @@
 
 <!-- STATUS-START -->
 **Active**: Phase 19 Residual — 감사 backlog 잔여 PR 실행
-**Wave**: W0 (착수 대기)
-**Task**: PR-0 착수 전 — `.claude/active-plan.json` 활성화 + 본 plan PR 머지
+**Wave**: W0 (PR-0 구현 완료, 머지 대기)
+**Task**: PR-0 Task 1–4, 6 완료 + Task 5 docs 완료 / commit + PR 생성 대기
 **State**: in_progress
-**Blockers**: 없음 (plan init PR 머지 대기)
+**Blockers**: user home chmod 정책 결정 대기 (Task 5 filesystem 파트) — docs-only 소프트 모드도 가능
 **Last updated**: 2026-04-21
 <!-- STATUS-END -->
 
 ## W0 — Foundation (PR-0 단독)
 
 ### PR-0: MEMORY Canonical Migration
-- [ ] user home `~/.claude/projects/.../memory/` ↔ repo `memory/` 파일 diff
-- [ ] Phase 17.5~18.8 누락 progress·feedback 최소 9건 repo 복원
-- [ ] `MEMORY.md` 인덱스 재작성 (현행 반영)
-- [ ] QMD `mmp-memory` 컬렉션 path 이전 + reindex
-- [ ] user home read-only 처리 + `CLAUDE.md` QMD 섹션 갱신
-- [ ] `memory/project_phase19_residual_progress.md` 초기 생성
+- [x] user home `~/.claude/projects/.../memory/` ↔ repo `memory/` 파일 diff (drift 4 + user-only 3 + repo-only 4 · 실제 복원 대상 7건)
+- [x] Phase 17.5~18.8 누락 progress·feedback 복원 (실제 7건: 4 copy + 1 MEMORY.md merge + 2 신규 `feedback_memory_canonical_repo.md`/`project_phase19_residual_progress.md`; `originSessionId` 전수 스트립)
+- [x] `MEMORY.md` 인덱스 재작성 (user home canonical 적용 67→68줄, `feedback_memory_canonical_repo` pointer 추가)
+- [x] QMD `mmp-memory` 컬렉션 path 이전 + reindex (store_collections.path: user-home → repo, 66 files indexed)
+- [~] user home read-only 처리 + `CLAUDE.md` QMD 섹션 갱신 (CLAUDE.md QMD 섹션 + `memory/feedback_memory_canonical_repo.md` ✓ / filesystem chmod 정책 결정 대기)
+- [x] `memory/project_phase19_residual_progress.md` 초기 생성 (`originSessionId` 없이 65줄, PR-0 수행 내역 포함)
 
-**Gate**: `qmd search -c mmp-memory` hit 유지 + user home write off
+**Gate**: `qmd search -c mmp-memory` hit 유지 + user home write off → docs-only 소프트 모드 적용 (hard chmod은 사용자 결정)
+
+**부수 PR**: #121 `chore(phase-19-residual): preflight 스킬 경로/인라인 훅 처리 수정` (commit `3d8ccec`, M3 cutover 이후 legacy plan-autopilot 경로 잔존 결함 + inline bash hook guard 추가, /plan-go 파이프라인 정상화)
 
 ---
 

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -22,6 +22,7 @@
 - [Phase 19.1 Audit Review Follow-ups](project_phase19_1_progress.md) — **완료** W1 3 PR 머지 (PR-A #111 strict env 제거+BuildState godoc / PR-B #112 coverage lint AST 재작성 · 4 우회 패턴 차단 / PR-C #113 PeerLeakAssert helper 패키지 + 3+players table + Restore/engine dispatch 통합 테스트). 리뷰 MEDIUM 2+LOW 1 해소. 2026-04-18
 - [Phase 20 플랜](project_phase20_plan.md) — 단서·장소 에디터 정식 승격 (6 PR, 4 Wave, 2026-04-17 시작)
 - [Phase 20 완료](project_phase20_progress.md) — **완료 + 스테이징 QA** 단서·장소 에디터 정식 승격 (6 PR #71~#77 + archive #78, 4 Wave, 2026-04-17). 통합 clue_edge_groups 스키마 + AUTO/CRAFT + CurrentRound + 라운드 필터 + 프론트 승격. 스테이징 DB 00020~00025 적용 + 라운드 왕복 QA 7/7 통과 (CHECK 제약 9건 활성 확인)
+- [Phase 19 Residual 활성화](project_phase19_residual_progress.md) — **진행 중** 감사 backlog 잔여 9 PR + 2 hotfix (W0 PR-0 ↔ W4 PR-10). Plan PR #119 머지(`19446a2`, 2026-04-21). active-plan.json 활성화 완료. W0 PR-0 MEMORY Canonical Migration부터 착수.
 - [에디터 개방 + 심사 + 이미지 업로드](project_editor_open_access.md) — 전유저 에디터, 게시 심사, 크롭 업로드 (2026-04-13)
 - [Phase 10.0 완료](project_phase100_progress.md) — QA Bugfix Sprint (5 PRs, 15 tasks, 커밋 dfbc340)
 - [Phase 9.0 완료](project_phase90_progress.md) — 전체 완료 (16 PRs, 7 Waves, 31 모듈, 4장르 e2e)
@@ -30,7 +31,7 @@
 - [Phase 7.7 후속 작업](project_phase77_followups.md) — Phase 8.0 종료 후 cleanup용 Medium 이슈 목록
 - [소셜 시스템](project_social_system.md) — SocialHub, Redis Presence, WS 핸들러, 차단 필터링
 - [에러 처리 체계](project_error_system.md) — AppError, ErrorBoundary 3계층, Sentry, OTel
-- [모듈 시스템](project_module_system.md) — 29개 모듈, BaseModule+ConfigSchema+PhaseReactor+Factory
+- [모듈 시스템](project_module_system.md) — 33개 모듈 (spec 29 + crime_scene 3 + media 1), BaseModule+ConfigSchema+PhaseReactor+Factory+PlayerAware 게이트
 - [코딩 규칙](project_coding_rules.md) — Go/React 계층구조, DI, 상태관리, 테스트
 - [mmp-pilot 통합 시스템](project_mmp_pilot.md) — plan-autopilot+mmp하네스 병합, /plan-go 단일 진입점, 3-Layer, M0-M3 cutover 완료 (2026-04-15 commit cdd498e)
 
@@ -50,6 +51,9 @@
 - [main 직접 push 금지 · feature branch + PR 필수](feedback_branch_pr_workflow.md) — branch protection + 15 status check, bypass 금지 (2026-04-17 `d1262a7` 사건 이후)
 - [아키텍처·의존성 질문은 graphify 먼저](feedback_graphify_first.md) — QMD와 대칭 규칙, `/graphify query|explain|path` 우선, `--update` 증분만 사용 (2026-04-18)
 - [4-agent 코드리뷰는 admin-merge 전에 수행](feedback_4agent_review_before_admin_merge.md) — Auto mode + CI admin-skip 에서도 security/perf/arch/test 4 병렬 리뷰 선행. PR-2c (#107) 리뷰 생략 후 HIGH deadlock 이슈가 hotfix #108 로 발견된 사례 (2026-04-18)
+- [서브에이전트 Sonnet 4.6 기본](feedback_sonnet_46_default.md) — 서브에이전트 spawn 시 `claude-sonnet-4-6` 명시, 4.5 금지. 보안·아키텍처는 opus-4-7, 간단 검색은 haiku-4-5 (2026-04-19)
+- [메모리 canonical = repo/memory/](feedback_memory_canonical_repo.md) — 신규 memory는 repo만 작성, user home은 archival. QMD `mmp-memory` 컬렉션 경로 repo 이전, `originSessionId` 프론트매터 금지 (2026-04-21 PR-0)
+- [2026-04-19 세션 — 토큰 최적화](project_session_2026-04-19_optimization.md) — 3 PR (#116 module-spec 33, #117 hook slim + advisor, #118 /plan-* QMD + Sonnet 4.6). 세션당 ~8~25K 절감
 
 ## 코드 리뷰 패턴 & 프로세스
 - [코드 리뷰 패턴 통합](feedback_code_review_patterns.md) — Go/React/DB/보안/PWA/오디오 전 Phase 통합 패턴
@@ -60,5 +64,5 @@
 - [plan-resume QMD 효율화](feedback_plan_resume_qmd.md) — Read 대신 QMD로 필요 섹션만 로드, 컨텍스트 토큰 절약
 - [plan-resume에서도 QMD 우선](feedback_qmd_plan_resume.md) — 스킬 지시와 무관하게 docs/plans, memory 경로는 QMD get 필수
 - [WS 토큰 쿼리 파라미터](feedback_ws_token_query.md) — WebSocket은 ?token= 쿼리로 인증 (Authorization 헤더 아님)
-- [파일/함수 크기 티어](feedback_file_size_limit.md) — Go 500/함수 80, TS·TSX 400/함수 60·컴포넌트 150, MD 200 (2026-04-15 변경)
+- [파일/함수 크기 티어](feedback_file_size_limit.md) — Go 500/함수 80, TS·TSX 400/함수 60·컴포넌트 150, MD 500(CLAUDE.md만 200, 2026-04-21 변경)
 - [QMD MCP 메모리 누수 운영](feedback_qmd_memory_leak.md) — 컬렉션 최소화 + 장시간 세션 주기 재시작, vantict 등 타프로젝트 분리

--- a/memory/feedback_file_size_limit.md
+++ b/memory/feedback_file_size_limit.md
@@ -1,8 +1,7 @@
 ---
-name: 파일/함수 크기 티어 (Go 500 / TS·TSX 400 / MD 200 분할 기준)
-description: 유형별 하드 리밋. 2026-04-16 MD는 "분할 기준"으로 완화 — 요약 금지, index + refs/ 분할 공식화. Go 500/함수 80, TS·TSX 400/함수 60·컴포넌트 150.
+name: 파일/함수 크기 티어 (Go 500 / TS·TSX 400 / MD 500 · CLAUDE.md만 200)
+description: 유형별 하드 리밋. 2026-04-21 MD 200→500 완화 (CLAUDE.md만 자동 로딩 비용 때문에 200 유지). 한도 초과 시 요약 금지, index + refs/ 분할 공식.
 type: feedback
-originSessionId: 0a24815c-1878-4801-8c1c-2465d442d1b3
 ---
 모든 소스 파일은 유형별 티어 한도 이내로 유지.
 
@@ -10,19 +9,22 @@ originSessionId: 0a24815c-1878-4801-8c1c-2465d442d1b3
 |------|------|-------------|
 | `.go` | **500줄** | 80줄 (table-driven 데이터 제외) |
 | `.ts` / `.tsx` | **400줄** | 일반 60줄, JSX 컴포넌트 150줄 |
-| `.md` | **200줄 (분할 기준)** | - |
+| `.md` | **500줄 (분할 기준)** | - |
+| `CLAUDE.md` | **200줄** | - |
 
-**예외**: sqlc/mockgen 자동 생성물. MD는 index 파일일 경우 200줄 초과 OK(단 refs 분할 선검토 후).
+**예외**: sqlc/mockgen 자동 생성물. MD는 index 파일일 경우 한도 초과 OK(단 refs 분할 선검토 후).
 
-**Why:** 200줄 일괄 규칙은 Go 패키지(에러 체이닝 + DI + 인터페이스)에 과도하게 타이트해 잦은 분할 노이즈를 만들었다. 업계 표준(stdlib 평균 300~500, Clean Code 함수 20~80)에 맞춰 유형별 티어로 진화. 1차 변경: 2026-04-15 commit `52c6216`. **2차 변경 (2026-04-16 PR #65)**: MD 200 하드 강제가 설계 근거·시나리오를 잘라내는 역효과 발견. 분할 기준으로 완화, `index + refs/<topic>.md` 분할을 공식 패턴으로 채택. 내용 보존 ≻ 줄 수 준수.
+**Why:** 200줄 일괄 규칙은 Go 패키지(에러 체이닝 + DI + 인터페이스)에 과도하게 타이트해 잦은 분할 노이즈를 만들었다. 업계 표준(stdlib 평균 300~500, Clean Code 함수 20~80)에 맞춰 유형별 티어로 진화. 1차 변경: 2026-04-15 commit `52c6216`. **2차 변경 (2026-04-16 PR #65)**: MD 200 하드 강제가 설계 근거·시나리오를 잘라내는 역효과. 분할 기준으로 완화 + `index + refs/<topic>.md` 분할 공식. **3차 변경 (2026-04-21 phase-19-residual md-rule-relax-500)**: MD 200줄 강제가 여전히 plan/PR 스펙을 과도하게 잘라 분할 노이즈 누적. CLAUDE.md만 자동 로딩 토큰 비용 때문에 200 유지하고 나머지 MD는 500으로 완화. 분할 임계는 올라가도 패턴(index+refs)은 동일.
 
 **How to apply:**
 1. **구현 전**: 변경 예정 파일의 현재 `wc -l` + 추가 예상 라인을 유형별 한도에 대조. 초과 예상 시 분할 설계 먼저 제시.
-2. **서브에이전트 프롬프트**: 파일/함수 한도를 유형에 맞게 명시 ("Go 500/80" 또는 "TS 400/60·컴포넌트 150").
-3. **분할 패턴**:
+2. **CLAUDE.md 편집 시 200줄 한도 우선** — 토큰 비용 직결.
+3. **그 외 MD**: 500줄까지 허용. 초과 시 `refs/<topic>.md` 분리 패턴 공식.
+4. **서브에이전트 프롬프트**: 파일/함수 한도를 유형에 맞게 명시 ("Go 500/80" / "TS 400/60·컴포넌트 150" / "MD 500 (CLAUDE.md 200)").
+5. **분할 패턴**:
    - Go: handler 분리 / service 인터페이스 쪼개기 / 모듈은 core+schema+factory+reactor / 긴 함수 헬퍼 추출
    - React: 서브컴포넌트 추출 / hooks 개별 파일 + 배럴 / api 도메인별 파일 + 배럴
-   - MD: `design.md`/`plan.md`/`checklist.md` index + `refs/architecture.md`, `refs/execution-model.md`, `refs/prs/pr-N.md` 등 — 요약 금지, 상세 보존 (예: Phase 18.8 13개 파일 모두 200줄 이하)
+   - MD: `design.md`/`plan.md`/`checklist.md` index + `refs/architecture.md`, `refs/execution-model.md`, `refs/prs/pr-N.md` 등 — 요약 금지, 상세 보존
    - 공통: 한 파일 내 anonymous closure 욱여넣기 금지
-4. **코드 리뷰 체크**: `wc -l` + 큰 함수 스캔 (`awk '/^func /{...}'`)
-5. **mmp-200-line-rule** 스킬은 하위 호환을 위해 디렉터리명만 유지, 내부 규칙은 티어 시스템 사용.
+6. **코드 리뷰 체크**: `wc -l` + 큰 함수 스캔 (`awk '/^func /{...}'`)
+7. **mmp-200-line-rule** 스킬은 하위 호환을 위해 디렉터리명만 유지, 내부 규칙은 티어 시스템 사용.

--- a/memory/feedback_memory_canonical_repo.md
+++ b/memory/feedback_memory_canonical_repo.md
@@ -1,0 +1,16 @@
+---
+name: 메모리 canonical = repo/memory/ (user home은 archival)
+description: 프로젝트 메모리 단일 출처는 repo `memory/`. auto-memory 기본값인 user home `~/.claude/projects/.../memory/`는 읽지·쓰지 않음. frontmatter `originSessionId` 금지.
+type: feedback
+---
+프로젝트 메모리의 단일 출처는 **repo `memory/`**. user home 경로는 auto-memory 시스템 기본값이지만 이 프로젝트에서는 archival 스냅샷으로 격하.
+
+**Why:** 2026-04-21 Phase 19 Residual PR-0에서 확인 — user home과 repo가 동시에 누적되면서 drift 발생 (MEMORY.md 기준 3건 누락, feedback 3건 구버전, QMD `mmp-memory` 컬렉션 경로가 user home을 바라봐 repo 업데이트 반영 불가). 단일 경로로 통일하지 않으면 재발.
+
+**How to apply:**
+1. **신규 memory 파일 작성 시**: Write tool 경로를 `memory/<name>.md` (repo 상대)로 지정. user home 경로 사용 금지.
+2. **MEMORY.md index**: repo의 `memory/MEMORY.md`만 갱신. user home의 것은 읽지 않음.
+3. **QMD 재인덱싱**: `qmd update` 또는 `qmd collection remove mmp-memory && qmd collection add <repo>/memory --name mmp-memory`. `sqlite3 ~/.cache/qmd/index.sqlite "SELECT path FROM store_collections WHERE name='mmp-memory'"`로 canonical path 검증.
+4. **frontmatter `originSessionId` 금지**: auto-memory가 세션 UUID를 자동 주입하는 필드. 수동 memory 작성 시 포함하지 말 것. 기존 user home 스냅샷을 repo로 가져올 때 `sed '/^originSessionId: /d'`로 스트립.
+5. **예외 (auto-memory가 user home에 쓴 경우)**: 드물게 시스템 프롬프트가 user home 경로를 강제하는 케이스 — 세션 종료 전 `diff -rq <user-home> memory/`로 확인하고 repo로 동기화 + session-id 스트립 + MEMORY.md pointer 추가 + `qmd update`.
+6. **검증 Gate**: 세션 종료 전 `diff -rq <user-home> memory/` drift 0건 + `qmd search -c mmp-memory` 전수 hit.

--- a/memory/feedback_sonnet_46_default.md
+++ b/memory/feedback_sonnet_46_default.md
@@ -1,0 +1,19 @@
+---
+name: 서브에이전트 모델은 Sonnet 4.6 기본
+description: Claude Sonnet 4.6 출시 이후 서브에이전트 생성 시 `claude-sonnet-4-6` 명시. 4.5 사용 금지
+type: feedback
+---
+서브에이전트 spawn 시 모델 파라미터는 `claude-sonnet-4-6` 기본. 4.5(`claude-sonnet-4-5`)는 구버전이므로 사용 금지.
+
+**Why**: 2026-04-19 세션에서 사용자가 "Sonnet 4.6 나왔으니까 4.5 말고 4.6으로" 명시. 성능·가격 유지하면서 최신 capability 사용.
+
+**How to apply**:
+- `Agent` tool 호출 시 `model: "claude-sonnet-4-6"` 또는 `subagent_type` 지정 후 내부 inherit 관계 확인
+- `oh-my-claudecode:executor`·`writer` 등 OMC 에이전트는 대부분 sonnet 계열 — 모델 오버라이드 필요 없으면 skip, 필요하면 명시
+- 예외: 보안·아키텍처 판단은 `claude-opus-4-7` 사용 (advisor 패턴, CLAUDE.md § Opus↔Sonnet 위임)
+- 간단 검색·요약은 `claude-haiku-4-5-20251001` 허용
+
+**모델 ID 요약**:
+- Opus 4.7: `claude-opus-4-7`
+- Sonnet 4.6: `claude-sonnet-4-6`
+- Haiku 4.5: `claude-haiku-4-5-20251001`

--- a/memory/project_module_system.md
+++ b/memory/project_module_system.md
@@ -1,24 +1,36 @@
 ---
 name: MMP v3 모듈 시스템 설계
-description: 29개 게임 모듈 시스템 - BaseModule, ConfigSchema, PhaseReactor, AutoContent, Factory 패턴
+description: 33개 게임 모듈 (spec 29 + crime_scene 3 + media 1) — BaseModule, ConfigSchema, PhaseReactor, AutoContent, Factory 패턴, PlayerAware 게이트
 type: project
 ---
-
 **모듈 시스템 핵심:**
 - BaseModule + ConfigSchema(선언적 설정) + AutoContent(자동 콘텐츠)
 - PhaseReactor(선택적): PhaseAction에 반응하는 모듈만 구현
 - Factory 패턴: 세션별 독립 인스턴스 (싱글턴 금지)
 - init() + blank import 등록
+- **🔴 PlayerAware 게이트 (F-sec-2, Phase 19.1 PR-A 이후 필수)** — 모든 `engine.Module`은 `BuildStateFor(playerID)` redaction **또는** `engine.PublicStateMarker` 임베드 둘 중 하나 충족. registry boot panic. escape hatch 없음.
 
-**29개 모듈 (6 카테고리):**
-- Core 4개, Progression 8개, Communication 5개
-- Decision 3개, Exploration 4개, Clue Distribution 5개
+**33개 모듈 (8 카테고리) — 2026-04-19 기준:**
+- **Core 4**: connection, room, ready, clue_interaction
+- **Progression 8**: script/hybrid/event_progression, skip_consensus, gm_control, consensus_control, reading, ending
+- **Communication 5**: text_chat, whisper, group_chat, voice_chat, spatial_voice
+- **Decision 3**: voting, accusation, hidden_mission
+- **Exploration 4**: floor/room/timed_exploration, location_clue
+- **Clue Distribution 5**: conditional/starting/round/timed/trade_clue
+- **Crime Scene 3** (Phase 11+ 승격): location, evidence, combination
+- **Media 1** (Phase 11+ 승격): audio
 
-**PhaseAction 12종:** configJson.phases에서 선언적으로 정의
+**PhaseAction 12종:** configJson.phases에서 선언적 정의. `PLAY_SOUND/PLAY_MEDIA/SET_BGM/STOP_AUDIO`는 Audio 모듈이 EventBus로 브리지.
 
 **게임 엔진:** GameProgressionEngine (3가지 Strategy: Script/Hybrid/Event) + ActionDispatcher
 
-**상세 스펙:** docs/plans/2026-04-05-rebuild/module-spec.md + refs/modules/
+**네이밍 혼동 주의:**
+- `LocationClueModule` (#24, exploration, 공용 단서 풀)
+- `LocationModule` (#30, crime_scene, per-player 이동·검사) — 별개 모듈
 
-**Why:** v2 싱글턴 버그 해결, 모듈=설정 단일 소스로 에디터 자동 UI
-**How to apply:** Phase 3(게임엔진 코어) + Phase 5(모듈 이식)에서 구현
+**상세 스펙:**
+- `docs/plans/2026-04-05-rebuild/module-spec.md` (33 모듈 인덱스, 2026-04-19 갱신 — PR #116)
+- `refs/modules/core.md`, `progression.md`, `communication.md`, `decision.md`, `exploration.md`, `clue-distribution.md`, `crime_scene.md` (신규), `media.md` (신규)
+
+**Why:** v2 싱글턴 버그 해결, 모듈=설정 단일 소스로 에디터 자동 UI. PlayerAware 게이트로 per-player state 누출 차단.
+**How to apply:** Phase 3(게임엔진 코어) + Phase 5(모듈 이식)에서 구현. 신규 모듈 추가 시 `.claude/skills/mmp-module-factory/SKILL.md` 체크리스트 준수.

--- a/memory/project_phase19_residual_progress.md
+++ b/memory/project_phase19_residual_progress.md
@@ -1,0 +1,65 @@
+---
+name: Phase 19 Residual — 감사 backlog 잔여 PR 실행
+description: Phase 19 audit + Architecture Audit Delta 11 PR 중 미착수 7건 + 신규 2건(WS Auth/Payload Validation) + 독립 hotfix 2건. Plan PR #119 머지, W0 PR-0 진행 중.
+type: project
+---
+## 활성화 (2026-04-21)
+
+- **Plan dir**: `docs/plans/2026-04-21-phase-19-residual/`
+- **Plan PR**: #119 머지 (commit `19446a2`, admin-skip squash)
+- **MD 한도 완화 PR**: #120 머지 (commit `317be66`, 200→500, CLAUDE.md만 200)
+- **Active**: `.claude/active-plan.json` → `phase-19-residual` / W0 / PR-0
+
+## 범위 (9 PR + 2 hotfix)
+
+| Wave | 항목 | 상태 |
+|------|------|------|
+| W0 | PR-0 MEMORY Canonical Migration | **진행 중** |
+| W1 | PR-3 HTTP Error / PR-1 WS Contract / PR-6 Auditlog + H-1 voice token | pending |
+| W2 | PR-5a/b/c Coverage Gate + mockgen → PR-7 Zustand Action | pending |
+| W3 | PR-8 Module Cache Isolation + H-2 focus-visible | pending |
+| W4 | PR-9 WS Auth Protocol / PR-10 Runtime Payload Validation | pending |
+
+## 부수 PR
+
+- **#121 preflight chore** (commit `3d8ccec`, 2026-04-21) — `.claude/scripts/plan-preflight.sh` M3 cutover(2026-04-15) 이후 legacy `~/.claude/skills/plan-autopilot` 경로 잔존 결함 수정. 추가로 inline bash hook(`[ -f x ] && touch y`) 오해석도 guard로 차단. `/plan-go` 파이프라인 정상화. PR-0 진행 전제 조건.
+
+## W0 PR-0 진행
+
+branch: `chore/phase-19-residual/pr-0-memory-canonical`
+
+| Task | 상태 | 결과 |
+|------|------|------|
+| 1. user home ↔ repo diff | ✅ | drift 4건 + user-only 3건 + repo-only 4건 (repo-only는 정상). 예상 9건 → 실제 7건으로 scope 정정 |
+| 2. 누락 feedback·progress 복원 | ✅ | 4 파일 복사 (session-id 스트립): feedback_file_size_limit, project_module_system, feedback_sonnet_46_default, project_session_2026-04-19_optimization |
+| 3. MEMORY.md 인덱스 재작성 | ✅ | user home canonical 버전 적용 (67줄), 신규 feedback_memory_canonical_repo pointer 추가 |
+| 4. QMD mmp-memory path 이전 | ✅ | store_collections.path: `~/.claude/projects/.../memory` → `<repo>/memory`. 64 files 재인덱싱 + context 갱신 |
+| 5. user home read-only + CLAUDE.md 갱신 | 🟡 부분 | CLAUDE.md QMD 섹션 갱신 + feedback_memory_canonical_repo.md 신설 완료. 실제 filesystem chmod은 auto-memory 시스템 충돌 리스크로 사용자 결정 대기 |
+| 6. 본 progress 메모리 생성 | ✅ | 이 파일 |
+
+## 결정 사항
+
+1. ✅ Phase 19 디렉터리 재활용 대신 신규 `2026-04-21-phase-19-residual/` 생성 — 기존 Phase 19 checklist archived
+2. ✅ MD 파일 한도 200→500 완화 (CLAUDE.md만 200) — plan/PR 스펙 분할 노이즈 해소
+3. ✅ active-plan.json 13 PR 전부 schema 등록 (PR-0/1/3/5a/5b/5c/6/7/8/9/10 + H-1/H-2)
+4. ✅ **memory canonical = repo `memory/`** (Task 5) — auto-memory user home 경로는 archival, `originSessionId` frontmatter 금지, QMD mmp-memory 컬렉션 repo 바인딩
+5. 🟡 user home chmod은 사용자 확인 후 결정 — 하드 락은 미래 세션의 auto-memory write 실패 노이즈 유발 가능
+
+## 비범위
+
+- PR-2a/b/c, PR-4a/b — Phase 19 implementation에서 머지 완료
+- graphify-driven PR-11~14 (Mutex/Linter/Dead-code/Audio) — Phase 21로 이월
+- P2 백로그 28건 — Phase 22+ 기술 부채
+
+## 예상 기간
+16–19 영업일 (W0 0.5d / W1 4–5d / W2 6–7d / W3 2d / W4 3–4d)
+
+## 참조
+
+- design: `docs/plans/2026-04-21-phase-19-residual/design.md`
+- plan: `docs/plans/2026-04-21-phase-19-residual/plan.md`
+- checklist: `docs/plans/2026-04-21-phase-19-residual/checklist.md`
+- backlog source: `docs/plans/2026-04-21-phase-19-residual/refs/backlog-source.md`
+- 원 backlog: `docs/plans/2026-04-17-platform-deep-audit/refs/phase19-backlog.md`
+- delta priority: `docs/plans/2026-04-18-architecture-audit-delta/priority-update.md`
+- memory canonical rule: `memory/feedback_memory_canonical_repo.md`

--- a/memory/project_session_2026-04-19_optimization.md
+++ b/memory/project_session_2026-04-19_optimization.md
@@ -1,0 +1,39 @@
+---
+name: 2026-04-19 세션 — 토큰 최적화 + 스펙 동기화
+description: 3 PR 머지 (#116 module-spec 33 동기화, #117 hook slim + advisor 패턴, #118 /plan-* QMD 전환 + Sonnet 4.6 기준). 글로벌 plan-autopilot archive.
+type: project
+---
+**수행 작업:**
+
+1. **PR #116 `docs(module-spec)`** — crime_scene + media 카테고리 신설
+   - `docs/plans/2026-04-05-rebuild/module-spec.md` 29 → 33 모듈 인덱스
+   - `refs/modules/crime_scene.md` (Location/Evidence/Combination 3종) + `media.md` (Audio) 신규
+   - PlayerAware 게이트 분포 표 + LocationClue vs Location 네이밍 혼동 주의표
+
+2. **PR #117 `chore(hooks)`** — 토큰 절감 최적화
+   - `.claude/settings.json`: graphify Glob|Grep 리마인더 hook 삭제 (매 grep ~120 토큰 중복)
+   - `.claude/scripts/plan-status.sh --compact`: plan 필드 `?`일 때 침묵
+   - `.claude/scripts/plan-remind.sh`: 4줄 → 1줄
+   - `CLAUDE.md`: graphify 섹션 70줄 → `.claude/refs/graphify.md` + 강제 규칙 5줄 (281→241)
+   - `CLAUDE.md`: **Opus↔Sonnet 위임 규칙 (advisor 패턴)** 섹션 신규 추가
+
+3. **PR #118 `chore(plan)`** — /plan-* 커맨드 slim
+   - `plan-resume.md`: Read 5 files → `qmd get` 2개 (현재 PR spec + checklist). design/plan은 PreToolUse가 편집 직전 강제하므로 선로드 금지. 호출당 ~10K 절감
+   - `plan-go.md`: 103→52줄, Phase 상세 mmp-pilot/SKILL.md 단일 소스 참조
+   - `plan-status.md`: deprecated `autopilot-state.json` cat 제거
+   - `CLAUDE.md`: **Sonnet 4.6 모델 기준** 섹션 (서브에이전트 `claude-sonnet-4-6`, 4.5 금지)
+
+4. **글로벌 직접 적용** (repo 외)
+   - `~/.claude/skills/plan-autopilot/` → `~/.claude/_archive/plan-autopilot-20260419/` 이동 후 plan-go canonical rename (심볼릭 링크 정리)
+   - `~/.claude/skills/plan-go/SKILL.md`: frontmatter name 교정 + Anti-patterns → `refs/STOP-list.md` 분리
+   - `~/.claude/scripts/skill-injector.sh`: 슬래시/20자 미만 프롬프트 스킵 + skills 빈 rule 침묵
+   - `~/.claude/scripts/skill-rules.json`: `design-docs` rule 제거 (10→9)
+
+**예상 세션당 절감:**
+- 일반 세션: ~8~15K 토큰
+- /plan-resume 쓰는 세션: 추가 ~10K
+- /plan-go 반복 세션: 추가 ~2K × N회
+
+**Why**: 직전 세션 (module-spec #116) ~69K 컨텍스트 소모 분석 후 프로젝트 스코프에서 조정 가능한 노이즈·중복 제거. advisor tool (Anthropic API beta) 패턴의 Claude Code 등가 문서화.
+
+**How to apply**: 다음 세션부터 `/plan-resume` 호출 시 QMD get 2개만 로드됨. 서브에이전트 spawn 시 `model: "claude-sonnet-4-6"` 명시 필수.


### PR DESCRIPTION
## Summary
- Phase 19 Residual **W0 유일 PR**. auto-memory user home과 repo `memory/` 사이 drift를 제거하고 repo를 canonical 단일 출처로 정립.
- QMD `mmp-memory` 컬렉션 경로를 user home → repo로 이전 + 재인덱싱 (66 files).
- 신규 규칙 메모리 `feedback_memory_canonical_repo.md` — 쓰기 금지 규칙 + `originSessionId` 금지 + 재발 방지 절차.
- 선행 머지된 preflight chore(#121, `3d8ccec`)와 짝을 이루어 `/plan-go` 파이프라인 정상화.

## 변경 내역 (9 files · +197 / -35)

| 구분 | 파일 | 크기 |
|------|------|------|
| 복원 (신규) | `memory/feedback_sonnet_46_default.md` | 19L |
| 복원 (신규) | `memory/project_session_2026-04-19_optimization.md` | 39L |
| 복원 (수정) | `memory/feedback_file_size_limit.md` | +3L / strip session-id |
| 복원 (수정) | `memory/project_module_system.md` | +13L / strip session-id |
| 메타 | `memory/MEMORY.md` | user home canonical 적용(68L) + 신규 pointer 3건 |
| 메타 | `CLAUDE.md` | § QMD 컬렉션 갱신 + canonical 경고 블록 |
| 신규 규칙 | `memory/feedback_memory_canonical_repo.md` | 16L |
| 진행 기록 | `memory/project_phase19_residual_progress.md` | 65L |
| 플랜 sync | `docs/plans/2026-04-21-phase-19-residual/checklist.md` | STATUS + Task 1–6 체크박스 |

## Test plan
- [x] `diff -rq <user-home>/memory/ memory/` → 잔존 차이는 frontmatter session-id 5건(기존 repo 파일, 후속 hygiene PR 대상) + canonical 방향 일치
- [x] `qmd search "phase19 residual" -c mmp-memory` → 93% score hit
- [x] `qmd search "memory canonical" -c mmp-memory` → 90% score hit
- [x] `sqlite3 ~/.cache/qmd/index.sqlite "SELECT path FROM store_collections WHERE name='mmp-memory'"` → repo 경로 확인 (실행 시점 기준)
- [x] `qmd update` → 66 files indexed, orphaned hash cleanup 완료
- [ ] staging 관측 1 세션 — 다음 세션에서 `/plan-resume` 시 QMD hit 정상 + MEMORY.md 로드 정상

## Scope 일치성
- Phase 19 Residual plan scope (`memory/**`, `MEMORY.md`, `CLAUDE.md`) 내에서만 변경
- `.claude/active-plan.json` · `graphify-out/**` 모두 제외 (CLAUDE.md 정책 준수)

## 후속 PR
- **hygiene**: 기존 repo 42건 `originSessionId` 일괄 스트립 (XS, 단일 sed 커밋, PR-0 직후)
- **Task 5 filesystem chmod**: auto-memory 충돌 리스크로 사용자 결정 대기 (docs-only 소프트 모드는 이번 PR에서 적용 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)