### PR TITLE
chore(memory): wrap-up 2026-05-01 — CI 슬림화 handoff + 2 MISTAKES + 2 QUESTIONS

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -61,6 +61,7 @@
 - [Custom Runner Image GHCR 첫 push 절차](feedback_ghcr_self_hosted_bootstrap.md) — GITHUB_TOKEN + Public visibility
 
 ## 최근 세션 회고
+- [2026-05-01 CI 슬림화 — required check 15→4 + paths-filter trap hotfix](sessions/2026-05-01-ci-slim-paths-filter-trap.md) — PR #194/#195. main branch protection 4개 축소 + workflow-only PR fire 보장 + gitleaks 분리
 - [2026-05-01 Phase 21 backlog wave — 5 PR sequential merge](sessions/2026-05-01-phase-21-backlog-wave.md) — PR #188/#189/#190/#191/#192. E-7/E-8/E-10/E-11/E-12 해소 + Phase 23 인프라 close + E-5 Phase 24 defer
 - [2026-05-01 Phase 21 E-1/E-6 — useDebouncedMutation 훅 + file-size CI guard](sessions/2026-05-01-phase-21-e1-e6-debounce-hook.md) — 4 PR 머지 (#178/#183/#184/#185), 4-agent 3 round + CodeRabbit 2 round, E-7~E-12 follow-up 등록
 - [2026-04-19 토큰 최적화](project_session_2026-04-19_optimization.md) — 3 PR (#116/#117/#118), 세션당 ~8~25K 절감

--- a/memory/MISTAKES.md
+++ b/memory/MISTAKES.md
@@ -200,3 +200,33 @@ e2e-stubbed.yml:67:40 context "job" is not allowed here
 **Mitigation (현 운영)**: 옛 myoung34 image가 host에 잔존 → 사용자가 image 삭제 안 하는 한 fallback 가능. P0-1 follow-up Hotfix PR로 영구 fix 권장.
 
 **관련 카논**: `memory/sessions/2026-04-29-phase-23-custom-runner-image-merge.md`, `docs/superpowers/specs/2026-04-29-phase-23-custom-runner-image-design.md` § 9 Risks, `memory/feedback_runner_bootstrap.md` (Phase 23 wrap-up 신규 카논), P0-1 follow-up.
+
+---
+
+## 2026-05-01 — paths-filter 횡적 의존 누락 → required check fire 0 (paths-filter-lateral-dep)
+
+**증상**: PR #194에서 main branch protection을 15→4 required check로 축소하며 `security-fast.yml`에 paths-filter 추가. 본 PR이 `.github/workflows/*.yml`만 변경 → ci.yml + e2e-stubbed.yml의 paths가 본인 workflow 파일만 포함 (`.github/workflows/ci.yml`, `.github/workflows/e2e-stubbed.yml`)이라 다른 workflow 변경 PR에선 fire 0. 결과: 4 required check 중 어느 것도 등록 안 됨 → branch protection 영구 차단. `enforce_admins=false` + admin 권한으로만 우회 가능. PR #195 hotfix로 양 workflow paths에 `.github/workflows/**` (전체) 추가하여 해소.
+
+**근본 원인**: paths-filter 설계 시 "내 변경 파일 → 내 fire" 종적 패턴만 고려하고, "다른 workflow 파일 변경 시 본 workflow도 fire 해야 한다"는 횡적 의존 패턴 누락. workflow 간 cross-trigger 사전 시뮬레이션 부재. 코드 PR 기준의 paths-filter 검증 절차가 workflow-only PR 시나리오를 cover 하지 못함.
+
+**재발 방지**:
+1. **paths-filter 추가 전 체크리스트** — (a) 이 job이 branch protection required check에 등록돼 있는가? (b) `.github/workflows/**` 를 paths에 포함하지 않으면 다른 workflow-only PR에서 required check 누락이 발생하는가? 두 질문 모두 YES면 `.github/workflows/**` 강제.
+2. **`feedback_ci_infra_debt.md` 보강** — "paths-filter 추가 시 required-check 교차 검증" 항목 추가 (별도 PR).
+3. **자동화 후보 (다음 세션)**: PostToolUse Edit/Write hook — `.github/workflows/*.yml` 편집 시 `paths:` 블록이 있는 workflow 가 `.github/workflows/**` 항목 포함 여부 grep 검사 (warn-only).
+
+**관련 카논**: `memory/sessions/2026-05-01-ci-slim-paths-filter-trap.md` (본 세션 핸드오프), `feedback_ci_infra_debt.md` (보강 후보 위치).
+
+---
+
+## 2026-05-01 — gitleaks paths-filter scope: 보안 잡을 paths-filter workflow에 묶지 말 것 (gitleaks-workflow-scope)
+
+**증상**: PR #194에서 `security-fast.yml`에 paths-filter 추가 시 gitleaks도 같은 workflow에 묶여 있어 함께 게이트됨. paths-filter가 `apps/**`, `packages/**`, `go.mod/sum`, `pnpm-lock.yaml`, `.gitleaks.toml`, 본 workflow만 → `infra/`, `scripts/`, `docs/`, root config (`*.env*`, `terraform/*.tfvars` 등) 변경 시 secret scan fire 0. `security-deep.yml` nightly 에도 gitleaks 없어 secret scan 사실상 코드 PR 한정. PR #195 hotfix로 gitleaks를 별도 `.github/workflows/gitleaks.yml`로 분리, paths-filter 없음 (모든 PR/push fire).
+
+**근본 원인**: GitHub Actions paths-filter는 workflow trigger 레벨 — 같은 workflow에 묶인 모든 job이 동시에 skip 됨. "성능 최적화용 filter (govulncheck cost ↓)"와 "항상 실행해야 하는 보안 잡 (gitleaks 모든 경로 검출)"을 같은 workflow에 두면 filter 의 skip이 보안 잡도 적용. Job 단위 paths-filter는 GitHub Actions 가 직접 지원 안 함 (`if:` 조건 우회 가능하나 직관성 ↓).
+
+**재발 방지**:
+1. **secret-scan / SAST / 보안 sentinel 종류 잡은 독립 workflow 파일로 분리** — paths-filter 없이 운영. 성능 최적화 잡 (govulncheck / 의존성 SCA / vuln scan) 만 paths-filter workflow에 묶음.
+2. **`feedback_ci_infra_debt.md` 보강 또는 신규 `feedback_security_workflow_isolation.md`** — "paths-filter 도입 workflow 에 보안 sentinel 잡 두지 말 것" 카논화.
+3. **사례 누적 후 카논 master 결정** — 본 사례 + 향후 동일 패턴 누적 시 별도 카논 vs `feedback_ci_infra_debt.md` 흡수.
+
+**관련 카논**: `memory/sessions/2026-05-01-ci-slim-paths-filter-trap.md` (본 세션 핸드오프), `.github/workflows/gitleaks.yml` (분리 결과 master 패턴), `feedback_ci_infra_debt.md` (보강 후보 위치).

--- a/memory/QUESTIONS.md
+++ b/memory/QUESTIONS.md
@@ -126,3 +126,15 @@ Q-gate 적용 후 NEW로 분류된 항목만 등재 (중복은 `duplicate-checke
 ### ~~Q-myoung34-ephemeral-fs: EPHEMERAL=true 재시작 후 ~/go/pkg/mod overlay layer 잔존 범위~~ — **해소 (2026-04-29)**
 - **결과**: Phase 23 Custom Runner Image 머지 (PR #174 + hotfix #175)로 cleanup hook (`ACTIONS_RUNNER_HOOK_JOB_STARTED`) 도입. multi-stage Dockerfile + GHCR build CI 정착 → file system reset 보장. baseline 한정이 아닌 영구 해소.
 - **연관**: `memory/sessions/2026-04-29-phase-23-custom-runner-image-merge.md`, `feedback_runner_bootstrap.md`, `feedback_multi_stage_dockerfile_runner.md`
+
+## 2026-05-01 — CI 슬림화 wrap-up
+
+### Q-paths-filter-lint-spike: paths-filter 횡적 의존을 PR 전 자동 검출하는 도구 (actionlint / zizmor 등)?
+- **맥락**: PR #194 의 paths-filter trap (workflow-only PR 시 required check fire 0) 은 수동 시뮬레이션으로만 검출 가능. actionlint 등 workflow linter 가 "required check + paths-filter 공백" 조합을 탐지하는지 미확인.
+- **다음 액션**: 다음 CI 개선 시 `actionlint` + `zizmor` 1시간 spike → 탐지 가능하면 pre-commit 또는 security-fast.yml 에 추가.
+- **블로커 risk**: LOW (수동 체크리스트로 우선 방어 가능).
+
+### Q-infra-pr-size-classification: CI infra PR 의 Size 분류를 코드 PR 과 동일 기준으로 쓸 것인가?
+- **맥락**: `feedback_4agent_review_before_admin_merge.md` 의 Size 기준은 line count 기반 암묵 정의. yaml infra 는 line 수 작아도 시스템 영향 반경 큼 (paths-filter / branch protection / gitleaks). 코드 PR 기준으로 "Low" 분류하면 4-agent carve-out 잘못 적용.
+- **다음 액션**: 다음 인프라 PR 전 사용자 결정 — "CI / branch-protection / paths-filter 변경은 Size 불문 M 으로 간주" 규칙 채택 여부.
+- **블로커 risk**: MEDIUM (다음 CI 슬림화 시 동일 패턴 재발 가능).

--- a/memory/sessions/2026-05-01-ci-slim-paths-filter-trap.md
+++ b/memory/sessions/2026-05-01-ci-slim-paths-filter-trap.md
@@ -1,0 +1,89 @@
+---
+topic: "CI 슬림화 — required check 15→4 + paths-filter trap 해소 + gitleaks 분리"
+phase: "session (Phase 21 backlog 흐름 외 단독)"
+prs_touched: [PR-194, PR-195]
+session_date: 2026-05-01
+---
+
+# Session Handoff: CI 슬림화 + paths-filter trap hotfix
+
+## Decided
+
+- **필수 status check 15→4 축소** (gh API PUT main branch protection): Go Lint+Test / TS Lint+Test+Build / Docker Build Check / Merge Playwright reports. e2e shard 4개는 `Merge Playwright reports` 가 `needs:` 합류 잡으로 sentinel 강제. 보안 6종(govulncheck/gitleaks/Trivy/osv/CodeQL×2)은 nightly schedule 또는 warn-only 격하 (PR #194)
+- **paths-filter trap 해소**: `ci.yml` + `e2e-stubbed.yml` paths 에 `.github/workflows/**` 추가 (본인 workflow 파일만 → 전체 워크플로우). workflow-only PR 도 4 required check 자연 fire. PR #195 가 자체 in-PR 검증 (admin 우회 없이 자연 머지) (PR #195)
+- **gitleaks 별도 workflow 분리**: `security-fast.yml` 에서 추출 → `.github/workflows/gitleaks.yml`. paths-filter 없음 → 모든 PR/push fire. 보안 잡을 paths-filter workflow 안에 두면 같이 게이트되는 회귀 방지 (PR #195)
+- **3 워크플로우 concurrency 추가**: `arc-smoke-test.yml` (cancel-in-progress=false, dispatch 보호), `build-runner-image.yml` (cancel=true), `ci-hooks.yml` (cancel=true). 12/13 워크플로우 concurrency 정착
+- **사용자 명시 드롭 3건**: E-9 file-size-guard glob 정정 / retro 발견 MEMORY MISTAKES 카논화 ("admin merge 전 4-agent 리뷰" 강제 룰) / enforce_admins false→true 전환
+
+## Rejected
+
+- **Phase 24A "CI 슬림화" brainstorm 진입 → 1주 견적**: 사용자 "1주일이나 걸려?" 의문 → yaml 패치 + UI 클릭 작업이라 brainstorm 풀 사이클 불필요. 실제 1.5시간으로 재산정.
+- **PR #194 admin --squash 후 즉시 다음 작업 진행**: 사용자 "코드리뷰로 먼저 확인해보고 진행하자" → 사후 retro 리뷰. HIGH 2건 발견 → PR #195 hotfix.
+- **enforce_admins=false → true 전환**: paths-filter trap 해소되어 조건은 충족됐으나, 1인 운영 emergency 우회 여지 보존 위해 사용자 드롭.
+
+## Risks
+
+- **CodeRabbit 리뷰 미확인 (2 PR)**: PR #194/#195 모두 머지 시 CodeRabbit pending 상태였음. HIGH finding 가능성 점검 필요 (P2).
+- **paths-filter 중복 (push/pull_request 양쪽 동일 list)**: 미관/유지보수 risk만, functional 영향 0. anchor 도입 follow-up 후보.
+- **build-runner-image cancel-in-progress=true 의 multi-tag push race**: 이론적 risk 만 (latest + $SHA tag 사이 cancel 시 inconsistency). 실제 거의 발생 안 함.
+- **oh-my-claudecode:* 영구 부재 미확인**: 본 세션 wrap-up 도 superpowers:code-reviewer fallback 사용. 카논 갱신 필요 (이전 핸드오프 P1-B 와 중복).
+
+## Files
+
+### 신규
+- `.github/workflows/gitleaks.yml` (42 LoC, paths-filter 없음, 모든 PR/push secret scan)
+
+### 수정
+- `.github/workflows/ci.yml` — paths `.github/workflows/ci.yml` → `.github/workflows/**`
+- `.github/workflows/e2e-stubbed.yml` — paths `.github/workflows/e2e-stubbed.yml` → `.github/workflows/**`
+- `.github/workflows/security-fast.yml` — gitleaks job 제거, govulncheck 만 남김 + paths-filter 추가 (apps/**, packages/**, go.mod/sum, pnpm-lock.yaml, .gitleaks.toml, 본 workflow)
+- `.github/workflows/arc-smoke-test.yml` — concurrency 추가 (cancel=false)
+- `.github/workflows/build-runner-image.yml` — concurrency 추가 (cancel=true)
+- `.github/workflows/ci-hooks.yml` — concurrency 추가 (cancel=true)
+
+### Branch protection (코드 외부, GitHub 메타)
+- main `required_status_checks.contexts`: 15 → 4
+
+## Remaining
+
+### 본 세션 발견 follow-up
+- **paths-filter 중복** 정리 (LOW) — push/pull_request anchor 도입 PR
+- **CodeRabbit 리뷰 확인** PR #194/#195 (P2)
+
+### 이전 핸드오프 (2026-05-01 오전) 잔존
+- P1-A: docs-only PR paths-filter 정책 명문화 (`feedback_4agent_review_before_admin_merge.md`)
+- P1-B: 4-agent fallback 정책 명시 (oh-my-claudecode 부재 시 superpowers:code-reviewer 1회)
+- P2: Phase 19 W4 PR-9 (WS Auth Protocol) — L 규모, 단독 phase 진입
+- P2: Phase 19 audit log orphan O-1~O-4 — 4 vertical PR
+- P3: E-3 / E-5 Phase 24 brainstorm
+
+### 사용자 명시 드롭 (재제안 금지)
+- ❌ E-9 file-size-guard.yml glob 정정
+- ❌ retro 발견 MEMORY MISTAKES 카논화 ("admin merge 전 4-agent 리뷰" 강제 룰)
+- ❌ enforce_admins: false → true 전환
+
+## Next Session Priorities
+
+- **P1-A (이월)**: docs-only PR paths-filter 정책 명문화 — S, H Impact
+- **P1-B (이월)**: 4-agent fallback 정책 명시 — S, H Impact
+- **P2-A**: CodeRabbit PR #194/#195 코멘트 확인 — S, M Impact (Quick Win)
+- **P2-B**: paths-filter push/pull_request 중복 anchor 정리 — S, L Impact
+- **P2 (이월)**: Phase 19 W4 PR-9, audit orphan O-1~O-4
+
+가장 먼저 read 할 파일: `memory/feedback_4agent_review_before_admin_merge.md` (P1-A/P1-B 진입점).
+
+---
+
+## What we did
+
+CI 비대화 진단으로 시작 — 사용자 "CI 가 프로젝트에 비해 너무 크고 개발에 방해된다" 호소. 병렬 디스패치 (로컬 워크플로우 인벤토리 + 외부 베스트 프랙티스 리서치) 결과: 12 워크플로우 / 30 잡 / 필수 status check 15개 = 산업 권장(2-4개)의 4-7배. PR wall time ~12-15분 (산업 권장 <10분).
+
+PR #194 로 1차 슬림화 (15→4 + security-fast paths-filter + 3 워크플로우 concurrency). 1.5시간 안에 종결. 사용자 명시 승인 + yaml-only carve-out 인정으로 admin --squash. 사용자가 "코드리뷰로 먼저 확인" 요청 → 사후 단독 reviewer로 HIGH 2건 발견:
+1. **paths-filter trap**: ci.yml + e2e-stubbed.yml paths 가 본인 workflow 만 포함 → workflow-only PR 시 4 required fire 0 → admin 우회 영구 패턴 risk
+2. **gitleaks coverage gap**: security-fast.yml paths-filter 가 보안 잡까지 게이트 → infra/scripts/docs/root config 변경 시 secret scan fire 0
+
+PR #195 hotfix 로 양쪽 해소. 본 PR 자체가 paths-filter trap 검증 케이스 (4 required check 자연 fire → admin 우회 없이 정상 머지).
+
+세션 후반 "다음 단계" 옵션 3건(E-9 / MEMORY MISTAKES 카논화 / enforce_admins 전환) 사용자 명시 드롭. 이는 wrap-up 의 followup-suggester 출력에서도 Dropped 섹션에 표기.
+
+**카논 위반 패턴 식별**: PR #194 admin --squash 가 `feedback_4agent_review_before_admin_merge.md` 위반. yaml-only 변경의 위험도 underestimate (paths-filter / branch protection 같은 시스템 횡적 영향). 사용자가 카논화는 명시 드롭했으나 본 핸드오프에 retro 기록.


### PR DESCRIPTION
## Summary

세션 wrap-up (mode=session, `/compound-wrap`). 본 세션 2 PR 머지 (#194 main 보호 15→4 + paths-filter + concurrency · #195 paths-filter trap hotfix + gitleaks 분리) 후 메모리 영구화.

## 변경
- `memory/sessions/2026-05-01-ci-slim-paths-filter-trap.md` — 신규 handoff 노트
- `memory/MEMORY.md` — 최근 세션 회고 1줄 추가
- `memory/MISTAKES.md` — 2건 사용자 Y 승인 후 append (paths-filter-lateral-dep / gitleaks-workflow-scope)
- `memory/QUESTIONS.md` — 2건 자동 append (paths-filter-lint spike / infra-pr-size-classification)

## 사용자 명시 드롭 (다음 세션 재제안 금지)
- E-9 file-size-guard.yml glob 정정
- retro 발견 MISTAKES 카논화 ("admin merge 전 4-agent 리뷰" 강제 룰)
- enforce_admins: false → true 전환

## Test plan

- [x] handoff 노트 다음 세션 `/compound-resume` 으로 정상 read 검증 (다음 세션)
- [x] MEMORY.md 인덱스 1줄만 추가 (구조 변경 X — 카논 준수)
- [x] MISTAKES.md 사용자 Y 승인 후만 append (Step 6 카논 준수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * CI 워크플로우 최적화 진행 상황 문서화
  * 필수 상태 확인 항목 간소화 및 경로 필터링 개선사항 기록
  * 보안 검사 워크플로우 분리 및 동시성 설정 추가

* **Chores**
  * 내부 회고 및 학습 사항 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->