### PR TITLE
feat(compound-mmp): PR-5 size hook + TDD soft ask + Wave 1 follow-up canon

### DIFF
--- a/.claude/plugins/compound-mmp/commands/compound-wrap.md
+++ b/.claude/plugins/compound-mmp/commands/compound-wrap.md
@@ -6,26 +6,21 @@ argument-hint: "[--session|--wave|--phase] (기본 --session)"
 
 # /compound-wrap
 
+> **Single source of truth**: `skills/wrap-up-mmp/SKILL.md`. 이 command는 thin pointer — 7단계 본문은 skill을 따른다 (PR-5 카논화).
+
 세션·Wave·Phase 종료 시 자동 분석 + 학습 영구화 + 다음 세션 핸드오프.
 
 ## 인자
 
-- `--session` (기본) — 가장 가벼운 모드. graphify decision = skip
-- `--wave` — Wave 종료. graphify `--update` 안내만 (자동 실행 X)
-- `--phase` — Phase 종료. graphify fresh rebuild 자동 실행 (`make graphify-refresh`)
+- `--session` (기본) — graphify skip, 가장 가벼움
+- `--wave` — Wave 머지 직후. graphify `--update` 안내만
+- `--phase` — Phase 종료. graphify fresh rebuild 자동 실행
 
-## 실행 절차
+## 실행
 
-`skills/wrap-up-mmp/SKILL.md`의 7단계 시퀀스를 따른다. 카논 위치: `refs/wrap-up-checklist.md`.
+`skills/wrap-up-mmp/SKILL.md`의 7단계 시퀀스(Pre-scan → 4 agent 병렬 → duplicate-checker → 통합 → 자동 실행 → 승인 실행 → graphify decision)를 그대로 실행. 세부 prompt 구성·정책·예외는 모두 SKILL이 master.
 
-핵심:
-1. Pre-scan (git status + diff stat + log)
-2. Phase 1 — 4 agent 병렬 (한 메시지에서 4 Task tool 동시 spawn)
-3. Phase 2 — duplicate-checker 순차 (QMD 검증)
-4. 결과 통합 + 사용자 표시
-5. **자동 실행** — QUESTIONS append + sessions/handoff 생성 + MEMORY entry append
-6. **승인 실행** — MISTAKES append + checklist STATUS 갱신
-7. graphify decision (`--phase`만 자동 rebuild)
+카논 ref: `refs/wrap-up-checklist.md` (단계별 자동/승인 매트릭스).
 
 ## 사용 예
 

--- a/.claude/plugins/compound-mmp/hooks/hooks.json
+++ b/.claude/plugins/compound-mmp/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" pre-edit-size"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "*",

--- a/.claude/plugins/compound-mmp/hooks/pre-edit-size-check.sh
+++ b/.claude/plugins/compound-mmp/hooks/pre-edit-size-check.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# pre-edit-size-check.sh
+# PreToolUse(Edit|Write) hook — 파일 사이즈 한도 + TDD soft ask 통합.
+#
+# 카논:
+#   - 파일 한도: memory/feedback_file_size_limit.md (Go 500 / TS·TSX 400 / MD 500 · CLAUDE.md 200)
+#   - TDD 정책: refs/tdd-enforcement.md (Soft ask, N 응답 진행 허용)
+#   - anti-patterns #1: 자동 fix-loop 폐기 → 검사만 하고 진행 결정은 사용자에게
+#
+# 입력 (stdin JSON):
+#   {tool_name: "Edit"|"Write",
+#    tool_input: {file_path, content (Write), new_string·old_string·replace_all (Edit)}}
+#
+# 출력 (stdout):
+#   - silent (size·TDD 모두 통과 또는 무관): exit 0, 빈 출력
+#   - deny (size 한도 초과 또는 unsafe replace_all): {hookSpecificOutput: {permissionDecision: "deny", ...}}
+#   - ask (TDD 부재, Write 신규 .go/.tsx만): {hookSpecificOutput: {permissionDecision: "ask", ...}}
+#
+# 비차단 보장: jq 부재 / 비정상 stdin은 silent exit 0 (PreToolUse를 break 시키지 않음).
+# 긴급 비활성: COMPOUND_MMP_SIZE_HOOK_DISABLE=1 환경변수.
+#
+# 성능: jq fork 호출을 5→2회로 압축 (review code-perf P1). 메타 1회 + content 1회 (분기시).
+
+set -eu
+
+# 긴급 비활성 토글
+if [ "${COMPOUND_MMP_SIZE_HOOK_DISABLE:-}" = "1" ]; then
+  exit 0
+fi
+
+# jq 부재 시 silent (비차단)
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+[ -z "$input" ] && exit 0
+
+# === 메타 추출 (jq 1회) ===
+# tool_name, file_path, replace_all 동시 추출 (TSV로 묶어 단일 jq 호출)
+meta=$(printf '%s' "$input" | jq -r '[.tool_name // "", .tool_input.file_path // "", (.tool_input.replace_all // false | tostring)] | @tsv' 2>/dev/null || printf '\t\tfalse')
+tool_name=""
+file_path=""
+replace_all="false"
+IFS=$'\t' read -r tool_name file_path replace_all <<EOF
+$meta
+EOF
+
+case "$tool_name" in
+  Edit|Write) ;;
+  *) exit 0 ;;
+esac
+
+[ -z "$file_path" ] && exit 0
+
+basename_file=$(basename "$file_path")
+
+# === 자동 통과 예외 (size + TDD 모두 스킵) ===
+case "$file_path" in
+  *_test.go|*.test.tsx|*.test.ts) exit 0 ;;
+  *_mock.go|*_gen.go|*sqlc.go|*.pb.go) exit 0 ;;
+  */apps/server/cmd/*) exit 0 ;;
+  */apps/web/src/types/*|*/apps/web/src/constants/*) exit 0 ;;
+  */migrations/*) exit 0 ;;
+  *.sql) exit 0 ;;
+esac
+
+# === 사이즈 한도 결정 ===
+# CLAUDE.md 200 한도는 카논 "CLAUDE.md만 200"의 자동 로딩 토큰 비용 근거를
+# repo root CLAUDE.md에만 적용 (review critic P1 #1).
+# 서브디렉토리 CLAUDE.md (apps/server/CLAUDE.md 등)는 자동 로딩 X → .md 500 적용.
+limit=0
+if [ "$basename_file" = "CLAUDE.md" ]; then
+  proj="${CLAUDE_PROJECT_DIR:-}"
+  if [ -n "$proj" ] && [ "$file_path" = "$proj/CLAUDE.md" ]; then
+    limit=200
+  elif [ -z "$proj" ]; then
+    # CLAUDE_PROJECT_DIR 부재 (CI/test 환경): git toplevel fallback
+    root=$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [ -n "$root" ] && [ "$file_path" = "$root/CLAUDE.md" ]; then
+      limit=200
+    fi
+  fi
+  # nested CLAUDE.md 또는 root 미확인: 일반 .md 500 fallthrough
+fi
+if [ "$limit" -eq 0 ]; then
+  case "$file_path" in
+    *.go) limit=500 ;;
+    *.ts|*.tsx) limit=400 ;;
+    *.md) limit=500 ;;
+  esac
+fi
+
+# === 사이즈 검사 (limit > 0) ===
+if [ "$limit" -gt 0 ]; then
+  proposed_lines=0
+  if [ "$tool_name" = "Write" ]; then
+    content=$(printf '%s' "$input" | jq -r '.tool_input.content // empty' 2>/dev/null || echo "")
+    if [ -n "$content" ]; then
+      proposed_lines=$(printf '%s' "$content" | awk 'END{print NR}')
+    fi
+  else
+    # Edit — multi-line content가 @tsv에서 \n으로 escape되어 line 카운트가 깨지는 이슈로
+    # new_string/old_string은 분리 호출 유지 (정확도 우선). 메타 1회 + Edit 2회 = 총 3회 jq.
+    new_string=$(printf '%s' "$input" | jq -r '.tool_input.new_string // empty' 2>/dev/null || echo "")
+    old_string=$(printf '%s' "$input" | jq -r '.tool_input.old_string // empty' 2>/dev/null || echo "")
+    current_lines=0
+    if [ -f "$file_path" ]; then
+      current_lines=$(awk 'END{print NR}' "$file_path" 2>/dev/null || echo 0)
+    fi
+    new_lines=0
+    old_lines=0
+    [ -n "$new_string" ] && new_lines=$(printf '%s' "$new_string" | awk 'END{print NR}')
+    [ -n "$old_string" ] && old_lines=$(printf '%s' "$old_string" | awk 'END{print NR}')
+
+    # replace_all=true 가드 (review critic P1 #2):
+    # multiple-occurrence 시 정확한 line projection 불가 (false negative 위험).
+    # 보수적 deny: new_lines가 old_lines를 초과하면 차단 + multiple Edit calls 안내.
+    if [ "$replace_all" = "true" ] && [ "$new_lines" -gt "$old_lines" ]; then
+      jq -nc \
+        --arg fp "$file_path" \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: ("Edit replace_all=true 이고 new_string이 old_string보다 길어 size 한도 우회 가능 (다중 occurrence 정확 추정 불가). 개별 Edit call 여러 번으로 분리하거나 replace_all=false 후 명시적 위치별로 수정. 파일: " + $fp + ". 카논: refs/tdd-enforcement.md.")}}'
+      exit 0
+    fi
+
+    proposed_lines=$((current_lines + new_lines - old_lines))
+  fi
+
+  if [ "$proposed_lines" -gt "$limit" ]; then
+    jq -nc \
+      --arg fp "$file_path" \
+      --arg lim "$limit" \
+      --arg act "$proposed_lines" \
+      '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: ("파일 크기 한도 초과: " + $fp + " 예상 " + $act + "줄 (한도 " + $lim + "줄). 분할 패턴은 memory/feedback_file_size_limit.md 참조 — Go: handler/service/factory/reactor 분리, React: 서브컴포넌트 추출, MD: index + refs/<topic>.md 분할. 긴급 우회는 COMPOUND_MMP_SIZE_HOOK_DISABLE=1.")}}'
+    exit 0
+  fi
+fi
+
+# === TDD soft ask (Write 신규 파일 + .go/.tsx만) ===
+if [ "$tool_name" = "Write" ] && [ ! -f "$file_path" ]; then
+  dir=$(dirname "$file_path")
+  case "$file_path" in
+    *.go)
+      base="${basename_file%.go}"
+      if [ -d "$dir" ]; then
+        if [ -f "${dir}/${base}_test.go" ]; then
+          exit 0
+        fi
+        # bash 3.2 호환: ls glob exit code로 매치 검사
+        if ls "$dir"/*_test.go >/dev/null 2>&1; then
+          exit 0
+        fi
+      fi
+      jq -nc \
+        --arg fp "$file_path" \
+        --arg base "$base" \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: ("TDD soft ask: " + $fp + " 의 " + $base + "_test.go (또는 동일 디렉토리 *_test.go) 가 없습니다. 테스트를 먼저 만드시겠습니까? (Y/n) — 도메인 모델·마이그레이션은 N 응답 가능. 카논: refs/tdd-enforcement.md.")}}'
+      exit 0
+      ;;
+    *.tsx)
+      base="${basename_file%.tsx}"
+      if [ -d "$dir" ]; then
+        if [ -f "${dir}/${base}.test.tsx" ]; then
+          exit 0
+        fi
+        if [ -f "${dir}/__tests__/${base}.test.tsx" ]; then
+          exit 0
+        fi
+        # 부모의 __tests__ (apps/web/src/<module>/__tests__/<name>.test.tsx legacy)
+        parent=$(dirname "$dir")
+        if [ -f "${parent}/__tests__/${base}.test.tsx" ]; then
+          exit 0
+        fi
+      fi
+      jq -nc \
+        --arg fp "$file_path" \
+        --arg base "$base" \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: ("TDD soft ask: " + $fp + " 의 " + $base + ".test.tsx 가 없습니다. Vitest+RTL+MSW 패턴으로 테스트를 먼저 만드시겠습니까? (Y/n) — 카논: apps/web/CLAUDE.md.")}}'
+      exit 0
+      ;;
+  esac
+fi
+
+exit 0

--- a/.claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh
+++ b/.claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh
@@ -3,12 +3,26 @@
 # 비차단 hook. additionalContext만 반환.
 #
 # 트리거 조건:
-#   1. 최근 10 commit + 미커밋 working tree 변경의 changed lines >= 50
+#   1. 최근 10 commit + 미커밋 working tree 변경의 changed lines >= COMPOUND_WRAP_MIN_LINES (기본 50)
 #   2. 세션 내 /compound-wrap 실행 흔적 없음 (휴리스틱: memory/sessions/<today>-*.md 부재)
+#
+# 환경 변수 (PR-5 카논화):
+#   COMPOUND_WRAP_MIN_LINES   임계 줄수 (기본 50, PR-10 dogfooding 후 calibration)
+#   COMPOUND_WRAP_REMINDER_DISABLE=1   리마인드 전체 비활성
 #
 # 출력: stdout JSON (hookSpecificOutput.additionalContext) 또는 빈 응답
 
 set -euo pipefail
+
+# 긴급 비활성 토글
+if [ "${COMPOUND_WRAP_REMINDER_DISABLE:-}" = "1" ]; then
+  exit 0
+fi
+
+THRESHOLD="${COMPOUND_WRAP_MIN_LINES:-50}"
+case "$THRESHOLD" in
+  ''|*[!0-9]*) THRESHOLD=50 ;;  # 비숫자 입력 fallback
+esac
 
 # 변경량 측정 — 커밋 이력(HEAD~10..HEAD) + 미커밋 변경(HEAD vs working tree) 합산
 sum_shortstat() {
@@ -29,7 +43,7 @@ UNCOMMITTED_LINES="${UNCOMMITTED_LINES:-0}"
 DIFF_LINES=$((COMMIT_LINES + UNCOMMITTED_LINES))
 
 # 임계값 미만이면 silent
-if [ "$DIFF_LINES" -lt 50 ]; then
+if [ "$DIFF_LINES" -lt "$THRESHOLD" ]; then
   exit 0
 fi
 

--- a/.claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
+++ b/.claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# pre-edit-size-check.sh 테스트 fixture.
+# 카논: refs/tdd-enforcement.md + memory/feedback_file_size_limit.md
+
+set -eu
+
+HOOK="$(dirname "$0")/pre-edit-size-check.sh"
+VERBOSE="${1:-}"
+PASS=0
+FAIL=0
+FIXTURE_DIR=""
+
+# CLAUDE_PROJECT_DIR을 가짜 root로 설정 (CLAUDE.md scope test).
+# hook은 file_path가 "$CLAUDE_PROJECT_DIR/CLAUDE.md"인 경우만 200 적용.
+export CLAUDE_PROJECT_DIR="/repo"
+
+cleanup() {
+  if [ -n "$FIXTURE_DIR" ] && [ -d "$FIXTURE_DIR" ]; then
+    rm -rf "$FIXTURE_DIR"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+FIXTURE_DIR=$(mktemp -d)
+
+# 줄수 N으로 content 생성 (각 라인 = "line $i\n")
+make_content() {
+  local n="$1"
+  local i=0
+  local out=""
+  while [ "$i" -lt "$n" ]; do
+    out="${out}line ${i}"$'\n'
+    i=$((i+1))
+  done
+  printf '%s' "$out"
+}
+
+assert_silent() {
+  local description="$1"
+  local input="$2"
+  local output
+  output=$(printf '%s' "$input" | bash "$HOOK" 2>/dev/null || true)
+  if [ -z "$output" ]; then
+    PASS=$((PASS+1))
+    if [ "$VERBOSE" = "verbose" ]; then
+      echo "PASS: $description"
+    fi
+  else
+    FAIL=$((FAIL+1))
+    echo "FAIL: $description"
+    echo "  expected: silent"
+    echo "  actual:   $output"
+  fi
+}
+
+assert_decision() {
+  local description="$1"
+  local input="$2"
+  local expected="$3"
+  local output
+  output=$(printf '%s' "$input" | bash "$HOOK" 2>/dev/null || true)
+  if [ -z "$output" ]; then
+    FAIL=$((FAIL+1))
+    echo "FAIL: $description"
+    echo "  expected: $expected"
+    echo "  actual:   silent"
+    return 0
+  fi
+  local actual
+  actual=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || echo "parse_error")
+  if [ "$actual" = "$expected" ]; then
+    PASS=$((PASS+1))
+    if [ "$VERBOSE" = "verbose" ]; then
+      echo "PASS: $description"
+    fi
+  else
+    FAIL=$((FAIL+1))
+    echo "FAIL: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    echo "  output:   $output"
+  fi
+}
+
+# === A. 무관한 tool ===
+assert_silent "tool_name=Read는 통과" \
+  '{"tool_name": "Read", "tool_input": {"file_path": "/tmp/x.go"}}'
+assert_silent "tool_name=Bash는 통과" \
+  '{"tool_name": "Bash", "tool_input": {}}'
+
+# === B. JSON 비정상 (비차단 보장) ===
+assert_silent "빈 stdin은 비차단" ""
+assert_silent "tool_input 누락" '{"tool_name": "Write"}'
+assert_silent "file_path 누락" '{"tool_name": "Write", "tool_input": {"content": "x"}}'
+
+# === C. 자동 통과 예외 패턴 (size 검사 자체 스킵) ===
+big_content=$(make_content 600)
+
+assert_silent "_test.go 자체 신규는 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/foo_test.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "_mock.go 자동 생성 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/bar_mock.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "_gen.go 자동 생성 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/baz_gen.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "*sqlc.go 자동 생성 통과 (review test P1)" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/internal/db/queriessqlc.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "*.pb.go 자동 생성 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/proto/api.pb.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "apps/server/cmd entrypoint 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/apps/server/cmd/server/main.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "apps/web/src/types 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/apps/web/src/types/index.ts" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "apps/web/src/constants 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/apps/web/src/constants/foo.ts" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "migrations 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/migrations/0001_init.sql" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+assert_silent "*.sql 통과" \
+  "$(jq -nc --arg c "$big_content" --arg fp "/repo/queries/users.sql" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+# === D. 사이즈 deny (Write 신규) ===
+go_510=$(make_content 510)
+assert_decision "Go 510줄은 deny" \
+  "$(jq -nc --arg c "$go_510" --arg fp "/repo/foo.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "deny"
+
+# Go 499줄 + 같은 디렉토리에 _test.go 미리 둠 → size·TDD 모두 통과
+test_dir_499="${FIXTURE_DIR}/dir499"
+mkdir -p "$test_dir_499"
+touch "${test_dir_499}/sibling_test.go"
+go_499=$(make_content 499)
+assert_silent "Go 499줄 + _test.go 존재 → 통과" \
+  "$(jq -nc --arg c "$go_499" --arg fp "${test_dir_499}/foo499.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+tsx_410=$(make_content 410)
+assert_decision "TSX 410줄은 deny" \
+  "$(jq -nc --arg c "$tsx_410" --arg fp "/repo/apps/web/src/components/Foo.tsx" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "deny"
+
+ts_410=$(make_content 410)
+assert_decision "TS 410줄은 deny" \
+  "$(jq -nc --arg c "$ts_410" --arg fp "/repo/apps/web/src/utils/foo.ts" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "deny"
+
+# .ts ≤ 400은 explicit silent — review test P2 #1
+ts_399_dir="${FIXTURE_DIR}/ts399"
+mkdir -p "$ts_399_dir"
+touch "${ts_399_dir}/foo.test.ts"   # test fallback 자동 통과 패턴은 *.test.ts
+ts_399=$(make_content 399)
+assert_silent "TS 399줄 (한도 이하) → 통과" \
+  "$(jq -nc --arg c "$ts_399" --arg fp "/repo/apps/web/src/utils/safe.ts" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+md_510=$(make_content 510)
+assert_decision "MD 510줄은 deny" \
+  "$(jq -nc --arg c "$md_510" --arg fp "/repo/docs/plans/foo.md" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "deny"
+
+md_499=$(make_content 499)
+assert_silent "MD 499줄은 통과" \
+  "$(jq -nc --arg c "$md_499" --arg fp "/repo/docs/plans/foo.md" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+# === D-2. CLAUDE.md scope (review critic P1 #1) ===
+# repo root CLAUDE.md만 200 한도, nested CLAUDE.md는 .md 500 fallthrough.
+claude_md_210=$(make_content 210)
+assert_decision "root CLAUDE.md 210줄은 deny (CLAUDE_PROJECT_DIR root)" \
+  "$(jq -nc --arg c "$claude_md_210" --arg fp "/repo/CLAUDE.md" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "deny"
+
+claude_md_199=$(make_content 199)
+assert_silent "root CLAUDE.md 199줄은 통과" \
+  "$(jq -nc --arg c "$claude_md_199" --arg fp "/repo/CLAUDE.md" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+# nested CLAUDE.md (apps/server/CLAUDE.md 등): 200 한도 미적용, .md 500 적용
+nested_claude_210=$(make_content 210)
+assert_silent "nested apps/server/CLAUDE.md 210줄은 통과 (.md 500 fallthrough)" \
+  "$(jq -nc --arg c "$nested_claude_210" --arg fp "/repo/apps/server/CLAUDE.md" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+nested_claude_510=$(make_content 510)
+assert_decision "nested apps/server/CLAUDE.md 510줄은 deny (.md 500)" \
+  "$(jq -nc --arg c "$nested_claude_510" --arg fp "/repo/apps/web/CLAUDE.md" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "deny"
+
+# === E. 사이즈 deny (Edit) — 실 fixture 파일 ===
+existing_go="${FIXTURE_DIR}/existing.go"
+make_content 200 > "$existing_go"
+new_chunk=$(make_content 350)
+old_chunk=$(make_content 40)
+# 200 + 350 - 40 = 510 → deny
+assert_decision "Edit 후 510줄 → deny" \
+  "$(jq -nc --arg ns "$new_chunk" --arg os "$old_chunk" --arg fp "$existing_go" '{tool_name:"Edit",tool_input:{file_path:$fp,new_string:$ns,old_string:$os}}')" \
+  "deny"
+
+new_chunk_small=$(make_content 90)
+old_chunk_small=$(make_content 40)
+# 200 + 90 - 40 = 250 → silent (Edit이므로 TDD ask 미발동)
+assert_silent "Edit 후 250줄 → 통과 (TDD ask 미발동)" \
+  "$(jq -nc --arg ns "$new_chunk_small" --arg os "$old_chunk_small" --arg fp "$existing_go" '{tool_name:"Edit",tool_input:{file_path:$fp,new_string:$ns,old_string:$os}}')"
+
+# === E-2. replace_all 가드 (review critic P1 #2) ===
+# replace_all=true && new_lines > old_lines → 보수적 deny
+ns_long=$(make_content 50)
+os_short=$(make_content 1)
+assert_decision "Edit replace_all=true & new>old → deny (다중 occurrence 우회 차단)" \
+  "$(jq -nc --arg ns "$ns_long" --arg os "$os_short" --arg fp "$existing_go" '{tool_name:"Edit",tool_input:{file_path:$fp,new_string:$ns,old_string:$os,replace_all:true}}')" \
+  "deny"
+
+# replace_all=true && new <= old → 정상 size 검사 (감소이므로 통과)
+ns_short=$(make_content 5)
+os_long=$(make_content 30)
+assert_silent "Edit replace_all=true & new<=old → 정상 (size 감소)" \
+  "$(jq -nc --arg ns "$ns_short" --arg os "$os_long" --arg fp "$existing_go" '{tool_name:"Edit",tool_input:{file_path:$fp,new_string:$ns,old_string:$os,replace_all:true}}')"
+
+# replace_all=false (기본) + new>old → 정상 size 검사 (한도 내라서 silent)
+assert_silent "Edit replace_all=false & new>old & 한도 내 → 통과 (정상 추정)" \
+  "$(jq -nc --arg ns "$ns_long" --arg os "$os_short" --arg fp "$existing_go" '{tool_name:"Edit",tool_input:{file_path:$fp,new_string:$ns,old_string:$os,replace_all:false}}')"
+
+# === F. TDD soft ask (Write 신규 파일 + .go/.tsx만) ===
+# F1: 신규 .go (동일 디렉토리 _test.go 부재) → ask
+no_test_dir="${FIXTURE_DIR}/no_test"
+mkdir -p "$no_test_dir"
+small_go=$(make_content 100)
+assert_decision "신규 Go (test 부재) → ask" \
+  "$(jq -nc --arg c "$small_go" --arg fp "${no_test_dir}/handler.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "ask"
+
+# F2: 신규 .go (동일 디렉토리 다른 *_test.go 존재) → 통과
+has_test_dir="${FIXTURE_DIR}/has_test"
+mkdir -p "$has_test_dir"
+touch "${has_test_dir}/other_test.go"
+assert_silent "신규 Go (sibling _test.go 존재) → 통과" \
+  "$(jq -nc --arg c "$small_go" --arg fp "${has_test_dir}/handler.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+# F3: 신규 .tsx (test 부재) → ask
+no_tsx_test_dir="${FIXTURE_DIR}/no_tsx"
+mkdir -p "$no_tsx_test_dir"
+small_tsx=$(make_content 100)
+assert_decision "신규 TSX (test 부재) → ask" \
+  "$(jq -nc --arg c "$small_tsx" --arg fp "${no_tsx_test_dir}/Button.tsx" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')" \
+  "ask"
+
+# F4: 신규 .tsx (동일 디렉토리 Button.test.tsx 존재) → 통과
+has_tsx_test_dir="${FIXTURE_DIR}/has_tsx_test"
+mkdir -p "$has_tsx_test_dir"
+touch "${has_tsx_test_dir}/Button.test.tsx"
+assert_silent "신규 TSX (Button.test.tsx 존재) → 통과" \
+  "$(jq -nc --arg c "$small_tsx" --arg fp "${has_tsx_test_dir}/Button.tsx" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+# F5: 신규 .tsx (__tests__/Card.test.tsx 존재 — 동일 디렉토리 하위) → 통과
+under_tests_dir="${FIXTURE_DIR}/under_tests"
+mkdir -p "$under_tests_dir/__tests__"
+touch "${under_tests_dir}/__tests__/Card.test.tsx"
+assert_silent "신규 TSX (__tests__/Card.test.tsx 존재) → 통과" \
+  "$(jq -nc --arg c "$small_tsx" --arg fp "${under_tests_dir}/Card.tsx" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+# F6: 신규 .tsx (parent __tests__/Widget.test.tsx 존재 — review test P1) → 통과
+parent_tests_dir="${FIXTURE_DIR}/parent_tests"
+mkdir -p "${parent_tests_dir}/__tests__"
+mkdir -p "${parent_tests_dir}/Widget"
+touch "${parent_tests_dir}/__tests__/Widget.test.tsx"
+assert_silent "신규 TSX (parent __tests__/Widget.test.tsx 존재 — legacy) → 통과" \
+  "$(jq -nc --arg c "$small_tsx" --arg fp "${parent_tests_dir}/Widget/Widget.tsx" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')"
+
+# === G. ENV var 환경 토글 (긴급 비활성) ===
+big_go=$(make_content 600)
+disable_input=$(jq -nc --arg c "$big_go" --arg fp "/repo/forced.go" '{tool_name:"Write",tool_input:{file_path:$fp,content:$c}}')
+disable_output=$(printf '%s' "$disable_input" | COMPOUND_MMP_SIZE_HOOK_DISABLE=1 bash "$HOOK" 2>/dev/null || true)
+if [ -z "$disable_output" ]; then
+  PASS=$((PASS+1))
+  if [ "$VERBOSE" = "verbose" ]; then
+    echo "PASS: COMPOUND_MMP_SIZE_HOOK_DISABLE=1 비활성화"
+  fi
+else
+  FAIL=$((FAIL+1))
+  echo "FAIL: COMPOUND_MMP_SIZE_HOOK_DISABLE=1 비활성화"
+  echo "  expected: silent"
+  echo "  actual:   $disable_output"
+fi
+
+# === Summary ===
+echo
+echo "=========================================="
+TOTAL=$((PASS+FAIL))
+if [ "$FAIL" -gt 0 ]; then
+  RATE=$((PASS*100/TOTAL))
+  echo "Pass: $PASS, Fail: $FAIL (${RATE}% fixture pass rate) — review failing cases"
+  exit 1
+else
+  echo "Pass: $PASS, Fail: $FAIL (100% fixture pass rate, $PASS/$TOTAL cases)"
+  exit 0
+fi

--- a/.claude/plugins/compound-mmp/refs/auto-dispatch.md
+++ b/.claude/plugins/compound-mmp/refs/auto-dispatch.md
@@ -87,3 +87,27 @@ PR-4 진입 전 최근 30 prompt 샘플로 hit rate 측정. 50% 미만이면 hoo
 - Hook 스크립트: `hooks/dispatch-router.sh`
 - 디스패처 디스패치 (단일 진입점): `hooks/run-hook.sh dispatch`
 - 매니페스트 등록: 플러그인 install 시 `.claude/settings.json` `hooks.UserPromptSubmit` 자동 머지
+
+## skill-injector 직렬 실행 (UserPromptSubmit slot 공존 카논)
+
+> 핸드오프 Risk 카논화 (Wave 1 후속, PR-5).
+
+같은 `UserPromptSubmit` matcher에 다중 hook이 등록될 수 있다. 대표 케이스:
+
+| 출처 | 위치 | 역할 | 출력 |
+|------|------|------|------|
+| compound-mmp dispatch | repo `.claude/plugins/compound-mmp/hooks/hooks.json` | 4단계 stage 분류 | `additionalContext` ("[compound-mmp dispatch] stage=...") |
+| skill-injector | user home `~/.claude/settings.json` | 관련 skill 목록 + 폴더 구조 룰 주입 | `additionalContext` ("📋 관련 스킬 감지...") |
+
+### 실행 순서 카논
+- Claude Code runtime은 매칭되는 모든 hook을 **직렬 실행**한다 (병렬 X). 출력은 모두 메인 컨텍스트의 system reminder 큐에 append.
+- 각 hook이 **`permissionDecision: "deny"`를 사용하지 않는 한** 다른 hook의 실행을 차단하지 않는다 (anti-patterns #11 강제).
+- compound-mmp dispatch는 의도적으로 `additionalContext`만 반환 → skill-injector와 충돌 없음.
+
+### 충돌 회피 룰
+1. **dispatch는 stage 라벨만 echo, raw prompt 금지** (이미 강제, security MEDIUM-1).
+2. **skill-injector hint와 dispatch hint가 상충하면 사용자 의도 우선** (Override 우선순위 #2).
+3. **새 UserPromptSubmit hook 추가 시** — `permissionDecision` 사용 여부를 명시. 이 카논 표를 갱신.
+
+### 검증
+- PR-4 dispatch fixture 41/41 PASS는 skill-injector 비활성 환경에서 측정. 둘 다 활성인 실 사용자 환경 hit rate는 PR-10 dogfooding에서 측정.

--- a/.claude/plugins/compound-mmp/refs/spike-omc-overlap.md
+++ b/.claude/plugins/compound-mmp/refs/spike-omc-overlap.md
@@ -40,12 +40,13 @@ OMC team mode (`/oh-my-claudecode:team`, `skills/team/SKILL.md`) 는 `team-plan 
 | **followup-suggester** (P0–P3 + Effort/Impact 매트릭스) | `oh-my-claudecode:critic` (Pre-Mortem, Devil's Advocate) 또는 `analyst` | **KEEP_NEW** | critic은 "이 plan이 실패할 시나리오", analyst는 "현재 plan의 gap". P0–P3 우선순위 + Effort(S/M/L) × Impact(low/med/high) 매트릭스 출력은 둘 다 출력 형식이 다름. critic 호출 + post-processing prompt 가능하나 매번 prompt 인라인이 길어짐 → 전용 agent .md 1개 유지가 cleaner. |
 | **duplicate-checker** (QMD vector_search 중복 검증) | (없음) | **KEEP_NEW** | OMC 어떤 agent도 `mcp__plugin_qmd_qmd__vector_search`를 사용 안 함. document-specialist는 chub/Context7 백엔드 전용. haiku-4-5 + Read만 필요 → 가벼운 신규 정의가 정당. wiki skill에 `wiki_query`가 있지만 `.omc/wiki/` 저장소 한정. |
 
-**최종 결정**: 신규 agent 5개 → **3개**로 축소.
-- doc-curator → OMC `document-specialist` 호출 (compound-mmp wrap-up skill에서 prompt 주입)
-- learning-extractor, followup-suggester, duplicate-checker → 신규 `compound-mmp:*` agent 정의 유지
-- automation-scout → 신규 정의 유지 (직접 매핑 OMC 없음)
+**최종 결정**: 신규 agent 5개 후보 → **신규 4개 정의 + OMC 호출 1개** (wrap Phase 1 총 5 agent 호출 유지).
+- doc-curator → OMC `document-specialist` 호출 (compound-mmp wrap-up skill에서 prompt 주입, 신규 정의 0)
+- automation-scout / learning-extractor / followup-suggester / duplicate-checker → 신규 `compound-mmp:*` agent 정의 4개 (`agents/`)
 
-(critic MAJOR #4 부분 수용 — 5개 중 1개 OMC 대체)
+(critic MAJOR #4 부분 수용 — 5개 후보 중 1개를 OMC 대체. wrap-up 단계의 호출 수 5는 유지하되 자체 정의 파일은 4로 감소.)
+
+> **표기 정정 (PR-5)**: 이전 표기 "5개 → 3개"는 부정확. 실제는 "신규 정의 5 → 4 + OMC 호출 1"이며 wrap에서의 총 agent 호출은 그대로 5. 핸드오프 노트 (memory/sessions/2026-04-28-compound-mmp-wave1-complete.md) "4 신규 + OMC document-specialist 호출 = wrap Phase 1 5 agent"가 정확한 표현.
 
 ## C) OMC 기존 wrap 기능
 

--- a/.claude/plugins/compound-mmp/skills/tdd-mmp-go/SKILL.md
+++ b/.claude/plugins/compound-mmp/skills/tdd-mmp-go/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: tdd-mmp-go
+description: |
+  Go 새 파일 작성 시 동일 디렉토리에 *_test.go가 없으면 TDD soft ask로 테스트를 먼저 만들도록 안내.
+  자동 활성화 트리거: "Go 코드 작성", "Go 핸들러 만들어", "internal/<pkg> 구현", "go test", "testify",
+  "mockgen", "table-driven test", apps/server/internal/ 하위 .go 파일 작성, 새 Go 패키지 도입.
+  Soft ask 모드 — N 응답으로 진행 허용 (도메인 모델·마이그레이션·자동 생성물 예외).
+  4-agent test-engineer가 사후 P2 coverage 검증 수행.
+---
+
+# tdd-mmp-go — Go TDD Soft Ask
+
+## 정책 요약
+
+- **트리거**: 새 `.go` 파일 작성 시도 (Write tool, file_path가 `apps/server/.../*.go` 또는 repo 내 `.go`).
+- **검사**: 동일 디렉토리에 `*_test.go` (또는 `<base>_test.go`) 존재 여부.
+- **부재 시 동작**: PreToolUse hook이 `permissionDecision: "ask"` JSON 출력 → 사용자 Y/N 결정.
+- **N 응답**: 진행 허용. 4-agent `oh-my-claudecode:test-engineer`가 PR review 시 P2(MEDIUM) coverage 경고 생성 가능.
+
+카논 root: `.claude/plugins/compound-mmp/refs/tdd-enforcement.md`.
+
+## 자동 통과 예외
+
+> **Single source of truth**: `hooks/pre-edit-size-check.sh` § "자동 통과 예외 (size + TDD 모두 스킵)" case 블록. 아래 표는 참조용 사본 — drift 발견 시 hook이 master.
+
+| 패턴 | 이유 |
+|------|------|
+| `*_test.go` | 본인이 테스트 |
+| `*_mock.go`, `*_gen.go`, `*sqlc.go`, `*.pb.go` | 자동 생성 |
+| `apps/server/cmd/*` | main 엔트리포인트 |
+| `migrations/*`, `*.sql` | DB 마이그레이션 |
+
+자동 통과는 `hooks/pre-edit-size-check.sh` 단일 hook이 size 검사와 함께 처리.
+
+## Go 코드 룰 (apps/server/CLAUDE.md 카논)
+
+테스트 패턴 권장 순서:
+1. **table-driven test** — `tests := []struct{name string; in T1; want T2}{...}` for-range. testify `assert`.
+2. **interface mock** — `mockgen` 자동 생성 (`go:generate mockgen -destination=mock_foo.go ...`). hand-written mock 금지.
+3. **race detector** — `go test -race ./internal/<pkg>/...` 항상 활성.
+4. **t.Cleanup** — defer 대신 t.Cleanup으로 fixture 정리.
+
+## 파일 시그니처 예시
+
+```go
+// apps/server/internal/domain/foo/handler.go (신규)
+package foo
+
+func Handle(ctx context.Context, req *Request) (*Response, error) {
+    // ...
+}
+```
+
+```go
+// apps/server/internal/domain/foo/handler_test.go (먼저 작성 권장)
+package foo
+
+import (
+    "context"
+    "testing"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestHandle(t *testing.T) {
+    tests := []struct{
+        name    string
+        in      *Request
+        want    *Response
+        wantErr bool
+    }{
+        {name: "happy path", in: &Request{...}, want: &Response{...}, wantErr: false},
+        {name: "invalid input", in: nil, wantErr: true},
+    }
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            got, err := Handle(context.Background(), tc.in)
+            if tc.wantErr { assert.Error(t, err); return }
+            assert.NoError(t, err)
+            assert.Equal(t, tc.want, got)
+        })
+    }
+}
+```
+
+## N 응답 시 명시 권장
+
+```
+사용자: N
+이유: 도메인 모델 (struct만 정의, 행위 없음)
+```
+
+PR description 또는 commit body에 "N 응답 사유"를 한 줄 명시 → 4-agent test-engineer가 이해 후 false positive 방지.
+
+## 카논 ref
+
+- TDD 정책 근거: `refs/tdd-enforcement.md` (PR-2c handleCombine deadlock 사례)
+- Go 코드 룰: `apps/server/CLAUDE.md`
+- 4-agent 매핑: `refs/post-task-pipeline-bridge.md`
+- Anti-patterns: `refs/anti-patterns.md`

--- a/.claude/plugins/compound-mmp/skills/tdd-mmp-react/SKILL.md
+++ b/.claude/plugins/compound-mmp/skills/tdd-mmp-react/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: tdd-mmp-react
+description: |
+  React 새 .tsx 컴포넌트 작성 시 .test.tsx가 없으면 TDD soft ask로 테스트를 먼저 만들도록 안내.
+  자동 활성화 트리거: "React 컴포넌트 만들어", ".tsx 작성", "Vitest", "RTL", "MSW", "user-event",
+  "components/", "pages/", "hooks/", apps/web/src/ 하위 .tsx 파일 작성, 새 페이지·컴포넌트 도입.
+  Soft ask 모드 — N 응답으로 진행 허용 (types/constants 예외).
+  Vitest + React Testing Library + MSW 패턴 카논(apps/web/CLAUDE.md) 인용.
+---
+
+# tdd-mmp-react — React TDD Soft Ask
+
+## 정책 요약
+
+- **트리거**: 새 `.tsx` 파일 작성 시도 (Write tool, file_path가 `apps/web/src/.../*.tsx`).
+- **검사**: 동일 디렉토리 `<base>.test.tsx` / `__tests__/<base>.test.tsx` / 부모 `__tests__/<base>.test.tsx` 존재.
+- **부재 시 동작**: PreToolUse hook이 `permissionDecision: "ask"` JSON 출력.
+- **N 응답**: 진행 허용. 4-agent test-engineer가 PR review 시 P2 coverage 경고 가능.
+
+카논 root: `.claude/plugins/compound-mmp/refs/tdd-enforcement.md`.
+
+## 자동 통과 예외
+
+> **Single source of truth**: `hooks/pre-edit-size-check.sh` § "자동 통과 예외" case 블록. 아래 표는 참조용 사본 — drift 발견 시 hook이 master.
+
+| 패턴 | 이유 |
+|------|------|
+| `*.test.tsx`, `*.test.ts` | 본인이 테스트 |
+| `apps/web/src/types/*` | 순수 타입 선언 |
+| `apps/web/src/constants/*` | 상수만 |
+
+## React 코드 룰 (apps/web/CLAUDE.md 카논)
+
+테스트 스택 권장:
+1. **Vitest** — Jest 대신 Vitest (Vite-native, ESM, TypeScript first).
+2. **React Testing Library** — `@testing-library/react` + `@testing-library/user-event`. queryBy/findBy 우선, getBy는 예외.
+3. **MSW** — `msw/node` 로 API 모의. 직접 fetch mock 금지.
+4. **vitest browser mode** (앞으로) — DOM 접근이 필요한 컴포넌트는 jsdom 대신 Browser Mode 검토.
+
+> 글로벌 override 적용 안 됨: 이 프로젝트는 Tailwind 4 직접 사용 — Seed Design 3단계 룰 미적용 (CLAUDE.md 명시).
+
+## 파일 시그니처 예시
+
+```tsx
+// apps/web/src/components/Button.tsx (신규)
+import { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export function Button({ variant = 'primary', ...rest }: ButtonProps) {
+  return <button data-variant={variant} {...rest} />;
+}
+```
+
+```tsx
+// apps/web/src/components/Button.test.tsx (먼저 작성 권장)
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders with primary variant by default', () => {
+    render(<Button>Click</Button>);
+    expect(screen.getByRole('button', { name: 'Click' })).toHaveAttribute('data-variant', 'primary');
+  });
+
+  it('triggers onClick handler', async () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Click</Button>);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});
+```
+
+## __tests__ 디렉토리 패턴
+
+apps/web/src 하위에서 두 패턴 모두 자동 통과 처리:
+- 동일 디렉토리: `components/Button.tsx` + `components/Button.test.tsx`
+- `__tests__` 서브: `components/Button.tsx` + `components/__tests__/Button.test.tsx`
+- 부모 `__tests__` (legacy): `components/Button.tsx` + `__tests__/Button.test.tsx`
+
+## N 응답 사유 명시
+
+PR description에 한 줄 명시:
+- "N 응답: page-level 컴포넌트 (E2E Playwright로 커버)"
+- "N 응답: 순수 presentational 컴포넌트 (시각 회귀로 커버)"
+
+## 카논 ref
+
+- TDD 정책 근거: `refs/tdd-enforcement.md`
+- React 코드 룰: `apps/web/CLAUDE.md`
+- 4-agent 매핑: `refs/post-task-pipeline-bridge.md`
+- Anti-patterns: `refs/anti-patterns.md`

--- a/.claude/plugins/compound-mmp/skills/wrap-up-mmp/SKILL.md
+++ b/.claude/plugins/compound-mmp/skills/wrap-up-mmp/SKILL.md
@@ -168,6 +168,17 @@ session_date: 2026-MM-DD
 
 `--phase`는 fresh rebuild이므로 graph.json 업데이트 PR이 별도 필요 (anti-patterns #4 carve-out).
 
+### 실패 처리 (PR-5 카논화)
+
+`--phase` 모드에서 `make graphify-refresh` 실패 시:
+1. **stderr 그대로 사용자에게 표시** — 메인 컨텍스트가 가공·요약 X.
+2. **자동 retry 금지** — anti-patterns #1 (자동 fix-loop 폐기 정책) 강제.
+3. **수동 retry 안내**: `cd $(git rev-parse --show-toplevel) && make graphify-refresh` 다시 실행 또는 `make graphify-update` 증분 시도.
+4. **graph.json 부분 손상 의심 시**: `git restore graphify-out/graph.json && make graphify-refresh` (이전 fresh 결과로 롤백 후 재시도).
+5. **wrap 자체는 정상 완료로 간주** — Step 1~6은 이미 성공했으므로 graphify 실패가 wrap 결과를 무효화하지 않음. 사용자가 후속 작업 결정.
+
+이 정책은 graphify가 외부 인덱싱이며 wrap의 critical path가 아니라는 카논(`.claude/refs/graphify.md`)을 따른다.
+
 ## 종료 후
 
 다음 SessionStart hook이 `memory/sessions/`에서 가장 최근 1개 파일을 자동 inject (PR-6에서 구현).

--- a/.github/workflows/ci-hooks.yml
+++ b/.github/workflows/ci-hooks.yml
@@ -1,0 +1,59 @@
+name: ci-hooks (compound-mmp plugin self-tests)
+
+on:
+  pull_request:
+    paths:
+      - '.claude/plugins/compound-mmp/**'
+      - '.github/workflows/ci-hooks.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/plugins/compound-mmp/**'
+      - '.github/workflows/ci-hooks.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck (compound-mmp hooks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update -qq && sudo apt-get install -y shellcheck
+      - name: shellcheck hooks
+        run: |
+          set -e
+          for f in .claude/plugins/compound-mmp/hooks/*.sh; do
+            echo "shellcheck $f"
+            shellcheck -e SC2155,SC2086 "$f"
+          done
+
+  hook-tests-ubuntu:
+    name: hook self-tests (ubuntu, bash 5.x)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get update -qq && sudo apt-get install -y jq
+      - name: bash version
+        run: bash --version | head -1
+      - name: dispatch-router self-tests
+        run: bash .claude/plugins/compound-mmp/hooks/test-dispatch.sh
+      - name: pre-edit-size self-tests
+        run: bash .claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
+
+  hook-tests-macos:
+    name: hook self-tests (macOS, bash 3.2)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify default bash is 3.2 (system bash)
+        run: /bin/bash --version | head -1
+      - name: Verify jq present
+        run: jq --version
+      - name: dispatch-router self-tests (system bash 3.2)
+        run: /bin/bash .claude/plugins/compound-mmp/hooks/test-dispatch.sh
+      - name: pre-edit-size self-tests (system bash 3.2)
+        run: /bin/bash .claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh


### PR DESCRIPTION
## Summary

Wave 2 진입 1번째 PR. PreToolUse(Edit|Write) hook이 파일 크기 한도와 TDD soft ask를 단일 진입점에서 강제. Wave 1 핸드오프 노트의 후속 카논화 5건도 포함.

- **size 한도**: `.go` 500 / `.tsx`·`.ts` 400 / `.md` 500 / repo root `CLAUDE.md` 200 (자동 로딩 비용 카논). nested `CLAUDE.md`는 `.md` 500 fallthrough.
- **TDD soft ask**: 신규 `.go` (sibling `*_test.go` 부재) 또는 신규 `.tsx` (`<base>.test.tsx` 또는 `__tests__/<base>.test.tsx` 또는 parent `__tests__/<base>.test.tsx` 부재) 시 `permissionDecision: ask`. N 응답 진행 허용.
- **자동 통과 예외**: `*_test.go` / `*_mock.go` / `*_gen.go` / `*sqlc.go` / `*.pb.go` / `apps/server/cmd/*` / `apps/web/src/types/*` · `constants/*` / `migrations/*` / `*.sql`.
- **replace_all 가드**: Edit replace_all=true & new_string > old_string 시 보수적 deny — 다중 occurrence 정확 추정 불가.
- **ENV var**: `COMPOUND_MMP_SIZE_HOOK_DISABLE=1` 긴급 비활성. `COMPOUND_WRAP_MIN_LINES` (stop-wrap-reminder 임계, 기본 50) 도 신규 노출.

## 4-agent 리뷰

| reviewer | model | verdict | 결과 |
|---|---|---|---|
| security-reviewer | opus | APPROVE | P0/P1/P2 0건, P3 advisory 2건 (glob metachar 비차단, env literal 안전) |
| code-reviewer (perf) | sonnet | APPROVE-WITH-COMMENTS | P1 jq fork 5→2-3회 적용, P2 SKILL master 명시 적용 |
| critic (arch) | opus | APPROVE (재re-review) | P1 #1 CLAUDE.md scope + P1 #2 replace_all guard 적용 |
| test-engineer | sonnet | APPROVE-WITH-COMMENTS | P1 missing(\*sqlc.go, parent __tests__) fixture 추가 |

핸드오프 카논 "4-agent 리뷰는 admin-merge 전에 수행" + critic 재re-review 패턴 충족.

## 검증

- 로컬: bash 3.2(macOS) + 5.x(Linux) 모두 **38/38 size+TDD PASS** + **41/41 dispatch PASS**.
- CI: `.github/workflows/ci-hooks.yml`이 ubuntu-latest + macos-latest matrix로 shellcheck + dispatch + size-tdd 자가 테스트 실행.

## 신규/수정 파일

```
NEW  .claude/plugins/compound-mmp/hooks/pre-edit-size-check.sh
NEW  .claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
NEW  .claude/plugins/compound-mmp/skills/tdd-mmp-go/SKILL.md
NEW  .claude/plugins/compound-mmp/skills/tdd-mmp-react/SKILL.md
NEW  .github/workflows/ci-hooks.yml
MOD  .claude/plugins/compound-mmp/hooks/hooks.json (PreToolUse 등록)
MOD  .claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh (ENV var)
MOD  .claude/plugins/compound-mmp/refs/auto-dispatch.md (skill-injector 직렬 카논)
MOD  .claude/plugins/compound-mmp/refs/spike-omc-overlap.md (agent 표기 정정)
MOD  .claude/plugins/compound-mmp/skills/wrap-up-mmp/SKILL.md (graphify 실패 처리)
MOD  .claude/plugins/compound-mmp/commands/compound-wrap.md (thin pointer)
```

## Out of scope (follow-up)

- **enabledPlugins 미등록** (critic Q9): repo `.claude/settings.json`에 `compound-mmp@local` 미등록 — PR-1 scaffold 책임. 별도 hotfix PR로 분리. Plan 디스패처/wrap hook이 실제 발화하려면 해당 hotfix 머지 필요.
- **Phase 19 Residual W4** (PR-9 WS Auth / PR-10 Runtime Payload Validation, 미착수, L+L 규모): hook 활성화로 W4 작업자에게 영향 가능 (PreToolUse가 새 .go 파일 작성 시 ask). PR-9/10 시작 시점에 dogfooding 모니터링.
- **dogfooding 보정** (Wave 1 Risk): 50줄 임계값(stop-wrap-reminder)·dispatch hit-rate(PR-4)·MEMORY drift는 PR-10 dogfooding 1주 후 calibration.

## Test plan

- [ ] CI ci-hooks workflow green (ubuntu shellcheck + ubuntu hook tests + macOS hook tests)
- [ ] CI 외 기존 워크플로우는 paths filter로 미실행
- [ ] 머지 후 다음 세션에서 dispatch 41/41 + size-tdd 38/38 회귀 없음 확인
- [ ] 신규 .go 파일 Write 시도 → ask 발동 (dogfooding)
- [ ] 510줄 .go Write 시도 → deny 발동 (dogfooding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)