### PR TITLE
fix(hooks): Stop event 스키마 준수 — hookSpecificOutput → systemMessage

### DIFF
--- a/.claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh
+++ b/.claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh
@@ -56,6 +56,7 @@ if ls "$REPO_ROOT/memory/sessions/${TODAY}-"*.md >/dev/null 2>&1; then
 fi
 
 # 리마인드 출력 (raw prompt echo X — anti-pattern security MEDIUM-1 준수)
+# Stop event 스키마: hookSpecificOutput 미지원 — systemMessage 사용.
 cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"[compound-mmp] 세션 변경 ${DIFF_LINES}줄. \`/compound-wrap\` 으로 7단계 wrap-up 시퀀스 실행 권장 (handoff 노트 + MEMORY.md 갱신)."}}
+{"systemMessage":"[compound-mmp] 세션 변경 ${DIFF_LINES}줄. \`/compound-wrap\` 으로 7단계 wrap-up 시퀀스 실행 권장 (handoff 노트 + MEMORY.md 갱신)."}
 EOF


### PR DESCRIPTION
## Summary

Claude Code hook 시스템의 Stop event 출력 스키마 위반 fix:

```
Hook JSON output validation failed — (root): Invalid input
Expected schema: ... hookSpecificOutput.for Stop = (none) ...
```

Stop event 는 `hookSpecificOutput` 키 미지원. 허용 키: `continue`, `suppressOutput`, `stopReason`, `decision`, `reason`, **`systemMessage`**, `permissionDecision`. `hookSpecificOutput` 은 PreToolUse / UserPromptSubmit / PostToolUse / PostToolBatch 한정.

`compound-mmp:stop-wrap-reminder` 가 잘못된 키 사용 → 매 Stop hook 호출 시 validation 실패 + 노이즈 출력.

## Fix

`.claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh:60` 1 line:

```diff
-{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"[compound-mmp] 세션 변경 ${DIFF_LINES}줄..."}}
+{"systemMessage":"[compound-mmp] 세션 변경 ${DIFF_LINES}줄..."}
```

스키마 허용 키만 사용. 효과 동일 (Stop hook 시점에 Claude 세션에 메시지 인젝트).

## Test

```bash
echo '{}' | bash .claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print('OK:', list(d.keys()))"
# → OK: ['systemMessage']
```

## Files

- `.claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh` (+2/-1)

## Test plan

- [x] JSON validation OK (`python3 -c "import json"` parse)
- [x] hook output schema 준수 (Stop event allowed keys only)
- [x] 메시지 내용 보존 ($DIFF_LINES interpolation 그대로)
- [ ] CI green (single line change, low risk)

## 카논 ref

- Stop event 스키마: Claude Code hook system docs
- Repo `.claude/plugins/compound-mmp/hooks/stop-wrap-reminder.sh` (master)
- User home plugin cache 도 같이 sync (이미 적용됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)