### PR TITLE
feat(compound-mmp): PR-6 PreToolUse(Task) Sonnet 4.5 차단 hook + bash 3.2/5.x CI matrix

### DIFF
--- a/.claude/plugins/compound-mmp/hooks/hooks.json
+++ b/.claude/plugins/compound-mmp/hooks/hooks.json
@@ -9,6 +9,15 @@
             "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" pre-edit-size"
           }
         ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" pre-task-model"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.claude/plugins/compound-mmp/hooks/pre-task-model-guard.sh
+++ b/.claude/plugins/compound-mmp/hooks/pre-task-model-guard.sh
@@ -36,17 +36,17 @@ command -v jq >/dev/null 2>&1 || exit 0
 input=$(cat)
 [ -z "$input" ] && exit 0
 
-# tool_name 게이트 (Task 만 검사)
-tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
-[ "$tool_name" != "Task" ] && exit 0
-
-# prompt + model 동시 추출 (jq 1회, @tsv)
-meta=$(printf '%s' "$input" | jq -r '[.tool_input.prompt // "", .tool_input.model // ""] | @tsv' 2>/dev/null || printf '\t')
+# 메타 추출 (jq 1회, @tsv) — tool_name + prompt + model 동시 (자매 pre-edit-size 패턴 대칭)
+meta=$(printf '%s' "$input" | jq -r '[.tool_name // "", .tool_input.prompt // "", .tool_input.model // ""] | @tsv' 2>/dev/null || printf '\t\t')
+tool_name=""
 prompt=""
 model=""
-IFS=$'\t' read -r prompt model <<EOF
+IFS=$'\t' read -r tool_name prompt model <<EOF
 $meta
 EOF
+
+# tool_name 게이트 (Task 만 검사)
+[ "$tool_name" != "Task" ] && exit 0
 
 # Sonnet 4.5 정규식 (bash 3.2 호환: 변수 unquoted RHS)
 # (claude-)?sonnet-4[-.]5 — sonnet-4-5 / sonnet-4.5 / claude-sonnet-4-5 / *-20250929 모두 catch

--- a/.claude/plugins/compound-mmp/hooks/pre-task-model-guard.sh
+++ b/.claude/plugins/compound-mmp/hooks/pre-task-model-guard.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# pre-task-model-guard.sh
+# PreToolUse(Task) hook — Sonnet 4.5 차단 + 4.6 안내.
+#
+# 카논:
+#   - Sonnet 4.6 기본: memory/feedback_sonnet_46_default.md
+#                     (서브에이전트 = sonnet-4-6, 검색 = haiku-4-5, 보안/아키텍처 = opus-4-7)
+#   - 검증 시뮬레이션 Case C: refs/sim-case-c.md
+#
+# 입력 (stdin JSON, Claude Code PreToolUse 표준 payload):
+#   {tool_name: "Task",
+#    tool_input: {prompt, subagent_type, model?, ...}}
+#
+# 출력 (stdout):
+#   - silent (tool_name != Task, 또는 4.5 미언급): exit 0, 빈 출력
+#   - deny: {hookSpecificOutput: {permissionDecision: "deny", ...}}
+#
+# 비차단 보장: jq 부재 / 비정상 stdin은 silent exit 0.
+# 긴급 비활성: COMPOUND_MMP_MODEL_GUARD_DISABLE=1 환경변수.
+#
+# 매칭 정책:
+#   - prompt 또는 tool_input.model 에 정규식 (claude-)?sonnet-4[-.]5 매칭 (case insensitive)
+#   - sonnet-4-5 / sonnet-4.5 / claude-sonnet-4-5-<date> 모두 catch
+#   - haiku-4-5 (검색 카논) 및 sonnet-4-6/opus-4-7 은 false positive 없음
+
+set -eu
+
+# 긴급 비활성 토글
+if [ "${COMPOUND_MMP_MODEL_GUARD_DISABLE:-}" = "1" ]; then
+  exit 0
+fi
+
+# jq 부재 시 silent (비차단)
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+[ -z "$input" ] && exit 0
+
+# tool_name 게이트 (Task 만 검사)
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+[ "$tool_name" != "Task" ] && exit 0
+
+# prompt + model 동시 추출 (jq 1회, @tsv)
+meta=$(printf '%s' "$input" | jq -r '[.tool_input.prompt // "", .tool_input.model // ""] | @tsv' 2>/dev/null || printf '\t')
+prompt=""
+model=""
+IFS=$'\t' read -r prompt model <<EOF
+$meta
+EOF
+
+# Sonnet 4.5 정규식 (bash 3.2 호환: 변수 unquoted RHS)
+# (claude-)?sonnet-4[-.]5 — sonnet-4-5 / sonnet-4.5 / claude-sonnet-4-5 / *-20250929 모두 catch
+# haiku-4-5 / sonnet-4-6 / opus-4-7 미매칭
+PATTERN='(claude-)?sonnet-4[-.]5'
+
+shopt -s nocasematch
+violation=""
+if [[ "$prompt" =~ $PATTERN ]]; then
+  violation="prompt"
+fi
+if [ -z "$violation" ] && [[ "$model" =~ $PATTERN ]]; then
+  violation="model"
+fi
+shopt -u nocasematch
+
+if [ -z "$violation" ]; then
+  exit 0
+fi
+
+# deny reason 작성 (4.6 안내 + 우회 토글 명시)
+if [ "$violation" = "prompt" ]; then
+  reason="Task prompt에 Sonnet 4.5 모델 참조가 포함되었습니다. 카논: Sonnet 4.6 (claude-sonnet-4-6) 사용 — memory/feedback_sonnet_46_default.md. 서브에이전트 spawn 시 model='claude-sonnet-4-6' 명시. 검색 전용은 haiku-4-5, 보안/아키텍처는 opus-4-7. 긴급 우회는 COMPOUND_MMP_MODEL_GUARD_DISABLE=1."
+else
+  reason="Task tool_input.model 이 Sonnet 4.5 ID 입니다. 카논: Sonnet 4.6 (claude-sonnet-4-6) 사용 — memory/feedback_sonnet_46_default.md. 검색 전용은 haiku-4-5, 보안/아키텍처는 opus-4-7. 긴급 우회는 COMPOUND_MMP_MODEL_GUARD_DISABLE=1."
+fi
+
+jq -nc \
+  --arg reason "$reason" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+
+exit 0

--- a/.claude/plugins/compound-mmp/hooks/test-pre-task-model.sh
+++ b/.claude/plugins/compound-mmp/hooks/test-pre-task-model.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# pre-task-model-guard.sh 테스트 fixture.
+# 카논: memory/feedback_sonnet_46_default.md (Sonnet 4.6 기본, 4.5 차단)
+#       refs/sim-case-c.md (검증 시뮬레이션 Case C)
+#
+# 시나리오:
+#   A. tool_name 게이트 (Task 만 검사, 나머지 silent)
+#   B. JSON 비정상 비차단 보장
+#   C. prompt sonnet-4-5 매칭 deny (변형 포함)
+#   D. tool_input.model 매칭 deny
+#   E. False positive 회피 (haiku-4-5, sonnet-4-6, "version 4.5" 등)
+#   F. COMPOUND_MMP_MODEL_GUARD_DISABLE=1 환경 토글
+
+set -eu
+
+HOOK="$(dirname "$0")/pre-task-model-guard.sh"
+VERBOSE="${1:-}"
+PASS=0
+FAIL=0
+
+assert_silent() {
+  local description="$1"
+  local input="$2"
+  local output
+  output=$(printf '%s' "$input" | bash "$HOOK" 2>/dev/null || true)
+  if [ -z "$output" ]; then
+    PASS=$((PASS+1))
+    if [ "$VERBOSE" = "verbose" ]; then
+      echo "PASS: $description"
+    fi
+  else
+    FAIL=$((FAIL+1))
+    echo "FAIL: $description"
+    echo "  expected: silent"
+    echo "  actual:   $output"
+  fi
+}
+
+assert_decision() {
+  local description="$1"
+  local input="$2"
+  local expected="$3"
+  local output
+  output=$(printf '%s' "$input" | bash "$HOOK" 2>/dev/null || true)
+  if [ -z "$output" ]; then
+    FAIL=$((FAIL+1))
+    echo "FAIL: $description"
+    echo "  expected: $expected"
+    echo "  actual:   silent"
+    return 0
+  fi
+  local actual
+  actual=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || echo "parse_error")
+  if [ "$actual" = "$expected" ]; then
+    PASS=$((PASS+1))
+    if [ "$VERBOSE" = "verbose" ]; then
+      echo "PASS: $description"
+    fi
+  else
+    FAIL=$((FAIL+1))
+    echo "FAIL: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    echo "  output:   $output"
+  fi
+}
+
+# === A. tool_name 게이트 (Task 만 검사) ===
+assert_silent "tool_name=Read는 통과 (sonnet-4-5 prompt 무관)" \
+  '{"tool_name": "Read", "tool_input": {"file_path": "/tmp/x.go", "prompt": "use sonnet-4-5"}}'
+
+assert_silent "tool_name=Edit는 통과" \
+  '{"tool_name": "Edit", "tool_input": {"new_string": "claude-sonnet-4-5"}}'
+
+assert_silent "tool_name=Bash는 통과" \
+  '{"tool_name": "Bash", "tool_input": {"command": "echo claude-sonnet-4-5"}}'
+
+assert_silent "tool_name=Task + 깨끗한 prompt는 통과" \
+  '{"tool_name": "Task", "tool_input": {"prompt": "explore the repo and report findings"}}'
+
+# === B. JSON 비정상 비차단 보장 ===
+assert_silent "빈 stdin은 비차단" ""
+assert_silent "tool_name 누락" '{"tool_input": {"prompt": "sonnet-4-5"}}'
+assert_silent "tool_input 누락 (Task)" '{"tool_name": "Task"}'
+assert_silent "tool_input.prompt 누락 (Task)" '{"tool_name": "Task", "tool_input": {"subagent_type": "general-purpose"}}'
+
+# === C. prompt sonnet-4-5 매칭 deny ===
+assert_decision "prompt 'claude-sonnet-4-5' deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"please use claude-sonnet-4-5 model"}}' \
+  "deny"
+
+assert_decision "prompt 'sonnet-4-5' deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"spawn agent with sonnet-4-5"}}' \
+  "deny"
+
+assert_decision "prompt 'Sonnet-4-5' (case 변형) deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"Sonnet-4-5 should be used"}}' \
+  "deny"
+
+assert_decision "prompt 'SONNET-4-5' (전 대문자) deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"USE SONNET-4-5 NOW"}}' \
+  "deny"
+
+assert_decision "prompt 'claude-sonnet-4-5-20250929' (full date ID) deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"model: claude-sonnet-4-5-20250929"}}' \
+  "deny"
+
+assert_decision "prompt 'sonnet-4.5' (dot 표기) deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"upgrade to sonnet-4.5"}}' \
+  "deny"
+
+# === D. tool_input.model 매칭 deny ===
+assert_decision "model='claude-sonnet-4-5' deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"clean prompt","model":"claude-sonnet-4-5"}}' \
+  "deny"
+
+assert_decision "model='claude-sonnet-4-5-20250929' deny" \
+  '{"tool_name":"Task","tool_input":{"prompt":"clean prompt","model":"claude-sonnet-4-5-20250929"}}' \
+  "deny"
+
+# === E. False positive 회피 ===
+assert_silent "prompt 'haiku-4-5' 통과 (Haiku 4.5 검색 카논)" \
+  '{"tool_name":"Task","tool_input":{"prompt":"use haiku-4-5 for quick search"}}'
+
+assert_silent "prompt 'sonnet-4-6' 통과 (4.6 카논)" \
+  '{"tool_name":"Task","tool_input":{"prompt":"please spawn claude-sonnet-4-6"}}'
+
+assert_silent "prompt 'opus-4-7' 통과 (Opus 4.7)" \
+  '{"tool_name":"Task","tool_input":{"prompt":"use claude-opus-4-7 for security"}}'
+
+assert_silent "prompt 'version 4.5 of unrelated thing' 통과 (sonnet 미언급)" \
+  '{"tool_name":"Task","tool_input":{"prompt":"version 4.5 of postgres has new features"}}'
+
+assert_silent "prompt 단순 'sonnet' 통과 (버전 명시 없음)" \
+  '{"tool_name":"Task","tool_input":{"prompt":"use sonnet model"}}'
+
+assert_silent "model='claude-haiku-4-5' 통과" \
+  '{"tool_name":"Task","tool_input":{"prompt":"clean","model":"claude-haiku-4-5"}}'
+
+assert_silent "model='claude-sonnet-4-6' 통과" \
+  '{"tool_name":"Task","tool_input":{"prompt":"clean","model":"claude-sonnet-4-6"}}'
+
+# === F. ENV 환경 토글 (긴급 비활성) ===
+violation_input='{"tool_name":"Task","tool_input":{"prompt":"use claude-sonnet-4-5"}}'
+disable_output=$(printf '%s' "$violation_input" | COMPOUND_MMP_MODEL_GUARD_DISABLE=1 bash "$HOOK" 2>/dev/null || true)
+if [ -z "$disable_output" ]; then
+  PASS=$((PASS+1))
+  if [ "$VERBOSE" = "verbose" ]; then
+    echo "PASS: COMPOUND_MMP_MODEL_GUARD_DISABLE=1 비활성화"
+  fi
+else
+  FAIL=$((FAIL+1))
+  echo "FAIL: COMPOUND_MMP_MODEL_GUARD_DISABLE=1 비활성화"
+  echo "  expected: silent"
+  echo "  actual:   $disable_output"
+fi
+
+# === G. deny reason 메시지 검증 (4.6 안내 + 우회 토글 명시) ===
+deny_input='{"tool_name":"Task","tool_input":{"prompt":"use claude-sonnet-4-5"}}'
+deny_output=$(printf '%s' "$deny_input" | bash "$HOOK" 2>/dev/null || true)
+deny_reason=$(printf '%s' "$deny_output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || echo "")
+if printf '%s' "$deny_reason" | grep -q "4.6\|4-6" && printf '%s' "$deny_reason" | grep -q "COMPOUND_MMP_MODEL_GUARD_DISABLE"; then
+  PASS=$((PASS+1))
+  if [ "$VERBOSE" = "verbose" ]; then
+    echo "PASS: deny reason 메시지 형식"
+  fi
+else
+  FAIL=$((FAIL+1))
+  echo "FAIL: deny reason 메시지 형식 (4.6 안내 + 우회 토글 누락)"
+  echo "  reason: $deny_reason"
+fi
+
+# === Summary ===
+echo
+echo "=========================================="
+TOTAL=$((PASS+FAIL))
+if [ "$FAIL" -gt 0 ]; then
+  RATE=$((PASS*100/TOTAL))
+  echo "Pass: $PASS, Fail: $FAIL (${RATE}% fixture pass rate) — review failing cases"
+  exit 1
+else
+  echo "Pass: $PASS, Fail: $FAIL (100% fixture pass rate, $PASS/$TOTAL cases)"
+  exit 0
+fi

--- a/.github/workflows/ci-hooks.yml
+++ b/.github/workflows/ci-hooks.yml
@@ -43,6 +43,8 @@ jobs:
         run: bash .claude/plugins/compound-mmp/hooks/test-dispatch.sh
       - name: pre-edit-size self-tests
         run: bash .claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
+      - name: pre-task-model self-tests
+        run: bash .claude/plugins/compound-mmp/hooks/test-pre-task-model.sh
 
   hook-tests-macos:
     name: hook self-tests (macOS, bash 3.2)
@@ -57,3 +59,5 @@ jobs:
         run: /bin/bash .claude/plugins/compound-mmp/hooks/test-dispatch.sh
       - name: pre-edit-size self-tests (system bash 3.2)
         run: /bin/bash .claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
+      - name: pre-task-model self-tests (system bash 3.2)
+        run: /bin/bash .claude/plugins/compound-mmp/hooks/test-pre-task-model.sh


### PR DESCRIPTION
## Summary

- **`pre-task-model-guard.sh`** — PreToolUse(Task) hook. `tool_input.prompt` 또는 `.model` 에 `(claude-)?sonnet-4[-.]5` 매칭 시 `deny` + Sonnet 4.6 / Haiku 4.5 / Opus 4.7 카논 안내 메시지 출력. 4.6 카논(`memory/feedback_sonnet_46_default.md`) 강제.
- **25 케이스 self-test** (`test-pre-task-model.sh`) — bash 3.2.57 (macOS system) + bash 5.3.9 (Linux) 양쪽 100% pass. tool_name 게이트 / JSON 비정상 / prompt deny 변형 6 / model 매칭 / false positive 회피 6 (haiku-4-5, sonnet-4-6, opus-4-7, "version 4.5 of postgres") / env disable / reason 형식.
- **CI matrix 추가** (`ci-hooks.yml`) — ubuntu (bash 5.x) + macOS (bash 3.2) 각각에 `pre-task-model self-tests` step. shellcheck loop는 `*.sh` glob이라 자동 커버.

## 카논 매핑

| 영역 | 카논 |
|------|------|
| 4.6 정책 | `memory/feedback_sonnet_46_default.md` (서브에이전트 4.6, 검색 haiku-4-5, 보안 opus-4-7) |
| Plan spec | `~/.claude/plans/vivid-snuggling-pascal.md` § Wave 2 PR-6 / Appendix C |
| 디스패처 | `hooks/run-hook.sh` `pre-task-model)` case (이미 ready) |
| 검증 시뮬레이션 | Case C (sim doc 자체는 PR-10 dogfooding scope) |

## 매칭 정책 (정규식)

```
PATTERN='(claude-)?sonnet-4[-.]5'   # case insensitive
```

매치: `sonnet-4-5`, `sonnet-4.5`, `claude-sonnet-4-5`, `claude-sonnet-4-5-20250929`, `Sonnet-4-5`, `SONNET-4-5`
미매치: `haiku-4-5`, `sonnet-4-6`, `claude-opus-4-7`, `version 4.5 of postgres`, plain `sonnet`

## 비차단 보장

- `jq` 부재 → silent exit 0
- 빈 stdin / 비정상 JSON → silent exit 0
- `tool_name != "Task"` → silent exit 0
- `COMPOUND_MMP_MODEL_GUARD_DISABLE=1` → silent exit 0 (긴급 우회 토글, pre-edit-size 패턴 일치)

## Test plan

- [x] bash 5.3.9 로컬 25/25 pass
- [x] bash 3.2.57 (macOS `/bin/bash`) 로컬 25/25 pass
- [ ] CI ubuntu (bash 5.x) `test-pre-task-model.sh` pass
- [ ] CI macOS (bash 3.2) `test-pre-task-model.sh` pass
- [ ] CI shellcheck (기존 glob loop) `pre-task-model-guard.sh` + `test-pre-task-model.sh` 0 issues

## Out of scope

- `refs/sim-case-c.md` 시뮬레이션 문서 작성 → PR-10 dogfooding scope (plan §"검증 절차 3개 시뮬레이션 케이스")
- `dispatch-router.sh` `shopt -u nocasematch` 복원 carry-over P1 → 별도 small PR
- `memory/MEMORY.md` `ctm` marketplace 인덱스 추가 carry-over P1 → 다음 wrap

## 근거 (anti-patterns)

- ❌ TDD 강제 삭제 (Superpowers 스타일) — soft ask 정책 유지 (`refs/tdd-enforcement.md`). 이 PR은 model 차단으로 4.6 정책 강제만 수행.
- ❌ 4-agent 리뷰 스킵 후 admin-merge — PR-2c (#107) 사고 재발 방지 (`memory/feedback_4agent_review_before_admin_merge.md`). 이 PR은 admin-merge 전 4-agent 병렬 리뷰 수행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)