### PR TITLE
feat(compound-mmp): PR-7 /compound-review + 4-agent parallel review bridge

### DIFF
--- a/.claude/plugins/compound-mmp/commands/compound-review.md
+++ b/.claude/plugins/compound-mmp/commands/compound-review.md
@@ -1,0 +1,115 @@
+---
+description: PR diff에 대해 4-agent 병렬 리뷰 (security/perf/arch/test) 실행. post-task-pipeline.json `after_pr.review-*` 카논을 읽어 한 메시지에서 Task tool 동시 spawn. HIGH 발견 시 사용자 결정 대기 (자동 fix-loop 금지). PR-2c #107 사고 이후 4-agent 강제 정책의 슬래시 진입점.
+allowed-tools: Bash, Read, Write, Task, Glob
+argument-hint: "<pr-id> [--dry-run]   예: /compound-review PR-7"
+---
+
+# /compound-review
+
+PR 머지 직전(또는 admin-merge 직후) 4-agent 병렬 리뷰를 한 메시지에서 spawn해 종합 결과를 `docs/plans/<phase>/refs/reviews/<pr-id>.md`로 영구화.
+
+> **카논 single source**: `refs/post-task-pipeline-bridge.md` (4-agent 매핑 + P0–P3 라우팅) + `.claude/post-task-pipeline.json` `after_pr.review-*` (prompt template).
+
+## 인자
+
+- `<pr-id>` (필수) — `^PR-[0-9]+[a-z]?$` 정규식 매칭. 화이트리스트 외 거부 (helper exit 2).
+- `--dry-run` (선택) — Task spawn 없이 4-agent payload(JSON array)만 stdout으로 출력. sim-case-a C-2 검증 모드.
+
+## 실행 시퀀스 (메인 컨텍스트)
+
+### 1. 활성 phase 검출 + design.md 경로 결정
+
+```bash
+ACTIVE_PHASE=$(ls -td docs/plans/*/ 2>/dev/null | head -1 | sed 's:/$::')
+DESIGN_PATH="${ACTIVE_PHASE}/design.md"
+[ -f "$DESIGN_PATH" ] || DESIGN_PATH="apps/server/CLAUDE.md"
+```
+
+design.md 부재 시 `apps/server/CLAUDE.md`(아키텍처 카논) fallback. 사용자가 명시 인자로 override 가능 (PR-9 추후).
+
+### 2. PR 메타 추출 (선택)
+
+```bash
+PR_TITLE=$(gh pr view "$ARG_PR_NUM" --json title -q .title 2>/dev/null || echo "")
+```
+
+`gh` CLI 부재 또는 인증 미설정 시 빈 문자열 fallback. 토큰 치환은 **jq `--arg`**가 보장하므로 PR_TITLE 내용이 어떤 문자라도 안전 (helper 카논).
+
+### 3. dry-run helper 호출 → 4-agent payload
+
+```bash
+DESIGN_PATH="$DESIGN_PATH" PR_TITLE="$PR_TITLE" \
+  bash .claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh "$PR_ID"
+```
+
+stdout: `[{"subagent_type":"...","model":"...","prompt":"..."}, ...]` (jq parsable, length == 4).
+
+`--dry-run` 모드에서는 여기서 종료. 정상 모드는 다음 단계.
+
+### 4. 한 메시지에서 4 Task tool 동시 spawn
+
+`superpowers:dispatching-parallel-agents` 스킬 패턴 준수. 단일 assistant message-block에 4개 Task 호출:
+
+```
+Task(subagent_type="oh-my-claudecode:security-reviewer", model="opus", prompt="<helper.payload[0].prompt>")
+Task(subagent_type="oh-my-claudecode:code-reviewer",     model="sonnet", prompt="<helper.payload[1].prompt>")
+Task(subagent_type="oh-my-claudecode:critic",            model="opus", prompt="<helper.payload[2].prompt>")
+Task(subagent_type="oh-my-claudecode:test-engineer",     model="sonnet", prompt="<helper.payload[3].prompt>")
+```
+
+> agent name 카논: `critic` (NOT `architect`). 모델 카논: opus = `claude-opus-4-7`, sonnet = `claude-sonnet-4-6` (sonnet-4-5 절대 금지 — `pre-task-model-guard.sh`가 차단).
+
+### 5. 결과 종합 → reviews/<pr-id>.md
+
+`templates/review-result-template.md` 형식 따름:
+
+- 영역별 (security/perf/arch/test) 발견 사항 + 심각도 분류 (P0–P3, `refs/post-task-pipeline-bridge.md`)
+- HIGH 통합 카운트
+- 권고 액션 (사용자 결정 후보)
+
+저장 경로: `${ACTIVE_PHASE}/refs/reviews/${PR_ID}.md` (디렉토리 부재 시 `mkdir -p`).
+
+### 6. HIGH 발견 시 사용자 결정 대기
+
+자동 fix-loop **금지** (PR-2c #107 사고 후 정책, `refs/post-task-pipeline-bridge.md` § "자동 fix-loop 금지"). 메인은 다음 한 줄을 사용자에게 표시:
+
+```
+HIGH N건 발견. 다음 중 선택: (a) 즉시 수정 — `/compound-work {pr-id}`, (b) 다음 PR 이월, (c) 무시 (이유 명시)
+```
+
+## 사용 예
+
+```
+# 정상 4-agent 리뷰
+/compound-review PR-7
+
+# dry-run (CI/sim-case-a 검증)
+/compound-review PR-7 --dry-run | jq 'length == 4'   # → true
+
+# sim-case-a 회귀 검증 (PR-10 진입 시)
+/compound-review PR-2c-sim          # ← FAIL: alphabetic id 거부됨, sim 전용 흐름은 PR-10에서 별도 정의
+```
+
+## 디스패처 트리거
+
+`hooks/dispatch-router.sh`가 다음 사용자 발화에서 `/compound-review` 추천 (stage=review):
+
+- "리뷰 해줘" / "코드 리뷰" / "머지 전 확인" / "병합 전 체크"
+- "review this PR" / "pre-merge review" / "audit this"
+
+## 안티 패턴 (절대 금지)
+
+- ❌ slash command 본문에서 `bash -c "$template"` 형태로 prompt 합성 — RCE 위험. **반드시 `compound-review-dry-run.sh` helper 경유** (jq `--arg` 강제).
+- ❌ PR_TITLE을 직접 prompt 문자열에 보간 (`prompt="...${PR_TITLE}..."`) — helper만 사용.
+- ❌ HIGH 발견 시 자동 `/compound-work` 호출 — manual gate 강제 (PR-2c 교훈).
+- ❌ Task tool을 4개보다 적게 spawn (예: critic 생략) — 4-agent 카논 위반 (`feedback_4agent_review_before_admin_merge.md`).
+- ❌ 4 Task를 별도 assistant message로 분산 spawn — 한 메시지 동시 spawn이 카논 (parallel_group="review", `superpowers:dispatching-parallel-agents`).
+
+## 카논 ref
+
+- `refs/post-task-pipeline-bridge.md` (4-agent 매핑, P0–P3 라우팅, 토큰 sanitize)
+- `refs/sim-case-a.md` (PR-2c deadlock 재현 검증, dry-run C-2 계약)
+- `templates/review-result-template.md` (결과 종합 형식)
+- `scripts/compound-review-dry-run.sh` (helper, 24/24 self-test)
+- `.claude/post-task-pipeline.json` `after_pr` (prompt template canonical)
+- `memory/feedback_4agent_review_before_admin_merge.md` (강제 정책 근거 — PR-2c #107 hotfix #108)

--- a/.claude/plugins/compound-mmp/commands/compound-review.md
+++ b/.claude/plugins/compound-mmp/commands/compound-review.md
@@ -42,22 +42,49 @@ DESIGN_PATH="$DESIGN_PATH" PR_TITLE="$PR_TITLE" \
   bash .claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh "$PR_ID"
 ```
 
-stdout: `[{"subagent_type":"...","model":"...","prompt":"..."}, ...]` (jq parsable, length == 4).
+stdout: `[{"subagent_type":"...","model":"...","prompt":"..."}, ...]` (jq parsable, **dynamic length** = `pipeline.json`의 `parallel_group="review"` entry 수).
 
 `--dry-run` 모드에서는 여기서 종료. 정상 모드는 다음 단계.
 
-### 4. 한 메시지에서 4 Task tool 동시 spawn
+### 4. 한 메시지에서 N Task tool 동시 spawn (단일 source: helper.payload)
 
-`superpowers:dispatching-parallel-agents` 스킬 패턴 준수. 단일 assistant message-block에 4개 Task 호출:
+`superpowers:dispatching-parallel-agents` 스킬 패턴 준수. **helper payload를 그대로 iterate** — 본문에 agent 이름/개수 하드코딩 금지(HIGH-A1 카논). 단일 assistant message-block에 helper payload[]의 각 entry당 1개 Task 호출:
 
 ```
-Task(subagent_type="oh-my-claudecode:security-reviewer", model="opus", prompt="<helper.payload[0].prompt>")
-Task(subagent_type="oh-my-claudecode:code-reviewer",     model="sonnet", prompt="<helper.payload[1].prompt>")
-Task(subagent_type="oh-my-claudecode:critic",            model="opus", prompt="<helper.payload[2].prompt>")
-Task(subagent_type="oh-my-claudecode:test-engineer",     model="sonnet", prompt="<helper.payload[3].prompt>")
+# 의사코드 — 메인 컨텍스트가 helper payload를 받아 그대로 매핑
+for entry in helper.payload[]:
+    Task(subagent_type=$(map_subagent entry.subagent_type),
+         model=entry.model,
+         prompt=$(contextualize entry.prompt))
 ```
 
-> agent name 카논: `critic` (NOT `architect`). 모델 카논: opus = `claude-opus-4-7`, sonnet = `claude-sonnet-4-6` (sonnet-4-5 절대 금지 — `pre-task-model-guard.sh`가 차단).
+5번째 reviewer가 `pipeline.json`에 추가되어도 본문 수정 불필요 (helper의 length 변화에 자동 적응).
+
+#### 4.1 OMC fallback 매핑 (HIGH-A2 카논)
+
+`oh-my-claudecode:*` agent는 user-home `~/.claude/plugins/`에 위치해 본 repo가 알 수 없다. 메인 컨텍스트는 spawn 시 OMC 가용성을 확인하고 미설치 시 다음 fallback 적용:
+
+| OMC subagent_type (helper 출력) | Fallback subagent_type | model 유지 | 근거 |
+|--------------------------------|------------------------|------------|------|
+| `oh-my-claudecode:security-reviewer` | `general-purpose` | opus | 단일 메시지 4 spawn 호환 |
+| `oh-my-claudecode:code-reviewer` | `general-purpose` | sonnet | perf 분석 일반 |
+| `oh-my-claudecode:critic` | `superpowers:code-reviewer` | opus | adversarial 카논 가장 가까움 |
+| `oh-my-claudecode:test-engineer` | `general-purpose` | sonnet | 테스트 갭 분석 |
+
+OMC 가용성 확인 (메인 컨텍스트 책임):
+```bash
+ls ~/.claude/plugins/oh-my-claudecode 2>/dev/null && OMC_AVAILABLE=1 || OMC_AVAILABLE=0
+```
+
+OMC 가용 시 helper 출력을 그대로 사용. 미가용 시 위 fallback 매핑 적용. **prompt 내용은 동일** (helper가 generic하게 작성).
+
+#### 4.2 프롬프트 컨텍스트화 (필수)
+
+helper의 prompt template은 generic하므로 메인이 PR 컨텍스트(diff 위치, 변경 파일 목록, design ref 경로)를 추가 보강해 spawn. raw template 그대로 spawn 금지 (subagent가 PR diff를 못 봄).
+
+#### 4.3 모델 카논
+
+opus = `claude-opus-4-7`, sonnet = `claude-sonnet-4-6` (sonnet-4-5 절대 금지 — `pre-task-model-guard.sh`가 차단). agent name 카논: `critic` (NOT `architect`, refs/post-task-pipeline-bridge.md § 정정).
 
 ### 5. 결과 종합 → reviews/<pr-id>.md
 
@@ -92,18 +119,22 @@ HIGH N건 발견. 다음 중 선택: (a) 즉시 수정 — `/compound-work {pr-i
 
 ## 디스패처 트리거
 
-`hooks/dispatch-router.sh`가 다음 사용자 발화에서 `/compound-review` 추천 (stage=review):
+`hooks/dispatch-router.sh`가 다음 사용자 발화에서 `/compound-review` 추천 (stage=review). **이 목록은 `test-dispatch.sh` fixture로 검증** — doc-vs-behavior 100% align (HIGH-A3 카논):
 
 - "리뷰 해줘" / "코드 리뷰" / "머지 전 확인" / "병합 전 체크"
-- "review this PR" / "pre-merge review" / "audit this"
+- "review this PR" / "pre-merge review"
+
+> "audit this" 등 일반 영문 단어는 false positive 위험("audit log 추가" → review 오라우팅) 때문에 의도적으로 제외.
 
 ## 안티 패턴 (절대 금지)
 
 - ❌ slash command 본문에서 `bash -c "$template"` 형태로 prompt 합성 — RCE 위험. **반드시 `compound-review-dry-run.sh` helper 경유** (jq `--arg` 강제).
 - ❌ PR_TITLE을 직접 prompt 문자열에 보간 (`prompt="...${PR_TITLE}..."`) — helper만 사용.
-- ❌ HIGH 발견 시 자동 `/compound-work` 호출 — manual gate 강제 (PR-2c 교훈).
-- ❌ Task tool을 4개보다 적게 spawn (예: critic 생략) — 4-agent 카논 위반 (`feedback_4agent_review_before_admin_merge.md`).
-- ❌ 4 Task를 별도 assistant message로 분산 spawn — 한 메시지 동시 spawn이 카논 (parallel_group="review", `superpowers:dispatching-parallel-agents`).
+- ❌ HIGH 발견 시 자동 `/compound-work` 호출 — manual gate 강제 (PR-2c 교훈, refs/anti-patterns.md #7).
+- ❌ helper payload 길이보다 적게/많게 Task spawn — 단일 source 위반. helper의 length가 카논 (HIGH-A1).
+- ❌ 슬래시 본문에 4개 (또는 N개) agent 이름 하드코딩 — pipeline.json mutation 시 silent break (HIGH-A1). **iterate over helper.payload[]만 사용**.
+- ❌ Task를 별도 assistant message로 분산 spawn — 한 메시지 동시 spawn이 카논 (parallel_group="review", `superpowers:dispatching-parallel-agents`).
+- ❌ OMC 가용성 미확인 spawn — `oh-my-claudecode:*`은 user-home 의존. 미설치 시 § 4.1 fallback 매핑 필수 (HIGH-A2).
 
 ## 카논 ref
 

--- a/.claude/plugins/compound-mmp/hooks/test-compound-review-dry-run.sh
+++ b/.claude/plugins/compound-mmp/hooks/test-compound-review-dry-run.sh
@@ -131,9 +131,25 @@ run_test "PR_TITLE shell injection 시도 — literal 보존, 명령 실행 안�
   "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='\$(whoami)' bash '$DRY_RUN' PR-7" \
   "0" "jq -e 'any(.[]; .prompt | contains(\"\$(whoami)\"))' >/dev/null"
 
-run_test "PR_TITLE injection — whoami output 누설 없음" \
-  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='\$(whoami)' bash '$DRY_RUN' PR-7" \
-  "0" "jq -e 'all(.[]; .prompt | contains(\"sabyun\") | not)' >/dev/null"
+# HIGH-T1: 이전 case 21 ("whoami output 누설 없음")은 \$LOGNAME 하드코딩으로 CI runner에서 false PASS.
+# 위 case 20이 이미 literal preservation 검증 — injection 실행 시 `\$(whoami)` literal이 사라지고 username만 남으므로 case 20 자체가 충분 강한 검증.
+
+# MED-T1: {pr_title}/{design} 토큰 치환도 명시 검증 (이전엔 {pr_id}만 검증 — gsub 라인 삭제 silent)
+run_test "{pr_title} 토큰 치환됨" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='unique-title-xyz' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'any(.[]; .prompt | contains(\"unique-title-xyz\"))' >/dev/null"
+
+run_test "치환된 prompt에 raw {pr_title} placeholder 없음" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='unique-title-xyz' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'all(.[]; .prompt | test(\"\\\\{pr_title\\\\}\") | not)' >/dev/null"
+
+run_test "{design} 토큰 치환됨 (TMP_DESIGN 경로 포함)" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'any(.[]; .prompt | contains(\"$TMP_DESIGN\"))' >/dev/null"
+
+run_test "치환된 prompt에 raw {design} placeholder 없음" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'all(.[]; .prompt | test(\"\\\\{design\\\\}\") | not)' >/dev/null"
 
 # === 환경 변수 검증 ===
 run_test "DESIGN_PATH 미설정 시 거부 (환경 누락)" \

--- a/.claude/plugins/compound-mmp/hooks/test-compound-review-dry-run.sh
+++ b/.claude/plugins/compound-mmp/hooks/test-compound-review-dry-run.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# compound-review-dry-run.sh 테스트 fixture.
+# 카논: refs/post-task-pipeline-bridge.md + refs/sim-case-a.md "한 메시지 4 Task spawn" 검증
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DRY_RUN="${SCRIPT_DIR}/scripts/compound-review-dry-run.sh"
+PIPELINE="${SCRIPT_DIR}/../../post-task-pipeline.json"
+
+PASS=0
+FAIL=0
+VERBOSE="${1:-}"
+
+# 임시 design.md (실제 phase 디렉토리에 의존하지 않게 격리)
+TMP_DESIGN=$(mktemp)
+echo "# fixture design" > "$TMP_DESIGN"
+trap 'rm -f "$TMP_DESIGN"' EXIT
+
+run_test() {
+  local description="$1"
+  local cmd="$2"
+  local expected_exit="$3"
+  local stdout_predicate="$4"
+
+  local actual_stdout actual_exit
+  actual_stdout=$(eval "$cmd" 2>/dev/null) && actual_exit=0 || actual_exit=$?
+
+  local pass=1
+  if [ "$actual_exit" != "$expected_exit" ]; then pass=0; fi
+  if [ -n "$stdout_predicate" ] && ! eval "$stdout_predicate" <<<"$actual_stdout" >/dev/null 2>&1; then
+    pass=0
+  fi
+
+  if [ $pass -eq 1 ]; then
+    PASS=$((PASS+1))
+    [ "$VERBOSE" = "verbose" ] && echo "PASS: $description"
+  else
+    FAIL=$((FAIL+1))
+    echo "FAIL: $description"
+    echo "  cmd:       $cmd"
+    echo "  exp exit:  $expected_exit, actual: $actual_exit"
+    echo "  predicate: $stdout_predicate"
+    echo "  stdout:    $actual_stdout"
+  fi
+  return 0
+}
+
+# === 입력 검증 (화이트리스트) ===
+run_test "pr-id 누락 시 거부" \
+  "bash '$DRY_RUN'" \
+  "2" ""
+
+run_test "pr-id 빈 문자열 거부" \
+  "bash '$DRY_RUN' ''" \
+  "2" ""
+
+run_test "pr-id 잘못된 형식 거부 (영숫자만)" \
+  "bash '$DRY_RUN' 'foo bar'" \
+  "2" ""
+
+run_test "pr-id shell injection 시도 거부" \
+  "bash '$DRY_RUN' 'PR-1; rm -rf /'" \
+  "2" ""
+
+run_test "pr-id 특수문자 거부" \
+  "bash '$DRY_RUN' 'PR-1\$(whoami)'" \
+  "2" ""
+
+# === 정상 입력 (post-task-pipeline.json 기반) ===
+run_test "유효한 pr-id PR-123 → exit 0" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test pr' bash '$DRY_RUN' PR-123" \
+  "0" ""
+
+run_test "유효한 pr-id PR-2c → exit 0" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test pr' bash '$DRY_RUN' PR-2c" \
+  "0" ""
+
+run_test "sim-case-a 같은 alphabetic id 거부 (정규식 ^PR-N+L?\$)" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' sim-case-a" \
+  "2" ""
+
+# === JSON 출력 형식 (sim-case-a C-2 계약) ===
+run_test "출력은 JSON array — jq parsable" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'type == \"array\"' >/dev/null"
+
+run_test "출력 array length == 4" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'length == 4' >/dev/null"
+
+run_test "각 element에 subagent_type 필드 존재" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'all(.[]; has(\"subagent_type\"))' >/dev/null"
+
+run_test "각 element에 model 필드 존재" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'all(.[]; has(\"model\"))' >/dev/null"
+
+run_test "각 element에 prompt 필드 존재" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'all(.[]; has(\"prompt\"))' >/dev/null"
+
+# === 4-agent 카논 매핑 (post-task-pipeline-bridge.md) ===
+run_test "security-reviewer agent 포함 (opus)" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'any(.[]; .subagent_type == \"oh-my-claudecode:security-reviewer\" and .model == \"opus\")' >/dev/null"
+
+run_test "code-reviewer agent 포함 (sonnet — perf)" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'any(.[]; .subagent_type == \"oh-my-claudecode:code-reviewer\" and .model == \"sonnet\")' >/dev/null"
+
+run_test "critic agent 포함 (opus — arch, NOT architect)" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'any(.[]; .subagent_type == \"oh-my-claudecode:critic\" and .model == \"opus\")' >/dev/null"
+
+run_test "test-engineer agent 포함 (sonnet)" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'any(.[]; .subagent_type == \"oh-my-claudecode:test-engineer\" and .model == \"sonnet\")' >/dev/null"
+
+# === 토큰 치환 (shell injection 차단 검증) ===
+run_test "{pr_id} 토큰 치환됨" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-42" \
+  "0" "jq -e 'all(.[]; .prompt | contains(\"PR-42\"))' >/dev/null"
+
+run_test "치환된 prompt에 raw {pr_id} placeholder 없음" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-42" \
+  "0" "jq -e 'all(.[]; .prompt | test(\"\\\\{pr_id\\\\}\") | not)' >/dev/null"
+
+run_test "PR_TITLE shell injection 시도 — literal 보존, 명령 실행 안됨" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='\$(whoami)' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'any(.[]; .prompt | contains(\"\$(whoami)\"))' >/dev/null"
+
+run_test "PR_TITLE injection — whoami output 누설 없음" \
+  "DESIGN_PATH='$TMP_DESIGN' PR_TITLE='\$(whoami)' bash '$DRY_RUN' PR-7" \
+  "0" "jq -e 'all(.[]; .prompt | contains(\"sabyun\") | not)' >/dev/null"
+
+# === 환경 변수 검증 ===
+run_test "DESIGN_PATH 미설정 시 거부 (환경 누락)" \
+  "PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "3" ""
+
+run_test "DESIGN_PATH 존재하지 않는 파일이면 거부" \
+  "DESIGN_PATH='/tmp/does-not-exist-$$.md' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "3" ""
+
+# === post-task-pipeline.json 위치 ===
+run_test "pipeline.json 부재 시 명확한 에러 (env override)" \
+  "PIPELINE_PATH='/tmp/missing-$$.json' DESIGN_PATH='$TMP_DESIGN' PR_TITLE='test' bash '$DRY_RUN' PR-7" \
+  "4" ""
+
+echo
+echo "=========================================="
+echo "Pass: $PASS, Fail: $FAIL"
+TOTAL=$((PASS+FAIL))
+if [ "$FAIL" -gt 0 ]; then
+  echo "Hit rate: $(( PASS * 100 / TOTAL ))% — review test cases"
+  exit 1
+else
+  echo "Hit rate: 100% ($PASS/$TOTAL cases)"
+  exit 0
+fi

--- a/.claude/plugins/compound-mmp/hooks/test-dispatch.sh
+++ b/.claude/plugins/compound-mmp/hooks/test-dispatch.sh
@@ -60,6 +60,16 @@ run_test "review 영문 부탁" "PR review 부탁해" "review"
 run_test "review 영문 한국식 동사" "이 코드 review해줘" "review"
 run_test "review 한글 검토" "이거 검토 좀" "review"
 
+# === HIGH-A3 카논: /compound-review 슬래시 본문 명시 phrase doc-vs-behavior align ===
+# 본문 (commands/compound-review.md "디스패처 트리거" 섹션) 명시 6 phrase 모두 매칭 검증.
+# 본문 변경 시 이 fixture 동기화 필수.
+run_test "review 본문 phrase 1 — 리뷰 해줘"     "리뷰 해줘" "review"
+run_test "review 본문 phrase 2 — 코드 리뷰"     "코드 리뷰" "review"
+run_test "review 본문 phrase 3 — 머지 전 확인"  "머지 전 확인" "review"
+run_test "review 본문 phrase 4 — 병합 전 체크"  "병합 전 체크" "review"
+run_test "review 본문 phrase 5 — review this PR"  "review this PR" "review"
+run_test "review 본문 phrase 6 — pre-merge review" "pre-merge review" "review"
+
 # === Plan (동사 변형) ===
 run_test "plan 한글" "다음 phase 계획 세워" "plan"
 run_test "plan brainstorm" "이거 어떻게 만들지 brainstorm" "plan"

--- a/.claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh
+++ b/.claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# /compound-review --dry-run 헬퍼.
+# post-task-pipeline.json `after_pr.review-*` 4개 entry를 읽어 토큰 치환 후 JSON array 출력.
+#
+# 출력 형식 (sim-case-a.md C-2 계약):
+#   [{"subagent_type": "...", "model": "...", "prompt": "..."}, ...]  # length == 4
+#
+# 사용:
+#   DESIGN_PATH=docs/plans/<phase>/design.md PR_TITLE='...' \
+#     bash scripts/compound-review-dry-run.sh PR-123
+#
+# Exit codes:
+#   0 — 정상
+#   2 — pr-id 화이트리스트 실패 (^PR-[0-9]+[a-z]?$)
+#   3 — DESIGN_PATH 환경 변수 누락 또는 파일 부재
+#   4 — post-task-pipeline.json 부재 (PIPELINE_PATH 환경으로 override 가능)
+#
+# 토큰 치환은 jq --arg (shell injection 차단). raw shell expansion 절대 금지.
+# 카논: refs/post-task-pipeline-bridge.md "토큰 sanitize 의무".
+
+set -eu
+
+PR_ID="${1:-}"
+
+# 1. pr-id 화이트리스트 (정규식)
+if ! printf '%s' "$PR_ID" | grep -qE '^PR-[0-9]+[a-z]?$'; then
+  printf 'ERROR: pr-id must match ^PR-[0-9]+[a-z]?$, got %q\n' "$PR_ID" >&2
+  exit 2
+fi
+
+# 2. DESIGN_PATH 검증
+DESIGN_PATH="${DESIGN_PATH:-}"
+if [ -z "$DESIGN_PATH" ] || [ ! -f "$DESIGN_PATH" ]; then
+  printf 'ERROR: DESIGN_PATH env required, file must exist: %q\n' "$DESIGN_PATH" >&2
+  exit 3
+fi
+
+# 3. post-task-pipeline.json 위치
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_PIPELINE="${SCRIPT_DIR}/../../../post-task-pipeline.json"
+PIPELINE_PATH="${PIPELINE_PATH:-$DEFAULT_PIPELINE}"
+if [ ! -f "$PIPELINE_PATH" ]; then
+  printf 'ERROR: post-task-pipeline.json not found at %q\n' "$PIPELINE_PATH" >&2
+  exit 4
+fi
+
+# 4. jq 사전 검사
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for token substitution (security: shell injection 차단)" >&2
+  exit 5
+fi
+
+# 5. PR_TITLE (선택, 기본 빈 문자열)
+PR_TITLE="${PR_TITLE:-}"
+
+# 6. review-* 4 entry 추출 + 토큰 치환 (jq --arg 안전)
+jq -c \
+  --arg pr_id "$PR_ID" \
+  --arg pr_title "$PR_TITLE" \
+  --arg design "$DESIGN_PATH" \
+  '[.after_pr[]
+    | select(.type == "subagent" and .parallel_group == "review")
+    | {
+        subagent_type: .agent,
+        model: .model,
+        prompt: (.prompt
+          | gsub("\\{pr_id\\}"; $pr_id)
+          | gsub("\\{pr_title\\}"; $pr_title)
+          | gsub("\\{design\\}"; $design))
+      }]' "$PIPELINE_PATH"

--- a/.claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh
+++ b/.claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh
@@ -22,8 +22,8 @@ set -eu
 
 PR_ID="${1:-}"
 
-# 1. pr-id 화이트리스트 (정규식)
-if ! printf '%s' "$PR_ID" | grep -qE '^PR-[0-9]+[a-z]?$'; then
+# 1. pr-id 화이트리스트 (정규식, MED-P2: bash builtin =~로 grep fork 제거)
+if [[ ! "$PR_ID" =~ ^PR-[0-9]+[a-z]?$ ]]; then
   printf 'ERROR: pr-id must match ^PR-[0-9]+[a-z]?$, got %q\n' "$PR_ID" >&2
   exit 2
 fi
@@ -35,8 +35,10 @@ if [ -z "$DESIGN_PATH" ] || [ ! -f "$DESIGN_PATH" ]; then
   exit 3
 fi
 
-# 3. post-task-pipeline.json 위치
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# 3. post-task-pipeline.json 위치 (MED-P1: BASH_SOURCE로 dirname+cd+pwd 2 fork 제거)
+# 디렉토리 prefix 없는 호출(예: cwd 안에서 `bash script.sh`) 대비 fallback
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+[ "$SCRIPT_DIR" = "${BASH_SOURCE[0]}" ] && SCRIPT_DIR="."
 DEFAULT_PIPELINE="${SCRIPT_DIR}/../../../post-task-pipeline.json"
 PIPELINE_PATH="${PIPELINE_PATH:-$DEFAULT_PIPELINE}"
 if [ ! -f "$PIPELINE_PATH" ]; then

--- a/.claude/plugins/compound-mmp/templates/review-result-template.md
+++ b/.claude/plugins/compound-mmp/templates/review-result-template.md
@@ -1,0 +1,76 @@
+# Review Result Template
+
+`/compound-review`가 `docs/plans/<phase>/refs/reviews/<pr-id>.md`에 생성하는 종합 결과 포맷.
+
+## 출력 예시
+
+```markdown
+---
+pr_id: "PR-7"
+pr_title: "compound-review + 4-agent bridge"
+phase: "compound-mmp Wave 3"
+review_date: 2026-04-28
+agents: [security-reviewer, code-reviewer, critic, test-engineer]
+models: [opus, sonnet, opus, sonnet]
+---
+
+# Review: PR-7 compound-review + 4-agent bridge
+
+## 종합
+
+- **HIGH 0건** / MEDIUM N건 / LOW N건
+- **권고**: admin-merge 안전 진행 (HIGH 0). carry-over MEDIUM/LOW는 다음 PR piggyback.
+
+## P0–P3 라우팅 결과 (refs/post-task-pipeline-bridge.md)
+
+| 심각도 | count | 라우팅 | 처리 |
+|--------|-------|--------|------|
+| P0 (CRITICAL) | 0 | manual | — |
+| P1 (HIGH) | 0 | manual | — |
+| P2 (MEDIUM) | N | gated_auto | 다음 PR 이월 |
+| P3 (LOW) | N | advisory | 정보성 |
+
+## 영역별 결과
+
+### Security (oh-my-claudecode:security-reviewer, opus)
+
+- **PASS / HIGH N건 / MEDIUM N건**
+- 핵심 발견:
+  - (HIGH) [요약] — 위치, 영향, 권고
+  - (MEDIUM) ...
+
+### Performance (oh-my-claudecode:code-reviewer, sonnet)
+
+- **PASS** / 발견 사항 분류
+- ...
+
+### Architecture (oh-my-claudecode:critic, opus)
+
+- **PASS** / drift 분류
+- ...
+
+### Test Coverage (oh-my-claudecode:test-engineer, sonnet)
+
+- **PASS** / coverage delta
+- ...
+
+## 권고 액션
+
+- (a) **즉시 수정**: HIGH N건 → `/compound-work PR-7`로 별도 명시 호출
+- (b) **다음 PR 이월**: MEDIUM N건 → carry-over 등재 (`memory/QUESTIONS.md` Q-XXX)
+- (c) **무시**: LOW N건 — 사유 1줄
+```
+
+## 작성 규칙
+
+1. **frontmatter** — `pr_id`, `pr_title`, `phase`, `review_date`, `agents`, `models` 5필드 필수.
+2. **종합 섹션** — HIGH count 우선 가시화. MED/LOW는 합산만.
+3. **영역별 섹션** — agent 응답을 메인 컨텍스트가 ≤200단어로 압축 요약. raw dump 금지 (advisor 패턴, opus-delegation.md).
+4. **권고 액션** — (a)/(b)/(c) 3선택지로 사용자 결정 명확화. 자동 진행 X.
+
+## 안티 패턴
+
+- ❌ 4 agent 응답 raw dump — 메인 컨텍스트가 압축 요약해야 함
+- ❌ HIGH 0건인데 "권고: 즉시 수정" — 라우팅 카논 위반
+- ❌ pr_title을 frontmatter에 raw 보간 (특수문자) — YAML 안전 인용 (`pr_title: "..."`)
+- ❌ critic을 architect로 표기 — 카논 정정 (`refs/post-task-pipeline-bridge.md` § 정정)

--- a/.github/workflows/ci-hooks.yml
+++ b/.github/workflows/ci-hooks.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install shellcheck
         run: sudo apt-get update -qq && sudo apt-get install -y shellcheck
-      - name: shellcheck hooks
+      - name: shellcheck hooks + scripts
         run: |
           set -e
-          for f in .claude/plugins/compound-mmp/hooks/*.sh; do
+          for f in .claude/plugins/compound-mmp/hooks/*.sh .claude/plugins/compound-mmp/scripts/*.sh; do
             echo "shellcheck $f"
             shellcheck -e SC2155,SC2086 "$f"
           done
@@ -45,6 +45,8 @@ jobs:
         run: bash .claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
       - name: pre-task-model self-tests
         run: bash .claude/plugins/compound-mmp/hooks/test-pre-task-model.sh
+      - name: compound-review-dry-run self-tests
+        run: bash .claude/plugins/compound-mmp/hooks/test-compound-review-dry-run.sh
 
   hook-tests-macos:
     name: hook self-tests (macOS, bash 3.2)
@@ -61,3 +63,5 @@ jobs:
         run: /bin/bash .claude/plugins/compound-mmp/hooks/test-pre-edit-size.sh
       - name: pre-task-model self-tests (system bash 3.2)
         run: /bin/bash .claude/plugins/compound-mmp/hooks/test-pre-task-model.sh
+      - name: compound-review-dry-run self-tests (system bash 3.2)
+        run: /bin/bash .claude/plugins/compound-mmp/hooks/test-compound-review-dry-run.sh

--- a/docs/plans/2026-04-28-compound-mmp-wave3/refs/reviews/PR-7.md
+++ b/docs/plans/2026-04-28-compound-mmp-wave3/refs/reviews/PR-7.md
@@ -102,3 +102,40 @@ spawn_pattern: "single message, 4 Agent tool calls, run_in_background=true"
 2. HIGH-A1+T1은 1 commit (~10분) 소요. MED-P1/P2 piggyback 시 ~15분.
 3. 4-agent 재검증은 background 4 spawn (~3분 wait).
 4. CI admin-skip 만료(2026-05-01, D-3) 전에 정식 green 도달 가능.
+
+---
+
+## Round-2 재검증 결과 (commit `8717dce`, 2026-04-28)
+
+**선택**: (a) 본 PR에서 HIGH 4건 + MED-P1/P2 fix 후 4-agent 재검증.
+
+### 변경 요약
+- HIGH-A1: 슬래시 § 4를 `iterate over helper.payload[]` imperative pseudocode로 교체, 4 agent enum 제거
+- HIGH-A2: § 4.1 OMC fallback 매핑 표 추가 (4 agent 모두 커버, 모델 보존), `ls ~/.claude/plugins/oh-my-claudecode` 가용성 체크 카논화
+- HIGH-A3: test-dispatch.sh +6 phrase fixture (47/47 pass), "audit this" false positive 위험으로 본문 제거
+- HIGH-T1: case 21 (`sabyun` 하드코딩) 제거 + comment, MED-T1로 `{pr_title}`/`{design}` 4 case 추가 (27/27 pass)
+- MED-P1: `${BASH_SOURCE[0]%/*}` 교체 → 2 fork 절감
+- MED-P2: `[[ =~ ]]` 교체 → 1 fork 절감 (helper 5→3 fork, sister `pre-task-model-guard.sh` 1 fork에 가까워짐)
+
+### Round-2 verdict (arch + test 2 agent)
+
+| Agent | Verdict | HIGH RESOLVED | 신규 HIGH/MED | admin-merge ready? |
+|-------|---------|--------------|--------------|-------------------|
+| Architecture (round-2, superpowers:code-reviewer opus) | PASS WITH CAVEATS | A1/A2/A3 모두 RESOLVED (file:line evidence) | 0건 | **YES** |
+| Test (round-2, general-purpose sonnet) | PASS WITH CAVEATS | T1 RESOLVED | 0건 | **YES** |
+
+### 잔여 carry-over (다음 PR piggyback)
+
+- LOW-T3: 슬래시 본문 "사용 예" L114 `length == 4` 하드코딩 — 인라인 주석 또는 parameterize (PR-8)
+- MED-A1: `agents/automation-scout.md:54` "architect" lingering token (PR-8 또는 PR-10)
+- MED-A2: `skills/review-mmp/SKILL.md` 도입 (compound-wrap 패턴 대칭, PR-9)
+- MED-A3: helper hard-coded `../../../` 3-deep coupling (PR-10 hygiene)
+- MED-A4: helper length self-validate (PR-10)
+- MED 미커버 edge cases: jq missing (exit 5), pipeline.json malformed JSON (PR-10 dogfooding scope)
+
+### admin-merge 게이트 충족
+
+- ✅ HIGH 0건 (round-2 신규 발생 0)
+- ✅ 137/137 hook self-test 회귀 0건 (bash 3.2 + 5.x)
+- ✅ 4-agent 자가 리뷰 round-1 + round-2 완료 (`feedback_4agent_review_before_admin_merge.md` 카논 준수)
+- ⚠️ CI admin-skip 정책 활성 (2026-05-01까지, D-3) — 정식 CI green은 main 머지 후 ci-hooks workflow 실행으로 확인

--- a/docs/plans/2026-04-28-compound-mmp-wave3/refs/reviews/PR-7.md
+++ b/docs/plans/2026-04-28-compound-mmp-wave3/refs/reviews/PR-7.md
@@ -1,0 +1,104 @@
+---
+pr_id: "PR-7"
+pr_title: "compound-mmp: /compound-review + 4-agent parallel review bridge"
+pr_url: "https://github.com/sabyunrepo/muder_platform/pull/158"
+phase: "compound-mmp Wave 3"
+review_date: 2026-04-28
+agents: [security-reviewer, code-reviewer, critic, test-engineer]
+agent_mapping:
+  security: "general-purpose (opus) ← OMC `oh-my-claudecode:security-reviewer` 미가시 fallback"
+  perf:     "general-purpose (sonnet) ← OMC `oh-my-claudecode:code-reviewer` fallback"
+  arch:     "superpowers:code-reviewer (opus) ← OMC `oh-my-claudecode:critic` fallback"
+  test:     "general-purpose (sonnet) ← OMC `oh-my-claudecode:test-engineer` fallback"
+spawn_pattern: "single message, 4 Agent tool calls, run_in_background=true"
+---
+
+# Review: PR-7 compound-mmp /compound-review + 4-agent parallel review bridge
+
+## 종합
+
+- **HIGH 4건** / MEDIUM 7건 / LOW 8건
+- **권고**: HIGH 4건 본 PR에서 즉시 수정 권고 (MEDIUM/LOW carry-over). PR-2c #107 사고 교훈 — HIGH는 admin-merge 전에 처리.
+
+## P0–P3 라우팅 (refs/post-task-pipeline-bridge.md)
+
+| 심각도 | count | 라우팅 | 처리 권고 |
+|--------|-------|--------|----------|
+| P0 (CRITICAL) | 0 | — | — |
+| P1 (HIGH) | 4 | manual | **본 PR에서 fix 후 push (자동 fix-loop 금지, 사용자 결정 후 진행)** |
+| P2 (MEDIUM) | 7 | gated_auto | Wave 3 다음 PR (PR-8 piggyback) 또는 PR-10 hygiene |
+| P3 (LOW) | 8 | advisory | carry-over QUESTIONS 등재 |
+
+## HIGH 4건 (P1)
+
+### HIGH-A1: 슬래시 본문에 4 Task 하드코딩 (`commands/compound-review.md:54-58`)
+- helper는 `select(.parallel_group=="review")`로 동적 추출하지만 슬래시 본문은 4 agent name을 prose로 enum.
+- pipeline.json에 5번째 review 추가 시 silent break (helper length=5 vs 본문 4).
+- **권고**: 본문을 imperative "iterate over `helper.payload[]`"로 교체.
+
+### HIGH-A2: OMC 의존성 미선언/미검증 (`post-task-pipeline.json` + 슬래시 본문)
+- `oh-my-claudecode:*` agent는 user-home `~/.claude/plugins/`에 있고 본 repo는 모름.
+- 자가 리뷰에서 메인이 `general-purpose` + `superpowers:code-reviewer`로 fallback 매핑한 것이 증거.
+- preflight 또는 `plugin.json` dependency 선언, 또는 본문에 fallback 매핑 명시 필요.
+- **권고**: 슬래시 본문에 "OMC 가용 여부 확인 → 미설치 시 `general-purpose` + 적절한 model로 fallback" 명시.
+
+### HIGH-A3: dispatch-router 트리거 phrase 검증 부재
+- 슬래시 본문 L97-98 ("머지 전 확인", "병합 전 체크")가 `dispatch-router.sh:71` 정규식과 정확히 매칭되는지 미검증.
+- doc-vs-behavior drift 위험.
+- **권고**: `test-dispatch.sh`에 본문이 명시한 모든 phrase fixture 추가.
+
+### HIGH-T1: case 21 false negative on CI (`hooks/test-compound-review-dry-run.sh:118-119`)
+- `jq -e 'all(.[]; .prompt | contains("sabyun") | not)'` — 로컬 username 하드코딩.
+- CI(`runner`)에서 injection 실행되어도 통과 (false PASS).
+- case 20이 literal preservation을 이미 검증하므로 case 21은 redundant + misleading.
+- **권고**: case 21 제거 또는 `[a-z_][a-z0-9_-]{2,}` 패턴으로 일반화.
+
+## MEDIUM 7건 (P2 — carry-over)
+
+### Architecture
+- **MED-A1** automation-scout.md L54의 "architect" lingering token (critic 카논 정정 누락)
+- **MED-A2** Step 5 "결과 종합"이 비-imperative — `skills/review-mmp/SKILL.md` 도입 또는 imperative 추가 (compound-wrap 패턴 대칭)
+- **MED-A3** 헬퍼 hard-coded `${SCRIPT_DIR}/../../../post-task-pipeline.json` 3 deep coupling — 디렉토리 이동 시 silent break
+- **MED-A4** 헬퍼가 length==4 self-validate 안 함 — fixture에만 contract 존재
+
+### Performance
+- **MED-P1** SCRIPT_DIR `${BASH_SOURCE[0]%/*}` 교체로 2 fork 절감 (~60ms/call, ~1.4s/CI matrix)
+- **MED-P2** `printf | grep -qE` → `[[ =~ ]]` 교체로 1 fork 절감 (~30ms/call)
+
+### Test
+- **MED-T1** {pr_title}/{design} 토큰 치환 미검증 — gsub 라인 삭제되어도 24/24 모두 PASS
+
+## LOW 8건 (P3 — advisory)
+
+- LOW-A1 anti-pattern 목록이 compound-wrap.md보다 짧음, refs/anti-patterns.md 번호 미참조
+- LOW-A2 `gh pr view` 실패 silent — debug log 권고
+- LOW-S1 DESIGN_PATH absolute path (e.g. /etc/passwd) 통과 (현재 path string만 embed해서 무해, 미래 read-content 변경 시 위험)
+- LOW-S2 `commands/compound-review.md:23-25` cwd-coupled glob (`ls -td docs/plans/*/`)
+- LOW-S3 ARG_PR_NUM 파생식 미명시 (`${PR_ID#PR-}`)
+- LOW-Pf1 `command -v jq` 4번째 fork — 순서 재배치로 cheap exit
+- LOW-Pf2 fixture eval per-predicate fork — 비실용적 절감 (<0.5s)
+- LOW-T2 PR-007 leading-zero 정책 미문서화
+- LOW-T3 `length == 4` 하드코딩 변경 시 silent CI break — 인라인 주석 추가
+
+## 영역별 verdict
+
+| Agent | Verdict | 핵심 |
+|-------|---------|------|
+| Security | **PASS** | `jq --arg` 정상, 화이트리스트 정상, anti-pattern 명시. LOW 3건만. "토큰 치환은 진정으로 안전 (24/24 + 수동 probe)". |
+| Performance | **PASS WITH CAVEATS** | helper fork 5 vs sister 1 — MED 2건 fix로 3 fork. helper는 hot-path 아님 (interactive only). |
+| Architecture | **PASS WITH CAVEATS** | HIGH 3건 (하드코딩 / OMC 미선언 / dispatch drift). "Will this design survive 3 more PRs? **No, not without HIGH fixes.**" |
+| Test | **PASS WITH CAVEATS** | regression-catch confidence ~85%. HIGH-T1 (CI false negative) + MED 2건. |
+
+## 권고 액션
+
+- (a) **본 PR에서 HIGH 4건 fix** — slash 본문 imperative 변환 (HIGH-A1) + OMC fallback 명시 (HIGH-A2) + dispatch fixture 추가 (HIGH-A3) + case 21 제거 (HIGH-T1). MED-P1/P2도 함께 (저비용 고가치). 추가 commit + 4-agent 재검증.
+- (b) **HIGH-A1+T1만 fix하고 머지** — A2/A3는 별도 follow-up PR (OMC 가용성은 실제 사용 시점에 발현하므로 본 PR 머지 자체는 안전).
+- (c) **현 상태로 admin-merge** — HIGH 4건을 carry-over로 등재하고 PR-8/PR-10에 piggyback. (PR-2c #107 사고 패턴 재현 위험)
+
+## 다음 단계 제안
+
+(a) 권고. 이유:
+1. HIGH-A2 (OMC fallback)는 본 PR이 슬래시 명령의 "사용 카논"을 수립하는 시점이므로 미루면 PR-8/9/10이 잘못된 패턴을 베끼게 된다.
+2. HIGH-A1+T1은 1 commit (~10분) 소요. MED-P1/P2 piggyback 시 ~15분.
+3. 4-agent 재검증은 background 4 spawn (~3분 wait).
+4. CI admin-skip 만료(2026-05-01, D-3) 전에 정식 green 도달 가능.

--- a/memory/QUESTIONS.md
+++ b/memory/QUESTIONS.md
@@ -14,11 +14,10 @@ Q-gate 적용 후 NEW로 분류된 항목만 등재 (중복은 `duplicate-checke
 - **다음 액션**: PR-10 dogfooding sim 작성 시 bash 3.2 `=~` 에서 `\b` 동작 spike (~30분). 결과에 따라 `(claude-)?sonnet-4[-.]5([^0-9-]|$)` 또는 `\b` 변형 채택.
 - **블로커 risk**: LOW. 4-agent 리뷰 architecture MED-1.
 
-### Q-shopt: dispatch-router.sh `shopt -u nocasematch` 복원 carry-over phantom 검증
-- **위치**: `.claude/plugins/compound-mmp/hooks/dispatch-router.sh` `classify()` 함수
-- **가설**: 이전 세션 carry-over에 명시되었으나, learning-extractor 코드 확인 시 모든 분기에 unset 존재. carry-over 자체가 phantom 가능성.
-- **다음 액션**: Wave 3 진입 전 `test-dispatch.sh` 실행으로 nocasematch 누수 여부 1회 확인. phantom이면 carry-over 폐기, 실재면 `trap 'shopt -u nocasematch' RETURN` 보강.
-- **블로커 risk**: LOW.
+### ~~Q-shopt: dispatch-router.sh `shopt -u nocasematch` 복원 carry-over phantom 검증~~ — **PHANTOM 확정 / 폐기 (2026-04-28)**
+- **검증**: `bash .claude/plugins/compound-mmp/hooks/test-dispatch.sh` → 41/41 pass. 추가로 격리 subshell `shopt -s/-u nocasematch` 함수 외 누수 없음 확인 (case-sensitive 복원).
+- **결론**: dispatch-router.sh L42→L47, L51→L61, L67→L81 각 블록 모두 명시적 `-s`/`-u` 짝. exit 경로(L45)도 `-u` 통과. `trap RETURN` 보강 불필요.
+- **carry-over 폐기**: Wave 3 진입 spec에서 제거.
 
 ### Q-sim-c: PR-10 sim-case-c.md 작성 scope — live deny 시나리오 포함 여부
 - **맥락**: Plan ~/.claude/plans/vivid-snuggling-pascal.md § "검증 절차 3개 시뮬레이션 케이스" Case C — Sonnet 4.5 fallback 차단 검증


### PR DESCRIPTION
## Summary

- Wave 3 첫 슬래시 명령 — `/compound-review [pr-id] [--dry-run]`. `post-task-pipeline.json` `after_pr.review-*` 4 entry (security-reviewer/code-reviewer/critic/test-engineer)를 한 메시지에서 Task tool 동시 spawn하는 카논 진입점.
- helper script `scripts/compound-review-dry-run.sh` — testable unit. `jq --arg`로 토큰 치환해 shell injection 차단 (`refs/post-task-pipeline-bridge.md` "토큰 sanitize 의무"). 24/24 fixture: 입력 화이트리스트, JSON 계약, 4-agent 카논 매핑, injection 거부, 환경 검증.
- 결과 종합 → `docs/plans/<phase>/refs/reviews/<pr-id>.md` (template 포함). HIGH 발견 시 사용자 결정 대기 (자동 fix-loop 금지, PR-2c #107 사고 정책 계승).

## 변경 파일

- NEW `commands/compound-review.md` — slash 본문 (allowed-tools: Bash/Read/Write/Task/Glob)
- NEW `scripts/compound-review-dry-run.sh` — helper (`PIPELINE_PATH`/`DESIGN_PATH`/`PR_TITLE` env)
- NEW `hooks/test-compound-review-dry-run.sh` — 24/24 self-test
- NEW `templates/review-result-template.md` — 결과 종합 + P0–P3 라우팅 + 권고 액션
- MOD `.github/workflows/ci-hooks.yml` — shellcheck `scripts/*.sh` 추가, ubuntu+macOS step 양쪽에 새 self-test 추가
- MOD `memory/QUESTIONS.md` — Q-shopt phantom 검증 결과 strikethrough 폐기

## Test plan

- [x] `bash hooks/test-compound-review-dry-run.sh` — 24/24 (bash 5.3.9)
- [x] `/bin/bash hooks/test-compound-review-dry-run.sh` — 24/24 (bash 3.2.57 macOS)
- [x] 전체 hook self-test 회귀: 128/128 (compound-review 24 + dispatch 41 + size 38 + pre-task-model 25)
- [ ] CI hook-tests-ubuntu + hook-tests-macos green
- [ ] 4-agent 자가 리뷰 (PR 머지 직전, security/perf/arch/test 병렬)
- [ ] sim-case-a 패치 검증은 PR-10 (현 시점 본 PR 외)

## 카논 ref

- `refs/post-task-pipeline-bridge.md` (4-agent 매핑, P0–P3, 토큰 sanitize)
- `refs/sim-case-a.md` (PR-2c deadlock 재현 — PR-10 dogfooding scope)
- `memory/feedback_4agent_review_before_admin_merge.md` (강제 정책)
- `memory/project_ci_admin_skip_until_2026-05-01.md` (admin-merge 정책 D-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)