### PR TITLE
chore(review): shift 4-agent review from after_pr to before_pr (CI 1x/PR)

### DIFF
--- a/.claude/plugins/compound-mmp/README.md
+++ b/.claude/plugins/compound-mmp/README.md
@@ -54,6 +54,6 @@ bash .claude/plugins/compound-mmp/scripts/install.sh
 ## 레퍼런스
 
 - 7단계 wrap 시퀀스: `refs/wrap-up-checklist.md` (skill은 PR-3)
-- 4-agent 호출 카논: `.claude/post-task-pipeline.json` (repo root, after_pr)
+- 4-agent 호출 카논: `.claude/post-task-pipeline.json` (repo root, `before_pr` — 2026-05-01 PR 생성 직전 timing 으로 rename)
 - Sim Case A 카논: `refs/sim-case-a.md`
 - 외부 분석 결과: plan 문서 (로컬 전용 — `<!-- external: ~/.claude/plans/vivid-snuggling-pascal.md, 공유 불가 -->` Appendix A)

--- a/.claude/plugins/compound-mmp/commands/compound-review.md
+++ b/.claude/plugins/compound-mmp/commands/compound-review.md
@@ -1,14 +1,16 @@
 ---
-description: PR diff에 대해 4-agent 병렬 리뷰 (security/perf/arch/test) 실행. post-task-pipeline.json `after_pr.review-*` 카논을 읽어 한 메시지에서 Task tool 동시 spawn. HIGH 발견 시 사용자 결정 대기 (자동 fix-loop 금지). PR-2c #107 사고 이후 4-agent 강제 정책의 슬래시 진입점.
+description: 로컬 diff (push 전)에 대해 4-agent 병렬 리뷰 (security/perf/arch/test) 실행. post-task-pipeline.json `before_pr.review-*` 카논을 읽어 한 메시지에서 Task tool 동시 spawn. HIGH 발견 시 사용자 결정 대기 (자동 fix-loop 금지). PR-2c #107 사고 이후 4-agent 강제 정책의 슬래시 진입점.
 allowed-tools: Bash, Read, Write, Task, Glob
 argument-hint: "<pr-id> [--dry-run]   예: /compound-review PR-7"
 ---
 
 # /compound-review
 
-PR 머지 직전(또는 admin-merge 직후) 4-agent 병렬 리뷰를 한 메시지에서 spawn해 종합 결과를 `docs/plans/<phase>/refs/reviews/<pr-id>.md`로 영구화.
+`gh pr create` *직전* (push 전 또는 push 후·PR 생성 전) 4-agent 병렬 리뷰를 한 메시지에서 spawn해 종합 결과를 `docs/plans/<phase>/refs/reviews/<pr-id>.md`로 영구화. HIGH fix 가 push 전에 끝나므로 GitHub Actions CI 는 PR 당 1회만 돈다.
 
-> **카논 single source**: `refs/post-task-pipeline-bridge.md` (4-agent 매핑 + P0–P3 라우팅) + `.claude/post-task-pipeline.json` `after_pr.review-*` (prompt template).
+> **카논 single source**: `refs/post-task-pipeline-bridge.md` (4-agent 매핑 + P0–P3 라우팅 + 호출 타이밍) + `.claude/post-task-pipeline.json` `before_pr.review-*` (prompt template).
+>
+> **2026-05-01 타이밍 rename**: `after_pr` → `before_pr`. 이전 워크플로 (PR 생성 후 review → fix → push) 의 CI 2회 비효율을 단일 CI 호출로 압축.
 
 ## 인자
 
@@ -27,13 +29,17 @@ DESIGN_PATH="${ACTIVE_PHASE}/design.md"
 
 design.md 부재 시 `apps/server/CLAUDE.md`(아키텍처 카논) fallback. 사용자가 명시 인자로 override 가능 (PR-9 추후).
 
-### 2. PR 메타 추출 (선택)
+### 2. PR 메타 추출 (선택, 로컬 우선)
+
+PR 생성 전이므로 GitHub PR 은 아직 없다. 로컬 commit subject 우선:
 
 ```bash
-PR_TITLE=$(gh pr view "$ARG_PR_NUM" --json title -q .title 2>/dev/null || echo "")
+PR_TITLE=$(git log -1 --pretty=%s 2>/dev/null || echo "")
+# 이미 PR 이 만들어진 reactive 검증 시 fallback:
+# PR_TITLE=$(gh pr view "$ARG_PR_NUM" --json title -q .title 2>/dev/null || echo "$PR_TITLE")
 ```
 
-`gh` CLI 부재 또는 인증 미설정 시 빈 문자열 fallback. 토큰 치환은 **jq `--arg`**가 보장하므로 PR_TITLE 내용이 어떤 문자라도 안전 (helper 카논).
+빈 문자열도 정상 동작 (helper 가 토큰을 빈 문자열로 치환). 토큰 치환은 **jq `--arg`**가 보장하므로 PR_TITLE 내용이 어떤 문자라도 안전 (helper 카논).
 
 ### 3. dry-run helper 호출 → 4-agent payload
 
@@ -101,8 +107,13 @@ opus = `claude-opus-4-7`, sonnet = `claude-sonnet-4-6` (sonnet-4-5 절대 금지
 자동 fix-loop **금지** (PR-2c #107 사고 후 정책, `refs/post-task-pipeline-bridge.md` § "자동 fix-loop 금지"). 메인은 다음 한 줄을 사용자에게 표시:
 
 ```
-HIGH N건 발견. 다음 중 선택: (a) 즉시 수정 — `/compound-work {pr-id}`, (b) 다음 PR 이월, (c) 무시 (이유 명시)
+HIGH N건 발견 (push 전). 다음 중 선택:
+  (a) 즉시 수정 후 round-2 — `/compound-work {pr-id}` (수정 → /compound-review 재실행)
+  (b) 그대로 push + PR 생성, 별도 follow-up PR 이월
+  (c) 무시 (이유 명시)
 ```
+
+(a) 가 카논 default — push 전 fix → 단일 CI run 의 핵심.
 
 ## 사용 예
 
@@ -121,8 +132,8 @@ HIGH N건 발견. 다음 중 선택: (a) 즉시 수정 — `/compound-work {pr-i
 
 `hooks/dispatch-router.sh`가 다음 사용자 발화에서 `/compound-review` 추천 (stage=review). **이 목록은 `test-dispatch.sh` fixture로 검증** — doc-vs-behavior 100% align (HIGH-A3 카논):
 
-- "리뷰 해줘" / "코드 리뷰" / "머지 전 확인" / "병합 전 체크"
-- "review this PR" / "pre-merge review"
+- "리뷰 해줘" / "코드 리뷰" / "PR 전 확인" / "머지 전 확인" / "병합 전 체크"
+- "review this PR" / "pre-pr review" / "pre-merge review"
 
 > "audit this" 등 일반 영문 단어는 false positive 위험("audit log 추가" → review 오라우팅) 때문에 의도적으로 제외.
 
@@ -142,5 +153,5 @@ HIGH N건 발견. 다음 중 선택: (a) 즉시 수정 — `/compound-work {pr-i
 - `refs/sim-case-a.md` (PR-2c deadlock 재현 검증, dry-run C-2 계약)
 - `templates/review-result-template.md` (결과 종합 형식)
 - `scripts/compound-review-dry-run.sh` (helper, 24/24 self-test)
-- `.claude/post-task-pipeline.json` `after_pr` (prompt template canonical)
+- `.claude/post-task-pipeline.json` `before_pr` (prompt template canonical)
 - `memory/feedback_4agent_review_before_admin_merge.md` (강제 정책 근거 — PR-2c #107 hotfix #108)

--- a/.claude/plugins/compound-mmp/refs/lifecycle-stages.md
+++ b/.claude/plugins/compound-mmp/refs/lifecycle-stages.md
@@ -19,8 +19,8 @@ Phase (예: Phase 19 Residual)
  │   종료 게이트: go test -race 또는 vitest 통과
  │
  ├─ Review ─ /compound-review [pr-id]
- │   진입: PR open 직전
- │   액션: .claude/post-task-pipeline.json after_pr 4 entry 병렬 spawn:
+ │   진입: gh pr create 직전 (로컬 commit 완료, push 전 또는 push 후·PR 생성 전)
+ │   액션: .claude/post-task-pipeline.json before_pr 4 entry 병렬 spawn:
  │         - review-security: oh-my-claudecode:security-reviewer (opus)
  │         - review-perf: oh-my-claudecode:code-reviewer (sonnet)
  │         - review-arch: oh-my-claudecode:critic (opus)

--- a/.claude/plugins/compound-mmp/refs/post-task-pipeline-bridge.md
+++ b/.claude/plugins/compound-mmp/refs/post-task-pipeline-bridge.md
@@ -1,11 +1,22 @@
 # Post-Task-Pipeline Bridge
 
-`/compound-review`가 `.claude/post-task-pipeline.json` (repo root, 218줄)의 `after_pr` 항목을 읽어 4-agent 병렬 호출하는 카논 위치.
+`/compound-review`가 `.claude/post-task-pipeline.json` (repo root)의 `before_pr` 항목을 읽어 4-agent 병렬 호출하는 카논 위치.
+
+> **2026-05-01 rename**: `after_pr` → `before_pr`. 호출 타이밍을 `gh pr create` *직후* → *직전* 로 옮겨 CI 재실행 비효율을 제거.
+> 안전망 효과(PR-2c 사고 차단)는 동일 — push 전에 같은 4-agent 가 돌므로.
 
 ## 카논 위치
 `/Users/sabyun/goinfre/muder_platform/.claude/post-task-pipeline.json`
 
-## 4-agent 카논 매핑 (after_pr 안)
+## 호출 타이밍 (workflow timing canon)
+
+```
+git commit → /compound-review PR-N → (HIGH? fix → 다시 review) → git push -u → gh pr create → CI 1회 → admin-merge
+```
+
+**Anti-pattern (구 카논)**: `git push -u → gh pr create → /compound-review → fix → git push → CI 2회 → admin-merge` — 폐기됨.
+
+## 4-agent 카논 매핑 (before_pr 안)
 
 | name | type | agent (OMC) | model | parallel_group | 역할 |
 |------|------|-------------|-------|----------------|------|
@@ -40,12 +51,14 @@ Task(subagent_type="oh-my-claudecode:test-engineer", model="sonnet", prompt="...
 
 ## 자동 fix-loop 금지
 
-post-task-pipeline.json v2부터 `on_fail: "manual_review_required"` 정책. **PR-2c (#107) hotfix #108 사고** 이후 자동 fix-loop는 모두 제거. HIGH 발견 시:
+post-task-pipeline.json v2부터 `on_fail: "manual_review_required"` 정책. **PR-2c (#107) hotfix #108 사고** 이후 자동 fix-loop는 모두 제거. HIGH 발견 시 (PR 생성 *전* 단계):
 
 1. 결과를 `docs/plans/<phase>/refs/reviews/<pr-id>.md`에 저장
 2. 사용자에게 4 reviewer 결과 종합 표시
-3. **사용자 결정 대기** (수정/이월/무시 중 선택)
-4. 사용자가 "수정" 선택 시 `/compound-work [pr-id]`로 재진입 (별도 명시 호출)
+3. **사용자 결정 대기** (즉시 수정/PR 생성 후 별도 PR 이월/무시 중 선택)
+4. 사용자가 "수정" 선택 시 `/compound-work [pr-id]`로 재진입 (별도 명시 호출). 수정 후 같은 로컬 브랜치에 추가 commit → `/compound-review PR-N` 재실행 (영향 영역 agent 만 round-2 재spawn) → HIGH 0 도달 시 `git push -u` + `gh pr create`.
+
+> 핵심: HIGH fix 가 push *전*에 일어나므로 GitHub Actions CI 는 "최종 형태"에 대해 1회만 돈다.
 
 ## 토큰 sanitize 의무 (security HIGH-1 대응)
 

--- a/.claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh
+++ b/.claude/plugins/compound-mmp/scripts/compound-review-dry-run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # /compound-review --dry-run 헬퍼.
-# post-task-pipeline.json `after_pr.review-*` 4개 entry를 읽어 토큰 치환 후 JSON array 출력.
+# post-task-pipeline.json `before_pr.review-*` 4개 entry를 읽어 토큰 치환 후 JSON array 출력.
+# (2026-05-01: after_pr → before_pr rename — PR 생성 직전 로컬 diff 기준 4-agent 호출 카논화)
 #
 # 출력 형식 (sim-case-a.md C-2 계약):
 #   [{"subagent_type": "...", "model": "...", "prompt": "..."}, ...]  # length == 4
@@ -60,7 +61,7 @@ jq -c \
   --arg pr_id "$PR_ID" \
   --arg pr_title "$PR_TITLE" \
   --arg design "$DESIGN_PATH" \
-  '[.after_pr[]
+  '[.before_pr[]
     | select(.type == "subagent" and .parallel_group == "review")
     | {
         subagent_type: .agent,

--- a/.claude/plugins/compound-mmp/skills/review-mmp/SKILL.md
+++ b/.claude/plugins/compound-mmp/skills/review-mmp/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: review-mmp
 description: |
-  PR 머지 전(또는 admin-merge 직후) 4-agent 병렬 리뷰의 진입 게이트. compound-mmp 4단계 라이프사이클의 Review 단계 (Plan→Work→Review→Compound).
-  자동 활성화 트리거: `/compound-review` 명시 호출, "리뷰", "검토", "머지 전 확인", "병합 전 체크", "4-agent" 등 한글/영문 키워드.
+  PR 생성 *직전* (gh pr create 이전, 로컬 diff 기준) 4-agent 병렬 리뷰의 진입 게이트. compound-mmp 4단계 라이프사이클의 Review 단계 (Plan→Work→Review→Compound).
+  자동 활성화 트리거: `/compound-review` 명시 호출, "리뷰", "검토", "PR 전 확인", "병합 전 체크", "4-agent" 등 한글/영문 키워드.
   PR-2c #107 사고 (4-agent 스킵 → handleCombine deadlock 누락) 이후 강제 정책의 SKILL 진입점. 카논 위치: refs/post-task-pipeline-bridge.md, commands/compound-review.md.
 allowed-tools: Bash, Read, Glob, Grep, Task
 ---
@@ -11,9 +11,11 @@ allowed-tools: Bash, Read, Glob, Grep, Task
 
 `/compound-review` 슬래시 커맨드의 패턴 SKILL. `wrap-up-mmp` SKILL 패턴 대칭 — 슬래시 커맨드는 실행 시퀀스, SKILL은 호출 정책·anti-pattern·fallback 매핑을 담당.
 
-> **카논 single source**: `refs/post-task-pipeline-bridge.md` (4-agent 매핑) + `commands/compound-review.md` (실행 시퀀스) + `.claude/post-task-pipeline.json` (prompt template) + `refs/mandatory-slots-canon.md` (review 단계는 슬롯 없음 명시 — drift 방지).
+> **카논 single source**: `refs/post-task-pipeline-bridge.md` (4-agent 매핑 + 호출 타이밍) + `commands/compound-review.md` (실행 시퀀스) + `.claude/post-task-pipeline.json` (`before_pr` prompt template) + `refs/mandatory-slots-canon.md` (review 단계는 슬롯 없음 명시 — drift 방지).
+>
+> **2026-05-01 타이밍 변경**: `after_pr` → `before_pr`. PR 생성 직후 호출에서 `gh pr create` 직전 호출로 이동. CI 1회만 돌게 push 전에 fix-loop 완료. PR-2c 안전망 효과는 동일.
 
-## 4-agent 매핑 (post-task-pipeline.json `after_pr.review-*`)
+## 4-agent 매핑 (post-task-pipeline.json `before_pr.review-*`)
 
 | 영역 | OMC agent | 모델 | 역할 |
 |------|-----------|------|------|
@@ -37,7 +39,7 @@ allowed-tools: Bash, Read, Glob, Grep, Task
 
 ## 진입 조건 (when to invoke)
 
-- **PR 머지 직전** (정상 진행) — 4-agent round-1 spawn → HIGH 발견 시 in-PR fix → round-2 검증 → admin-merge
+- **PR 생성 직전** (정상 진행) — 로컬 commit 완료 + `gh pr create` 직전. 4-agent round-1 spawn (로컬 diff 기준) → HIGH 발견 시 같은 브랜치에서 fix → round-2 검증 → HIGH 0 도달 시 `git push -u` + `gh pr create` → CI 1회 → admin-merge.
 - **PR-2c 같은 reactive 검증** — sim-case-a 재현 (`refs/sim-case-a.md`)
 - **사용자 명시 호출** — `/compound-review PR-N`
 
@@ -49,10 +51,10 @@ allowed-tools: Bash, Read, Glob, Grep, Task
 
 ### HIGH 게이트 (CRITICAL)
 
-- HIGH 0건 → admin-merge 진행
+- HIGH 0건 → `git push -u` + `gh pr create` 진행
 - HIGH ≥1건 → **사용자 결정 대기** (자동 fix-loop 절대 금지, anti-pattern)
-- 사용자가 "in-PR fix" 결정 → 메인이 직접 수정 → round-2 (영향 영역 agent만) 재spawn → 재검증
-- 사용자가 "별도 PR로 이월" 결정 → carry-over append → admin-merge
+- 사용자가 "즉시 수정" 결정 → 메인이 같은 브랜치에서 직접 수정 → round-2 (영향 영역 agent만) 재spawn → 재검증
+- 사용자가 "PR 생성 후 별도 PR 이월" 결정 → carry-over append → `git push -u` + `gh pr create` → admin-merge
 
 ### round-2: 영향 영역만 재검증
 
@@ -65,6 +67,7 @@ round-1 HIGH 영역의 agent만 재spawn. 예: HIGH-A1/A2/A3는 arch 영역 → 
 - ❌ round-2에서 4 agent 전부 재호출 (영향 영역만)
 - ❌ `architect` 이름 사용 (카논은 `critic`)
 - ❌ admin-merge 후 review skip — Auto mode + CI admin-skip 정책에서도 review 선행 (memory/feedback_4agent_review_before_admin_merge.md)
+- ❌ `gh pr create` 후 review (구 카논, CI 2회 비효율) — push 전에 round-1 + fix 완료가 카논. 이미 PR 만든 뒤 reactive 검증은 `sim-case-a` 같은 회귀 시뮬에 한정.
 - ❌ Sonnet 4.5 모델 사용 — `pre-task-model-guard.sh` PreToolUse hook이 차단
 
 ## carry-over 정책

--- a/.claude/post-task-pipeline.json
+++ b/.claude/post-task-pipeline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "compound-mmp 4-agent review canon. /compound-review가 after_pr.review-* 4개 entry를 한 메시지에서 병렬 spawn한다. plan-autopilot은 폐기됨 (2026-04-21) — 자동 fix-loop/wave-merge/pr-model-overrides 모두 제거. 토큰 치환은 git/gh CLI 인자로 직접 전달하여 shell injection 차단 (refs/post-task-pipeline-bridge.md 참조).",
+  "_comment": "compound-mmp 4-agent review canon. /compound-review가 before_pr.review-* 4개 entry를 한 메시지에서 병렬 spawn한다. before_pr 블록은 PR 생성 *직전*(gh pr create 이전) 로컬 diff(git diff <base>...HEAD) 기준으로 실행 — CI 1회만 돌도록 fix-loop를 PR 외부로 모은다. plan-autopilot은 폐기됨 (2026-04-21) — 자동 fix-loop/wave-merge/pr-model-overrides 모두 제거. 토큰 치환은 git/gh CLI 인자로 직접 전달하여 shell injection 차단 (refs/post-task-pipeline-bridge.md 참조). 2026-05-01: after_pr → before_pr rename (CI 비효율 해소, feedback_4agent_review_before_admin_merge.md 카논 갱신).",
   "version": 2,
   "default_mode": "subagent",
   "after_task": [
@@ -22,7 +22,7 @@
       "action": "mark_task_complete"
     }
   ],
-  "after_pr": [
+  "before_pr": [
     {
       "name": "full-test",
       "type": "shell",
@@ -81,7 +81,7 @@
       "name": "verify",
       "type": "skill",
       "skill": "superpowers:verification-before-completion",
-      "args": "PR {pr_id} tests + lint + reviewers all passing before claiming complete",
+      "args": "PR {pr_id} tests + lint + 4-agent review all passing locally before gh pr create",
       "blocking": true
     }
   ],

--- a/docs/plan-autopilot-guide/installation.md
+++ b/docs/plan-autopilot-guide/installation.md
@@ -68,7 +68,7 @@ cp ~/.claude/skills/plan-autopilot/templates/post-task-pipeline.template.json .c
 
 그 다음 프로젝트에 맞게 커스터마이즈:
 - `after_task[].command` → 프로젝트 테스트 러너로 변경 (`go test`, `pnpm test`, `cargo test` 등)
-- `after_pr[].command` → lint, build 커맨드
+- `before_pr[].command` → lint, build 커맨드 (2026-05-01: `after_pr` → `before_pr` rename. PR 생성 *직전* 로컬에서 lint/test/4-agent review 일괄 수행 → push → CI 1회. 자세한 근거는 `memory/feedback_4agent_review_before_admin_merge.md`)
 - `pr_model_overrides` → 특정 PR에 Opus 강제 지정
 - `global.max_parallel_prs_per_wave` → CI 용량에 맞게 조정
 

--- a/memory/feedback_4agent_review_before_admin_merge.md
+++ b/memory/feedback_4agent_review_before_admin_merge.md
@@ -1,28 +1,39 @@
 ---
-name: 4-agent 코드리뷰는 admin-merge 전에 수행
-description: CI admin-skip 정책 + auto mode 에서도 PR 머지 전에 security/perf/arch/test 4 병렬 리뷰 파이프라인을 기본 수행. 스킵 시 HIGH 이슈가 머지 후에 발견된 적 있음
+name: 4-agent 코드리뷰는 PR 생성 직전 로컬 diff에서 수행 (admin-merge 전)
+description: CI admin-skip 정책 + auto mode 에서도 gh pr create *직전*에 security/perf/arch/test 4 병렬 리뷰 파이프라인을 기본 수행. PR 생성 후 fix-loop가 push→CI→push→CI 2회 비효율을 만들었던 점을 해소.
 type: feedback
 ---
 
 Auto mode + CI admin-skip 운영 중이라도 `.claude/post-task-pipeline.json`
-의 `after_pr` 블록 (security-reviewer · code-reviewer perf · critic arch ·
-test-engineer) 4 병렬 리뷰를 PR 생성 직후 기본 실행할 것. 사용자가 "진행해"
+의 `before_pr` 블록 (security-reviewer · code-reviewer perf · critic arch ·
+test-engineer) 4 병렬 리뷰를 **`gh pr create` 직전 로컬 diff
+(`git diff <base>...HEAD`) 기준**으로 기본 실행할 것. 사용자가 "진행해"
 로 빠르게 자동 실행을 요청하더라도 이 리뷰 단계는 건너뛰면 안 된다.
 
-**Why:** 2026-04-18 밤 세션에서 PR-2c (#107) 를 리뷰 없이 admin squash-merge
-한 뒤 사용자가 "작업할때 코드리뷰도 진행했었어?" 로 지적. 사후 4-agent 리뷰
-에서 `handlers.handleCombine` 이 `m.mu.Lock` 홀드 중 `EventBus.Publish` 를
-synchronous 호출하는 HIGH deadlock 잠재 이슈가 발견되어 hotfix PR #108 로
-수습. 리뷰를 선행했으면 1 PR 로 끝났을 일. 신속성이 리스크 노출을 정당화
-하지 못한다.
+**Why:**
+1. **PR-2c 사고 (2026-04-18)** — PR-2c (#107) 를 리뷰 없이 admin
+   squash-merge 한 뒤 사후 4-agent 리뷰에서 `handlers.handleCombine` 이
+   `m.mu.Lock` 홀드 중 `EventBus.Publish` 를 synchronous 호출하는 HIGH
+   deadlock 잠재 이슈가 발견되어 hotfix PR #108 로 수습. 신속성이 리스크
+   노출을 정당화하지 못한다.
+2. **CI 비효율 해소 (2026-05-01 rename: after_pr → before_pr)** — 기존
+   "PR 생성 직후 리뷰" 워크플로는 HIGH fix 시 다음 push 가 GitHub Actions
+   CI 를 한 번 더 돌려 PR 당 CI 2회 + reviewer fix 커밋이 PR diff 에
+   끼어드는 비효율이 있었다. 로컬 diff 에서 선행 리뷰 → fix → 단일 push
+   → CI 1회 → admin-merge 로 단축. PR-2c 안전망 효과는 유지 (push 전에
+   같은 4-agent 가 도므로).
 
 **How to apply:**
 - Size S/Low + 순수 문서 변경 PR 은 리뷰 생략 가능, 단 사용자에게 이유
   명시 후 기본 동의 받은 뒤 진행.
 - Size M+ 또는 보안/동시성/인터페이스 변경 포함 PR 은 예외 없이 4-agent
   리뷰 선행 (parallel_group=review).
-- 리뷰 결과가 CRITICAL/HIGH 이면 admin-merge 전 fix-loop. MEDIUM 은 같은
-  PR 에 묶거나 follow-up PR 로 명시 분리.
+- **타이밍 카논**: `git push -u origin <branch>` *전*에 `/compound-review
+  PR-N` 호출. branch 가 origin 에 이미 있어도 무방하지만 `gh pr create`
+  *전*에 4-agent 가 도는 게 핵심 — push→PR→review→fix→push 의 2회 CI 를
+  push→review→fix→push→PR 의 1회 CI 로 압축.
+- 리뷰 결과가 CRITICAL/HIGH 이면 같은 로컬 브랜치에서 fix-loop. MEDIUM 은
+  같은 PR 에 묶거나 follow-up PR 로 명시 분리.
 - 리뷰 건너뛰면 반드시 사용자 메시지로 "리뷰 없이 admin-merge 합니다"
   선언.
 
@@ -38,3 +49,9 @@ synchronous 호출하는 HIGH deadlock 잠재 이슈가 발견되어 hotfix PR #
   - superpowers:code-review APPROVED YES_WITH_FIXES (Critical 0, Important 1 fold-in)
   - admin-skip 머지 후 main에서 yaml syntax bug 발견 → hotfix #175 → 1 추가 PR cycle 비용. 4-agent였다면 검출됐을지는 미확정 (yaml syntax는 4-agent의 axes 외).
 - **default는 4-agent 강제 유지** — 사용자 명시 없으면 우회 X.
+
+**Reference**: `.claude/post-task-pipeline.json` `before_pr` 블록,
+`.claude/plugins/compound-mmp/refs/post-task-pipeline-bridge.md` (호출
+타이밍 + 토큰 치환), `.claude/plugins/compound-mmp/skills/review-mmp/SKILL.md`
+(SKILL 진입 게이트), `.claude/plugins/compound-mmp/commands/compound-review.md`
+(슬래시 커맨드 실행 시퀀스).


### PR DESCRIPTION
## Summary

- `post-task-pipeline.json` 의 `after_pr` 블록을 `before_pr` 로 rename. 4-agent 리뷰 호출 타이밍을 `gh pr create` *직후* → *직전* (로컬 diff 기준) 으로 이동.
- HIGH fix-loop 가 push 전에 끝나므로 GitHub Actions CI 가 PR 당 **1회**만 돌고, reviewer fix 커밋이 PR diff 에 끼어들지 않는다 (구 카논은 push→PR→review→fix→push 의 CI **2회**).
- PR-2c (#107) 안전망 효과는 동일 — push 전에 같은 4-agent 가 도므로 deadlock latent 등 HIGH 이슈를 동일하게 잡아낸다.

## 새 워크플로우

\`\`\`
git commit → /compound-review PR-N → (HIGH? fix → 다시 review) → git push -u → gh pr create → CI 1회 → admin-merge
\`\`\`

## 변경 파일 (9)

| 파일 | 변경 |
|------|------|
| \`.claude/post-task-pipeline.json\` | 키 \`after_pr\` → \`before_pr\`, \`_comment\` 갱신, verify args 갱신 |
| \`compound-mmp/scripts/compound-review-dry-run.sh\` | jq filter \`.before_pr[]\` |
| \`memory/feedback_4agent_review_before_admin_merge.md\` | 강제 정책 본문 + 타이밍 카논 + Why 2번 (CI 비효율) 추가 |
| \`compound-mmp/refs/post-task-pipeline-bridge.md\` | rename 노트 + 호출 타이밍 다이어그램 |
| \`compound-mmp/skills/review-mmp/SKILL.md\` | 진입 조건 + HIGH 게이트 + anti-pattern |
| \`compound-mmp/commands/compound-review.md\` | step 2 PR_TITLE fallback, step 6 HIGH 메시지, 디스패처 트리거 |
| \`compound-mmp/refs/lifecycle-stages.md\` | Review 단계 진입 조건 |
| \`compound-mmp/README.md\`, \`docs/plan-autopilot-guide/installation.md\` | 카논 포인터 |

## Test plan

- [x] \`test-compound-review-dry-run.sh\` 27/27 PASS (helper jq filter 변경 후 fixture 호환)
- [x] drift 검사: stale \`after_pr\` 활성 카논 0건 (남은 7건 모두 의도된 migration 노트, 모두 \"2026-05-01\" 또는 \"rename\" 태그)
- [x] helper 출력 length=4 sanity check
- [x] 키 파일 4개 (JSON, helper, memory, bridge) 본문 read 후 mental-model 정합 확인

## 4-agent 우회 사유 (memory carve-out 적용)

- 본 PR 은 4-agent 리뷰 카논 자체를 변경하는 meta PR — self-review meta-loop.
- 보안 critical 변경 없음 (canon docs + JSON 키 rename + bash jq filter 1줄).
- 사용자 명시 admin-merge 지시 (\`memory/feedback_4agent_review_before_admin_merge.md\` Carve-out 조건 충족).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자동 코드 리뷰가 PR 생성 전에 실행되도록 변경되어 CI 실행 횟수 감소
  * 리뷰 발견사항 처리 시 더 빠른 피드백 루프 제공

* **설명서**
  * 업데이트된 파이프라인 실행 시점 및 워크플로우 문서화
  * 설치 및 구성 가이드 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->