### PR TITLE
chore(w1-5): PR-5 — ci.yml runs-on [self-hosted, containerized] 전환

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   go-check:
     name: Go Lint + Test
-    runs-on: self-hosted
+    runs-on: [self-hosted, containerized]
     defaults:
       run:
         working-directory: apps/server
@@ -199,7 +199,7 @@ jobs:
 
   ts-check:
     name: TypeScript Lint + Test + Build
-    runs-on: self-hosted
+    runs-on: [self-hosted, containerized]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -270,7 +270,7 @@ jobs:
     #   Phase 21: Go 70% / FE Lines 65% / FE Branches 85% (+15%p — 하한 상향 전 반드시 테스트 보강)
     #   하한 상향 전에 반드시 추가 테스트 PR 로 baseline 끌어올리기.
     name: Coverage Regression Guard
-    runs-on: self-hosted
+    runs-on: [self-hosted, containerized]
     needs: [go-check, ts-check]
     steps:
       - name: Harden Runner
@@ -358,7 +358,7 @@ jobs:
 
   docker-build:
     name: Docker Build Check
-    runs-on: self-hosted
+    runs-on: [self-hosted, containerized]
     needs: [go-check, ts-check]
     permissions:
       contents: read

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md
@@ -41,11 +41,11 @@ prs_estimated: 3
 - **상세**: `refs/pr-8-runner-action-compat.md` (본 PR 진입 시 작성)
 
 ### PR-5 — ci.yml runs-on `[self-hosted, containerized]` 전환
-- **Effort** S, **Impact** Med (CI Lint/Test 도 cache 효과)
+- **Effort** S, **Impact** Med (bare-host tar 충돌 해소 + cache 통일)
 - **branch**: `chore/w1-5-ci-runs-on`
 - **변경**: `.github/workflows/ci.yml` 의 4 job `runs-on` → `[self-hosted, containerized]`
-- **의존**: PR-4 머지 + 사용자 SSH 재배포 완료
-- **권고**: PR-4 의 효과 측정 후 진행 (1st/2nd run 비교)
+- **의존**: PR-4 머지 ✅ + PR-170 fold-in 머지 ✅ + 사용자 SSH 재배포 ✅
+- **상세**: [`refs/pr-5-ci-runs-on.md`](refs/pr-5-ci-runs-on.md) — 진단 데이터, single-concern 카논, carry-over 명시
 
 ### PR-4 — Runner Cache Volume (Playwright/pnpm/Go)
 - **Effort** S~M, **Impact** Very High (CI 시간 ~70% 단축)
@@ -129,6 +129,8 @@ PR-170 4-agent 리뷰 (security/performance/architecture/test) 잔여 — 모두
 
 - **[W3] RUNNERS_NET regex 강화** (Sec-MED-1) — `grep -E '(^|_)runners-net$'` 가 `bad_runners-net` 등 악성 네트워크 매칭 가능. PR-168 LOW-1 패턴이 ci.yml 로 확산. compose project prefix 안정화 후 정확 매칭 (`name: runners-net` explicit 만 검증).
 - **[W3] e2e-stubbed.yml 의 동일 패턴** — PR-170 fold-in 으로 health-wait 30→60s 동시 상향 했으나 RUNNERS_NET regex 는 둘 다 동일 약점.
+- **[W3] ci.yml `go-check` fork PR 게이트 추가** (PR-5 spec carry-over) — `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false`. fork PR 의 `sudo go test` testcontainers + `sudo docker build` 가 host docker.sock 임의 조작 가능. PR-5 single-concern scope 밖.
+- **[W3] bare-host self-hosted runner 등록 해제** (PR-5 spec carry-over) — `/home/sabyun/actions-runner/` bare-host runner 가 GitHub 에 등록된 채 잔존 가능성. PR-5 후 ci.yml 4 job 은 0 routing, 그러나 다른 workflow 가 의도치 않게 routing 될 위험. 사용자 SSH 직접 작업.
 
 ### W1.5 PR-170 노출 부채 처리 결과
 

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-5-ci-runs-on.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-5-ci-runs-on.md
@@ -1,0 +1,129 @@
+# PR-5 — ci.yml runs-on `[self-hosted, containerized]` 전환
+
+> Parent: [`../checklist.md`](../checklist.md)
+
+**Goal**: ci.yml 4 job (`go-check`, `ts-check`, `coverage-guard`, `docker-build`) 의 `runs-on: self-hosted` → `[self-hosted, containerized]` 전환. PR-170 fold-in 으로 모든 step 이 이미 containerized runner 호환 (`sudo docker run` services + `sudo go test` testcontainers + `sudo apt-get install -y jq` + manual `sudo docker build`) — 본 PR 은 routing label 만 좁힌다.
+
+## 적용 범위
+
+- `.github/workflows/ci.yml` 4 job (단일 파일, 4줄)
+- e2e-stubbed.yml: 이미 `[self-hosted, containerized]` (PR-167 부터)
+- security-fast.yml / security-deep.yml: 이미 `[self-hosted, containerized]` (PR-170 부터)
+
+## 변경 요약
+
+| 파일 | 변경 |
+|---|---|
+| `.github/workflows/ci.yml` | 4 job 의 `runs-on: self-hosted` → `[self-hosted, containerized]` |
+| `docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-5-ci-runs-on.md` | 본 spec |
+| `docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md` | PR-5 status update |
+
+## 의존성 (사전 조건 — 모두 충족)
+
+- PR-4 (`feat(w1-5): PR-4 Runner Cache + service container + 4-agent fold-in`) 머지 완료 (`bddb68b`)
+- PR-170 (`fix(w1-5): PR-8 — runner third-party action 호환`) 머지 완료 (`99aa825`) — services block 우회 + testcontainers-go fold-in + jq install + manual docker build
+- 4 containerized runner Up (`docker compose ps` host 검증)
+- 사용자 SSH 재배포 완료 (`infra/runners/.env` + `playwright-cache` + `hostedtool-cache` named volume)
+
+## 진단 데이터 (PR-170 1st CI run)
+
+PR-170 의 go-check job (당시 `runs-on: self-hosted` — bare-host 로 routing) 로그 분석:
+
+- Setup Go: `Cache hit for: setup-go-Linux-x64-undefined-go-1.25.0-...` ✅
+- 그러나 tar 추출 시 `/usr/bin/tar: ../../../../go/pkg/mod/...: Cannot open: File exists` 다수
+- 경로: `/home/sabyun/actions-runner/_work/...` — bare-host runner 디스크
+- 해석: GHA cache 자체는 정상 hit, 그러나 이전 run 의 `go/pkg/mod` 가 디스크에 잔존 → tar 가 덮어쓰기 충돌. cache 효과 0 (이미 디스크에 있는 모듈 사용).
+
+containerized runner 로 전환 시 `EPHEMERAL=true` 로 매 job 후 컨테이너 재시작 → 디스크 clean → tar 충돌 해소 + GHA cache fetch 정상 효과. **GHA cache fetch (~369MB) 비용은 본 PR 신규 도입이 아님** — bare-host 에서도 이미 발생 중이었으나 tar 충돌로 효과 0이었다 (Performance review MED-1 명시 보완). 추정 효과: `go-check` 기준 +10~20s/run 절감.
+
+## 보안 — Public repo + Fork PR 게이트
+
+본 PR 은 fork PR 게이트 추가 X (PR-168/PR-170 의 e2e-stubbed.yml + security-deep.yml 게이트와 별개).
+
+**근거**: ci.yml 4 job 은 named volume mount X (Playwright/hostedtool 무관) — fork PR 의 untrusted code 가 cache 경로에 횡전파할 통로 부재. `Run tests` 의 `sudo go test` 는 host docker.sock 접근하므로 fork PR 게이트는 보안 가치 있으나 carry-over.
+
+**Carry-over (Phase 22 W3 또는 별도 PR)**: ci.yml `go-check` 에 `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false` 게이트 추가. 본 PR scope 밖 (single-concern: routing label 만).
+
+## H-1 결정 — `[self-hosted, containerized]` 매트릭스 의미
+
+GitHub Actions runner labels 는 모두 매칭 (AND). 4 containerized runner 가 `self-hosted,linux,containerized` 라벨 보유 → `[self-hosted, containerized]` matcher 가 정확히 4 runner 만 routing.
+
+bare-host runner (`/home/sabyun/actions-runner/`) 는 `containerized` 라벨 없음 → 본 PR 머지 후 ci.yml 은 bare-host runner 로 routing 되지 않음. tar 충돌 영구 해소.
+
+**Phase 22 W3 carry-over**: bare-host runner 등록 해제 — 사용자 SSH 직접 작업, infra-runners 와 무관.
+
+## H-2 결정 — services block / testcontainers-go / jq / docker build
+
+본 PR 시점에 이미 PR-170 fold-in 으로 4 부채 해소:
+
+| 부채 | PR-170 fold-in 위치 |
+|---|---|
+| services block ↔ myoung34 호환 | ci.yml#go-check `Start postgres + redis` (manual `sudo docker run`) |
+| testcontainers-go ↔ docker.sock permission | ci.yml#go-check `Run tests` (`sudo -E env "PATH=$PATH" go test`) |
+| jq 부재 | ci.yml#coverage-guard `Ensure jq installed` (`sudo apt-get install -y jq`) |
+| docker.sock build permission | ci.yml#docker-build `Build Docker image (manual via sudo docker)` |
+
+→ 본 PR 의 routing 변경 후 4 부채 모두 즉시 작동. 추가 fold-in 불필요.
+
+## H-3 결정 — single-concern
+
+본 PR scope: 4 줄 routing label 변경만. fork PR 게이트, RUNNERS_NET regex 강화, Phase 23 Custom Image migration 은 모두 carry-over.
+
+**근거**: `memory/feedback_branch_pr_workflow.md` single-concern 카논. 4 줄 변경의 root cause 는 단일 (routing 좁힘). 다른 concern fold-in 시 review scope 폭증.
+
+## 검증 시뮬
+
+### Case A — main push (1st run)
+
+- 4 job 모두 containerized runner 4대 중 하나로 routing
+- Setup Go: GHA cache hit (PR-170 진단 동일)
+- Run tests: `sudo go test` testcontainers-go SUCCESS (PR-170 동일 fold-in)
+- Build Docker image: `sudo docker build` SUCCESS (PR-170 fold-in)
+- Coverage guard: `jq` 사전 install 후 통과 (PR-170 fold-in)
+
+### Case B — bare-host runner 활용도
+
+- ci.yml 의 4 job → bare-host 0 routing (label mismatch)
+- security-fast/deep, e2e-stubbed.yml → containerized 4대 (이미 PR-170 부터)
+- bare-host runner 는 사용자 host 의 별도 self-hosted runner 등록일 가능성 — 본 PR scope 밖
+- Phase 22 W3 carry-over: bare-host runner 등록 해제 (사용자 SSH 작업)
+
+### Case C — 4 containerized runner 동시 점유
+
+- PR-167 부터 e2e-stubbed.yml 이 4 shard 동시 routing (4 runner 점유)
+- 본 PR 후 ci.yml 의 go-check + ts-check + coverage-guard + docker-build 도 4 runner 풀 공유
+- pull_request 이벤트 시 모든 workflow 동시 trigger → 4 runner pool 포화 가능
+- queue 대기 시간 ↑ 가능성. PR-4 의 cache 효과 (Playwright + hostedtool hit) 로 job 시간 단축 → 점유 해소 빠름
+
+## Out of Scope (carry-over)
+
+### Phase 22 W3
+- ci.yml `go-check` fork PR 게이트 추가
+- bare-host runner 등록 해제 (사용자 SSH 작업)
+- RUNNERS_NET regex 정확 매칭 (PR-170 Sec-MED-1) — `bad_runners-net` 매칭 가능 패턴
+
+### Phase 23 (Custom Image Option A)
+- base image 사전 install (Node v20 + docker group GID 990 + Playwright + jq + govulncheck)
+- PR-170 fold-in 4건 자연 dead code 가능
+- Composite action `.github/actions/start-services/action.yml` (PR-170 Arch-HIGH-1)
+
+## 4-agent review 결과 요약
+
+본 PR diff 기준 (4줄 변경 + spec):
+
+| Agent | 검토 영역 | 예상 결과 |
+|---|---|---|
+| Security | fork PR 게이트 부재 (carry-over OK), 4 runner pool 점유 | LOW (carry-over 명시) |
+| Performance | bare-host tar 충돌 해소, 4 job 시간 단축, queue 점유 ↑ | LOW~MED (queue trade-off 수용) |
+| Architecture | single-concern, spec drift 부재 | LOW (clean) |
+| Test | regression test 추가 X (workflow level), CI 통과 = 검증 | LOW (CI = test) |
+
+상세는 `reviews/PR-5-{security,performance,arch,test}.md` 4 파일.
+
+## 카논 ref
+
+- 부모 plan: `../checklist.md`
+- PR-4 spec: `pr-4-runner-cache.md`
+- PR-170 1st CI run 진단: `pr-8-runner-action-compat.md`
+- 4-agent 강제 정책: `memory/feedback_4agent_review_before_admin_merge.md`
+- single-concern: `memory/feedback_branch_pr_workflow.md`

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-arch.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-arch.md
@@ -1,0 +1,71 @@
+# PR-5 Architecture Review
+
+> Reviewer: opus-4-7 (architecture lens)
+> Diff scope: `.github/workflows/ci.yml` 4 jobs `runs-on: self-hosted` → `[self-hosted, containerized]` (4 lines) + checklist.md status update (4 lines)
+> Date: 2026-04-29
+
+## Verdict: pass
+
+근거: single-concern 카논을 정밀하게 준수했고 (4 라인 routing label만), 모든 step-level 호환 부채는 PR-170 fold-in 으로 선행 해소되어 있으며, carry-over (W3 / Phase 23) 매핑이 spec/checklist 양쪽에 일관되게 명시됨. 발견된 architectural 부채는 모두 PR-5 scope 밖 carry-over 로 정확히 escalate.
+
+## HIGH (구조적 부채 / 다음 PR 필수)
+
+없음. 본 PR diff 자체는 4 라인 routing 변경이며, HIGH 급 구조 부채는 모두 W3/Phase 23 carry-over 로 분리됨 (아래 carry-over 매핑 검증 참조).
+
+## MEDIUM (개선 권고)
+
+- **M-1 Composite action 추출 (PR-170 Arch-HIGH-1) 의 deferred 상태 재확인 필요**
+  PR-170 review 에서 escalate 된 `.github/actions/start-services/action.yml` 추출은 Phase 23 carry-over 로 명시됨 (spec L108, checklist L119). 그러나 PR-5 머지 후 ci.yml#go-check (L34-92, 59 lines) + e2e-stubbed.yml 의 `Start postgres + redis` step 이 95% 동일 패턴으로 양쪽 동시 routing 됨 → 보일러플레이트 확산 위험. PR-5 의 single-concern 정당성은 인정하지만, Phase 23 entry 의 첫 번째 task 로 composite action 추출을 우선순위 1 로 고정 권고. routing 좁힘만 하는 PR-5 가 추출을 미루는 것은 정합성 있음 (4 lines vs 60+ lines refactor 의 review scope 분리).
+
+- **M-2 RUNNERS_NET regex (`grep -E '(^|_)runners-net$'`) 의 routing 확장 영향**
+  ci.yml L44 의 동적 검출 regex 는 PR-170 fold-in 산출물. PR-5 머지 후 본 패턴이 ci.yml 4 job 중 go-check 1 job 만 사용하나, e2e-stubbed.yml 이 이미 동일 regex 보유. W3 RUNNERS_NET 강화 carry-over (spec L102-104, checklist L130-131) 가 두 파일 동시 적용 필요함을 명시. 본 PR 은 ci.yml 의 regex 노출을 늘리지 않음 (PR-170 에 이미 존재) — PR-5 fault 아님. 단, W3 PR 진입 시 ci.yml + e2e-stubbed.yml 동시 수정 single-concern 묶음 정당화 필요.
+
+## LOW (관찰)
+
+- **L-1 4 runner pool 점유 trade-off**
+  spec L91-96 에서 명시: PR-167 부터 e2e-stubbed.yml 4 shard 가 4 containerized runner 점유 → PR-5 머지 후 ci.yml 4 job 도 동일 풀 공유. pull_request 이벤트 시 동시 trigger 로 queue 포화 가능. 그러나 PR-4 의 named volume cache (Playwright + hostedtool) 효과로 job 시간 단축이 점유 해소 상쇄. 카운터 메저는 W3 stable 1주 관측 후 평가가 합리적 — 본 PR 에서 별도 조치 불필요.
+
+- **L-2 bare-host runner 가시성 (사용자 host 상태)**
+  spec L86-89 (Case B) 가 이를 정확히 식별: bare-host runner 등록은 사용자 SSH 직접 작업 영역으로 PR scope 밖. PR-5 routing 좁힘 후 ci.yml 의 4 job 은 bare-host 0 routing → tar 충돌 영구 해소 (이전 PR-170 1st CI run 진단 데이터, spec L29-37). bare-host runner 의 다른 workflow (현재 0건 — security-fast/deep, e2e-stubbed.yml 모두 containerized) 가시성은 W3 PR (사용자 SSH `./svc.sh uninstall`) carry-over 로 깔끔히 분리.
+
+- **L-3 Spec drift 부재**
+  spec (`refs/pr-5-ci-runs-on.md`) 가 본 PR diff 4 라인을 정확히 기술 (L17). H-1/H-2/H-3 결정 (matrix 의미, fold-in 의존, single-concern) 이 구조적 root cause 와 일치. 미래 reader 가 4-line diff 의 정공 fix 근거를 spec 만으로 재구성 가능.
+
+## carry-over 매핑 검증
+
+PR-5 spec Out of Scope (L98-108) ↔ checklist.md Carry-over (L113-131) 5 항목 일치 확인:
+
+| spec carry-over | checklist 매핑 위치 | 일치 |
+|---|---|---|
+| W3 fork PR 게이트 (spec L102) | checklist L128 ("PR-5 의존" 섹션 부재 — fork 게이트 단독 entry 없음) | **부분 누락** |
+| W3 bare-host runner 등록 해제 (spec L103) | checklist Carry-over 본문 미명시 | **누락** |
+| W3 RUNNERS_NET regex (spec L104) | checklist L130 ("RUNNERS_NET regex 강화" Sec-MED-1) | OK |
+| Phase 23 Custom Image (spec L106-107) | checklist L120-124 ("Custom Image Option A") | OK |
+| Phase 23 Composite action (spec L108) | checklist L119 ("Composite action 추출") | OK |
+
+**발견**: checklist.md 의 "Phase 22 W3 carry-over (PR-5 의존)" 섹션 (L128-131) 에 W3 carry-over 3건 중 1건만 수록 (RUNNERS_NET). fork PR 게이트 + bare-host 등록 해제 2건이 spec 에는 있으나 checklist 에는 미수록.
+
+**권고**: PR-5 머지 PR body 또는 follow-up commit 에서 checklist.md L128-131 섹션에 다음 2 라인 추가:
+- `- **[W3] ci.yml#go-check fork PR 게이트** (Sec carry-over) — public repo + sudo go test host docker.sock 접근. 본 PR scope 밖 (single-concern: routing label).`
+- `- **[W3] bare-host runner 등록 해제** (사용자 SSH 작업) — ci.yml routing 후 bare-host 0 routing 이지만 다른 workflow 에서 dead reference 방지.`
+
+이는 PR-5 의 single-concern 자체에는 영향 없으나 (4 라인 diff 변경 없음), 미래 reader 의 carry-over 추적성 보호 — checklist 가 phase 진입의 single source of truth 이므로.
+
+## 결론
+
+PR-5 는 본 phase 의 single-concern 카논을 가장 정밀하게 적용한 사례 (PR-170 의 4 DEBT 묶음 single-concern 예외와 대비됨 — PR-170 spec L29 명시). 4 라인 routing 변경이 PR-170 fold-in 으로 선행 해소된 step-level 부채 4건 (services block / testcontainers-go / jq / docker.sock build) 위에 안전하게 얹힘. fold-in 욕구 (composite action / fork 게이트 / RUNNERS_NET regex) 는 모두 carry-over 명시.
+
+**머지 가능 (admin-skip 만료 시점에도 자체 ALL pass 예상)**.
+
+**조건부 후속**: checklist.md L128-131 에 W3 carry-over 2건 (fork 게이트 + bare-host 등록 해제) 추가하여 spec ↔ checklist 5/5 일치 회복. PR-5 자체 머지 차단 조건은 아님 — follow-up commit (또는 PR body changelog) 으로도 충분.
+
+**Phase 23 진입 시 우선순위**: composite action 추출 (Arch-HIGH-1) 을 첫 task 로 — PR-5 머지 후 ci.yml + e2e-stubbed.yml 양쪽에서 60+ 라인 보일러플레이트 동시 active 상태 확대. Custom Image Option A 보다 선행 가능 (independent change, image migration 의존 없음).
+
+## 카논 ref
+
+- 부모 plan: `../checklist.md`
+- PR-5 spec: `../pr-5-ci-runs-on.md`
+- PR-170 review (composite action escalate 출처): `../reviews/PR-170-arch.md`
+- PR-168 spec drift 패턴: `../pr-4-runner-cache.md` (In-flight Spec drift 섹션)
+- single-concern 카논: `memory/feedback_branch_pr_workflow.md`
+- 4-agent 강제 정책: `memory/feedback_4agent_review_before_admin_merge.md`

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-performance.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-performance.md
@@ -1,0 +1,60 @@
+---
+pr: 5
+title: "Performance Review — ci.yml runs-on [self-hosted, containerized] 전환"
+branch: chore/w1-5-ci-runs-on
+base: main
+reviewer_focus: performance / efficiency
+review_date: 2026-04-29
+files_changed: 2
+diff: "+4/-4 (ci.yml 4줄 + checklist 2줄)"
+---
+
+# PR-5 Performance Review
+
+## Verdict: conditional
+
+조건: MEDIUM-1 carry-over spec 보완 명시 후 머지 허용. HIGH 항목 없음.
+
+---
+
+## HIGH (정량 회귀)
+
+없음.
+
+---
+
+## MEDIUM (정량 trade-off 수용 가능)
+
+### MEDIUM-1 — GHA cache fetch 비용: PR-5 신규 도입이 아님을 명시 필요
+
+bare-host 에서 `go-check` 의 GHA Go module cache (~369MB, Azure blob, 다운로드 ~15~30초) 는 이미 매 run 비용으로 지불되었으나 `Cannot open: File exists` tar 충돌로 효과 0 이었다. containerized (EPHEMERAL=true, 매 job 후 컨테이너 재시작) 전환 시 `~/go/pkg/mod` 디스크 clean → tar 정상 추출 → 약 **+10~20초/run 절감** (기존 효과 없던 cache 가 정상화). `ts-check` 는 bare-host 에서도 tar 충돌 없이 동작 중이었으므로 변화 없음. `docker-build` 는 PR-170 fold-in 으로 `sudo docker build` 직접 실행 — GHA cache 해당 없음.
+
+**신규 비용 없음**. 단, spec §진단 데이터에 "GHA cache 비용 신규 미발생" 명시 미완료 상태로 다음 리뷰어 혼동 가능. carry-over 권고.
+
+### MEDIUM-2 — `coverage-guard` jq apt-get install: 매 run ~5~13초, Phase 23 까지 누적
+
+`Ensure jq installed` step 은 EPHEMERAL=true 로 컨테이너 재시작 시 jq 소멸 → 매 run `apt-get update -qq` (~3~8초) + `apt-get install -y -qq jq` (~2~5초) 실행. 연간 100 run 가정 시 누적 ~17분. Phase 23 Custom Image 에 jq 사전 포함으로 자연 해소 예정 (pr-5-ci-runs-on.md §Phase 23 carry-over 기명시). 추가 조치 불필요.
+
+---
+
+## LOW (관찰)
+
+- **4 runner pool 포화**: PR push 시 동시 trigger 추정 8 job (ci.yml 2 + e2e 4 shard + security 2) → 4 runner 포화. warm cache 기준 e2e shard ~1분 → ci.yml 최대 ~1분 queue 대기. cold cache 기준 ~5분. `cancel-in-progress: true` 로 중복 push cancel 완화. runner 증설은 Phase 23 검토.
+- **docker-build full build 매 run**: EPHEMERAL 로 BuildKit layer cache 소멸 → ~2~4분/run. PR Build Check 목적 (push 없음) 이므로 기능 목표 충족. Phase 23 persistent layer cache 검토 가능.
+- **go-check postgres+redis manual startup latency**: warm ~5~15초, cold ~30~60초. PR-168 MEDIUM-PERF-3 와 동일 패턴으로 이미 수용 결정.
+
+---
+
+## carry-over 명시
+
+| 우선순위 | 항목 | 대상 Phase |
+|---|---|---|
+| P1 (任意) | spec §진단 데이터에 "GHA cache 비용 신규 미발생" 보완 (MEDIUM-1) | Phase 23 이전 任意 |
+| P2 | Phase 23 Custom Image 에 jq 사전 포함 (MEDIUM-2) | Phase 23 |
+| P3 | runner pool 증설 검토 (LOW-1) | Phase 23 |
+
+---
+
+## 결론
+
+PR-5 는 routing label 4줄 변경이며 성능 관점 **순이익 PR** 이다. bare-host tar 충돌로 무효화되던 `go-check` GHA cache (~369MB, ~10~20초/run) 가 정상화되고, 신규 성능 비용 도입은 없다. `coverage-guard` jq install (~5~13초/run) 은 Phase 23 Custom Image carry-over 로 기명시. HIGH 항목 없음. carry-over MEDIUM-1 spec 보완 후 **conditional pass — 머지 권고**.

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-security.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-security.md
@@ -1,0 +1,86 @@
+---
+pr: 5
+reviewer: security (sonnet-4-6)
+date: 2026-04-29
+findings: {high: 0, medium: 0, low: 2}
+verdict: pass
+---
+
+# PR-5 Security Review
+
+## Verdict: pass
+
+본 PR의 실제 변경은 ci.yml 4개 job의 `runs-on: self-hosted` → `runs-on: [self-hosted, containerized]` 라벨 좁힘 4줄이다. 새로운 공격 면은 도입하지 않는다. 기존 위험(fork PR 게이트 부재, `sudo go test` docker.sock 노출, RUNNERS_NET regex)은 PR-170에서 이미 존재했으며 본 PR이 증폭하지 않는다.
+
+---
+
+## HIGH
+
+없음
+
+---
+
+## MEDIUM
+
+없음
+
+**판단 근거**: 아래 두 항목은 최초 도입이 PR-170임을 확인했으므로 본 PR의 carry-over 명시로 처리한다.
+
+**① `sudo go test` docker.sock 노출** — `go-check` job의 `Run tests` step이 `sudo -E env "PATH=$PATH" go test`로 root 권한 + docker.sock 접근. fork PR 코드가 이 step에서 실행되면 host docker daemon 임의 조작(컨테이너 escape 경로) 가능. **도입: PR-170** (`fix(w1-5): PR-8 — runner third-party action 호환`, `99aa825`). 본 PR는 routing label만 변경하므로 이 step의 존재 여부·권한 모두 PR-170 이전과 동일. **증폭 없음.**
+
+**② fork PR의 악성 Dockerfile RCE** — `docker-build` job이 checkout된 PR ref의 `apps/server/Dockerfile`을 `sudo docker build`로 빌드. fork PR 기여자가 Dockerfile에 임의 명령 삽입 시 runner host에서 RCE 가능. **도입: PR-170** (manual `sudo docker build` fold-in). routing 변경으로 bare-host → containerized runner 전환이 일어나지만, 컨테이너화된 runner도 docker.sock을 공유하므로 호스트 격리 수준은 실질적으로 동일. **증폭 없음.**
+
+두 항목 모두 현재 admin-skip 정책(`project_ci_admin_skip_until_2026-05-01.md`) 하에서는 fork PR이 CI를 통과할 수 없는 구조이므로 실질 위험이 억제되어 있다. 부채 정리 완료 후 admin-skip 만료 전에 반드시 fork PR 게이트를 적용해야 한다.
+
+---
+
+## LOW
+
+### LOW-1 [Network Spoofing] RUNNERS_NET regex — `bad_runners-net` 오매칭 가능
+
+**위치**: `ci.yml` line 44 (`grep -E '(^|_)runners-net$'`)
+
+**분석**: PR-168 `e2e-stubbed.yml` LOW-1, PR-170 MEDIUM-1 carry-over. 본 PR이 이 패턴을 ci.yml에 '확산'하는 것이 아니라 해당 패턴은 PR-170에서 이미 ci.yml에 존재한다. 본 PR은 routing label만 변경하므로 이 line에 대한 직접적 기여 없음.
+
+**권고**: Phase 23 `.github/actions/start-services/action.yml` 추출 시 `^(runners-net|infra-runners_runners-net)$` 허용 목록으로 교체. 현재 docker.sock 접근이 이미 runner 침해를 전제로 하므로 즉각 차단 사유 아님.
+
+### LOW-2 [bare-host runner 잔존] ci.yml 완전 전환 후에도 bare-host runner 다른 workflow 라우팅 가능
+
+**위치**: `/home/sabyun/actions-runner/` (사용자 host)
+
+**분석**: 본 PR 머지 후 ci.yml의 4 job은 containerized runner로만 라우팅된다. 그러나 bare-host runner가 여전히 GitHub에 등록된 상태이므로, `runs-on: self-hosted` label을 사용하는 다른 workflow(또는 미래 추가 workflow)에 의도치 않게 routing될 수 있다. bare-host runner는 격리 없음(EPHEMERAL=false 가능성), 디스크 잔존, 비ephemeral 환경 위험을 가진다.
+
+**권고**: Phase 22 W3에서 bare-host runner 등록 해제 (사용자 SSH 직접 작업). 본 PR scope 밖이므로 즉각 차단 사유 아님.
+
+---
+
+## carry-over 명시
+
+### Phase 22 W3 (조건부 우선 처리)
+
+| ID | 내용 | 우선도 |
+|----|------|--------|
+| SEC-W3-1 | ci.yml `go-check` + `docker-build` fork PR 게이트 추가 (`if: github.event.pull_request.head.repo.fork == false`) | **admin-skip 만료 전 필수** |
+| SEC-W3-2 | bare-host runner 등록 해제 (사용자 SSH) | P1 |
+
+### Phase 23 escalate
+
+| ID | 내용 | 우선도 |
+|----|------|--------|
+| SEC-23-1 | RUNNERS_NET regex 허용 목록 강화 (Arch-HIGH-1 composite action 추출 시 적용) | P2 |
+| SEC-23-2 | runner image에 docker group GID 990 정착 → `sudo go test` / `sudo docker build` `sudo` 제거 | P1 |
+
+---
+
+## 결론
+
+본 PR은 routing label 4줄 변경으로 scope가 극히 좁다. 새로운 보안 위험을 도입하지 않으며, 기존 위험(fork PR 게이트 부재 · docker.sock 노출 · RUNNERS_NET regex)은 모두 PR-170 이전부터 존재하던 carry-over임을 코드 추적으로 확인했다. bare-host runner에서 containerized runner로의 전환은 보안 면에서 EPHEMERAL=true에 의한 잡 격리 향상이라는 긍정적 효과가 있다. **보안 관점 merge-ready (pass).**
+
+---
+
+## 카논 ref
+
+- `memory/feedback_4agent_review_before_admin_merge.md`
+- `memory/project_ci_admin_skip_until_2026-05-01.md`
+- `docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-170-security.md` (MEDIUM-1 RUNNERS_NET 원출처)
+- `docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-5-ci-runs-on.md` (H-1/H-2/H-3 결정)

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-test.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-test.md
@@ -1,0 +1,56 @@
+# PR-5 Test Review
+
+## Verdict: pass
+
+---
+
+## HIGH (regression 위험)
+
+없음.
+
+PR-170 fold-in(PR-8)이 이미 containerized runner 환경의 4대 실질 부채(services block, testcontainers-go docker.sock, jq 부재, docker build permission)를 모두 해소했다. 본 PR은 4줄 routing label 변경만이므로 새로운 regression 경로가 없다.
+
+---
+
+## MEDIUM (gap)
+
+**M-1. `setup-go` hostedtoolcache atomic install 검증 미완**
+
+4 containerized runner가 동일 `hostedtoolcache` named volume(`/opt/hostedtoolcache`)을 공유한다. go-check + ts-check + coverage-guard + docker-build가 동시 trigger될 때 `setup-go`가 동일 Go 1.25 캐시 키로 `/opt/hostedtoolcache/go/1.25.x/...`에 동시 write를 시도할 수 있다.
+
+- **CI가 가릴 수 있는 부분**: 첫 PR run(cold cache)이 통과하면 install 자체는 성공. 동시 4 job race는 coverage-guard가 go-check에 `needs:` 의존하므로 go-check/ts-check 완료 후에야 coverage-guard 기동 → 실제 동시 점유는 go-check + ts-check + docker-build 3 job에 한정.
+- **CI가 가릴 수 없는 부분**: `setup-go@v5`의 hostedtoolcache write가 non-atomic일 경우 간헐적 corrupt 가능. 이 경로는 단일 PR run으로 검증 불가(통계적으로 희귀). 현재 캐시 hit이면 write skip → 문제 잠복.
+
+**M-2. fork PR 게이트 부재 (carry-over 명시됨)**
+
+`go-check`의 `sudo go test`와 `sudo docker run`은 host docker.sock에 접근한다. fork PR의 untrusted code가 이 경로로 실행된다면 host runner 환경에 영향 가능. spec의 carry-over 판단(Phase 22 W3)은 적절하나 이 gap은 PR run CI로 검증 불가 — CI가 통과해도 위험이 닫히지 않는다.
+
+---
+
+## LOW (관찰)
+
+**L-1. CI 자체가 regression test인 것의 정당성**
+
+workflow routing 변경의 검증 수단은 PR run의 4 job 통과가 전부이며 이는 정당하다. GHA workflow 파일에 대해 별도 unit test를 작성하는 패턴(act 기반 local run 등)은 이 프로젝트의 CI 철학(실제 runner 환경 사용)과 맞지 않는다. routing label 변경의 부작용은 오직 실제 runner dispatch 결과로만 확인 가능하다.
+
+**L-2. PR-170 1st run의 go-check 선행 검증**
+
+spec의 진단 데이터에 따르면 PR-170 시점 go-check는 `runs-on: self-hosted`(bare-host)로 실행됐고 tar 충돌이 관찰됐다. mockgen drift, WS contract drift, PlayerAware coverage lint 3 step은 해당 run에서 모두 통과했다. 본 PR 전환 후 이 step들은 동일 바이너리(go generate, go run ./cmd/wsgen, bash script)를 containerized runner에서 실행하며 환경 의존성이 없으므로 정상 작동 예상.
+
+**L-3. `Fix coverage.out ownership`의 sudo chown**
+
+containerized runner에서 `sudo go test`가 root:root로 생성한 `coverage.out`을 `sudo chown "$(id -u):$(id -g)"`로 정정하는 패턴은 PR-170 fold-in에서 이미 검증됐다. runner 컨테이너의 UID/GID가 고정된 환경이라면 이 step은 멱등 동작한다.
+
+---
+
+## carry-over
+
+- **Phase 22 W3**: `go-check` fork PR 게이트 (`github.event.pull_request.head.repo.fork == false`)
+- **Phase 22 W3**: bare-host runner 등록 해제 (사용자 SSH 직접 작업)
+- **Phase 23**: hostedtoolcache write atomic 보장 — custom image에 Go 사전 install → `setup-go` write skip 경로 고정
+
+---
+
+## 결론
+
+4줄 routing 변경의 실질 위험은 PR run CI가 대부분 커버한다. CI가 가릴 수 없는 위험은 M-1(hostedtoolcache write race, 통계적 희귀)과 M-2(fork PR sudo 실행, carry-over 명시)이며 모두 이 PR의 scope 밖 판단이 이미 spec에 문서화됐다. 4-agent 리뷰 선행 없이 admin-merge 하는 경우가 아닌 한 pass 판정이 적절하다.


### PR DESCRIPTION
## Summary

- ci.yml 4 job (`go-check`, `ts-check`, `coverage-guard`, `docker-build`) routing label을 `[self-hosted, containerized]`로 좁힘
- PR-170 fold-in으로 이미 모든 step이 containerized 호환 — 본 PR은 routing label 4줄만
- bare-host runner의 tar `Cannot open: File exists` 충돌 영구 해소 (EPHEMERAL=true 컨테이너 → 매 job 디스크 clean)

## 진단 데이터 (PR-170 1st CI run 직접 검증)

| Runner | Cache 동작 |
|---|---|
| bare-host go-check | ✅ GHA cache hit + 🚨 tar `Cannot open: File exists` (cache 효과 0) |
| containerized e2e | ✅ GHA cache hit + ✅ pnpm `reused 705/705 downloaded 0` + named volume hit |

**효과**: `go-check` 기준 +10~20s/run 절감 (Performance review).

## 4-agent review (`memory/feedback_4agent_review_before_admin_merge.md` 카논)

| Agent | Verdict | HIGH | MED | LOW |
|---|---|---|---|---|
| Security (sonnet) | pass | 0 | 0 | 2 |
| Performance (sonnet) | conditional | 0 | 2 (carry-over) | 3 |
| Architecture (opus) | pass | 0 | 2 (carry-over) | 3 |
| Test (sonnet) | pass | 0 | 2 (carry-over) | — |

상세는 `docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-5-{security,performance,arch,test}.md`.

## Fold-in (review 권고)

- checklist W3 carry-over에 fork PR 게이트 + bare-host runner 등록 해제 2건 추가 (Architecture)
- spec ref에 GHA cache fetch 비용 본 PR 신규 도입 아님 명시 (Performance MED-1)

## Carry-over

### Phase 22 W3
- ci.yml `go-check` fork PR 게이트
- bare-host self-hosted runner 등록 해제 (사용자 SSH 직접 작업)
- RUNNERS_NET regex 정확 매칭 (`name: runners-net` explicit 매칭)

### Phase 23
- Custom Image Option A (Node v20 + docker GID 990 + Playwright + jq + govulncheck)
- Composite action `.github/actions/start-services/action.yml` 추출

## Test plan

- [ ] CI 4 job (`go-check`, `ts-check`, `coverage-guard`, `docker-build`) 4 containerized runner로 routing 확인
- [ ] go-check `Cache hit for: setup-go-...` ✅ + tar `File exists` 에러 0 검증
- [ ] coverage-guard `Ensure jq installed` step 정상 작동
- [ ] docker-build manual `sudo docker build` SUCCESS
- [ ] Security/E2E workflow regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)