### PR TITLE
hotfix(ci): paths-filter trap + gitleaks coverage gap (post-#194 retro)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'turbo.json'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
     paths:
@@ -23,7 +23,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'turbo.json'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -26,7 +26,7 @@ on:
       - 'turbo.json'
       - 'playwright.config.ts'
       - 'e2e/**'
-      - '.github/workflows/e2e-stubbed.yml'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
     paths:
@@ -38,7 +38,7 @@ on:
       - 'turbo.json'
       - 'playwright.config.ts'
       - 'e2e/**'
-      - '.github/workflows/e2e-stubbed.yml'
+      - '.github/workflows/**'
   # Phase 18.8 PR-5: 수동 트리거 추가. PR에서 stubbed CI를 재실행하거나
   # 베타 단계에서 임시 시나리오 재현이 필요할 때 사용.
   workflow_dispatch:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,42 @@
+name: Gitleaks Secret Scan
+
+# Secret scan은 모든 PR/push에 fire (paths-filter 없음).
+# 이유: secret leak은 코드 외 경로(infra/, scripts/, docs/, root config)에서도 발생 가능.
+# security-fast.yml의 paths-filter trap (코드 PR에만 fire) 회귀 hotfix.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks (Secret scan)
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_COMMENTS: false
+          # Phase 23 Custom Image: docker GID 990 + working dir 정합성. artifact upload (Sec-MED-2).
+          GITLEAKS_ENABLE_SUMMARY: true

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -2,6 +2,7 @@ name: Security — Fast Feedback
 
 # paths filter (CI 슬림화 — Phase 23 follow-up "CI pruning P0" 후속):
 # docs/memory/plan 변경 PR 시 fire 0. Go/Node 의존성 또는 본 workflow 자체 변경에만 fire.
+# gitleaks는 별도 .github/workflows/gitleaks.yml 로 분리됨 (모든 경로 secret scan 보장).
 on:
   pull_request:
     branches: [main]
@@ -64,28 +65,3 @@ jobs:
         working-directory: apps/server
         continue-on-error: true
         run: govulncheck ./...
-
-  gitleaks:
-    name: gitleaks (Secret scan)
-    runs-on: arc-runner-set
-    timeout-minutes: 5
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
-          GITLEAKS_ENABLE_COMMENTS: false
-          # Phase 23 Custom Image: docker GID 990 + working dir 정합성. artifact upload 복원 (Sec-MED-2).
-          # Verify는 본 PR 머지 + 사용자 host 재배포 후 첫 CI run에서 자연 발생 — fail 시 hotfix + #3 follow-up PR.
-          GITLEAKS_ENABLE_SUMMARY: true


### PR DESCRIPTION
## Summary

PR #194 사후 코드 리뷰에서 발견된 **HIGH 2건** 정리.

## 발견 2 (HIGH) — paths-filter trap 해소

`ci.yml` / `e2e-stubbed.yml` 의 paths 가 본인 workflow 파일만 포함해서 (`.github/workflows/ci.yml`, `.github/workflows/e2e-stubbed.yml`) **다른 workflow yml 변경 PR 에선 fire 0**. 4 required status check 등록 안 됨 → branch protection 영구 차단.

`enforce_admins=false` 라 admin 우회 가능했지만 일반 사용자 환경 또는 future workflow PR 영구 admin merge 패턴 = main 보호 무력화 risk.

**해결**: 양 workflow paths 에 `.github/workflows/**` (전체) 추가. workflow-only PR 시도 4 required 자연 fire.

## 발견 3 (HIGH) — gitleaks coverage gap

PR #194 가 `security-fast.yml` 에 paths-filter 도입하면서 gitleaks 도 같이 게이트됨. `apps/**`, `packages/**`, lockfile 등 **코드 경로에만 fire** → `infra/`, `scripts/`, `docs/`, root config (`*.env*`, `terraform/*.tfvars` 등) 변경 시 secret scan fire 0. `security-deep.yml` nightly 에도 gitleaks 없음 → secret scan 사실상 코드 PR 한정 = 보안 회귀.

**해결**: gitleaks 잡을 `security-fast.yml` 에서 추출 → `.github/workflows/gitleaks.yml` 별도 workflow. paths-filter 없음 (**모든 PR/push fire**). `security-fast.yml` 은 govulncheck 만 남겨 paths-filter 유지 (도입 의도 보존, docs PR 시간 절감).

## Diff

| 파일 | 변경 |
|------|------|
| `ci.yml` | paths `.github/workflows/ci.yml` → `.github/workflows/**` |
| `e2e-stubbed.yml` | paths `.github/workflows/e2e-stubbed.yml` → `.github/workflows/**` |
| `security-fast.yml` | gitleaks job 제거, 분리 안내 주석 추가, govulncheck 만 남김 |
| `gitleaks.yml` | **신규** — paths-filter 없음, 모든 PR/push fire |

## Test plan

- [x] yaml 문법 검증 (python yaml.safe_load 4 파일 통과)
- [ ] 본 PR 자체 ci.yml + e2e-stubbed.yml fire → 4 required check 자연 통과 검증 (paths-filter 효과 in-PR 검증)
- [ ] 머지 후 다음 workflow-only PR 에서 4 required check fire 확인
- [ ] 머지 후 docs-only PR 에서 gitleaks fire 확인 (secret scan coverage 검증)

## Retro

PR #194 의 HIGH 2건은 단일 review pass 에서 검출됐으나 admin --squash 로 사후 발견됨. **admin merge 전 4-agent 리뷰 카논** (`memory/feedback_4agent_review_before_admin_merge.md`) 가 본 케이스에서 카논대로 적용됐으면 hotfix 불필요했을 것. 다음 admin merge 전 4-agent 리뷰 강제 다시 점검 필요 (별도 MEMORY 후속).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI 워크플로우 트리거 조건을 확대하여 더 많은 파일 변경 시 자동으로 실행되도록 개선했습니다.
  * 새로운 보안 스캔 워크플로우를 추가했습니다.
  * 보안 검사 워크플로우를 재구성하여 더 명확한 책임 분담을 구현했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->