### PR TITLE
feat(phase-19-residual): PR-5b Coverage Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,13 @@ jobs:
           flags: backend
           fail_ci_if_error: false
 
+      - name: Upload Go coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-coverage
+          path: apps/server/coverage.out
+          retention-days: 1
+
       - name: Build server
         run: go build ./cmd/server
 
@@ -168,6 +175,13 @@ jobs:
           flags: frontend
           fail_ci_if_error: false
 
+      - name: Upload Web coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-coverage
+          path: apps/web/coverage/coverage-summary.json
+          retention-days: 1
+
       - name: Vitest coverage PR summary
         if: github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@c0c9b09c93750ee1d8335d14e94ce3d6fc61df50 # v2.11.0
@@ -179,7 +193,14 @@ jobs:
         run: pnpm turbo build
 
   coverage-guard:
-    name: Coverage Regression Guard (warn-only)
+    # Phase 19 Residual PR-5b — Coverage Gate.
+    # baseline: Go 43.9% / FE Lines 51.75% / FE Branches 79.66% / FE Functions 55.66% (2026-04-21)
+    # current threshold: Go 41% / FE Lines 49% / FE Branches 77% / FE Functions 53% (baseline-2% buffer)
+    # 로드맵:
+    #   Phase 20: Go 55% / FE Lines 55% / FE Branches 80% (+~5%p — 추가 테스트 PR 선행 필수)
+    #   Phase 21: Go 70% / FE Lines 65% / FE Branches 85% (+15%p — 하한 상향 전 반드시 테스트 보강)
+    #   하한 상향 전에 반드시 추가 테스트 PR 로 baseline 끌어올리기.
+    name: Coverage Regression Guard
     runs-on: self-hosted
     needs: [go-check, ts-check]
     steps:
@@ -188,11 +209,70 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Coverage delta placeholder
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download Go coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: go-coverage
+          path: apps/server
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: apps/server/go.sum
+
+      - name: Go coverage gate
+        working-directory: apps/server
         run: |
-          echo "::notice::Coverage regression guard is currently warn-only."
-          echo "::notice::Enforcement PR follow-up scheduled after 2026-05-28."
-          echo "::notice::Codecov dashboard provides delta visibility: https://codecov.io/gh/sabyunrepo/muder_platform"
+          TOTAL=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | tr -d '%')
+          THRESHOLD=41
+          if awk "BEGIN {exit !($TOTAL < $THRESHOLD)}"; then
+            echo "::error::Go coverage ${TOTAL}% is below threshold ${THRESHOLD}%"
+            echo "::error::Run 'cd apps/server && go test -coverprofile=coverage.out ./...' locally to investigate"
+            exit 1
+          fi
+          echo "::notice::Go coverage ${TOTAL}% >= ${THRESHOLD}% (threshold)"
+
+      - name: Download Web coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: web-coverage
+          path: apps/web/coverage
+
+      - name: Web coverage gate
+        run: |
+          LINES=$(jq '.total.lines.pct' apps/web/coverage/coverage-summary.json)
+          BRANCHES=$(jq '.total.branches.pct' apps/web/coverage/coverage-summary.json)
+          FUNCTIONS=$(jq '.total.functions.pct' apps/web/coverage/coverage-summary.json)
+          LINES_THR=49
+          BRANCHES_THR=77
+          FUNCTIONS_THR=53
+          FAIL=0
+          if awk "BEGIN {exit !($LINES < $LINES_THR)}"; then
+            echo "::error::FE Lines coverage ${LINES}% is below threshold ${LINES_THR}%"
+            FAIL=1
+          else
+            echo "::notice::FE Lines coverage ${LINES}% >= ${LINES_THR}% (threshold)"
+          fi
+          if awk "BEGIN {exit !($BRANCHES < $BRANCHES_THR)}"; then
+            echo "::error::FE Branches coverage ${BRANCHES}% is below threshold ${BRANCHES_THR}%"
+            FAIL=1
+          else
+            echo "::notice::FE Branches coverage ${BRANCHES}% >= ${BRANCHES_THR}% (threshold)"
+          fi
+          if awk "BEGIN {exit !($FUNCTIONS < $FUNCTIONS_THR)}"; then
+            echo "::error::FE Functions coverage ${FUNCTIONS}% is below threshold ${FUNCTIONS_THR}%"
+            FAIL=1
+          else
+            echo "::notice::FE Functions coverage ${FUNCTIONS}% >= ${FUNCTIONS_THR}% (threshold)"
+          fi
+          if [ "$FAIL" = "1" ]; then
+            echo "::error::Run 'cd apps/web && pnpm test:coverage' locally to investigate"
+            exit 1
+          fi
 
   docker-build:
     name: Docker Build Check

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -27,6 +27,17 @@ export default defineConfig({
         "src/main.tsx",
         "src/vite-env.d.ts",
       ],
+      // Phase 19 Residual PR-5b — Coverage Gate.
+      // baseline: Lines 51.75% / Branches 79.66% / Functions 55.66% (2026-04-21)
+      // threshold: baseline - 2% buffer to absorb flaky/env variance.
+      // 로드맵: Phase 20 → Lines 55% / Branches 80% / Functions 58%
+      //         Phase 21 → Lines 65% / Branches 85% / Functions 68%
+      thresholds: {
+        lines: 49,
+        statements: 49,
+        branches: 77,
+        functions: 53,
+      },
     },
   },
 });

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,11 +3,11 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0%
+        threshold: 1%  # 기존 대비 1%p 회귀 허용 (noise margin)
     patch:
       default:
-        target: auto
-        threshold: 0%
+        target: 70%    # 신규 코드는 70% 커버 요구 (patch 집중)
+        threshold: 0%  # 신규 코드 회귀 0 허용
 
 # Phase 19 Residual PR-5a: 자동 생성 mockgen 산출물 + 전환기 shim 은
 # coverage 집계에서 제외. auto-generated 코드는 테스트 대상 아니며 집계에

--- a/memory/project_phase19_residual_progress.md
+++ b/memory/project_phase19_residual_progress.md
@@ -16,7 +16,7 @@ type: project
 |------|------|------|
 | W0 | PR-0 MEMORY Canonical Migration | ✅ 완료 (#122 `c2f34a9`) + hygiene #123 `22b1a5a` + finalize #124 `6d24a29` |
 | W1 | PR-3 HTTP Error / H-1 voice token / PR-1 WS Contract / PR-6 Auditlog | ✅ 완료 — PR-3 #128 `03897f9` + H-1 #125 `367ca35` + PR-1 #129 `80b603e` + PR-6 머지 대기 (브랜치 `feat/phase-19-residual/pr-6-auditlog-expansion`, 7 신규 테스트 + F-sec-4 fallback + smoke doc) |
-| W2 | PR-5a/b/c Coverage Gate + mockgen → PR-7 Zustand Action | pending |
+| W2 | PR-5a/b/c Coverage Gate + mockgen → PR-7 Zustand Action | PR-5b ✅ 완료 (branch `feat/phase-19-residual/pr-5b-coverage-gate`) |
 | W3 | PR-8 Module Cache Isolation + H-2 focus-visible | pending |
 | W4 | PR-9 WS Auth Protocol / PR-10 Runtime Payload Validation | pending |
 
@@ -91,6 +91,34 @@ branch: `chore/phase-19-residual/pr-0-memory-canonical`
   - T8 CI drift gate: `.github/workflows/ci.yml:79-80` `go run ./cmd/wsgen` + `git diff --exit-code`
 - **본 PR 실질 변경**: `cmd/wsgen/render.go` 의 `headerBlock` const → `renderHeader()` 동적 함수. 이벤트 총수 + active/stub/deprec breakdown + payload struct 수를 헤더에 기록. Status 만 바뀐 경우도 headerline 변경 → drift gate 가시화.
 - **검증**: `go run ./cmd/wsgen` → 130 events, 2 payload structs · `go test ./internal/ws/...` → 86 pass · 첫 시도에 pending.go 에 auth.* 중복 추가 → panic → 즉시 되돌림 (system.go 에 이미 있음을 재발견)
+
+## W2 PR-5b Coverage Gate (2026-04-21)
+
+### 베이스라인 측정 결과
+- **Go**: 43.9% (60 packages, 1464 tests, mockgen 포함)
+- **FE Lines/Statements**: 51.75% (11652/22513)
+- **FE Branches**: 79.66% (2159/2710)
+- **FE Functions**: 55.66% (614/1103)
+
+### 적용 Threshold (baseline - 2% buffer)
+- **Go**: 41% (plan target 70%는 Phase 21 — 테스트 보강 PR 선행 필수)
+- **FE Lines/Statements**: 49%
+- **FE Branches**: 77%
+- **FE Functions**: 53%
+
+### 변경 파일
+- `.github/workflows/ci.yml` — go-check에 `upload-artifact: go-coverage`, ts-check에 `upload-artifact: web-coverage`, coverage-guard job 실제 gate로 교체 (warn-only placeholder 제거)
+- `apps/web/vitest.config.ts` — `thresholds` 블록 추가 (lines/statements 49, branches 77, functions 53)
+- `codecov.yml` — project threshold 1%, patch target 70%/threshold 0%
+
+### 로드맵
+| Phase | Go | FE Lines | FE Branches | FE Functions |
+|-------|----|----------|-------------|--------------|
+| 현재(19R) | 41% | 49% | 77% | 53% |
+| Phase 20 | 55% | 55% | 80% | 58% |
+| Phase 21 | 70% | 65% | 85% | 68% |
+
+하한 상향 전 반드시 추가 테스트 PR로 baseline 끌어올리기.
 
 ## 결정 사항
 


### PR DESCRIPTION
## Summary
- `coverage-guard` job: warn-only placeholder → **실제 enforcement gate**.
- baseline 측정 후 **baseline-2% buffer 규칙** 으로 threshold 설정 (plan target 은 Go 60% 였지만 baseline 43.9% → 즉시 fail 위험 → 41% 로 완화).
- Go/FE coverage artifact upload + download 파이프라인.
- `codecov.yml` project threshold 1% / patch target 70% (신규 코드 집중).
- 점진 상향 로드맵 주석 (Phase 20 +5%p / Phase 21 +15%p).

## Baseline
- Go: 43.9% (60 packages, 1464 tests)
- FE: Lines 51.75% / Branches 79.66% / Functions 55.66% (1047 tests)

## Threshold
| 지표 | Threshold |
|------|-----------|
| Go total | 41% |
| FE Lines/Statements | 49% |
| FE Branches | 77% |
| FE Functions | 53% |

## Plan 이탈
원 plan "Go 60% / FE 50% hard fail" 을 즉시 강제하면 Go baseline 43.9% 기준 -16%p 미달 → 첫 PR 부터 gate fail → 머지 불가. `memory/project_phase19_residual_progress.md` W2 PR-5b 섹션에 계획과의 차이 명시 + Phase 20/21 상향 로드맵 기록.

## Test plan
- [x] `go build ./...` → success
- [x] `pnpm test:coverage` → 1047 pass / 0 fail, threshold 전수 pass
- [ ] CI coverage-guard job green
- [ ] CI 전체 required checks green (admin-skip 정책 하 red 도 수용)

## 후속
- **Phase 20**: 추가 테스트 PR 로 baseline 55%/55% 달성 후 threshold 상향
- **Phase 21**: baseline 70%/65% 달성 후 threshold 상향

🤖 Generated with [Claude Code](https://claude.com/claude-code)