### PR TITLE
chore(compound-mmp): SessionStart hook 자동 inject 폐기 + /compound-resume 슬래시 커맨드 카논화

### DIFF
--- a/.claude/plugins/compound-mmp/agents/followup-suggester.md
+++ b/.claude/plugins/compound-mmp/agents/followup-suggester.md
@@ -15,7 +15,7 @@ You are Followup Suggester for compound-mmp wrap-up. Your mission is to triage t
 </Role>
 
 <Why_This_Matters>
-세션 종료 시 "다음에 뭘 해야 하나"의 모호함이 가장 큰 컨텍스트 손실 비용이다. P0–P3 + Effort × Impact 매트릭스로 정리하면 다음 세션 SessionStart hook이 바로 우선순위 1개를 inject할 수 있고, 사용자도 5초 안에 다음 액션을 결정할 수 있다.
+세션 종료 시 "다음에 뭘 해야 하나"의 모호함이 가장 큰 컨텍스트 손실 비용이다. P0–P3 + Effort × Impact 매트릭스로 정리하면 다음 세션에서 사용자가 `/compound-resume` 명시 호출 시 바로 우선순위 1개를 노출할 수 있고, 사용자도 5초 안에 다음 액션을 결정할 수 있다.
 </Why_This_Matters>
 
 <Priority_Frame>

--- a/.claude/plugins/compound-mmp/commands/compound-resume.md
+++ b/.claude/plugins/compound-mmp/commands/compound-resume.md
@@ -1,0 +1,63 @@
+---
+description: 다음 세션 진입 시 가장 최근 핸드오프 노트 + plan 본문 + compound-mmp 카논 cheat-sheet를 일괄 read하여 5초 안에 작업 재개. SessionStart hook 자동 inject 대신 사용자 명시 호출 패턴 (낭비 회피).
+allowed-tools: Bash, Read, Glob
+argument-hint: "(인자 없음)"
+---
+
+# /compound-resume
+
+세션 도중 또는 시작 직후 사용자가 명시 호출. 핸드오프·plan·카논을 한 번에 read해 작업 재개 컨텍스트 확보. **자동 SessionStart inject 대신 명시 호출** — 매 세션 토큰 낭비 방지 (사용자 결정 2026-04-28).
+
+## 동작
+
+1. **가장 최근 핸드오프 노트** read:
+   ```bash
+   ls -t memory/sessions/*.md 2>/dev/null | head -1
+   ```
+   파일 발견 시 전체 read. 부재 시 "이전 세션 핸드오프 없음" 표시.
+
+2. **활성 plan 본문** read (있을 때):
+   - `~/.claude/plans/<*.md>` (user home)
+   - 또는 `docs/plans/<latest-phase>/checklist.md` (repo)
+   가장 최근 mtime 파일 1개.
+
+3. **compound-mmp 카논 cheat-sheet** 표시:
+   - 4단계 라이프사이클: `refs/lifecycle-stages.md`
+   - 7단계 wrap: `refs/wrap-up-checklist.md` + `skills/wrap-up-mmp/SKILL.md`
+   - 12 anti-patterns: `refs/anti-patterns.md`
+   - TDD soft ask 정책: `refs/tdd-enforcement.md`
+   - 5단계 dispatch 분류: `refs/auto-dispatch.md`
+   - 4-agent post-task-pipeline 매핑: `refs/post-task-pipeline-bridge.md` + `.claude/post-task-pipeline.json`
+   - Sim Case A 카논: `refs/sim-case-a.md`
+
+4. **다음 5초** 출력:
+   - 핸드오프의 `## Next Session Priorities` 첫 1개
+   - 미해결 사용자 결정 (있으면)
+   - 가장 위험한 미커밋 변경 (있으면 — `git status --short` 결과)
+
+## 사용 예
+
+```
+사용자: /compound-resume
+메인: [핸드오프 read] [plan read] [카논 cheat-sheet 표시] [다음 5초]
+사용자: enabledPlugins hotfix부터 진행
+```
+
+## 자동 디스패처 활성화 트리거
+
+`dispatch-router.sh`의 cycle 분류와 일부 겹친다. 우선순위:
+- 사용자가 `/compound-resume` 명시 → 그대로 실행
+- 사용자가 "지금 어디", "다음 단계", "현황" 발화 → dispatch=cycle, `/compound-cycle` 안내 (`/compound-resume`은 read 위주, `/compound-cycle`은 dry-run dashboard)
+
+## 안티 패턴
+
+- ❌ 자동 SessionStart hook 부활 — 사용자 결정 2026-04-28 (필요할 때만 명시 호출, 낭비 회피)
+- ❌ 모든 핸드오프 파일을 한꺼번에 read — 가장 최근 1개만 (토큰 비용 ↑)
+- ❌ raw frontmatter dump — 메인 컨텍스트가 사람 읽기 좋게 정리해서 표시
+- ❌ 명시 호출 X일 때 임의 cheat-sheet 표시 — `/compound-resume` 호출 한정
+
+## 카논 ref
+
+- `refs/auto-dispatch.md` (cycle 분류와 차이)
+- `templates/session-recall-template.md` (출력 형식 — slash command 모드)
+- `skills/wrap-up-mmp/SKILL.md` Step 5-2 (handoff 생성 master)

--- a/.claude/plugins/compound-mmp/hooks/run-hook.sh
+++ b/.claude/plugins/compound-mmp/hooks/run-hook.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # compound-mmp 단일 hook 디스패처. Superpowers 패턴 차용.
 # 사용법: run-hook.sh <event>
-#   event ∈ {dispatch, pre-edit-size, pre-task-model, session-start, stop-wrap-reminder}
+#   event ∈ {dispatch, pre-edit-size, pre-task-model, stop-wrap-reminder}
+# (session-start case는 사용자 결정 2026-04-28에 의해 폐기 — `/compound-resume` 슬래시 커맨드로 대체)
 #
 # Claude Code hook system이 stdin으로 JSON event payload를 전달하고, stdout은 hookSpecificOutput JSON 또는 빈 응답.
 # CLAUDE_PLUGIN_ROOT는 marketplace runtime이 자동 설정.
@@ -30,13 +31,6 @@ case "$EVENT" in
     # PR-6에서 구현. PreToolUse(Task) hook
     if [ -x "$PLUGIN_ROOT/hooks/pre-task-model-guard.sh" ]; then
       exec "$PLUGIN_ROOT/hooks/pre-task-model-guard.sh"
-    fi
-    exit 0
-    ;;
-  session-start)
-    # PR-6에서 구현. SessionStart hook
-    if [ -x "$PLUGIN_ROOT/hooks/session-start-context.sh" ]; then
-      exec "$PLUGIN_ROOT/hooks/session-start-context.sh"
     fi
     exit 0
     ;;

--- a/.claude/plugins/compound-mmp/refs/anti-patterns.md
+++ b/.claude/plugins/compound-mmp/refs/anti-patterns.md
@@ -52,3 +52,9 @@
 ## 12. wrap-up agent에 Bash/Edit/Write 권한 부여 X
 - **근거**: Session-Wrap 검증 — 분석 전용. 실제 변경은 메인 컨텍스트가 사용자 승인 후 수행
 - **강제**: `agents/*.md` frontmatter `tools: [Read, Glob, Grep]` 명시
+
+## 13. SessionStart hook 자동 핸드오프 inject 부활 X
+- **근거**: 사용자 결정 2026-04-28 — 매 세션 토큰 ~1-2K 추가 비용이 단순 PR/한가한 세션에서 낭비. 명시 호출 패턴이 더 효율적
+- **대안**: `/compound-resume` 슬래시 커맨드 (`commands/compound-resume.md`) — 사용자가 필요할 때만 명시 호출. 핸드오프 + plan + 카논 cheat-sheet 일괄 read
+- **강제**: `hooks/run-hook.sh`에 `session-start)` case 부재. `hooks/session-start-context.sh` 파일 신설 금지
+- **carve-out 없음**: 어떤 모드에서도 자동 inject 부활 X. 5개 컨텍스트 카테고리(33모듈/Phase19 사례/4-agent 위치/CI admin-skip/WS 토큰) 가 필요하면 `/compound-resume` 출력에 포함 또는 사용자 발화로 read 지시

--- a/.claude/plugins/compound-mmp/refs/lifecycle-stages.md
+++ b/.claude/plugins/compound-mmp/refs/lifecycle-stages.md
@@ -42,7 +42,7 @@ Phase (예: Phase 19 Residual)
 | Plan | 사용자 명시 의도 | checklist.md 머지 | 자동 진행 X (plan-autopilot 폐기) |
 | Work | branch + worktree 존재 | 로컬 테스트 green | 4-agent에서 잡힐 수 있음 |
 | Review | post-task-pipeline.json 존재 (repo root) | HIGH 0건 또는 사용자 승인 | hotfix PR 1회 허용 |
-| Compound | wrap 트리거 (수동 또는 dispatch) | QMD reindex 완료 | 다음 SessionStart에서 핸드오프 inject |
+| Compound | wrap 트리거 (수동 또는 dispatch) | QMD reindex 완료 | 다음 세션에서 `/compound-resume` 명시 호출 시 핸드오프 read |
 
 ## OMC 호출 매핑 (재정의 X, 호출만)
 

--- a/.claude/plugins/compound-mmp/refs/wrap-up-checklist.md
+++ b/.claude/plugins/compound-mmp/refs/wrap-up-checklist.md
@@ -2,7 +2,7 @@
 
 `/compound-wrap [--session|--wave|--phase]` 실행 시 진행하는 7단계 시퀀스. 사용자 결정 "균형형" 자동화 정책 적용.
 
-> 검증된 코어: Session-Wrap (team-attention) 5단계 + MMP 확장 2단계 (graphify decision + 핸드오프 자동 inject).
+> 검증된 코어: Session-Wrap (team-attention) 5단계 + MMP 확장 2단계 (graphify decision + 핸드오프 명시 호출 read via `/compound-resume`).
 
 ## 단계별 시퀀스
 
@@ -97,7 +97,7 @@ OMC team 5섹션 (`Decided/Rejected/Risks/Files/Remaining`)과 정확히 동일 
 | `--wave` | `make graphify-update` 안내만 (자동 실행 X) |
 | `--phase` | `make graphify-refresh` 자동 실행 → fresh rebuild PR 생성 안내 |
 
-이후 다음 SessionStart hook이 `memory/sessions/`에서 가장 최근 1개 파일을 자동 inject.
+이후 다음 세션에서 사용자가 `/compound-resume` 명시 호출 시 `memory/sessions/`에서 가장 최근 1개 파일 read (자동 SessionStart inject 폐기 — 사용자 결정 2026-04-28, 매 세션 토큰 낭비 회피).
 
 ## 자동 vs 승인 정리
 

--- a/.claude/plugins/compound-mmp/skills/wrap-up-mmp/SKILL.md
+++ b/.claude/plugins/compound-mmp/skills/wrap-up-mmp/SKILL.md
@@ -181,11 +181,11 @@ session_date: 2026-MM-DD
 
 ## 종료 후
 
-다음 SessionStart hook이 `memory/sessions/`에서 가장 최근 1개 파일을 자동 inject (PR-6에서 구현).
+다음 세션에서 사용자가 `/compound-resume` 명시 호출 시 `memory/sessions/`에서 가장 최근 1개 파일 read. 자동 SessionStart inject 폐기 — 사용자 결정 2026-04-28 (매 세션 토큰 낭비 회피, 필요할 때만 명시 호출). 카논: `commands/compound-resume.md`, `templates/session-recall-template.md`.
 
 ## 검증 (PR-10 dogfooding)
 
-- Step 5-2 handoff 노트가 다음 세션 SessionStart에 정상 inject 되는지
+- Step 5-2 handoff 노트가 다음 세션 `/compound-resume` 호출 시 정상 read 되는지
 - Step 5-3 MEMORY.md drift 측정 (1주 누적)
 - Step 6-1 MISTAKES.md 사용자 승인율 (≥80% 권장 — 너무 낮으면 learning-extractor Q-gate 강화)
 

--- a/.claude/plugins/compound-mmp/templates/session-recall-template.md
+++ b/.claude/plugins/compound-mmp/templates/session-recall-template.md
@@ -1,39 +1,49 @@
-# Session Recall Template (메인 컨텍스트가 SessionStart에 inject)
+# Session Recall Template (`/compound-resume` 명시 호출 시 메인 컨텍스트 출력 형식)
 
-다음 세션 시작 시 SessionStart hook이 `memory/sessions/` 디렉토리에서 가장 최근 파일 1개를 read하고 다음 형식으로 컨텍스트에 주입한다.
+세션 도중 또는 시작 직후 사용자가 `/compound-resume` 호출 시, 메인 컨텍스트가 `memory/sessions/` 디렉토리에서 가장 최근 파일 1개를 read 후 다음 형식으로 정리해 출력한다.
 
-## 주입 형식 (≤30 lines)
+> **사용자 결정 2026-04-28**: SessionStart hook 자동 inject 폐기. 매 세션 토큰 낭비 회피 위해 명시 호출 패턴만 유지.
+
+## 출력 형식 (≤30 lines)
 
 ```
-[compound-mmp handoff] 마지막 세션: <YYYY-MM-DD> · <topic>
+[compound-mmp resume] 마지막 세션: <YYYY-MM-DD> · <topic>
 - Phase: <phase>
 - 결정: <decided 첫 2개 항목>
 - 미완료: <remaining 첫 2개 항목>
 - 다음 5초: <next_session_priorities 첫 1개>
 - 자세한 내용: memory/sessions/<YYYY-MM-DD>-<topic>.md
+
+[plan] <~/.claude/plans/<latest>.md 또는 docs/plans/<latest>/checklist.md>
+
+[카논 cheat-sheet]
+- 4단계: refs/lifecycle-stages.md
+- 7단계 wrap: refs/wrap-up-checklist.md
+- anti-patterns: refs/anti-patterns.md
+- 4-agent: refs/post-task-pipeline-bridge.md
 ```
 
 ## 트리거
 
-`hooks/session-start-context.sh` (PR-6에서 구현). 출력:
-
-```bash
-ls -t memory/sessions/*.md 2>/dev/null | head -1
+`commands/compound-resume.md` (slash command). 사용자 명시 호출:
+```
+/compound-resume
 ```
 
-으로 최신 파일 read 후 frontmatter parse → 위 형식으로 stdout JSON 반환.
+dispatch-router의 cycle 분류와 별개 — `cycle`은 dry-run dashboard 출력, `resume`은 read 위주.
 
 ## 사용자 override
 
-세션 시작 시 사용자가 "이전 컨텍스트 무시"라고 발화하면, 메인 컨텍스트는 inject된 내용을 무시. dispatch-router의 override 우선순위 (refs/auto-dispatch.md §Override 우선순위 참조)와 동일 패턴.
+`/compound-resume` 호출 후 사용자가 "이전 컨텍스트 무시"라고 발화하면, 메인 컨텍스트는 read한 내용을 무시. dispatch-router의 override 우선순위 (refs/auto-dispatch.md §Override 우선순위 참조)와 동일 패턴.
 
 ## 안티 패턴
 
-- ❌ 30 lines 초과 — SessionStart hook은 토큰 가벼워야 함
+- ❌ 30 lines 초과 — 출력은 토큰 가벼워야 함 (사용자가 깊게 read 원하면 명시 추가 발화)
 - ❌ raw frontmatter dump — 사람이 읽기 어렵고 토큰 낭비
-- ❌ 여러 세션 파일 동시 inject — 가장 최근 1개만
+- ❌ 여러 세션 파일 동시 read — 가장 최근 1개만
 - ❌ frontmatter에 sensitive 데이터 (예: secret, 사용자 개인정보) — 다음 세션에 무한 leak
+- ❌ 자동 SessionStart hook 부활 — 사용자 결정 2026-04-28 (anti-patterns.md 신규 후보)
 
 ## 검증
 
-PR-10 dogfooding 1주 동안 inject 정상도 측정 (사용자 발화에 "어제 뭐 했지?" 빈도 — 0건이면 inject 효과 입증).
+PR-10 dogfooding 1주 동안 `/compound-resume` 사용률 측정 (사용자 발화에 "어제 뭐 했지?" 빈도 — 0건이면 명시 호출 패턴 효과 입증).

--- a/memory/sessions/2026-04-28-compound-mmp-wave2-pr5.md
+++ b/memory/sessions/2026-04-28-compound-mmp-wave2-pr5.md
@@ -58,9 +58,9 @@ session_date: 2026-04-28
 
 ## Remaining
 
-### Wave 2 PR-6 (model guard + SessionStart inject)
-- **Done**: `pre-task-model-guard.sh` (Sonnet 4.5 차단), `session-start-context.sh` (5 컨텍스트 + memory/sessions/ 최신 1개 inject), `templates/session-recall-template.md` 활성, hooks.json PreToolUse(Task) + SessionStart 등록.
-- **Done**: bats 테스트 추가 (model-guard fixture + session-start fixture). CI matrix 동일.
+### Wave 2 PR-6 (model guard 단독 — SessionStart hook 폐기)
+- **Done**: `pre-task-model-guard.sh` (Sonnet 4.5 차단), hooks.json PreToolUse(Task) 등록, bats 테스트 fixture, CI matrix 동일.
+- **Note**: 사용자 결정 2026-04-28 — `session-start-context.sh` 자동 inject 폐기. 대신 `/compound-resume` 슬래시 커맨드가 PR `chore/compound-mmp/resume-slash-only` (#152)에서 별도 머지됨. PR-6 scope에서 SessionStart inject 작업 모두 제거.
 
 ### 즉시 hotfix
 - **enabledPlugins 등록** (`chore/compound-mmp-enable`): repo `.claude/settings.json`에 `compound-mmp@local: true` 추가 + 검증. PR-5 hook이 실 발화하는지 dogfooding 1회.
@@ -74,9 +74,9 @@ session_date: 2026-04-28
 ## Next Session Priorities
 
 1. **enabledPlugins hotfix 우선** — 1줄 변경, dogfooding 가능 환경 확보. PR-5의 hook이 실 발화하는지 검증 후 Wave 2 진행.
-2. **Wave 2 PR-6 진입** — `pre-task-model-guard.sh` + `session-start-context.sh`. 동일 단일 hook + run-hook 디스패치 패턴.
+2. **Wave 2 PR-6 진입** — `pre-task-model-guard.sh` 단독 (Sonnet 4.5 차단). 동일 단일 hook + run-hook 디스패치 패턴. SessionStart hook 작업 폐기 — `/compound-resume` 슬래시 커맨드가 #152에서 이미 카논화됨.
 3. **dogfooding 시작** — 다음 PR 작업 시 size hook 차단 1회 + TDD ask 1회 실 사용 후 임계값/예외 calibration.
-4. **TaskList #13 (이번 세션) 후속**: 다음 세션 SessionStart hook이 이 핸드오프 자동 inject (PR-6 후 동작). PR-6 머지 전까지는 수동 read.
+4. **다음 세션 진입 패턴**: 사용자가 `/compound-resume` 명시 호출 → 메인이 가장 최근 핸드오프 + plan + 카논 cheat-sheet read. 자동 SessionStart inject은 폐기 (낭비 회피, 사용자 결정 2026-04-28). 카논: `commands/compound-resume.md`, `templates/session-recall-template.md`.
 
 ## What we did
 


### PR DESCRIPTION
## Summary

사용자 결정 2026-04-28 — 자동 SessionStart inject가 단순 PR/한가한 세션에 매번 ~1-2K 토큰 낭비. 명시 호출 패턴(`/compound-resume`)만 유지.

- **NEW**: `commands/compound-resume.md` — 사용자 명시 호출 시 가장 최근 핸드오프 + plan 본문 + 카논 cheat-sheet 일괄 read
- **재정의**: `templates/session-recall-template.md` — slash command 출력 형식
- **anti-patterns #13**: SessionStart hook 자동 inject 부활 X (carve-out 없음)
- **hook 제거**: `run-hook.sh` `session-start)` case 제거 (4 case 유지: dispatch / pre-edit-size / pre-task-model / stop-wrap-reminder)
- **카논 7개 ref 갱신**: lifecycle/wrap-up-checklist/wrap-up SKILL/followup-suggester
- **핸드오프 갱신**: PR-5 wrap 노트의 Wave 2 PR-6 spec에서 `session-start-context.sh` 제거

## 검증

- 회귀: `size+TDD 38/38` + `dispatch 41/41` PASS (macOS bash 3.2 + Linux bash 5.x)
- `run-hook.sh session-start` → "Unknown event" 반환 (case 정확히 제거)

## Test plan

- [ ] 머지 후 다음 세션에서 `/compound-resume` 한 마디 호출 시 핸드오프·plan·카논 read 동작
- [ ] CI ci-hooks workflow green
- [ ] PR-6 spec에서 SessionStart 작업이 모두 제거되었는지 (memory/sessions/2026-04-28-compound-mmp-wave2-pr5.md § Wave 2 PR-6 확인)

## Out of scope (follow-up)

- `commands/compound-resume.md`의 동작은 메인 컨텍스트가 read하는 형식 정의. 실제 read 로직은 메인이 description 따라 수행 (별도 hook/script 불필요).
- enabledPlugins hotfix (PR-5 wrap에 명시) 여전히 P0 — 별도 hotfix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)