### PR TITLE
refactor(editor): inline useDebouncedMutation FlushRefs bag + E-12 regression tests

### DIFF
--- a/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
@@ -166,6 +166,27 @@ describe("EndingNodePanel debounce + onBlur flush", () => {
     expect(mutateMock).toHaveBeenCalledTimes(1);
   });
 
+  it("pending body가 있는 상태에서 unmount 시 자동 flush된다", async () => {
+    // E-12 회귀: schedule 직후 (debounce window 만료 전) 컴포넌트가 unmount되면
+    // useDebouncedMutation의 useUnmountFlush가 pending body를 즉시 발화해야 한다.
+    // 다른 panel로 이동하거나 탭을 떠나도 마지막 입력이 사라지지 않도록 보장.
+    const { unmount } = renderWithClient(
+      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+    );
+
+    const labelInput = screen.getByPlaceholderText("엔딩 이름");
+    fireEvent.change(labelInput, { target: { value: "마지막 입력" } });
+    expect(mutateMock).not.toHaveBeenCalled();
+
+    // Unmount — debounce timer 만료 전이라도 pending body는 자동 flush.
+    unmount();
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    const [arg] = mutateMock.mock.calls[0] as [
+      { nodeId: string; body: { data: { label: string } } },
+    ];
+    expect(arg.body.data.label).toBe("마지막 입력");
+  });
+
   it("mutate 실패 시 graph cache가 rollback되고 toast.error가 발화한다", async () => {
     const { qc } = renderWithClient(
       <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,

--- a/apps/web/src/hooks/__tests__/useDebouncedMutation.test.ts
+++ b/apps/web/src/hooks/__tests__/useDebouncedMutation.test.ts
@@ -331,6 +331,71 @@ describe("useDebouncedMutation", () => {
     expect(mutate).not.toHaveBeenCalled();
   });
 
+  it("schedule across two debounce windows fires twice with independent bodies", () => {
+    // E-12 회귀: 한 debounce cycle이 완료된 뒤 새 schedule을 시작하면 별도
+    // window로 동작해야 한다. timer 재사용/누수 또는 pendingRef 비움 누락 시
+    // 첫 body가 두 번째 발화에 누설되는 회귀를 잡는다.
+    const mutate = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 1000 }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "first" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenLastCalledWith({ label: "first" }, expect.any(Object));
+
+    // Second window — body 격리 + timer 재시작 검증.
+    act(() => {
+      result.current.schedule({ label: "second" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mutate).toHaveBeenCalledTimes(2);
+    expect(mutate).toHaveBeenLastCalledWith({ label: "second" }, expect.any(Object));
+  });
+
+  it("re-entrant schedule from inside mutate is queued for the next window", () => {
+    // E-12 회귀: JSDoc은 mutate 콜백 안에서 schedule 동기 호출을 금지하지만
+    // 실수로 호출되어도 hook이 손상되지 않아야 한다 (timer/pending invariant 유지).
+    // 기대 동작: 동기 schedule은 새 timer를 arm하고 다음 window에서 1번 더 발화.
+    let scheduledFollowUp = false;
+    const mutate = vi.fn((_body: TestBody) => {
+      if (!scheduledFollowUp) {
+        scheduledFollowUp = true;
+        result.current.schedule({ label: "follow-up" });
+      }
+    });
+    const { result } = renderHook(() =>
+      useDebouncedMutation<TestBody>({ mutate, debounceMs: 500 }),
+    );
+
+    act(() => {
+      result.current.schedule({ label: "initial" });
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenNthCalledWith(1, { label: "initial" }, expect.any(Object));
+
+    // re-entrant schedule이 새 timer를 arm했는지 — 다음 window에서 1번 더 발화.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mutate).toHaveBeenCalledTimes(2);
+    expect(mutate).toHaveBeenNthCalledWith(2, { label: "follow-up" }, expect.any(Object));
+  });
+
   it("applyOptimistic that throws leaves the hook in a consistent state", () => {
     // Defensive: if a host's setQueryData impl throws (e.g. malformed key),
     // flush must clear the timer + pending body before propagating so the

--- a/apps/web/src/hooks/useDebouncedMutation.ts
+++ b/apps/web/src/hooks/useDebouncedMutation.ts
@@ -56,7 +56,7 @@
  *
  * // input change → debouncer.schedule(merged); blur → debouncer.flush();
  */
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 export interface UseDebouncedMutationOptions<TBody> {
   /**
@@ -104,17 +104,13 @@ interface OptsRef<TBody> {
   onError: UseDebouncedMutationOptions<TBody>["onError"];
 }
 
-interface FlushRefs<TBody> {
-  timerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
-  pendingRef: React.MutableRefObject<TBody | null>;
-  optsRef: React.MutableRefObject<OptsRef<TBody>>;
-}
+type TimerRef = React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
 
 /** Cancel any active timer; idempotent. */
-function clearTimer<TBody>(refs: FlushRefs<TBody>): void {
-  if (refs.timerRef.current) {
-    clearTimeout(refs.timerRef.current);
-    refs.timerRef.current = null;
+function clearTimer(timerRef: TimerRef): void {
+  if (timerRef.current) {
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
   }
 }
 
@@ -123,50 +119,22 @@ function clearTimer<TBody>(refs: FlushRefs<TBody>): void {
  * rollback closure is created lazily here (not at schedule time) so a fast
  * keystroke burst does not write to the query cache N times.
  */
-function flushMutation<TBody>(refs: FlushRefs<TBody>): void {
-  clearTimer(refs);
-  const body = refs.pendingRef.current;
+function flushPending<TBody>(
+  timerRef: TimerRef,
+  pendingRef: React.MutableRefObject<TBody | null>,
+  optsRef: React.MutableRefObject<OptsRef<TBody>>,
+): void {
+  clearTimer(timerRef);
+  const body = pendingRef.current;
   if (body === null) return;
-  refs.pendingRef.current = null;
-
-  const rollback = refs.optsRef.current.applyOptimistic?.(body) ?? null;
-  refs.optsRef.current.mutate(body, {
+  pendingRef.current = null;
+  const rollback = optsRef.current.applyOptimistic?.(body) ?? null;
+  optsRef.current.mutate(body, {
     onError: (error) => {
       rollback?.();
-      refs.optsRef.current.onError?.(error);
+      optsRef.current.onError?.(error);
     },
   });
-}
-
-/** Update pending body (with optional merge accumulator) and (re)arm the timer. */
-function schedulePending<TBody>(
-  refs: FlushRefs<TBody>,
-  debounceMs: number,
-  body: TBody,
-  merge: ((prev: TBody | null) => TBody) | undefined,
-): void {
-  refs.pendingRef.current = merge ? merge(refs.pendingRef.current) : body;
-  clearTimer(refs);
-  refs.timerRef.current = setTimeout(() => {
-    refs.timerRef.current = null;
-    flushMutation(refs);
-  }, debounceMs);
-}
-
-/**
- * Effect-only helper that flushes pending body on unmount via a `flushRef`
- * (latest closure) so the cleanup never captures a stale `flush` identity.
- */
-function useUnmountFlush(flush: () => void): void {
-  const flushRef = useRef(flush);
-  useEffect(() => {
-    flushRef.current = flush;
-  }, [flush]);
-  useEffect(() => {
-    return () => {
-      flushRef.current();
-    };
-  }, []);
 }
 
 export function useDebouncedMutation<TBody>(
@@ -177,43 +145,44 @@ export function useDebouncedMutation<TBody>(
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingRef = useRef<TBody | null>(null);
 
-  // Latest options snapshot. Synced in render body (not in an effect) so the
-  // ref is up to date even if an immediate schedule fires before the next
-  // commit — also avoids re-running the effect on every parent re-render
-  // when callers pass inline lambdas.
   // Latest options snapshot, synced via useEffect so we only mutate the ref
-  // post-commit. (Round-2 N-2: writing a ref in the render body is unsafe
-  // under React 19 concurrent rendering — speculative renders can be replayed
-  // and the ref would briefly hold stale-or-future values during that window.)
+  // post-commit (Round-2 N-2: render-body ref writes are unsafe under React 19
+  // concurrent rendering — speculative renders can replay).
   const optsRef = useRef<OptsRef<TBody>>({ mutate, applyOptimistic, onError });
   useEffect(() => {
     optsRef.current = { mutate, applyOptimistic, onError };
   }, [mutate, applyOptimistic, onError]);
 
-  // useRef return values have stable identity, so memoizing the bag with
-  // empty deps gives us a once-and-done refs object — callbacks below can
-  // depend on `refs` without re-creating their identity per render.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const refs: FlushRefs<TBody> = useMemo(
-    () => ({ timerRef, pendingRef, optsRef }),
+  const flush = useCallback(
+    () => flushPending(timerRef, pendingRef, optsRef),
     [],
   );
 
-  const flush = useCallback(() => flushMutation(refs), [refs]);
-
   const schedule = useCallback(
     (body: TBody, merge?: (prev: TBody | null) => TBody) => {
-      schedulePending(refs, debounceMs, body, merge);
+      pendingRef.current = merge ? merge(pendingRef.current) : body;
+      clearTimer(timerRef);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        flushPending(timerRef, pendingRef, optsRef);
+      }, debounceMs);
     },
-    [refs, debounceMs],
+    [debounceMs],
   );
 
   const cancel = useCallback(() => {
-    clearTimer(refs);
-    refs.pendingRef.current = null;
-  }, [refs]);
+    clearTimer(timerRef);
+    pendingRef.current = null;
+  }, []);
 
-  useUnmountFlush(flush);
+  // Unmount cleanup: flush via a latest-closure ref so the cleanup never
+  // captures a stale `flush` identity. StrictMode double-mount is safe — the
+  // pending-null guard inside flushPending makes a second cleanup a no-op.
+  const flushRef = useRef(flush);
+  useEffect(() => {
+    flushRef.current = flush;
+  }, [flush]);
+  useEffect(() => () => flushRef.current(), []);
 
   return { schedule, flush, cancel };
 }

--- a/apps/web/src/hooks/useDebouncedMutation.ts
+++ b/apps/web/src/hooks/useDebouncedMutation.ts
@@ -27,6 +27,12 @@
  * 이미 사용된 상태다. 재진입이 필요하면 `queueMicrotask` 또는
  * `setTimeout(..., 0)`으로 비동기 dispatch.
  *
+ * 동기 재진입이 실수로 발생한 경우 hook은 손상되지 않는다 — `pendingRef`는
+ * 비워진 상태에서 새 schedule이 들어오므로 다음 debounce window에 1회 더
+ * 발화한다 (회귀 테스트 "re-entrant schedule from inside mutate" 검증).
+ * 그러나 의도된 사용 패턴은 아니며, `applyOptimistic`이 두 번째 발화에서도
+ * latest body 기준으로 다시 호출되는 점에 유의.
+ *
  * ## Optimistic 시점에 대한 결정 (perf-H2)
  *
  * 빠른 타이핑 시 schedule이 N번 → 매 호출마다 setQueryData 발화 시 cache


### PR DESCRIPTION
## Summary

Phase 21 backlog **E-10 + E-11 + E-12** 묶음 처리.

- **E-10**: `useDebouncedMutation` hook의 `FlushRefs` bag interface(`{ timerRef, pendingRef, optsRef }`) 제거. 헬퍼 `flushPending`이 individual ref 인자를 받음. round-2 arch reviewer LOW로 지적된 YAGNI bag 정리.
- **E-11**: `useUnmountFlush` helper(useRef + 2 useEffect) hook 본문에 inline. 단일 호출 helper.
- **E-12**: 회귀 테스트 3건 추가 — schedule×2 windows / mutate 안 schedule 재진입 / EndingNodePanel unmount-during-pending.

## Changes

| 파일 | 변경 |
|------|------|
| `apps/web/src/hooks/useDebouncedMutation.ts` | 213 → 188 LOC. 함수 본문 49줄 (60룰 충족). FlushRefs interface 제거, useUnmountFlush inline. JSDoc 재진입 contract 명확화. |
| `apps/web/src/hooks/__tests__/useDebouncedMutation.test.ts` | 14 → 16 tests (+2 회귀: schedule×2 windows, 재진입 contract). |
| `apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx` | 5 → 6 tests (+1 회귀: unmount-during-pending 자동 flush). |

## Verification

- ✅ vitest 1080/1080 pass (web 전체)
- ✅ typecheck 0 errors
- ✅ lint quiet 0 warnings
- ✅ 함수 본문 49줄 / file 188줄 (file-size 카논 충족)
- ✅ 4-agent carve-out review (superpowers:code-reviewer): **Critical 0 / High 0**, 3 LOW 중 1건 in-PR fix (JSDoc 재진입 contract), 2건 defer (LOW doc traceability nit)

## Test plan

- [x] `pnpm test` (web)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] 3 consumer 공개 API 변화 0 (`schedule` / `flush` / `cancel` + `{ mutate, debounceMs, applyOptimistic, onError }`)
- [x] perf-H2 (flush-time `applyOptimistic`) 유지

## Backlog 갱신

- E-9 (file-size-guard glob 정정), E-3 (Config 409 3-way merge), E-5 (location_clue v2 flag), E-7/E-8 (panel 컴포넌트 분리)는 후속 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 테스트
* 컴포넌트 언마운트 중 미결 작업 처리 검증 테스트 추가
* 타이밍 및 동시성 시나리오에 대한 추가 테스트 케이스 추가

## 개선 사항
* 내부 구현 최적화로 코드 구조 개선
* 공개 API 인터페이스는 유지됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->