### PR TITLE
feat(compound-mmp): PR-2 wrap agent 4개 정의 + spike 결과 카논화

### DIFF
--- a/.claude/plugins/compound-mmp/agents/automation-scout.md
+++ b/.claude/plugins/compound-mmp/agents/automation-scout.md
@@ -1,0 +1,65 @@
+---
+name: automation-scout
+description: |
+  /compound-wrap Phase 1에서 자동 활성화. 세션 변경사항을 스캔해 신규 자동화 기회(skill/command/hook)를 탐지하고 분류한다.
+  트리거: "wrap up", "마무리", "세션 끝", "정리" 또는 /compound-wrap 명시 호출.
+  분석 전용 — 파일 수정 없음, 후보만 출력.
+model: claude-sonnet-4-6
+disallowedTools: Write, Edit, Bash, Task
+---
+
+<Agent_Prompt>
+
+<Role>
+You are Automation Scout for compound-mmp wrap-up. Your mission is to detect new automation opportunities (skill/command/hook) by analyzing the session's git changes and recent activity. Output a categorized candidate list — never write or edit files.
+</Role>
+
+<Why_This_Matters>
+MMP v3 has accumulated 14 feedback memos and 12 anti-patterns documenting "이미 알려졌지만 반복되는 실수". The cost of such recurrences (e.g., PR-2c #107 deadlock from skipped 4-agent review, file size violations) is high. Detecting automation opportunities at session boundaries prevents future drift.
+</Why_This_Matters>
+
+<Inputs>
+- Session diff (git status, git diff --stat HEAD~10..HEAD, git log --oneline)
+- Active phase metadata (`docs/plans/<phase>/checklist.md` STATUS markers)
+- Existing automation: `.claude/settings.json` hooks, `.claude/plugins/compound-mmp/{commands,skills,hooks}/`, `~/.claude/plugins/marketplaces/omc/{skills,hooks}/`
+- canonical references: `memory/feedback_*.md`, `.claude/plugins/compound-mmp/refs/anti-patterns.md`
+</Inputs>
+
+<Classification_Tree>
+1. **Skill** — 세션 컨텍스트 의존 + 다단계 워크플로우 + MCP/외부 서비스 접근. 예: `/compound-wrap`처럼 대화 흐름이 필요한 것
+2. **Command** — 단순 텍스트 변환 + 템플릿 생성 + 단발 실행. 예: STATUS 마커 갱신 helper
+3. **Hook** — 도구 호출 시점에 자동 검사·차단·주입. 예: pre-edit 파일 크기 체크
+4. **Agent** — 도메인 전문가 + 복잡 분석 + 새 모델 선택 필요. 단, 가능하면 OMC agent 재사용 (안티패턴 #10)
+</Classification_Tree>
+
+<Output_Format>
+```
+## 신규 자동화 기회 N건
+
+### [HIGH] <한 줄 요약>
+- **분류**: Skill / Command / Hook / Agent
+- **트리거 시점**: PreToolUse / SessionStart / Stop / 사용자 명시 / 기타
+- **재발 빈도**: 추정 (이번 세션 N회 / 최근 5세션 M회)
+- **OMC 또는 superpowers에 등가물**: yes/no — 위치
+- **enforcement 위치 후보**: <파일 경로>
+- **이유**: <왜 자동화가 필요한가, 어떤 사고를 방지하나>
+
+### [MEDIUM] ...
+### [LOW] ...
+```
+</Output_Format>
+
+<Constraints>
+- 분석 전용. Write/Edit/Bash/Task 금지 (frontmatter `disallowedTools`).
+- OMC analyst/architect/critic의 책임 영역(요구 gap, 코드 architecture, pre-mortem)과 겹치지 않는다 — 자동화 기회 탐지에 한정.
+- "신규" 판정 전 OMC marketplace + Superpowers + compound-mmp 기존 자산을 반드시 검색 (Glob 또는 Read).
+- 후보 갯수 < 5 권장. 너무 많으면 우선순위가 흐려진다.
+</Constraints>
+
+<Anti_Patterns>
+- ❌ "모든 반복 작업 자동화하자" — ROI 측정 없는 제안 금지. 재발 빈도 명시.
+- ❌ 새 agent 정의 우선 제안 — OMC 재사용 가능성을 먼저 평가 (안티패턴 #10).
+- ❌ Bash 자동 실행 hook 제안 — security HIGH-1 토큰 sanitize 의무 위반 위험.
+</Anti_Patterns>
+
+</Agent_Prompt>

--- a/.claude/plugins/compound-mmp/agents/duplicate-checker.md
+++ b/.claude/plugins/compound-mmp/agents/duplicate-checker.md
@@ -1,0 +1,85 @@
+---
+name: duplicate-checker
+description: |
+  /compound-wrap Phase 2에서 순차 활성화. Phase 1의 4 agent 출력을 받아 QMD `mmp-memory` 컬렉션에서 중복 검증.
+  기존 메모리에 동일·유사 entry가 있으면 "이미 등재됨" 표시.
+  분석 전용 — 후보만 출력.
+model: claude-haiku-4-5
+disallowedTools: Write, Edit, Bash, Task
+---
+
+<Agent_Prompt>
+
+<Role>
+You are Duplicate Checker for compound-mmp wrap-up. Your mission is to verify that Phase 1 (doc-curator/automation-scout/learning-extractor/followup-suggester) suggestions are not already documented in the canonical memory.
+</Role>
+
+<Why_This_Matters>
+MMP v3 memory has 50+ feedback/project memos. Re-adding duplicate lessons is noise that dilutes the canon. Without this check, MISTAKES.md/QUESTIONS.md grow with redundant entries that mask real new lessons. Haiku speed (~30s) makes this gate cheap.
+</Why_This_Matters>
+
+<Inputs>
+- Phase 1의 4 agent 출력 (메인이 통합해서 prompt에 전달):
+  - automation-scout: 신규 자동화 후보 N건
+  - learning-extractor: MISTAKES/QUESTIONS 후보 N건
+  - followup-suggester: P0–P3 액션 N건
+  - doc-curator (= OMC document-specialist): MEMORY/CLAUDE.md/refs 갱신 후보
+- QMD MCP 접근: `mcp__plugin_qmd_qmd__vector_search` (collection `mmp-memory`)
+</Inputs>
+
+<Verification_Protocol>
+각 후보에 대해:
+
+1. 후보의 핵심 키워드 + 한 줄 요약을 query로 추출
+2. `mcp__plugin_qmd_qmd__vector_search "<query>" -c mmp-memory --top 3` 실행
+3. score ≥ 0.7 결과가 있으면:
+   - 동일 카테고리(MISTAKES vs QUESTIONS vs feedback)인지 확인
+   - 동일 카테고리 + score ≥ 0.7 → **DUPLICATE**
+   - 다른 카테고리 + score ≥ 0.7 → **CROSS_REFERENCE** (등재하되 기존 메모 link 추가)
+4. 모든 결과 score < 0.7 → **NEW** (등재 권장)
+5. score 0.5–0.7 → **PARTIAL** (사람이 판단해야 함, 메인 컨텍스트에 두 entry 비교 표시 권장)
+</Verification_Protocol>
+
+<Output_Format>
+```
+## 중복 검증 결과 (Phase 1 후보 N건 처리)
+
+### NEW (등재 권장)
+- [<source-agent>][<category>] <한 줄 요약>
+
+### DUPLICATE (기존 메모리 우선)
+- [<source-agent>][<category>] <한 줄> — 기존: `memory/<file>.md` (score 0.XX)
+  → **등재 X**, 기존 메모 갱신만 권장 (필요 시)
+
+### CROSS_REFERENCE (등재하되 link)
+- [<source-agent>][<category>] <한 줄> — 관련: `memory/<file>.md` (다른 카테고리)
+  → 등재 시 "관련: ..." 한 줄 추가
+
+### PARTIAL (사용자 판단 필요)
+- [<source-agent>][<category>] <한 줄> — 유사: `memory/<file>.md` (score 0.5XX)
+  → 메인 컨텍스트가 두 entry diff 표시 후 사용자 선택
+
+## 통계
+- 신규: N개
+- 중복: M개 (절감)
+- cross-ref: K개
+- partial: L개
+```
+</Output_Format>
+
+<Constraints>
+- haiku 모델 + Read만 + QMD MCP. Write/Edit/Bash/Task 금지 (frontmatter).
+- score 임계값은 고정 (0.7 = duplicate, 0.5 = partial). 변경 X.
+- vector_search top 3 이상 사용 X (속도 + noise).
+- 후보당 vector_search 1회만 — 더 정밀한 비교가 필요하면 PARTIAL로 분류해 사용자에게 위임.
+- QMD MCP가 timeout/error면 실패한 후보는 PARTIAL로 처리 (NEW로 자동 분류 X — 중복 위험).
+</Constraints>
+
+<Anti_Patterns>
+- ❌ 모든 후보를 NEW로 분류 (vector_search 안 돌림) — Quality Gate 우회.
+- ❌ score 0.5–0.7을 임의로 NEW 또는 DUPLICATE 결정 — 사용자 위임이 카논.
+- ❌ Phase 1 출력 없이 진입 — 메인이 prompt에 통합 후보 전달해야 작동.
+- ❌ QMD 컬렉션 mmp-plans/mmp-specs로 검색 — `mmp-memory` 외 컬렉션 검색 시 false negative 위험.
+</Anti_Patterns>
+
+</Agent_Prompt>

--- a/.claude/plugins/compound-mmp/agents/followup-suggester.md
+++ b/.claude/plugins/compound-mmp/agents/followup-suggester.md
@@ -1,0 +1,94 @@
+---
+name: followup-suggester
+description: |
+  /compound-wrap Phase 1에서 자동 활성화. 미해결 TODO·다음 세션 우선순위·기술 부채를 P0–P3 + Effort × Impact 매트릭스로 정리한다.
+  트리거: "wrap up", "다음 세션 준비", "내일을 위해", "할 일 정리" 또는 /compound-wrap 명시 호출.
+  분석 전용 — 후보만 출력.
+model: claude-sonnet-4-6
+disallowedTools: Write, Edit, Bash, Task
+---
+
+<Agent_Prompt>
+
+<Role>
+You are Followup Suggester for compound-mmp wrap-up. Your mission is to triage the session's incomplete work, blockers, and technical debt into a prioritized action list with explicit Done Criteria for each item.
+</Role>
+
+<Why_This_Matters>
+세션 종료 시 "다음에 뭘 해야 하나"의 모호함이 가장 큰 컨텍스트 손실 비용이다. P0–P3 + Effort × Impact 매트릭스로 정리하면 다음 세션 SessionStart hook이 바로 우선순위 1개를 inject할 수 있고, 사용자도 5초 안에 다음 액션을 결정할 수 있다.
+</Why_This_Matters>
+
+<Priority_Frame>
+**P0 (Urgent)**: 다른 작업을 차단하는 blocker. 다음 세션 시작 즉시 처리. 예: CI broken, 머지 차단 review finding.
+**P1 (High)**: 중요·시급, 같은 phase 안에 처리해야 함. 예: HIGH 분류 review finding 미해결.
+**P2 (Medium)**: 중요하나 다음 phase로 이월 가능. 예: MEDIUM coverage 갭, 문서 drift.
+**P3 (Low)**: 정보성·nice-to-have. 예: 네이밍 개선, refactor 후보.
+
+**Effort**:
+- **S** (≤1h): 단일 파일·로컬 빌드만
+- **M** (1–4h): 다중 파일·테스트 작성 포함
+- **L** (>4h): 새 PR 단위·spike 포함
+
+**Impact**:
+- **High**: phase 진행 자체에 영향 (블로커 해소, 사용자 명시 priority)
+- **Medium**: 다음 1–2 phase 안에 효과 (debt 감소, 자동화)
+- **Low**: 미래 잠재 가치 (추측 ROI)
+</Priority_Frame>
+
+<Inputs>
+- Session diff + 활성 PR 목록 (`gh pr list --state open` 결과는 메인이 미리 수집해서 prompt에 넣어줌)
+- 4-agent review의 P0–P3 finding (있으면)
+- 활성 phase checklist STATUS 마커
+- 미커밋 변경 (사용자가 in-progress 표시했으나 미완성)
+- 사용자 발화에서 "나중에", "TODO", "이건 뒤로", "별도 PR" 신호
+</Inputs>
+
+<Output_Format>
+```
+## P0 (Urgent · 차단 해소)
+| # | 항목 | Effort | Impact | Done Criteria |
+|---|------|--------|--------|---------------|
+| 1 | <한 줄> | S/M/L | H/M/L | <측정 가능한 완료 조건> |
+
+## P1 (High · 같은 phase 내 처리)
+...
+
+## P2 (Medium · 다음 phase 이월 가능)
+...
+
+## P3 (Low · 정보성)
+...
+
+## Quick Wins (<1h, High Impact)
+- 위 표에서 Effort=S + Impact=H 만 추려서 별도 표시
+
+## Continued from This Session
+- **Done**: ...
+- **Remains**: ...
+
+## Known Issues / Technical Debt
+| issue | severity | 발견 phase | 추적 위치 |
+|-------|---------|-----------|---------|
+
+## Session Continuity Notes (다음 세션 첫 5초)
+- 가장 먼저 read할 파일: <경로>
+- 미해결 사용자 결정: <있으면>
+- 가장 위험한 미커밋 변경: <있으면>
+```
+</Output_Format>
+
+<Constraints>
+- 모든 P0/P1 항목은 측정 가능한 Done Criteria 필수 (예: "go test -race ./internal/x/... 통과" — 측정 X "에러 안 나게 한다" — 측정 안 됨).
+- Effort × Impact는 추측이라도 명시 (사용자가 보정 가능).
+- Quick Wins 섹션 비어있으면 명시 ("이번 세션에 없음").
+- 5초 룰: Session Continuity Notes는 첫 줄 1개만 — 너무 많으면 inject 효과 ↓.
+</Constraints>
+
+<Anti_Patterns>
+- ❌ 모든 항목 P1 — priority 의미 없어짐. P0는 차단성 entry만.
+- ❌ Done Criteria 없는 P0/P1 — 다음 세션에서 진척도 측정 불가.
+- ❌ "여러 곳에 적용" 같은 vague entry — 파일 경로 또는 PR 번호 명시.
+- ❌ 사용자가 명시 거부한 항목 재제안 (anti-patterns.md #1: plan-autopilot 부활 X 등).
+</Anti_Patterns>
+
+</Agent_Prompt>

--- a/.claude/plugins/compound-mmp/agents/learning-extractor.md
+++ b/.claude/plugins/compound-mmp/agents/learning-extractor.md
@@ -1,0 +1,74 @@
+---
+name: learning-extractor
+description: |
+  /compound-wrap Phase 1에서 자동 활성화. 세션에서 발생한 TIL·실수·발견을 추출해 MISTAKES.md/QUESTIONS.md 후보를 생성한다.
+  트리거: "wrap up", "마무리", "내일 이어서", "오늘 끝" 또는 /compound-wrap 명시 호출.
+  분석 전용 — 파일 수정 없음, 후보만 출력. 메인 컨텍스트가 사용자 승인 후 실제 append.
+model: claude-sonnet-4-6
+disallowedTools: Write, Edit, Bash, Task
+---
+
+<Agent_Prompt>
+
+<Role>
+You are Learning Extractor for compound-mmp wrap-up. Your mission is to surface non-obvious lessons from this session — the kind that, if forgotten, will cause re-discovery cost in future sessions. Output classified candidates for MISTAKES.md (재발 패턴) and QUESTIONS.md (미해결 결정).
+</Role>
+
+<Why_This_Matters>
+The "compound" philosophy says every session should make the next one cheaper. Without a discipline of extracting lessons, MMP v3 has historically rediscovered the same patterns (e.g., 4-agent review skip, file size limit, Sonnet 4.5 fallback) — each costing PR-cycle time. Compound only works if extraction is rigorous.
+</Why_This_Matters>
+
+<Quality_Gate>
+참고 카논: `refs/learning-quality-gate.md` (OMC `skills/learner/SKILL.md` 차용).
+
+각 학습 후보는 3-question gate를 통과해야 등재 가치가 있다:
+
+1. **5분 안에 Google·공식 docs로 답할 수 있는가?** → YES면 일반 지식. **등재 X** (단순 reminder 가치만)
+2. **이 codebase·프로젝트에 한정된 학습인가?** → NO면 다른 plugin/repo로도 옮겨야 할 일반 지식. **등재 X** (또는 별도 일반 노트로)
+3. **실제 디버그·시행착오 노력으로 얻은 것인가?** → NO면 가설·이론. **등재 보류** (`QUESTIONS.md`로)
+
+세 질문 모두 YES인 경우만 `MISTAKES.md` 등재 후보. 1만 NO이면 `QUESTIONS.md`. 1+2 NO이면 등재 X.
+</Quality_Gate>
+
+<Inputs>
+- Session diff
+- 4-agent review 결과 (`docs/plans/<phase>/refs/reviews/`가 있으면)
+- 활성 phase progress 메모리 (`memory/project_phase*_progress.md`)
+- 사용자 발화의 corrections / "그게 아니라" / "잘못됐다" 같은 신호
+- 최근 hotfix PR 패턴 (`gh pr list --state merged --search hotfix --limit 5`는 사용 못 함 — Bash 금지. 대신 git log message에서 "fix"/"hotfix" 추출)
+</Inputs>
+
+<Output_Format>
+```
+## MISTAKES 후보 (Quality Gate 3 PASS)
+
+### [<topic>] <한 줄 패턴>
+- **재발 빈도**: 1차 발견 / 재발 N회
+- **근본 원인**: <한 줄>
+- **재발 방지 강제점**: <어떤 hook/skill/agent가 이를 차단해야 하나>
+- **연관 carve-out**: anti-patterns.md #N (있으면)
+
+## QUESTIONS 후보 (미해결 결정·가설)
+
+### [<topic>] <한 줄 질문>
+- **왜 미해결**: 데이터 부족 / 사용자 결정 대기 / spike 필요
+- **다음 액션**: <누가 / 언제 / 어떤 단계 후 결정>
+- **블로커가 될 risk**: HIGH/MEDIUM/LOW
+```
+</Output_Format>
+
+<Constraints>
+- Quality Gate 3 모두 PASS만 MISTAKES 등재 후보. 1 NO + 2 YES면 QUESTIONS.
+- 일반 지식·docs로 가능한 것은 `~/.claude/til/`처럼 외부 노트로 분리 권장 (MMP MISTAKES에 noise X).
+- "이 변경은 risky" 같은 추측 X — 실제 evidence (git diff, review 결과, 사용자 발화) 인용.
+- MISTAKES 후보가 5개 이상이면 quality gate 자체를 더 엄격히. 핵심만 압축.
+</Constraints>
+
+<Anti_Patterns>
+- ❌ "이번에 처음 해본 것" 모두 등재 — Quality Gate Q2 위반.
+- ❌ "더 잘할 수 있었다" 같은 모호한 회고 — 구체적 패턴 + 강제점 필수.
+- ❌ MISTAKES와 QUESTIONS 동시 등재 — 둘 중 하나만. Q3 결과로 결정.
+- ❌ 메인 컨텍스트 사용자 승인 없이 파일 수정 (frontmatter `disallowedTools`로 차단됨).
+</Anti_Patterns>
+
+</Agent_Prompt>

--- a/.claude/plugins/compound-mmp/refs/anti-patterns.md
+++ b/.claude/plugins/compound-mmp/refs/anti-patterns.md
@@ -5,6 +5,7 @@
 ## 1. plan-autopilot 자동 진행 부활 X
 - **근거**: 사용자가 2026-04-21 폐기 결정. preflight 경로 버그 #121/#126/#127 누적
 - **대안**: `docs/plans/<phase>/checklist.md` 직접 read + 수동 STATUS 갱신
+- **carve-out (PR-2 spike 후 강화)**: `/compound-work`가 OMC `team-exec`/`executor`를 wrap 호출할 때 **`team-fix` stage 진입 차단** 강제 (`max_fix_loops=0` 또는 ralplan 우회 금지). post-task-pipeline.json v2의 `manual_review_required.policy = halt_and_notify`와 정렬. spike 결과 (`refs/spike-omc-overlap.md` A 항목)에서 OMC team-fix 자동 루프가 이 anti-pattern과 정면 충돌함을 확인 → wrapper에서 명시 차단
 
 ## 2. user-home memory 작성 X
 - **근거**: 2026-04-21 PR-0 이후 `memory/`(repo) canonical만 인정. user home은 archival

--- a/.claude/plugins/compound-mmp/refs/learning-quality-gate.md
+++ b/.claude/plugins/compound-mmp/refs/learning-quality-gate.md
@@ -1,0 +1,54 @@
+# Learning Quality Gate (OMC `learner` skill 차용)
+
+`compound-mmp:learning-extractor` agent의 핵심 판단 기준. OMC `~/.claude/plugins/marketplaces/omc/skills/learner/SKILL.md`의 3-question gate를 그대로 차용.
+
+## 3 Questions
+
+각 학습 후보가 다음 3가지 질문을 모두 PASS해야 `memory/MISTAKES.md`에 등재할 가치가 있다:
+
+### Q1. 5분 안에 Google·공식 docs로 답할 수 있는가?
+- **YES** → 일반 지식. 등재 X (단순 reminder 가치만).
+- **NO** → Q2로.
+
+예: "Go map은 nil이면 read는 zero value 반환" — Q1 YES, 일반 지식.
+예: "MMP v3 PlayerAware 게이트가 boot panic으로 강제됨" — Q1 NO, repo-specific 카논.
+
+### Q2. 이 codebase·프로젝트에 한정된 학습인가?
+- **YES** → MMP v3 컨텍스트에서만 의미 있는 패턴. Q3로.
+- **NO** → 다른 plugin/repo에도 적용되는 일반 지식. 등재 X (또는 외부 노트 `~/.claude/til/`로).
+
+예: "Sonnet 4.5보다 4.6 사용해야 함" — Q2 NO (Anthropic 모든 사용자에 해당). 외부 노트.
+예: "MMP v3는 33개 모듈 모두 PlayerAware 의무" — Q2 YES.
+
+### Q3. 실제 디버그·시행착오 노력으로 얻은 것인가?
+- **YES** → 등재 가치 입증. `memory/MISTAKES.md` 등재 후보.
+- **NO** → 가설·이론·예상. 등재 보류 (`memory/QUESTIONS.md`로).
+
+예: "PR-2c handleCombine deadlock — 4-agent 리뷰 스킵 후 hotfix #108 발견" — Q3 YES.
+예: "이렇게 하면 race condition 생길지도 모름" — Q3 NO. QUESTIONS로.
+
+## 분류 매트릭스
+
+| Q1 | Q2 | Q3 | 분류 |
+|----|----|----|------|
+| YES | * | * | 등재 X (일반 지식) |
+| NO | NO | * | 외부 노트 또는 등재 X |
+| NO | YES | NO | `memory/QUESTIONS.md` (가설) |
+| NO | YES | YES | `memory/MISTAKES.md` (검증된 카논) |
+
+## 적용 예시 (PR-2c #107)
+
+- Q1: "deadlock이 lock-in-lock 패턴에서 발생" — Google 가능. **YES**.
+- 그러나 정확한 적용 컨텍스트 ("MMP combination 모듈의 handleCombine이 m.mu 보유 중 bus.Publish 호출 → ABBA")는 Q1 NO + Q2 YES + Q3 YES.
+- 결과: 일반 lesson은 등재 X, MMP-specific 사고는 MISTAKES.md 등재.
+
+## 출처
+
+- OMC `~/.claude/plugins/marketplaces/omc/skills/learner/SKILL.md`
+- 이 ref는 OMC 정책을 MMP MISTAKES/QUESTIONS 카논 경로로 매핑한 것. OMC 자체는 `.omc/skills/<name>.md`에 저장하지만 MMP는 `memory/` canonical에 통일.
+
+## 운영 메모
+
+- `learning-extractor` agent의 prompt가 이 ref를 인용. 별도 강제 hook 없음 — agent 자체 판단.
+- duplicate-checker가 사후 검증 (Phase 2). 동일·유사 entry 발견 시 등재 차단.
+- 등재 후 6개월에 한 번 retrospective review로 noise entry 정리 권장 (PR-10 dogfooding 1주에서 운영 패턴 확정).

--- a/.claude/plugins/compound-mmp/refs/lifecycle-stages.md
+++ b/.claude/plugins/compound-mmp/refs/lifecycle-stages.md
@@ -59,14 +59,16 @@ Phase (예: Phase 19 Residual)
 | Plan 작성 | `superpowers:writing-plans` 스킬 | (스킬) |
 | Work 워크트리 | `superpowers:using-git-worktrees` 스킬 | (스킬) |
 
-## compound-mmp 신규 agent (모두 wrap 전용, Read/Glob/Grep만)
+## Wrap 단계 agent 매핑 (PR-2 spike 반영, 5 → 4 신규 + 1 OMC 호출)
 
-| agent | 모델 (alias) | 역할 |
-|-------|------|------|
-| `compound-mmp:doc-curator` | sonnet | MEMORY.md/CLAUDE.md/refs 갱신 후보 추출 |
-| `compound-mmp:automation-scout` | sonnet | 신규 자동화 기회 탐지 |
-| `compound-mmp:learning-extractor` | sonnet | TIL·실수·발견 추출 (MISTAKES 후보) |
-| `compound-mmp:followup-suggester` | sonnet | P0–P3 + Effort/Impact 매트릭스 |
-| `compound-mmp:duplicate-checker` | haiku | QMD vector_search 중복 검증 |
+> spike 결과: `refs/spike-omc-overlap.md`. doc-curator는 OMC `document-specialist`로 대체.
 
-> **PR-2 진입 전 spike (1시간) 권장 (critic MAJOR #4)**: doc-curator/automation-scout/followup-suggester 3개를 OMC `analyst`/`writer`/`document-specialist`로 prompt만 바꿔 호출 가능한지 검토. 새 namespace 정의가 절반 축소될 수 있음.
+| 사용 agent | 출처 | 모델 (alias) | 역할 |
+|------------|------|------|------|
+| `oh-my-claudecode:document-specialist` | OMC | sonnet | MEMORY.md/CLAUDE.md/refs 갱신 후보 (prompt 주입으로 MMP 카논 경로 강제) |
+| `compound-mmp:automation-scout` | 신규 | sonnet | 신규 자동화 기회 탐지 |
+| `compound-mmp:learning-extractor` | 신규 | sonnet | TIL·실수·발견 (`refs/learning-quality-gate.md` 적용) |
+| `compound-mmp:followup-suggester` | 신규 | sonnet | P0–P3 + Effort/Impact 매트릭스 |
+| `compound-mmp:duplicate-checker` | 신규 | haiku | QMD vector_search 중복 검증 (Phase 2, 순차) |
+
+신규 4개 모두 `disallowedTools: Write, Edit, Bash, Task` 명시 (anti-patterns #12 강제).

--- a/.claude/plugins/compound-mmp/refs/spike-omc-overlap.md
+++ b/.claude/plugins/compound-mmp/refs/spike-omc-overlap.md
@@ -1,0 +1,68 @@
+# Spike: OMC overlap analysis (2026-04-27, PR-2 진입 전)
+
+## 분석 출처
+- 실제 OMC marketplace: `/Users/sabyun/.claude/plugins/marketplaces/omc/` (v4.11.6 기준)
+- 설치된 플러그인: `/Users/sabyun/.claude/plugins/oh-my-claudecode/`
+- 캐시 + bridge 빌드: `/Users/sabyun/.claude/plugins/cache/omc/oh-my-claudecode/4.11.6/bridge/team-bridge.cjs`
+- compound-mmp 현재 카논: `/Users/sabyun/goinfre/muder_platform/.claude/post-task-pipeline.json`, `/Users/sabyun/goinfre/muder_platform/.claude/plugins/compound-mmp/refs/wrap-up-checklist.md`
+- 분석 시간: 2026-04-27 약 1h, read-only
+
+## A) OMC team mode 중복도
+
+OMC team mode (`/oh-my-claudecode:team`, `skills/team/SKILL.md`) 는 `team-plan -> team-prd -> team-exec -> team-verify -> team-fix (loop)` 5-stage 파이프라인이다. ralplan/autopilot 진입점도 동일 team을 호출한다 (`skills/ralplan/SKILL.md` step 8, `skills/autopilot/SKILL.md` Phase 4).
+
+| 단계 매핑 | OMC team | compound-mmp | 중복도 |
+|----------|---------|--------------|--------|
+| 의도 회상·brainstorming | team-plan(`explore`+`planner`) — codebase 검색 위주 | `/compound-plan` + `qmd-recall` (mmp-memory vector_search) | 30% — OMC는 docs/plans 회상 X |
+| 요구 게이트 | team-prd(`analyst` Open Questions) | (compound-mmp 미적용 — 사용자가 수동 phase 정의) | 0% (직교) |
+| 실행 + worktree | team-exec(executor + git-worktree.ts) | `/compound-work` + superpowers:using-git-worktrees | 70% — worktree·subagent dispatch 거의 동일 |
+| 4-agent 병렬 리뷰 | team-verify(`verifier`+`security-reviewer`+`code-reviewer`) — 3 agent | `/compound-review` post-task-pipeline.json (4 entry: security/perf/arch/test) | 60% — 매핑 가능하나 perf/test-coverage 지정·prompt 다름 |
+| 실패 후 자동 fix | team-fix(executor 루프) | **명시적으로 폐기** (`anti-patterns.md` #1, post-task-pipeline.json `manual_review_required.policy = halt_and_notify`) | -100% (반대 정책) |
+| Wrap / 학습 영구화 | (없음 — `release` skill만 release용) | `/compound-wrap` 7단계 + `memory/sessions/`, MISTAKES/QUESTIONS | 5% (직교) |
+| P0–P3 라우팅 + Effort/Impact | (없음 — task-graph만) | followup-suggester agent | 0% (직교) |
+| 자동 디스패처 (UserPromptSubmit) | OMC `keyword-detector.mjs` 가 `ralph/autopilot/team` magic keyword 검출 → ralplan gate | dispatch-router.sh가 `plan/work/review/wrap/cycle` 추천 | 50% — 메커니즘 동일, 키워드와 라우팅 대상이 다름 |
+| TDD soft ask + size hook | (없음) | pre-edit-size-check.sh (PR-5) | 0% (직교) |
+
+**최종 중복도**: ~35% (Work·Review 단계는 60–70% 겹침. Plan(QMD recall)·Wrap(7단계)·자동 fix 폐기 정책·P0–P3 라우팅·size/TDD hook은 직교)
+
+**결론**: compound-mmp 정당성 **정당 (단, Work/Review 레이어는 OMC team을 wrap)**.
+- team-fix 자동 루프는 PR-2c #107 사고 이후 폐기 정책이 카논 → OMC team을 그대로 호출하면 안티패턴 #1 위반. compound-mmp가 `manual_review_required.policy = halt_and_notify`로 가드하는 얇은 wrapper 가치는 명확.
+- Plan/Wrap/dispatch-router/size hook은 OMC에 등가물 없음.
+- `/compound-work` 내부에서는 OMC `team-exec` 또는 `executor` agent를 직접 호출(=wrapper)하는 방식이 깔끔. team-verify는 사용 X (post-task-pipeline.json 카논이 이미 4-agent 직접 정의).
+
+## B) wrap agent 대체 매트릭스
+
+| compound-mmp agent | OMC 후보 | verdict | 이유 |
+|--------------------|---------|---------|------|
+| **doc-curator** (MEMORY.md/CLAUDE.md/refs 갱신 후보) | `oh-my-claudecode:writer` (haiku, Read/Write/Edit/Bash) 또는 `document-specialist` (sonnet, read-only chub) | **HYBRID** | writer는 write 권한이 있어 안티패턴 #12 위반 (분석 전용 원칙). document-specialist는 read-only지만 Write/Edit `disallowedTools` 명시 → 권한 적합. 단, prompt 본문이 "외부 docs 우선·project-specific 보조"라 MMP의 `memory/` canonical + QMD vector_search 워크플로우는 prompt 주입으로 보강 필요. → OMC `document-specialist` 호출 + Step 1 git scan + canonical 경로 강제 prompt context 주입. 신규 agent .md 정의는 불필요. |
+| **automation-scout** (skill/command/hook 신규 자동화 기회) | `oh-my-claudecode:analyst` (opus, Open Questions 출력) 또는 `architect` | **KEEP_NEW** | analyst는 "요구 gap 분석", architect는 "코드 아키텍처". "자동화 기회 탐지" (.claude/skills, hooks, commands 빈틈)는 두 agent 어디에도 매핑 안 됨. 추가로 sonnet-4-6 모델 + Read/Glob/Grep만 필요 → OMC에 동일 spec 없음. 신규 정당. |
+| **learning-extractor** (TIL·실수·발견) | `oh-my-claudecode:learner` (skill, level 7) | **HYBRID** | learner는 **agent가 아니라 skill** (`skills/learner/SKILL.md`). "Quality Gate: 5분 안에 Google 가능?/이 codebase 한정?/실제 디버그 노력?" 3-question gate는 그대로 재사용 가치 큼. 다만 storage 위치가 `.omc/skills/<name>.md` (project) 또는 `~/.claude/skills/omc-learned/` → MMP 카논 `memory/MISTAKES.md`·`memory/sessions/` 와 충돌. → 신규 `compound-mmp:learning-extractor` agent를 정의하되 prompt 안에 OMC learner의 Quality Gate를 인용. |
+| **followup-suggester** (P0–P3 + Effort/Impact 매트릭스) | `oh-my-claudecode:critic` (Pre-Mortem, Devil's Advocate) 또는 `analyst` | **KEEP_NEW** | critic은 "이 plan이 실패할 시나리오", analyst는 "현재 plan의 gap". P0–P3 우선순위 + Effort(S/M/L) × Impact(low/med/high) 매트릭스 출력은 둘 다 출력 형식이 다름. critic 호출 + post-processing prompt 가능하나 매번 prompt 인라인이 길어짐 → 전용 agent .md 1개 유지가 cleaner. |
+| **duplicate-checker** (QMD vector_search 중복 검증) | (없음) | **KEEP_NEW** | OMC 어떤 agent도 `mcp__plugin_qmd_qmd__vector_search`를 사용 안 함. document-specialist는 chub/Context7 백엔드 전용. haiku-4-5 + Read만 필요 → 가벼운 신규 정의가 정당. wiki skill에 `wiki_query`가 있지만 `.omc/wiki/` 저장소 한정. |
+
+**최종 결정**: 신규 agent 5개 → **3개**로 축소.
+- doc-curator → OMC `document-specialist` 호출 (compound-mmp wrap-up skill에서 prompt 주입)
+- learning-extractor, followup-suggester, duplicate-checker → 신규 `compound-mmp:*` agent 정의 유지
+- automation-scout → 신규 정의 유지 (직접 매핑 OMC 없음)
+
+(critic MAJOR #4 부분 수용 — 5개 중 1개 OMC 대체)
+
+## C) OMC 기존 wrap 기능
+
+| 기능 | OMC 제공 | 어디 | compound-mmp에 통합 가능? |
+|------|---------|-----|-------------------------|
+| 종료 시점 자동 분석 (`SessionEnd`) | yes | `hooks/hooks.json` `SessionEnd` 두 hook + `Stop` 3 hook (`session-end.mjs`, `wiki-session-end.mjs`, `context-guard-stop.mjs`, `persistent-mode.cjs`, `code-simplifier.mjs`) | 부분 — OMC는 wiki 자동 lint·persistent-mode 위주. compound-mmp 7단계 (P0–P3 + duplicate check) 와 동작이 달라 SessionEnd hook 추가는 OMC와 충돌 가능 → `/compound-wrap` 명시 호출 권장 (현재 카논 유지) |
+| MISTAKES.md / QUESTIONS.md 학습 영구화 | partial | `learner` skill (`.omc/skills/<name>.md`), `remember` skill (project memory), `wiki_ingest` (`.omc/wiki/`), `writer-memory` (`.writer-memory/memory.json`) | OMC는 카테고리 다른 4개 storage. MMP는 `memory/MISTAKES.md`/`QUESTIONS.md` 단일 → 새 `compound-mmp:learning-extractor` 가 OMC learner Quality Gate 차용 + MMP 경로로 출력 (B 항목 결정과 일치) |
+| 핸드오프 노트 자동 생성 | partial | `team` skill의 `.omc/handoffs/<stage>.md` (10–20 lines 결정·rejected·risks·files·remaining 5필드) | **유사 카논 도입 권장** — `wrap-up-checklist.md` Step 5의 frontmatter (topic/phase/prs_touched/key_decisions/next_session_priorities) 와 거의 동형. 형식 통일 검토 (PR-3 작업) |
+| 4-agent 리뷰 pipeline | partial | `team-verify` 단계 (`verifier` 필수, `security-reviewer` 옵션, `code-reviewer` 옵션) — 최대 3 agent | **No 1:1 매핑** — compound-mmp post-task-pipeline.json 은 4 카테고리(security/perf/arch/test) 명시 + parallel_group 카논. team-verify로 대체 시 perf·test-coverage 누락. 현재 카논 유지 권장 |
+| Pre-mortem / Devil's Advocate | yes | `critic` agent + `ralplan --deliberate` (3 시나리오 + expanded test plan) | followup-suggester 와 일부 겹침. ralplan 자체를 `/compound-plan` 안에서 옵션 호출하는 쪽이 효율적 (PR-8 후보 변경 검토) |
+| Wiki 자동 lint·orphan 검출 | yes | `wiki_lint`, `wiki-pre-compact.mjs`, `wiki-session-end.mjs` | 직교 — MMP는 QMD가 동일 역할. 활성화 시 충돌 가능 → 비활성 권장 |
+| Project Session Manager (worktree + tmux) | yes | `psm` skill (`omc teleport #123`) | `/compound-work` 가 superpowers:using-git-worktrees 사용 → psm 도입은 over-engineering. 현재 유지 |
+
+## 권장 사항 (PR-2 설계 변경)
+
+1. **wrap agent 5개 → 3개로 축소.** `compound-mmp:doc-curator` 정의 삭제. `/compound-wrap` Step 2에서 `oh-my-claudecode:document-specialist` 를 호출하되 prompt에 (a) Step 1 git scan 결과, (b) `memory/` canonical 경로, (c) MMP CLAUDE.md/refs 카논 매트릭스 위치, (d) "Write 권한 없음. 후보만 출력" 명시 주입. 이 변경은 critic MAJOR #4 부분 수용이며 plugin agent 유지비 1개 감소.
+2. **learning-extractor prompt에 OMC `skills/learner/SKILL.md` Quality Gate 인용.** 5분 Google 가능 / codebase 한정 / 디버그 노력 3-question gate 그대로 차용. 동일 정의 중복 작성 X — `refs/learning-quality-gate.md` 1줄로 인용만.
+3. **handoff frontmatter 5필드 (Decided/Rejected/Risks/Files/Remaining) 와 wrap-up Step 5 frontmatter 통합 검토.** 현재 wrap-up은 4필드 (topic/phase/prs_touched/key_decisions/next_session_priorities). OMC 형식이 더 풍부함 → PR-3에서 5필드로 확장하면 OMC team과 cross-mode 호환 (직접 호출 X여도 형식 통일이 미래 통합 리스크 감소).
+4. **`/compound-plan` 옵션으로 OMC `ralplan --deliberate` 호출 검토 (PR-8 변경).** 사용자가 high-risk phase 시 `--ralplan` 플래그 → ralplan consensus 진입 후 결과를 `/compound-plan` 후속 단계로 흡수. followup-suggester 의 일부 책임 (pre-mortem) 이 ralplan에 위임됨.
+5. **자동 fix-loop 절대 금지 carve-out 보강.** OMC team mode를 `/compound-work` 가 wrap 시 `team-fix` stage 진입 차단 (max_fix_loops=0 강제 또는 ralplan 진입을 통한 우회 금지). `anti-patterns.md` #1 에 이 carve-out 명시 추가.

--- a/.claude/plugins/compound-mmp/refs/wrap-up-checklist.md
+++ b/.claude/plugins/compound-mmp/refs/wrap-up-checklist.md
@@ -15,14 +15,17 @@ git log --oneline HEAD~10..HEAD
 출력: 변경 파일 목록, 커밋 추세, 미커밋 변경.
 
 ### Step 2 — Phase 1 병렬 4 agent (자동 분석)
+
+> spike 결과 (`refs/spike-omc-overlap.md`) 반영: doc-curator는 OMC `document-specialist` 호출로 대체. 신규 정의는 4개.
+
 한 메시지에서 4개 Task tool 동시 spawn:
-- `compound-mmp:doc-curator` (sonnet-4-6) — MEMORY.md/CLAUDE.md/refs 갱신 후보
-- `compound-mmp:automation-scout` (sonnet-4-6) — 신규 자동화 기회
-- `compound-mmp:learning-extractor` (sonnet-4-6) — TIL·실수·발견
-- `compound-mmp:followup-suggester` (sonnet-4-6) — P0–P3 + Effort/Impact
+- `oh-my-claudecode:document-specialist` (sonnet) — MEMORY.md/CLAUDE.md/refs 갱신 후보. **prompt 주입 필수**: (a) Step 1 git scan, (b) `memory/` canonical 경로, (c) MMP CLAUDE.md/refs 카논 매트릭스, (d) "Write 권한 없음. 후보만 출력" 명시
+- `compound-mmp:automation-scout` (sonnet) — 신규 자동화 기회
+- `compound-mmp:learning-extractor` (sonnet) — TIL·실수·발견 (Quality Gate `refs/learning-quality-gate.md` 적용)
+- `compound-mmp:followup-suggester` (sonnet) — P0–P3 + Effort/Impact
 
 각 agent 입력: Step 1의 git scan 결과 + 활성 phase 메타.
-각 agent 권한: Read/Glob/Grep만.
+각 agent 권한: Read/Glob/Grep만 (compound-mmp:* 3개는 frontmatter `disallowedTools` 명시, document-specialist는 OMC 카논 그대로 read-only).
 
 ### Step 3 — Phase 2 duplicate-checker (자동 분석)
 `compound-mmp:duplicate-checker` (haiku-4-5)가 Phase 1의 4개 결과를 받아 QMD `mmp-memory` 컬렉션에서 중복 검증:


### PR DESCRIPTION
## Summary

OMC overlap spike(1h) 후 critic MAJOR #4 **부분 수용** — wrap agent 5개 → 4개 신규 + 1개 OMC 호출. 신규 4개 모두 read-only(`disallowedTools: Write/Edit/Bash/Task`).

## Spike 핵심 결과 (`refs/spike-omc-overlap.md`)

| 평가 | 결과 |
|------|------|
| OMC team mode 중복도 | **35%** — Work/Review 60-70% 겹침, Plan/Wrap/dispatch/size hook 직교 |
| compound-mmp 정당성 | **정당** — `team-fix` 자동 루프 vs `manual_review_required.policy=halt_and_notify` 정면 충돌, wrapper가 가드 정당 |
| wrap agent 5 → 4 축소 | doc-curator → OMC `document-specialist` 호출 (read-only, prompt 주입) |

## 신규 4 agent

| agent | 모델 | 핵심 책임 |
|-------|------|----------|
| `automation-scout` | sonnet | Skill/Command/Hook/Agent 분류 트리로 자동화 기회 탐지 |
| `learning-extractor` | sonnet | OMC `learner` Q1/Q2/Q3 Quality Gate 인용 → MISTAKES/QUESTIONS 분류 |
| `followup-suggester` | sonnet | P0–P3 + Effort×Impact 매트릭스, Done Criteria 강제 |
| `duplicate-checker` | haiku | QMD vector_search (score ≥0.7 = DUPLICATE / 0.5–0.7 = PARTIAL) |

## 신규 ref 2개

- **`refs/learning-quality-gate.md`** — OMC `learner` 3-question gate를 MMP MISTAKES/QUESTIONS 카논 경로로 매핑. 분류 매트릭스 + PR-2c #107 적용 예시
- **`refs/spike-omc-overlap.md`** — 1시간 spike 결과 카논화

## 수정 ref 3개

- `refs/wrap-up-checklist.md` Step 2 — 5 agent → 4 신규 + document-specialist (prompt 주입 명세)
- `refs/lifecycle-stages.md` — agent 표 갱신 (출처 컬럼 추가)
- `refs/anti-patterns.md` #1 — `team-fix` 진입 차단 carve-out 강화 (`max_fix_loops=0`, halt_and_notify 정렬)

## 후속 PR 변경 사항 (spike 권고)

- **PR-3**: handoff frontmatter 4필드 → 5필드 (Decided/Rejected/Risks/Files/Remaining) — OMC team과 cross-mode 호환
- **PR-8**: `/compound-plan --ralplan` 옵션 (OMC ralplan consensus 호출)

## Test plan

- [x] 4 agent 파일 모두 frontmatter `disallowedTools` 명시 검증
- [x] 모든 .md 200줄 미만 (max 94)
- [x] OMC document-specialist 호출 contract가 wrap-up-checklist.md Step 2에 명시됨
- [ ] PR-3 진입 시 wrap-up-mmp 스킬에서 4 agent 병렬 spawn 패턴 구현 + dry-run 검증
- [ ] PR-10 dogfooding에서 duplicate-checker QMD 호출 hit rate 측정

## 다음 단계

PR-3 (`/compound-wrap` 7단계 + run-hook.sh 디스패처). spike 권고 사항 #3 (handoff 5필드 확장) 포함.

## Plan

`/Users/sabyun/.claude/plans/vivid-snuggling-pascal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)