### PR TITLE
chore(compound-mmp): enable plugin via local ctm marketplace

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "ctm",
+  "owner": {
+    "name": "MMP v3"
+  },
+  "plugins": [
+    {
+      "name": "compound-mmp",
+      "source": "./compound-mmp",
+      "description": "MMP v3 Plan-Work-Review-Compound 4단계 라이프사이클 (Compound Engineering + Session-Wrap + Superpowers 통합)",
+      "version": "0.1.0-alpha"
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,15 @@
     ]
   },
   "enabledPlugins": {
-    "harness@harness-marketplace": true
+    "harness@harness-marketplace": true,
+    "compound-mmp@ctm": true
+  },
+  "extraKnownMarketplaces": {
+    "ctm": {
+      "source": {
+        "source": "directory",
+        "path": ".claude/plugins"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- 신규 `.claude/plugins/.claude-plugin/marketplace.json` (directory marketplace `ctm`, `compound-mmp` 1개 entry)
- `.claude/settings.json`: `extraKnownMarketplaces.ctm` + `enabledPlugins["compound-mmp@ctm"]`

핸드오프 P0 hotfix — Wave 2 dogfooding 시작 전 필수.
**증상**: 직전 세션에서 `/compound-resume` 호출 시 "Unknown command" 발생. 원인은 plugin 미등록.

활성화 후 발화:
- PR-5 hook: `pre-edit-size-check.sh` (size 한도), TDD soft ask (Go/React)
- Slash commands: `/compound-resume`, `/compound-wrap`
- Skills: `wrap-up-mmp`, `tdd-mmp-go`, `tdd-mmp-react`

## 4-agent 리뷰 결과

- **Security**: P0 0건 APPROVED. P1 1건(`dispatch-router.sh` `shopt -s nocasematch` 복원 누락 — 이 PR scope 외, follow-up).
- **Architecture**: P0 0건 APPROVED. marketplace `ctm` 명칭은 사용자 확정. directory source 패턴 확장 가능. P1: `MEMORY.md` 인덱스 갱신은 다음 wrap.
- **Test/CI**: P0 0건 APPROVED. ci-hooks.yml path filter 미트리거 (settings/marketplace JSON만 변경). 기존 status check 영향 없음.
- **Perf**: N/A (config-only, 코드 0줄).

## Test plan

- [ ] 머지 후 새 세션에서 `/compound-resume` 정상 인식 확인
- [ ] `cat .claude/settings.json | jq '.enabledPlugins'` 출력에 `"compound-mmp@ctm": true` 노출 확인
- [ ] PreToolUse hook 발화 — Edit으로 size 한도 초과 파일 작성 시도 → 차단 확인 (PR-5 fixture 재현)
- [ ] Wave 2 PR-6 작업 중 dogfooding 1회 이상

## Refs

- 핸드오프: `memory/sessions/2026-04-28-compound-mmp-resume-slash.md`
- 카논 plan: `~/.claude/plans/vivid-snuggling-pascal.md` § 사전 정비 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)