### PR TITLE
chore(w1-5): PR-12 — actions/setup-go cache narrowing (build cache 제외)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,25 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
-          cache-dependency-path: apps/server/go.sum
+          # PR-12: setup-go default cache 가 ~/.cache/go-build 까지 push →
+          # 매 run 누적으로 cache 폭증 (369MB → 2.4GB+, fetch stuck 야기).
+          # cache: false 로 setup-go 자체 cache 비활성 + 직후 actions/cache 로
+          # ~/go/pkg/mod 만 narrow cache.
+          cache: false
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      # PR-12 Security MED-1 fold-in: restore-keys fallback 시 stale/오염 cache
+      # 차단. go mod verify 가 모든 module 의 sum 을 go.sum 과 비교 — checksum
+      # 불일치 시 step fail.
+      - name: Verify Go module integrity
+        run: go mod verify
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
@@ -291,7 +309,19 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      - name: Verify Go module integrity
+        working-directory: apps/server
+        run: go mod verify
 
       - name: Go coverage gate
         working-directory: apps/server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,14 @@ jobs:
           # ~/go/pkg/mod 만 narrow cache.
           cache: false
 
+      # PR-12 hotfix: containerized runner 의 EPHEMERAL=true 가 runner process
+      # 만 재등록 — 컨테이너 file system 의 ~/go/pkg/mod 잔존 → actions/cache
+      # restore 시 `tar: Cannot open: File exists` 충돌 + restore fail.
+      # 정공: image level fix (Phase 23 Custom Image entrypoint cleanup) 까지
+      # workflow level 사전 cleanup.
+      - name: Cleanup stale Go module directory
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
+
       - name: Cache Go modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -310,6 +318,9 @@ jobs:
         with:
           go-version: "1.25"
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
 
       - name: Cache Go modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -132,7 +132,19 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.24"
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      - name: Verify Go module integrity
+        working-directory: apps/server
+        run: go mod verify
 
       - name: Build server
         working-directory: apps/server

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -134,6 +134,9 @@ jobs:
           go-version: "1.24"
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
 
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
+
       - name: Cache Go modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/flaky-report.yml
+++ b/.github/workflows/flaky-report.yml
@@ -72,6 +72,9 @@ jobs:
           go-version: "1.24"
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
 
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
+
       - name: Cache Go modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/flaky-report.yml
+++ b/.github/workflows/flaky-report.yml
@@ -70,7 +70,19 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.24"
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      - name: Verify Go module integrity
+        working-directory: apps/server
+        run: go mod verify
 
       - name: Build server
         working-directory: apps/server

--- a/.github/workflows/module-isolation.yml
+++ b/.github/workflows/module-isolation.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           go-version: "1.24"
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/module-isolation.yml
+++ b/.github/workflows/module-isolation.yml
@@ -28,7 +28,16 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.24"
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+      - name: Verify Go module integrity
+        working-directory: apps/server
+        run: go mod verify
       - name: Module Isolation
         run: ../../scripts/test-module-isolation.sh
       - name: E2E Smoke Tests

--- a/.github/workflows/phase-18.1-real-backend.yml
+++ b/.github/workflows/phase-18.1-real-backend.yml
@@ -72,7 +72,19 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      - name: Verify Go module integrity
+        working-directory: apps/server
+        run: go mod verify
 
       - name: Build server
         working-directory: apps/server

--- a/.github/workflows/phase-18.1-real-backend.yml
+++ b/.github/workflows/phase-18.1-real-backend.yml
@@ -74,6 +74,9 @@ jobs:
           go-version: "1.25"
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
 
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
+
       - name: Cache Go modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -94,6 +94,9 @@ jobs:
           go-version-file: apps/server/go.mod
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
 
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
+
       - name: Cache Go modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -149,6 +152,10 @@ jobs:
         with:
           go-version-file: apps/server/go.mod
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        if: matrix.language == 'go'
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
 
       - name: Cache Go modules
         if: matrix.language == 'go'

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -92,7 +92,19 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: apps/server/go.mod
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      - name: Verify Go module integrity
+        working-directory: apps/server
+        run: go mod verify
 
       - name: Install osv-scanner
         run: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5
@@ -136,7 +148,21 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: apps/server/go.mod
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cache Go modules
+        if: matrix.language == 'go'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      - name: Verify Go module integrity
+        if: matrix.language == 'go'
+        working-directory: apps/server
+        run: go mod verify
 
       # Phase 22 W1.5 PR-8 DEBT-2: myoung34/github-runner image default Node
       # v10.19.0 가 ?? syntax 미지원. CodeQL action 의 spawn child process 가

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -34,7 +34,19 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: apps/server/go.mod
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
+
+      - name: Verify Go module integrity
+        working-directory: apps/server
+        run: go mod verify
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -36,6 +36,9 @@ jobs:
           go-version-file: apps/server/go.mod
           cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
 
+      - name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+        run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
+
       - name: Cache Go modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md
@@ -90,6 +90,14 @@ prs_estimated: 3
 - **검증**: `govulncheck ./...` 0 CRITICAL + 0 HIGH (또는 모두 allowlist 등록)
 - **상세**: [`refs/pr-3-govulncheck.md`](refs/pr-3-govulncheck.md) (작성 예정)
 
+### PR-12 — actions/setup-go cache narrowing (build cache 제외)
+- **Effort** S, **Impact** Very High (cache 폭증 369MB→2.4GB+ 정공 fix, Setup Go stuck 해소)
+- **branch**: `chore/w1-5-go-cache-narrow`
+- **변경**: 9 setup-go 호출 (`ci.yml` 2 + `e2e-stubbed.yml` 1 + `security-deep.yml` 2 + `security-fast.yml` 1 + `module-isolation.yml` 1 + `flaky-report.yml` 1 + `phase-18.1-real-backend.yml` 1) 에 `cache: false` + 명시적 `actions/cache` step 추가 (`~/go/pkg/mod` 만 cache, `~/.cache/go-build` 제외)
+- **의존**: PR-5 (#172) 와 parallel mergeable
+- **trigger**: PR-172 E2E shard 4개 모두 Setup Go stuck (1GB cache 0.0 MB/s, 5분+) → `gh cache list` 진단으로 cache 폭증 확인
+- **상세**: [`refs/pr-12-go-cache-narrow.md`](refs/pr-12-go-cache-narrow.md)
+
 ---
 
 ## Out of Scope

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-12-go-cache-narrow.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-12-go-cache-narrow.md
@@ -1,0 +1,169 @@
+# PR-12 — actions/setup-go cache narrowing (build cache 제외)
+
+> Parent: [`../checklist.md`](../checklist.md)
+
+**Goal**: `actions/setup-go` 의 default cache 가 `~/go/pkg/mod` + `~/.cache/go-build` 둘 다 push → 매 run 마다 build cache 누적 폭증 (369MB → 2.4GB+). `cache: false` + 명시적 `actions/cache` step 으로 `~/go/pkg/mod` 만 cache 하여 baseline 회복.
+
+## 진단 데이터 (PR-172 stuck 시점, 2026-04-29)
+
+GHA cache 크기 history (`gh cache list`):
+
+| 시점 | Go cache key | 크기 |
+|---|---|---|
+| 2026-04-22 (Go 1.25.9) | `setup-go-Linux-x64-ubuntu24-...` | 611MB |
+| 2026-04-28 09:27 (Go 1.25.0) | `setup-go-Linux-x64-undefined-go-1.25.0-...` | **369MB** ← 정상 baseline |
+| 2026-04-28 17:35 (Go 1.24.13) | `setup-go-Linux-x64-undefined-go-1.24.13-...` | 934MB |
+| 2026-04-28 23:26 (Go 1.24.13) | 동일 | 1,009MB |
+| 2026-04-29 00:37 (Go 1.24.13) | 동일 | 1,017MB |
+| 2026-04-29 00:47 (Go 1.25.0) | 동일 | 2,549MB |
+| 2026-04-29 01:31 (Go 1.24.13) | 동일 | **2,312MB** |
+
+PR-172 의 E2E shard 4개 모두 "Setup Go" 단계에서 5분+ stuck:
+```
+Cache hit for: setup-go-Linux-x64-undefined-go-1.24.13-...
+Received 0 of 1009429718 (0.0%), 0.0 MBs/sec  ← 1GB stuck
+Received 0 of 1009429718 (0.0%), 0.0 MBs/sec
+```
+
+GHA cache (Azure blob) → containerized runner (`runners-net` bridge) throughput 정체 + 1GB+ tar 추출 비용.
+
+## Root cause
+
+`actions/setup-go@v5` default 동작:
+- `~/go/pkg/mod` (GOMODCACHE) cache push
+- `~/.cache/go-build` (GOCACHE) cache push ← **이것이 폭증 원인**
+
+testcontainers-go + race-instrumented test build 의 incremental build cache 가 매 run 마다 누적되어 cache key 안에서 size 폭증.
+
+## 변경 요약
+
+| 파일 | setup-go 호출 수 | 변경 |
+|---|---|---|
+| `.github/workflows/ci.yml` | 2 (`go-check`, `coverage-guard`) | `cache: false` + `actions/cache` step 추가 |
+| `.github/workflows/e2e-stubbed.yml` | 1 | 동일 |
+| `.github/workflows/security-deep.yml` | 2 (`osv-scanner`, `codeql go`) | 동일 |
+| `.github/workflows/security-fast.yml` | 1 (`govulncheck`) | 동일 |
+| `.github/workflows/module-isolation.yml` | 1 | 동일 |
+| `.github/workflows/flaky-report.yml` | 1 | 동일 |
+| `.github/workflows/phase-18.1-real-backend.yml` | 1 | 동일 |
+
+**총 9 setup-go 호출** — single root cause (build cache 폭증) → single concern (cache narrowing) 카논 부합.
+
+### 패턴 (5 곳 동일)
+
+```yaml
+- name: Setup Go
+  uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+  with:
+    go-version: "..."
+    cache: false  # PR-12: ~/.cache/go-build 누적 폭증 회피
+
+- name: Cache Go modules
+  uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+  with:
+    path: ~/go/pkg/mod
+    key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
+    restore-keys: |
+      go-mod-${{ runner.os }}-
+```
+
+## 의존성
+
+- PR-5 (#172) 와 **parallel mergeable** — 같은 파일들 (`ci.yml`) 이지만 다른 영역 (PR-5: routing label / PR-12: setup-go cache)
+- `actions/cache@v4.2.3` SHA pin 신규 — Renovate digest 추적 (Phase 18.7 카논)
+
+## 검증 시뮬
+
+### Case A — fresh cache (cache miss)
+
+- Setup Go: hostedtoolcache hit (Go toolchain 자체)
+- Cache Go modules: miss → restore-keys fallback → 비어있으면 0
+- `go test` 첫 실행: `~/go/pkg/mod` fresh download (~1~2분)
+- post-job: `~/go/pkg/mod` 만 cache push (~370MB)
+
+### Case B — go.sum 동일 (cache hit)
+
+- Setup Go: hostedtoolcache hit
+- Cache Go modules: exact key hit → `~/go/pkg/mod` restore (~370MB, 30~60s)
+- `go test` 빠른 실행 (build cache 없으니 컴파일 비용 발생, 그러나 fetch 비용 절감 > 컴파일 비용)
+
+### Case C — go.sum 변경 (cache restore-keys hit)
+
+- Cache Go modules: exact key miss → restore-keys 으로 이전 cache fetch
+- `go test`: 새 dependency download + 변경 module 재컴파일
+- post-job: 새 cache key 로 push
+
+### 효과 추정
+
+- Cache 크기: 2.4GB+ → ~370MB (PR-170 baseline 수준)
+- Setup Go step: 5분+ stuck → 30~60s
+- 매 run 절감: ~3~4분 (fetch 비용 - 컴파일 비용 차)
+
+## H-1 결정 — PR-168 H-2 결정과 양립 가능
+
+PR-168 H-2 결정: "GHA cache 가 actions/setup-go cache 를 처리하므로 named volume 불필요" — **PR-12 는 H-2 retract 아님**. GHA cache 사용은 그대로, cache 범위만 좁힘 (`~/.cache/go-build` 제외).
+
+## H-2 결정 — `restore-keys` fallback 정당화
+
+`go.sum` 변경 시 exact key miss → `restore-keys: go-mod-${{ runner.os }}-` 로 가장 최근 partial cache fetch. `go mod download` 가 신규 dependency 만 추가 fetch — 효율적.
+
+## H-3 결정 — Go version 별 cache key 분리 X
+
+`~/go/pkg/mod` 는 Go version 무관 (module 자체는 source). 5 setup-go (Go 1.24/1.25 혼재) 모두 같은 key 공유 가능. cache 1개로 통일 → cache slot 효율.
+
+## H-4 결정 — `cache-dependency-path` 제거
+
+`cache-dependency-path: apps/server/go.sum` 은 setup-go cache 의 input. `cache: false` 로 setup-go 자체 cache 비활성화 후 무의미 — 명시적 actions/cache 의 `hashFiles` 가 동일 역할. 5 곳 모두 제거.
+
+## Carry-over
+
+### Phase 23 (Custom Image Option A)
+- base image 에 `~/go/pkg/mod` 사전 populate → PR-12 의 actions/cache fetch 도 dead code 가능
+- 현 PR 의 9 fold-in 은 W1.5 임시 fix, Phase 23 까지 운영
+- **composite action `.github/actions/setup-go-narrow/action.yml` 추출** (Architecture HIGH-A1 carry-over) — 9 callsite × 8 line YAML 복제 (~72 라인). setup-go v6 / actions/cache v5 버전업 시 9 곳 일괄 갱신 부담 해소. PR-170 Arch-HIGH-1 (`start-services` composite action) 와 함께 Phase 23 진입 시 추출.
+
+### W1.5 후속 PR (PR-13 후보)
+- **build cache 별도 actions/cache** (Performance HIGH-1 carry-over) — `~/.cache/go-build` 제외로 매 run cold compile (`-race` instrumented test ~90~120s 추가). 정공: `path: ~/.cache/go-build` + `key: go-build-${{ runner.os }}-${{ github.sha }}` + `save-always: true` 별도 cache. sha 기반 key 라 매 run 새 entry → 10GB / 7day GHA eviction 정책으로 자동 정리.
+- **`go-mod-${{ runner.os }}-` cache key 의 Go version split** (Architecture LOW carry-over) — 현재 9 workflow 가 Go 1.24/1.25 혼재한 단일 key. 향후 build cache 재도입 시 version-split 필수 (1.24 build object ↔ 1.25 호환 문제).
+- **schedule-only workflow 검증** (Test HIGH carry-over) — `flaky-report.yml`, `phase-18.1-real-backend.yml` 은 PR run 미실행. main 머지 후 첫 nightly/push 결과 관측 후 회귀 발견 시 hotfix.
+- **`timeout-minutes` 명시** (Test MED carry-over) — `ci.yml#go-check` + 8 workflow 의 `Run tests`/`Build server` step 에 `timeout-minutes: 15` 등 명시. silent hang 방지.
+
+## 4-agent review fold-in 항목
+
+본 PR 에 fold-in (코드 변경):
+- **Security MED-1**: 9 workflow 의 actions/cache step 다음에 `go mod verify` step 추가 — `restore-keys` fallback 시 stale/오염 cache 차단. checksum 불일치 시 step fail.
+
+본 PR 에 fold-in (문서 변경):
+- **Architecture HIGH-A1**: composite action 추출 Phase 23 carry-over 명시 (위 "Carry-over" 섹션)
+- **Performance HIGH-1**: build cache 제외 trade-off 명시 + PR-13 carry-over (위 "Carry-over" 섹션)
+- **Test HIGH-1**: schedule-only workflow 검증 한계 carry-over (위 "Carry-over" 섹션)
+
+본 PR 에 fold-in 안 함 (carry-over 명시):
+- Security LOW-1 (SHA pin 직접 검증) — Renovate 자동 추적으로 위임
+- Security LOW-2 (9 workflow cache 공유 ops 문서화) — README 별도 PR
+- Performance MED-1 (9 workflow 동시 push race) — GHA cache eviction 정책 의존, 운영 관찰
+- Performance LOW-1 (Go version 혼재 stale 경고) — version-split carry-over
+- Architecture MED 1-3 (모두 정당화 성립, 코드 변경 X)
+- Test MED-2 (1st PR run cache miss 검증 한계) — 본 PR run 자체가 baseline 형성
+- Test LOW 2 (sudo HOME 경로 / 이중 layer) — 운영 관찰
+
+## 4-agent review 결과 요약
+
+본 PR diff 기준 (9 setup-go 호출 변경 + 9 actions/cache step 추가 + 9 verify step 추가 + spec):
+
+| Agent | HIGH | MEDIUM | LOW | Verdict |
+|---|---|---|---|---|
+| Security | 0 | 1 (fold-in: go mod verify) | 2 (carry-over) | conditional → fold-in 후 pass |
+| Performance | 1 (PR-13 carry-over) | 1 (race) | 1 (version stale) | conditional |
+| Architecture | 1 (Phase 23 composite carry-over) | 3 (정당화) | 2 (관찰) | conditional |
+| Test | 1 (schedule-only carry-over) | 2 (timeout / 1st run miss) | 2 (관찰) | conditional |
+
+상세는 `reviews/PR-12-{security,performance,arch,test}.md` 4 파일.
+
+## 카논 ref
+
+- 부모 plan: `../checklist.md`
+- PR-5 spec: `pr-5-ci-runs-on.md` (parallel)
+- PR-168 H-2 (GHA cache 사용 정당화): `pr-4-runner-cache.md`
+- 4-agent 강제 정책: `memory/feedback_4agent_review_before_admin_merge.md`
+- single-concern: `memory/feedback_branch_pr_workflow.md`

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-12-go-cache-narrow.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/pr-12-go-cache-narrow.md
@@ -128,10 +128,37 @@ PR-168 H-2 결정: "GHA cache 가 actions/setup-go cache 를 처리하므로 nam
 - **schedule-only workflow 검증** (Test HIGH carry-over) — `flaky-report.yml`, `phase-18.1-real-backend.yml` 은 PR run 미실행. main 머지 후 첫 nightly/push 결과 관측 후 회귀 발견 시 hotfix.
 - **`timeout-minutes` 명시** (Test MED carry-over) — `ci.yml#go-check` + 8 workflow 의 `Run tests`/`Build server` step 에 `timeout-minutes: 15` 등 명시. silent hang 방지.
 
+## 1차 push 후 발견 (hotfix)
+
+**PR-173 첫 CI run (`25095791678` 등) 에서 govulncheck + osv-scanner timeout fail**:
+
+```
+/usr/bin/tar: ../../../../home/runner/go/pkg/mod/dario.cat/mergo@v1.0.2/...: Cannot open: File exists
+##[warning]Failed to restore: tar exit code 2
+Cache not found for input keys: go-mod-Linux-...
+##[error]The operation was canceled.
+```
+
+**진짜 root cause**: containerized runner 의 EPHEMERAL=true 가 runner process 만 재등록 — 컨테이너 file system 의 `~/go/pkg/mod` 잔존. `actions/cache` restore 가 tar 추출 시 "File exists" 충돌 → restore fail → cache miss fallback → fresh download → job timeout.
+
+PR-170 진단 시 본 동일 메커니즘 — bare-host 가설 부정확. **containerized runner 도 file system reset 안 됨** (runner deregister + register 만, container file system 보존).
+
+**Hotfix fold-in (이번 PR 에 추가, 9 곳)**:
+
+```yaml
+- name: Cleanup stale Go module directory  # PR-12 hotfix: tar 충돌 방지
+  run: sudo rm -rf ~/go/pkg/mod ~/.cache/go-build
+```
+
+setup-go 직후 + actions/cache 직전. setup-go 의 hostedtoolcache (`/opt/hostedtoolcache`) 는 named volume 이라 영향 X. `~/go/pkg/mod` + `~/.cache/go-build` 만 cleanup.
+
+**Phase 23 carry-over 정공**: Custom Image entrypoint 또는 myoung34 image 의 EPHEMERAL 동작 fix → workflow level cleanup step dead code.
+
 ## 4-agent review fold-in 항목
 
 본 PR 에 fold-in (코드 변경):
 - **Security MED-1**: 9 workflow 의 actions/cache step 다음에 `go mod verify` step 추가 — `restore-keys` fallback 시 stale/오염 cache 차단. checksum 불일치 시 step fail.
+- **Hotfix (1차 push 후 발견)**: 9 workflow 의 setup-go 직후에 `sudo rm -rf ~/go/pkg/mod ~/.cache/go-build` cleanup step 추가 — tar 충돌 차단.
 
 본 PR 에 fold-in (문서 변경):
 - **Architecture HIGH-A1**: composite action 추출 Phase 23 carry-over 명시 (위 "Carry-over" 섹션)

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-arch.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-arch.md
@@ -1,0 +1,45 @@
+# PR-12 Architecture Review
+
+## Verdict: conditional
+
+분기 1건 (HIGH-A1, composite action 추출 carry-over 명시) 만 충족하면 머지 가능. nine-callsite fold-in 자체는 single root cause(`~/.cache/go-build` 누적) → single concern 카논 부합.
+
+## HIGH
+
+### HIGH-A1 — DRY 위반의 운영 부채 명시 부재
+
+9 callsite × 8 line YAML 블록 = 72 줄 사실상 동일 패턴 복제. `actions/cache@v4.2.3` SHA, key 포맷, `restore-keys` 폴백, 주석 9곳 일괄 갱신 의무 발생. setup-go v6 또는 actions/cache v5 출시 시 9 PR 또는 1 거대 PR 강제 — DRY 카논 명백 위반. spec 의 carry-over 섹션에 **"Phase 23 entry: composite action `.github/actions/setup-go-narrow` 추출, 9곳을 `uses: ./.github/actions/setup-go-narrow` 1줄로 환원"** 항목을 명시 추가 필요. carry-over 명문화 없으면 영구 부채화.
+
+## MEDIUM
+
+### MED-A1 — H-2 정합성 narrative 정밀 (정당)
+
+PR-168 H-2 의 본질은 "GHA cache 메커니즘 사용 자체" (named volume override 금지) 였지 "setup-go default cache 범위 보존"이 아니었다. PR-12 는 GHA cache 사용을 유지하면서 path 만 `~/go/pkg/mod` 로 좁히므로 **H-2 retract 아님 정당화 성립**. 단 spec H-1 의 표현을 "H-2 의 *cache 메커니즘 선택* 결정과 양립; *cache 범위* 결정은 본 PR 에서 신규" 로 정밀화하면 audit trail 명확.
+
+### MED-A2 — single-concern 카논 부합 (9 fold-in 정당)
+
+`feedback_branch_pr_workflow.md` 는 type/scope/slug 한 단위만 강조; 9 fold-in 의 위험 신호는 (a) 다른 root cause, (b) 다른 패턴, (c) 독립 rollback 필요. PR-12 는 (a) 단일 root cause(`~/.cache/go-build` size 누적), (b) 8 line 동일 패턴, (c) 1 workflow 만 부분 적용 시 cache key collision 위험 — 9 일괄 갱신이 오히려 **atomicity 보장**. 4 분리는 reject (audit trail noise + 부분 적용 cache pollution 위험).
+
+### MED-A3 — H-3 cache key 통일 정당화 (구조적 정합)
+
+`~/go/pkg/mod` 의 module cache 는 Go toolchain version 무관 (소스 + checksum). Go 1.24/1.25 혼재 7 workflow 에서 단일 key 공유 → cache slot 1개 점유 + cross-workflow restore-keys hit 활성화. version 분리는 슬롯 2배 + hit rate 절반의 anti-pattern. **결정 정당**, 단 spec 에 "상위 build cache(`~/.cache/go-build`)는 toolchain 종속이므로 향후 재도입 시 version-split 필수" 단서 추가 권장.
+
+## LOW
+
+### LOW-A1 — Phase 23 dead code 가능성
+
+base image populate 시 `actions/cache` step 자체가 dead. 다만 image rebuild 주기 vs `go.sum` drift 빈도 트레이드오프 존재 — PR-12 는 image refresh 후에도 incremental delta restore 역할 유지 가능. dead 가 아닌 **fallback 안전망**으로 재정의.
+
+### LOW-A2 — PR-5 (#172) 동시 머지 안전
+
+PR-5 변경은 `runs-on:` 라벨, PR-12 변경은 `setup-go`/`actions/cache` step. 동일 파일이지만 직교 영역. 머지 순서 무관, conflict 없음 — 단 두 PR rebase 시 둘 다 같은 9 workflow touch 했음을 자동 conflict resolver 가 인지하도록 `git rerere` 활성화 권장.
+
+## carry-over (Phase 23)
+
+1. **HIGH-A1 후속**: composite action `.github/actions/setup-go-narrow` 추출 (input: go-version, sum-path → step output: cache-hit). 9 callsite → 1 줄 환원.
+2. **LOW-A1 평가**: Custom Image populate 후 `actions/cache` 효과 측정 (hit rate < 5% 시 제거).
+3. **W1.5 후속**: PR-167 fold-in 이후 `~/.cache/go-build` 누적이 진짜 root cause 인지 1주 cache size 추적.
+
+## 결론
+
+architectural soundness **conditional pass**. 9 fold-in 은 single root cause + atomicity 측면에서 카논 부합, H-2/H-3 결정은 구조적으로 정당. 단 72줄 YAML 복제는 DRY 부채로 영구화될 위험 — Phase 23 carry-over 에 composite action 추출을 명시 추가 후 머지 권고. PR-5 와 parallel mergeable 정당.

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-performance.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-performance.md
@@ -1,0 +1,42 @@
+# PR-12 Performance Review
+
+## Verdict: conditional
+
+---
+
+## HIGH
+
+**build cache 미포함 → 매 run 전체 컴파일** — `~/.cache/go-build` 제외로 incremental compile 가속이 사라짐. testcontainers-go v0.42 + race-instrumented 테스트의 컴파일 비용은 cold 기준 약 90~120초 추정 (go.sum 477줄·중규모 dep tree, -race 2~3× overhead). golangci-lint, coverage, e2e-stubbed build 합산 시 CI 1회 실행 총 컴파일 추가 비용 ~3~5분.
+
+---
+
+## MEDIUM
+
+**cache key 공유 race** — 9개 workflow 모두 동일 key `go-mod-Linux-<go.sum hash>`. 동시 push 시 마지막 `actions/cache` save 만 살아남음 (GHA last-writer-wins). 발생 빈도는 낮지만 force-push / merge train 환경에서 cache miss → 연쇄 full-download 위험.
+
+**restore-keys fallback 의 false economy** — `go-mod-Linux-` partial hit 시 stale mod cache 로 빌드 시도 → go download 보정 발생. 실제 절감 없이 복잡성만 추가되는 케이스 가능.
+
+---
+
+## LOW
+
+**Go 버전 혼재** — ci.yml + security 계열은 `1.25`, e2e-stubbed/flaky/module-isolation 은 `1.24`. 동일 key prefix 공유 시 mod 캐시는 호환 가능하나, `go build` 아티팩트는 별도 디렉토리라 실질 충돌 없음. 단, 두 버전이 같은 restore-keys 에 매칭되면 stale 경고 가능.
+
+---
+
+## 정량 추정
+
+| 구간 | Before (PR-172 stuck) | After (PR-12) |
+|------|----------------------|---------------|
+| mod cache fetch | 5분+ (0.0 MB/s 정체) | ~30초 (370 MB @ 50 MB/s 추정) |
+| build cache fetch | 포함 → 2.4 GB+ 비대 (stuck 원인) | 없음 (0초) |
+| 컴파일 (incremental) | ~30초 (cache hit) | **~90~120초 (cold, -race)** |
+| 총 예상 | ∞ (stuck) | **~2~2.5분** |
+
+**순효과**: fetch 정체 5분+ → 2.5분 이하. **~2.5분 단축**. build cache 미포함 컴파일 추가비용 (~90초) 을 감수해도 stuck 상태 대비 압도적 개선.
+
+---
+
+## 결론
+
+fetch throughput 정체(Azure blob → containerized runner 0.0 MB/s) 는 2.4 GB build cache가 직접 원인이므로 제외 결정은 타당. 단, build cache 를 장기적으로 포기하면 -race 컴파일 비용이 누적됨. **조건부 통과**: 머지는 허용하되 `~/.cache/go-build` 를 별도 key(`go-build-${{ github.sha }}`) + `save-always: true` 로 작게 분리하는 후속 DEBT를 등록 권고.

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-security.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-security.md
@@ -1,0 +1,83 @@
+---
+pr: 12
+title: "chore(w1-5): 9 workflow setup-go cache: false + actions/cache narrow (go/pkg/mod only)"
+branch: chore/w1-5-go-cache-narrow
+base: main
+review_type: security
+reviewer: security-agent
+review_date: 2026-04-29
+files_reviewed:
+  - .github/workflows/ci.yml
+  - .github/workflows/e2e-stubbed.yml
+  - .github/workflows/flaky-report.yml
+  - .github/workflows/module-isolation.yml
+  - .github/workflows/phase-18.1-real-backend.yml
+  - .github/workflows/security-deep.yml (2 job)
+  - .github/workflows/security-fast.yml
+verdict: "conditional — MEDIUM-1 수정 권고, 나머지 pass"
+---
+
+# PR-12 Security Review
+
+## Verdict: conditional
+
+MEDIUM-1 (fork PR write isolation) 을 merge 전 해소 권고. HIGH 없음. SHA pin + single-concern 은 pass.
+
+---
+
+## HIGH
+
+없음.
+
+---
+
+## MEDIUM
+
+### MEDIUM-1 [Fork PR Cache Write] 5개 pull_request 트리거 workflow — restore-keys fallback 이 stale cache carryover 허용
+
+**대상**: `ci.yml`, `module-isolation.yml`, `security-deep.yml`, `security-fast.yml` (pull_request 트리거 4개 + e2e-stubbed.yml 은 fork gate 기존 존재)
+
+**시나리오**:
+- GitHub Actions `actions/cache` 는 `pull_request` 이벤트에서 **write(save)를 fork PR 에 차단**하지만, **same-repo PR 은 cache write 허용**된다.
+- 같은 `go-mod-Linux-` restore-keys prefix 를 9 workflow 가 공유한다. same-repo malicious PR 이 go.sum 을 수정해 악성 module 을 `~/go/pkg/mod` 에 populate 하면, 동일 prefix cache entry 가 저장된다.
+- 다음 run 에서 다른 workflow 의 restore-keys fallback (`go-mod-Linux-`) 이 이 오염된 partial cache 를 히트, 악성 module 이 carryover된다.
+- 단, `go mod verify` 가 없는 job 은 체크섬 검증 없이 오염 module 을 사용하게 된다.
+
+**실제 위험도**: same-repo write access 가 전제이므로 외부 공격자 경로는 차단됨. 그러나 내부 contributor trust + supply chain 사고(계정 탈취) 가 결합되면 실현 가능.
+
+**권고 (둘 중 택1)**:
+1. (선호) `go mod verify` step 을 Go 테스트 실행 직전에 추가:
+   ```yaml
+   - name: Verify Go modules
+     working-directory: apps/server
+     run: go mod verify
+   ```
+2. (대안) restore-keys fallback 제거 — exact key miss 시 cache 없이 진행:
+   ```yaml
+   # restore-keys 블록 전체 제거
+   ```
+
+---
+
+## LOW
+
+### LOW-1 [SHA 검증] `5a3ec84eff668545956fd18022155c47e93e2684` — v4.2.3 태그 일치 확인 필요
+
+PR 에서 사용하는 `actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3` SHA 를 독립 검증하지 못했다 (오프라인 환경). 단, Renovate `helpers:pinGitHubActionDigests` 가 활성화되어 있고 이 SHA 가 PR-12 내 신규 도입이므로, **merge 전 담당자가 `gh api repos/actions/cache/git/ref/tags/v4.2.3` 으로 SHA 일치 여부를 직접 확인**할 것을 권고. Renovate 가 다음 monthly PR 에서 자동 업데이트 추적한다.
+
+### LOW-2 [Cache Scope 공유] 9 workflow 동일 key prefix — 비정상 cache hit 가능성
+
+`go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}` 를 9 workflow 가 공유한다. go.sum 이 동일하면 모든 workflow 가 같은 cache entry 를 사용하는 것이 **의도된 설계**이며 운영 효율이 높다. 단, 하나의 workflow job 이 cache 를 corrupt 시키면 9 workflow 전체가 영향받는 구조임을 문서화 권고 (ops 인지).
+
+---
+
+## carry-over
+
+- `go mod verify` 추가를 PR-12 에서 해소하거나 Phase 23 task 로 명시 등록 필요.
+- SHA `5a3ec84e...` 검증 결과를 pr-12-go-cache-narrow.md 에 기록.
+
+---
+
+## 결론
+
+SHA pin + `helpers:pinGitHubActionDigests` + Renovate monthly tracking 조합은 supply chain pin 카논(Phase 18.7)과 일치한다. `cache: false` + narrow path 는 `~/.cache/go-build` 누락이라는 single root cause 에 대한 일관된 수정이므로 single-concern 위반 아님. fork PR write 는 GitHub Actions 기본 정책(fork PR = read-only cache)으로 **외부 공격 경로는 차단**되나, same-repo PR 의 restore-keys fallback 오염 경로(MEDIUM-1) 는 `go mod verify` 한 줄로 완전 차단 가능하다. 이를 추가하면 unconditional pass.

--- a/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-test.md
+++ b/docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-test.md
@@ -1,0 +1,53 @@
+# PR-12 Test Review
+
+## Verdict: conditional
+
+---
+
+## HIGH
+
+**main-only workflow 3개 — PR run 에서 검증 불가**
+
+`flaky-report.yml` (schedule 전용, Monday 06:00 UTC), `phase-18.1-real-backend.yml` (schedule + push, PR trigger 없음) 는 본 PR run 에서 실행되지 않는다. `security-deep.yml` 은 `pull_request: branches: [main]` + `push: branches: [main]` 모두 트리거되므로 PR run 에서 실행되나, CodeQL matrix job(`matrix.language == 'go'`) 에만 `if: matrix.language == 'go'` 조건이 붙은 actions/cache step 이 있고 govulncheck job 에는 조건이 없다 — 정합성은 맞으나 matrix miss 시 cache step 이 go 외 언어에도 실행되는 구조적 노이즈가 남아 있다.
+
+`flaky-report.yml` + `phase-18.1-real-backend.yml` 의 `cache: false` + `actions/cache` 패턴은 **main 머지 후 첫 push/nightly** 에서야 검증된다. 이 두 workflow 에서 step 순서 오류(e.g. `go install` 이 mod cache restore 보다 앞에 오는 경우) 또는 `path: ~/go/pkg/mod` 경로 오인식이 있어도 PR CI 는 green 이다.
+
+---
+
+## MEDIUM
+
+**`go test -race` 의 step timeout 미설정 — fresh compile 조건에서 timeout 위험**
+
+`ci.yml` 의 `go-test` job 에 `timeout-minutes` 선언이 없다(기본 6시간). build cache(`~/.cache/go-build`) 제외로 testcontainers-go v0.42 race-instrumented cold compile 이 매 run 발생한다(추정 90~120초 추가). 현재 은 self-hosted runner 에서 고정 GHA 기본값에 의존 — 향후 runner 자원 부족 시 silent hang 가능. `timeout-minutes: 20` 명시 권고.
+
+**cache hit 검증은 2nd run 이후에만 가능**
+
+1st PR run 은 항상 cache miss (new branch key). `actions/cache` 가 정상 save → 2nd run(re-push 또는 merge 후 push)에서 hit 여부 확인 가능. PR 머지 전 단 1회 green 만으로는 restore 경로가 실제로 동작하는지 검증되지 않는다. cache miss/hit 상태를 출력하는 step 이 없어 artifact 없이는 판별 불가.
+
+---
+
+## LOW
+
+**`go test -race` 커버리지 step 의 sudo 권한 + build cache 미포함 조합**
+
+`ci.yml` L176: `sudo -E env "PATH=$PATH" go test -race -coverprofile=coverage.out ./...` — sudo 환경에서 `~/go/pkg/mod` 는 실제 `/root/go/pkg/mod` 로 resolve 될 수 있다. actions/cache 의 `path: ~/go/pkg/mod` 는 `runner` 사용자 홈(`/home/runner/go/pkg/mod`)으로 restore 되므로 sudo go test 가 mod cache 를 miss 할 가능성 있음. 로컬에서 재현 어렵고 runner 이미지에 따라 다름.
+
+**hostedtoolcache vs actions/cache 통합 검증 step 부재**
+
+`setup-go` 의 Go 바이너리 toolchain 은 hostedtoolcache 에, mod cache 는 `~/go/pkg/mod` 에 별도 저장된다. 두 경로가 모두 정상인지 확인하는 step(e.g. `go env GOPATH GOMODCACHE` 출력) 이 없어 장애 발생 시 어느 레이어가 문제인지 구분하기 어렵다.
+
+---
+
+## carry-over
+
+| # | 항목 | 권고 |
+|---|------|------|
+| C-1 | `flaky-report.yml` + `phase-18.1-real-backend.yml` cache 패턴 — main 1st push green 확인 후 W1.5 wrap 체크리스트에 결과 기록 | main 머지 후 필수 관측 |
+| C-2 | `go test -race` job 에 `timeout-minutes: 20` 추가 | 별도 hygiene commit 또는 PR-12 fold-in |
+| C-3 | `sudo go test` + `~/go/pkg/mod` cache path 불일치 — runner 이미지 업그레이드 시 재현 여부 확인 | Phase 22 W2 DEBT 등록 |
+
+---
+
+## 결론
+
+PR run 에서 실행되는 4개 workflow(ci.yml, e2e-stubbed.yml, security-fast.yml, module-isolation.yml)는 변경 패턴을 검증한다. 그러나 **`flaky-report.yml` 과 `phase-18.1-real-backend.yml` 은 PR CI 사각지대** — main 머지 후 첫 nightly/push 에서야 fail 이 드러난다. 이 두 workflow 의 cache step 오류는 flaky test 감지 지연 또는 backend real-backend nightly 중단으로 이어질 수 있다. 머지는 허용하되 main 첫 push 결과를 carry-over C-1 로 추적하는 조건부 통과.


### PR DESCRIPTION
## Summary

- `actions/setup-go` default cache가 `~/.cache/go-build`까지 push해서 매 run 누적 폭증 (369MB → 2.4GB+, fetch stuck 0.0 MB/s 야기)
- 9 setup-go 호출에 `cache: false` + 명시적 `actions/cache` step (`~/go/pkg/mod`만)
- 9 verify step (`go mod verify`) fold-in — Security MED-1 (cache poisoning 차단)

## 진단 데이터 (PR-172 stuck 시점)

E2E shard 4개 모두 Setup Go stuck:
```
Cache hit for: setup-go-Linux-x64-undefined-go-1.24.13-...
Received 0 of 1009429718 (0.0%), 0.0 MBs/sec  ← 5분+ 지속
```

`gh cache list` 폭증 history:
| 시점 | 크기 |
|---|---|
| 2026-04-28 09:27 | **369MB** ← 정상 baseline |
| 2026-04-29 00:47 | **2,549MB** ← 폭증 |
| 2026-04-29 01:31 | **2,312MB** |

**Root cause**: `actions/setup-go@v5` default가 `~/.cache/go-build` (incremental build cache)까지 push → testcontainers-go + race-instrumented test의 build output 누적.

## 변경 (9 setup-go 호출)

| 파일 | 호출 수 | trigger |
|---|---|---|
| `ci.yml` | 2 (go-check, coverage-guard) | PR + push |
| `e2e-stubbed.yml` | 1 | PR + push |
| `security-deep.yml` | 2 (osv, codeql go) | PR + push |
| `security-fast.yml` | 1 (govulncheck) | PR + push |
| `module-isolation.yml` | 1 | PR + push |
| `flaky-report.yml` | 1 | schedule-only |
| `phase-18.1-real-backend.yml` | 1 | schedule + push |

각 곳에 동일 패턴:
```yaml
- name: Setup Go
  uses: actions/setup-go@40f1582b... # v5.6.0
  with:
    go-version: "..."
    cache: false  # ~/.cache/go-build 누적 폭증 회피

- name: Cache Go modules
  uses: actions/cache@5a3ec84e... # v4.2.3
  with:
    path: ~/go/pkg/mod
    key: go-mod-${{ runner.os }}-${{ hashFiles('apps/server/go.sum') }}
    restore-keys: |
      go-mod-${{ runner.os }}-

- name: Verify Go module integrity  # Security MED-1 fold-in
  working-directory: apps/server
  run: go mod verify
```

## 4-agent review (`memory/feedback_4agent_review_before_admin_merge.md`)

| Agent | Verdict | HIGH | merge 전 fold-in |
|---|---|---|---|
| Security (sonnet) | conditional → pass | 0 | ✅ MED-1 `go mod verify` 9 곳 추가 |
| Performance (sonnet) | conditional | 1 | spec carry-over (PR-13 build cache) |
| Architecture (opus) | conditional | 1 | spec carry-over (Phase 23 composite action) |
| Test (sonnet) | conditional | 1 | spec carry-over (schedule-only verification) |

상세는 `docs/plans/2026-04-28-phase-22-w1-5-debt-cleanup/refs/reviews/PR-12-{security,performance,arch,test}.md`.

## Carry-over

### W1.5 PR-13 후보
- `~/.cache/go-build` 별도 actions/cache (key: `github.sha`, `save-always: true`) — Performance HIGH-1 (cold compile +90~120s/run) 회복

### Phase 23 (Custom Image)
- composite action `.github/actions/setup-go-narrow/action.yml` 추출 — Architecture HIGH-A1 (9 callsite × 8 line YAML 복제 ~72 라인)
- base image populate 시 actions/cache 자체 dead code 가능

### main 머지 후 관측 (Test HIGH-1)
- `flaky-report.yml`, `phase-18.1-real-backend.yml` schedule-only — 첫 nightly/push에서 회귀 발견 시 hotfix

## Test plan

- [ ] PR run 4 workflow (ci, e2e, security-fast, module-isolation) green
- [ ] go-check `Cache Go modules` step 의 cache key 확인 (`go-mod-Linux-${hash}`)
- [ ] `Verify Go module integrity` step 통과 (checksum 일치)
- [ ] 다음 PR run에서 cache hit 시 ~/go/pkg/mod fetch <1분
- [ ] main 머지 후 `gh cache list`에서 Go cache 크기 ~370MB로 회복 확인
- [ ] flaky-report nightly + phase-18.1 push 첫 실행 회귀 없음

## 의존성 / 머지 순서

- PR-5 (#172) 와 **parallel mergeable** — 같은 파일 (`ci.yml` 등) 이지만 다른 영역 (PR-5: routing label / PR-12: setup-go cache)
- PR-12가 먼저 머지되면 → PR-5 (#172)의 cache stuck 자연 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)