### PR TITLE
fix(ci): job context는 step-level에서만 평가 가능 (PR-164 회귀)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
     defaults:
       run:
         working-directory: apps/server
-    env:
-      DATABASE_URL: postgres://mmp:mmp_test@localhost:${{ job.services.postgres.ports['5432'] }}/mmp_test?sslmode=disable
-      REDIS_URL: redis://localhost:${{ job.services.redis.ports['6379'] }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -53,6 +50,14 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # Export service connection env (job context는 step-level에서만 평가 가능 — PR-164 회귀 fix).
+      # ephemeral host port를 GITHUB_ENV로 export해 후속 step의 Go test가 자동 읽음.
+      - name: Export service connection env
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "DATABASE_URL=postgres://mmp:mmp_test@localhost:${{ job.services.postgres.ports['5432'] }}/mmp_test?sslmode=disable" >> "$GITHUB_ENV"
+          echo "REDIS_URL=redis://localhost:${{ job.services.redis.ports['6379'] }}" >> "$GITHUB_ENV"
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -63,8 +63,6 @@ jobs:
           --health-retries 10
 
     env:
-      DATABASE_URL: postgres://mmp:mmp_e2e@localhost:${{ job.services.postgres.ports['5432'] }}/mmp_e2e?sslmode=disable
-      REDIS_URL: redis://localhost:${{ job.services.redis.ports['6379'] }}
       GAME_RUNTIME_V2: "true"
       PLAYWRIGHT_BACKEND: "1"
 
@@ -76,6 +74,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # Export service connection env (job context는 step-level에서만 평가 가능 — PR-164 회귀 fix).
+      # ephemeral host port를 GITHUB_ENV로 export해 후속 step의 server/migration이 자동 읽음.
+      - name: Export service connection env
+        run: |
+          echo "DATABASE_URL=postgres://mmp:mmp_e2e@localhost:${{ job.services.postgres.ports['5432'] }}/mmp_e2e?sslmode=disable" >> "$GITHUB_ENV"
+          echo "REDIS_URL=redis://localhost:${{ job.services.redis.ports['6379'] }}" >> "$GITHUB_ENV"
 
       # ── Go server ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

PR-164 회귀 fix. 4 line 변경으로 main의 ci.yml/e2e-stubbed.yml 0s "workflow file issue" 해소.

## Root cause

PR-164에서 도입한 \`\${{ job.services.X.ports['Y'] }}\`가 **job-level env 블록에서 사용 불가** (GitHub Actions context availability 규칙). step-level에서만 평가 가능. workflow schema validation 실패 → 모든 push 0s fail. admin-skip 정책이 가려준 상태.

actionlint 검출:
- ci.yml:46:59, 47:40 — context "job" is not allowed here
- e2e-stubbed.yml:66:58, 67:40 — context "job" is not allowed here

## Fix

job-level env 블록에서 DATABASE_URL/REDIS_URL 제거 → 첫 step "Export service connection env"에서 \`GITHUB_ENV\`로 export. step-level은 job context 평가 가능 + 후속 step의 env에서 자동 사용. ephemeral host port 카논(PR-164 의도) 보존.

GAME_RUNTIME_V2/PLAYWRIGHT_BACKEND은 정적 string이라 그대로 job-level env 유지.

## Test plan

- [x] actionlint: ci.yml/e2e-stubbed.yml 0 finding
- [x] python yaml.safe_load PASS
- [ ] CI 12 job (PR 자체 실행) green — 본 PR이 admin-skip 마지막 사용

## Background

\`memory/project_ci_admin_skip_until_2026-05-01.md\` — 2026-04-28 D-3 조기 만료 결정. 본 PR이 admin-skip 정책의 마지막 사용 (2026-04-18 ~ 2026-04-28 운영 종료). 머지 후 PR #165 (Phase 22 W1)는 정상 CI green 후 머지.

## Rollback

\`gh pr revert\` 시 \`job context not allowed\` 회귀 → main이 다시 0s fail 상태. fallback은 PR-164 reverse가 아니라 본 PR을 즉시 hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)