### PR TITLE
refactor(phase-23): image-resident toolchain — GHA cache 다운로드 0

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -6,11 +6,17 @@ on:
       - 'infra/runners/Dockerfile'
       - 'infra/runners/hooks/**'
       - '.github/workflows/build-runner-image.yml'
+      # Image-resident Go module pre-bake: go.mod/go.sum 변경 시 image rebuild.
+      - 'apps/server/go.mod'
+      - 'apps/server/go.sum'
   pull_request:
     paths:
       - 'infra/runners/Dockerfile'
       - 'infra/runners/hooks/**'
       - '.github/workflows/build-runner-image.yml'
+      - 'apps/server/go.mod'
+      - 'apps/server/go.sum'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -48,21 +54,26 @@ jobs:
             echo "FAIL: image not loaded — check buildx load behavior"
             exit 1
           }
-      - name: Verify cleanup hook fires
+      - name: Verify image-resident toolchain
         if: github.event_name == 'pull_request'
         run: |
           docker run --rm --entrypoint /bin/bash \
             ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }} \
             -c '
               set -euo pipefail
+              # Toolchain pre-bake
               jq --version
               govulncheck -version
               ls /opt/hostedtoolcache/go/1.25.0/x64/bin/go
               ls /opt/hostedtoolcache/node/20.18.0/x64/bin/node
-              mkdir -p ~/go/pkg/mod/dummy ~/.cache/go-build/dummy
-              touch ~/go/pkg/mod/dummy/file ~/.cache/go-build/dummy/file
+              # PATH가 image ENV로 설정 — go/node가 PATH로 직접 호출 가능해야
+              go version | grep -q "go1.25"
+              node --version | grep -q "v20"
+              # Image-resident GOMODCACHE pre-bake (apps/server/go.mod deps)
+              [ -d /home/runner/go/pkg/mod/cache ] || (echo "FAIL: GOMODCACHE pre-bake missing" && exit 1)
+              # Hook 실행 후에도 pre-bake 데이터 보존 (image-resident 카논)
+              touch /home/runner/go/pkg/mod/cache/sentinel
               bash /opt/runner-hooks/job-started.sh
-              [ -z "$(ls -A ~/go/pkg/mod 2>/dev/null)" ] || (echo "FAIL: go pkg mod not cleaned" && exit 1)
-              [ -z "$(ls -A ~/.cache/go-build 2>/dev/null)" ] || (echo "FAIL: go-build cache not cleaned" && exit 1)
-              echo "PASS: cleanup hook works"
+              [ -f /home/runner/go/pkg/mod/cache/sentinel ] || (echo "FAIL: hook이 GOMODCACHE 삭제 (image-resident 위배)" && exit 1)
+              echo "PASS: image-resident toolchain verified"
             '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: "1.25"
-          cache-dependency-path: apps/server/go.sum
+          go-version-file: apps/server/go.mod
+          cache: false  # image-resident toolchain: GOMODCACHE/GOCACHE는 named volume mount.
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
@@ -201,7 +201,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
-          cache: 'pnpm'
+          # image-resident toolchain: PNPM_STORE_PATH는 named volume mount, GHA cache 미사용.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -275,8 +275,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: "1.25"
-          cache-dependency-path: apps/server/go.sum
+          go-version-file: apps/server/go.mod
+          cache: false  # image-resident toolchain: GOMODCACHE/GOCACHE는 named volume mount.
 
       - name: Go coverage gate
         working-directory: apps/server

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: "1.24"
-          cache-dependency-path: apps/server/go.sum
+          go-version-file: apps/server/go.mod
+          cache: false  # image-resident toolchain: GOMODCACHE/GOCACHE는 named volume mount.
 
       - name: Build server
         working-directory: apps/server

--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -19,6 +19,8 @@ RUN /opt/hostedtoolcache/go/${GO_VERSION}/x64/bin/go install \
     && cp /root/go/bin/govulncheck /usr/local/bin/
 
 FROM myoung34/github-runner@sha256:85a7a6a73abd0c0e679ea315b0e773c4a118315e21f47c864041ae6d73d21ea3
+ARG GO_VERSION=1.25.0
+ARG NODE_VERSION=20.18.0
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
       jq libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
@@ -31,4 +33,21 @@ RUN groupadd -g 990 docker-host 2>/dev/null || true \
     && usermod -aG docker-host runner
 COPY --chmod=0755 infra/runners/hooks/job-started.sh /opt/runner-hooks/job-started.sh
 ENV ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runner-hooks/job-started.sh
+# Image-resident toolchain — setup-go/setup-node 의 GHA cache 다운로드 차단.
+# named volume mount (compose) 와 결합해 매 run 의 GOMODCACHE/GOCACHE/PNPM_STORE 다운로드 0.
+ENV PATH=/opt/hostedtoolcache/go/${GO_VERSION}/x64/bin:/opt/hostedtoolcache/node/${NODE_VERSION}/x64/bin:${PATH}
+ENV GOTOOLCHAIN=local
+ENV GOPATH=/home/runner/go
+ENV GOMODCACHE=/home/runner/go/pkg/mod
+ENV GOCACHE=/home/runner/.cache/go-build
+ENV PNPM_STORE_PATH=/home/runner/.pnpm-store
+RUN mkdir -p /home/runner/go/pkg/mod /home/runner/.cache/go-build /home/runner/.pnpm-store \
+    && chown -R runner:runner /home/runner/go /home/runner/.cache /home/runner/.pnpm-store
+# Pre-bake apps/server Go module deps — go.sum 변경 시 image rebuild (paths filter trigger).
+# Node monorepo deps 는 named volume only (image 비대 회피).
+USER runner
+COPY --chown=runner:runner apps/server/go.mod apps/server/go.sum /tmp/prebake/
+RUN cd /tmp/prebake && go mod download
+USER root
+RUN rm -rf /tmp/prebake
 USER runner

--- a/infra/runners/README.md
+++ b/infra/runners/README.md
@@ -29,9 +29,10 @@ myoung34/github-runner 4 컨테이너 ephemeral pool. PR-164 fix를 넘어 runne
 이 pool은 **`ghcr.io/sabyunrepo/mmp-runner` Custom Image**로 가동합니다 (myoung34 base 직접 사용 X). 정공:
 
 - 사전 install: jq, govulncheck, Go 1.25, Node 20, Playwright deps
+- **Image-resident toolchain (Phase 23 follow-up)** — `PATH`에 Go/Node bin 추가, `GOMODCACHE`/`GOCACHE`/`PNPM_STORE_PATH` ENV pre-set, `apps/server/go.mod` deps `go mod download` pre-bake
 - docker GID 990 정착 (testcontainers-go + Trivy 자연 권한)
   - **GID 990 의미**: Dockerfile이 `groupadd -g 990 docker-host`로 group 생성 후 runner user에 가입. 사용자 host의 docker.sock GID와 매칭되어야 효력. `.env`의 `DOCKER_GID`가 dual-control 추가 안전망 (compose `group_add: ${DOCKER_GID}`)
-- `ACTIONS_RUNNER_HOOK_JOB_STARTED` cleanup script — `~/go/pkg/mod` + `~/.cache/go-build`을 매 job 직전 비움 (EPHEMERAL=true가 file system reset 안 하는 myoung34 동작 정공)
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED` script — image-resident cache 보존, idempotent `mkdir`만 수행 (옛 카논의 `rm -rf ~/go/pkg/mod`은 image pre-bake와 충돌해서 제거)
 
 이미지 빌드는 `.github/workflows/build-runner-image.yml`이 main 머지 시 자동 push. visibility = Public (사용자 host pull 인증 0건).
 
@@ -102,35 +103,67 @@ docker compose up -d
 6. `docker compose up -d`.
 7. GitHub Settings → Actions → Runners → 4 row idle 확인.
 
-## Cache Volumes (PR-4 + fold-in, 2026-04-28)
+## Cache Volumes (Phase 23 follow-up — image-resident toolchain)
 
 4 runner 가 공유하는 cache named volume. EPHEMERAL=true 와 무관하게 유지.
 
-**PR-168 fold-in (H-2)**: `pnpm-cache`/`go-cache` 제거 — `actions/setup-go`/`actions/setup-node` 의 GHA cache 와 충돌. `setup-*` 자체 cache 보존, Playwright (GHA cache 미적용) + hostedtool 만 volume cache 사용.
+**카논 reverse (PR-168 H-2 → Phase 23 follow-up)**: 옛 카논은 `pnpm-cache`/`go-cache` 를 제거하고 `setup-*` 의 GHA cache 사용. 그러나 매 run 913MB GOMODCACHE 다운로드 + image의 toolcache pre-bake 무효화 부작용 발견 → image-resident toolchain 카논으로 전환.
 
 ### 구성
 
 | volume | mount | 용도 |
 |---|---|---|
 | `playwright-cache` | `/opt/cache/playwright` | Playwright browser binary (chromium/firefox) |
-| `hostedtool-cache` | `/opt/hostedtoolcache` | actions/setup-go, actions/setup-node 의 toolchain cache |
+| `hostedtool-cache` | `/opt/hostedtoolcache` | Go/Node binary toolchain (image pre-bake 대상) |
+| `go-mod-cache` | `/home/runner/go/pkg/mod` | `apps/server` Go module deps (image pre-bake + persist) |
+| `go-build-cache` | `/home/runner/.cache/go-build` | Go build artifact cache |
+| `pnpm-store` | `/home/runner/.pnpm-store` | pnpm content-addressable store (workspace deps) |
 
-### 환경변수
+### 환경변수 (image ENV로 정의 — Dockerfile)
 
-`x-runner-base.environment` 에서 명시 (workflow step 이 직접 읽음):
+`setup-go`/`setup-node` 가 PATH 자동 hit:
+- `PATH=/opt/hostedtoolcache/go/${GO_VERSION}/x64/bin:/opt/hostedtoolcache/node/${NODE_VERSION}/x64/bin:${PATH}`
+- `GOPATH=/home/runner/go`
+- `GOMODCACHE=/home/runner/go/pkg/mod`
+- `GOCACHE=/home/runner/.cache/go-build`
+- `PNPM_STORE_PATH=/home/runner/.pnpm-store`
+- `GOTOOLCHAIN=local` (project go.mod 의 toolchain directive 무시 — image pre-bake 강제)
+
+compose `x-runner-base.environment` 는 Playwright 만 (image ENV 와 별개):
 - `PLAYWRIGHT_BROWSERS_PATH=/opt/cache/playwright`
-- `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` (L-ARCH-1: actions/setup-* hostedtoolcache 위치 명시)
+- `RUNNER_TOOL_CACHE=/opt/hostedtoolcache`
 
-### Phase 1 효과 (재산정 — PR-168 fold-in 후)
+### Workflow 카논 (self-hosted only)
 
-cache mount 범위가 `playwright-cache` + `hostedtool-cache` 2개로 축소 (pnpm-store/Go mod cache 는 GH-managed cache 사용 — H-2 fold-in).
+`actions/setup-go` / `actions/setup-node` 의 `cache:` 옵션을 **`false`** 로 명시:
+```yaml
+- uses: actions/setup-go@...
+  with:
+    go-version-file: apps/server/go.mod
+    cache: false  # image-resident: GOMODCACHE/GOCACHE는 named volume mount.
+```
 
-- 1st run: ~10분 setup (full download → cache 빌드)
-- 2nd run+: setup ~2~3분 (Playwright + Go/Node toolchain hit, pnpm install 은 GHA cache 의존)
-- pnpm-lock 변경 시: GHA cache miss → 새 install ~2~3분
-- Playwright bump 시: 해당 browser ~1분 download
+GHA cache restore 가 일어나지 않음 → 매 run 의 ~913MB 다운로드 0. cloud (`runs-on: ubuntu-latest`) workflow 는 그대로 GHA cache 사용 (image-resident 무관).
 
-→ "최대 70% 단축" 은 GHA cache 가 정상 작동할 때의 추가 효과 (Playwright 만 단독).
+### 효과 (Phase 23 follow-up)
+
+| 항목 | 옛 (PR-168 H-2) | 새 (image-resident) |
+|---|---|---|
+| 매 run GOMODCACHE 다운로드 | ~913MB (~13초) | **0 (image pre-bake)** |
+| Go toolchain mismatch fallback | 매 fire 마다 다운로드 후 named volume 비대 | image PATH 즉시 hit |
+| pnpm install 첫 run | GHA cache restore 의존 | named volume 영구 persist (4 runner 공유) |
+
+### 운영 카논 — image rebuild 후 cleanup
+
+`apps/server/go.sum` 변경 → build CI 가 새 image push. host 재배포 시 `go-mod-cache` 옛 데이터를 명시 cleanup 해야 image의 새 pre-bake 가 적용:
+```bash
+docker compose down
+docker volume rm $(docker volume ls -q | grep -E "go-mod-cache|go-build-cache") 2>/dev/null || true
+docker compose pull
+docker compose up -d
+```
+
+`hostedtool-cache` 도 GO_VERSION/NODE_VERSION bump 시 동일 cleanup 필요.
 
 ### 보안 — Public repo + Fork PR 가드
 
@@ -155,31 +188,36 @@ PR 머지 후 host (sabyun@100.90.38.7) 에서:
 ssh sabyun@100.90.38.7
 cd ~/infra/runners
 
-# 새 docker-compose.yml 가져오기
+# 새 docker-compose.yml 가져오기 (또는 SCP — host의 ~/infra/runners 가 git clone 아닐 시)
 git pull origin main
 
-# 기존 named volume 삭제 (volume 정의 변경 — pnpm-cache/go-cache 제거됨)
+# 기존 named volume 삭제 (Phase 23 follow-up: image pre-bake 적용 위해 옛 cache 제거)
 docker compose down
-docker volume rm runner-cache_pnpm-cache runner-cache_go-cache 2>/dev/null || true
+docker volume rm $(docker volume ls -q | grep -E "go-mod-cache|go-build-cache|hostedtool-cache|pnpm-store") 2>/dev/null || true
 
 # 재배포
+docker compose pull
 docker compose up -d
 
 # 검증
 docker compose ps                                          # 4 service Up
-docker volume ls | grep -E "(playwright|hostedtool)-cache"  # 2 cache volume 생성
+docker volume ls | grep -E "(playwright|hostedtool|go-mod|go-build|pnpm)"  # 5 cache volume 생성
 docker compose logs runner-1 --tail 10                     # "Listening for Jobs"
+docker exec containerized-runner-1 ls /home/runner/go/pkg/mod/cache  # image pre-bake 데이터 확인
 ```
 
 GH UI Settings → Actions → Runners 에서 4 runner idle 재확인.
 
-### 디스크 사용량
+### 디스크 사용량 (image-resident toolchain 후)
 
 cache 누적 후 예상치:
 - `playwright-cache`: 200~500MB (chromium 150MB + firefox 80MB + system deps)
-- `hostedtool-cache`: ~200MB (Go toolchain + Node)
+- `hostedtool-cache`: ~200MB (Go toolchain + Node — image pre-bake 동기화)
+- `go-mod-cache`: ~500MB ~ 1.5GB (apps/server deps + 누적 dependency)
+- `go-build-cache`: ~300MB ~ 1GB (build artifact cache)
+- `pnpm-store`: ~500MB ~ 1.5GB (monorepo content-addressable store)
 
-총 ~400~700MB (pnpm/Go cache 제거로 이전 대비 ~3~4GB → ~0.7GB 감소). 정기 재 build 시 docker volume prune 권장.
+총 ~1.7GB ~ 4.5GB. 옛 PR-168 카논 (~700MB) 대비 증가하지만 매 run 다운로드 0 + 13초 절감 trade-off. `apps/server/go.sum` bump 시 image rebuild + `docker volume rm` cleanup 필요 (위 카논 참조).
 
 ## Troubleshooting (PAT 만료 detection)
 

--- a/infra/runners/docker-compose.yml
+++ b/infra/runners/docker-compose.yml
@@ -19,8 +19,9 @@ x-runner-base: &runner-base
     RUN_AS_ROOT: "false"
     # 컨테이너 OS = linux (호스트 macOS와 별개). Phase 23 ARM image 진입 시 arm64/amd64 라벨 추가.
     LABELS: "self-hosted,linux,containerized"
-    # PR-4 fold-in (H-2): Playwright만 volume cache (GHA cache 미적용).
-    # GOMODCACHE/PNPM_STORE_PATH/GOCACHE 제거 — setup-go/setup-node 자체 GHA cache와 충돌.
+    # Image-resident toolchain (Phase 23 follow-up):
+    # GOMODCACHE/GOCACHE/PNPM_STORE_PATH는 image ENV에서 정의. compose는 named volume mount만.
+    # Playwright는 별 cache (GHA cache 미적용 — image 비대 회피).
     PLAYWRIGHT_BROWSERS_PATH: /opt/cache/playwright
     # L-ARCH-1: actions/setup-* 의 hostedtoolcache 위치 명시 (dead config 방지).
     RUNNER_TOOL_CACHE: /opt/hostedtoolcache
@@ -42,6 +43,9 @@ services:
       - runner1-work:/runner/_work
       - playwright-cache:/opt/cache/playwright
       - hostedtool-cache:/opt/hostedtoolcache
+      - go-mod-cache:/home/runner/go/pkg/mod
+      - go-build-cache:/home/runner/.cache/go-build
+      - pnpm-store:/home/runner/.pnpm-store
 
   runner-2:
     <<: *runner-base
@@ -54,6 +58,9 @@ services:
       - runner2-work:/runner/_work
       - playwright-cache:/opt/cache/playwright
       - hostedtool-cache:/opt/hostedtoolcache
+      - go-mod-cache:/home/runner/go/pkg/mod
+      - go-build-cache:/home/runner/.cache/go-build
+      - pnpm-store:/home/runner/.pnpm-store
 
   runner-3:
     <<: *runner-base
@@ -66,6 +73,9 @@ services:
       - runner3-work:/runner/_work
       - playwright-cache:/opt/cache/playwright
       - hostedtool-cache:/opt/hostedtoolcache
+      - go-mod-cache:/home/runner/go/pkg/mod
+      - go-build-cache:/home/runner/.cache/go-build
+      - pnpm-store:/home/runner/.pnpm-store
 
   runner-4:
     <<: *runner-base
@@ -78,16 +88,24 @@ services:
       - runner4-work:/runner/_work
       - playwright-cache:/opt/cache/playwright
       - hostedtool-cache:/opt/hostedtoolcache
+      - go-mod-cache:/home/runner/go/pkg/mod
+      - go-build-cache:/home/runner/.cache/go-build
+      - pnpm-store:/home/runner/.pnpm-store
 
 volumes:
   runner1-work:
   runner2-work:
   runner3-work:
   runner4-work:
-  # PR-4 fold-in (H-2): pnpm-cache/go-cache 제거 — setup-go/setup-node GHA cache 사용.
-  # 4 runner 공유 cache: playwright (GHA cache 미적용) + hostedtool (setup-* toolchain).
+  # 4 runner 공유 cache: image-resident toolchain backing storage.
+  # 첫 가동 시 image의 GOMODCACHE pre-bake 데이터가 named volume으로 자동 복사 (Docker 카논).
+  # image update (go.sum 변경 → image rebuild) 적용 시 사용자 host에서 명시 cleanup 필요:
+  #   docker compose down && docker volume rm <project>_go-mod-cache && docker compose up -d
   playwright-cache: {}
   hostedtool-cache: {}
+  go-mod-cache: {}
+  go-build-cache: {}
+  pnpm-store: {}
 
 networks:
   runners-net:

--- a/infra/runners/hooks/job-started.sh
+++ b/infra/runners/hooks/job-started.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # ACTIONS_RUNNER_HOOK_JOB_STARTED — 매 job 시작 직전 fire.
-# myoung34 EPHEMERAL=true가 file system reset 안 함에 대한 정공.
+#
+# Phase 23 follow-up (image-resident toolchain):
+# - GOMODCACHE/GOCACHE는 image pre-bake + named volume mount로 persist.
+# - setup-go의 `cache: false`와 결합해 GHA cache restore 자체가 일어나지 않음
+#   → 옛 카논의 tar 충돌 우려는 미발생. rm -rf 제거.
+#
+# myoung34 base image의 runner user home은 /home/runner 고정.
+# set -u로 인한 unbound variable abort 방지.
 set -euo pipefail
-# myoung34 base image의 runner user home은 /home/runner 고정. set -u로 인한 unbound variable abort 방지.
 HOME="${HOME:-/home/runner}"
-rm -rf "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build" 2>/dev/null || true
-# setup-go가 cache restore 시 parent dir 존재 가정 — rm -rf 후 재생성 필수.
+# setup-go가 cache restore disabled여도 parent dir 존재 가정 — 안전망 idempotent mkdir.
 mkdir -p "${HOME}/go/pkg/mod" "${HOME}/.cache/go-build"

--- a/infra/runners/hooks/job-started.test.sh
+++ b/infra/runners/hooks/job-started.test.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# bash unit test for job-started.sh — verifies cleanup hook behavior.
+# bash unit test for job-started.sh — verifies image-resident toolchain preservation.
+# Phase 23 follow-up: hook은 더 이상 cache 청소하지 않음. 기존 cache 데이터 보존 필수.
 set -euo pipefail
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="${THIS_DIR}/job-started.sh"
 
-# 임시 HOME 픽스처
+# Case 1: 기존 cache 데이터가 있을 때 — 보존되어야 함 (image-resident toolchain).
 TMP_HOME="$(mktemp -d)"
 trap 'rm -rf "$TMP_HOME"' EXIT
-mkdir -p "$TMP_HOME/go/pkg/mod/dummy" "$TMP_HOME/.cache/go-build/dummy"
-touch "$TMP_HOME/go/pkg/mod/dummy/file" "$TMP_HOME/.cache/go-build/dummy/file"
+mkdir -p "$TMP_HOME/go/pkg/mod/golang.org/x/sys@v0.20.0" "$TMP_HOME/.cache/go-build/00"
+touch "$TMP_HOME/go/pkg/mod/golang.org/x/sys@v0.20.0/sys.go" "$TMP_HOME/.cache/go-build/00/abc"
 
 HOME="$TMP_HOME" bash "$HOOK"
 
-# Assert: 두 디렉토리 비었음
-[ -z "$(ls -A "$TMP_HOME/go/pkg/mod" 2>/dev/null)" ] || { echo "FAIL: go/pkg/mod not cleaned"; exit 1; }
-[ -z "$(ls -A "$TMP_HOME/.cache/go-build" 2>/dev/null)" ] || { echo "FAIL: .cache/go-build not cleaned"; exit 1; }
+# Assert: 기존 cache 보존 (rm -rf 안 함)
+[ -f "$TMP_HOME/go/pkg/mod/golang.org/x/sys@v0.20.0/sys.go" ] || { echo "FAIL: GOMODCACHE 데이터 삭제됨 (image-resident 의도 위배)"; exit 1; }
+[ -f "$TMP_HOME/.cache/go-build/00/abc" ] || { echo "FAIL: GOCACHE 데이터 삭제됨"; exit 1; }
 
-# Assert: 빈 디렉토리 재생성됨 (setup-go가 기대)
-[ -d "$TMP_HOME/go/pkg/mod" ] || { echo "FAIL: go/pkg/mod not recreated"; exit 1; }
-[ -d "$TMP_HOME/.cache/go-build" ] || { echo "FAIL: .cache/go-build not recreated"; exit 1; }
+# Case 2: cache 디렉토리 부재 — idempotent mkdir로 재생성.
+TMP_HOME2="$(mktemp -d)"
+HOME="$TMP_HOME2" bash "$HOOK"
+[ -d "$TMP_HOME2/go/pkg/mod" ] || { echo "FAIL: GOMODCACHE dir 미생성"; exit 1; }
+[ -d "$TMP_HOME2/.cache/go-build" ] || { echo "FAIL: GOCACHE dir 미생성"; exit 1; }
+rm -rf "$TMP_HOME2"
 
-echo "PASS: job-started.sh cleanup correct"
+echo "PASS: job-started.sh preserves image-resident cache + idempotent mkdir"


### PR DESCRIPTION
## Summary

Phase 23 follow-up (P0-4). 옛 PR-168 H-2 카논 reverse.

- 매 self-hosted run의 ~913MB GOMODCACHE/GOCACHE GHA 다운로드를 0으로
- image의 Go toolcache pre-bake (현재 1.25.0) 무효화 차단
- cleanup hook이 image pre-bake 데이터 삭제하던 충돌 해소

## Background

- 사용자 host runner의 docker.sock permission denied 디버깅 중 발견
- self-hosted runner가 매 fire 마다 setup-go가 GHA cache(913MB)를 download — image pre-bake의 의미 상실
- `infra/runners/hooks/job-started.sh`이 매 job 직전 `~/go/pkg/mod` 를 `rm -rf` → image pre-bake 자체가 지워짐
- workflow의 \`go-version: \"1.24\"\` drift도 발견 (e2e-stubbed.yml — 본 PR에서 동기화)

## Changes

### Dockerfile (image-resident toolchain)
- final stage에 `ARG GO_VERSION` / `ARG NODE_VERSION` 재선언 (multi-stage scope)
- `ENV PATH` / `GOPATH` / `GOMODCACHE` / `GOCACHE` / `PNPM_STORE_PATH` / `GOTOOLCHAIN=local` pre-set
- `apps/server/go.mod` + `go.sum` copy + `go mod download` pre-bake (image layer)
- `chown` 으로 runner user 권한 정리

### docker-compose.yml
- 새 named volume 3건 추가 (4 runner 공유):
  - `go-mod-cache` → `/home/runner/go/pkg/mod`
  - `go-build-cache` → `/home/runner/.cache/go-build`
  - `pnpm-store` → `/home/runner/.pnpm-store`

### hooks/job-started.sh + .test.sh
- `rm -rf ~/go/pkg/mod ~/.cache/go-build` 라인 제거 — setup-go `cache: false` 와 결합해 tar 충돌 미발생
- idempotent `mkdir -p` 만 유지 (setup-go가 parent dir 존재 가정)
- test: 기존 cache 데이터 보존 검증 + 부재 시 mkdir 검증으로 재작성

### Workflows (self-hosted only)
- `ci.yml` — 2 setup-go `cache: false` + `go-version-file: apps/server/go.mod`, setup-node `cache: 'pnpm'` 제거
- `e2e-stubbed.yml` — setup-go `cache: false` + `go-version-file` (drift \`\"1.24\"\` 동시 fix)
- `build-runner-image.yml`:
  - paths filter에 `apps/server/go.mod` / `apps/server/go.sum` 추가 (deps 변경 시 image rebuild)
  - `workflow_dispatch` trigger 추가
  - verify step을 image-resident marker 검증으로 재작성 (PATH go/node + GOMODCACHE pre-bake + hook 이 데이터 보존하는지)

### README.md
- Cache Volumes 섹션 카논 reverse 명시 (PR-168 H-2 → image-resident)
- image rebuild 후 사용자 host 의 `docker volume rm` 운영 절차 추가
- 디스크 사용량 재산정 (~700MB → ~4.5GB, trade-off 기록)

## Out of scope (별 PR)

Cloud workflow 3건의 \`go-version: \"1.24\"\` drift는 본 PR scope 외 (image-resident와 무관):
- `flaky-report.yml`
- `module-isolation.yml`
- `phase-18.1-real-backend.yml`

## Trade-off

| 항목 | 옛 (PR-168 H-2) | 새 (image-resident) |
|---|---|---|
| 매 run GOMODCACHE 다운로드 | ~913MB (~13초) | **0** |
| Go toolchain mismatch fallback | 매 fire 다운로드 + named volume 비대 | image PATH 즉시 hit |
| 디스크 사용량 | ~700MB | ~1.7~4.5GB (4 runner 공유) |
| go.sum 변경 후 운영 | GHA cache 자동 갱신 | host 재배포 시 `docker volume rm` 필요 |

## Test plan

- [x] Dockerfile syntax — `docker buildx build --check` clean (no warnings)
- [x] hook unit test — `bash infra/runners/hooks/job-started.test.sh` PASS
- [ ] Build CI fire (이 PR push 시) — image-resident verify step 통과
- [ ] PR 머지 후 사용자 host 재배포 + 첫 self-hosted CI run에서 setup-go 1초 이내 + GHA cache 다운로드 0 확인

## 적용 흐름 (사용자 host, 머지 후)

\`\`\`bash
ssh sabyun@100.90.38.7
cd ~/infra/runners
# docker-compose.yml 새 버전 가져오기 (host가 git clone 아니면 SCP 또는 curl)
docker compose down
docker volume rm \$(docker volume ls -q | grep -E "go-mod-cache|go-build-cache|hostedtool-cache|pnpm-store") 2>/dev/null || true
docker compose pull
docker compose up -d
docker exec containerized-runner-1 ls /home/runner/go/pkg/mod/cache  # image pre-bake 데이터 확인
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)