### PR TITLE
feat(arc): runner image source KT registry → ghcr.io

### DIFF
--- a/infra/k8s/arc/README.md
+++ b/infra/k8s/arc/README.md
@@ -9,7 +9,7 @@ GitHub Actions Self-hosted Runner를 KT Cloud Managed KS(`github-actions-runner`
 
 - 클러스터: `github-actions-runner` (1.33.7, containerd 2.2.2, Calico, Private 티어)
 - ARC chart: `gha-runner-scale-set-controller@0.14.1` + `gha-runner-scale-set@0.14.1`
-- Runner 이미지: `registry.cloud.kt.com/dldxu5p5/mmp-runner:latest` (Phase 23 GHCR 미러)
+- Runner 이미지: `ghcr.io/sabyunrepo/mmp-runner:latest` (build-runner-image.yml 자동 build/push, Phase 24 actions-runner 베이스). KT registry mirror (`registry.cloud.kt.com/dldxu5p5/mmp-runner:latest`) 는 fallback 으로 imagePullSecrets 에 함께 유지.
 - Container mode: **DinD sidecar** (`containerMode.type: dind`) — 노드가 containerd 전용이라 `/var/run/docker.sock` 없음
 - Runner pool: `arc-runner-set` namespace=`arc-runners`, min 0 / max 5
 - GitHub config: `https://github.com/sabyunrepo/muder_platform`
@@ -35,9 +35,10 @@ helm upgrade --install arc-runner-set \
 ## 사전 조건
 
 - `arc-systems` ns에 controller 설치 (`helm install arc oci://.../gha-runner-scale-set-controller`)
-- `arc-runners` ns에 두 secret:
-  - `github-pat-secret` — `github_token=<PAT>` (scope: `repo`, `workflow`)
-  - `kt-registry-secret` — KT Cloud Container Registry docker creds
+- `arc-runners` ns에 secret:
+  - `github-pat-secret` — `github_token=<PAT>` (scope: `repo`, `workflow`) — ARC controller registration
+  - `ghcr-secret` — `docker-registry` 타입, GitHub PAT(`read:packages` scope) — runner image pull
+  - `kt-registry-secret` — KT Cloud Container Registry docker creds (fallback 미러)
 - 노드 outbound: `0.0.0.0/0:443` 허용 (ghcr.io, api.github.com, broker.actions.githubusercontent.com)
 
 ## 사용

--- a/infra/k8s/arc/values-runner-set.yaml
+++ b/infra/k8s/arc/values-runner-set.yaml
@@ -15,11 +15,13 @@ containerMode:
 
 template:
   spec:
+    # Phase 24 follow-up: ghcr.io 로 이전. KT registry 는 fallback 으로 secret 유지.
     imagePullSecrets:
+      - name: ghcr-secret
       - name: kt-registry-secret
     containers:
       - name: runner
-        image: registry.cloud.kt.com/dldxu5p5/mmp-runner:latest
+        image: ghcr.io/sabyunrepo/mmp-runner:latest
         command: ["/home/runner/run.sh"]
         resources:
           requests:


### PR DESCRIPTION
## Summary
- ARC runner 이미지 source 를 KT Cloud Container Registry → **ghcr.io** 로 이전
- `build-runner-image.yml` 워크플로가 main push 시 자동 build + push to ghcr (chicken-egg 회피로 ubuntu-latest 유지)
- KT registry 는 imagePullSecrets 의 fallback 으로 유지

## Pre-merge 작업 (사용자 GitHub UI 완료)
- [x] `ghcr.io/sabyunrepo/mmp-runner` package → **Manage Actions access** 에 `muder_platform` repo Write 추가
- [x] Classic PAT (`read:packages` only) 발급
- [x] K8s secret `ghcr-secret` 생성 (arc-runners ns)

## 검증
- `gh run list build-runner-image.yml main` → 25142503393 rerun ✅ success (180s, ghcr push 정상)
- `docker manifest inspect ghcr.io/sabyunrepo/mmp-runner:latest` → digest `27f83bf7` (Phase 24 actions-runner base, externals/ + run.sh 모두 존재)
- `helm upgrade arc-runner-set` REVISION 3 적용 → 새 pod (vw642-*) image=ghcr, 3/4 Running

## 운영 변화
- Dockerfile 변경 → main push → CI 자동 build + ghcr push (수동 절차 0)
- 다음 ARC pod 자동 새 image pull (`imagePullPolicy: Always`)
- KT registry mirror 는 backup. 다음 세션에서 정리 검토

## Test plan
- [x] PR 머지 후 main 자동 트리거 워크플로 ARC 에서 동작 확인
- [ ] (별도 세션) `kt-registry-secret` 제거 검토 (ghcr 단일 source 안정 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)