### PR TITLE
chore(ci): pruning P0+P1+P2 — paths filter + security-deep PR fire 제거 + firefox PR-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,29 @@
 name: CI
 
+# paths filter (Phase 23 follow-up — CI pruning P0):
+# docs(wrap)/메모리/plan 변경 commit 시 fire 0. apps/server, packages, tooling, lockfile,
+# 본 workflow 자체 변경에만 fire.
 on:
   push:
     branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'turbo.json'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'turbo.json'
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -14,10 +14,31 @@ name: E2E — Stubbed Backend
 # this PR merges.
 
 on:
+  # paths filter (Phase 23 follow-up — CI pruning P0): docs/메모리 commit 시 fire 0.
   push:
     branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'turbo.json'
+      - 'playwright.config.ts'
+      - 'e2e/**'
+      - '.github/workflows/e2e-stubbed.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'turbo.json'
+      - 'playwright.config.ts'
+      - 'e2e/**'
+      - '.github/workflows/e2e-stubbed.yml'
   # Phase 18.8 PR-5: 수동 트리거 추가. PR에서 stubbed CI를 재실행하거나
   # 베타 단계에서 임시 시나리오 재현이 필요할 때 사용.
   workflow_dispatch:
@@ -34,10 +55,13 @@ jobs:
     # 악성 binary 를 심어 4 runner 횡전파하는 cache poisoning 차단.
     # fork PR 은 cache mount runner 를 우회 (skip). main / same-repo PR 만 실행.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Phase 23 follow-up — CI pruning P2: PR fire 시 chromium 만 (2 job).
+    # push main / workflow_dispatch 시 chromium + firefox (4 job).
+    # firefox-only 회귀는 main 머지 후 push fire 또는 dispatch 로 검증.
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox]
+        browser: ${{ fromJSON(github.event_name == 'pull_request' && '["chromium"]' || '["chromium","firefox"]') }}
         shard: [1, 2]
 
     env:

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -1,12 +1,14 @@
 name: Security — Deep Scan (SARIF)
 
 on:
-  pull_request:
-    branches: [main]
+  # Phase 23 follow-up — CI pruning P1: PR fire 제거 (Trivy + CodeQL = 매 PR 5~10분 부담).
+  # main 머지 후 push fire + daily 04:00 cron 으로 검증. 즉시 차단은 govulncheck (security-fast.yml) 매 PR 유지.
+  # dispatch 추가: 머지 전 직접 검증 필요 시 수동 fire.
   push:
     branches: [main]
   schedule:
     - cron: "0 4 * * *"    # 04:00 UTC daily
+  workflow_dispatch:
 
 concurrency:
   group: security-deep-${{ github.ref }}


### PR DESCRIPTION
## Summary

매 PR 시 다중 workflow 동시 fire 부담 정리. 3 변경 묶음.

## P0 — paths filter (ci.yml + e2e-stubbed.yml)

**문제**: docs(wrap)/메모리/plan/handoff commit 에도 `ci.yml` 4 job + `e2e-stubbed.yml` 4 job 모두 매번 fire.

**변경**: 두 workflow 의 trigger 에 paths filter 추가:
- `apps/**`, `packages/**`, `tooling/**`
- `package.json`, `pnpm-lock.yaml`, `turbo.json`
- e2e-stubbed: `playwright.config.ts`, `e2e/**`
- 본 workflow 자체

**효과**: docs/메모리 PR fire **0건**.

## P1 — security-deep.yml PR fire 제거

**문제**: Trivy + CodeQL = 매 PR **5~10분** 부담 (self-hosted runner 자원 1/3 점유).

**변경**: \`pull_request\` trigger 제거. 유지:
- `push main` (머지 후 검증)
- `schedule: daily 04:00 UTC`
- `workflow_dispatch` (수동 검증)

**즉시 차단 보장**: govulncheck (security-fast.yml) 매 PR fire 유지 → Go CVE 즉시 검출.

## P2 — e2e-stubbed.yml firefox shard PR-only skip

**문제**: chromium + firefox × 2 shard = **매 PR 4 job**. firefox-only 회귀는 드물어 PR마다 부담 과함.

**변경**: dynamic matrix
\`\`\`yaml
matrix:
  browser: \${{ fromJSON(github.event_name == 'pull_request' && '[\"chromium\"]' || '[\"chromium\",\"firefox\"]') }}
  shard: [1, 2]
\`\`\`
- PR fire 시 chromium 만 (**2 job**)
- push main / workflow_dispatch 시 chromium + firefox (**4 job**)

**효과**: PR e2e 시간 **~50% 단축**.

## 효과 합계 (PR 1건당)

| 항목 | 옛 | 새 |
|---|---|---|
| docs PR 시 fire 수 | ci 4 + e2e 4 + sec-fast 1 + sec-deep 3 = **12 job** | 0 (paths filter) |
| code PR 시 fire 수 | 12 | ci 4 + e2e 2 + sec-fast 1 = **7 job** |
| code PR 총 시간 | ~25~35분 | ~10~15분 |

## 잠재 영향 — Branch protection

paths filter 미매치 시 ci.yml / e2e-stubbed.yml 가 "skipped" 표시. **admin-skip 정책 2026-05-01 만료 전엔 무관** (admin override 로 머지). 만료 후 docs PR 머지 차단 가능 → 그 시점에 follow-up (P3):

- 옵션 A: doppelgänger workflow (paths-ignore + 동일 job name 으로 항상 success 반환)
- 옵션 B: step-level \`dorny/paths-filter\` 로 job 항상 fire + skip step

## Test plan

- [x] yaml syntax (\`yaml.safe_load\` 3 file OK)
- [x] dynamic matrix expression GitHub Actions 카논 검증 (fromJSON + ternary)
- [ ] PR 머지 후 docs commit 으로 fire 0 확인
- [ ] code commit 으로 chromium 만 fire 확인 (firefox shard 자동 skip)
- [ ] main push fire 시 firefox shard 도 fire 확인
- [ ] 다음 nightly (04:00 UTC) security-deep schedule 정상 fire 확인

## Out of scope (별 PR follow-up)

- P3: branch protection 설정 (admin-skip 만료 대비) doppelgänger or step-level skip
- 1.24 → 1.25 drift fix (cloud workflow 3건: flaky-report, module-isolation, phase-18.1-real-backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)