### PR TITLE
fix(phase-23): build-runner-image.yml yaml syntax (run: | multi-line)

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -43,7 +43,11 @@ jobs:
           load: ${{ github.event_name == 'pull_request' }}
       - name: Verify image loaded
         if: github.event_name == 'pull_request'
-        run: docker images "ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }}" --format '{{.Repository}}:{{.Tag}}' | grep -q "${{ github.sha }}" || (echo "FAIL: image not loaded — check buildx load behavior" && exit 1)
+        run: |
+          docker images "ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }}" --format '{{.Repository}}:{{.Tag}}' | grep -q "${{ github.sha }}" || {
+            echo "FAIL: image not loaded — check buildx load behavior"
+            exit 1
+          }
       - name: Verify cleanup hook fires
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
## Summary

PR #174 머지 후 main push event에서 `build-runner-image.yml`이 0s validation fail (commit 025ed78 등). 진단:

```
yaml.scanner.ScannerError: mapping values are not allowed here
  in build-runner-image.yml, line 46, column 158
```

원인: single-line `run:` 안에 `--format '{{.Repository}}:{{.Tag}}'` + `${{ github.sha }}` 콜론이 yaml mapping delimiter로 잘못 파싱.

Fix: `run: |` multi-line literal block + grep `||` 블록 escape.

## Why this matters

main의 build-runner-image.yml이 동작 안 하면 GHCR `ghcr.io/sabyunrepo/mmp-runner:latest` push 안 됨 → 사용자 host SSH 재배포 시 `docker compose pull`이 image not found.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` PASS (local)
- [ ] main 머지 후 build-runner-image.yml main push event 트리거 → PASS
- [ ] GHCR `mmp-runner:latest` + sha tag push 성공
- [ ] 사용자 host 재배포 시 pull 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)