### PR TITLE
chore(phase-19-residual): memory frontmatter originSessionId 일괄 스트립 (42건)

### DIFF
--- a/memory/feedback_branch_pr_workflow.md
+++ b/memory/feedback_branch_pr_workflow.md
@@ -2,7 +2,6 @@
 name: main 직접 push 금지 · feature branch + PR 필수
 description: MMP v3 레포는 branch protection이 걸려있어 모든 변경은 feature branch + PR을 거쳐야 한다. bypass 사용 금지. 문서·계획·설정 포함 예외 없음.
 type: feedback
-originSessionId: 64aa5888-7c28-4275-ba6c-d8a52b542164
 ---
 # main 직접 push 금지 · feature branch + PR 필수
 

--- a/memory/feedback_ci_infra_debt.md
+++ b/memory/feedback_ci_infra_debt.md
@@ -2,7 +2,6 @@
 name: CI 인프라 부채 (Phase 18.3에서 해결 완료)
 description: 2026-04-08 기준 발견, 2026-04-15 Phase 18.3 PR-1에서 전부 해결.
 type: feedback
-originSessionId: 0a24815c-1878-4801-8c1c-2465d442d1b3
 ---
 ## ✅ 해결 완료 (Phase 18.3 PR-1, 커밋 33d2d72)
 

--- a/memory/feedback_graphify_first.md
+++ b/memory/feedback_graphify_first.md
@@ -2,7 +2,6 @@
 name: 아키텍처·의존성 질문은 graphify 먼저
 description: 코드베이스 구조·의존성·"어디서 쓰이나" 질문은 graphify 지식 그래프를 우선 사용. QMD와 대칭 규칙.
 type: feedback
-originSessionId: 8288707a-145a-40ec-8b1e-5f6f11a2b6f7
 ---
 **규칙:** `graphify-out/graph.json` 존재 시 아키텍처·의존성·구조 질문은 **반드시 graphify 먼저**. 원시 파일 Grep/Glob 탐색은 graphify로 대상을 특정한 후에만 허용.
 

--- a/memory/feedback_opus_headquarter.md
+++ b/memory/feedback_opus_headquarter.md
@@ -2,7 +2,6 @@
 name: Opus 헤드쿼터 모드
 description: Opus는 판단/지시/종합만, 실제 구현은 Sonnet/Haiku 서브에이전트에게 위임
 type: feedback
-originSessionId: 323582ed-c085-474d-bc70-14bba54a7f6b
 ---
 Opus는 직접 코드 작성/편집하지 않고, 두뇌(헤드쿼터) 역할만 수행한다.
 

--- a/memory/feedback_plan_resume_qmd.md
+++ b/memory/feedback_plan_resume_qmd.md
@@ -2,7 +2,6 @@
 name: plan-resume은 QMD로 컨텍스트 효율화
 description: /plan-resume 시 Read 대신 QMD get/search로 필요한 섹션만 로드하여 컨텍스트 토큰 절약
 type: feedback
-originSessionId: c0b2a2da-c721-4cd4-b311-bba72e59e407
 ---
 plan-resume에서 Read로 6개 파일 전문(~550줄)을 올리지 말고, QMD를 활용할 것.
 

--- a/memory/feedback_qmd_memory_leak.md
+++ b/memory/feedback_qmd_memory_leak.md
@@ -2,7 +2,6 @@
 name: QMD MCP 메모리 누수 운영 규칙
 description: bun MCP 프로세스가 임베딩 캐시를 무한 상주시켜 장시간 세션에서 OOM 위험. 컬렉션 최소화 + 주기적 재시작
 type: feedback
-originSessionId: db46cd3e-7369-4f7a-b06e-2697758a806c
 ---
 QMD MCP는 단일 bun 프로세스가 모든 컬렉션의 벡터/임베딩 모델(embeddinggemma)을 힙에 상주시키며, 런타임 캐시 flush API가 없다. 장시간 세션에서 RSS 10GB+ 까지 누적 가능 (2026-04-15: PID 41571이 685 docs로 11.8GB / 36분 측정).
 

--- a/memory/feedback_qmd_plan_resume.md
+++ b/memory/feedback_qmd_plan_resume.md
@@ -2,7 +2,6 @@
 name: plan-resume에서도 QMD 우선
 description: /plan-resume 컨텍스트 복원 시에도 docs/plans, memory 경로는 Read 대신 QMD get 사용 필수
 type: feedback
-originSessionId: 6c3c79f2-2fec-425e-85a0-51decc6e6fa1
 ---
 plan-resume 스킬이 직접 Read를 지시하더라도, docs/plans/ 및 memory/ 경로의 .md 파일은 QMD get으로 로드해야 한다.
 

--- a/memory/feedback_work_routine.md
+++ b/memory/feedback_work_routine.md
@@ -2,7 +2,6 @@
 name: 작업 루틴 강제
 description: 매 작업 시작 시 QMD 컨텍스트 로드, 완료 시 문서 업데이트+재인덱싱 필수
 type: feedback
-originSessionId: 323582ed-c085-474d-bc70-14bba54a7f6b
 ---
 매 작업에 시작/완료 루틴을 강제한다.
 

--- a/memory/feedback_ws_token_query.md
+++ b/memory/feedback_ws_token_query.md
@@ -2,7 +2,6 @@
 name: WS 연결 시 토큰 쿼리 파라미터 필수
 description: WebSocket 업그레이드에서 JWTPlayerIDExtractor가 ?token= 쿼리로 인증, Authorization 헤더 아님
 type: feedback
-originSessionId: c9b808da-0f23-4f0e-b844-702c62f52efc
 ---
 WS 연결 시 토큰을 URL 쿼리 파라미터로 전달해야 함.
 

--- a/memory/project_ci_admin_skip_until_2026-05-01.md
+++ b/memory/project_ci_admin_skip_until_2026-05-01.md
@@ -2,7 +2,6 @@
 name: CI admin-skip 머지 정책 (2026-05-01까지)
 description: main branch protection required status checks를 admin 권한으로 skip 머지. 2026-05-01 이후 재검토
 type: project
-originSessionId: 23f1b5bf-4a2e-43fc-80d3-00b276d49de1
 ---
 2026-04-18 결정. 2026-05-01까지 **모든 PR은 admin 권한으로 required status checks를 스킵 머지**한다.
 

--- a/memory/project_e2e_testing.md
+++ b/memory/project_e2e_testing.md
@@ -2,7 +2,6 @@
 name: Playwright E2E 테스트 설정
 description: apps/web E2E 테스트 — Playwright + Chromium, 12개 프론트 페이지 테스트, pnpm test:e2e
 type: project
-originSessionId: b2c1ae4d-dc4a-4f34-bd7e-4301f4fcbcd4
 ---
 Playwright E2E 테스트가 `apps/web/e2e/`에 설정됨 (2026-04-12).
 

--- a/memory/project_editor_open_access.md
+++ b/memory/project_editor_open_access.md
@@ -2,7 +2,6 @@
 name: 에디터 개방 + 심사 플로우
 description: Phase 10.0 이후 — 에디터 전유저 개방, 게시 심사 워크플로우, 이미지 업로드/크롭 구현 완료
 type: project
-originSessionId: 9027290a-1112-4e04-8417-e6a1a5a9744a
 ---
 2026-04-13 작업 완료.
 

--- a/memory/project_graphify_refresh_policy.md
+++ b/memory/project_graphify_refresh_policy.md
@@ -2,7 +2,6 @@
 name: graphify refresh 정책 (D) — Phase 종료 시점 fresh rebuild만 허용
 description: repo graphify-out/graph.json은 Phase 종료 시 수동 fresh rebuild + PR. 일상 post-commit/watch/update는 개인 로컬 전용, 커밋 금지
 type: project
-originSessionId: 23f1b5bf-4a2e-43fc-80d3-00b276d49de1
 ---
 2026-04-18 결정. post-commit hook의 AST-only 재빌드가 semantic 개념 노드 53개(~6%, 852→799 source_file)를 영구 손실하는 upstream 버그 확인 후 수립.
 

--- a/memory/project_local_auth.md
+++ b/memory/project_local_auth.md
@@ -2,7 +2,6 @@
 name: MMP v3 이메일/비밀번호 인증
 description: 로컬 인증 (이메일/비밀번호), OAuth와 병행, E2E 테스트 계정 e2e@test.com
 type: project
-originSessionId: b2c1ae4d-dc4a-4f34-bd7e-4301f4fcbcd4
 ---
 이메일/비밀번호 로그인. OAuth(카카오/구글)와 병행.
 

--- a/memory/project_mmp_pilot.md
+++ b/memory/project_mmp_pilot.md
@@ -2,7 +2,6 @@
 name: mmp-pilot 통합 시스템 (M0-M3 cutover 완료)
 description: plan-* 체계와 mmp 하네스를 병합한 단일 파일럿 시스템. /plan-go 단일 진입점, 3-Layer 구조, A/B 자기개선 루프(M4 계획). M3 cutover 2026-04-15 commit cdd498e 완료 — plan-autopilot 제거.
 type: project
-originSessionId: 4b31801f-3661-4beb-a250-8271acf17e79
 ---
 # mmp-pilot — plan-autopilot + mmp 하네스 통합 시스템
 

--- a/memory/project_phase100_progress.md
+++ b/memory/project_phase100_progress.md
@@ -2,7 +2,6 @@
 name: Phase 10.0 — QA Bugfix Sprint 완료
 description: Playwright QA에서 발견된 5개 이슈 수정 완료
 type: project
-originSessionId: 4127eec9-9797-46ce-8953-06d681f348b1
 ---
 # Phase 10.0 — QA Bugfix Sprint 완료
 

--- a/memory/project_phase110_plan.md
+++ b/memory/project_phase110_plan.md
@@ -2,7 +2,6 @@
 name: Phase 11.0 메타포 테스트 게임
 description: 단서 아이템 시스템 + 메타포 6인 템플릿 + E2E 테스트 (2026-04-13 완료)
 type: project
-originSessionId: cabf1bd5-68d3-497d-bb1a-9aef975c8317
 ---
 Phase 11.0 — 메타포 테스트 게임 구현 **완료**.
 

--- a/memory/project_phase120_progress.md
+++ b/memory/project_phase120_progress.md
@@ -2,7 +2,6 @@
 name: Phase 12.0 완료
 description: 메타포 풀 경험 게임 모듈 프론트엔드 4개 구현 (5 PR, 3 Wave, 42 tests, 2026-04-13)
 type: project
-originSessionId: c9b808da-0f23-4f0e-b844-702c62f52efc
 ---
 Phase 12.0 완료 — 메타포 6인 테마 풀 게임 경험.
 

--- a/memory/project_phase130_plan.md
+++ b/memory/project_phase130_plan.md
@@ -2,7 +2,6 @@
 name: Phase 13.0 플랜 (게임 설계 에디터)
 description: 비개발자용 게임 설계 UI — 서브탭/ConfigSchema폼/맵장소/타임라인/배치/배정 (7 PR, 4 Wave)
 type: project
-originSessionId: c9b808da-0f23-4f0e-b844-702c62f52efc
 ---
 Phase 13.0 플랜 준비 완료 — 게임 설계 에디터.
 

--- a/memory/project_phase140_plan.md
+++ b/memory/project_phase140_plan.md
@@ -2,7 +2,6 @@
 name: Phase 14.0 완료 (에디터 UX 개선)
 description: 이미지fix + 반응형 + 히든미션 재설계 + 단서compact + 탭재편 — 5 PR, 3 Wave 완료 (2026-04-14)
 type: project
-originSessionId: ed931b94-5594-4647-ba7d-bf4d4a76ac6b
 ---
 Phase 14.0 **완료** (2026-04-14) — 에디터 UX 개선 + 버그 수정.
 

--- a/memory/project_phase150_plan.md
+++ b/memory/project_phase150_plan.md
@@ -2,7 +2,6 @@
 name: Phase 15.0 플랜 (React Flow 게임 흐름 에디터)
 description: React Flow 캔버스 + 분기/엔딩 노드 + 조건 규칙 빌더 + DB 확장 (8 PR, 4 Wave)
 type: project
-originSessionId: ed931b94-5594-4647-ba7d-bf4d4a76ac6b
 ---
 Phase 15.0 설계+계획 완료 — React Flow 게임 흐름 에디터.
 

--- a/memory/project_phase150_progress.md
+++ b/memory/project_phase150_progress.md
@@ -2,7 +2,6 @@
 name: Phase 15.0 완료
 description: React Flow 게임 흐름 에디터 — 8 PR, 4 Wave, Go 23 + Frontend 303 tests
 type: project
-originSessionId: 5f2c99b5-2ba5-42e7-9101-06686feccfc9
 ---
 Phase 15.0 — React Flow 게임 흐름 에디터 **완료** (2026-04-14)
 

--- a/memory/project_phase160_progress.md
+++ b/memory/project_phase160_progress.md
@@ -2,7 +2,6 @@
 name: Phase 16.0 완료
 description: 에디터 UX 버그픽스 + 개선 — 4 PR, 2 Wave, 이미지 캐시/모달 스크롤/모듈 토글/흐름 템플릿 + 핫픽스 3건
 type: project
-originSessionId: e1b3327b-168f-4343-935a-994532712f00
 ---
 Phase 16.0 — **완료** (2026-04-14)
 

--- a/memory/project_phase170_plan.md
+++ b/memory/project_phase170_plan.md
@@ -2,7 +2,6 @@
 name: Phase 17.0 완료
 description: 에디터 UX v2 이식 + 흐름 에디터 완성 — 7 PR, 4 Wave, 353 tests, 완료+archived
 type: project
-originSessionId: a2c03f54-3688-41cc-a720-6fc0298ca899
 ---
 Phase 17.0 — **완료** (2026-04-14)
 

--- a/memory/project_phase175_progress.md
+++ b/memory/project_phase175_progress.md
@@ -2,7 +2,6 @@
 name: Phase 17.5 완료 — 단서 관계 그래프
 description: 단서 간 의존 관계 DAG 편집 + 시각화 완료 (4 PRs, 3 Waves, 12 Vitest + 4 Go tests, 2026-04-14)
 type: project
-originSessionId: 5ea385bb-f64c-468a-a30a-3e1db6e680ab
 ---
 # Phase 17.5 완료
 

--- a/memory/project_phase180_plan.md
+++ b/memory/project_phase180_plan.md
@@ -2,7 +2,6 @@
 name: Phase 18.0 플랜 — 게임 런타임 통합
 description: PhaseEngine+모듈 WS 연결 + 게임 클라이언트 (10 PR, 6 Wave, W0는 Phase 17.5 cleanup 포함)
 type: project
-originSessionId: 5ea385bb-f64c-468a-a30a-3e1db6e680ab
 ---
 # Phase 18.0 — 게임 런타임 통합 (계획)
 

--- a/memory/project_phase180_progress.md
+++ b/memory/project_phase180_progress.md
@@ -2,7 +2,6 @@
 name: Phase 18.0 게임 런타임 통합 완료
 description: Phase 18.0 — 에디터 configJson 으로 실제 게임 세션 구동, 10 PR / 6 Wave / 50 tasks 완료 (2026-04-15)
 type: project
-originSessionId: cd68ad41-eafc-4fad-ba2f-64ea3cbb8f63
 ---
 ## 개요
 

--- a/memory/project_phase181_progress.md
+++ b/memory/project_phase181_progress.md
@@ -2,7 +2,6 @@
 name: Phase 18.1 게임 런타임 Hotfix 완료
 description: Phase 18.0 코드리뷰 ship-blocker 4건 + high 4건 해결 — main wiring, snapshot redaction, configJson 경계, 프론트 store 통합, 실백엔드 E2E (2026-04-15)
 type: project
-originSessionId: cd68ad41-eafc-4fad-ba2f-64ea3cbb8f63
 ---
 ## 개요
 

--- a/memory/project_phase183_progress.md
+++ b/memory/project_phase183_progress.md
@@ -2,7 +2,6 @@
 name: Phase 18.3 완료 — 보안 하드닝 + CI 정비
 description: Phase 18.3 전체 PR-0~PR-4 완료 요약. M-7/M-a/M-e + L-2~L-8 + CI-1/2/3 해결.
 type: progress
-originSessionId: 0a24815c-1878-4801-8c1c-2465d442d1b3
 ---
 ## 개요
 

--- a/memory/project_phase184_progress.md
+++ b/memory/project_phase184_progress.md
@@ -2,7 +2,6 @@
 name: Phase 18.4 에디터 UX Bugfix 완료
 description: 에디터 저작 골든패스 복구 — 9 버그 + 3 hotfix + E2E, 2026-04-15 단일일 완료
 type: project
-originSessionId: eec4a7b6-fc14-40e7-b876-9bb1b4210c13
 ---
 # Phase 18.4 — 에디터 UX Bugfix 완료
 

--- a/memory/project_phase185_progress.md
+++ b/memory/project_phase185_progress.md
@@ -2,7 +2,6 @@
 name: Phase 18.5 완료
 description: 에디터 리팩터링 + 테스트 보강 (ValidateTheme 추출, flowApi MSW, request_id trace) — 2 커밋 main 머지
 type: project
-originSessionId: a17861e7-5524-41d6-b0e3-eebb414caa6c
 ---
 # Phase 18.5 — Editor Refactor + Test Hardening (완료)
 

--- a/memory/project_phase186_plan.md
+++ b/memory/project_phase186_plan.md
@@ -2,7 +2,6 @@
 name: Phase 18.6 E2E Recovery 진행중
 description: login timeout + theme seed — Phase 18.4/PR#48 후속, CI green 확보
 type: project
-originSessionId: eec4a7b6-fc14-40e7-b876-9bb1b4210c13
 ---
 # Phase 18.6 — E2E Recovery (진행중)
 

--- a/memory/project_phase187_progress.md
+++ b/memory/project_phase187_progress.md
@@ -2,7 +2,6 @@
 name: Phase 18.7 완료
 description: CI/Test automation hardening (Hotfix + 7 PR, 4 Wave) — migration drift gate, cache, SHA pin, coverage upload, security scans, SBOM, E2E shard+firefox, Renovate
 type: project
-originSessionId: a17861e7-5524-41d6-b0e3-eebb414caa6c
 ---
 # Phase 18.7 — CI/Test Automation Hardening (완료)
 

--- a/memory/project_phase188_plan.md
+++ b/memory/project_phase188_plan.md
@@ -2,7 +2,6 @@
 name: Phase 18.8 — E2E Skip Recovery 플랜
 description: 5 PR / 3 Wave로 E2E 11 skip 복구 + real-backend CI 점진 승격. H7 MaxPlayers + MSW + multi-context party + stubbed 복제. 2026-04-16 계획 승인 대기.
 type: project
-originSessionId: 7224d753-392e-4ac3-8d06-97bbcf225fe8
 ---
 **Phase 18.8 E2E Skip Recovery** — 2026-04-16 플랜 머지 (PR #66). 실행 시작 전.
 

--- a/memory/project_phase19_audit_progress.md
+++ b/memory/project_phase19_audit_progress.md
@@ -2,7 +2,6 @@
 name: Phase 19 Platform Deep Audit 진행 상황
 description: 9영역 심층 감사 + 8 cross-cutting + 9 PR backlog + 4 decisions resolved. PR #69 (2026-04-17)
 type: project
-originSessionId: 59a1a14f-e060-4f0d-b252-ee4accb74a14
 ---
 # Phase 19 Platform Deep Audit — 완료 보고
 

--- a/memory/project_phase20_plan.md
+++ b/memory/project_phase20_plan.md
@@ -2,7 +2,6 @@
 name: Phase 20 플랜 — 단서·장소 에디터 정식 승격
 description: PoC → 백엔드 연동 (clue_type 제거 + 통합 엣지 그래프 + 라운드 스케줄 + 프론트 승격). 6 PR · 4 Wave.
 type: project
-originSessionId: 40df8816-19e4-4b87-ae1f-dbc0f2c72cc1
 ---
 # Phase 20 — 단서·장소 에디터 정식 승격
 

--- a/memory/project_phase20_progress.md
+++ b/memory/project_phase20_progress.md
@@ -2,7 +2,6 @@
 name: Phase 20 진행 상황 (완료)
 description: Phase 20 단서·장소 에디터 정식 승격. 6 PR + 1 chore, 4 Wave, 2026-04-17 완료
 type: project
-originSessionId: 4f653890-5e72-4b41-aeda-8c53f3d68b79
 ---
 # Phase 20 — 단서·장소 에디터 정식 승격 (완료)
 

--- a/memory/project_phase90_progress.md
+++ b/memory/project_phase90_progress.md
@@ -2,7 +2,6 @@
 name: Phase 9.0 진행 상황
 description: Composable Module Engine Redesign — 전체 완료 (W1~W7, 16 PRs)
 type: project
-originSessionId: cfce10f9-039a-4ad8-bee3-4752b5da9e80
 ---
 ## Phase 9.0 — Composable Module Engine Redesign ✅
 

--- a/memory/project_phases.md
+++ b/memory/project_phases.md
@@ -2,7 +2,6 @@
 name: MMP v3 Phase 체크리스트
 description: Phase 0~16.0 완료, Phase 17.0 진행 예정
 type: project
-originSessionId: e1b3327b-168f-4343-935a-994532712f00
 ---
 ## 현재: Phase 17.0 플랜 확정 (2026-04-14)
 

--- a/memory/reference_graphify_setup.md
+++ b/memory/reference_graphify_setup.md
@@ -2,7 +2,6 @@
 name: graphify 지식 그래프 인덱스
 description: MMP v3 전체 코드·문서 graphify 인덱스 상태, 도구 사용법, Hook 강제 구조, 산출물 위치
 type: reference
-originSessionId: 8288707a-145a-40ec-8b1e-5f6f11a2b6f7
 ---
 ## 인덱스 상태 (2026-04-18 구축)
 

--- a/memory/reference_plan_go_setup.md
+++ b/memory/reference_plan_go_setup.md
@@ -2,7 +2,6 @@
 name: plan-go 커맨드 ↔ plan-autopilot 스킬 연결
 description: 프로젝트의 /plan-* 커맨드가 ~/.claude/skills/plan-go/ 경로를 참조하지만 실제 스킬은 plan-autopilot. symlink 필요
 type: reference
-originSessionId: db46cd3e-7369-4f7a-b06e-2697758a806c
 ---
 프로젝트 `.claude/commands/plan-*.md` 파일들이 `$HOME/.claude/skills/plan-go/scripts/...` 경로의 스크립트(`plan-preflight.sh`, `plan-status.sh`, `plan-tasks.sh`, `autopilot-loop.sh`)와 `templates/`, `refs/` 를 참조한다. 글로벌 스킬은 `~/.claude/skills/plan-autopilot/`만 존재 — `/plan-go`가 plan-autopilot의 후계라서 디렉터리 구조가 동일하므로 symlink로 해결.
 

--- a/memory/reference_qmd_setup.md
+++ b/memory/reference_qmd_setup.md
@@ -2,7 +2,6 @@
 name: QMD 로컬 문서 검색 설정
 description: QMD MCP 서버 설정, 컬렉션 구성, Hook 강제 구조 — 설계 문서 검색 시 참조
 type: reference
-originSessionId: 03af9547-3119-43e4-acf8-127b84e2e0e6
 ---
 QMD가 MCP 서버로 등록됨 (`~/.claude/settings.json` → mcpServers.qmd)
 


### PR DESCRIPTION
## Summary
- PR-0 Canonical Migration(#122) 직후 hygiene. repo에 이미 커밋된 기존 memory 42건이 auto-memory 시점의 세션 UUID(`originSessionId`)를 보유한 상태.
- PR-0에서 정립한 `memory/feedback_memory_canonical_repo.md` § 4 "frontmatter `originSessionId` 금지" 규칙에 맞춰 일괄 제거.

## 변경
- `sed '/^originSessionId: /d'` 42 파일
- **42 files changed, 42 deletions(-)** — 정확히 파일당 -1줄, 추가 0
- 로직 변경 0, 다른 프론트매터 필드(`name`/`description`/`type`) 무수정

## 검증
- [x] `grep -l "^originSessionId: " memory/*.md` → 0건 잔존
- [x] `git diff memory/ | grep "^-" | grep -v "^---"` → 모두 `-originSessionId: <uuid>` 패턴만
- [x] `git diff --shortstat memory/` → `42 files changed, 42 deletions(-)` 일치
- [ ] 다음 세션 `/plan-resume` 시 QMD 조회 정상 (후속 관측)

## 영향
- 신규 memory 작성 흐름 무영향 (PR-0 이후 규칙)
- QMD 재인덱싱 **불필요** — 본문 변경 없음, frontmatter 1줄만 감소
- user home archival 원본은 변경 없음 (read-only 소프트 모드 유지)

## Scope
- `memory/*.md` 42 파일 단독 변경
- CLAUDE.md · plan 문서 · graphify-out 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)