### PR TITLE
feat(phase-23): Custom Runner Image (multi-stage + 9 workflow 정리)

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -20,17 +20,17 @@ jobs:
   build:
     runs-on: [self-hosted, containerized]
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       - name: Login to GHCR
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           file: infra/runners/Dockerfile
@@ -52,9 +52,10 @@ jobs:
               govulncheck -version
               ls /opt/hostedtoolcache/go/1.25.0/x64/bin/go
               ls /opt/hostedtoolcache/node/20.18.0/x64/bin/node
-              mkdir -p ~/go/pkg/mod/dummy
-              touch ~/go/pkg/mod/dummy/file
+              mkdir -p ~/go/pkg/mod/dummy ~/.cache/go-build/dummy
+              touch ~/go/pkg/mod/dummy/file ~/.cache/go-build/dummy/file
               bash /opt/runner-hooks/job-started.sh
               [ -z "$(ls -A ~/go/pkg/mod 2>/dev/null)" ] || (echo "FAIL: go pkg mod not cleaned" && exit 1)
+              [ -z "$(ls -A ~/.cache/go-build 2>/dev/null)" ] || (echo "FAIL: go-build cache not cleaned" && exit 1)
               echo "PASS: cleanup hook works"
             '

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -1,0 +1,60 @@
+name: Build Runner Image
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/runners/Dockerfile'
+      - 'infra/runners/hooks/**'
+      - '.github/workflows/build-runner-image.yml'
+  pull_request:
+    paths:
+      - 'infra/runners/Dockerfile'
+      - 'infra/runners/hooks/**'
+      - '.github/workflows/build-runner-image.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: [self-hosted, containerized]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/runners/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ghcr.io/sabyunrepo/mmp-runner:latest
+            ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: ${{ github.event_name == 'pull_request' }}
+      - name: Verify cleanup hook fires
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm --entrypoint /bin/bash \
+            ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }} \
+            -c '
+              set -euo pipefail
+              jq --version
+              govulncheck -version
+              ls /opt/hostedtoolcache/go/1.25.0/x64/bin/go
+              ls /opt/hostedtoolcache/node/20.18.0/x64/bin/node
+              mkdir -p ~/go/pkg/mod/dummy
+              touch ~/go/pkg/mod/dummy/file
+              bash /opt/runner-hooks/job-started.sh
+              [ -z "$(ls -A ~/go/pkg/mod 2>/dev/null)" ] || (echo "FAIL: go pkg mod not cleaned" && exit 1)
+              echo "PASS: cleanup hook works"
+            '

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -38,9 +38,12 @@ jobs:
           tags: |
             ghcr.io/sabyunrepo/mmp-runner:latest
             ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=runner-image
+          cache-to: type=gha,mode=max,scope=runner-image
           load: ${{ github.event_name == 'pull_request' }}
+      - name: Verify image loaded
+        if: github.event_name == 'pull_request'
+        run: docker images "ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }}" --format '{{.Repository}}:{{.Tag}}' | grep -q "${{ github.sha }}" || (echo "FAIL: image not loaded — check buildx load behavior" && exit 1)
       - name: Verify cleanup hook fires
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,19 @@ jobs:
           echo "REDIS_NAME=$REDIS_NAME" >> "$GITHUB_ENV"
 
           # runners-net network 동적 검출 (compose project prefix 무관).
-          RUNNERS_NET=$(sudo docker network ls --format '{{.Name}}' | grep -E '(^|_)runners-net$' | head -1)
+          RUNNERS_NET=$(docker network ls --format '{{.Name}}' | grep -E '(^|_)runners-net$' | head -1)
           if [ -z "$RUNNERS_NET" ]; then
             echo "::error::runners-net network not found on host"
-            sudo docker network ls
+            docker network ls
             exit 1
           fi
           echo "RUNNERS_NET=$RUNNERS_NET" >> "$GITHUB_ENV"
           echo "Detected runners-net: $RUNNERS_NET"
 
           # 이전 run cleanup (이름 충돌 방지)
-          sudo docker rm -f "$PG_NAME" "$REDIS_NAME" 2>/dev/null || true
+          docker rm -f "$PG_NAME" "$REDIS_NAME" 2>/dev/null || true
 
-          sudo docker run -d --name "$PG_NAME" \
+          docker run -d --name "$PG_NAME" \
             --network "$RUNNERS_NET" \
             -e POSTGRES_DB=mmp_test \
             -e POSTGRES_USER=mmp \
@@ -64,7 +64,7 @@ jobs:
             --health-retries 10 \
             postgres:17-alpine
 
-          sudo docker run -d --name "$REDIS_NAME" \
+          docker run -d --name "$REDIS_NAME" \
             --network "$RUNNERS_NET" \
             --health-cmd "redis-cli ping" \
             --health-interval 5s \
@@ -76,8 +76,8 @@ jobs:
           # PR-170 4-agent review (Perf-1 + Test-1) fold-in: 60s ceiling 으로 상향.
           # 30s 이전 ceiling 은 cold start (image pull + initdb) 시 false-fail 가능.
           for i in $(seq 1 60); do
-            pg_health=$(sudo docker inspect --format='{{.State.Health.Status}}' "$PG_NAME" 2>/dev/null || echo "starting")
-            redis_health=$(sudo docker inspect --format='{{.State.Health.Status}}' "$REDIS_NAME" 2>/dev/null || echo "starting")
+            pg_health=$(docker inspect --format='{{.State.Health.Status}}' "$PG_NAME" 2>/dev/null || echo "starting")
+            redis_health=$(docker inspect --format='{{.State.Health.Status}}' "$REDIS_NAME" 2>/dev/null || echo "starting")
             if [ "$pg_health" = "healthy" ] && [ "$redis_health" = "healthy" ]; then
               echo "Both services healthy after ${i}s"
               break
@@ -86,8 +86,8 @@ jobs:
           done
           if [ "$pg_health" != "healthy" ] || [ "$redis_health" != "healthy" ]; then
             echo "::error::services failed to become healthy (postgres=$pg_health, redis=$redis_health)"
-            sudo docker logs "$PG_NAME" 2>&1 | tail -30
-            sudo docker logs "$REDIS_NAME" 2>&1 | tail -30
+            docker logs "$PG_NAME" 2>&1 | tail -30
+            docker logs "$REDIS_NAME" 2>&1 | tail -30
             exit 1
           fi
 
@@ -150,23 +150,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bash scripts/check-playeraware-coverage.sh
 
-      # Phase 22 W1.5 PR-8 testcontainers-go fold-in (PR-170 1st CI run 이후
-      # 노출된 pre-existing 부채):
-      # internal/auditlog, internal/editor 등 패키지가 testcontainers-go 로
-      # host docker.sock 직접 접근 → containerized runner 의 sup group 990
-      # lost 환경에서 permission denied.
-      # 정공: sudo -E env "PATH=$PATH" go test 로 root 권한 docker.sock
-      # 접근 + 환경변수 (HOME, GOPATH, GOCACHE, DATABASE_URL, REDIS_URL,
-      # PG_NAME, REDIS_NAME) 보존.
-      # Image level fix (runner user 의 docker group GID 990 정착) 은
-      # Phase 23 Custom Image carry-over.
       - name: Run tests
-        run: sudo -E env "PATH=$PATH" go test -race -coverprofile=coverage.out ./...
-
-      # sudo go test 로 root:root 생성 → 후속 step (Codecov upload + artifact
-      # upload) 가 read 가능하게 ownership 정정.
-      - name: Fix coverage.out ownership
-        run: sudo chown "$(id -u):$(id -g)" coverage.out
+        run: go test -race -coverprofile=coverage.out ./...
 
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -20
@@ -195,7 +180,7 @@ jobs:
         if: always()
         working-directory: ${{ github.workspace }}
         run: |
-          sudo docker rm -f "${PG_NAME:-}" "${REDIS_NAME:-}" 2>/dev/null || true
+          docker rm -f "${PG_NAME:-}" "${REDIS_NAME:-}" 2>/dev/null || true
 
   ts-check:
     name: TypeScript Lint + Test + Build
@@ -311,19 +296,6 @@ jobs:
           name: web-coverage
           path: apps/web/coverage
 
-      # Phase 22 W1.5 PR-8 fold-in (PR-170 ce1fa62 1st CI run 노출):
-      # containerized runner image / bare-host runner 모두 jq 미사전 install.
-      # Web coverage gate step 이 jq 의존 → "jq: command not found" exit 127.
-      # apt-get 으로 사전 install (idempotent, 이미 있으면 skip).
-      # Image level fix (Custom Image 에 jq 포함) 은 Phase 23 carry-over.
-      - name: Ensure jq installed
-        run: |
-          if ! command -v jq >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq jq
-          fi
-          jq --version
-
       - name: Web coverage gate
         run: |
           LINES=$(jq '.total.lines.pct' apps/web/coverage/coverage-summary.json)
@@ -373,31 +345,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      # Phase 22 W1.5 PR-8 Docker Build Check fold-in (PR-170 ce1fa62 1st CI
-       # run 노출): docker/setup-buildx-action + docker/build-push-action 모두
-      # docker.sock 직접 접근 → containerized runner sup group 990 lost 환경
-      # 에서 permission denied. Trivy 와 동일 root cause.
-      # 정공: setup-buildx 제거 + manual sudo docker build (GHA cache 효과
-      # 포기, push branch 가 아닌 PR Build Check 라 cache 무가치).
-      # SBOM: anchore/sbom-action 도 docker.sock 사용 → manual syft 으로 교체
-      # 검토 필요. 현 단계는 sudo docker save 로 tarball 생성 후 syft input.
-      # Image level fix (docker group GID 990 정착) 은 Phase 23 Custom Image.
-      - name: Build Docker image (manual via sudo docker)
+      - name: Build Docker image
         id: docker-build
         run: |
           set -euo pipefail
           IMAGE_REF="ghcr.io/sabyunrepo/mmp-server:ci-${{ github.sha }}"
-          sudo docker build \
+          docker build \
             -f apps/server/Dockerfile \
             -t "$IMAGE_REF" \
             apps/server
           # digest 추출 (attest-build-provenance 는 push branch 만 사용 — PR
           # 단계는 skip 이지만 step output 일관성 위해 emit)
-          DIGEST=$(sudo docker inspect "$IMAGE_REF" --format='{{.Id}}')
+          DIGEST=$(docker inspect "$IMAGE_REF" --format='{{.Id}}')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           # SBOM 용 tarball export
-          sudo docker save "$IMAGE_REF" -o /tmp/mmp-server-ci.tar
-          sudo chown "$(id -u):$(id -g)" /tmp/mmp-server-ci.tar
+          docker save "$IMAGE_REF" -o /tmp/mmp-server-ci.tar
 
       # PR-170 4c7e8ca run 에서 anchore/sbom-action 의 syft install 실패
       # ("gzip: stdin: not in gzip format") — containerized runner 환경

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -30,26 +30,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      # Phase 22 W1.5 PR-8 DEBT-3: containerized runner sup group 990
-      # (host docker.sock GID) lost in workflow step. docker/build-push-action
-      # + trivy-action 모두 socket access denied.
-      # 정공 fix: sudo docker build → sudo docker save tarball → trivy-action
-      # 의 input: 파라미터 (tarball mode) 로 docker.sock 우회.
-      # 1st CI run (commit fd227f9) 에서 sudo docker build 까지만 했으나
-      # trivy-action 자체가 docker.sock 접근 → fail. tarball mode 가 정공.
-      # Image level fix (runner user 의 docker group 정착) 은 Phase 23 Custom
-      # Image carry-over.
-      - name: Build server image + save tarball (manual via sudo docker)
+      # Phase 23 Custom Image: docker GID 990 정착 (group docker-host + runner user 가입).
+      # docker.sock 직접 접근 가능 — sudo + tarball 우회 dead code.
+      - name: Build server image + save tarball
         run: |
           set -euo pipefail
-          sudo docker build \
+          docker build \
             -f apps/server/Dockerfile \
             -t mmp-server:security-scan \
             apps/server
           # tarball 으로 export — trivy-action input mode 가 docker.sock 불필요
-          sudo docker save mmp-server:security-scan -o /tmp/mmp-server.tar
-          # runner user 가 trivy-action 안에서 read 가능하게 ownership 변경
-          sudo chown "$(id -u):$(id -g)" /tmp/mmp-server.tar
+          docker save mmp-server:security-scan -o /tmp/mmp-server.tar
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
@@ -65,6 +56,11 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
           category: trivy-container
+
+      # Phase 23 #2 fold-in (Sec-MED-3): host disk 누적 cleanup.
+      - name: Cleanup security-scan image
+        if: always()
+        run: docker rmi mmp-server:security-scan 2>/dev/null || true
 
   osv-scanner:
     # Warn-only policy (Phase 18.7 Wave 2 onboarding, 6 weeks).

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -138,30 +138,8 @@ jobs:
           go-version-file: apps/server/go.mod
           cache-dependency-path: apps/server/go.sum
 
-      # Phase 22 W1.5 PR-8 DEBT-2: myoung34/github-runner image default Node
-      # v10.19.0 가 ?? syntax 미지원. CodeQL action 의 spawn child process 가
-      # system Node 사용 → setup-node@v4 가 PATH 만 update 해도 subprocess
-      # resolve 실패. setup-node 의 SHA-pinned v20 binary 를 /usr/local/bin
-      # 에 symlink → /usr/bin/node 보다 PATH 우선이라 spawn child 도 v20 사용.
-      # Image level fix (base image 에 Node v20 사전 install) 은 Phase 23
-      # Custom Image carry-over.
-      - name: Setup Node.js v20 (action — SHA-pinned binary)
-        if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "20"
-
-      - name: Override system node with setup-node v20 binary
-        if: matrix.language == 'javascript-typescript'
-        run: |
-          set -euo pipefail
-          NODE_BIN=$(which node)
-          NPM_BIN=$(which npm)
-          echo "setup-node node: $NODE_BIN ($(node --version))"
-          sudo ln -sf "$NODE_BIN" /usr/local/bin/node
-          sudo ln -sf "$NPM_BIN" /usr/local/bin/npm
-          /usr/local/bin/node --version
-
+      # Phase 23 Custom Image: base에 Node v20 사전 install (system PATH 노출).
+      # CodeQL action의 spawn child process가 자연 v20 사용 — setup-node + symlink 우회 dead code.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -68,10 +68,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
           GITLEAKS_ENABLE_COMMENTS: false
-          # Phase 22 W1.5 PR-8: containerized runner working dir mismatch.
-          # gitleaks-action v2.3.9 의 artifact upload step 이 rootDirectory:
-          # /home/runner 를 하드코딩 → containerized runner 환경에서 fail.
-          # scan 자체는 SUCCESS, summary 는 GHA job summary 로 표시.
-          # Artifact 복원은 Phase 23 Custom Image migration 후 검토.
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          # Phase 23 Custom Image: docker GID 990 + working dir 정합성. artifact upload 복원 (Sec-MED-2).
+          # Verify는 본 PR 머지 + 사용자 host 재배포 후 첫 CI run에서 자연 발생 — fail 시 hotfix + #3 follow-up PR.
           GITLEAKS_ENABLE_SUMMARY: true

--- a/docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md
+++ b/docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md
@@ -1,0 +1,140 @@
+---
+phase_id: "phase-23-custom-runner-image"
+phase_title: "Phase 23 — Custom Runner Image (Option A multi-stage)"
+created: 2026-04-29
+status: "draft (worktree 분기 + first commit 대기)"
+parent_phase: "phase-22-w1-5-debt-cleanup"
+spec: "docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md"
+prs_estimated: 1
+---
+
+# Phase 23 — Custom Runner Image Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` 또는 `superpowers:executing-plans` 로 task 단위 실행. 모든 코드 작성은 sonnet-4-6 sub-agent 위임 (`memory/feedback_sonnet_46_default.md` 카논).
+>
+> **Spec 카논 단일 source**: `docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md` (343 line, 모든 코드 예시 포함). 본 plan은 task 추적용. Spec과 drift 시 **spec 우선** + plan revise.
+>
+> **MD 500-line 카논**: 본 checklist는 index. Wave별 task 상세는 `refs/wave-N-*.md`로 분할.
+
+**Goal:** Custom Runner Image (`ghcr.io/sabyunrepo/mmp-runner`) 도입으로 (a) myoung34 EPHEMERAL fs 잔존 정공 + (b) 9 workflow 우회 step 제거 + (c) GHCR build CI 정착.
+
+**Architecture:** multi-stage Dockerfile (builder=ubuntu:22.04 + final=myoung34 base) + `ACTIONS_RUNNER_HOOK_JOB_STARTED` cleanup script + `.github/workflows/build-runner-image.yml` (GHA cache, Public visibility, GITHUB_TOKEN). 단일 mega PR (4-agent 우회, admin-skip 머지).
+
+**Tech Stack:** Docker multi-stage, GitHub Actions (`docker/build-push-action@v5`, `docker/login-action@v3`), Bash (cleanup hook), GHCR Public.
+
+---
+
+## File Structure
+
+| 변경 | 경로 | 책임 | 작성 task |
+|------|------|------|----------|
+| 신규 | `infra/runners/Dockerfile` | multi-stage 이미지 정의 (Spec 4.1) | Wave 1 Task 2 |
+| 신규 | `infra/runners/hooks/job-started.sh` | EPHEMERAL fs cleanup (Spec 4.2) | Wave 1 Task 1 |
+| 신규 | `infra/runners/hooks/job-started.test.sh` | hook bash unit test (TDD) | Wave 1 Task 1 |
+| 신규 | `.github/workflows/build-runner-image.yml` | PR build + verify, main GHCR push (Spec 4.3) | Wave 1 Task 3 |
+| 수정 | `infra/runners/docker-compose.yml` | image: + pull_policy: 변경 (Spec 4.4) | Wave 2 Task 4 |
+| 수정 | `infra/runners/README.md` | Custom Image 섹션 + GHCR 첫 push 절차 | Wave 2 Task 5 |
+| 수정 | `.github/workflows/ci.yml` | sudo go test 제거, ownership step 제거, jq install 제거, manual sudo docker build 정리 | Wave 3 Task 6 |
+| 수정 | `.github/workflows/security-deep.yml` | CodeQL setup-node + symlink 제거; Trivy sudo docker 제거 + image cleanup 1줄 추가 (#2) | Wave 3 Task 7-8 |
+| 수정 | `.github/workflows/security-fast.yml` | `GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false` env 제거 (#3) | Wave 3 Task 9 |
+
+**Out of scope** (별 phase): Composite action 추출 (Arch-HIGH-1), gitleaks SARIF/upload 메커니즘 재설계 (verify fail 시), ARM64 build, multi-stage builder 보안 표면 정량 측정.
+
+---
+
+## Wave 인덱스
+
+각 wave 상세는 `refs/wave-N-*.md`. 본 checklist는 task 진행 추적용 체크박스만 유지.
+
+### Wave 0 — Worktree 분기 ([refs/wave-0-setup.md](refs/wave-0-setup.md))
+
+- [ ] **Task 0**: `superpowers:using-git-worktrees`로 분기 + spec/plan untracked 인계
+
+### Wave 1 — Image Build Infrastructure ([refs/wave-1-image-build.md](refs/wave-1-image-build.md))
+
+- [ ] **Task 1**: cleanup hook script `job-started.sh` + bash unit test (TDD red→green→commit)
+- [ ] **Task 2**: multi-stage `Dockerfile` (Spec 4.1) + 로컬 docker build syntax 검증 + ad-hoc 컨테이너 verify + commit
+- [ ] **Task 3**: `.github/workflows/build-runner-image.yml` (Spec 4.3) + yaml syntax 검증 + commit
+
+### Wave 2 — Compose + README ([refs/wave-2-compose-readme.md](refs/wave-2-compose-readme.md))
+
+- [ ] **Task 4**: `infra/runners/docker-compose.yml` image + pull_policy 2줄 patch + `docker compose config` 검증 + commit
+- [ ] **Task 5**: `infra/runners/README.md`에 "Custom Image (Phase 23+)" 섹션 + GHCR 첫 push 운영 절차 + 사용자 host 재배포 + Rollback + commit
+
+### Wave 3 — 9 workflow Dead Code 정리 (Fold-In) ([refs/wave-3-workflow-cleanup.md](refs/wave-3-workflow-cleanup.md))
+
+- [ ] **Task 6**: `ci.yml` sudo docker / sudo go test / ownership step / jq install / manual docker build 정리 + commit
+- [ ] **Task 7**: `security-deep.yml` CodeQL setup-node + symlink override 제거 + commit
+- [ ] **Task 8**: `security-deep.yml` Trivy sudo docker 정리 + image cleanup 1줄 (#2 fold-in) + commit
+- [ ] **Task 9**: `security-fast.yml` `GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false` env 제거 (#3 fold-in) + commit
+
+### Wave 4 — Code Review + PR ([refs/wave-4-pr.md](refs/wave-4-pr.md))
+
+- [ ] **Task 10**: 로컬 docker build 종합 검증 (선택, PR CI 위임 가능)
+- [ ] **Task 11**: 모든 commit 확인 + spec/plan 첫 stage commit + branch push
+- [ ] **Task 12**: `superpowers:requesting-code-review` 호출 (4-agent 우회, 사용자 명시 결정) + fix fold-in
+- [ ] **Task 13**: PR 생성 + build-runner-image.yml CI verify 통과 확인 + 사용자 결정 admin-skip 머지
+
+### Wave 5 — Operational Verify (사용자 host 작업) ([refs/wave-5-operational.md](refs/wave-5-operational.md))
+
+- [ ] **Task 14**: GHCR push 성공 확인 + Public visibility + 첫 push 후 repo connection 1회 설정
+- [ ] **Task 15**: 사용자 host SSH 재배포 (`docker compose pull && up -d`) + 4 runner idle 확인 + 사전 install + hook env 확인
+- [ ] **Task 16**: 첫 실 CI run cleanup hook fire + tar 충돌 0건 + GHA cache size + gitleaks artifact upload (#3 verify, fail 시 hotfix + #3 follow-up PR)
+- [ ] **Task 17**: PR-5 (#172) main rebase + CI 자연 통과 + 머지 (자동 unblock)
+- [ ] **Task 18**: Spec 7.5 종료 조건 8건 verify + `/compound-wrap` 호출 + status `closed`
+
+---
+
+## Self-Review (writing-plans 카논)
+
+### Spec coverage
+- Spec § 4.1 Dockerfile → Task 2 ✓
+- Spec § 4.2 hook script → Task 1 ✓
+- Spec § 4.3 build CI workflow → Task 3 ✓
+- Spec § 4.4 compose 변경 → Task 4 ✓
+- Spec § 4.5 9 workflow 정리 → Task 6-9 ✓
+- Spec § 6 Error Handling → Wave 5 verify steps + Task 16 fail 분기 ✓
+- Spec § 7 Testing → Task 1 (TDD) + Task 2 step 2-4 + Task 16 ✓
+- Spec § 7.5 종료 조건 → Task 18 ✓
+
+### Placeholder scan
+- "결정 필요" / "TBD" / "TODO" / "fill in" 매칭 0건 (모든 step 실 명령 + 코드 inline 또는 spec reference)
+- 사용자 host 정보 (sabyun@100.90.38.7) 명시 (Wave 2 Task 5 + Wave 5 Task 15)
+- GHCR repo connection 절차 명시 (Wave 2 Task 5 + Wave 5 Task 14)
+
+### Type consistency
+- `mmp-runner` 이미지 이름 모든 task 일치
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runner-hooks/job-started.sh` 경로 모든 task 일치
+- `chore/phase-23-custom-runner-image` 브랜치 이름 모든 task 일치
+- `ghcr.io/sabyunrepo/mmp-runner:latest` GHCR 경로 모든 task 일치
+
+### Scope check
+- single mega PR로 결정 (사용자) → Wave 분해 0~5 (워크플로우 단계, PR 분해 X)
+- Out of Scope 명시 (Composite action, gitleaks 메커니즘 재설계)
+
+### MD 500-line 카논 align
+- 본 checklist는 index (~150 line)
+- Wave 상세는 `refs/wave-N-*.md`로 분할 (`feedback_file_size_limit.md` 카논)
+
+---
+
+## 사용자 승인 게이트
+
+다음 진입은 **사용자 명시 승인 후**:
+- `/compound-work Task-0` 또는 worktree 분기 직접 진행 (Wave 0 시작)
+- 초안 직접 수정 — Wave/Task 분해 또는 step 단위 조정
+- `/compound-cycle` — 본 plan 진행 상태 확인
+
+---
+
+## 카논 ref
+
+- Spec 단일 source: [Phase 23 design](../../superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md)
+- 부모 plan: [Phase 22 W1.5](../2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md)
+- 직전 핸드오프: [`memory/sessions/2026-04-29-phase-23-custom-image-pivot.md`](../../../memory/sessions/2026-04-29-phase-23-custom-image-pivot.md)
+- single-concern PR 카논: [`memory/feedback_branch_pr_workflow.md`](../../../memory/feedback_branch_pr_workflow.md)
+- admin-skip 정책: [`memory/project_ci_admin_skip_until_2026-05-01.md`](../../../memory/project_ci_admin_skip_until_2026-05-01.md)
+- 4-agent 카논 (사용자 override): [`memory/feedback_4agent_review_before_admin_merge.md`](../../../memory/feedback_4agent_review_before_admin_merge.md)
+- file size 카논: [`memory/feedback_file_size_limit.md`](../../../memory/feedback_file_size_limit.md)
+- Sonnet 4.6 sub-agent: [`memory/feedback_sonnet_46_default.md`](../../../memory/feedback_sonnet_46_default.md)
+- compound-mmp lifecycle: [`refs/lifecycle-stages.md`](../../../.claude/plugins/compound-mmp/refs/lifecycle-stages.md)

--- a/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-0-setup.md
+++ b/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-0-setup.md
@@ -1,0 +1,32 @@
+# Wave 0 — Worktree 분기
+
+> 부모: [checklist.md](../checklist.md) | 다음: [Wave 1](wave-1-image-build.md)
+
+## Task 0: 분기 + spec/plan untracked 인계
+
+**Files:**
+- Untracked: `docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md`
+- Untracked: `docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md`
+- Untracked: `docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-{0..5}-*.md`
+
+- [ ] **Step 1: superpowers:using-git-worktrees 호출**
+
+```
+branch: chore/phase-23-custom-runner-image
+base: main
+location: ../muder_platform.wt/phase-23-custom-runner-image
+```
+
+untracked 파일은 worktree에서 access 가능 (git worktree 특성 — index와 working tree 분리, untracked는 working tree 공유).
+
+- [ ] **Step 2: worktree로 이동 + 상태 확인**
+
+```bash
+cd ../muder_platform.wt/phase-23-custom-runner-image
+git status --short
+# Expected:
+#   ?? docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md
+#   ?? docs/plans/2026-04-29-phase-23-custom-runner-image/
+```
+
+> spec/plan 첫 commit은 Wave 4 Task 11에서 wave 1-3의 task별 commit과 함께 진행. 본 task에서는 stage 없음.

--- a/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-1-image-build.md
+++ b/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-1-image-build.md
@@ -1,0 +1,250 @@
+# Wave 1 — Image Build Infrastructure
+
+> 부모: [checklist.md](../checklist.md) | 이전: [Wave 0](wave-0-setup.md) | 다음: [Wave 2](wave-2-compose-readme.md)
+
+## Task 1: cleanup hook script + bash unit test (TDD)
+
+**Files:**
+- Create: `infra/runners/hooks/job-started.sh`
+- Create: `infra/runners/hooks/job-started.test.sh`
+
+- [ ] **Step 1: 실패 test 먼저 작성 (`job-started.test.sh`)**
+
+```bash
+#!/usr/bin/env bash
+# bash unit test for job-started.sh — verifies cleanup hook behavior.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${THIS_DIR}/job-started.sh"
+
+# 임시 HOME 픽스처
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+mkdir -p "$TMP_HOME/go/pkg/mod/dummy" "$TMP_HOME/.cache/go-build/dummy"
+touch "$TMP_HOME/go/pkg/mod/dummy/file" "$TMP_HOME/.cache/go-build/dummy/file"
+
+HOME="$TMP_HOME" bash "$HOOK"
+
+# Assert: 두 디렉토리 비었음
+[ -z "$(ls -A "$TMP_HOME/go/pkg/mod" 2>/dev/null)" ] || { echo "FAIL: go/pkg/mod not cleaned"; exit 1; }
+[ -z "$(ls -A "$TMP_HOME/.cache/go-build" 2>/dev/null)" ] || { echo "FAIL: .cache/go-build not cleaned"; exit 1; }
+
+# Assert: 빈 디렉토리 재생성됨 (setup-go가 기대)
+[ -d "$TMP_HOME/go/pkg/mod" ] || { echo "FAIL: go/pkg/mod not recreated"; exit 1; }
+[ -d "$TMP_HOME/.cache/go-build" ] || { echo "FAIL: .cache/go-build not recreated"; exit 1; }
+
+echo "PASS: job-started.sh cleanup correct"
+```
+
+- [ ] **Step 2: test 실행 → 실패 확인**
+
+```bash
+chmod +x infra/runners/hooks/job-started.test.sh
+bash infra/runners/hooks/job-started.test.sh
+# Expected: bash: infra/runners/hooks/job-started.sh: No such file or directory
+```
+
+- [ ] **Step 3: hook script 작성 (`job-started.sh`)**
+
+```bash
+#!/usr/bin/env bash
+# ACTIONS_RUNNER_HOOK_JOB_STARTED — 매 job 시작 직전 fire.
+# myoung34 EPHEMERAL=true가 file system reset 안 함에 대한 정공.
+set -euo pipefail
+rm -rf "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build" 2>/dev/null || true
+mkdir -p "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build"
+```
+
+- [ ] **Step 4: chmod + test 재실행 → 통과 확인**
+
+```bash
+chmod +x infra/runners/hooks/job-started.sh
+bash infra/runners/hooks/job-started.test.sh
+# Expected: PASS: job-started.sh cleanup correct
+```
+
+- [ ] **Step 5: commit**
+
+```bash
+git add infra/runners/hooks/job-started.sh infra/runners/hooks/job-started.test.sh
+git commit -m "feat(phase-23): cleanup hook script + bash unit test"
+```
+
+---
+
+## Task 2: Dockerfile multi-stage
+
+**Files:**
+- Create: `infra/runners/Dockerfile`
+
+코드 카논: Spec 4.1 (`docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md` Section 4.1)에 multi-stage 전체 정의. plan에서는 핵심 구조만 inline 인용. drift 시 spec 우선.
+
+- [ ] **Step 1: Dockerfile 작성** (Spec 4.1 카논 그대로)
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+FROM ubuntu:22.04 AS builder
+ARG GO_VERSION=1.25.0
+ARG NODE_VERSION=20.18.0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/hostedtoolcache/go/${GO_VERSION}/x64 \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+       | tar -xzf - -C /opt/hostedtoolcache/go/${GO_VERSION}/x64 --strip-components=1 \
+    && touch /opt/hostedtoolcache/go/${GO_VERSION}/x64.complete
+RUN mkdir -p /opt/hostedtoolcache/node/${NODE_VERSION}/x64 \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+       | tar -xJf - -C /opt/hostedtoolcache/node/${NODE_VERSION}/x64 --strip-components=1 \
+    && touch /opt/hostedtoolcache/node/${NODE_VERSION}/x64.complete
+RUN /opt/hostedtoolcache/go/${GO_VERSION}/x64/bin/go install \
+      golang.org/x/vuln/cmd/govulncheck@latest \
+    && cp /root/go/bin/govulncheck /usr/local/bin/
+
+FROM myoung34/github-runner@sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      jq libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+      libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \
+      libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /opt/hostedtoolcache /opt/hostedtoolcache
+COPY --from=builder /usr/local/bin/govulncheck /usr/local/bin/govulncheck
+RUN groupadd -g 990 docker-host 2>/dev/null || true \
+    && usermod -aG docker-host runner
+COPY infra/runners/hooks/job-started.sh /opt/runner-hooks/job-started.sh
+RUN chmod +x /opt/runner-hooks/job-started.sh
+ENV ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runner-hooks/job-started.sh
+USER runner
+```
+
+- [ ] **Step 2: 로컬 docker build syntax check**
+
+```bash
+docker buildx build --no-cache --load \
+  --platform linux/amd64 \
+  -f infra/runners/Dockerfile \
+  -t mmp-runner:local-test \
+  .
+# Expected: build complete, image local 등재
+```
+
+> 사용자 dev (Apple Silicon)에서 amd64 emulation으로 느릴 수 있음. 본 step skip하고 PR CI에 위임 가능 (옵션 C carry).
+
+- [ ] **Step 3: ad-hoc 컨테이너 검증** (로컬 빌드한 경우만)
+
+```bash
+docker run --rm --entrypoint /bin/bash mmp-runner:local-test \
+  -c 'jq --version && govulncheck -version && ls /opt/hostedtoolcache/go/1.25.0/x64/bin/go && ls /opt/hostedtoolcache/node/20.18.0/x64/bin/node && [ -f /opt/runner-hooks/job-started.sh ]'
+# Expected: 각 binary 정상 + hook script 존재
+```
+
+- [ ] **Step 4: cleanup hook fire 검증** (Spec 7.1 카논)
+
+```bash
+docker run --rm --entrypoint /bin/bash mmp-runner:local-test -c '
+  set -euo pipefail
+  mkdir -p ~/go/pkg/mod/dummy
+  touch ~/go/pkg/mod/dummy/file
+  bash /opt/runner-hooks/job-started.sh
+  [ -z "$(ls -A ~/go/pkg/mod 2>/dev/null)" ] || (echo "FAIL: go pkg mod not cleaned" && exit 1)
+  echo PASS
+'
+# Expected: PASS
+```
+
+- [ ] **Step 5: commit**
+
+```bash
+git add infra/runners/Dockerfile
+git commit -m "feat(phase-23): multi-stage Dockerfile (Go 1.25 + Node 20 + cleanup hook)"
+```
+
+---
+
+## Task 3: build-runner-image.yml
+
+**Files:**
+- Create: `.github/workflows/build-runner-image.yml`
+
+- [ ] **Step 1: workflow 작성** (Spec 4.3 카논 그대로)
+
+```yaml
+name: Build Runner Image
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/runners/Dockerfile'
+      - 'infra/runners/hooks/**'
+      - '.github/workflows/build-runner-image.yml'
+  pull_request:
+    paths:
+      - 'infra/runners/Dockerfile'
+      - 'infra/runners/hooks/**'
+      - '.github/workflows/build-runner-image.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: [self-hosted, containerized]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/runners/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ghcr.io/sabyunrepo/mmp-runner:latest
+            ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: ${{ github.event_name == 'pull_request' }}
+      - name: Verify cleanup hook fires
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm --entrypoint /bin/bash \
+            ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }} \
+            -c '
+              set -euo pipefail
+              jq --version
+              govulncheck -version
+              ls /opt/hostedtoolcache/go/1.25.0/x64/bin/go
+              ls /opt/hostedtoolcache/node/20.18.0/x64/bin/node
+              mkdir -p ~/go/pkg/mod/dummy
+              touch ~/go/pkg/mod/dummy/file
+              bash /opt/runner-hooks/job-started.sh
+              [ -z "$(ls -A ~/go/pkg/mod 2>/dev/null)" ] || (echo "FAIL: go pkg mod not cleaned" && exit 1)
+              echo "PASS: cleanup hook works"
+            '
+```
+
+- [ ] **Step 2: yaml syntax check**
+
+```bash
+# 로컬 yamllint 또는 actionlint
+yamllint .github/workflows/build-runner-image.yml || true
+actionlint .github/workflows/build-runner-image.yml || true
+# 도구 부재 시 PR CI의 자동 actionlint에 의존
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add .github/workflows/build-runner-image.yml
+git commit -m "feat(phase-23): GHCR build CI workflow (PR verify + main push)"
+```

--- a/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-2-compose-readme.md
+++ b/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-2-compose-readme.md
@@ -1,0 +1,123 @@
+# Wave 2 — Compose + README
+
+> 부모: [checklist.md](../checklist.md) | 이전: [Wave 1](wave-1-image-build.md) | 다음: [Wave 3](wave-3-workflow-cleanup.md)
+
+## Task 4: docker-compose.yml 수정
+
+**Files:**
+- Modify: `infra/runners/docker-compose.yml`
+
+- [ ] **Step 1: image + pull_policy 변경**
+
+`x-runner-base` 블록의 image/pull_policy 2줄 patch:
+```diff
+-  image: myoung34/github-runner@sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3
+-  pull_policy: never
++  image: ghcr.io/sabyunrepo/mmp-runner:latest
++  pull_policy: always
+```
+
+`docker-compose.yml`의 anchor `*runner-base` 1곳만 변경 (4 service 모두 자동 적용).
+
+- [ ] **Step 2: docker compose config 검증**
+
+```bash
+cd infra/runners
+docker compose config | head -30
+# Expected: image: ghcr.io/sabyunrepo/mmp-runner:latest 표시
+cd -
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add infra/runners/docker-compose.yml
+git commit -m "chore(phase-23): switch compose to GHCR Custom Image"
+```
+
+---
+
+## Task 5: README.md 갱신
+
+**Files:**
+- Modify: `infra/runners/README.md`
+
+- [ ] **Step 1: Custom Image 섹션 추가** (`Bootstrap` 섹션 위)
+
+```markdown
+## Custom Image (Phase 23+)
+
+이 pool은 **`ghcr.io/sabyunrepo/mmp-runner` Custom Image**로 가동합니다 (myoung34 base 직접 사용 X). 정공:
+
+- 사전 install: jq, govulncheck, Go 1.25, Node 20, Playwright deps
+- docker GID 990 정착 (testcontainers-go + Trivy 자연 권한)
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED` cleanup script (EPHEMERAL fs 잔존 정공)
+
+이미지 빌드는 `.github/workflows/build-runner-image.yml`이 main 머지 시 자동 push. visibility = Public (사용자 host pull 인증 0건).
+
+### GHCR 첫 push 후 1회 운영 절차
+
+1. https://github.com/sabyunrepo/packages/container/mmp-runner/settings → "Manage Actions access" → `muder_platform` add
+2. visibility → Public (image에 secret 없음)
+
+### 사용자 host 재배포 (main 머지 후)
+
+```bash
+ssh sabyun@100.90.38.7
+cd ~/muder_platform/infra/runners
+git pull
+docker compose pull
+docker compose up -d
+docker compose ps  # 4 service Started
+```
+
+### Rollback (재배포 후 광범위 fail 시)
+
+```bash
+git revert <Phase 23 commit>  # compose.yml만 되돌림
+docker compose pull
+docker compose up -d
+# ~5분 내 myoung34 base 또는 직전 GHCR sha tag로 복귀
+```
+
+### Verification (재배포 후)
+
+```bash
+# 컨테이너 부팅
+docker logs containerized-runner-1 2>&1 | head -50 | grep -i "Listening for Jobs"
+
+# 사전 install 검증
+docker exec containerized-runner-1 bash -c '
+  jq --version
+  govulncheck -version
+  /opt/hostedtoolcache/go/1.25.0/x64/bin/go version
+  /opt/hostedtoolcache/node/20.18.0/x64/bin/node --version
+  echo "ACTIONS_RUNNER_HOOK_JOB_STARTED=$ACTIONS_RUNNER_HOOK_JOB_STARTED"
+'
+
+# GitHub Settings → Actions → Runners → 4 idle 확인
+```
+```
+
+- [ ] **Step 2: 기존 Bootstrap 섹션의 image pull 절차 갱신** (Step 5 영역)
+
+기존:
+```bash
+# 5. **Image pull (최초 1회 필수)** — `pull_policy: never` + digest pinning ...
+IMAGE=$(grep -E 'image:' docker-compose.yml | head -1 | awk '{print $2}')
+docker pull "$IMAGE"
+```
+
+→ 갱신:
+```bash
+# 5. **Image pull (Phase 23+ Custom Image)** — `pull_policy: always` 라 compose up이 자동 pull.
+#    그러나 첫 부팅 또는 GHCR 권한 검증을 위해 manual pull 권장:
+docker compose pull
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add infra/runners/README.md
+git commit -m "docs(phase-23): README Custom Image 섹션 + GHCR 운영 절차"
+```

--- a/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-3-workflow-cleanup.md
+++ b/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-3-workflow-cleanup.md
@@ -1,0 +1,150 @@
+# Wave 3 — 9 workflow Dead Code 정리 (Fold-In)
+
+> 부모: [checklist.md](../checklist.md) | 이전: [Wave 2](wave-2-compose-readme.md) | 다음: [Wave 4](wave-4-pr.md)
+
+## Task 6: ci.yml 정리
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+대상 변경 (line 번호는 변경 시점 git blame으로 재확인):
+
+| 변경 | line 영역 (현 main 기준) | 이유 |
+|------|----------|------|
+| `sudo docker network ls` → `docker network ls` (등 docker 명령들 in Start postgres+redis 영역) | 44, 47, 54, 56, 67, 79, 80, 89, 90, 198 | docker GID 990 정착 |
+| `sudo -E env "PATH=$PATH" go test` → `go test` | 164 | testcontainers-go 자연 권한 |
+| `Fix coverage.out ownership` step 제거 | 168-169 | RUN_AS_ROOT=false + group_add docker-host로 자동 |
+| `Ensure jq installed` step 제거 (`if ! command -v jq...`) | 315-325 | base에 jq 사전 install |
+| `Build Docker image (manual via sudo docker)` step → 일반 `docker build` (또는 `docker/build-push-action@v5` 마이그) | 380-400 | docker GID 990 정착 |
+
+- [ ] **Step 1: Edit tool 다중 patch**
+
+각 영역별 sudo 제거 + step 삭제. 각 patch는 작은 단위로 (대규모 search/replace는 의도치 않은 매칭 위험).
+
+- [ ] **Step 2: yaml syntax + actionlint 검증**
+
+```bash
+actionlint .github/workflows/ci.yml || true
+# 또는 PR CI의 자동 actionlint에 의존
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "chore(phase-23): ci.yml — sudo docker/go test 제거 + jq install 제거"
+```
+
+---
+
+## Task 7: security-deep.yml CodeQL 정리
+
+**Files:**
+- Modify: `.github/workflows/security-deep.yml` (CodeQL javascript-typescript matrix 영역, 현 main 기준 line 143-162)
+
+- [ ] **Step 1: setup-node@v4 + symlink override step 제거**
+
+제거 대상 (현 main 인용):
+```yaml
+- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+  with:
+    node-version: 20
+
+- name: Override system node with setup-node v20 binary
+  run: |
+    NODE_BIN=$(which node)
+    NPM_BIN=$(which npm)
+    echo "setup-node node: $NODE_BIN ($(node --version))"
+    sudo ln -sf "$NODE_BIN" /usr/local/bin/node
+    sudo ln -sf "$NPM_BIN" /usr/local/bin/npm
+```
+
+base image에 Node v20 사전 install되어 system PATH에 노출되므로 setup-node 자체 불필요. CodeQL action의 spawn child process가 `which node`로 자연 resolve.
+
+- [ ] **Step 2: commit**
+
+```bash
+git add .github/workflows/security-deep.yml
+git commit -m "chore(phase-23): security-deep CodeQL setup-node + symlink override 제거"
+```
+
+---
+
+## Task 8: security-deep.yml Trivy 정리 + #2 fold-in
+
+**Files:**
+- Modify: `.github/workflows/security-deep.yml` (Trivy job, 현 main 기준 line 36-52)
+
+- [ ] **Step 1: sudo docker build/save/chown → 일반 docker**
+
+```yaml
+# 변경 전 (line 42-52):
+- name: Build server image + save tarball (manual via sudo docker)
+  run: |
+    sudo docker build \
+      -t mmp-server:security-scan \
+      -f apps/server/Dockerfile \
+      apps/server
+    sudo docker save mmp-server:security-scan -o /tmp/mmp-server.tar
+    sudo chown "$(id -u):$(id -g)" /tmp/mmp-server.tar
+
+# 변경 후 (sudo 제거 + chown 제거):
+- name: Build server image + save tarball
+  run: |
+    docker build \
+      -t mmp-server:security-scan \
+      -f apps/server/Dockerfile \
+      apps/server
+    docker save mmp-server:security-scan -o /tmp/mmp-server.tar
+```
+
+docker GID 990 정착으로 `runner` user가 docker.sock 직접 접근 가능 → sudo 불필요. tarball 소유권도 자연 정상.
+
+- [ ] **Step 2: image cleanup step 추가 (#2 fold-in, Sec-MED-3)**
+
+Trivy job 마지막 step (현 마지막 step 또는 trivy scan step 직후)에:
+```yaml
+- name: Cleanup security-scan image
+  if: always()
+  run: docker rmi mmp-server:security-scan 2>/dev/null || true
+```
+
+`if: always()`로 scan 성공/실패 무관 cleanup.
+
+- [ ] **Step 3: commit**
+
+```bash
+git add .github/workflows/security-deep.yml
+git commit -m "chore(phase-23): Trivy sudo docker 제거 + image cleanup 1줄 (Sec-MED-3 #2)"
+```
+
+---
+
+## Task 9: security-fast.yml gitleaks #3 fold-in
+
+**Files:**
+- Modify: `.github/workflows/security-fast.yml` (현 main 기준 line 76)
+
+- [ ] **Step 1: GITLEAKS_ENABLE_UPLOAD_ARTIFACT env 제거**
+
+```yaml
+# 변경 전 (env 블록 내):
+GITLEAKS_CONFIG: .gitleaks.toml
+GITLEAKS_ENABLE_COMMENTS: false
+GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false  # ← 이 줄 삭제
+GITLEAKS_ENABLE_SUMMARY: true
+
+# 변경 후 (gitleaks default = artifact upload 활성):
+GITLEAKS_CONFIG: .gitleaks.toml
+GITLEAKS_ENABLE_COMMENTS: false
+GITLEAKS_ENABLE_SUMMARY: true
+```
+
+> **Verify**: 본 PR 머지 + 사용자 host 재배포 후 첫 CI run에서 artifact upload 실 동작 확인. fail 시 즉시 hotfix (`GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false` 복원) + #3 follow-up PR (SARIF/upload 메커니즘 재설계).
+
+- [ ] **Step 2: commit**
+
+```bash
+git add .github/workflows/security-fast.yml
+git commit -m "chore(phase-23): gitleaks artifact upload 복원 (Sec-MED-2 #3 verify)"
+```

--- a/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-4-pr.md
+++ b/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-4-pr.md
@@ -1,0 +1,134 @@
+# Wave 4 — Code Review + PR
+
+> 부모: [checklist.md](../checklist.md) | 이전: [Wave 3](wave-3-workflow-cleanup.md) | 다음: [Wave 5](wave-5-operational.md)
+
+## Task 10: 로컬 docker build 종합 검증 (선택)
+
+선택 task — Wave 1 Task 2 step 2-4에서 이미 docker build + verify 수행 가능. **GHA cache로 PR CI에 위임도 가능**. 사용자 dev (Apple Silicon)에서 amd64 빌드 시 emulation 느림이라 PR CI 위임 권장.
+
+- [ ] **Step 1: PR CI 위임 결정 또는 로컬 buildx로 amd64 emulation 빌드**
+
+선택 사항. PR CI가 self-hosted [containerized] runner에서 native amd64 빌드 → 빠르고 정확.
+
+---
+
+## Task 11: spec + plan first commit + branch push
+
+- [ ] **Step 1: 모든 task별 commit 확인**
+
+```bash
+git log --oneline main..HEAD
+# Expected: Wave 1-3의 task별 commit ~7건 (Task 1, 2, 3, 4, 5, 6, 7, 8, 9)
+```
+
+- [ ] **Step 2: spec/plan 파일을 worktree에 stage**
+
+Wave 0 Task 0에서 untracked 상태로 인계된 spec/plan을 commit:
+
+```bash
+git add docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md
+git add docs/plans/2026-04-29-phase-23-custom-runner-image/
+git commit -m "docs(phase-23): spec + plan checklist (brainstorm + writing-plans 산출)"
+```
+
+- [ ] **Step 3: branch push (PR 미생성)**
+
+```bash
+git push -u origin chore/phase-23-custom-runner-image
+```
+
+PR 생성은 Task 13에서 진행 — push만으로는 build-runner-image.yml CI가 자동 트리거되지 않음 (path filter는 PR/push event에서만 활성).
+
+---
+
+## Task 12: superpowers:requesting-code-review
+
+사용자 명시 결정: 4-agent 우회, superpowers code-review만.
+
+- [ ] **Step 1: Skill `superpowers:requesting-code-review` 호출**
+
+review brief 인자:
+- branch: `chore/phase-23-custom-runner-image`
+- scope: Custom Image PR (Dockerfile + hook + workflow + compose + README + 9 workflow 정리)
+- focus:
+  - 보안 표면 (multi-stage builder의 install tool 분리)
+  - GHCR push 권한 (GITHUB_TOKEN + `permissions: packages: write`만)
+  - EPHEMERAL fs cleanup hook 동작 가설 검증 (옵션 C — CI build verify step에 통합)
+  - 9 workflow dead code 정리의 정확성 (잔존 우회 step 누락 없는지)
+- decisions to challenge:
+  - 사용자가 4-agent 리뷰 우회 결정 (이 review가 단일 안전망)
+  - admin-skip 머지로 운영 시간차 위험 mitigation
+  - mega PR (single-concern 카논 위반의 사용자 명시 override)
+
+- [ ] **Step 2: review 결과 검토 + 사용자 결정**
+
+review가 변경 요청 → fix or fold-in 결정. 변경 없음 → 다음 task.
+
+- [ ] **Step 3: review fix가 있으면 추가 commit + push**
+
+```bash
+git add <fix files>
+git commit -m "fix(phase-23): code review fold-in <항목>"
+git push
+```
+
+---
+
+## Task 13: PR 생성 + admin-skip 머지 게이트
+
+- [ ] **Step 1: PR 생성**
+
+```bash
+gh pr create \
+  --title "feat(phase-23): Custom Runner Image (multi-stage + 9 workflow 정리)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Custom Runner Image (`ghcr.io/sabyunrepo/mmp-runner`) multi-stage Dockerfile (builder=ubuntu:22.04 + final=myoung34 base)
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED` cleanup hook script (EPHEMERAL fs 잔존 정공)
+- GHCR build CI (`.github/workflows/build-runner-image.yml`, Public visibility, GITHUB_TOKEN)
+- docker-compose image + pull_policy 변경
+- 9 workflow dead code 정리 (sudo go test, ownership step, jq install, setup-node symlink, manual sudo docker build)
+- Trivy image cleanup 1줄 (Sec-MED-3 #2 fold-in)
+- gitleaks artifact upload 복원 (Sec-MED-2 #3 fold-in, verify는 다음 CI run)
+
+## Test plan
+- [x] cleanup hook bash unit test PASS (Wave 1 Task 1)
+- [x] Dockerfile multi-stage build syntax check PASS (Wave 1 Task 2 또는 PR CI 위임)
+- [x] PR build-runner-image.yml CI verify PASS (cleanup hook fire assertion 통과)
+- [ ] 머지 후 GHCR push 성공 확인 (Wave 5 Task 14)
+- [ ] 사용자 host 재배포 후 4 runner idle (Wave 5 Task 15)
+- [ ] 첫 실 CI run cleanup hook fire + tar 충돌 0건 (Wave 5 Task 16)
+- [ ] gitleaks artifact upload 동작 확인 (Wave 5 Task 16, fail 시 hotfix + #3 follow-up)
+- [ ] PR-5 (#172) 자동 unblock + 머지 (Wave 5 Task 17)
+
+## Refs
+- Spec: `docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md`
+- Plan: `docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md`
+- 부모: Phase 22 W1.5 plan (carry-over Sec-MED-2/3, DEBT-2/3/4 자연 해소)
+- 핸드오프: `memory/sessions/2026-04-29-phase-23-custom-image-pivot.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: PR build-runner-image.yml CI verify 통과 확인**
+
+```bash
+gh pr checks
+# Expected: build-runner-image.yml job SUCCESS (cleanup hook fire assertion 통과)
+```
+
+verify fail 시 → hook script 또는 Dockerfile fix → push → 재시도. **이 verify가 옵션 C 카논의 핵심 안전망**.
+
+- [ ] **Step 3: 사용자 결정 — admin-skip 머지 시점**
+
+`active CI 0건 확인` 후:
+```bash
+# active CI run 조회
+gh run list --status in_progress --limit 5
+# 0건이면 머지
+gh pr merge <PR#> --admin --squash --delete-branch
+```
+
+머지 직후 즉시 사용자 host SSH 재배포 (Wave 5 진입). 머지 → 재배포 사이 새 CI run 발생 시 9 workflow 정리된 step이 옛 base image runner로 fail 가능 — admin-skip 정책으로 통과.

--- a/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-5-operational.md
+++ b/docs/plans/2026-04-29-phase-23-custom-runner-image/refs/wave-5-operational.md
@@ -1,0 +1,210 @@
+# Wave 5 — Operational Verify (사용자 host 작업)
+
+> 부모: [checklist.md](../checklist.md) | 이전: [Wave 4](wave-4-pr.md)
+
+## Task 14: GHCR push 성공 확인
+
+- [ ] **Step 1: main의 build-runner-image.yml run 결과**
+
+```bash
+gh run list --workflow=build-runner-image.yml --limit=1
+gh run view <run-id> --log | grep -i "pushed"
+# Expected: pushed: ghcr.io/sabyunrepo/mmp-runner:latest, :<sha>
+```
+
+- [ ] **Step 2: GHCR public visibility 확인**
+
+```bash
+curl -s https://ghcr.io/v2/sabyunrepo/mmp-runner/tags/list | jq .
+# Expected: tags JSON (latest + sha tag) — 인증 없이 응답
+```
+
+- [ ] **Step 3: 첫 push 후 repo connection 설정 (1회)**
+
+수동 절차 (브라우저):
+1. https://github.com/sabyunrepo/packages/container/mmp-runner/settings
+2. "Manage Actions access" → `muder_platform` add (이렇게 해야 향후 본 repo의 GITHUB_TOKEN이 push 가능)
+3. visibility → Public 확인 (image에 secret 없으니 OK)
+
+> 본 1회 설정 후 향후 자동 push.
+
+---
+
+## Task 15: 사용자 host SSH 재배포
+
+- [ ] **Step 1: SSH 접속 + git pull**
+
+```bash
+ssh sabyun@100.90.38.7
+cd ~/muder_platform/infra/runners
+git pull
+# Expected: docker-compose.yml + README.md 변경 가져옴
+```
+
+- [ ] **Step 2: image pull + 재시작**
+
+```bash
+docker compose pull
+# Expected: 4 service Pulled (ghcr.io/sabyunrepo/mmp-runner:latest)
+
+docker compose up -d
+# Expected: 4 service Started
+
+docker compose ps
+# Expected: 4 service Up, image=ghcr.io/sabyunrepo/mmp-runner:latest
+```
+
+- [ ] **Step 3: 컨테이너 부팅 + GitHub idle 확인**
+
+```bash
+docker logs containerized-runner-1 2>&1 | head -50 | grep -i "Listening for Jobs"
+# Expected: "Listening for Jobs" 메시지
+
+# 또는 GitHub UI:
+# Settings → Actions → Runners → 4 runner idle 확인
+```
+
+- [ ] **Step 4: 사전 install + hook env 확인**
+
+```bash
+docker exec containerized-runner-1 bash -c '
+  jq --version
+  govulncheck -version
+  /opt/hostedtoolcache/go/1.25.0/x64/bin/go version
+  /opt/hostedtoolcache/node/20.18.0/x64/bin/node --version
+  echo "ACTIONS_RUNNER_HOOK_JOB_STARTED=$ACTIONS_RUNNER_HOOK_JOB_STARTED"
+  ls /opt/runner-hooks/job-started.sh
+'
+# Expected: 모든 binary version 정상 출력 + hook env=/opt/runner-hooks/job-started.sh + 파일 존재
+```
+
+---
+
+## Task 16: 첫 실 CI run verify
+
+- [ ] **Step 1: 트리거 (사용자 PR 또는 작은 noise PR로 자연 트리거)**
+
+또는 PR-5 (#172)의 main rebase + push로 자연 트리거 (Task 17과 묶어서 진행 가능).
+
+- [ ] **Step 2: cleanup hook 실 fire 확인**
+
+```bash
+gh run view <run-id> --log | grep -i "Run /opt/runner-hooks/job-started.sh\|ACTIONS_RUNNER_HOOK_JOB_STARTED"
+# Expected: hook 실행 라인 존재
+```
+
+> **fail 시**: spike (Wave 1 PR CI verify) 통과 + 실 runner fail = `ACTIONS_RUNNER_HOOK_JOB_STARTED` fire 누락. **plan 자체 재검토** (entrypoint override 패턴 전환). myoung34 base의 entrypoint chain이 `ACTIONS_RUNNER_HOOK_*` env를 무시할 가능성. follow-up 별 PR로 entrypoint override.
+
+- [ ] **Step 3: tar 충돌 0건 확인**
+
+```bash
+gh run view <run-id> --log | grep -i "tar.*Cannot open.*File exists"
+# Expected: 매칭 0건
+```
+
+- [ ] **Step 4: GHA cache size 확인**
+
+```bash
+gh cache list | awk '{sum+=$3} END {print sum/1024/1024 " MB"}'
+# Expected: 1GB 이하 (369MB ~ 800MB 범위)
+```
+
+> 폭증 시: 본 PR scope에서 cache narrow는 미포함 (PR-12 retract). 필요 시 별 PR (PR-12 재진입 후보) 또는 hostedtool-cache volume이 setup-go cache 기능을 대체하는지 검토.
+
+- [ ] **Step 5: gitleaks artifact upload (#3 verify)**
+
+```bash
+gh run view <run-id> | grep -i "gitleaks"
+# 또는 GitHub UI: PR Run → Artifacts 섹션에 gitleaks-report 링크 존재
+```
+
+→ **fail 시**:
+1. **즉시 hotfix**: `.github/workflows/security-fast.yml`에 `GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false` 복원 PR
+2. **#3 follow-up PR**: SARIF/upload-artifact 메커니즘 재설계 (PR-168 H-ARCH-2 lesson + Custom Image GID 정착 못 잡는 actions/upload-artifact 호환 issue)
+
+- [ ] **Step 6: 9 workflow 정리 step 통과 확인**
+
+```bash
+# ci.yml: go-check / ts-check / coverage-guard
+gh run view <run-id> | grep -E "(go-check|ts-check|coverage-guard|codeql|trivy|gitleaks)"
+# Expected: 모든 job SUCCESS
+```
+
+→ 특정 job fail 시 진단 + hotfix.
+
+---
+
+## Task 17: PR-5 (#172) main rebase + 머지 (자동 unblock)
+
+- [ ] **Step 1: PR-5 (#172) base에 main rebase**
+
+```bash
+gh pr checkout 172
+git fetch origin main
+git rebase origin/main
+git push --force-with-lease
+```
+
+- [ ] **Step 2: CI 재실행 확인**
+
+```bash
+gh pr checks 172
+# Expected: 모든 status check SUCCESS (osv/govulncheck 자연 통과 — Custom Image의 govulncheck 사전 install 효과)
+```
+
+- [ ] **Step 3: PR-5 머지**
+
+```bash
+gh pr merge 172 --admin --squash --delete-branch
+# Expected: PR closed + branch deleted
+```
+
+→ ci.yml의 4 job (`go-check`, `ts-check`, `coverage-guard`, `docker-build`)이 `[self-hosted, containerized]` runs-on으로 전환됨. 향후 모든 PR이 containerized runner로 routing.
+
+---
+
+## Task 18: Phase 23 종료 조건 verify + close-out
+
+- [ ] **Step 1: Spec 7.5 종료 조건 8건 체크**
+
+- [ ] PR 머지 + GHCR push 성공 (Task 14)
+- [ ] host 4 runner 재배포 + idle (Task 15)
+- [ ] 첫 실 CI run cleanup hook fire + tar 충돌 0건 (Task 16 step 2-3)
+- [ ] 9 workflow 정리 step 통과 (Task 16 step 6)
+- [ ] gitleaks artifact upload 동작 (또는 #3 follow-up 등록) (Task 16 step 5)
+- [ ] GHA cache 1GB 이하 1주 stable (Task 16 step 4 + 1주 모니터링)
+- [ ] PR-5 (#172) main rebase + 머지 (Task 17)
+- [ ] follow-up #1 (Composite action 추출) Phase 23.1 또는 Phase 24 plan 등재
+
+> 1주 stable 모니터링은 **Phase 23 close-out 미루기 정당화 근거** — 즉시 close 안 하고 1주 관찰 후 final close.
+
+- [ ] **Step 2: `/compound-wrap` 호출**
+
+세션 wrap-up:
+- handoff 노트 작성: `memory/sessions/<date>-phase-23-close.md`
+- MEMORY.md entry 갱신 (Phase 23 완료 또는 W1 stable 관찰 stash)
+- MISTAKES.md / QUESTIONS.md append (만약 Q-myoung34-ephemeral-fs 결과)
+- 4 carry-over (Composite action / 9 workflow 정리 잔여 / gitleaks 메커니즘 / GHA cache narrow) 별 phase 등재
+
+- [ ] **Step 3: status 업데이트**
+
+```bash
+# checklist.md frontmatter
+status: "completed (1주 stable 관찰 후 close)"  # 또는
+status: "closed"
+```
+
+---
+
+## 부수 follow-up 등재 (Phase 23 close-out 시)
+
+### Confirmed follow-up
+
+- **Phase 23.1 또는 24**: Composite action 추출 (Arch-HIGH-1) — `.github/actions/start-services/action.yml` 신규
+- **Phase 23.x or W1.5 잔여**: orphan-gate fixture (PR-1), gitleaks Secret scan 분석 (PR-2), govulncheck CRITICAL/HIGH (PR-3), host git clone 절차 (PR-7)
+
+### Conditional follow-up
+
+- **gitleaks SARIF/upload 메커니즘 재설계** (#3 follow-up) — Task 16 step 5에서 fail 시만 trigger
+- **GHA cache narrow** (PR-12 재진입 후보) — Task 16 step 4에서 폭증 발견 시만 trigger
+- **EPHEMERAL fs entrypoint override 패턴** — Task 16 step 2에서 hook fire 누락 발견 시만 trigger (가설 부정 시 plan 재검토)

--- a/docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md
+++ b/docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md
@@ -1,0 +1,350 @@
+---
+title: Phase 23 — Custom Runner Image (Option A multi-stage)
+date: 2026-04-29
+status: design
+parent_phase: phase-22-w1-5-debt-cleanup
+prerequisite_pr: "#172 (chore/w1-5-ci-runs-on, open 보류 — 본 phase 머지 후 자동 unblock)"
+---
+
+# Phase 23 — Custom Runner Image (Option A multi-stage)
+
+> 부모: [Phase 22 W1.5 plan](../../plans/2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md) | 직전 핸드오프: [`memory/sessions/2026-04-29-phase-23-custom-image-pivot.md`](../../../memory/sessions/2026-04-29-phase-23-custom-image-pivot.md)
+
+## 0. 진단 요약 (이전 세션 결정 카논)
+
+| 발견 | 출처 |
+|------|------|
+| `myoung34/github-runner` EPHEMERAL=true가 **filesystem reset 안 함** — runner process만 deregister/register, Docker overlay layer는 잔존 | PR-173 첫 CI run `tar: Cannot open: File exists` 패턴 (2026-04-29) |
+| `actions/setup-go` default cache가 `~/.cache/go-build`까지 push → cache 369MB → 2,549MB 폭증 (6시간) | `gh cache list` 사용자 직접 관찰 |
+| 9 workflow에 base image 결함 우회용 step 누적 (jq install, sudo go test, sudo apt-get, manual sudo docker build) | Phase 22 W1.5 plan PR-8 spec (`refs/pr-8-runner-action-compat.md`) |
+
+→ **정공 fix**: Custom Image base에 사전 install + cleanup hook + 9 workflow 우회 step 제거.
+
+## 1. Goal
+
+Phase 22 W1 containerization (PR-165/166) + W1.5 admin-merge cleanup (PR-167/168/170) 의 누적 부채를 single PR로 정공 해소:
+
+- **Custom Runner Image** (`ghcr.io/sabyunrepo/mmp-runner`)에 다음 사전 install:
+  - Go toolchain v1.25.0 (RUNNER_TOOL_CACHE 호환 위치)
+  - Node v20.18.0 (DEBT-2 자연 해소)
+  - jq, govulncheck (workflow 우회 step 자연 해소)
+  - Playwright system deps (E2E 1st run cold start ↓)
+  - docker GID 990 정착 (DEBT-3 + testcontainers-go 자연 해소)
+- **`ACTIONS_RUNNER_HOOK_JOB_STARTED`** cleanup hook script (EPHEMERAL fs 잔존 정공)
+- **9 workflow dead code 정리** (fold-in)
+- **Trivy scan image cleanup** Sec-MED-3 1줄 fold-in
+- **gitleaks artifact upload 복원** Sec-MED-2 (verify는 다음 CI run)
+
+## 2. 사용자 결정 (brainstorming 카논)
+
+| 결정 | 사유 |
+|------|------|
+| **단일 mega PR** (Custom Image + 9 workflow 정리) | single-concern 카논상 위반이지만 사용자 명시 결정. 운영 시간차 위험은 admin-skip으로 mitigation. |
+| **4-agent 리뷰 우회** | 사용자 명시 결정. `superpowers:requesting-code-review`만 사용. `feedback_4agent_review_before_admin_merge.md` 카논 override (사용자 explicit instructions가 최우선). |
+| **admin-skip 머지** | 운영 시간차 위험 (host 재배포 전 main fail) mitigation. 다음 PR에서 자연 verify. |
+| **GITHUB_TOKEN 사용** | `secrets.ACCESS_TOKEN` 재사용 거부. blast radius 분리 (`Administration: write` 권한 우회). |
+| **GHCR Public visibility** | 사용자 host pull 인증 0건. image에 secret 없으니 risk 낮음. |
+| **multi-stage build (Approach B)** | 보안 표면 축소 (builder의 curl/xz 제외) + GHA cache 효율. |
+| **EPHEMERAL fs spike = 옵션 C** | base image 검증 무의미. CI 빌드 step에 verify 통합 (`docker run` + cleanup hook fire assert). |
+| **Composite action 추출 (Arch-HIGH-1) 별 phase** | 다른 root cause (보일러플레이트). Phase 23.1 또는 Phase 24 후보. |
+| **gitleaks artifact 복원 본 PR fold-in** | Custom Image 머지 후 artifact upload env 켜고 verify. fail 시만 별 follow-up. |
+
+## 3. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 23 Custom Runner Image                                │
+│                                                             │
+│  Dockerfile (multi-stage)                                   │
+│   ├─ Stage 1 builder (ubuntu:22.04)                         │
+│   │   ├─ Go 1.25.0 tarball → /opt/hostedtoolcache/go/...    │
+│   │   ├─ Node 20.18.0 tarball → /opt/hostedtoolcache/node/  │
+│   │   └─ govulncheck install → /usr/local/bin               │
+│   │                                                         │
+│   └─ Stage 2 final (FROM myoung34 base@sha256:85a7...)      │
+│       ├─ COPY --from=builder /opt/hostedtoolcache           │
+│       ├─ COPY --from=builder /usr/local/bin/govulncheck     │
+│       ├─ RUN apt-get install jq + Playwright deps           │
+│       ├─ RUN groupadd -g 990 docker-host                    │
+│       ├─ COPY infra/runners/hooks/job-started.sh            │
+│       └─ ENV ACTIONS_RUNNER_HOOK_JOB_STARTED=...            │
+│                                                             │
+│  build-runner-image.yml                                     │
+│   ├─ on: push branches main + pull_request paths            │
+│   ├─ permissions: packages: write                           │
+│   ├─ build (PR + main, gha cache)                           │
+│   ├─ verify (PR only, docker run + cleanup hook assert)     │
+│   └─ push (main only, GHCR latest + sha tags)               │
+│                                                             │
+│  docker-compose.yml diff:                                   │
+│   - image: myoung34/github-runner@sha256:85a7...            │
+│   + image: ghcr.io/sabyunrepo/mmp-runner:latest             │
+│   - pull_policy: never                                      │
+│   + pull_policy: always                                     │
+│                                                             │
+│  9 workflow dead code 정리 (fold-in)                        │
+│   ci.yml          : sudo go test 제거, ownership step 제거  │
+│   security-deep   : setup-node@v4 + symlink 제거            │
+│   security-deep   : usermod docker / sudo docker 제거       │
+│   security-deep   : Trivy image cleanup 1줄 추가 (#2)       │
+│   security-fast   : GITLEAKS_ENABLE_UPLOAD_ARTIFACT 제거(#3)│
+│   여러 workflow   : apt-get install jq 제거                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 4. Components
+
+### 4.1 `infra/runners/Dockerfile` (신규)
+
+multi-stage:
+- **Stage 1 builder** (`ubuntu:22.04`): Go/Node tarball download + govulncheck install. install tool (curl, ca-certificates, xz-utils) 보존하지만 final stage에 미반영.
+- **Stage 2 final** (`FROM myoung34/github-runner@sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3`): COPY install artifacts + apt-get install jq + Playwright deps + docker GID 990 + cleanup hook script.
+
+ARG:
+- `GO_VERSION=1.25.0` (renovate 추적 후보)
+- `NODE_VERSION=20.18.0` (renovate 추적 후보)
+
+ENV:
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runner-hooks/job-started.sh`
+- `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` (compose env와 align, Dockerfile에는 설정 안 함 — compose 우선)
+
+USER: 최종 `runner` (myoung34 base 표준).
+
+### 4.2 `infra/runners/hooks/job-started.sh` (신규)
+
+```bash
+#!/usr/bin/env bash
+# ACTIONS_RUNNER_HOOK_JOB_STARTED — 매 job 시작 직전 fire.
+# myoung34 EPHEMERAL=true가 file system reset 안 함에 대한 정공.
+set -euo pipefail
+# myoung34 base image의 runner user home은 /home/runner 고정. set -u로 인한 unbound variable abort 방지.
+HOME="${HOME:-/home/runner}"
+rm -rf "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build" 2>/dev/null || true
+# setup-go가 cache restore 시 parent dir 존재 가정 — rm -rf 후 재생성 필수.
+mkdir -p "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build"
+```
+
+용도: 매 job 시작 직전 fire (myoung34의 EPHEMERAL fs reset 누락 정공). HOME guard는 W1.T1 review fold-in (set -u 안전망).
+
+permission: 755 (Dockerfile `COPY --chmod=0755`).
+
+### 4.3 `.github/workflows/build-runner-image.yml` (신규)
+
+action SHA pinning은 Phase 18.7 카논 + W1.T3 review fold-in. release.yml align.
+
+| step | 동작 |
+|------|------|
+| 1 | `actions/checkout@34e1148` (v4.3.1) |
+| 2 | `docker/setup-buildx-action@f7ce87c` (v3.9.0) |
+| 3 | `docker/login-action@4907a6d` (v4.1.0, push event만, GITHUB_TOKEN) |
+| 4 | `docker/build-push-action@4f58ea7` (v6.9.0, PR=load, main=push) — `cache-from: type=gha`, `cache-to: type=gha,mode=max` |
+| 5 | verify step (PR만) — `docker run` + jq/govulncheck/Go/Node check + cleanup hook fire assert (`~/go/pkg/mod` + `~/.cache/go-build` 둘 다 비었음 검증 — W1.T3 review fold-in) |
+
+trigger paths:
+- `infra/runners/Dockerfile`
+- `infra/runners/hooks/**`
+- `.github/workflows/build-runner-image.yml`
+
+permissions: `contents: read`, `packages: write`.
+
+runs-on: `[self-hosted, containerized]` (runner pool 사용).
+
+### 4.4 `infra/runners/docker-compose.yml` (수정)
+
+diff:
+```diff
+-  image: myoung34/github-runner@sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3
+-  pull_policy: never
++  image: ghcr.io/sabyunrepo/mmp-runner:latest
++  pull_policy: always
+```
+
+기타 (group_add, mem_limit, networks, volumes, environment): 변경 없음. PR-4 fold-in의 hostedtool-cache/playwright-cache volume 보존.
+
+### 4.5 9 workflow dead code 정리 (fold-in)
+
+| workflow | 변경 | 이유 |
+|----------|------|------|
+| `ci.yml` | `sudo -E env "PATH=$PATH" go test` → `go test` | docker GID 990 정착 |
+| `ci.yml` | `Fix coverage.out ownership` step 제거 | RUN_AS_ROOT=false + group_add로 자동 |
+| `security-deep.yml` (CodeQL) | `setup-node@v4` + `/usr/local/bin/node` symlink override 제거 | base에 Node v20 사전 install |
+| `security-deep.yml` (Trivy) | `usermod -aG docker` + `sudo docker buildx` → 일반 `docker buildx` | docker GID 990 |
+| `security-deep.yml` (Trivy) | (신규) `if: always()` `docker rmi mmp-server:security-scan` 1줄 (#2 fold-in) | host disk 누적 cleanup |
+| `security-fast.yml` (gitleaks) | `GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false` env 제거 (#3 fold-in) | Custom Image GID 정착 가설 verify, fail 시 별 PR |
+| 여러 workflow | `apt-get install jq` step 제거 | base에 jq 사전 install |
+
+## 5. Data Flow
+
+```
+PR push → build-runner-image.yml 트리거 (paths match)
+  └─ build (load=true) → verify (cleanup hook assert)
+                              ↓ assert pass
+PR superpowers:requesting-code-review (4-agent 우회)
+  └─ review fix 또는 fold-in
+                              ↓
+admin-skip 머지 (gh pr merge --admin --squash)
+  └─ main → build-runner-image.yml 재트리거 (push event)
+       └─ GHCR push (latest + sha tag)
+                              ↓
+사용자 host SSH:
+  cd ~/muder_platform/infra/runners
+  git pull
+  docker compose pull (Public, 인증 0건)
+  docker compose up -d (4 runner 재시작)
+                              ↓
+첫 실 CI run:
+  ├─ cleanup hook 실 fire 확인 (gh run view --log)
+  ├─ tar 충돌 0건
+  ├─ GHA cache size < 1GB
+  ├─ 9 workflow 정리 step 통과
+  └─ gitleaks artifact upload 동작 (#3 verify)
+                              ↓
+PR-5 (#172) main rebase + 자동 unblock + 머지
+```
+
+## 6. Error Handling
+
+### 6.1 PR build/verify
+
+| 실패 모드 | 대응 |
+|----------|------|
+| multi-stage builder fail (tarball 404) | upstream 일시 장애. 1회 재실행. 영구 fail 시 version arg 검토. |
+| myoung34 base SHA pull fail | base SHA가 회수됨 (드물지만 가능). Renovate가 latest digest로 갱신 (Phase 18.7 카논). |
+| 사전 install 검증 fail | Dockerfile RUN block 누락. fix 후 PR push. |
+| **cleanup hook 동작 안 함 (verify assert fail)** | **옵션 C 가설 부정**. plan 자체 재검토 (entrypoint override 패턴 전환). |
+| build CI hang (cache fetch 정체) | 10분 timeout. 발생 시 `gh cache delete` 또는 cache-from/to 비활성. |
+
+### 6.2 main 머지 + GHCR push
+
+| 실패 모드 | 대응 |
+|----------|------|
+| GHCR login 401 | `permissions: packages: write` 누락 검증. |
+| GHCR push 403 | package 신규 생성 → repo connection 미설정. 첫 push 후 수동 1회: `https://github.com/sabyunrepo/packages/container/mmp-runner/settings` → "Manage Actions access" → `muder_platform` add. |
+| GHCR rate limit 429 | free tier 한도. 기다림 + 재push. |
+| **9 workflow main 부분 fail (host 재배포 전)** | admin-skip 정책으로 통과. host 재배포 후 자연 정상화. |
+
+### 6.3 사용자 host 재배포
+
+| 실패 모드 | 대응 |
+|----------|------|
+| `docker compose pull` 401/404 | GHCR Public 미설정. package settings 확인. |
+| 4 runner 일부 옛 image 잔존 | `docker compose down && up -d` (강제 재생성). |
+| runner 재등록 fail | `.env` ACCESS_TOKEN 만료 검증 (README PAT scope curl). |
+| 재배포 도중 active CI 중단 | EPHEMERAL=true graceful: deregister 후 새 image. **active CI 0건일 때 재배포** 권고. |
+| 컨테이너 부팅 직후 exit | `docker logs` 확인. **rollback**: compose.yml `image:` 직전 GHCR sha 또는 myoung34 base SHA로 복귀. |
+
+### 6.4 첫 CI run verify
+
+| 실패 모드 | 대응 |
+|----------|------|
+| **cleanup hook 미작동 (실 runner)** | spike 통과 + 실 runner fail = `ACTIONS_RUNNER_HOOK_JOB_STARTED` fire 누락. **plan 재검토** (entrypoint override 전환). |
+| **gitleaks artifact upload fail** | Custom Image GID 정착 불충분. **#3 follow-up PR**로 escalate. 즉시 hotfix: `GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false` 복원. |
+| govulncheck PATH miss | builder stage `/root/go/bin/govulncheck` 가정 오류. `find / -name govulncheck` 진단. |
+| 9 workflow 정리 과도 | step 제거 범위 큼. 필요 step 복구 + dead code 재분류. |
+
+### 6.5 Rollback (전체)
+
+```
+사용자 host:
+  cd ~/muder_platform/infra/runners
+  git revert <Phase 23 commit> (compose.yml만)
+  docker compose pull
+  docker compose up -d
+  → ~5분 내 복귀
+
+main revert PR:
+  gh pr create로 revert (compose + 9 workflow 동시 revert)
+  admin-skip 머지
+
+사후 진단:
+  - Dockerfile / hook / 9 workflow / gitleaks 중 어느 컴포넌트 fail
+  - hotfix PR 작성
+```
+
+## 7. Testing / Verification Matrix
+
+### 7.1 PR build CI
+
+- Dockerfile 빌드 exit 0
+- multi-stage cache hit (2nd run)
+- 사전 install 검증 (jq, govulncheck, Go, Node — 모두 exit 0)
+- hostedtool-cache 위치 + `.complete` 마커 존재
+- cleanup hook fire 시뮬 통과 (`[ -z "$(ls -A ~/go/pkg/mod)" ]`)
+- hook script permission 755
+- docker GID 990 정착 (`getent group docker-host`)
+- runner user PATH 노출 (`docker run --user runner` + `which go && which node`)
+- image 크기 < 2GB
+- base image SHA pinning 보존
+
+### 7.2 main 머지 + GHCR push
+
+- GHCR login 성공
+- GHCR push 성공 (latest + sha tag)
+- Public visibility (인증 없이 tags JSON 반환)
+
+### 7.3 사용자 host 재배포
+
+- `docker compose pull` 4 service Pulled
+- `docker compose up -d` 4 service Started
+- `docker logs` "Listening for Jobs"
+- `docker exec` ENTRYPOINT 정상 (Runner.Listener 프로세스)
+- 사전 install 노출
+- GitHub Settings → Runners 4 idle
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED` env 노출
+
+### 7.4 첫 실 CI run
+
+- cleanup hook 실 fire (`gh run view --log` grep)
+- tar 충돌 0건
+- GHA cache size < 1GB
+- 9 workflow 정리 step 통과
+- CodeQL JS-TS 통과 (Node v20)
+- Trivy + image cleanup (#2)
+- gitleaks artifact upload (#3 verify, fail 시 follow-up)
+- testcontainers-go 통과
+- E2E run 통과
+
+### 7.5 Phase 23 종료 조건
+
+- [ ] PR 머지 + GHCR push
+- [ ] host 4 runner 재배포 + idle
+- [ ] 첫 실 CI run cleanup hook fire 확인 + tar 충돌 0건
+- [ ] 9 workflow 정리 step 통과
+- [ ] gitleaks artifact upload 동작 (또는 #3 follow-up 등록)
+- [ ] GHA cache 1GB 이하 1주 stable
+- [ ] PR-5 (#172) main rebase + 머지 (자동 unblock)
+- [ ] follow-up #1 (Composite action) Phase 23.1 또는 Phase 24 plan 등재
+
+## 8. Out of Scope
+
+- Composite action 추출 (Arch-HIGH-1) — 별 phase
+- gitleaks SARIF/upload 메커니즘 재설계 — verify fail 시만 별 follow-up
+- ARM64 image build — 현 host linux/amd64만
+- multi-stage builder 보안 표면 정량 측정 (trivy image scan) — 별 phase
+- image 크기 최적화 — 1차 < 2GB 만족 시 충분
+
+## 9. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `RUNNER_TOOL_CACHE` 정밀 매칭 실패 (setup-go가 사전 install 미인식) | `.complete` 마커 검증 + `actions/setup-go` source 확인. fail 시 매번 download fallback이라 fail 모드 가벼움. |
+| myoung34 base의 ENTRYPOINT/CMD 손상 | final stage에서 ENTRYPOINT 미override. `USER runner`만 명시. |
+| GHA cache size 회귀 | hostedtool-cache volume + setup-go default cache narrow는 본 PR 미포함 (PR-12 retract). 첫 CI run에서 size 측정 필수. 폭증 시 별 PR (PR-12 재진입 후보). |
+| `ACTIONS_RUNNER_HOOK_JOB_STARTED` 실 fire 미보장 | 옵션 C verify는 ad-hoc `docker run`으로 검증. 실 runner의 myoung34 entrypoint chain은 다름. **다음 CI run에서 `gh run view --log`로 hook 실행 라인 grep 필수.** fail 시 plan 재검토. |
+| 사용자 host 재배포 시점 active CI 충돌 | active CI 0건 확인 후 재배포. 또는 `docker compose down --timeout 120`으로 graceful 대기. |
+
+## 10. Implementation 진입
+
+본 spec 승인 후 `superpowers:writing-plans` 진입 → `docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md` 작성. 단일 mega PR이라 Wave 분해 X (PR 1개로 종결).
+
+## 11. 카논 ref
+
+- 부모 plan: [Phase 22 W1.5](../../plans/2026-04-28-phase-22-w1-5-debt-cleanup/checklist.md)
+- 직전 핸드오프: [`memory/sessions/2026-04-29-phase-23-custom-image-pivot.md`](../../../memory/sessions/2026-04-29-phase-23-custom-image-pivot.md)
+- 진단 카논: PR-173 retract 사유 (`tar: Cannot open: File exists`)
+- PAT Blast Radius: [`infra/runners/README.md`](../../../infra/runners/README.md)
+- single-concern PR: [`memory/feedback_branch_pr_workflow.md`](../../../memory/feedback_branch_pr_workflow.md)
+- admin-skip 정책: [`memory/project_ci_admin_skip_until_2026-05-01.md`](../../../memory/project_ci_admin_skip_until_2026-05-01.md)
+- 4-agent 카논 (사용자 override): [`memory/feedback_4agent_review_before_admin_merge.md`](../../../memory/feedback_4agent_review_before_admin_merge.md)
+- file/함수 크기 티어: [`memory/feedback_file_size_limit.md`](../../../memory/feedback_file_size_limit.md)
+- compound-mmp lifecycle: [`refs/lifecycle-stages.md`](../../../.claude/plugins/compound-mmp/refs/lifecycle-stages.md)

--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7
 FROM ubuntu:22.04 AS builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG GO_VERSION=1.25.0
 ARG NODE_VERSION=20.18.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -28,7 +29,6 @@ COPY --from=builder /opt/hostedtoolcache /opt/hostedtoolcache
 COPY --from=builder /usr/local/bin/govulncheck /usr/local/bin/govulncheck
 RUN groupadd -g 990 docker-host 2>/dev/null || true \
     && usermod -aG docker-host runner
-COPY infra/runners/hooks/job-started.sh /opt/runner-hooks/job-started.sh
-RUN chmod +x /opt/runner-hooks/job-started.sh
+COPY --chmod=0755 infra/runners/hooks/job-started.sh /opt/runner-hooks/job-started.sh
 ENV ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runner-hooks/job-started.sh
 USER runner

--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7
+FROM ubuntu:22.04 AS builder
+ARG GO_VERSION=1.25.0
+ARG NODE_VERSION=20.18.0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/hostedtoolcache/go/${GO_VERSION}/x64 \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+       | tar -xzf - -C /opt/hostedtoolcache/go/${GO_VERSION}/x64 --strip-components=1 \
+    && touch /opt/hostedtoolcache/go/${GO_VERSION}/x64.complete
+RUN mkdir -p /opt/hostedtoolcache/node/${NODE_VERSION}/x64 \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+       | tar -xJf - -C /opt/hostedtoolcache/node/${NODE_VERSION}/x64 --strip-components=1 \
+    && touch /opt/hostedtoolcache/node/${NODE_VERSION}/x64.complete
+RUN /opt/hostedtoolcache/go/${GO_VERSION}/x64/bin/go install \
+      golang.org/x/vuln/cmd/govulncheck@latest \
+    && cp /root/go/bin/govulncheck /usr/local/bin/
+
+FROM myoung34/github-runner@sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      jq libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+      libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \
+      libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /opt/hostedtoolcache /opt/hostedtoolcache
+COPY --from=builder /usr/local/bin/govulncheck /usr/local/bin/govulncheck
+RUN groupadd -g 990 docker-host 2>/dev/null || true \
+    && usermod -aG docker-host runner
+COPY infra/runners/hooks/job-started.sh /opt/runner-hooks/job-started.sh
+RUN chmod +x /opt/runner-hooks/job-started.sh
+ENV ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runner-hooks/job-started.sh
+USER runner

--- a/infra/runners/README.md
+++ b/infra/runners/README.md
@@ -24,6 +24,62 @@ myoung34/github-runner 4 컨테이너 ephemeral pool. PR-164 fix를 넘어 runne
 2. **30일 회전** — admin-skip 정책 종료(2026-05-01) 전까지. 6개월 표준은 정책 만료 후 적용.
 3. **PAT 노출 금지** — 스크린샷, PR description, log, Slack 모두. 노출 발견 시 즉시 revoke + repo audit log 검토.
 
+## Custom Image (Phase 23+)
+
+이 pool은 **`ghcr.io/sabyunrepo/mmp-runner` Custom Image**로 가동합니다 (myoung34 base 직접 사용 X). 정공:
+
+- 사전 install: jq, govulncheck, Go 1.25, Node 20, Playwright deps
+- docker GID 990 정착 (testcontainers-go + Trivy 자연 권한)
+  - **GID 990 의미**: Dockerfile이 `groupadd -g 990 docker-host`로 group 생성 후 runner user에 가입. 사용자 host의 docker.sock GID와 매칭되어야 효력. `.env`의 `DOCKER_GID`가 dual-control 추가 안전망 (compose `group_add: ${DOCKER_GID}`)
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED` cleanup script — `~/go/pkg/mod` + `~/.cache/go-build`을 매 job 직전 비움 (EPHEMERAL=true가 file system reset 안 하는 myoung34 동작 정공)
+
+이미지 빌드는 `.github/workflows/build-runner-image.yml`이 main 머지 시 자동 push. visibility = Public (사용자 host pull 인증 0건).
+
+> Spec: `docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md`
+
+### GHCR 첫 push 후 1회 운영 절차
+
+1. https://github.com/sabyunrepo/packages/container/mmp-runner/settings → "Manage Actions access" → `muder_platform` add (이렇게 해야 향후 본 repo의 GITHUB_TOKEN이 push 가능)
+2. visibility → Public (image에 secret 없음 — Dockerfile은 git 공개)
+
+### 사용자 host 재배포 (main 머지 후)
+
+```bash
+ssh sabyun@100.90.38.7
+cd ~/muder_platform/infra/runners
+git pull
+docker compose pull
+docker compose up -d
+docker compose ps  # 4 service Started
+```
+
+### Verification (재배포 후)
+
+```bash
+# 컨테이너 부팅
+docker logs containerized-runner-1 2>&1 | head -50 | grep -i "Listening for Jobs"
+
+# 사전 install + hook env 검증
+docker exec containerized-runner-1 bash -c '
+  jq --version
+  govulncheck -version
+  /opt/hostedtoolcache/go/1.25.0/x64/bin/go version
+  /opt/hostedtoolcache/node/20.18.0/x64/bin/node --version
+  echo "ACTIONS_RUNNER_HOOK_JOB_STARTED=$ACTIONS_RUNNER_HOOK_JOB_STARTED"
+'
+
+# GitHub Settings → Actions → Runners → 4 idle 확인
+```
+
+### Rollback (재배포 후 광범위 fail 시)
+
+```bash
+git revert <Phase 23 commit>  # compose.yml만 되돌림
+docker compose pull
+docker compose up -d
+# ~5분 내 myoung34 base 또는 직전 GHCR sha tag로 복귀
+```
+
 ## Bootstrap (최초 1회)
 
 1. fine-grained PAT 발급 (`.env.example` 주석 참조).
@@ -39,11 +95,9 @@ myoung34/github-runner 4 컨테이너 ephemeral pool. PR-164 fix를 넘어 runne
      https://api.github.com/repos/sabyunrepo/muder_platform/actions/runners | jq '.total_count'
    ```
    숫자(0 이상) 반환 시 정상. `401`/`404`이면 PAT 또는 Resource owner 잘못.
-5. **Image pull (최초 1회 필수)** — `pull_policy: never` + digest pinning(H-1)이라 호스트에 image 부재 시 compose up이 `No such image` error로 실패. 첫 부팅 또는 digest 변경(rotation) 시 manual pull:
+5. **Image pull (Phase 23+ Custom Image)** — `pull_policy: always`로 compose up 시 자동 pull. 첫 부팅 또는 GHCR 권한 검증을 위해 manual pull 권장:
    ```bash
-   # docker-compose.yml의 image: ... 라인에서 digest 추출
-   IMAGE=$(grep -E 'image:' docker-compose.yml | head -1 | awk '{print $2}')
-   docker pull "$IMAGE"
+   docker compose pull
    ```
 6. `docker compose up -d`.
 7. GitHub Settings → Actions → Runners → 4 row idle 확인.

--- a/infra/runners/docker-compose.yml
+++ b/infra/runners/docker-compose.yml
@@ -7,9 +7,10 @@
 # 라벨/EPHEMERAL/RUN_AS_ROOT 변경은 본 파일에서 수정.
 
 x-runner-base: &runner-base
-  # Image: latest digest pinning (PR-1 H-1 fix). Renovate가 digest 추적 (Phase 18.7 카논).
-  image: myoung34/github-runner@sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3
-  pull_policy: never
+  # Phase 23 Custom Runner Image (`build-runner-image.yml` GHCR push, Public visibility).
+  # Renovate가 GHCR digest 추적 (Phase 18.7 카논 + Phase 23 spec § 4.4).
+  image: ghcr.io/sabyunrepo/mmp-runner:latest
+  pull_policy: always
   restart: always
   env_file: .env
   environment: &runner-env

--- a/infra/runners/hooks/job-started.sh
+++ b/infra/runners/hooks/job-started.sh
@@ -2,5 +2,8 @@
 # ACTIONS_RUNNER_HOOK_JOB_STARTED — 매 job 시작 직전 fire.
 # myoung34 EPHEMERAL=true가 file system reset 안 함에 대한 정공.
 set -euo pipefail
+# myoung34 base image의 runner user home은 /home/runner 고정. set -u로 인한 unbound variable abort 방지.
+HOME="${HOME:-/home/runner}"
 rm -rf "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build" 2>/dev/null || true
+# setup-go가 cache restore 시 parent dir 존재 가정 — rm -rf 후 재생성 필수.
 mkdir -p "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build"

--- a/infra/runners/hooks/job-started.sh
+++ b/infra/runners/hooks/job-started.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# ACTIONS_RUNNER_HOOK_JOB_STARTED — 매 job 시작 직전 fire.
+# myoung34 EPHEMERAL=true가 file system reset 안 함에 대한 정공.
+set -euo pipefail
+rm -rf "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build" 2>/dev/null || true
+mkdir -p "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build"

--- a/infra/runners/hooks/job-started.test.sh
+++ b/infra/runners/hooks/job-started.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# bash unit test for job-started.sh — verifies cleanup hook behavior.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${THIS_DIR}/job-started.sh"
+
+# 임시 HOME 픽스처
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+mkdir -p "$TMP_HOME/go/pkg/mod/dummy" "$TMP_HOME/.cache/go-build/dummy"
+touch "$TMP_HOME/go/pkg/mod/dummy/file" "$TMP_HOME/.cache/go-build/dummy/file"
+
+HOME="$TMP_HOME" bash "$HOOK"
+
+# Assert: 두 디렉토리 비었음
+[ -z "$(ls -A "$TMP_HOME/go/pkg/mod" 2>/dev/null)" ] || { echo "FAIL: go/pkg/mod not cleaned"; exit 1; }
+[ -z "$(ls -A "$TMP_HOME/.cache/go-build" 2>/dev/null)" ] || { echo "FAIL: .cache/go-build not cleaned"; exit 1; }
+
+# Assert: 빈 디렉토리 재생성됨 (setup-go가 기대)
+[ -d "$TMP_HOME/go/pkg/mod" ] || { echo "FAIL: go/pkg/mod not recreated"; exit 1; }
+[ -d "$TMP_HOME/.cache/go-build" ] || { echo "FAIL: .cache/go-build not recreated"; exit 1; }
+
+echo "PASS: job-started.sh cleanup correct"


### PR DESCRIPTION
## Summary

- **Custom Runner Image** (`ghcr.io/sabyunrepo/mmp-runner`) multi-stage Dockerfile (builder=ubuntu:22.04 + final=myoung34 base @sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3)
- **`ACTIONS_RUNNER_HOOK_JOB_STARTED`** cleanup hook script (EPHEMERAL fs 잔존 정공 — `~/go/pkg/mod` + `~/.cache/go-build` 매 job 직전 비움)
- **GHCR build CI** (`.github/workflows/build-runner-image.yml`, Public visibility, GITHUB_TOKEN, 4 action SHA pin, scope=runner-image)
- **docker-compose** image + pull_policy 변경 (myoung34 → ghcr.io/sabyunrepo/mmp-runner:latest, never → always)
- **9 workflow dead code 정리** (sudo go test, ownership, jq install, setup-node + symlink, manual sudo docker)
- **Trivy image cleanup** 1줄 (Sec-MED-3 #2 fold-in)
- **gitleaks artifact upload 복원** (Sec-MED-2 #3 fold-in, verify는 다음 CI run)
- **README** Custom Image 섹션 + GHCR 운영 절차 + Rollback

## 사용자 명시 결정 (spec § 2)

- 단일 mega PR (single-concern 카논 explicit override)
- 4-agent 리뷰 우회 (superpowers:code-reviewer 1회 — APPROVED YES_WITH_FIXES, fold-in 완료)
- admin-skip 머지 (운영 시간차 위험 mitigation, 머지 직후 사용자 host SSH 재배포)
- GITHUB_TOKEN (별도 PAT 발급 X) + GHCR Public visibility
- multi-stage build (보안 표면 축소)
- EPHEMERAL fs spike = 옵션 C (CI build verify step에 cleanup hook fire assert 통합)

## Test plan

- [x] cleanup hook bash unit test PASS (Wave 1 Task 1)
- [x] Dockerfile multi-stage syntax check (PR build CI에서 native amd64 빌드)
- [x] superpowers:code-reviewer (opus-4-7) APPROVED YES_WITH_FIXES — Critical 0
- [ ] PR build-runner-image.yml CI verify PASS (cleanup hook fire assertion)
- [ ] 머지 후 GHCR push 성공 확인 (Wave 5 Task 14)
- [ ] 사용자 host 재배포 후 4 runner idle (Wave 5 Task 15)
- [ ] 첫 실 CI run cleanup hook fire + tar 충돌 0건 (Wave 5 Task 16)
- [ ] gitleaks artifact upload 동작 확인 (Wave 5 Task 16, fail 시 hotfix + #3 follow-up)
- [ ] PR-5 (#172) 자동 unblock + 머지 (Wave 5 Task 17)

## Refs

- Spec: `docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md` (350 line)
- Plan: `docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md` + 6 wave refs (1039 line, MD 500-line 카논)
- 부모: Phase 22 W1.5 plan (carry-over Sec-MED-2/3, DEBT-2/3/4 자연 해소)
- 핸드오프: `memory/sessions/2026-04-29-phase-23-custom-image-pivot.md`

## Follow-up flags (review에서 식별, 별 phase)

- M-1 ARG DOCKER_GID parameterize (future hardening)
- M-4 Trivy scan으로 mmp-runner image 자체 CVE 검사 (Phase 23.x 또는 24)
- ubuntu:22.04 builder SHA pin (Renovate `pinDigests: true`)
- govulncheck@latest version pin
- Composite action 추출 (Arch-HIGH-1, 별 phase)
- gitleaks SARIF/upload 메커니즘 재설계 (Wave 5 verify fail 시만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)