### PR TITLE
refactor(editor): extract useDebouncedMutation hook + file-size CI guard

### DIFF
--- a/.github/workflows/file-size-guard.yml
+++ b/.github/workflows/file-size-guard.yml
@@ -47,7 +47,9 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          changed=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" || true)
+          # --diff-filter=AMR: include Added, Modified, AND Renamed-and-modified
+          # (CR-1) so a large rename does not bypass the size guard.
+          changed=$(git diff --name-only --diff-filter=AMR "$BASE_SHA" "$HEAD_SHA" || true)
           if [ -z "$changed" ]; then
             echo "No changed files in diff."
             exit 0

--- a/.github/workflows/file-size-guard.yml
+++ b/.github/workflows/file-size-guard.yml
@@ -1,0 +1,106 @@
+name: File Size Guard
+
+# Phase 21 E-6 — 파일 크기 누적 가드.
+#
+# 카논: memory/feedback_file_size_limit.md 의 유형별 티어 한도를 PR diff에서 검사.
+# warn-only — 실제 차단은 하지 않고 GitHub Actions ::warning:: 메시지로 PR check에
+# 표시한다. 누적 +수줄 패턴(예: ClueForm 474→481→490 ...)을 사람이 보고 판단할 수
+# 있도록 가시화하는 게 목적.
+#
+# 한도:
+#   .go            500
+#   .ts / .tsx     400
+#   .md            500
+#   CLAUDE.md      200 (자동 로딩 토큰 비용)
+#
+# 예외: sqlc/mockgen 자동 생성물, packages/*/dist/**, 테스트 fixture.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: file-size-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: File size warn (warn-only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Inspect changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" || true)
+          if [ -z "$changed" ]; then
+            echo "No changed files in diff."
+            exit 0
+          fi
+
+          over=0
+          summary="| 파일 | LOC | 한도 | 유형 |"$'\n'"|------|-----|------|------|"
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            [ -f "$f" ] || continue
+            # Skip auto-generated and vendored.
+            case "$f" in
+              *.sql.go|*_mock.go|*/mocks/*) continue ;;
+              packages/*/dist/*|**/dist/**) continue ;;
+              **/__fixtures__/**|**/fixtures/**) continue ;;
+            esac
+            limit=0
+            kind=""
+            case "$f" in
+              CLAUDE.md|*/CLAUDE.md)
+                limit=200; kind="CLAUDE.md" ;;
+              *.md)
+                limit=500; kind="md" ;;
+              *.go)
+                limit=500; kind="go" ;;
+              *.ts|*.tsx)
+                limit=400; kind="ts/tsx" ;;
+              *)
+                continue ;;
+            esac
+            lines=$(wc -l < "$f" | tr -d ' ')
+            if [ "$lines" -gt "$limit" ]; then
+              echo "::warning file=$f::file-size $lines > $limit ($kind, canon: memory/feedback_file_size_limit.md)"
+              summary="$summary"$'\n'"| \`$f\` | $lines | $limit | $kind |"
+              over=$((over + 1))
+            fi
+          done <<EOF
+          $changed
+          EOF
+
+          {
+            echo "## File Size Guard"
+            echo ""
+            if [ "$over" -eq 0 ]; then
+              echo "All changed files within tier limits ✓"
+            else
+              echo "**$over file(s) over the tier limit** — warn-only, no merge block."
+              echo ""
+              echo "$summary"
+              echo ""
+              echo "Canon: \`memory/feedback_file_size_limit.md\`. Split pattern: \`index + refs/<topic>.md\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # warn-only — never fail.
+          exit 0

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { User } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
@@ -9,6 +9,7 @@ import {
   useEditorClues,
   useUpdateConfigJson,
 } from '@/features/editor/api';
+import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
 import type { Mission } from './MissionEditor';
 import { CharacterDetailPanel } from './CharacterDetailPanel';
 
@@ -28,6 +29,8 @@ interface CharacterAssignPanelProps {
   theme: EditorThemeResponse;
 }
 
+type ConfigPatch = Record<string, unknown>;
+
 // ---------------------------------------------------------------------------
 // CharacterAssignPanel
 // ---------------------------------------------------------------------------
@@ -38,9 +41,6 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
   const updateConfig = useUpdateConfigJson(themeId);
   const queryClient = useQueryClient();
   const [selectedCharId, setSelectedCharId] = useState<string | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingRef = useRef<Record<string, unknown> | null>(null);
-  const rollbackRef = useRef<EditorThemeResponse | undefined>(undefined);
 
   const characterClues = useMemo((): Record<string, string[]> => {
     const cc = (theme.config_json ?? {}).character_clues;
@@ -54,78 +54,43 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
       ? (cm as Record<string, Mission[]>) : {};
   }, [theme.config_json]);
 
-  /**
-   * Fire the pending save immediately (cancels debounce). Used by:
-   *   - `useEffect` cleanup on unmount
-   *   - `selectedCharId` change (switching characters should persist edits)
-   *   - explicit blur handler from {@link CharacterDetailPanel}
-   */
-  const flush = useCallback(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
-    }
-    if (!pendingRef.current) return;
-    const payload = pendingRef.current;
-    pendingRef.current = null;
-    updateConfig.mutate(payload, {
-      onSuccess: () => toast.success('저장되었습니다'),
-      onError: () => {
-        // Rollback optimistic update on failure.
-        if (rollbackRef.current) {
-          queryClient.setQueryData(editorKeys.theme(themeId), rollbackRef.current);
-        }
-        toast.error('저장에 실패했습니다');
-      },
-    });
-  }, [queryClient, themeId, updateConfig]);
-
-  useEffect(() => {
-    return () => {
-      // Flush any pending edit so navigation away from the tab persists data.
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = null;
-      }
-      if (pendingRef.current) {
-        updateConfig.mutate(pendingRef.current);
-        pendingRef.current = null;
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const saveConfig = useCallback(
-    (updates: Record<string, unknown>) => {
-      // --- Optimistic update: apply to query cache immediately so the UI
-      // reflects the change within the same tick. Rollback on error.
+  const debouncer = useDebouncedMutation<ConfigPatch>({
+    debounceMs: SAVE_DEBOUNCE_MS,
+    mutate: (body, opts) =>
+      updateConfig.mutate(body, {
+        onSuccess: () => toast.success('저장되었습니다'),
+        onError: opts.onError,
+      }),
+    applyOptimistic: (body) => {
+      // Capture the previous theme snapshot inside the closure so concurrent
+      // flushes each rollback to their own pre-state instead of sharing a ref.
       const cacheKey = editorKeys.theme(themeId);
       const previous = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
-      if (previous) {
-        rollbackRef.current = previous;
-        queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
-          ...previous,
-          config_json: { ...(previous.config_json ?? {}), ...updates },
-        });
-      }
-
-      // --- Debounced network write (1500ms, flush-on-blur).
-      // Merge basis priority (H-W2-1): accumulated pending > optimistic cache >
-      // theme.config_json fallback. Prevents loss of earlier edits made within
-      // the same debounce window on different keys.
-      const basis =
-        pendingRef.current ??
-        queryClient.getQueryData<EditorThemeResponse>(cacheKey)?.config_json ??
-        theme.config_json ??
-        {};
-      pendingRef.current = { ...basis, ...updates };
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        debounceRef.current = null;
-        flush();
-      }, SAVE_DEBOUNCE_MS);
+      if (!previous) return null;
+      queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
+        ...previous,
+        config_json: { ...(previous.config_json ?? {}), ...body },
+      });
+      return () => queryClient.setQueryData(cacheKey, previous);
     },
-    [flush, queryClient, theme.config_json, themeId],
+    onError: () => toast.error('저장에 실패했습니다'),
+  });
+  const flush = debouncer.flush;
+
+  const saveConfig = useCallback(
+    (updates: ConfigPatch) => {
+      // Merge basis priority (H-W2-1): pending body > optimistic cache >
+      // theme.config_json. Prevents loss of earlier edits made within the
+      // same debounce window on different keys.
+      debouncer.schedule(updates, (prev) => {
+        const cached = queryClient.getQueryData<EditorThemeResponse>(
+          editorKeys.theme(themeId),
+        )?.config_json;
+        const basis = prev ?? cached ?? theme.config_json ?? {};
+        return { ...basis, ...updates };
+      });
+    },
+    [debouncer, queryClient, theme.config_json, themeId],
   );
 
   const handleSelectChar = useCallback(

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -79,13 +79,26 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
 
   const saveConfig = useCallback(
     (updates: ConfigPatch) => {
+      // Schedule-time UI mirror — character assignments need to flip
+      // synchronously (toggle/checkbox UX). The hook's `applyOptimistic`
+      // runs at flush time only (perf-H2 — avoids N cache writes per
+      // keystroke burst), so we mirror here for *immediate* visual feedback.
+      // The flush-time apply still captures rollback for the network failure
+      // path; both layers are intentional.
+      const cacheKey = editorKeys.theme(themeId);
+      const previous = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
+      if (previous) {
+        queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
+          ...previous,
+          config_json: { ...(previous.config_json ?? {}), ...updates },
+        });
+      }
+
       // Merge basis priority (H-W2-1): pending body > optimistic cache >
       // theme.config_json. Prevents loss of earlier edits made within the
       // same debounce window on different keys.
       debouncer.schedule(updates, (prev) => {
-        const cached = queryClient.getQueryData<EditorThemeResponse>(
-          editorKeys.theme(themeId),
-        )?.config_json;
+        const cached = queryClient.getQueryData<EditorThemeResponse>(cacheKey)?.config_json;
         const basis = prev ?? cached ?? theme.config_json ?? {};
         return { ...basis, ...updates };
       });

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { User } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
@@ -54,23 +54,36 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
       ? (cm as Record<string, Mission[]>) : {};
   }, [theme.config_json]);
 
+  // Pre-edit snapshot captured at the FIRST schedule of a debounce window —
+  // distinct from the schedule-time UI mirror that follows. This is the
+  // correct rollback target on mutation failure (round-2 N-1 / CodeRabbit).
+  // Cleared after the mutation settles (success or rollback) so the next
+  // edit window starts fresh.
+  const pendingSnapshotRef = useRef<EditorThemeResponse | undefined>(undefined);
+
   const debouncer = useDebouncedMutation<ConfigPatch>({
     debounceMs: SAVE_DEBOUNCE_MS,
     mutate: (body, opts) =>
       updateConfig.mutate(body, {
-        onSuccess: () => toast.success('저장되었습니다'),
-        onError: opts.onError,
+        onSuccess: () => {
+          toast.success('저장되었습니다');
+          pendingSnapshotRef.current = undefined;
+        },
+        onError: (err) => {
+          // The hook's onError chain runs first (rollback → toast.error),
+          // then we clear so a follow-up edit captures a fresh snapshot.
+          opts.onError(err);
+          pendingSnapshotRef.current = undefined;
+        },
       }),
-    applyOptimistic: (body) => {
-      // Capture the previous theme snapshot inside the closure so concurrent
-      // flushes each rollback to their own pre-state instead of sharing a ref.
-      const cacheKey = editorKeys.theme(themeId);
-      const previous = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
+    applyOptimistic: () => {
+      // Build the rollback closure from the pre-edit snapshot captured in
+      // saveConfig — NOT from the current cache (which already has the
+      // schedule-time mirror applied). On failure, restore truly to the
+      // pre-edit state.
+      const previous = pendingSnapshotRef.current;
       if (!previous) return null;
-      queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
-        ...previous,
-        config_json: { ...(previous.config_json ?? {}), ...body },
-      });
+      const cacheKey = editorKeys.theme(themeId);
       return () => queryClient.setQueryData(cacheKey, previous);
     },
     onError: () => toast.error('저장에 실패했습니다'),
@@ -79,18 +92,24 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
 
   const saveConfig = useCallback(
     (updates: ConfigPatch) => {
-      // Schedule-time UI mirror — character assignments need to flip
-      // synchronously (toggle/checkbox UX). The hook's `applyOptimistic`
-      // runs at flush time only (perf-H2 — avoids N cache writes per
-      // keystroke burst), so we mirror here for *immediate* visual feedback.
-      // The flush-time apply still captures rollback for the network failure
-      // path; both layers are intentional.
       const cacheKey = editorKeys.theme(themeId);
-      const previous = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
-      if (previous) {
+
+      // Capture the *true* pre-edit snapshot once per debounce window. This
+      // is the rollback target on mutation failure — distinct from the
+      // schedule-time UI mirror below.
+      if (!pendingSnapshotRef.current) {
+        pendingSnapshotRef.current = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
+      }
+
+      // Schedule-time UI mirror — character toggles need sync feedback so
+      // users see the flip immediately, not after the debounce window. The
+      // hook's `applyOptimistic` runs at flush time and captures the rollback
+      // closure pointing at `pendingSnapshotRef.current`.
+      const cacheNow = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
+      if (cacheNow) {
         queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
-          ...previous,
-          config_json: { ...(previous.config_json ?? {}), ...updates },
+          ...cacheNow,
+          config_json: { ...(cacheNow.config_json ?? {}), ...updates },
         });
       }
 

--- a/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
@@ -1,7 +1,9 @@
-import { useRef, useEffect } from "react";
 import type { Node } from "@xyflow/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { useUpdateFlowNode } from "../../flowApi";
-import type { FlowNodeData } from "../../flowTypes";
+import { flowKeys, type FlowGraphResponse, type FlowNodeData } from "../../flowTypes";
+import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -13,6 +15,9 @@ interface EndingNodePanelProps {
   onUpdate: (id: string, data: Partial<FlowNodeData>) => void;
 }
 
+/** Debounce window for ending-node saves. Preserves prior 500ms behavior. */
+const SAVE_DEBOUNCE_MS = 500;
+
 // ---------------------------------------------------------------------------
 // EndingNodePanel — 엔딩 노드 편집 패널
 // ---------------------------------------------------------------------------
@@ -23,24 +28,35 @@ export function EndingNodePanel({
   onUpdate,
 }: EndingNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queryClient = useQueryClient();
   const data = node.data as FlowNodeData;
 
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
+  const debouncer = useDebouncedMutation<FlowNodeData>({
+    debounceMs: SAVE_DEBOUNCE_MS,
+    mutate: (body, opts) =>
+      updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
+    applyOptimistic: (body) => {
+      const cacheKey = flowKeys.graph(themeId);
+      const previous = queryClient.getQueryData<FlowGraphResponse>(cacheKey);
+      if (!previous) return null;
+      queryClient.setQueryData<FlowGraphResponse>(cacheKey, {
+        ...previous,
+        nodes: previous.nodes.map((n) =>
+          n.id === node.id ? { ...n, data: { ...n.data, ...body } } : n,
+        ),
+      });
+      return () => queryClient.setQueryData(cacheKey, previous);
+    },
+    onError: () => toast.error("저장에 실패했습니다"),
+  });
+  const flush = debouncer.flush;
 
   const handleChange = (patch: Partial<FlowNodeData>) => {
     onUpdate(node.id, patch);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      updateNode.mutate({
-        nodeId: node.id,
-        body: { data: { ...data, ...patch } },
-      });
-    }, 500);
+    debouncer.schedule(
+      { ...data, ...patch },
+      (prev) => ({ ...data, ...(prev ?? {}), ...patch }),
+    );
   };
 
   return (
@@ -56,6 +72,7 @@ export function EndingNodePanel({
           type="text"
           value={data.label ?? ""}
           onChange={(e) => handleChange({ label: e.target.value })}
+          onBlur={flush}
           placeholder="엔딩 이름"
           className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
@@ -67,6 +84,7 @@ export function EndingNodePanel({
         <textarea
           value={data.description ?? ""}
           onChange={(e) => handleChange({ description: e.target.value })}
+          onBlur={flush}
           placeholder="엔딩 설명"
           rows={3}
           className="resize-none rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
@@ -88,6 +106,7 @@ export function EndingNodePanel({
                 : undefined,
             })
           }
+          onBlur={flush}
           placeholder="1.0"
           className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -1,4 +1,3 @@
-import { useRef, useEffect, useCallback } from "react";
 import type { Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -9,6 +8,7 @@ import type {
   PhaseAction,
 } from "../../flowTypes";
 import { flowKeys } from "../../flowTypes";
+import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
 import { ActionListEditor } from "./ActionListEditor";
 
 // ---------------------------------------------------------------------------
@@ -39,78 +39,34 @@ const SAVE_DEBOUNCE_MS = 1500;
 export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingRef = useRef<FlowNodeData | null>(null);
   const data = node.data as FlowNodeData;
 
-  /** Send the pending network write immediately and cancel the debounce timer. */
-  const flush = useCallback(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
-    }
-    if (!pendingRef.current) return;
-    const body = pendingRef.current;
-    pendingRef.current = null;
-
-    // Optimistic update: patch the node inside the flow-graph cache so other
-    // subscribers (canvas) see the latest data without waiting for the PATCH
-    // response. Capture the previous graph snapshot in closure for rollback on
-    // error — mutation-scoped so concurrent flushes don't overwrite each
-    // other's rollback targets.
-    const cacheKey = flowKeys.graph(themeId);
-    const previous = queryClient.getQueryData<FlowGraphResponse>(cacheKey);
-    if (previous) {
+  const debouncer = useDebouncedMutation<FlowNodeData>({
+    debounceMs: SAVE_DEBOUNCE_MS,
+    mutate: (body, opts) =>
+      updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
+    applyOptimistic: (body) => {
+      const cacheKey = flowKeys.graph(themeId);
+      const previous = queryClient.getQueryData<FlowGraphResponse>(cacheKey);
+      if (!previous) return null;
       queryClient.setQueryData<FlowGraphResponse>(cacheKey, {
         ...previous,
         nodes: previous.nodes.map((n) =>
           n.id === node.id ? { ...n, data: { ...n.data, ...body } } : n,
         ),
       });
-    }
-
-    updateNode.mutate(
-      { nodeId: node.id, body: { data: body } },
-      {
-        onError: () => {
-          if (previous) {
-            queryClient.setQueryData(cacheKey, previous);
-          }
-          // On unmount, the toast surface may be torn down; sonner tolerates
-          // a post-unmount call (silent no-op if host is gone).
-          toast.error("저장에 실패했습니다");
-        },
-      },
-    );
-  }, [node.id, queryClient, themeId, updateNode]);
-
-  // Keep the latest flush reference so the unmount cleanup routes through the
-  // same optimistic + rollback path instead of a raw mutate call (M1).
-  const flushRef = useRef(flush);
-  useEffect(() => {
-    flushRef.current = flush;
-  }, [flush]);
-
-  useEffect(() => {
-    return () => {
-      // Fire any pending save on unmount so the user doesn't lose edits when
-      // they switch nodes or close the panel within the debounce window.
-      // Delegates to flush() so optimistic cache write + rollback closure stay
-      // consistent with the blur/debounce paths.
-      flushRef.current();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+      return () => queryClient.setQueryData(cacheKey, previous);
+    },
+    onError: () => toast.error("저장에 실패했습니다"),
+  });
+  const flush = debouncer.flush;
 
   const handleChange = (patch: Partial<FlowNodeData>) => {
     onUpdate(node.id, patch);
-    const merged = { ...data, ...(pendingRef.current ?? {}), ...patch };
-    pendingRef.current = merged;
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      debounceRef.current = null;
-      flush();
-    }, SAVE_DEBOUNCE_MS);
+    debouncer.schedule(
+      { ...data, ...patch },
+      (prev) => ({ ...data, ...(prev ?? {}), ...patch }),
+    );
   };
 
   return (

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -182,6 +182,40 @@ describe('CharacterAssignPanel', () => {
     expect(() => opts.onError?.(new Error('boom'))).not.toThrow();
   });
 
+  it('rollback이 진짜 pre-edit snapshot으로 복원한다 (round-2 N-1 / CR)', async () => {
+    // round-2: schedule-time mirror로 즉시 cache가 변경된 후, mutation 실패
+    // 시 rollback이 그 mirror된 상태가 아니라 *진짜 pre-edit* snapshot으로
+    // 되돌아가야 한다. pendingSnapshotRef가 첫 schedule 시점에 캡처한
+    // baseTheme로 cache가 복원되는지 검증.
+    const { qc } = renderPanel();
+    fireEvent.click(screen.getByText('홍길동'));
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    // schedule-time mirror 즉시 적용된 상태 확인.
+    const mirrored = qc.getQueryData<typeof baseTheme>(['editor', 'themes', 'theme-1']);
+    expect(
+      (mirrored?.config_json?.character_clues as Record<string, string[]>)?.['char-1'],
+    ).toContain('clue-1');
+
+    await act(async () => { vi.advanceTimersByTime(1500); });
+    const [, opts] = mutateMock.mock.calls[0] as [
+      unknown,
+      { onError?: (e: Error) => void },
+    ];
+
+    // Trigger the failure path.
+    act(() => {
+      opts.onError?.(new Error('boom'));
+    });
+
+    // Cache is restored to the original baseTheme snapshot — character_clues
+    // was undefined originally, so the toggled key is gone.
+    const restored = qc.getQueryData<typeof baseTheme>(['editor', 'themes', 'theme-1']);
+    expect(restored?.config_json?.character_clues).toBeUndefined();
+  });
+
   it('미션 추가 버튼이 동작한다 (1500ms debounce)', async () => {
     renderPanel();
     fireEvent.click(screen.getByText('홍길동'));

--- a/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
@@ -138,7 +138,10 @@ describe("EndingNodePanel debounce + onBlur flush", () => {
     expect(mutateMock).toHaveBeenCalledTimes(1);
   });
 
-  it("optimistic update: graph cache가 즉시 갱신된다", () => {
+  it("optimistic update: flush 시점에 graph cache가 갱신된다", async () => {
+    // Phase 21 round-2 (perf-H2): applyOptimistic은 schedule이 아닌 flush
+    // 시점에만 호출되어 빠른 타이핑 시 canvas re-render 폭증을 회피한다.
+    // schedule 직후에는 cache 그대로, debounce window가 지나면 갱신.
     const { qc } = renderWithClient(
       <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
     );
@@ -147,10 +150,20 @@ describe("EndingNodePanel debounce + onBlur flush", () => {
     const labelInput = screen.getByPlaceholderText("엔딩 이름");
     fireEvent.change(labelInput, { target: { value: "엔딩 B" } });
 
-    const cached = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
-    const node = cached?.nodes.find((n) => n.id === "ending-1");
-    expect((node?.data as { label?: string }).label).toBe("엔딩 B");
+    // Schedule 직후 — cache 변경 없음 (perf-H2 fix).
+    const beforeFlush = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
+    const beforeNode = beforeFlush?.nodes.find((n) => n.id === "ending-1");
+    expect((beforeNode?.data as { label?: string }).label).toBe("엔딩 A");
     expect(mutateMock).not.toHaveBeenCalled();
+
+    // Debounce window 종료 → flush → applyOptimistic + mutate.
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    const afterFlush = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
+    const afterNode = afterFlush?.nodes.find((n) => n.id === "ending-1");
+    expect((afterNode?.data as { label?: string }).label).toBe("엔딩 B");
+    expect(mutateMock).toHaveBeenCalledTimes(1);
   });
 
   it("mutate 실패 시 graph cache가 rollback되고 toast.error가 발화한다", async () => {

--- a/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * EndingNodePanel — Phase 21 E-1 동등화 회귀 테스트.
+ *
+ * Phase 18.5 종료 시점에는 EndingNodePanel이 debounce(500ms) + unmount cleanup만
+ * 가지고 있었고 optimistic / rollback / onBlur flush가 누락된 미완성 상태였다.
+ * useDebouncedMutation 훅 도입으로 PhaseNodePanel 수준의 보호가 자동 적용되었으므로,
+ * 본 spec은 동등화된 동작을 회귀 가드로 잠근다:
+ *
+ *   1. debounce 500ms (window 보존)
+ *   2. 연속 change는 한 번만 저장 (debounce 재시작)
+ *   3. onBlur → 즉시 flush (timer 대기 없음)
+ *   4. optimistic graph cache 갱신
+ *   5. mutate onError → rollback + toast.error
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const { mutateMock, useUpdateFlowNodeMock, toastError } = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  useUpdateFlowNodeMock: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: toastError },
+}));
+
+vi.mock("../../../flowApi", () => ({
+  useUpdateFlowNode: () => useUpdateFlowNodeMock(),
+}));
+
+import { EndingNodePanel } from "../EndingNodePanel";
+import { flowKeys, type FlowGraphResponse } from "../../../flowTypes";
+
+function renderWithClient(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    qc,
+    ...render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>),
+  };
+}
+
+const makeGraph = (nodeId = "ending-1", data: Record<string, unknown> = {}): FlowGraphResponse => ({
+  nodes: [
+    {
+      id: nodeId,
+      theme_id: "t1",
+      type: "ending",
+      position_x: 0,
+      position_y: 0,
+      data: { label: "엔딩 A", ...data },
+      created_at: "2026-04-30T00:00:00Z",
+      updated_at: "2026-04-30T00:00:00Z",
+    },
+  ],
+  edges: [],
+});
+
+const makeNode = (data: Record<string, unknown> = {}) => ({
+  id: "ending-1",
+  type: "ending" as const,
+  position: { x: 0, y: 0 },
+  data: { label: "엔딩 A", ...data },
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useUpdateFlowNodeMock.mockReturnValue({ mutate: mutateMock });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("EndingNodePanel debounce + onBlur flush", () => {
+  it("debounce 500ms 후에 mutate가 1회 호출된다", async () => {
+    renderWithClient(
+      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+    );
+
+    const labelInput = screen.getByPlaceholderText("엔딩 이름");
+    fireEvent.change(labelInput, { target: { value: "정의 승리" } });
+
+    // 499ms — must NOT fire yet.
+    await act(async () => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(mutateMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    const [arg] = mutateMock.mock.calls[0] as [
+      { nodeId: string; body: { data: { label: string } } },
+    ];
+    expect(arg.nodeId).toBe("ending-1");
+    expect(arg.body.data.label).toBe("정의 승리");
+  });
+
+  it("연속 change는 한 번만 저장된다 (debounce 재시작)", async () => {
+    renderWithClient(
+      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+    );
+
+    const labelInput = screen.getByPlaceholderText("엔딩 이름");
+    fireEvent.change(labelInput, { target: { value: "A" } });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    fireEvent.change(labelInput, { target: { value: "AB" } });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(mutateMock).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("onBlur 발생 시 timer 대기 없이 즉시 저장된다", () => {
+    renderWithClient(
+      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+    );
+
+    const labelInput = screen.getByPlaceholderText("엔딩 이름");
+    fireEvent.change(labelInput, { target: { value: "즉시" } });
+    expect(mutateMock).not.toHaveBeenCalled();
+
+    fireEvent.blur(labelInput);
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("optimistic update: graph cache가 즉시 갱신된다", () => {
+    const { qc } = renderWithClient(
+      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+    );
+    qc.setQueryData(flowKeys.graph("t1"), makeGraph());
+
+    const labelInput = screen.getByPlaceholderText("엔딩 이름");
+    fireEvent.change(labelInput, { target: { value: "엔딩 B" } });
+
+    const cached = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
+    const node = cached?.nodes.find((n) => n.id === "ending-1");
+    expect((node?.data as { label?: string }).label).toBe("엔딩 B");
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("mutate 실패 시 graph cache가 rollback되고 toast.error가 발화한다", async () => {
+    const { qc } = renderWithClient(
+      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+    );
+    const original = makeGraph("ending-1", { label: "원본" });
+    qc.setQueryData(flowKeys.graph("t1"), original);
+
+    const labelInput = screen.getByPlaceholderText("엔딩 이름");
+    fireEvent.change(labelInput, { target: { value: "변경" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    const [, opts] = mutateMock.mock.calls[0] as [
+      unknown,
+      { onError?: (e: Error) => void },
+    ];
+    expect(typeof opts?.onError).toBe("function");
+
+    act(() => {
+      opts.onError?.(new Error("boom"));
+    });
+    const cached = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
+    const node = cached?.nodes.find((n) => n.id === "ending-1");
+    expect((node?.data as { label?: string }).label).toBe("원본");
+    expect(toastError).toHaveBeenCalledWith("저장에 실패했습니다");
+  });
+});

--- a/apps/web/src/hooks/__tests__/useDebouncedMutation.test.ts
+++ b/apps/web/src/hooks/__tests__/useDebouncedMutation.test.ts
@@ -1,0 +1,307 @@
+/**
+ * useDebouncedMutation — Phase 21 E-1
+ *
+ * Editor 패널에서 debounced auto-save 패턴(`useRef + setTimeout`) 보일러플레이트가
+ * 3개 컴포넌트에 복제되어 있던 것을 단일 훅으로 통합. 테스트는 다음을 검증:
+ *
+ *  1. schedule → debounce 후 mutate 호출 (timer)
+ *  2. 다중 schedule → 마지막만 발화 (timer reset)
+ *  3. flush() → 즉시 발화, timer 취소, pending 비움
+ *  4. cancel() → 발화 X, pending 비움
+ *  5. merge(prev) → 누적 동작 (key merge — 동일 debounce 윈도우 내 다른 키 보존)
+ *  6. applyOptimistic returning rollback → 성공 시 rollback 호출 X
+ *  7. applyOptimistic + mutate onError → rollback 호출 + options.onError 호출
+ *  8. unmount → pending body flush (PhaseNodePanel cleanup 패턴)
+ *  9. unmount with no pending → mutate 호출 X (no-op)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+
+interface TestBody {
+  label?: string;
+  count?: number;
+}
+
+describe("useDebouncedMutation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("schedules a mutation and fires after debounceMs", () => {
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "hello" });
+    });
+    expect(mutate).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(mutate).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith({ label: "hello" }, expect.any(Object));
+  });
+
+  it("resets the timer when schedule is called repeatedly", () => {
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "first" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    act(() => {
+      result.current.schedule({ label: "second" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mutate).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith({ label: "second" }, expect.any(Object));
+  });
+
+  it("flush() fires immediately and cancels the timer", () => {
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "now" });
+    });
+    act(() => {
+      result.current.flush();
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith({ label: "now" }, expect.any(Object));
+
+    // No further fire from the canceled timer.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush() with no pending body is a no-op", () => {
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    act(() => {
+      result.current.flush();
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("cancel() discards the pending body without firing", () => {
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "discard me" });
+    });
+    act(() => {
+      result.current.cancel();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(mutate).not.toHaveBeenCalled();
+
+    // flush() after cancel is also a no-op (pending was cleared).
+    act(() => {
+      result.current.flush();
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("accumulates body via merge(prev) callback", () => {
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    // First schedule → no prev (null).
+    act(() => {
+      result.current.schedule({ label: "a" }, (prev) => ({
+        ...(prev ?? {}),
+        label: "a",
+      }));
+    });
+    // Second schedule within window → prev = { label: "a" }.
+    act(() => {
+      result.current.schedule({ count: 5 }, (prev) => ({
+        ...(prev ?? {}),
+        count: 5,
+      }));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith(
+      { label: "a", count: 5 },
+      expect.any(Object),
+    );
+  });
+
+  it("calls applyOptimistic at schedule time (not at flush)", () => {
+    const rollback = vi.fn();
+    const applyOptimistic = vi.fn(() => rollback);
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 500, applyOptimistic }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "x" });
+    });
+    // Optimistic side-effect fires synchronously so the UI reflects the change.
+    expect(applyOptimistic).toHaveBeenCalledTimes(1);
+    expect(applyOptimistic).toHaveBeenCalledWith({ label: "x" });
+    // Mutation is still pending — only the timer is queued.
+    expect(mutate).not.toHaveBeenCalled();
+
+    // Success path: no onError invocation → rollback not called.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(rollback).not.toHaveBeenCalled();
+  });
+
+  it("re-captures rollback on each schedule (last-write-wins)", () => {
+    const rollback1 = vi.fn();
+    const rollback2 = vi.fn();
+    const applyOptimistic = vi
+      .fn<(body: TestBody) => () => void>()
+      .mockImplementationOnce(() => rollback1)
+      .mockImplementationOnce(() => rollback2);
+    const mutate = vi.fn((_body: TestBody, opts: { onError: (e?: unknown) => void }) => {
+      opts.onError(new Error("boom"));
+    });
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 500, applyOptimistic }),
+    );
+
+    // First schedule captures rollback1.
+    act(() => {
+      result.current.schedule({ label: "a" });
+    });
+    // Second schedule captures rollback2, replacing rollback1 (last-write-wins).
+    act(() => {
+      result.current.schedule({ label: "b" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    // Only the most recent rollback is invoked when the mutation fails.
+    expect(rollback1).not.toHaveBeenCalled();
+    expect(rollback2).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes rollback and onError when mutate fires onError", () => {
+    const rollback = vi.fn();
+    const applyOptimistic = vi.fn(() => rollback);
+    const onError = vi.fn();
+    // Simulated mutation: fire onError synchronously.
+    const mutate = vi.fn((_body: TestBody, opts: { onError: (err?: unknown) => void }) => {
+      opts.onError(new Error("boom"));
+    });
+
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({
+        mutate,
+        debounceMs: 500,
+        applyOptimistic,
+        onError,
+      }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "fail" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("flushes pending body on unmount", () => {
+    const mutate = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "pending" });
+    });
+    expect(mutate).not.toHaveBeenCalled();
+
+    unmount();
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith(
+      { label: "pending" },
+      expect.any(Object),
+    );
+  });
+
+  it("unmount with no pending body does not call mutate", () => {
+    const mutate = vi.fn();
+    const { unmount } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    unmount();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("isPending reflects the queued state", () => {
+    const mutate = vi.fn();
+    const { result, rerender } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    expect(result.current.isPending).toBe(false);
+
+    act(() => {
+      result.current.schedule({ label: "x" });
+    });
+    rerender();
+    expect(result.current.isPending).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    rerender();
+    expect(result.current.isPending).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useDebouncedMutation.test.ts
+++ b/apps/web/src/hooks/__tests__/useDebouncedMutation.test.ts
@@ -2,18 +2,28 @@
  * useDebouncedMutation — Phase 21 E-1
  *
  * Editor 패널에서 debounced auto-save 패턴(`useRef + setTimeout`) 보일러플레이트가
- * 3개 컴포넌트에 복제되어 있던 것을 단일 훅으로 통합. 테스트는 다음을 검증:
+ * 3개 컴포넌트에 복제되어 있던 것을 단일 훅으로 통합. round-2 (Phase 21)에서
+ * applyOptimistic을 schedule 시점이 아닌 flush 시점에 호출하도록 변경 (perf-H2).
  *
- *  1. schedule → debounce 후 mutate 호출 (timer)
- *  2. 다중 schedule → 마지막만 발화 (timer reset)
- *  3. flush() → 즉시 발화, timer 취소, pending 비움
- *  4. cancel() → 발화 X, pending 비움
- *  5. merge(prev) → 누적 동작 (key merge — 동일 debounce 윈도우 내 다른 키 보존)
- *  6. applyOptimistic returning rollback → 성공 시 rollback 호출 X
- *  7. applyOptimistic + mutate onError → rollback 호출 + options.onError 호출
- *  8. unmount → pending body flush (PhaseNodePanel cleanup 패턴)
- *  9. unmount with no pending → mutate 호출 X (no-op)
+ * 검증 대상:
+ *   1. schedule → debounce 후 mutate 호출
+ *   2. 다중 schedule → 마지막만 발화 (timer reset)
+ *   3. flush() → 즉시 발화, timer 취소, pending 비움
+ *   4. flush() with no pending → no-op
+ *   5. cancel() → 발화 X, pending 비움, applyOptimistic도 호출 X (의도된 설계)
+ *   6. merge(prev) → 누적 동작 (key merge — 같은 debounce 윈도우 내 다른 키 보존)
+ *   7. applyOptimistic은 flush 시점에 호출 (schedule 시점 X) — 빠른 타이핑 시
+ *      cache subscriber re-render 폭증 회피
+ *   8. applyOptimistic + mutate onError → rollback + options.onError
+ *   9. unmount → pending body 자동 flush (PhaseNodePanel cleanup 패턴)
+ *  10. unmount with no pending → mutate 호출 X
+ *  11. StrictMode 더블 mount/unmount → flush idempotent (pending null guard)
+ *  12. cancel() after schedule with applyOptimistic → rollback 호출 X
+ *      (cancel은 "버린다" — 외부 책임, JSDoc 계약 잠금)
+ *  13. applyOptimistic이 throw → schedule 정상 / flush에서 throw 전파, hook 상태
+ *      consistent (timer cleared, pending null)
  */
+import { StrictMode } from "react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
@@ -97,7 +107,6 @@ describe("useDebouncedMutation", () => {
     expect(mutate).toHaveBeenCalledTimes(1);
     expect(mutate).toHaveBeenCalledWith({ label: "now" }, expect.any(Object));
 
-    // No further fire from the canceled timer.
     act(() => {
       vi.advanceTimersByTime(2000);
     });
@@ -133,7 +142,6 @@ describe("useDebouncedMutation", () => {
     });
     expect(mutate).not.toHaveBeenCalled();
 
-    // flush() after cancel is also a no-op (pending was cleared).
     act(() => {
       result.current.flush();
     });
@@ -146,14 +154,12 @@ describe("useDebouncedMutation", () => {
       useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
     );
 
-    // First schedule → no prev (null).
     act(() => {
       result.current.schedule({ label: "a" }, (prev) => ({
         ...(prev ?? {}),
         label: "a",
       }));
     });
-    // Second schedule within window → prev = { label: "a" }.
     act(() => {
       result.current.schedule({ count: 5 }, (prev) => ({
         ...(prev ?? {}),
@@ -171,7 +177,7 @@ describe("useDebouncedMutation", () => {
     );
   });
 
-  it("calls applyOptimistic at schedule time (not at flush)", () => {
+  it("calls applyOptimistic at flush time (not at schedule)", () => {
     const rollback = vi.fn();
     const applyOptimistic = vi.fn(() => rollback);
     const mutate = vi.fn();
@@ -179,58 +185,54 @@ describe("useDebouncedMutation", () => {
       useDebouncedMutation<TestBody>({ mutate, debounceMs: 500, applyOptimistic }),
     );
 
+    // Schedule should NOT trigger optimistic side-effect — that's the perf-H2
+    // fix point. Fast keystroke bursts must not write the cache N times.
     act(() => {
       result.current.schedule({ label: "x" });
     });
-    // Optimistic side-effect fires synchronously so the UI reflects the change.
-    expect(applyOptimistic).toHaveBeenCalledTimes(1);
-    expect(applyOptimistic).toHaveBeenCalledWith({ label: "x" });
-    // Mutation is still pending — only the timer is queued.
+    expect(applyOptimistic).not.toHaveBeenCalled();
     expect(mutate).not.toHaveBeenCalled();
 
-    // Success path: no onError invocation → rollback not called.
+    // Timer fires → flushMutation → applyOptimistic invoked once with the
+    // queued body, then mutate.
     act(() => {
       vi.advanceTimersByTime(500);
     });
+    expect(applyOptimistic).toHaveBeenCalledTimes(1);
+    expect(applyOptimistic).toHaveBeenCalledWith({ label: "x" });
     expect(mutate).toHaveBeenCalledTimes(1);
     expect(rollback).not.toHaveBeenCalled();
   });
 
-  it("re-captures rollback on each schedule (last-write-wins)", () => {
-    const rollback1 = vi.fn();
-    const rollback2 = vi.fn();
-    const applyOptimistic = vi
-      .fn<(body: TestBody) => () => void>()
-      .mockImplementationOnce(() => rollback1)
-      .mockImplementationOnce(() => rollback2);
-    const mutate = vi.fn((_body: TestBody, opts: { onError: (e?: unknown) => void }) => {
-      opts.onError(new Error("boom"));
-    });
+  it("multiple schedule + flush only invokes applyOptimistic once (debounce)", () => {
+    const applyOptimistic = vi.fn(() => vi.fn());
+    const mutate = vi.fn();
     const { result } = renderHook(() =>
       useDebouncedMutation<TestBody>({ mutate, debounceMs: 500, applyOptimistic }),
     );
 
-    // First schedule captures rollback1.
+    // 5 rapid schedules within the window simulate fast typing.
     act(() => {
-      result.current.schedule({ label: "a" });
+      for (let i = 0; i < 5; i++) {
+        result.current.schedule({ label: `step-${i}` });
+      }
     });
-    // Second schedule captures rollback2, replacing rollback1 (last-write-wins).
-    act(() => {
-      result.current.schedule({ label: "b" });
-    });
+    // No optimistic side-effect yet — schedule is pure queueing.
+    expect(applyOptimistic).not.toHaveBeenCalled();
+
     act(() => {
       vi.advanceTimersByTime(500);
     });
-    // Only the most recent rollback is invoked when the mutation fails.
-    expect(rollback1).not.toHaveBeenCalled();
-    expect(rollback2).toHaveBeenCalledTimes(1);
+    // Exactly one optimistic apply with the latest body.
+    expect(applyOptimistic).toHaveBeenCalledTimes(1);
+    expect(applyOptimistic).toHaveBeenCalledWith({ label: "step-4" });
+    expect(mutate).toHaveBeenCalledTimes(1);
   });
 
   it("invokes rollback and onError when mutate fires onError", () => {
     const rollback = vi.fn();
     const applyOptimistic = vi.fn(() => rollback);
     const onError = vi.fn();
-    // Simulated mutation: fire onError synchronously.
     const mutate = vi.fn((_body: TestBody, opts: { onError: (err?: unknown) => void }) => {
       opts.onError(new Error("boom"));
     });
@@ -284,24 +286,78 @@ describe("useDebouncedMutation", () => {
     expect(mutate).not.toHaveBeenCalled();
   });
 
-  it("isPending reflects the queued state", () => {
+  it("StrictMode double-mount cleanup is idempotent", () => {
+    // React StrictMode (dev) intentionally mounts → unmounts → re-mounts so
+    // effects must be safe to run twice. The hook's unmount cleanup calls
+    // flushRef.current(); the pending-null guard inside flushMutation makes
+    // a second cleanup a no-op.
     const mutate = vi.fn();
-    const { result, rerender } = renderHook(() =>
-      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    const { result, unmount } = renderHook(
+      () => useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+      { wrapper: StrictMode },
     );
 
-    expect(result.current.isPending).toBe(false);
+    act(() => {
+      result.current.schedule({ label: "strict" });
+    });
+    unmount();
+    // First cleanup flushed; second cleanup (StrictMode synthetic) is a no-op
+    // because pendingRef is already null.
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() after schedule does NOT invoke applyOptimistic or rollback", () => {
+    // Contract: `cancel` discards without firing or rollback. Since the
+    // optimistic side-effect now happens at flush time, cancel never reaches
+    // applyOptimistic. The caller is responsible for any UI cleanup.
+    const rollback = vi.fn();
+    const applyOptimistic = vi.fn(() => rollback);
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 500, applyOptimistic }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "cancel-me" });
+    });
+    act(() => {
+      result.current.cancel();
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(applyOptimistic).not.toHaveBeenCalled();
+    expect(rollback).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("applyOptimistic that throws leaves the hook in a consistent state", () => {
+    // Defensive: if a host's setQueryData impl throws (e.g. malformed key),
+    // flush must clear the timer + pending body before propagating so the
+    // hook is not stuck in a half-fired state.
+    const applyOptimistic = vi.fn(() => {
+      throw new Error("optimistic-fail");
+    });
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 500, applyOptimistic }),
+    );
 
     act(() => {
       result.current.schedule({ label: "x" });
     });
-    rerender();
-    expect(result.current.isPending).toBe(true);
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    }).toThrow("optimistic-fail");
 
+    // pendingRef was cleared *before* applyOptimistic call (flushMutation
+    // clears it first), so a follow-up flush is a no-op.
+    expect(mutate).not.toHaveBeenCalled();
     act(() => {
-      vi.advanceTimersByTime(1000);
+      result.current.flush();
     });
-    rerender();
-    expect(result.current.isPending).toBe(false);
+    expect(mutate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/hooks/useDebouncedMutation.ts
+++ b/apps/web/src/hooks/useDebouncedMutation.ts
@@ -1,14 +1,41 @@
 /**
  * useDebouncedMutation — debounced auto-save 훅 (Phase 21 E-1).
  *
- * Editor 패널의 `useRef + setTimeout` debounce 패턴을 단일 훅으로 통합. PhaseNodePanel /
- * CharacterAssignPanel / EndingNodePanel의 보일러플레이트 (debounceRef + pendingRef +
- * flush + onBlur + unmount cleanup)를 캡슐화한다.
+ * Editor 패널의 `useRef + setTimeout` debounce 패턴 (PhaseNodePanel /
+ * CharacterAssignPanel / EndingNodePanel)을 단일 훅으로 통합한다. Timer 관리,
+ * pending body 누적, optimistic rollback closure 캡처, unmount cleanup이
+ * 캡슐화된다.
  *
- * Optimistic side-effect는 `schedule` 시점에 즉시 적용되어 UI가 같은 tick 안에서 반영되고,
- * `applyOptimistic`이 반환한 rollback 함수는 훅 내부에 저장되었다가 mutation의 `onError`에
- * 연결된다. 다중 schedule 호출 시 매번 새 rollback이 캡처되며 (기존 single-ref 패턴과
- * 동일한 의미론) — last-write-wins 의도이므로 동시 편집 race는 호출자가 처리한다.
+ * ## Lifecycle 의미론
+ *
+ * - `schedule(body, merge?)` — pending body를 갱신하고 debounce timer를
+ *   재시작한다. **사이드 이펙트 없음** (UI 즉시 반영을 원하면 호출자가
+ *   별도로 `queryClient.setQueryData` 호출).
+ * - `flush()` — timer 취소 + 즉시 fire. **이때 `applyOptimistic`이 호출되어
+ *   rollback closure를 캡처**하고, 그 직후 `mutate(body, { onError })`로
+ *   넘긴다. mutation이 onError를 발화하면 rollback이 실행되고 호출자의
+ *   `onError`도 함께 발화한다.
+ * - `cancel()` — timer 취소 + pending 폐기. rollback **호출하지 않음**
+ *   (호출자가 의도적으로 버린 상황).
+ * - 컴포넌트 unmount 시 pending body가 있으면 자동 flush.
+ *
+ * ## 호출 제약 (재진입 금지)
+ *
+ * `mutate`/`applyOptimistic`/`onError` 콜백 안에서 `schedule`/`flush`/`cancel`을
+ * 동기 호출하지 마라. flush는 `pendingRef.current`를 null로 비우고 `mutate`을
+ * 호출하므로, 재진입 schedule은 쓰지만 그 결과를 보호하는 rollback closure가
+ * 이미 사용된 상태다. 재진입이 필요하면 `queueMicrotask` 또는
+ * `setTimeout(..., 0)`으로 비동기 dispatch.
+ *
+ * ## Optimistic 시점에 대한 결정 (perf-H2)
+ *
+ * 빠른 타이핑 시 schedule이 N번 → 매 호출마다 setQueryData 발화 시 cache
+ * subscriber (예: FlowCanvas)가 N회 re-render. 이를 회피하기 위해
+ * `applyOptimistic`은 **flush 시점**에만 호출한다 (1 keystroke = 1 setState).
+ *
+ * 호출자가 schedule 시점 즉시 UI 반영을 원하면 `schedule` 호출 직전에 직접
+ * `queryClient.setQueryData`를 한다 (CharacterAssignPanel 패턴 — 토글 즉시
+ * 반응이 사용자 체감 critical).
  *
  * @example
  * const updateNode = useUpdateFlowNode(themeId);
@@ -29,23 +56,25 @@
  *
  * // input change → debouncer.schedule(merged); blur → debouncer.flush();
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 export interface UseDebouncedMutationOptions<TBody> {
   /**
-   * Underlying mutation. Called with the merged body and a `{ onError }` hook
+   * Underlying mutation. Called with the queued body and a `{ onError }` hook
    * the debouncer wires to its own rollback + onError chain. Typical wiring:
    *   mutate: (body, opts) => myMutation.mutate(adaptedRequest(body), opts)
+   *
+   * **재진입 금지**: 이 콜백 안에서 `schedule`/`flush`/`cancel`을 동기 호출
+   * 하지 마라. 필요하면 `queueMicrotask`로 다음 tick에 dispatch.
    */
   mutate: (body: TBody, opts: { onError: (error?: unknown) => void }) => void;
   /** Debounce window in milliseconds. Defaults to 1500 (Phase 18.5 W2 PR-5). */
   debounceMs?: number;
   /**
    * Apply an optimistic side-effect (typically `queryClient.setQueryData`) and
-   * return a rollback closure. Called at `schedule` time so the UI reflects the
-   * change within the same React tick. Returning `null` skips both the
-   * side-effect and rollback. Each schedule re-captures the rollback target
-   * (last-write-wins, mirrors the pre-hook pattern).
+   * return a rollback closure. **Called at flush time** (not schedule time)
+   * to avoid N re-renders during fast typing — see header comment.
+   * Returning `null` skips both the side-effect and rollback.
    */
   applyOptimistic?: (body: TBody) => (() => void) | null;
   /** Fired after rollback when the mutation hits onError. */
@@ -57,19 +86,88 @@ export interface UseDebouncedMutationReturn<TBody> {
    * Queue a body for the next debounced flush. Pass `merge` to accumulate
    * across schedules — `merge(prev)` receives the currently-pending body
    * (or `null` if the queue is empty) and must return the next pending body.
-   * Without `merge`, subsequent calls replace the pending body. The merged
-   * body is passed to `applyOptimistic` immediately.
+   * Without `merge`, subsequent calls replace the pending body. **No
+   * side-effect** — the optimistic apply happens at flush time.
    */
   schedule: (body: TBody, merge?: (prev: TBody | null) => TBody) => void;
   /** Cancel the timer and fire any pending body immediately. */
   flush: () => void;
   /** Cancel the timer and discard the pending body without firing or rollback. */
   cancel: () => void;
-  /** True while a body is queued (debounce timer is active). */
-  isPending: boolean;
 }
 
 const DEFAULT_DEBOUNCE_MS = 1500;
+
+interface OptsRef<TBody> {
+  mutate: UseDebouncedMutationOptions<TBody>["mutate"];
+  applyOptimistic: UseDebouncedMutationOptions<TBody>["applyOptimistic"];
+  onError: UseDebouncedMutationOptions<TBody>["onError"];
+}
+
+interface FlushRefs<TBody> {
+  timerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+  pendingRef: React.MutableRefObject<TBody | null>;
+  optsRef: React.MutableRefObject<OptsRef<TBody>>;
+}
+
+/** Cancel any active timer; idempotent. */
+function clearTimer<TBody>(refs: FlushRefs<TBody>): void {
+  if (refs.timerRef.current) {
+    clearTimeout(refs.timerRef.current);
+    refs.timerRef.current = null;
+  }
+}
+
+/**
+ * Apply optimistic side-effect, capture rollback, and fire the mutation. The
+ * rollback closure is created lazily here (not at schedule time) so a fast
+ * keystroke burst does not write to the query cache N times.
+ */
+function flushMutation<TBody>(refs: FlushRefs<TBody>): void {
+  clearTimer(refs);
+  const body = refs.pendingRef.current;
+  if (body === null) return;
+  refs.pendingRef.current = null;
+
+  const rollback = refs.optsRef.current.applyOptimistic?.(body) ?? null;
+  refs.optsRef.current.mutate(body, {
+    onError: (error) => {
+      rollback?.();
+      refs.optsRef.current.onError?.(error);
+    },
+  });
+}
+
+/** Update pending body (with optional merge accumulator) and (re)arm the timer. */
+function schedulePending<TBody>(
+  refs: FlushRefs<TBody>,
+  debounceMs: number,
+  body: TBody,
+  merge: ((prev: TBody | null) => TBody) | undefined,
+): void {
+  refs.pendingRef.current = merge ? merge(refs.pendingRef.current) : body;
+  clearTimer(refs);
+  refs.timerRef.current = setTimeout(() => {
+    refs.timerRef.current = null;
+    flushMutation(refs);
+  }, debounceMs);
+}
+
+/**
+ * Effect-only helper that flushes pending body on unmount via a `flushRef`
+ * (latest closure) so the cleanup never captures a stale `flush` identity.
+ */
+function useUnmountFlush(flush: () => void): void {
+  const flushRef = useRef(flush);
+  useEffect(() => {
+    flushRef.current = flush;
+  }, [flush]);
+  useEffect(() => {
+    return () => {
+      flushRef.current();
+    };
+  }, []);
+}
 
 export function useDebouncedMutation<TBody>(
   options: UseDebouncedMutationOptions<TBody>,
@@ -78,81 +176,38 @@ export function useDebouncedMutation<TBody>(
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingRef = useRef<TBody | null>(null);
-  const rollbackRef = useRef<(() => void) | null>(null);
-  const [isPending, setIsPending] = useState(false);
 
-  // Latest options snapshot — accessed inside the cleanup closure to avoid
-  // stale captures when the parent re-renders with new mutate/onError refs.
-  const optsRef = useRef({ mutate, applyOptimistic, onError });
-  useEffect(() => {
-    optsRef.current = { mutate, applyOptimistic, onError };
-  }, [mutate, applyOptimistic, onError]);
+  // Latest options snapshot. Synced in render body (not in an effect) so the
+  // ref is up to date even if an immediate schedule fires before the next
+  // commit — also avoids re-running the effect on every parent re-render
+  // when callers pass inline lambdas.
+  const optsRef = useRef<OptsRef<TBody>>({ mutate, applyOptimistic, onError });
+  optsRef.current = { mutate, applyOptimistic, onError };
 
-  const clearTimer = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
+  // useRef return values have stable identity, so memoizing the bag with
+  // empty deps gives us a once-and-done refs object — callbacks below can
+  // depend on `refs` without re-creating their identity per render.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const refs: FlushRefs<TBody> = useMemo(
+    () => ({ timerRef, pendingRef, optsRef }),
+    [],
+  );
 
-  const flush = useCallback(() => {
-    clearTimer();
-    const body = pendingRef.current;
-    if (body === null) return;
-    pendingRef.current = null;
-    setIsPending(false);
-
-    // Capture the rollback at flush-time so onError still has access after
-    // pendingRef is cleared. Reset rollbackRef so a follow-up schedule starts
-    // a fresh optimistic cycle.
-    const rollback = rollbackRef.current;
-    rollbackRef.current = null;
-
-    optsRef.current.mutate(body, {
-      onError: (error) => {
-        rollback?.();
-        optsRef.current.onError?.(error);
-      },
-    });
-  }, [clearTimer]);
+  const flush = useCallback(() => flushMutation(refs), [refs]);
 
   const schedule = useCallback(
     (body: TBody, merge?: (prev: TBody | null) => TBody) => {
-      const merged = merge ? merge(pendingRef.current) : body;
-      pendingRef.current = merged;
-      setIsPending(true);
-      // Apply optimistic at schedule-time so the UI reflects the change in
-      // the same tick. Last-write-wins for the rollback target.
-      rollbackRef.current = optsRef.current.applyOptimistic?.(merged) ?? null;
-      clearTimer();
-      timerRef.current = setTimeout(() => {
-        timerRef.current = null;
-        flush();
-      }, debounceMs);
+      schedulePending(refs, debounceMs, body, merge);
     },
-    [clearTimer, debounceMs, flush],
+    [refs, debounceMs],
   );
 
   const cancel = useCallback(() => {
-    clearTimer();
-    pendingRef.current = null;
-    rollbackRef.current = null;
-    setIsPending(false);
-  }, [clearTimer]);
+    clearTimer(refs);
+    refs.pendingRef.current = null;
+  }, [refs]);
 
-  // Unmount cleanup — fire any pending body so navigation away from the panel
-  // does not silently drop edits made within the debounce window. flushRef
-  // pattern avoids stale closure on unmount when `flush` identity changes.
-  const flushRef = useRef(flush);
-  useEffect(() => {
-    flushRef.current = flush;
-  }, [flush]);
+  useUnmountFlush(flush);
 
-  useEffect(() => {
-    return () => {
-      flushRef.current();
-    };
-  }, []);
-
-  return { schedule, flush, cancel, isPending };
+  return { schedule, flush, cancel };
 }

--- a/apps/web/src/hooks/useDebouncedMutation.ts
+++ b/apps/web/src/hooks/useDebouncedMutation.ts
@@ -181,8 +181,14 @@ export function useDebouncedMutation<TBody>(
   // ref is up to date even if an immediate schedule fires before the next
   // commit — also avoids re-running the effect on every parent re-render
   // when callers pass inline lambdas.
+  // Latest options snapshot, synced via useEffect so we only mutate the ref
+  // post-commit. (Round-2 N-2: writing a ref in the render body is unsafe
+  // under React 19 concurrent rendering — speculative renders can be replayed
+  // and the ref would briefly hold stale-or-future values during that window.)
   const optsRef = useRef<OptsRef<TBody>>({ mutate, applyOptimistic, onError });
-  optsRef.current = { mutate, applyOptimistic, onError };
+  useEffect(() => {
+    optsRef.current = { mutate, applyOptimistic, onError };
+  }, [mutate, applyOptimistic, onError]);
 
   // useRef return values have stable identity, so memoizing the bag with
   // empty deps gives us a once-and-done refs object — callbacks below can

--- a/apps/web/src/hooks/useDebouncedMutation.ts
+++ b/apps/web/src/hooks/useDebouncedMutation.ts
@@ -1,0 +1,158 @@
+/**
+ * useDebouncedMutation — debounced auto-save 훅 (Phase 21 E-1).
+ *
+ * Editor 패널의 `useRef + setTimeout` debounce 패턴을 단일 훅으로 통합. PhaseNodePanel /
+ * CharacterAssignPanel / EndingNodePanel의 보일러플레이트 (debounceRef + pendingRef +
+ * flush + onBlur + unmount cleanup)를 캡슐화한다.
+ *
+ * Optimistic side-effect는 `schedule` 시점에 즉시 적용되어 UI가 같은 tick 안에서 반영되고,
+ * `applyOptimistic`이 반환한 rollback 함수는 훅 내부에 저장되었다가 mutation의 `onError`에
+ * 연결된다. 다중 schedule 호출 시 매번 새 rollback이 캡처되며 (기존 single-ref 패턴과
+ * 동일한 의미론) — last-write-wins 의도이므로 동시 편집 race는 호출자가 처리한다.
+ *
+ * @example
+ * const updateNode = useUpdateFlowNode(themeId);
+ * const queryClient = useQueryClient();
+ * const debouncer = useDebouncedMutation<FlowNodeData>({
+ *   debounceMs: 1500,
+ *   mutate: (body, opts) =>
+ *     updateNode.mutate({ nodeId, body: { data: body } }, opts),
+ *   applyOptimistic: (body) => {
+ *     const key = flowKeys.graph(themeId);
+ *     const prev = queryClient.getQueryData<FlowGraphResponse>(key);
+ *     if (!prev) return null;
+ *     queryClient.setQueryData(key, patchedSnapshot(prev, body));
+ *     return () => queryClient.setQueryData(key, prev);
+ *   },
+ *   onError: () => toast.error('저장에 실패했습니다'),
+ * });
+ *
+ * // input change → debouncer.schedule(merged); blur → debouncer.flush();
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseDebouncedMutationOptions<TBody> {
+  /**
+   * Underlying mutation. Called with the merged body and a `{ onError }` hook
+   * the debouncer wires to its own rollback + onError chain. Typical wiring:
+   *   mutate: (body, opts) => myMutation.mutate(adaptedRequest(body), opts)
+   */
+  mutate: (body: TBody, opts: { onError: (error?: unknown) => void }) => void;
+  /** Debounce window in milliseconds. Defaults to 1500 (Phase 18.5 W2 PR-5). */
+  debounceMs?: number;
+  /**
+   * Apply an optimistic side-effect (typically `queryClient.setQueryData`) and
+   * return a rollback closure. Called at `schedule` time so the UI reflects the
+   * change within the same React tick. Returning `null` skips both the
+   * side-effect and rollback. Each schedule re-captures the rollback target
+   * (last-write-wins, mirrors the pre-hook pattern).
+   */
+  applyOptimistic?: (body: TBody) => (() => void) | null;
+  /** Fired after rollback when the mutation hits onError. */
+  onError?: (error?: unknown) => void;
+}
+
+export interface UseDebouncedMutationReturn<TBody> {
+  /**
+   * Queue a body for the next debounced flush. Pass `merge` to accumulate
+   * across schedules — `merge(prev)` receives the currently-pending body
+   * (or `null` if the queue is empty) and must return the next pending body.
+   * Without `merge`, subsequent calls replace the pending body. The merged
+   * body is passed to `applyOptimistic` immediately.
+   */
+  schedule: (body: TBody, merge?: (prev: TBody | null) => TBody) => void;
+  /** Cancel the timer and fire any pending body immediately. */
+  flush: () => void;
+  /** Cancel the timer and discard the pending body without firing or rollback. */
+  cancel: () => void;
+  /** True while a body is queued (debounce timer is active). */
+  isPending: boolean;
+}
+
+const DEFAULT_DEBOUNCE_MS = 1500;
+
+export function useDebouncedMutation<TBody>(
+  options: UseDebouncedMutationOptions<TBody>,
+): UseDebouncedMutationReturn<TBody> {
+  const { mutate, debounceMs = DEFAULT_DEBOUNCE_MS, applyOptimistic, onError } = options;
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<TBody | null>(null);
+  const rollbackRef = useRef<(() => void) | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  // Latest options snapshot — accessed inside the cleanup closure to avoid
+  // stale captures when the parent re-renders with new mutate/onError refs.
+  const optsRef = useRef({ mutate, applyOptimistic, onError });
+  useEffect(() => {
+    optsRef.current = { mutate, applyOptimistic, onError };
+  }, [mutate, applyOptimistic, onError]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const flush = useCallback(() => {
+    clearTimer();
+    const body = pendingRef.current;
+    if (body === null) return;
+    pendingRef.current = null;
+    setIsPending(false);
+
+    // Capture the rollback at flush-time so onError still has access after
+    // pendingRef is cleared. Reset rollbackRef so a follow-up schedule starts
+    // a fresh optimistic cycle.
+    const rollback = rollbackRef.current;
+    rollbackRef.current = null;
+
+    optsRef.current.mutate(body, {
+      onError: (error) => {
+        rollback?.();
+        optsRef.current.onError?.(error);
+      },
+    });
+  }, [clearTimer]);
+
+  const schedule = useCallback(
+    (body: TBody, merge?: (prev: TBody | null) => TBody) => {
+      const merged = merge ? merge(pendingRef.current) : body;
+      pendingRef.current = merged;
+      setIsPending(true);
+      // Apply optimistic at schedule-time so the UI reflects the change in
+      // the same tick. Last-write-wins for the rollback target.
+      rollbackRef.current = optsRef.current.applyOptimistic?.(merged) ?? null;
+      clearTimer();
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        flush();
+      }, debounceMs);
+    },
+    [clearTimer, debounceMs, flush],
+  );
+
+  const cancel = useCallback(() => {
+    clearTimer();
+    pendingRef.current = null;
+    rollbackRef.current = null;
+    setIsPending(false);
+  }, [clearTimer]);
+
+  // Unmount cleanup — fire any pending body so navigation away from the panel
+  // does not silently drop edits made within the debounce window. flushRef
+  // pattern avoids stale closure on unmount when `flush` identity changes.
+  const flushRef = useRef(flush);
+  useEffect(() => {
+    flushRef.current = flush;
+  }, [flush]);
+
+  useEffect(() => {
+    return () => {
+      flushRef.current();
+    };
+  }, []);
+
+  return { schedule, flush, cancel, isPending };
+}


### PR DESCRIPTION
## Summary

Phase 21 backlog E-1 (debounce 보일러플레이트 통합) + E-6 (파일 크기 누적 가드) 동시 처리.

### E-1 — useDebouncedMutation 훅

- 신규 \`apps/web/src/hooks/useDebouncedMutation.ts\` — debounce timer + pendingRef + optimistic apply + rollback closure + onBlur flush + unmount cleanup 단일 훅 캡슐화. 12 테스트 (TDD).
- 마이그레이션 3 consumer (\`useRef + setTimeout\` 보일러플레이트 → 훅 호출):
  - \`PhaseNodePanel.tsx\` 239 → 195 LOC
  - \`CharacterAssignPanel.tsx\` 251 → 216 LOC
  - \`EndingNodePanel.tsx\` 97 → 116 LOC — debounce 500ms 보존하되 optimistic graph cache + rollback + onBlur flush 추가로 \`PhaseNodePanel\` 수준 동등화. 회귀 spec 5건 신규.
- \`CluePlacementPanel\` / \`ModulesSubTab\`은 즉시 mutate (debounce 미사용) — 마이그레이션 대상 아님.

### E-6 — file-size warn-only CI guard

- 신규 \`.github/workflows/file-size-guard.yml\` — PR diff에서 변경된 파일만 검사, 유형별 한도 (Go 500 / TS·TSX 400 / MD 500 / CLAUDE.md 200) 위반 시 \`::warning::\` + Step Summary 출력. 실제 차단 X. 자동 생성물 (sqlc / mockgen / dist) 예외.

## 핵심 훅 의미론

- \`applyOptimistic\`은 schedule 시점에 호출 (UI 즉시 반영)
- 다중 schedule 시 last-write-wins로 rollback 재캡처 (기존 single-ref 패턴 보존)
- mutation onError 시 rollback 호출 + options.onError 호출
- unmount 시 pending body 자동 flush (flushRef 패턴으로 stale closure 회피)

## Test plan

- [x] \`pnpm vitest run\` → 1074/1074 pass (신규 12 hook + 5 EndingNodePanel 회귀 포함)
- [x] \`pnpm typecheck\` → 0 errors
- [x] \`pnpm lint\` → 0 errors (45 warnings 모두 기존 코드)
- [ ] CI green (full suite)
- [ ] 4-agent 리뷰 (admin-merge 전 카논)

## 후속 (Phase 21 backlog 잔여)

- E-3 Config 409 3-way merge (단독 phase, brainstorm 필요)
- E-5 \`location_clue_assignment_v2\` feature flag (런타임 엔진 게이트)

## 의존

선행 PR #183 (chore/phase-21-backlog-correction) — backlog 정정 (E-2 무효 / E-4 해소). 두 PR 모두 머지되면 \`memory/project_phase21_backlog.md\`가 정확한 상태로 동기화됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 디바운스된 저장을 위한 공통 훅 추가로 일관된 예약·즉시 플러시 동작 제공

* **개선사항**
  * 자동 저장 로직 일원화 및 낙관적 업데이트/실패 시 롤백 처리 통합
  * 입력 필드 블러 시 즉시 저장(플러시) 동작 보장 및 실패 시 사용자 오류 토스트 표시

* **테스트**
  * 훅과 편집 패널에 대한 포괄적 회귀·유닛 테스트 추가

* **잡무**
  * 파일 크기 경고 전용 CI 워크플로우(경고만, 실패로 처리하지 않음) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->