### PR TITLE
refactor(editor): split PhaseNodePanel + CharacterAssignPanel into sub-components (E-7+E-8)

### DIFF
--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -1,129 +1,37 @@
-import { useState, useCallback, useMemo, useRef } from 'react';
-import { User } from 'lucide-react';
-import { toast } from 'sonner';
-import { useQueryClient } from '@tanstack/react-query';
-import type { EditorThemeResponse } from '@/features/editor/api';
-import {
-  editorKeys,
-  useEditorCharacters,
-  useEditorClues,
-  useUpdateConfigJson,
-} from '@/features/editor/api';
-import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
-import type { Mission } from './MissionEditor';
-import { CharacterDetailPanel } from './CharacterDetailPanel';
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Debounce window for config saves (W2 PR-5: 500→1500ms). */
-const SAVE_DEBOUNCE_MS = 1500;
-
-// ---------------------------------------------------------------------------
-// Props
-// ---------------------------------------------------------------------------
+import { useState, useCallback, useMemo } from "react";
+import { User } from "lucide-react";
+import type { EditorThemeResponse } from "@/features/editor/api";
+import { useEditorCharacters, useEditorClues } from "@/features/editor/api";
+import { useCharacterConfigDebounce } from "@/features/editor/hooks/useCharacterConfigDebounce";
+import type { Mission } from "./MissionEditor";
+import { CharacterDetailPanel } from "./CharacterDetailPanel";
+import { CharacterList } from "./CharacterList";
 
 interface CharacterAssignPanelProps {
   themeId: string;
   theme: EditorThemeResponse;
 }
 
-type ConfigPatch = Record<string, unknown>;
-
-// ---------------------------------------------------------------------------
-// CharacterAssignPanel
-// ---------------------------------------------------------------------------
-
 export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelProps) {
   const { data: characters, isLoading: charsLoading } = useEditorCharacters(themeId);
   const { data: clues } = useEditorClues(themeId);
-  const updateConfig = useUpdateConfigJson(themeId);
-  const queryClient = useQueryClient();
   const [selectedCharId, setSelectedCharId] = useState<string | null>(null);
 
   const characterClues = useMemo((): Record<string, string[]> => {
     const cc = (theme.config_json ?? {}).character_clues;
-    return (cc && typeof cc === 'object' && !Array.isArray(cc))
-      ? (cc as Record<string, string[]>) : {};
+    return cc && typeof cc === "object" && !Array.isArray(cc)
+      ? (cc as Record<string, string[]>)
+      : {};
   }, [theme.config_json]);
 
   const characterMissions = useMemo((): Record<string, Mission[]> => {
     const cm = (theme.config_json ?? {}).character_missions;
-    return (cm && typeof cm === 'object' && !Array.isArray(cm))
-      ? (cm as Record<string, Mission[]>) : {};
+    return cm && typeof cm === "object" && !Array.isArray(cm)
+      ? (cm as Record<string, Mission[]>)
+      : {};
   }, [theme.config_json]);
 
-  // Pre-edit snapshot captured at the FIRST schedule of a debounce window —
-  // distinct from the schedule-time UI mirror that follows. This is the
-  // correct rollback target on mutation failure (round-2 N-1 / CodeRabbit).
-  // Cleared after the mutation settles (success or rollback) so the next
-  // edit window starts fresh.
-  const pendingSnapshotRef = useRef<EditorThemeResponse | undefined>(undefined);
-
-  const debouncer = useDebouncedMutation<ConfigPatch>({
-    debounceMs: SAVE_DEBOUNCE_MS,
-    mutate: (body, opts) =>
-      updateConfig.mutate(body, {
-        onSuccess: () => {
-          toast.success('저장되었습니다');
-          pendingSnapshotRef.current = undefined;
-        },
-        onError: (err) => {
-          // The hook's onError chain runs first (rollback → toast.error),
-          // then we clear so a follow-up edit captures a fresh snapshot.
-          opts.onError(err);
-          pendingSnapshotRef.current = undefined;
-        },
-      }),
-    applyOptimistic: () => {
-      // Build the rollback closure from the pre-edit snapshot captured in
-      // saveConfig — NOT from the current cache (which already has the
-      // schedule-time mirror applied). On failure, restore truly to the
-      // pre-edit state.
-      const previous = pendingSnapshotRef.current;
-      if (!previous) return null;
-      const cacheKey = editorKeys.theme(themeId);
-      return () => queryClient.setQueryData(cacheKey, previous);
-    },
-    onError: () => toast.error('저장에 실패했습니다'),
-  });
-  const flush = debouncer.flush;
-
-  const saveConfig = useCallback(
-    (updates: ConfigPatch) => {
-      const cacheKey = editorKeys.theme(themeId);
-
-      // Capture the *true* pre-edit snapshot once per debounce window. This
-      // is the rollback target on mutation failure — distinct from the
-      // schedule-time UI mirror below.
-      if (!pendingSnapshotRef.current) {
-        pendingSnapshotRef.current = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
-      }
-
-      // Schedule-time UI mirror — character toggles need sync feedback so
-      // users see the flip immediately, not after the debounce window. The
-      // hook's `applyOptimistic` runs at flush time and captures the rollback
-      // closure pointing at `pendingSnapshotRef.current`.
-      const cacheNow = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
-      if (cacheNow) {
-        queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
-          ...cacheNow,
-          config_json: { ...(cacheNow.config_json ?? {}), ...updates },
-        });
-      }
-
-      // Merge basis priority (H-W2-1): pending body > optimistic cache >
-      // theme.config_json. Prevents loss of earlier edits made within the
-      // same debounce window on different keys.
-      debouncer.schedule(updates, (prev) => {
-        const cached = queryClient.getQueryData<EditorThemeResponse>(cacheKey)?.config_json;
-        const basis = prev ?? cached ?? theme.config_json ?? {};
-        return { ...basis, ...updates };
-      });
-    },
-    [debouncer, queryClient, theme.config_json, themeId],
-  );
+  const { saveConfig, flush } = useCharacterConfigDebounce(themeId, theme.config_json);
 
   const handleSelectChar = useCallback(
     (id: string) => {
@@ -146,8 +54,15 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
   const handleAddMission = useCallback(() => {
     if (!selectedCharId) return;
     const current = characterMissions[selectedCharId] ?? [];
-    const mission: Mission = { id: crypto.randomUUID(), type: 'kill', description: '', points: 10 };
-    saveConfig({ character_missions: { ...characterMissions, [selectedCharId]: [...current, mission] } });
+    const mission: Mission = {
+      id: crypto.randomUUID(),
+      type: "kill",
+      description: "",
+      points: 10,
+    };
+    saveConfig({
+      character_missions: { ...characterMissions, [selectedCharId]: [...current, mission] },
+    });
   }, [characterMissions, saveConfig, selectedCharId]);
 
   const handleDeleteMission = useCallback(
@@ -155,7 +70,10 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
       if (!selectedCharId) return;
       const current = characterMissions[selectedCharId] ?? [];
       saveConfig({
-        character_missions: { ...characterMissions, [selectedCharId]: current.filter((m) => m.id !== missionId) },
+        character_missions: {
+          ...characterMissions,
+          [selectedCharId]: current.filter((m) => m.id !== missionId),
+        },
       });
     },
     [characterMissions, saveConfig, selectedCharId],
@@ -168,7 +86,9 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
       saveConfig({
         character_missions: {
           ...characterMissions,
-          [selectedCharId]: current.map((m) => (m.id === missionId ? { ...m, [field]: value } : m)),
+          [selectedCharId]: current.map((m) =>
+            m.id === missionId ? { ...m, [field]: value } : m,
+          ),
         },
       });
     },
@@ -207,29 +127,12 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
         if (!e.currentTarget.contains(e.relatedTarget as Node | null)) flush();
       }}
     >
-      {/* ── Left: Character list ── */}
-      <aside className="shrink-0 overflow-y-auto border-b border-slate-800 py-2 md:w-60 md:border-b-0 md:border-r">
-        {characters.map((char) => (
-          <button
-            key={char.id}
-            type="button"
-            onClick={() => handleSelectChar(char.id)}
-            className={`flex w-full items-center gap-2 px-4 py-2 text-left text-xs transition-colors ${
-              selectedCharId === char.id
-                ? 'bg-slate-800 text-amber-400'
-                : 'text-slate-400 hover:bg-slate-900 hover:text-slate-200'
-            }`}
-          >
-            <User className="h-3.5 w-3.5 shrink-0" />
-            <span className="truncate">{char.name}</span>
-            {char.is_culprit && (
-              <span className="ml-auto shrink-0 text-[10px] text-red-400">범인</span>
-            )}
-          </button>
-        ))}
-      </aside>
+      <CharacterList
+        characters={characters}
+        selectedCharId={selectedCharId}
+        onSelect={handleSelectChar}
+      />
 
-      {/* ── Right: Detail ── */}
       <div className="flex-1 overflow-y-auto px-6 py-4">
         <CharacterDetailPanel
           selectedChar={selectedChar}

--- a/apps/web/src/features/editor/components/design/CharacterList.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterList.tsx
@@ -1,0 +1,44 @@
+import { User } from "lucide-react";
+
+interface CharacterListItem {
+  id: string;
+  name: string;
+  is_culprit?: boolean;
+}
+
+interface CharacterListProps {
+  characters: CharacterListItem[];
+  selectedCharId: string | null;
+  onSelect: (id: string) => void;
+}
+
+export function CharacterList({
+  characters,
+  selectedCharId,
+  onSelect,
+}: CharacterListProps) {
+  return (
+    <aside className="shrink-0 overflow-y-auto border-b border-slate-800 py-2 md:w-60 md:border-b-0 md:border-r">
+      {characters.map((char) => (
+        <button
+          key={char.id}
+          type="button"
+          onClick={() => onSelect(char.id)}
+          className={`flex w-full items-center gap-2 px-4 py-2 text-left text-xs transition-colors ${
+            selectedCharId === char.id
+              ? "bg-slate-800 text-amber-400"
+              : "text-slate-400 hover:bg-slate-900 hover:text-slate-200"
+          }`}
+        >
+          <User className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{char.name}</span>
+          {char.is_culprit && (
+            <span className="ml-auto shrink-0 text-[10px] text-red-400">
+              범인
+            </span>
+          )}
+        </button>
+      ))}
+    </aside>
+  );
+}

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -10,10 +10,9 @@ import type {
 import { flowKeys } from "../../flowTypes";
 import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
 import { ActionListEditor } from "./ActionListEditor";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
+import { PhasePanelTimerSettings } from "./PhasePanelTimerSettings";
+import { PhasePanelAdvanceToggle } from "./PhasePanelAdvanceToggle";
 
 interface PhaseNodePanelProps {
   node: Node;
@@ -21,20 +20,8 @@ interface PhaseNodePanelProps {
   onUpdate: (id: string, data: Partial<FlowNodeData>) => void;
 }
 
-const PHASE_TYPES = [
-  { value: "investigation", label: "수사" },
-  { value: "discussion", label: "토론" },
-  { value: "voting", label: "투표" },
-  { value: "free", label: "자유" },
-  { value: "intermission", label: "인터미션" },
-];
-
 /** Debounce window for flow-node saves (W2 PR-5: 500→1500ms). */
 const SAVE_DEBOUNCE_MS = 1500;
-
-// ---------------------------------------------------------------------------
-// PhaseNodePanel — 페이즈 노드 편집 패널
-// ---------------------------------------------------------------------------
 
 export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
@@ -75,111 +62,27 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
         페이즈 설정
       </h3>
 
-      {/* Label */}
-      <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">라벨</label>
-        <input
-          type="text"
-          value={data.label ?? ""}
-          onChange={(e) => handleChange({ label: e.target.value })}
-          onBlur={flush}
-          placeholder="페이즈 이름"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        />
-      </div>
+      <PhasePanelBasicInfo
+        label={data.label}
+        phaseType={data.phase_type}
+        onChange={handleChange}
+        onFlush={flush}
+      />
+      <PhasePanelTimerSettings
+        duration={data.duration}
+        rounds={data.rounds}
+        autoAdvance={data.autoAdvance}
+        warningAt={data.warningAt}
+        onChange={handleChange}
+        onFlush={flush}
+      />
+      <PhasePanelAdvanceToggle
+        autoAdvance={data.autoAdvance}
+        onChange={handleChange}
+      />
 
-      {/* Phase type */}
-      <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">타입</label>
-        <select
-          value={data.phase_type ?? ""}
-          onChange={(e) => handleChange({ phase_type: e.target.value })}
-          onBlur={flush}
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        >
-          <option value="">선택 안 함</option>
-          {PHASE_TYPES.map((pt) => (
-            <option key={pt.value} value={pt.value}>
-              {pt.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* Duration */}
-      <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">시간 (분)</label>
-        <input
-          type="number"
-          min={0}
-          value={data.duration ?? ""}
-          onChange={(e) =>
-            handleChange({ duration: e.target.value ? Number(e.target.value) : undefined })
-          }
-          onBlur={flush}
-          placeholder="0"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        />
-      </div>
-
-      {/* Rounds */}
-      <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">라운드 수</label>
-        <input
-          type="number"
-          min={1}
-          value={data.rounds ?? ""}
-          onChange={(e) =>
-            handleChange({ rounds: e.target.value ? Number(e.target.value) : undefined })
-          }
-          onBlur={flush}
-          placeholder="1"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        />
-      </div>
-
-      {/* Auto-advance toggle */}
-      <div className="flex items-center justify-between">
-        <label className="text-[11px] text-slate-400">자동 진행</label>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={data.autoAdvance ?? false}
-          onClick={() => handleChange({ autoAdvance: !data.autoAdvance })}
-          className={`relative h-5 w-9 rounded-full transition-colors ${
-            data.autoAdvance ? "bg-amber-600" : "bg-slate-700"
-          }`}
-        >
-          <span
-            className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
-              data.autoAdvance ? "translate-x-4" : ""
-            }`}
-          />
-        </button>
-      </div>
-
-      {/* Warning timer — only when autoAdvance */}
-      {data.autoAdvance && (
-        <div className="flex flex-col gap-1">
-          <label className="text-[11px] text-slate-400">경고 타이머 (초)</label>
-          <input
-            type="number"
-            min={0}
-            value={data.warningAt ?? ""}
-            onChange={(e) =>
-              handleChange({ warningAt: e.target.value ? Number(e.target.value) : undefined })
-            }
-            onBlur={flush}
-            placeholder="30"
-            className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-          />
-        </div>
-      )}
-
-      {/* Divider */}
       <div className="border-t border-slate-800" />
 
-      {/* onEnter / onExit actions */}
       <ActionListEditor
         label="진입 액션 (onEnter)"
         actions={(data.onEnter as PhaseAction[]) ?? []}

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -71,14 +71,14 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
       <PhasePanelTimerSettings
         duration={data.duration}
         rounds={data.rounds}
-        autoAdvance={data.autoAdvance}
-        warningAt={data.warningAt}
         onChange={handleChange}
         onFlush={flush}
       />
       <PhasePanelAdvanceToggle
         autoAdvance={data.autoAdvance}
+        warningAt={data.warningAt}
         onChange={handleChange}
+        onFlush={flush}
       />
 
       <div className="border-t border-slate-800" />

--- a/apps/web/src/features/editor/components/design/PhasePanelAdvanceToggle.tsx
+++ b/apps/web/src/features/editor/components/design/PhasePanelAdvanceToggle.tsx
@@ -2,31 +2,54 @@ import type { FlowNodeData } from "../../flowTypes";
 
 interface PhasePanelAdvanceToggleProps {
   autoAdvance: boolean | undefined;
+  warningAt: number | undefined;
   onChange: (patch: Partial<FlowNodeData>) => void;
+  onFlush: () => void;
 }
 
 export function PhasePanelAdvanceToggle({
   autoAdvance,
+  warningAt,
   onChange,
+  onFlush,
 }: PhasePanelAdvanceToggleProps) {
   return (
-    <div className="flex items-center justify-between">
-      <label className="text-[11px] text-slate-400">자동 진행</label>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={autoAdvance ?? false}
-        onClick={() => onChange({ autoAdvance: !autoAdvance })}
-        className={`relative h-5 w-9 rounded-full transition-colors ${
-          autoAdvance ? "bg-amber-600" : "bg-slate-700"
-        }`}
-      >
-        <span
-          className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
-            autoAdvance ? "translate-x-4" : ""
+    <>
+      <div className="flex items-center justify-between">
+        <label className="text-[11px] text-slate-400">자동 진행</label>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={autoAdvance ?? false}
+          onClick={() => onChange({ autoAdvance: !autoAdvance })}
+          className={`relative h-5 w-9 rounded-full transition-colors ${
+            autoAdvance ? "bg-amber-600" : "bg-slate-700"
           }`}
-        />
-      </button>
-    </div>
+        >
+          <span
+            className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
+              autoAdvance ? "translate-x-4" : ""
+            }`}
+          />
+        </button>
+      </div>
+
+      {autoAdvance && (
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-slate-400">경고 타이머 (초)</label>
+          <input
+            type="number"
+            min={0}
+            value={warningAt ?? ""}
+            onChange={(e) =>
+              onChange({ warningAt: e.target.value ? Number(e.target.value) : undefined })
+            }
+            onBlur={onFlush}
+            placeholder="30"
+            className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/web/src/features/editor/components/design/PhasePanelAdvanceToggle.tsx
+++ b/apps/web/src/features/editor/components/design/PhasePanelAdvanceToggle.tsx
@@ -1,0 +1,32 @@
+import type { FlowNodeData } from "../../flowTypes";
+
+interface PhasePanelAdvanceToggleProps {
+  autoAdvance: boolean | undefined;
+  onChange: (patch: Partial<FlowNodeData>) => void;
+}
+
+export function PhasePanelAdvanceToggle({
+  autoAdvance,
+  onChange,
+}: PhasePanelAdvanceToggleProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <label className="text-[11px] text-slate-400">자동 진행</label>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={autoAdvance ?? false}
+        onClick={() => onChange({ autoAdvance: !autoAdvance })}
+        className={`relative h-5 w-9 rounded-full transition-colors ${
+          autoAdvance ? "bg-amber-600" : "bg-slate-700"
+        }`}
+      >
+        <span
+          className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
+            autoAdvance ? "translate-x-4" : ""
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/PhasePanelBasicInfo.tsx
+++ b/apps/web/src/features/editor/components/design/PhasePanelBasicInfo.tsx
@@ -1,0 +1,56 @@
+import type { FlowNodeData } from "../../flowTypes";
+
+interface PhasePanelBasicInfoProps {
+  label: string | undefined;
+  phaseType: string | undefined;
+  onChange: (patch: Partial<FlowNodeData>) => void;
+  onFlush: () => void;
+}
+
+const PHASE_TYPES = [
+  { value: "investigation", label: "수사" },
+  { value: "discussion", label: "토론" },
+  { value: "voting", label: "투표" },
+  { value: "free", label: "자유" },
+  { value: "intermission", label: "인터미션" },
+];
+
+export function PhasePanelBasicInfo({
+  label,
+  phaseType,
+  onChange,
+  onFlush,
+}: PhasePanelBasicInfoProps) {
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <label className="text-[11px] text-slate-400">라벨</label>
+        <input
+          type="text"
+          value={label ?? ""}
+          onChange={(e) => onChange({ label: e.target.value })}
+          onBlur={onFlush}
+          placeholder="페이즈 이름"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[11px] text-slate-400">타입</label>
+        <select
+          value={phaseType ?? ""}
+          onChange={(e) => onChange({ phase_type: e.target.value })}
+          onBlur={onFlush}
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+        >
+          <option value="">선택 안 함</option>
+          {PHASE_TYPES.map((pt) => (
+            <option key={pt.value} value={pt.value}>
+              {pt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/editor/components/design/PhasePanelTimerSettings.tsx
+++ b/apps/web/src/features/editor/components/design/PhasePanelTimerSettings.tsx
@@ -3,8 +3,6 @@ import type { FlowNodeData } from "../../flowTypes";
 interface PhasePanelTimerSettingsProps {
   duration: number | undefined;
   rounds: number | undefined;
-  autoAdvance: boolean | undefined;
-  warningAt: number | undefined;
   onChange: (patch: Partial<FlowNodeData>) => void;
   onFlush: () => void;
 }
@@ -15,8 +13,6 @@ const NUMBER_INPUT_CLASS =
 export function PhasePanelTimerSettings({
   duration,
   rounds,
-  autoAdvance,
-  warningAt,
   onChange,
   onFlush,
 }: PhasePanelTimerSettingsProps) {
@@ -51,23 +47,6 @@ export function PhasePanelTimerSettings({
           className={NUMBER_INPUT_CLASS}
         />
       </div>
-
-      {autoAdvance && (
-        <div className="flex flex-col gap-1">
-          <label className="text-[11px] text-slate-400">경고 타이머 (초)</label>
-          <input
-            type="number"
-            min={0}
-            value={warningAt ?? ""}
-            onChange={(e) =>
-              onChange({ warningAt: e.target.value ? Number(e.target.value) : undefined })
-            }
-            onBlur={onFlush}
-            placeholder="30"
-            className={NUMBER_INPUT_CLASS}
-          />
-        </div>
-      )}
     </>
   );
 }

--- a/apps/web/src/features/editor/components/design/PhasePanelTimerSettings.tsx
+++ b/apps/web/src/features/editor/components/design/PhasePanelTimerSettings.tsx
@@ -1,0 +1,73 @@
+import type { FlowNodeData } from "../../flowTypes";
+
+interface PhasePanelTimerSettingsProps {
+  duration: number | undefined;
+  rounds: number | undefined;
+  autoAdvance: boolean | undefined;
+  warningAt: number | undefined;
+  onChange: (patch: Partial<FlowNodeData>) => void;
+  onFlush: () => void;
+}
+
+const NUMBER_INPUT_CLASS =
+  "rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950";
+
+export function PhasePanelTimerSettings({
+  duration,
+  rounds,
+  autoAdvance,
+  warningAt,
+  onChange,
+  onFlush,
+}: PhasePanelTimerSettingsProps) {
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <label className="text-[11px] text-slate-400">시간 (분)</label>
+        <input
+          type="number"
+          min={0}
+          value={duration ?? ""}
+          onChange={(e) =>
+            onChange({ duration: e.target.value ? Number(e.target.value) : undefined })
+          }
+          onBlur={onFlush}
+          placeholder="0"
+          className={NUMBER_INPUT_CLASS}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[11px] text-slate-400">라운드 수</label>
+        <input
+          type="number"
+          min={1}
+          value={rounds ?? ""}
+          onChange={(e) =>
+            onChange({ rounds: e.target.value ? Number(e.target.value) : undefined })
+          }
+          onBlur={onFlush}
+          placeholder="1"
+          className={NUMBER_INPUT_CLASS}
+        />
+      </div>
+
+      {autoAdvance && (
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-slate-400">경고 타이머 (초)</label>
+          <input
+            type="number"
+            min={0}
+            value={warningAt ?? ""}
+            onChange={(e) =>
+              onChange({ warningAt: e.target.value ? Number(e.target.value) : undefined })
+            }
+            onBlur={onFlush}
+            placeholder="30"
+            className={NUMBER_INPUT_CLASS}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/editor/hooks/useCharacterConfigDebounce.ts
+++ b/apps/web/src/features/editor/hooks/useCharacterConfigDebounce.ts
@@ -93,6 +93,9 @@ export function useCharacterConfigDebounce(
         return { ...basis, ...updates };
       });
     },
+    // `themeConfigJson` is deliberately in deps as the *last-resort* merge
+    // basis — even though pending/cached fallbacks usually win, capturing the
+    // latest prop identity keeps the rare cold-start path correct.
     [debouncer, queryClient, themeConfigJson, themeId],
   );
 

--- a/apps/web/src/features/editor/hooks/useCharacterConfigDebounce.ts
+++ b/apps/web/src/features/editor/hooks/useCharacterConfigDebounce.ts
@@ -1,0 +1,100 @@
+import { useCallback, useRef } from "react";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import type { EditorThemeResponse } from "@/features/editor/api";
+import { editorKeys, useUpdateConfigJson } from "@/features/editor/api";
+import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+
+/** Debounce window for config saves (W2 PR-5: 500→1500ms). */
+const SAVE_DEBOUNCE_MS = 1500;
+
+export type ConfigPatch = Record<string, unknown>;
+
+export interface UseCharacterConfigDebounceReturn {
+  saveConfig: (updates: ConfigPatch) => void;
+  flush: () => void;
+}
+
+/**
+ * useCharacterConfigDebounce — `CharacterAssignPanel`의 debounce + optimistic
+ * + rollback + onBlur flush 합성을 캡슐화한다 (Phase 21 E-8).
+ *
+ * 두 layer 패턴 (PR #184, round-2 N-1 / CodeRabbit):
+ *
+ *  1. **schedule-time UI mirror** — 토글 즉시 반응이 critical하므로 `saveConfig`
+ *     본문에서 직접 `setQueryData`로 캐시를 갱신한다.
+ *  2. **flush-time `applyOptimistic`** — `pendingSnapshotRef`에 저장한 *진짜*
+ *     pre-edit 스냅샷을 기준으로 rollback closure를 작성한다. mirror 후의
+ *     캐시를 캡처하면 silent data divergence가 발생.
+ *
+ * 자세한 카논: `memory/feedback_optimistic_apply_timing.md`,
+ *            `memory/feedback_optimistic_rollback_snapshot.md`.
+ */
+export function useCharacterConfigDebounce(
+  themeId: string,
+  themeConfigJson: Record<string, unknown> | undefined,
+): UseCharacterConfigDebounceReturn {
+  const updateConfig = useUpdateConfigJson(themeId);
+  const queryClient = useQueryClient();
+
+  // Pre-edit snapshot captured at the FIRST schedule of a debounce window —
+  // distinct from the schedule-time UI mirror that follows. This is the
+  // correct rollback target on mutation failure (round-2 N-1 / CodeRabbit).
+  // Cleared after the mutation settles (success or rollback) so the next
+  // edit window starts fresh.
+  const pendingSnapshotRef = useRef<EditorThemeResponse | undefined>(undefined);
+
+  const debouncer = useDebouncedMutation<ConfigPatch>({
+    debounceMs: SAVE_DEBOUNCE_MS,
+    mutate: (body, opts) =>
+      updateConfig.mutate(body, {
+        onSuccess: () => {
+          toast.success("저장되었습니다");
+          pendingSnapshotRef.current = undefined;
+        },
+        onError: (err) => {
+          opts.onError(err);
+          pendingSnapshotRef.current = undefined;
+        },
+      }),
+    applyOptimistic: () => {
+      const previous = pendingSnapshotRef.current;
+      if (!previous) return null;
+      const cacheKey = editorKeys.theme(themeId);
+      return () => queryClient.setQueryData(cacheKey, previous);
+    },
+    onError: () => toast.error("저장에 실패했습니다"),
+  });
+
+  const saveConfig = useCallback(
+    (updates: ConfigPatch) => {
+      const cacheKey = editorKeys.theme(themeId);
+
+      if (!pendingSnapshotRef.current) {
+        pendingSnapshotRef.current =
+          queryClient.getQueryData<EditorThemeResponse>(cacheKey);
+      }
+
+      const cacheNow = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
+      if (cacheNow) {
+        queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
+          ...cacheNow,
+          config_json: { ...(cacheNow.config_json ?? {}), ...updates },
+        });
+      }
+
+      // Merge basis priority (H-W2-1): pending body > optimistic cache >
+      // theme.config_json. Prevents loss of earlier edits made within the
+      // same debounce window on different keys.
+      debouncer.schedule(updates, (prev) => {
+        const cached =
+          queryClient.getQueryData<EditorThemeResponse>(cacheKey)?.config_json;
+        const basis = prev ?? cached ?? themeConfigJson ?? {};
+        return { ...basis, ...updates };
+      });
+    },
+    [debouncer, queryClient, themeConfigJson, themeId],
+  );
+
+  return { saveConfig, flush: debouncer.flush };
+}


### PR DESCRIPTION
## Summary

Phase 21 backlog **E-7 + E-8** 묶음 처리 (CR-3 / CR-4 in-PR fold-in).

### E-7: PhaseNodePanel 분리 (195 → 98 LoC)

- 신규 `PhasePanelBasicInfo.tsx` (56 LoC) — label + phase type select
- 신규 `PhasePanelTimerSettings.tsx` (60 LoC) — duration + rounds
- 신규 `PhasePanelAdvanceToggle.tsx` (52 LoC) — auto-advance toggle + conditional warning timer (autoAdvance에 종속이므로 같이 묶음)
- 메인은 `useDebouncedMutation` 배선 + `handleChange` + `ActionListEditor` × 2 조합
- 컴포넌트 함수 본문 73줄 (150 룰 충족, 마진 77)

### E-8: CharacterAssignPanel 분리 (248 → 151 LoC)

- 신규 hook `useCharacterConfigDebounce.ts` (104 LoC) — debouncer + saveConfig + pendingSnapshotRef + flush. 두 layer 패턴 (schedule-time mirror + flush-time applyOptimistic) 캡슐화
- 신규 `CharacterList.tsx` (44 LoC) — left aside character buttons
- 메인은 selection state + memos + handlers + sub-components 조합
- 컴포넌트 함수 본문 137줄 (150 룰 충족, 마진 13)

## Verification

- ✅ vitest 1080/1080 pass
- ✅ typecheck 0 errors
- ✅ lint quiet 0 warnings
- ✅ 기존 테스트 모두 보존: PhaseNodePanelDebounce 9 + Extended 5 + CharacterAssignPanel 11 = 25 pass
- ✅ 4-agent carve-out review (superpowers:code-reviewer): Critical 0 / **High 1 fixed in-PR** (auto-advance toggle 위치 회귀 — Warning timer가 toggle 아래로 가야 함, fix commit cc16aae)
- ✅ MEDIUM 1건 (themeConfigJson deps 의도) 코멘트 fix

## Behavior preservation

- 두 layer 패턴 (`memory/feedback_optimistic_apply_timing.md`): schedule-time UI mirror + flush-time `applyOptimistic`은 hook 내부에서 동일 보존
- `pendingSnapshotRef` lifecycle (capture-once-per-window, clear-on-settle) 보존
- `onBlur` flush + `relatedTarget` null check 동작 변화 0
- `flush` / `saveConfig` identity 메모이제이션 그래프 분리 전후 동일

## Test plan

- [x] `pnpm vitest run` — 1080/1080 pass
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint --quiet` — 0 warnings
- [x] 4-agent carve-out review

## Backlog 갱신

E-7/E-8 해소 시 `memory/project_phase21_backlog.md` 갱신 + main 머지 후 wrap-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 캐릭터 할당 및 페이즈 구성 UI를 더 작은 컴포넌트로 분할하여 유지보수성 개선

* **개선 사항**
  * 설정 변경 시 오류 발생 시 이전 상태로 자동 복구되는 기능 추가
  * 설정 저장 성능 최적화로 더 빠른 응답성 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->