### PR TITLE
chore(memory): close Phase 23 infra follow-ups (superseded by KT Cloud KS ARC)

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -7,7 +7,7 @@
 - [Phase 19 Residual](project_phase19_residual_progress.md) — **진행 중** W0~W3 완료, **W4만 잔존** (PR-9 WS Auth Protocol + PR-10 Runtime Payload Validation, L+L 규모). 다음 작업
 
 ## Backlog
-- [Phase 21 backlog](project_phase21_backlog.md) — Phase 23 follow-ups (P0-1 chicken-egg / P1-4 Composite action / P1-5 govulncheck pin / P1-6 ubuntu SHA pin / P1-7 ARG DOCKER_GID), Phase 19 audit log orphan action 7건. 에디터 리팩터(useDebouncedMutation·@jittda/ui 마이그레이션·Config 409 3-way merge)는 Phase 24 후보로 별도 brainstorm
+- [Phase 21 backlog](project_phase21_backlog.md) — Phase 19 audit log orphan action 7건, 에디터 리팩터 7건(E-3/E-5/E-7/E-8/E-10/E-11/E-12). Phase 23 인프라 follow-ups 5건은 Closed 2026-05-01 (KT Cloud KS arc-runner-set 진화로 superseded)
 
 ## 도메인 카논
 - [소셜 시스템](project_social_system.md) — SocialHub, Redis Presence, WS 핸들러, 차단 필터링

--- a/memory/project_phase21_backlog.md
+++ b/memory/project_phase21_backlog.md
@@ -11,19 +11,14 @@ type: project
 
 ---
 
-## 인프라 follow-ups (Phase 23 이월)
+## 인프라 follow-ups (Phase 23 — Closed 2026-05-01)
 
-| ID | 항목 | 우선순위 | 위치 | 비고 |
-|----|------|----------|------|------|
-| P0-1 | chicken-egg fix `runs-on: ubuntu-latest` | High | `.github/workflows/build-runner-image.yml` | 사용자 host fallback 작동 중. main이 KT Cloud KS arc-runner-set로 진화하면서 자연 해소 가능성 — 재평가 필요 |
-| P1-4 | Composite action 추출 | Med | `.github/actions/start-services/action.yml` (신규) | 9 workflow 중복 제거 |
-| P1-5 | govulncheck version pin | Med | `.github/workflows/build-runner-image.yml` | `@latest` → SHA pin |
-| P1-6 | ubuntu builder SHA pin | Med | `infra/runners/Dockerfile` | builder stage `ubuntu:22.04` SHA pin |
-| P1-7 | ARG DOCKER_GID | Low | `infra/runners/Dockerfile` | hardcoded 990 → ARG |
+**Closed (2026-05-01) — superseded by KT Cloud KS arc-runner-set 진화 (PR #179/#180).**
+사용자 결정: Phase 23 Custom Runner Image 라인 자체를 종료. main이 KT Cloud KS ARC로 진화하면서 `build-runner-image.yml` / `infra/runners/Dockerfile` 자체가 obsolete 경로로 진입. P0-1 chicken-egg / P1-4 Composite action / P1-5 govulncheck pin / P1-6 ubuntu builder SHA pin / P1-7 ARG DOCKER_GID 5건 모두 backlog에서 영구 제거.
 
-P0-2 (GHCR repo connection)은 사용자 manual 1회 작업으로 이미 해소 — backlog 제외.
+P0-2 (GHCR repo connection)은 사용자 manual 1회 작업으로 이미 해소.
 
-근거: `docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md` follow_ups 섹션.
+근거: `docs/plans/2026-04-29-phase-23-custom-runner-image/checklist.md` follow_ups 섹션 + 사용자 결정 2026-05-01 (option a).
 
 ---
 


### PR DESCRIPTION
## Summary

- Phase 23 Custom Runner Image 라인 종료 (사용자 결정 2026-05-01, option a).
- 인프라 follow-ups 5건(P0-1 / P1-4 / P1-5 / P1-6 / P1-7)을 backlog에서 영구 제거.
- 근거: main이 PR #179/#180으로 KT Cloud KS arc-runner-set으로 진화하면서 `build-runner-image.yml` / `infra/runners/Dockerfile` 자체가 obsolete 경로로 진입.

## Changes

- `memory/project_phase21_backlog.md` — 인프라 follow-ups 섹션을 Closed 마킹으로 압축
- `memory/MEMORY.md` — Backlog 줄에서 Phase 23 항목 제거, 에디터 리팩터 7건(E-3/E-5/E-7/E-8/E-10/E-11/E-12) 명시

## Out of scope

- Phase 19 audit log orphan 7건 (별도 phase 분기)
- 에디터 리팩터 7건 (후속 PR로 진행)

## Test plan

- [x] memory 파일 텍스트 정합성만 변경 (코드 영향 0)
- [x] docs-only — `ci.yml` paths-filter로 fire 안 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 프로젝트 백로그 상태 정보 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->