### PR TITLE
chore(compound-mmp): directory-source install workaround script + README

### DIFF
--- a/.claude/plugins/compound-mmp/README.md
+++ b/.claude/plugins/compound-mmp/README.md
@@ -4,6 +4,18 @@ MMP v3 전용 Claude Code 플러그인. **Plan → Work → Review → Compound*
 
 > 외부 분석 보고서(Compound Engineering / Superpowers / Session-Wrap)에서 검증된 패턴 3가지를 MMP v3 인프라(QMD MCP, graphify, OMC 4-agent, post-task-pipeline)에 맞춰 통합.
 
+## Install
+
+clone 직후 1회 실행:
+
+```bash
+bash .claude/plugins/compound-mmp/scripts/install.sh
+```
+
+이후 Claude Code 재시작 시 `/compound-resume`, `/compound-review`, `/compound-wrap` 등 슬래시 커맨드가 등록된다.
+
+> **왜 필요한가**: Claude Code 의 `directory` source marketplace 는 enable 시 `installed_plugins.json` 메타만 기록하고 cache 디렉토리 파일 sync 를 누락한다 (2026-04-28 확인). 스크립트는 `~/.claude/plugins/cache/ctm/compound-mmp/<version>/` symlink 를 생성해 우회한다. python3 만 의존.
+
 ## 철학
 
 - **Compound** — Plan-Work-Review-Compound 순환으로 매 phase마다 지식이 영구 자산화된다 (`memory/sessions/`, `MEMORY.md` append, `MISTAKES.md`/`QUESTIONS.md`)

--- a/.claude/plugins/compound-mmp/scripts/install.sh
+++ b/.claude/plugins/compound-mmp/scripts/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# compound-mmp plugin - directory source install workaround.
+#
+# Claude Code 의 directory-source marketplace 는 enable 시 installed_plugins.json
+# 메타데이터만 기록하고 실제 cache 디렉토리(`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`)
+# 로의 파일 복사를 누락한다 (2026-04-28 확인). 그 결과 슬래시 커맨드가 등록되지 않음.
+#
+# 이 스크립트는 cache 경로를 plugin source 디렉토리로 가리키는 symlink 를 만들어
+# 슬래시 커맨드(`/compound-resume`, `/compound-review`, `/compound-wrap`)를 활성화한다.
+#
+# 사용법: 이 repo clone 직후 1회 실행. 이후 Claude Code 재시작.
+#   bash .claude/plugins/compound-mmp/scripts/install.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_NAME="compound-mmp"
+MARKETPLACE="ctm"
+
+VERSION="$(python3 -c "import json; print(json.load(open('$PLUGIN_DIR/.claude-plugin/plugin.json'))['version'])")"
+CACHE_BASE="${CLAUDE_PLUGINS_DIR:-$HOME/.claude/plugins}/cache/$MARKETPLACE/$PLUGIN_NAME"
+TARGET="$CACHE_BASE/$VERSION"
+
+mkdir -p "$CACHE_BASE"
+ln -sfn "$PLUGIN_DIR" "$TARGET"
+
+echo "✓ symlinked $TARGET → $PLUGIN_DIR"
+echo "✓ commands available after Claude Code restart:"
+ls "$TARGET/commands/" 2>/dev/null | sed 's/\.md$//' | sed 's/^/    \//'


### PR DESCRIPTION
## Summary

- Claude Code 의 `directory` source marketplace 는 plugin enable 시 `installed_plugins.json` 메타만 기록하고 cache 디렉토리 (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`) 파일 sync 를 누락한다 (2026-04-28 확인). 결과: `/compound-resume`, `/compound-review`, `/compound-wrap` 슬래시 커맨드가 등록되지 않음.
- `scripts/install.sh`: cache 경로를 plugin source 디렉토리로 가리키는 symlink 생성 → 슬래시 커맨드 활성화. 다른 컴퓨터/사용자가 clone 직후 1회 실행하면 됨.
- `README.md`: Install 섹션 추가 (사용법 + 우회 배경).

## Test plan

- [x] 로컬에서 install.sh 실행 → cache 경로에 symlink 생성 확인 (`~/.claude/plugins/cache/ctm/compound-mmp/0.1.0-alpha`)
- [x] symlink 통해 commands/ 3개 (`compound-resume.md`, `compound-review.md`, `compound-wrap.md`) 노출 확인
- [ ] Claude Code 재시작 후 `/compound-resume` 슬래시 커맨드 작동 (사용자 수동 검증 필요)

## Notes

- python3 만 의존 (macOS/Linux 기본 탑재)
- script 는 idempotent (`ln -sfn` + `mkdir -p`)
- Claude Code 자체 버그 (anthropics/claude-code) — 추후 본 fix 되면 이 workaround 제거 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)