### PR TITLE
feat(editor): add character mystery roles and entity preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# Murder Mystery Platform (MMP v3)
+
+다중 테마 실시간 멀티플레이어 머더미스터리 게임 플랫폼. Go 백엔드 + React SPA + PostgreSQL + Redis.
+
+이 파일은 기존 루트 `CLAUDE.md`를 Codex용으로 이전한 지시문이다. Claude Code용 레거시 문맥은 `CLAUDE.md`에 남겨두되, Codex가 따라야 할 규칙은 이 파일을 우선 갱신한다.
+
+## 기본 소통 언어
+
+- 사용자는 한국어 사용자다. 대화, 작업 보고, 설계 설명, 의사결정 설명은 기본적으로 한국어로 작성한다.
+- 코드 식별자, 로그, 명령어, 에러 메시지, 공식 API 명칭은 원문을 유지한다.
+- 사용자가 영어 산출물을 명시적으로 요청한 경우에만 영어로 작성한다.
+
+## 카논 위치
+
+- 하나의 규칙은 하나의 master 파일에서만 정의한다. 다른 파일은 세부 내용을 중복하지 말고 master 파일을 가리킨다.
+- 프로젝트 메모리의 canonical 위치는 repo 내부 `memory/`다. 사용자 홈의 메모리는 archival 용도로만 본다.
+- 진행 중 plan 추적의 canonical 위치는 `docs/plans/<phase>/checklist.md`와 활성 git branch다.
+- 충돌 시 우선순위: 이 파일 및 하위 `apps/*/AGENTS.md` > repo `CLAUDE.md` > 글로벌 Claude 설정.
+- Claude 전용 `@import`, hooks, status line, permission allowlist, plugin command는 Codex 네이티브 기능이 아니다. 필요한 경우 명시적 지시문이나 Codex MCP/plugin 설정으로 변환한다.
+
+## 작업 루틴
+
+- 비단순 작업을 시작할 때는 관련 `memory/MEMORY.md` 포인터와 활성 plan checklist를 먼저 확인한다.
+- `docs/plans`와 `memory` 검색은 `qmd`가 있으면 우선 사용하고, 없으면 `rg`를 사용한다.
+- 아키텍처나 의존성 질문은 `graphify-out/` 그래프가 있으면 먼저 참고한 뒤 소스를 확인한다.
+- 변경은 사용자 요청 범위에 맞춰 외과적으로 수행한다. 관련 없는 리팩터링은 하지 않는다.
+- 사용자가 명시적으로 spike를 요청하지 않는 한 partial 구현, TODO placeholder, mock 동작, 테스트 스킵, 우회성 fix를 남기지 않는다.
+- 실패가 발생하면 코드를 바꾸기 전에 근본 원인을 먼저 파악한다.
+- 워크트리의 사용자 변경을 보존한다. 내가 의도적으로 수정하지 않은 파일은 되돌리지 않는다.
+
+## 계획 및 보고
+
+- 진단, 설계, 의사결정 보고는 한국어로 `원인` -> `결과` -> `권장` 구조를 사용한다.
+- 계획과 보고는 비전문가도 이해할 수 있게 작성한다. 전문 용어는 처음 등장할 때 쉬운 말로 풀어쓰고, 명령어/도구 이름은 "무엇을 확인하거나 바꾸는지"를 함께 설명한다.
+- 선택지를 제시할 때는 기술적 장단점뿐 아니라 사용자 입장에서의 영향, 운영 부담, 실패 시 증상을 같이 설명한다.
+- 아키텍처, UI, 워크플로우, API, 데이터 모델의 선택지를 제시할 때는 실제 서비스, 오픈소스 레퍼런스, 표준 문서, 업계 사례를 먼저 조사하고 각 옵션의 근거를 밝힌다.
+- 여러 단계가 필요한 작업은 간결한 계획을 유지하고 진행 상태가 바뀔 때 갱신한다.
+- Codex sub-agent는 사용자가 명시적으로 위임이나 병렬 agent 작업을 요청한 경우에만 사용한다. Claude 시대의 자동 위임 규칙은 Codex에서는 로컬 계획으로 해석한다.
+
+## Git 및 PR 규율
+
+- `main`을 보호한다. 병합 가능한 변경은 feature branch와 PR을 사용한다.
+- PR 또는 merge 전에는 관련 focused check를 실행하고 `memory/feedback_pre_pr_review_checklist.md` 기준으로 검토한다.
+- PR 생성 후에는 GitHub Actions CI뿐 아니라 Codecov Report를 확인한다. 커버리지 리포트가 실패하거나 기준 미달 코멘트를 남기면 원인을 확인하고 필요한 테스트 보강 또는 코드 수정을 진행한 뒤 다시 검증한다.
+- PR 생성 후 CodeRabbit 리뷰를 확인한다. 문제 제기 코멘트는 수정 커밋으로 해결하고, GitHub review thread가 unresolved 상태로 남지 않도록 resolve 상태까지 확인한 뒤 merge한다.
+- 4-agent review 정책의 canonical 문서는 `memory/feedback_4agent_review_before_admin_merge.md`다. Codex에서 사용 가능한 도구와 사용자 승인 범위에 맞춰 적용한다.
+
+## 코드 및 아키텍처 규칙
+
+| 규칙 | Master |
+| ---- | ------ |
+| 코딩 작업 규율 | `memory/feedback_coding_discipline.md` |
+| 파일/함수 크기 제한 | `memory/feedback_file_size_limit.md` |
+| Git 워크플로우 | `memory/feedback_branch_pr_workflow.md` |
+| 4-agent 리뷰 정책 | `memory/feedback_4agent_review_before_admin_merge.md` |
+| 메모리 canonical 규칙 | `memory/feedback_memory_canonical_repo.md` |
+| 설명 형식 | `memory/feedback_explanation_style.md` |
+| 작업 루틴 | `memory/feedback_work_routine.md` |
+| Graphify 우선 정책 | `memory/feedback_graphify_first.md` |
+| 코드 리뷰 패턴 | `memory/feedback_code_review_patterns.md` |
+| 마이그레이션 워크플로우 | `memory/feedback_migration_workflow.md` |
+| WebSocket 토큰 쿼리 파라미터 | `memory/feedback_ws_token_query.md` |
+| 모듈 시스템 | `memory/project_module_system.md` |
+| 에러 시스템 | `memory/project_error_system.md` |
+| 코딩 규칙 | `memory/project_coding_rules.md` |
+| Graphify refresh 정책 | `memory/project_graphify_refresh_policy.md` |
+
+## 프로젝트 도구 참조
+
+| 도구 규칙 | Master |
+| --------- | ------ |
+| QMD 사용 | `.claude/refs/qmd-rules.md` |
+| Graphify 사용 | `.claude/refs/graphify.md` |
+| 이전 Opus/Sonnet 위임 참고 | `.claude/refs/opus-delegation.md` |
+
+## 하위 패키지 규칙
+
+- Go 백엔드 규칙: `apps/server/AGENTS.md`
+- React 프론트엔드 규칙: `apps/web/AGENTS.md`
+
+## 읽기 우선순위가 낮은 경로
+
+직접 관련이 없으면 생성물이나 대용량 artifact는 읽지 않는다.
+
+- `apps/server/tmp/`
+- `apps/web/dist/`
+- `pnpm-lock.yaml`
+- `apps/server/go.sum`
+- `apps/web/playwright-report/`
+- `apps/web/test-results/`
+- `screenshots/`
+- `*.pdf`, `*.png`, `*.jpg`, `*.svg`, `*.woff2`, `*.mp4` 같은 미디어/폰트 바이너리
+- `.omc/`, `.playwright-mcp/`, `.turbo/`, `.worktrees/`
+- `.claude/archived_plans/`
+- `apps/web/e2e/` 단, E2E 관련 작업이면 예외

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,10 @@
 
 - `main`을 보호한다. 병합 가능한 변경은 feature branch와 PR을 사용한다.
 - PR 또는 merge 전에는 관련 focused check를 실행하고 `memory/feedback_pre_pr_review_checklist.md` 기준으로 검토한다.
+- PR 제목과 본문은 기본적으로 한글로 작성한다. 코드 식별자, 명령어, 에러 메시지, 공식 API명은 원문을 유지한다.
 - PR 생성 후에는 GitHub Actions CI뿐 아니라 Codecov Report를 확인한다. 커버리지 리포트가 실패하거나 기준 미달 코멘트를 남기면 원인을 확인하고 필요한 테스트 보강 또는 코드 수정을 진행한 뒤 다시 검증한다.
 - PR 생성 후 CodeRabbit 리뷰를 확인한다. 문제 제기 코멘트는 수정 커밋으로 해결하고, GitHub review thread가 unresolved 상태로 남지 않도록 resolve 상태까지 확인한 뒤 merge한다.
+- PR/CI/리뷰 상태 확인을 반복할 때는 GitHub/API 호출을 과도하게 하지 않는다. 기본 폴링 간격은 30초~1분으로 두고, 긴 작업은 `--watch --interval 30` 이상 또는 단발 조회를 사용한다.
 - 4-agent review 정책의 canonical 문서는 `memory/feedback_4agent_review_before_admin_merge.md`다. Codex에서 사용 가능한 도구와 사용자 승인 범위에 맞춰 적용한다.
 
 ## 코드 및 아키텍처 규칙

--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -1274,6 +1274,10 @@ components:
         is_culprit:
           type: boolean
           default: false
+        mystery_role:
+          type: string
+          enum: [suspect, culprit, accomplice, detective]
+          default: suspect
         sort_order:
           type: integer
           minimum: 0
@@ -1293,6 +1297,9 @@ components:
           format: uri
         is_culprit:
           type: boolean
+        mystery_role:
+          type: string
+          enum: [suspect, culprit, accomplice, detective]
         sort_order:
           type: integer
           minimum: 0
@@ -1354,7 +1361,7 @@ components:
 
     EditorCharacterResponse:
       type: object
-      required: [id, theme_id, name, is_culprit, sort_order]
+      required: [id, theme_id, name, is_culprit, mystery_role, sort_order]
       properties:
         id:
           type: string
@@ -1371,6 +1378,9 @@ components:
           format: uri
         is_culprit:
           type: boolean
+        mystery_role:
+          type: string
+          enum: [suspect, culprit, accomplice, detective]
         sort_order:
           type: integer
 

--- a/apps/server/db/migrations/00028_character_mystery_role.sql
+++ b/apps/server/db/migrations/00028_character_mystery_role.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+ALTER TABLE theme_characters
+  ADD COLUMN mystery_role VARCHAR(20) NOT NULL DEFAULT 'suspect';
+
+UPDATE theme_characters
+SET mystery_role = CASE WHEN is_culprit THEN 'culprit' ELSE 'suspect' END;
+
+ALTER TABLE theme_characters
+  ADD CONSTRAINT valid_character_mystery_role
+  CHECK (mystery_role IN ('suspect', 'culprit', 'accomplice', 'detective'));
+
+CREATE INDEX idx_theme_characters_mystery_role
+  ON theme_characters(theme_id, mystery_role);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_theme_characters_mystery_role;
+
+ALTER TABLE theme_characters
+  DROP CONSTRAINT IF EXISTS valid_character_mystery_role;
+
+ALTER TABLE theme_characters
+  DROP COLUMN IF EXISTS mystery_role;

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -25,8 +25,8 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order;
 
 -- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, sort_order)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING *;
 
 -- name: UpdateTheme :one
@@ -48,7 +48,7 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE id = $1;
 
 -- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, sort_order = $6
+UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -283,6 +283,7 @@ type ThemeCharacter struct {
 	ImageUrl    pgtype.Text `json:"image_url"`
 	IsCulprit   bool        `json:"is_culprit"`
 	SortOrder   int32       `json:"sort_order"`
+	MysteryRole string      `json:"mystery_role"`
 }
 
 type ThemeClue struct {

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -86,9 +86,9 @@ func (q *Queries) CreateTheme(ctx context.Context, arg CreateThemeParams) (Theme
 }
 
 const createThemeCharacter = `-- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, sort_order)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order
+INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role
 `
 
 type CreateThemeCharacterParams struct {
@@ -97,6 +97,7 @@ type CreateThemeCharacterParams struct {
 	Description pgtype.Text `json:"description"`
 	ImageUrl    pgtype.Text `json:"image_url"`
 	IsCulprit   bool        `json:"is_culprit"`
+	MysteryRole string      `json:"mystery_role"`
 	SortOrder   int32       `json:"sort_order"`
 }
 
@@ -107,6 +108,7 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		arg.Description,
 		arg.ImageUrl,
 		arg.IsCulprit,
+		arg.MysteryRole,
 		arg.SortOrder,
 	)
 	var i ThemeCharacter
@@ -118,6 +120,7 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		&i.ImageUrl,
 		&i.IsCulprit,
 		&i.SortOrder,
+		&i.MysteryRole,
 	)
 	return i, err
 }
@@ -205,7 +208,7 @@ func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error
 }
 
 const getThemeCharacter = `-- name: GetThemeCharacter :one
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order FROM theme_characters WHERE id = $1
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role FROM theme_characters WHERE id = $1
 `
 
 func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCharacter, error) {
@@ -219,12 +222,13 @@ func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCha
 		&i.ImageUrl,
 		&i.IsCulprit,
 		&i.SortOrder,
+		&i.MysteryRole,
 	)
 	return i, err
 }
 
 const getThemeCharacters = `-- name: GetThemeCharacters :many
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]ThemeCharacter, error) {
@@ -244,6 +248,7 @@ func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]
 			&i.ImageUrl,
 			&i.IsCulprit,
 			&i.SortOrder,
+			&i.MysteryRole,
 		); err != nil {
 			return nil, err
 		}
@@ -502,9 +507,9 @@ func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme
 }
 
 const updateThemeCharacter = `-- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, sort_order = $6
+UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7
 WHERE id = $1
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role
 `
 
 type UpdateThemeCharacterParams struct {
@@ -513,6 +518,7 @@ type UpdateThemeCharacterParams struct {
 	Description pgtype.Text `json:"description"`
 	ImageUrl    pgtype.Text `json:"image_url"`
 	IsCulprit   bool        `json:"is_culprit"`
+	MysteryRole string      `json:"mystery_role"`
 	SortOrder   int32       `json:"sort_order"`
 }
 
@@ -523,6 +529,7 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		arg.Description,
 		arg.ImageUrl,
 		arg.IsCulprit,
+		arg.MysteryRole,
 		arg.SortOrder,
 	)
 	var i ThemeCharacter
@@ -534,6 +541,7 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		&i.ImageUrl,
 		&i.IsCulprit,
 		&i.SortOrder,
+		&i.MysteryRole,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -94,6 +94,7 @@ type CreateCharacterRequest struct {
 	Description *string `json:"description" validate:"omitempty,max=2000"`
 	ImageURL    *string `json:"image_url" validate:"omitempty,url"`
 	IsCulprit   bool    `json:"is_culprit"`
+	MysteryRole string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
 	SortOrder   int32   `json:"sort_order" validate:"min=0"`
 }
 
@@ -102,6 +103,7 @@ type UpdateCharacterRequest struct {
 	Description *string `json:"description" validate:"omitempty,max=2000"`
 	ImageURL    *string `json:"image_url" validate:"omitempty,url"`
 	IsCulprit   bool    `json:"is_culprit"`
+	MysteryRole string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
 	SortOrder   int32   `json:"sort_order" validate:"min=0"`
 }
 
@@ -112,6 +114,7 @@ type CharacterResponse struct {
 	Description *string   `json:"description,omitempty"`
 	ImageURL    *string   `json:"image_url,omitempty"`
 	IsCulprit   bool      `json:"is_culprit"`
+	MysteryRole string    `json:"mystery_role"`
 	SortOrder   int32     `json:"sort_order"`
 }
 

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -15,8 +16,39 @@ import (
 
 // --- Characters ---
 
+const (
+	MysteryRoleSuspect    = "suspect"
+	MysteryRoleCulprit    = "culprit"
+	MysteryRoleAccomplice = "accomplice"
+	MysteryRoleDetective  = "detective"
+)
+
+func normalizeMysteryRole(role string, isCulprit bool) (string, error) {
+	if role == "" {
+		if isCulprit {
+			return MysteryRoleCulprit, nil
+		}
+		return MysteryRoleSuspect, nil
+	}
+
+	switch role {
+	case MysteryRoleSuspect, MysteryRoleCulprit, MysteryRoleAccomplice, MysteryRoleDetective:
+		if isCulprit && role != MysteryRoleCulprit {
+			return "", apperror.BadRequest("mystery_role conflicts with is_culprit")
+		}
+		return role, nil
+	default:
+		return "", apperror.BadRequest(fmt.Sprintf("invalid mystery_role: %s", role))
+	}
+}
+
 func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.UUID, req CreateCharacterRequest) (*CharacterResponse, error) {
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
+		return nil, err
+	}
+
+	mysteryRole, err := normalizeMysteryRole(req.MysteryRole, req.IsCulprit)
+	if err != nil {
 		return nil, err
 	}
 
@@ -25,7 +57,8 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		Name:        req.Name,
 		Description: ptrToText(req.Description),
 		ImageUrl:    ptrToText(req.ImageURL),
-		IsCulprit:   req.IsCulprit,
+		IsCulprit:   mysteryRole == MysteryRoleCulprit,
+		MysteryRole: mysteryRole,
 		SortOrder:   req.SortOrder,
 	})
 	if err != nil {
@@ -48,12 +81,18 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		return nil, err
 	}
 
+	mysteryRole, err := normalizeMysteryRole(req.MysteryRole, req.IsCulprit)
+	if err != nil {
+		return nil, err
+	}
+
 	updated, err := s.q.UpdateThemeCharacter(ctx, db.UpdateThemeCharacterParams{
 		ID:          charID,
 		Name:        req.Name,
 		Description: ptrToText(req.Description),
 		ImageUrl:    ptrToText(req.ImageURL),
-		IsCulprit:   req.IsCulprit,
+		IsCulprit:   mysteryRole == MysteryRoleCulprit,
+		MysteryRole: mysteryRole,
 		SortOrder:   req.SortOrder,
 	})
 	if err != nil {
@@ -108,6 +147,7 @@ func toCharacterResponse(c db.ThemeCharacter) *CharacterResponse {
 		Description: textToPtr(c.Description),
 		ImageURL:    textToPtr(c.ImageUrl),
 		IsCulprit:   c.IsCulprit,
+		MysteryRole: c.MysteryRole,
 		SortOrder:   c.SortOrder,
 	}
 }

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -7,6 +7,41 @@ import (
 
 // --- Characters ---
 
+func TestNormalizeMysteryRole(t *testing.T) {
+	tests := []struct {
+		name      string
+		role      string
+		isCulprit bool
+		want      string
+		wantErr   bool
+	}{
+		{name: "empty role keeps legacy culprit flag", role: "", isCulprit: true, want: MysteryRoleCulprit},
+		{name: "empty role defaults to suspect", role: "", isCulprit: false, want: MysteryRoleSuspect},
+		{name: "explicit culprit can omit legacy flag", role: MysteryRoleCulprit, isCulprit: false, want: MysteryRoleCulprit},
+		{name: "explicit detective is accepted", role: MysteryRoleDetective, isCulprit: false, want: MysteryRoleDetective},
+		{name: "legacy culprit flag cannot conflict with explicit non-culprit role", role: MysteryRoleAccomplice, isCulprit: true, wantErr: true},
+		{name: "unknown role is rejected", role: "host", isCulprit: false, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeMysteryRole(tc.role, tc.isCulprit)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeMysteryRole: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("role mismatch: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestService_CreateCharacter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/apps/server/internal/domain/editor/service_validation.go
+++ b/apps/server/internal/domain/editor/service_validation.go
@@ -58,7 +58,7 @@ func (s *service) ValidateTheme(ctx context.Context, creatorID, themeID uuid.UUI
 	}
 	hasCulprit := false
 	for _, c := range chars {
-		if c.IsCulprit {
+		if c.MysteryRole == MysteryRoleCulprit || c.IsCulprit {
 			hasCulprit = true
 			break
 		}

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,124 @@
+# apps/web - React 프론트엔드 규칙
+
+React 19 + Vite SPA + Zustand + Tailwind CSS 4 직접 사용 + `lucide-react`.
+
+이 파일은 Codex에서 `apps/web/` 하위 파일을 작업할 때 자동으로 적용되는 프론트엔드 지침이다. Claude Code의 `CLAUDE.md`에 해당하는 Codex용 control surface는 `AGENTS.md`다.
+
+## 기본 소통 언어
+
+- 사용자-facing 설명, 작업 보고, UI/UX 의사결정 문서는 기본적으로 한국어로 작성한다.
+- 비전문가도 이해할 수 있게 작성한다. 프론트엔드, 상태 관리, 접근성, 성능 용어는 처음 등장할 때 쉬운 말로 풀어쓰고, 사용자가 체감하는 영향을 함께 설명한다.
+- 코드 식별자, 라이브러리명, 에러 메시지, 명령어는 원문을 유지한다.
+
+## 프론트엔드 카논
+
+- 라우팅: React Router lazy loading.
+- 상태: Zustand 3레이어. Connection, Domain, UI.
+- 데이터 fetching/cache: 서버 상태는 TanStack Query를 우선 사용한다.
+- 스타일: Tailwind CSS 4 직접 사용. 별도 디자인 시스템 패키지를 추가하지 않는다.
+- 색상/톤: 다크 모드 기본, slate/zinc + amber 계열을 기본 축으로 한다.
+- 아이콘: `lucide-react`만 사용한다. 다른 아이콘 라이브러리를 추가하지 않는다.
+- 글로벌 Claude 설정에 Seed Design, `@jittda/ui`, `/jittda-*` 스킬이 언급되어도 이 프로젝트에는 적용하지 않는다.
+
+## 사용자 친화성 / UIUX 원칙
+
+- 모든 프론트 작업은 기능 구현뿐 아니라 사용자가 실제로 이해하고 조작하기 쉬운지를 함께 검토한다.
+- 화면은 “무엇을 해야 하는지 → 현재 상태가 무엇인지 → 다음 행동이 무엇인지”가 즉시 보이게 구성한다.
+- 주요 액션은 명확한 라벨을 사용한다. 아이콘만 있는 버튼은 반드시 `aria-label` 또는 보이는 텍스트를 제공한다.
+- 복잡한 에디터 작업은 한 화면에 모두 밀어 넣지 말고, 목록/상세/검수/저장 상태를 단계적으로 읽히게 배치한다.
+- 빈 상태, 로딩 상태, 오류 상태, 저장 성공/실패 상태를 사용자가 이해할 수 있는 문장으로 표시한다.
+- 위험하거나 되돌리기 어려운 액션은 명확한 확인/경고를 제공한다. 예: 삭제, publish, 스포일러 공개.
+- 색상만으로 상태를 전달하지 않는다. 텍스트, 아이콘, 배지 등 보조 단서를 함께 제공한다.
+- 모바일 사용자를 2등 사용자로 취급하지 않는다. 모바일에서도 핵심 읽기/편집/확인 흐름이 완결되어야 한다.
+- UI가 좁아질 때 정보를 숨기기보다 우선순위를 정해 세로로 재배치한다. 꼭 숨겨야 하면 접힘/더보기 패턴을 사용한다.
+- 터치 환경을 고려해 클릭 영역, 카드 간격, 폼 필드 높이를 충분히 확보한다.
+- 긴 텍스트, 역할지, PDF/이미지 문서, 설명문은 모바일에서 읽기 가능한 줄 길이와 여백을 유지한다.
+- dev preview 또는 신규 UI를 만들면 가능하면 모바일 폭(예: 390px)과 데스크톱 폭을 모두 확인한다.
+
+## 반응형 UI 원칙
+
+- 모든 신규/수정 페이지는 모바일 우선으로 설계한다.
+- 모든 프론트 페이지는 반응형 디자인을 기본 요구사항으로 본다. 별도 요청이 없어도 모바일/태블릿/데스크톱을 함께 고려한다.
+- 모바일 기본 흐름은 세로 스택이다. 작은 화면에서 핵심 상세가 옆으로 밀리는 3열/4열 고정 레이아웃을 금지한다.
+- 모바일에서는 가로 스크롤 없이 주요 정보를 읽고 조작할 수 있어야 한다.
+- 데스크톱에서도 본문 폭을 과도하게 늘리지 않는다. 편집 폼/긴 텍스트/문서 뷰어는 읽기 가능한 폭을 유지한다.
+- 보조 정보는 작은 화면에서 본문 아래로 내려간다. 예: 참조상태, backlink, inspector, metadata.
+- Tailwind breakpoint 사용 기준:
+  - 기본: 모바일 세로 스택
+  - `sm`/`md`: 카드 2열까지 허용
+  - `lg` 이상: 보조 패널을 옆에 둘 수 있으나 핵심 편집 영역 너비를 먼저 확보
+  - 4열 이상은 dev-only diagnostics가 아니면 피한다
+- 터치 조작 기준으로 버튼/클릭 영역은 충분한 높이와 간격을 둔다.
+- 브라우저 확인 시 최소 1개 모바일 폭(예: 390px)과 데스크톱 폭을 같이 본다.
+
+## 에디터 UI 원칙
+
+- 제작자 에디터와 플레이어 런타임 UI를 분리한다.
+- 에디터에는 검수용 정보가 보일 수 있다. 예: 참조상태, 미사용 단서, backlink, 장소 tree-ready, validation warning.
+- 플레이어 화면에는 스포일러성 제작 정보가 노출되면 안 된다. 예: 범인 여부, 공범 여부, 단서 backlink, 다른 캐릭터 역할지.
+- 캐릭터/장소/단서 entity 화면은 세로 흐름을 기본으로 한다.
+  1. entity 타입 선택
+  2. entity 목록/검색
+  3. 선택 entity 상세
+  4. 모듈별 섹션
+  5. 참조/검수 패널
+- 캐릭터 역할지는 format 확장 가능성을 고려한다.
+  - Markdown: 텍스트 body
+  - PDF: document media 참조 + 페이지 단위 viewer
+  - Images: 이미지 배열 viewer
+- PDF/이미지 viewer는 모바일에서 한 페이지씩 읽는 경험을 우선한다. 전체 PDF 페이지를 한 번에 렌더링하지 않는다.
+- 범인/공범/탐정 같은 스포일러 속성은 에디터와 권한 있는 런타임 API에서만 다룬다.
+
+## React 구조 원칙
+
+- 컴포넌트는 변경 이유별로 분리한다. 긴 단일 TSX에 검색/list/detail/inspector/save 로직을 모두 넣지 않는다.
+- 데이터 로직과 view를 분리한다. 서버 상태는 query hook, 화면 상태는 가까운 컴포넌트에 둔다.
+- 단순 파생값은 `useEffect + setState`로 동기화하지 말고 render 중 계산한다.
+- 복잡한 다중 필드 전환은 `useReducer` 또는 명확한 helper 함수로 분리한다.
+- rapidly-changing 값에는 Context를 남용하지 않는다.
+- 테스트는 구현 세부보다 사용자 행동/보이는 결과를 검증한다.
+
+## 테스트
+
+- 스택: Vitest + Testing Library + MSW.
+- 현재 커버리지 gate: Lines 49%, Branches 77%, Functions 53%.
+- 목표: Phase 21에서 75%+ coverage.
+- E2E: `apps/web/e2e/` 아래 Playwright.
+- 코드 작성/수정 시 사용자 흐름이 바뀌면 E2E 테스트 작성 여부를 반드시 검토한다.
+  - 새 페이지, 라우트, 핵심 버튼/폼, 저장/업로드/권한/리다이렉트 흐름은 Playwright E2E를 추가하거나 기존 E2E를 갱신한다.
+  - 백엔드 의존 흐름은 `localhost:8080/health` 같은 사전 확인으로 실행 불가 환경에서 자동 skip되게 작성한다.
+  - 순수 컴포넌트 내부 동작만 바뀌고 실제 라우트/사용자 여정이 변하지 않으면 focused Vitest로 대체할 수 있으나, PR/보고에 “E2E 미작성 사유”를 남긴다.
+  - dev-only preview를 만든 경우 최소 1개 E2E 또는 브라우저 확인으로 모바일 폭과 데스크톱 폭의 핵심 표시를 검증한다.
+- 백엔드가 없으면 lobby flow E2E는 자동 skip되어야 한다.
+- 접근성 smoke: `@axe-core/playwright`, focus-visible, WCAG 2.1 AA 기본 항목.
+- UI 변경 후 가능하면 focused Vitest + typecheck를 실행한다.
+
+## 폴더 및 네이밍
+
+- 폴더: `apps/web/src/{components,pages,hooks,services,stores,utils,mocks}`.
+- 기능 단위 코드는 가능하면 `apps/web/src/features/<domain>/...` 아래에 둔다.
+- 컴포넌트: `<Domain><Feature>.tsx`, 예: `EditorClueGraph.tsx`.
+- 스토어: `gameSessionStore`, `moduleStoreFactory`처럼 도메인별로 둔다.
+- dev-only preview는 `apps/web/src/pages/*PreviewPage.tsx` 또는 feature-local dev component로 분리한다.
+
+## 에디터 Auto-Save
+
+- debounce + optimistic update + rollback + `onBlur` flush + unmount cleanup 조합은 `apps/web/src/hooks/useDebouncedMutation.ts`를 사용한다.
+- 에디터 패널에서 직접 `useRef + setTimeout` debounce boilerplate를 작성하지 않는다.
+- `applyOptimistic`은 flush 시점에만 호출한다. schedule 시점에 cache write를 하지 않는다.
+- 즉시 UI 반영이 필요하면 caller 쪽에서 `setQueryData`로 mirror하고, 진짜 pre-edit snapshot은 `pendingSnapshotRef`에 캡처한다.
+- 카논 상세: `memory/feedback_optimistic_apply_timing.md`, `memory/feedback_optimistic_rollback_snapshot.md`.
+
+## WebSocket Client
+
+- `packages/ws-client`를 사용한다. 앱 코드에서 `WebSocket`을 직접 instantiate하지 않는다.
+- 토큰은 `?token=` 쿼리 파라미터로 전달한다.
+- 재접속 정책: PR-9 이후 exponential backoff + `auth.resume`.
+
+## 프론트엔드 포인터
+
+| 규칙 | Master |
+| ---- | ------ |
+| 파일/함수 크기: TS/TSX 400줄, 일반 함수 60줄, JSX 컴포넌트 150줄 | `memory/feedback_file_size_limit.md` |
+| React/PWA/audio 리뷰 패턴 | `memory/feedback_code_review_patterns.md` |
+| WebSocket 토큰 쿼리 파라미터 | `memory/feedback_ws_token_query.md` |

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -189,6 +189,10 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
       body.mystery_role === "detective"
     ) {
       state.characterMysteryRole = body.mystery_role;
+    } else if (body.is_culprit === true) {
+      state.characterMysteryRole = "culprit";
+    } else if (body.is_culprit === false) {
+      state.characterMysteryRole = "suspect";
     }
     return r.fulfill({
       status: 200,
@@ -198,14 +202,18 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
   });
 
   await page.route(`**/v1/editor/themes/${THEME_ID}/content/**`, (r) => {
+    const url = new URL(r.request().url());
+    const key = decodeURIComponent(url.pathname.split("/content/")[1] ?? "");
+    const id = `content-${key.replace(/[^a-zA-Z0-9_-]/g, "-") || "unknown"}`;
+
     if (r.request().method() === "PUT") {
       return r.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          id: "content-role-sheet-char-1",
+          id,
           theme_id: THEME_ID,
-          key: "role_sheet:char-1",
+          key,
           body: JSON.parse(r.request().postData() ?? "{}").body ?? "",
           version: 2,
           updated_at: new Date().toISOString(),
@@ -216,9 +224,9 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        id: "content-role-sheet-char-1",
+        id,
         theme_id: THEME_ID,
-        key: "role_sheet:char-1",
+        key,
         body: "",
         version: 1,
         updated_at: new Date().toISOString(),

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -33,6 +33,9 @@ export interface MockState {
   conflictCountdown: number;
   flowPatchCalls: number;
   flowPutCalls: number;
+  characterUpdateCalls: number;
+  lastCharacterUpdateBody: Record<string, unknown> | null;
+  characterMysteryRole: "suspect" | "culprit" | "accomplice" | "detective";
   configPutCalls: number;
   imageUploadUrlCalls: number;
   templatesCalls: number;
@@ -51,6 +54,9 @@ export function freshState(): MockState {
     conflictCountdown: 1,
     flowPatchCalls: 0,
     flowPutCalls: 0,
+    characterUpdateCalls: 0,
+    lastCharacterUpdateBody: null,
+    characterMysteryRole: "detective",
     configPutCalls: 0,
     imageUploadUrlCalls: 0,
     templatesCalls: 0,
@@ -75,7 +81,26 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
     r.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ id: "user-1", nickname: "테스터", email: "e2e@test.com", role: "user" }),
+      body: JSON.stringify({
+        id: "user-1",
+        nickname: "테스터",
+        email: "e2e@test.com",
+        avatar_url: null,
+        role: "user",
+        provider: "local",
+      }),
+    }),
+  );
+
+  await page.route("**/v1/auth/refresh", (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        access_token: "e2e-access-token",
+        refresh_token: "e2e-refresh-token",
+        expires_in: 3600,
+      }),
     }),
   );
 
@@ -148,16 +173,56 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
     return r.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify([
-        {
-          id: "char-1",
+      body: JSON.stringify([characterPayload(state)]),
+    });
+  });
+
+  await page.route("**/v1/editor/characters/char-1", async (r) => {
+    if (r.request().method() !== "PUT") return r.continue();
+    const body = JSON.parse(r.request().postData() ?? "{}") as Record<string, unknown>;
+    state.characterUpdateCalls += 1;
+    state.lastCharacterUpdateBody = body;
+    if (
+      body.mystery_role === "suspect" ||
+      body.mystery_role === "culprit" ||
+      body.mystery_role === "accomplice" ||
+      body.mystery_role === "detective"
+    ) {
+      state.characterMysteryRole = body.mystery_role;
+    }
+    return r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(characterPayload(state)),
+    });
+  });
+
+  await page.route(`**/v1/editor/themes/${THEME_ID}/content/**`, (r) => {
+    if (r.request().method() === "PUT") {
+      return r.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "content-role-sheet-char-1",
           theme_id: THEME_ID,
-          name: "탐정 A",
-          starting_clue_ids: state.startingClueIds,
-          sort_order: 0,
-          created_at: new Date().toISOString(),
-        },
-      ]),
+          key: "role_sheet:char-1",
+          body: JSON.parse(r.request().postData() ?? "{}").body ?? "",
+          version: 2,
+          updated_at: new Date().toISOString(),
+        }),
+      });
+    }
+    return r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "content-role-sheet-char-1",
+        theme_id: THEME_ID,
+        key: "role_sheet:char-1",
+        body: "",
+        version: 1,
+        updated_at: new Date().toISOString(),
+      }),
     });
   });
 
@@ -264,10 +329,25 @@ function cluePayload(state: MockState) {
   };
 }
 
+function characterPayload(state: MockState) {
+  return {
+    id: "char-1",
+    theme_id: THEME_ID,
+    name: "탐정 A",
+    description: "사건을 추적하는 탐정입니다.",
+    image_url: null,
+    is_culprit: state.characterMysteryRole === "culprit",
+    mystery_role: state.characterMysteryRole,
+    starting_clue_ids: state.startingClueIds,
+    sort_order: 0,
+    created_at: new Date().toISOString(),
+  };
+}
+
 export async function loginAsE2EUser(page: Page): Promise<void> {
   await page.addInitScript(() => {
     try {
-      window.localStorage.setItem("auth_token", "e2e-test-token");
+      window.localStorage.setItem("mmp_refresh_token", "e2e-refresh-token");
       window.localStorage.setItem(
         "auth_user",
         JSON.stringify({ id: "user-1", email: "e2e@test.com" }),

--- a/apps/web/e2e/phase24-editor-character-role.spec.ts
+++ b/apps/web/e2e/phase24-editor-character-role.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import {
+  BASE,
+  THEME_ID,
+  freshState,
+  loginAsE2EUser,
+  mockCommonApis,
+  type MockState,
+} from "./helpers/editor-golden-path-fixtures";
+
+test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
+  let state: MockState;
+
+  test.beforeEach(async ({ page }) => {
+    state = freshState();
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+  });
+
+  test("실제 에디터 화면에서 캐릭터를 공범으로 변경하면 API에 mystery_role을 저장한다", async ({ page }) => {
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    await page.getByRole("tab", { name: "등장인물" }).click();
+    await expect(page.getByRole("button", { name: "배정" })).toBeVisible();
+    await page.getByRole("button", { name: "배정" }).click();
+
+    await page.getByRole("button", { name: /탐정 A/ }).click();
+
+    const updateRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === "PUT" &&
+        request.url().includes("/v1/editor/characters/char-1"),
+    );
+    await page.getByRole("button", { name: /공범/ }).click();
+    const updateRequest = await updateRequestPromise;
+
+    expect(updateRequest.postDataJSON()).toMatchObject({
+      name: "탐정 A",
+      is_culprit: false,
+      mystery_role: "accomplice",
+      sort_order: 0,
+    });
+  });
+});

--- a/apps/web/e2e/phase24-editor-character-role.spec.ts
+++ b/apps/web/e2e/phase24-editor-character-role.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
 import {
   BASE,
   THEME_ID,
@@ -40,5 +41,11 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
       mystery_role: "accomplice",
       sort_order: 0,
     });
+
+    const a11y = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(a11y.violations).toEqual([]);
   });
 });

--- a/apps/web/e2e/phase24-editor-preview.spec.ts
+++ b/apps/web/e2e/phase24-editor-preview.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
 
 test.describe("Phase 24 에디터 entity preview", () => {
   test("데스크톱에서 entity 탐색, 상세, 검수 패널을 표시한다", async ({ page }) => {
@@ -15,6 +16,12 @@ test.describe("Phase 24 에디터 entity preview", () => {
     await expect(page.getByRole("button", { name: "켜짐 · starting_clue" })).toBeVisible();
     await expect(page.getByText("참조 상태")).toBeVisible();
     await expect(page.getByText("단서 backlink")).toBeVisible();
+
+    const a11y = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(a11y.violations).toEqual([]);
   });
 
   test("모바일 폭에서도 핵심 흐름을 세로로 읽을 수 있다", async ({ page }) => {
@@ -27,5 +34,11 @@ test.describe("Phase 24 에디터 entity preview", () => {
 
     await expect(page.getByText("역할지 Markdown")).toBeVisible();
     await expect(page.getByText("참조 상태")).toBeVisible();
+
+    const a11y = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(a11y.violations).toEqual([]);
   });
 });

--- a/apps/web/e2e/phase24-editor-preview.spec.ts
+++ b/apps/web/e2e/phase24-editor-preview.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Phase 24 에디터 entity preview", () => {
+  test("데스크톱에서 entity 탐색, 상세, 검수 패널을 표시한다", async ({ page }) => {
+    await page.goto("/__dev/phase24-editor-preview");
+
+    await expect(page.getByRole("heading", { name: "에디터 Entity Page Preview" })).toBeVisible();
+    await expect(page.getByText("Phase 24 PR-3 entity workspace")).toBeVisible();
+
+    await expect(page.getByRole("button", { name: /캐릭터\s*5개 entity/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /김철수 상속자 범인 후보/ })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "김철수" })).toBeVisible();
+
+    await expect(page.getByText("역할지 Markdown")).toBeVisible();
+    await expect(page.getByRole("button", { name: "켜짐 · starting_clue" })).toBeVisible();
+    await expect(page.getByText("참조 상태")).toBeVisible();
+    await expect(page.getByText("단서 backlink")).toBeVisible();
+  });
+
+  test("모바일 폭에서도 핵심 흐름을 세로로 읽을 수 있다", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/__dev/phase24-editor-preview");
+
+    await expect(page.getByRole("heading", { name: "에디터 Entity Page Preview" })).toBeVisible();
+    await expect(page.getByText("모바일 우선 세로 흐름")).toBeVisible();
+    await expect(page.getByText("모바일에서는 위에서 아래로: 선택 → 베이스 → 모듈 → 참조 순서로 읽습니다.")).toBeVisible();
+
+    await expect(page.getByText("역할지 Markdown")).toBeVisible();
+    await expect(page.getByText("참조 상태")).toBeVisible();
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -159,6 +159,7 @@ export function App() {
               <Route element={<ProtectedRoute />}>
                 <Route path="/game/:id" element={<GamePage />} />
                 <Route path="/editor/:id" element={<EditorPage />} />
+                <Route path="/editor/:id/:tab" element={<EditorPage />} />
                 <Route element={<MainLayout />}>
                   <Route path="/" element={<LobbyPage />} />
                   <Route path="/lobby" element={<LobbyPage />} />

--- a/apps/web/src/features/editor/api/index.ts
+++ b/apps/web/src/features/editor/api/index.ts
@@ -12,6 +12,7 @@ export type {
   EditorThemeSummary,
   EditorThemeResponse,
   EditorCharacterResponse,
+  MysteryRole,
   CreateThemeRequest,
   UpdateThemeRequest,
   CreateCharacterRequest,

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -42,8 +42,11 @@ export interface EditorCharacterResponse {
   description: string | null;
   image_url: string | null;
   is_culprit: boolean;
+  mystery_role: MysteryRole;
   sort_order: number;
 }
+
+export type MysteryRole = "suspect" | "culprit" | "accomplice" | "detective";
 
 export interface CreateThemeRequest {
   title: string;
@@ -72,6 +75,7 @@ export interface CreateCharacterRequest {
   description?: string;
   image_url?: string;
   is_culprit?: boolean;
+  mystery_role?: MysteryRole;
   sort_order?: number;
 }
 
@@ -80,6 +84,7 @@ export interface UpdateCharacterRequest {
   description?: string;
   image_url?: string;
   is_culprit?: boolean;
+  mystery_role?: MysteryRole;
   sort_order?: number;
 }
 

--- a/apps/web/src/features/editor/components/CluesTab.tsx
+++ b/apps/web/src/features/editor/components/CluesTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { LayoutList, GitBranch } from 'lucide-react';
 import { ClueListView } from './clues/ClueListView';
 import { ClueEdgeGraph } from './clues/ClueEdgeGraph';
@@ -9,6 +9,7 @@ import { ClueEdgeGraph } from './clues/ClueEdgeGraph';
 
 interface CluesTabProps {
   themeId: string;
+  routeSegment?: string;
 }
 
 type SubTab = 'list' | 'relations';
@@ -22,8 +23,16 @@ const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
 // CluesTab
 // ---------------------------------------------------------------------------
 
-export function CluesTab({ themeId }: CluesTabProps) {
-  const [activeSubTab, setActiveSubTab] = useState<SubTab>('list');
+function readInitialSubTab(routeSegment?: string): SubTab {
+  return routeSegment === 'relations' ? 'relations' : 'list';
+}
+
+export function CluesTab({ themeId, routeSegment }: CluesTabProps) {
+  const [activeSubTab, setActiveSubTab] = useState<SubTab>(() => readInitialSubTab(routeSegment));
+
+  useEffect(() => {
+    setActiveSubTab(readInitialSubTab(routeSegment));
+  }, [routeSegment]);
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/web/src/features/editor/components/DesignTab.tsx
+++ b/apps/web/src/features/editor/components/DesignTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Puzzle, GitBranch, MapPin } from 'lucide-react';
 import type { EditorThemeResponse } from '@/features/editor/api';
 import { ModulesSubTab } from './design/ModulesSubTab';
@@ -14,6 +14,7 @@ type SubTab = 'modules' | 'flow' | 'locations';
 interface DesignTabProps {
   themeId: string;
   theme: EditorThemeResponse;
+  routeSegment?: string;
 }
 
 const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
@@ -26,8 +27,18 @@ const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
 // DesignTab
 // ---------------------------------------------------------------------------
 
-export function DesignTab({ themeId, theme }: DesignTabProps) {
-  const [activeSubTab, setActiveSubTab] = useState<SubTab>('modules');
+function readInitialSubTab(routeSegment?: string): SubTab {
+  if (routeSegment === 'flow') return 'flow';
+  if (routeSegment === 'locations') return 'locations';
+  return 'modules';
+}
+
+export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
+  const [activeSubTab, setActiveSubTab] = useState<SubTab>(() => readInitialSubTab(routeSegment));
+
+  useEffect(() => {
+    setActiveSubTab(readInitialSubTab(routeSegment));
+  }, [routeSegment]);
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -26,6 +26,7 @@ interface EditorLayoutProps {
   onPublish?: () => void;
   onValidate?: () => DesignWarning[];
   validationWarnings?: DesignWarning[];
+  routeSegment?: string;
 }
 
 export function EditorLayout({
@@ -38,6 +39,7 @@ export function EditorLayout({
   onPublish,
   onValidate,
   validationWarnings: externalWarnings,
+  routeSegment,
 }: EditorLayoutProps) {
   const navigate = useNavigate();
   const { activeTab } = useEditorUI();
@@ -147,7 +149,12 @@ export function EditorLayout({
             </div>
           }
         >
-          <TabContent tab={activeTab} theme={theme} themeId={themeId} />
+          <TabContent
+            tab={activeTab}
+            theme={theme}
+            themeId={themeId}
+            routeSegment={routeSegment}
+          />
         </Suspense>
       </div>
     </div>

--- a/apps/web/src/features/editor/components/TabContent.tsx
+++ b/apps/web/src/features/editor/components/TabContent.tsx
@@ -39,9 +39,10 @@ interface TabContentProps {
   tab: EditorTab;
   theme: EditorThemeResponse;
   themeId: string;
+  routeSegment?: string;
 }
 
-export function TabContent({ tab, theme, themeId }: TabContentProps) {
+export function TabContent({ tab, theme, themeId, routeSegment }: TabContentProps) {
   switch (tab) {
     case "overview":
       return <OverviewTab theme={theme} themeId={themeId} />;
@@ -50,9 +51,9 @@ export function TabContent({ tab, theme, themeId }: TabContentProps) {
     case "characters":
       return <CharactersTab theme={theme} themeId={themeId} />;
     case "clues":
-      return <CluesTab themeId={themeId} />;
+      return <CluesTab themeId={themeId} routeSegment={routeSegment} />;
     case "design":
-      return <DesignTab theme={theme} themeId={themeId} />;
+      return <DesignTab theme={theme} themeId={themeId} routeSegment={routeSegment} />;
     case "media":
       return <MediaTab themeId={themeId} />;
     case "advanced":

--- a/apps/web/src/features/editor/components/ThemeEditor.tsx
+++ b/apps/web/src/features/editor/components/ThemeEditor.tsx
@@ -32,9 +32,10 @@ function FullPageError({ message }: { message: string }) {
 
 interface ThemeEditorProps {
   themeId: string;
+  routeSegment?: string;
 }
 
-export function ThemeEditor({ themeId }: ThemeEditorProps) {
+export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
   const { data: theme, isLoading, isError } = useEditorTheme(themeId);
   const { data: clues } = useEditorClues(themeId);
   const { data: clueEdgeGroups } = useClueEdges(themeId);
@@ -66,5 +67,12 @@ export function ThemeEditor({ themeId }: ThemeEditorProps) {
   if (isLoading) return <FullPageSpinner />;
   if (isError || !theme) return <FullPageError message="테마를 찾을 수 없습니다" />;
 
-  return <EditorLayout theme={theme} themeId={themeId} onValidate={handleValidate} />;
+  return (
+    <EditorLayout
+      theme={theme}
+      themeId={themeId}
+      routeSegment={routeSegment}
+      onValidate={handleValidate}
+    />
+  );
 }

--- a/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  useEditorThemeMock,
+  useEditorCluesMock,
+  useClueEdgesMock,
+  editorLayoutMock,
+} = vi.hoisted(() => ({
+  useEditorThemeMock: vi.fn(),
+  useEditorCluesMock: vi.fn(),
+  useClueEdgesMock: vi.fn(),
+  editorLayoutMock: vi.fn(),
+}));
+
+vi.mock('@/features/editor/api', () => ({
+  useEditorTheme: (themeId: string) => useEditorThemeMock(themeId),
+}));
+
+vi.mock('@/features/editor/editorClueApi', () => ({
+  useEditorClues: (themeId: string) => useEditorCluesMock(themeId),
+}));
+
+vi.mock('@/features/editor/clueEdgeApi', () => ({
+  useClueEdges: (themeId: string) => useClueEdgesMock(themeId),
+}));
+
+vi.mock('@/features/editor/validation', () => ({
+  validateGameDesign: () => ['game-warning'],
+  validateClueGraph: () => ['graph-warning'],
+}));
+
+vi.mock('../EditorLayout', () => ({
+  EditorLayout: (props: Record<string, unknown>) => {
+    editorLayoutMock(props);
+    return <div>EditorLayout {String(props.routeSegment)}</div>;
+  },
+}));
+
+import { ThemeEditor } from '../ThemeEditor';
+
+const theme = {
+  id: 'theme-1',
+  title: '테스트 테마',
+  slug: 'test-theme',
+  description: '',
+  cover_image: null,
+  min_players: 4,
+  max_players: 6,
+  duration_min: 90,
+  price: 0,
+  status: 'DRAFT',
+  config_json: { characters: [{ id: 'char-1' }] },
+  version: 1,
+  created_at: '2026-05-02T00:00:00Z',
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ThemeEditor', () => {
+  beforeEach(() => {
+    useEditorThemeMock.mockReturnValue({ data: theme, isLoading: false, isError: false });
+    useEditorCluesMock.mockReturnValue({ data: [{ id: 'clue-1', name: '단서 A' }] });
+    useClueEdgesMock.mockReturnValue({
+      data: [{ targetId: 'clue-1', mode: 'requires', sources: ['clue-2', 'clue-3'] }],
+    });
+  });
+
+  it('로딩 중이면 전체 화면 스피너를 표시한다', () => {
+    useEditorThemeMock.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+
+    const { container } = render(<ThemeEditor themeId="theme-1" />);
+
+    expect(container.querySelector('.animate-spin')).not.toBeNull();
+  });
+
+  it('테마 로드 실패 시 오류 메시지를 표시한다', () => {
+    useEditorThemeMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+
+    render(<ThemeEditor themeId="theme-1" />);
+
+    expect(screen.getByText('테마를 찾을 수 없습니다')).toBeDefined();
+  });
+
+  it('routeSegment를 EditorLayout으로 전달하고 검증 결과를 합친다', () => {
+    render(<ThemeEditor themeId="theme-1" routeSegment="modules" />);
+
+    expect(screen.getByText('EditorLayout modules')).toBeDefined();
+    const props = editorLayoutMock.mock.calls[0][0] as { onValidate: () => string[]; routeSegment: string };
+    expect(props.routeSegment).toBe('modules');
+    expect(props.onValidate()).toEqual(['game-warning', 'graph-warning']);
+  });
+});

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { User } from "lucide-react";
-import type { EditorThemeResponse } from "@/features/editor/api";
-import { useEditorCharacters, useEditorClues } from "@/features/editor/api";
+import type { EditorThemeResponse, MysteryRole } from "@/features/editor/api";
+import { useEditorCharacters, useEditorClues, useUpdateCharacter } from "@/features/editor/api";
 import { useCharacterConfigDebounce } from "@/features/editor/hooks/useCharacterConfigDebounce";
 import type { Mission } from "./MissionEditor";
 import { CharacterDetailPanel } from "./CharacterDetailPanel";
@@ -19,6 +19,7 @@ interface CharacterAssignPanelProps {
 export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelProps) {
   const { data: characters, isLoading: charsLoading } = useEditorCharacters(themeId);
   const { data: clues } = useEditorClues(themeId);
+  const updateCharacter = useUpdateCharacter(themeId);
   const [selectedCharId, setSelectedCharId] = useState<string | null>(null);
 
   const characterClues = useMemo(
@@ -100,6 +101,27 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
     [characterMissions, saveConfig, selectedCharId],
   );
 
+  const handleMysteryRoleChange = useCallback(
+    (role: MysteryRole) => {
+      if (!selectedCharId) return;
+      const selected = characters?.find((char) => char.id === selectedCharId);
+      if (!selected) return;
+
+      updateCharacter.mutate({
+        characterId: selected.id,
+        body: {
+          name: selected.name,
+          description: selected.description ?? undefined,
+          image_url: selected.image_url ?? undefined,
+          is_culprit: role === "culprit",
+          mystery_role: role,
+          sort_order: selected.sort_order,
+        },
+      });
+    },
+    [characters, selectedCharId, updateCharacter],
+  );
+
   if (charsLoading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -140,6 +162,7 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
 
       <div className="flex-1 overflow-y-auto px-6 py-4">
         <CharacterDetailPanel
+          themeId={themeId}
           selectedChar={selectedChar}
           characters={characters ?? []}
           clues={clues}
@@ -149,6 +172,7 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
           onAddMission={handleAddMission}
           onChangeMission={handleMissionChange}
           onDeleteMission={handleDeleteMission}
+          onMysteryRoleChange={handleMysteryRoleChange}
         />
       </div>
     </div>

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -1,7 +1,9 @@
 import { Accordion } from '@/shared/components/ui';
+import type { MysteryRole } from '@/features/editor/api';
 import type { Mission } from './MissionEditor';
 import { MissionEditor } from './MissionEditor';
 import { StartingClueAssigner } from './StartingClueAssigner';
+import { CharacterRoleSheetSection } from './CharacterRoleSheetSection';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,9 +20,14 @@ interface ClueItem {
 interface CharacterItem {
   id: string;
   name: string;
+  description?: string | null;
+  image_url?: string | null;
+  is_culprit?: boolean;
+  mystery_role?: MysteryRole;
 }
 
 interface CharacterDetailPanelProps {
+  themeId: string;
   selectedChar: CharacterItem | null;
   characters: CharacterItem[];
   clues: ClueItem[] | undefined;
@@ -30,6 +37,18 @@ interface CharacterDetailPanelProps {
   onAddMission: () => void;
   onChangeMission: (missionId: string, field: keyof Mission, value: string | number) => void;
   onDeleteMission: (missionId: string) => void;
+  onMysteryRoleChange?: (role: MysteryRole) => void;
+}
+
+const mysteryRoleOptions: Array<{ value: MysteryRole; label: string; description: string }> = [
+  { value: 'suspect', label: '용의자', description: '일반 투표 후보' },
+  { value: 'culprit', label: '범인', description: '정답 캐릭터' },
+  { value: 'accomplice', label: '공범', description: '범인을 돕는 캐릭터' },
+  { value: 'detective', label: '탐정', description: '투표 후보 포함 여부를 별도 설정' },
+];
+
+function getMysteryRoleLabel(role: MysteryRole) {
+  return mysteryRoleOptions.find((option) => option.value === role)?.label ?? '용의자';
 }
 
 // ---------------------------------------------------------------------------
@@ -37,6 +56,7 @@ interface CharacterDetailPanelProps {
 // ---------------------------------------------------------------------------
 
 export function CharacterDetailPanel({
+  themeId,
   selectedChar,
   characters,
   clues,
@@ -46,6 +66,7 @@ export function CharacterDetailPanel({
   onAddMission,
   onChangeMission,
   onDeleteMission,
+  onMysteryRoleChange,
 }: CharacterDetailPanelProps) {
   if (!selectedChar) {
     return (
@@ -55,13 +76,82 @@ export function CharacterDetailPanel({
     );
   }
 
+  const selectedRole: MysteryRole = selectedChar.mystery_role
+    ?? (selectedChar.is_culprit ? 'culprit' : 'suspect');
+
   return (
     <div className="max-w-5xl space-y-4">
-      <h3 className="text-sm font-semibold text-slate-200">{selectedChar.name}</h3>
+      <div>
+        <h3 className="text-sm font-semibold text-slate-200">{selectedChar.name}</h3>
+        <p className="mt-1 text-xs text-slate-500">시스템 ID: <span className="font-mono text-slate-400">{selectedChar.id}</span></p>
+      </div>
 
       <Accordion
         storageKey={`editor:character:${selectedChar.id}:sections`}
         items={[
+          {
+            id: 'base',
+            title: '베이스',
+            subtitle: `${getMysteryRoleLabel(selectedRole)} · 공개 소개`,
+            defaultOpen: true,
+            forceOpen: true,
+            children: (
+              <div className="grid gap-3 md:grid-cols-[10rem_1fr]">
+                <div className="flex h-36 items-center justify-center rounded-lg border border-dashed border-slate-800 bg-slate-950 text-xs text-slate-600">
+                  {selectedChar.image_url ? '사진 등록됨' : '사진 없음'}
+                </div>
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">이름</p>
+                    <p className="mt-1 text-sm text-slate-200">{selectedChar.name}</p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">역할</p>
+                    <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                      {mysteryRoleOptions.map((option) => {
+                        const active = selectedRole === option.value;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            disabled={!onMysteryRoleChange}
+                            onClick={() => onMysteryRoleChange?.(option.value)}
+                            className={`rounded-lg border px-3 py-2 text-left transition ${
+                              active
+                                ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
+                                : 'border-slate-800 bg-slate-950 text-slate-400 hover:border-slate-700'
+                            } disabled:cursor-default disabled:opacity-80`}
+                          >
+                            <span className="block text-xs font-semibold">{option.label}</span>
+                            <span className="mt-1 block text-[11px] leading-4 text-slate-500">{option.description}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">공개 소개</p>
+                    <p className="mt-1 whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs leading-5 text-slate-400">
+                      {selectedChar.description || '공개 소개가 없습니다.'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ),
+          },
+          {
+            id: 'role-sheet',
+            title: '역할지',
+            subtitle: '플레이어 비공개 Markdown',
+            defaultOpen: true,
+            children: (
+              <CharacterRoleSheetSection
+                themeId={themeId}
+                characterId={selectedChar.id}
+                characterName={selectedChar.name}
+              />
+            ),
+          },
           {
             id: 'starting-clue',
             title: '시작 단서',

--- a/apps/web/src/features/editor/components/design/CharacterList.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterList.tsx
@@ -1,9 +1,18 @@
 import { User } from "lucide-react";
+import type { MysteryRole } from "@/features/editor/api";
+
+const mysteryRoleLabels: Record<MysteryRole, string> = {
+  suspect: "용의자",
+  culprit: "범인",
+  accomplice: "공범",
+  detective: "탐정",
+};
 
 interface CharacterListItem {
   id: string;
   name: string;
   is_culprit?: boolean;
+  mystery_role?: MysteryRole;
 }
 
 interface CharacterListProps {
@@ -32,9 +41,9 @@ export function CharacterList({
         >
           <User className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">{char.name}</span>
-          {char.is_culprit && (
-            <span className="ml-auto shrink-0 text-[10px] text-red-400">
-              범인
+          {(char.mystery_role || char.is_culprit) && (
+            <span className="ml-auto shrink-0 text-[10px] text-amber-400">
+              {char.mystery_role ? mysteryRoleLabels[char.mystery_role] : "범인"}
             </span>
           )}
         </button>

--- a/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FileText, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/shared/components/ui/Button';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import { useEditorContent, useUpsertContent } from '@/features/editor/api';
+import { isApiHttpError } from '@/lib/api-error';
 
 interface CharacterRoleSheetSectionProps {
   themeId: string;
@@ -21,20 +22,43 @@ export function CharacterRoleSheetSection({
   characterName,
 }: CharacterRoleSheetSectionProps) {
   const contentKey = roleSheetContentKey(characterId);
-  const { data, isLoading } = useEditorContent(themeId, contentKey);
+  const {
+    data,
+    error,
+    isError,
+    isLoading,
+    refetch,
+  } = useEditorContent(themeId, contentKey);
   const upsertContent = useUpsertContent(themeId, contentKey);
   const [draft, setDraft] = useState('');
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'failed'>('idle');
+  const manualSaveRef = useRef(false);
+  const isMissingDocument = isApiHttpError(error) && error.status === 404;
+  const originalBody = isMissingDocument ? '' : (data?.body ?? '');
 
   useEffect(() => {
-    setDraft(data?.body ?? '');
-  }, [data?.body, characterId]);
+    if (!isError || isMissingDocument) setDraft(originalBody);
+    setSaveStatus('idle');
+  }, [characterId, isError, isMissingDocument, originalBody]);
 
-  function save() {
+  function save(nextBody = draft) {
+    if (upsertContent.isPending) return;
+    if (originalBody === nextBody) {
+      setSaveStatus('saved');
+      return;
+    }
+
     upsertContent.mutate(
-      { body: draft },
+      { body: nextBody },
       {
-        onSuccess: () => toast.success('역할지가 저장되었습니다'),
-        onError: () => toast.error('역할지 저장에 실패했습니다'),
+        onSuccess: () => {
+          setSaveStatus('saved');
+          toast.success('역할지가 저장되었습니다');
+        },
+        onError: () => {
+          setSaveStatus('failed');
+          toast.error('역할지 저장에 실패했습니다');
+        },
       },
     );
   }
@@ -44,6 +68,23 @@ export function CharacterRoleSheetSection({
       <div className="flex items-center justify-center py-8">
         <Spinner size="sm" />
       </div>
+    );
+  }
+
+  if (isError && !isMissingDocument) {
+    return (
+      <section
+        className="space-y-3 rounded-lg border border-rose-900/60 bg-rose-950/20 p-4"
+        aria-label={`${characterName} 역할지 오류`}
+      >
+        <p className="text-sm font-semibold text-rose-200">역할지를 불러오지 못했습니다.</p>
+        <p className="text-xs leading-5 text-rose-200/70">
+          네트워크 또는 서버 응답을 확인한 뒤 다시 시도해 주세요.
+        </p>
+        <Button size="sm" variant="secondary" onClick={() => void refetch()}>
+          다시 시도
+        </Button>
+      </section>
     );
   }
 
@@ -62,16 +103,52 @@ export function CharacterRoleSheetSection({
       <textarea
         aria-label="역할지 Markdown"
         value={draft}
-        onChange={(event) => setDraft(event.target.value)}
+        onChange={(event) => {
+          setDraft(event.target.value);
+          setSaveStatus('idle');
+        }}
         onBlur={() => {
-          if ((data?.body ?? '') !== draft) save();
+          if (manualSaveRef.current) return;
+          save(draft);
         }}
         placeholder={`## ${characterName}의 정체\n\n## 비밀\n\n## 동기\n\n## 알리바이`}
         className="min-h-64 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-xs leading-5 text-slate-200 placeholder:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
       />
 
-      <div className="flex justify-end">
-        <Button size="sm" onClick={save} disabled={upsertContent.isPending}>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p
+          className={`text-xs ${
+            saveStatus === 'failed'
+              ? 'text-rose-300'
+              : saveStatus === 'saved'
+                ? 'text-emerald-300'
+                : 'text-slate-500'
+          }`}
+        >
+          {saveStatus === 'failed'
+            ? '저장하지 못했습니다. 다시 시도해 주세요.'
+            : saveStatus === 'saved'
+              ? '저장되었습니다.'
+              : isMissingDocument
+                ? '아직 저장된 역할지가 없습니다.'
+                : '수정 후 포커스를 벗어나면 자동 저장됩니다.'}
+        </p>
+        <Button
+          size="sm"
+          onMouseDown={() => {
+            manualSaveRef.current = true;
+          }}
+          onClick={() => {
+            save(draft);
+            window.setTimeout(() => {
+              manualSaveRef.current = false;
+            }, 0);
+          }}
+          onBlur={() => {
+            manualSaveRef.current = false;
+          }}
+          disabled={upsertContent.isPending}
+        >
           <Save className="mr-1.5 h-3.5 w-3.5" />
           역할지 저장
         </Button>

--- a/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { FileText, Save } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/shared/components/ui/Button';
+import { Spinner } from '@/shared/components/ui/Spinner';
+import { useEditorContent, useUpsertContent } from '@/features/editor/api';
+
+interface CharacterRoleSheetSectionProps {
+  themeId: string;
+  characterId: string;
+  characterName: string;
+}
+
+export function roleSheetContentKey(characterId: string) {
+  return `role_sheet:${characterId}`;
+}
+
+export function CharacterRoleSheetSection({
+  themeId,
+  characterId,
+  characterName,
+}: CharacterRoleSheetSectionProps) {
+  const contentKey = roleSheetContentKey(characterId);
+  const { data, isLoading } = useEditorContent(themeId, contentKey);
+  const upsertContent = useUpsertContent(themeId, contentKey);
+  const [draft, setDraft] = useState('');
+
+  useEffect(() => {
+    setDraft(data?.body ?? '');
+  }, [data?.body, characterId]);
+
+  function save() {
+    upsertContent.mutate(
+      { body: draft },
+      {
+        onSuccess: () => toast.success('역할지가 저장되었습니다'),
+        onError: () => toast.error('역할지 저장에 실패했습니다'),
+      },
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-3" aria-label={`${characterName} 역할지`}>
+      <div className="flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-950/80 p-3">
+        <FileText className="mt-0.5 h-4 w-4 shrink-0 text-amber-500/80" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold text-slate-300">역할지 Markdown</p>
+          <p className="mt-1 text-xs leading-5 text-slate-500">
+            게임 시작 시 이 캐릭터를 맡은 플레이어에게만 보이는 비밀·동기·알리바이를 작성합니다.
+          </p>
+        </div>
+      </div>
+
+      <textarea
+        aria-label="역할지 Markdown"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => {
+          if ((data?.body ?? '') !== draft) save();
+        }}
+        placeholder={`## ${characterName}의 정체\n\n## 비밀\n\n## 동기\n\n## 알리바이`}
+        className="min-h-64 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-xs leading-5 text-slate-200 placeholder:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+      />
+
+      <div className="flex justify-end">
+        <Button size="sm" onClick={save} disabled={upsertContent.isPending}>
+          <Save className="mr-1.5 h-3.5 w-3.5" />
+          역할지 저장
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/EntityPageMockup.tsx
+++ b/apps/web/src/features/editor/components/design/EntityPageMockup.tsx
@@ -1,0 +1,262 @@
+import {
+  BookOpen,
+  Boxes,
+  ChevronRight,
+  FileText,
+  Fingerprint,
+  GitBranch,
+  KeyRound,
+  Link2,
+  MapPin,
+  Package,
+  Plus,
+  Search,
+  ShieldAlert,
+  Sparkles,
+  UserRound,
+} from 'lucide-react';
+
+const entityTabs = [
+  { icon: UserRound, label: '캐릭터', count: 5, active: true },
+  { icon: MapPin, label: '장소', count: 8 },
+  { icon: Package, label: '단서', count: 12 },
+];
+
+const characterRows = [
+  { id: 'char-1', name: '김철수', role: '상속자', active: true, status: '범인 후보' },
+  { id: 'char-2', name: '홍길동', role: '탐정', status: '시작 단서 1' },
+  { id: 'char-3', name: '이영희', role: '비서', status: '접근 제한 1' },
+];
+
+const clueRows = [
+  { code: 'c1', name: '피 묻은 칼', refs: ['김철수 시작 단서', '서재 장소 단서'], tone: 'active' },
+  { code: 'c2', name: '비밀 편지', refs: ['홍길동 시작 단서'], tone: 'active' },
+  { code: 'c3', name: '담배꽁초', refs: [], tone: 'unused' },
+];
+
+function EntityTypeTabs() {
+  return (
+    <nav aria-label="Entity type" className="grid gap-2 sm:grid-cols-3">
+      {entityTabs.map(({ icon: Icon, label, count, active }) => (
+        <button
+          key={label}
+          type="button"
+          className={`flex items-center gap-3 rounded-2xl border px-4 py-3 text-left transition ${
+            active
+              ? 'border-amber-500/30 bg-amber-500/10 text-amber-100'
+              : 'border-slate-800 bg-slate-950/70 text-slate-400 hover:border-slate-700 hover:text-slate-200'
+          }`}
+        >
+          <Icon className="h-4 w-4 shrink-0" />
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-semibold">{label}</span>
+            <span className="block text-xs text-slate-500">{count}개 entity</span>
+          </span>
+          {active && <ChevronRight className="hidden h-4 w-4 sm:block" />}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+function CharacterPicker() {
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-950/80 p-3">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-xs text-slate-500">
+          <Search className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">캐릭터 검색 또는 필터</span>
+        </div>
+        <button className="rounded-xl bg-amber-500/10 p-2 text-amber-300" type="button" aria-label="캐릭터 추가">
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="grid gap-2 md:grid-cols-3">
+        {characterRows.map((row) => (
+          <button
+            key={row.id}
+            type="button"
+            className={`rounded-xl border px-3 py-3 text-left transition ${
+              row.active
+                ? 'border-amber-500/30 bg-amber-500/10'
+                : 'border-slate-800 bg-slate-900/60 hover:border-slate-700'
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <UserRound className={row.active ? 'h-4 w-4 text-amber-300' : 'h-4 w-4 text-slate-500'} />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-slate-100">{row.name}</p>
+                <p className="text-xs text-slate-500">{row.role}</p>
+              </div>
+            </div>
+            <p className="mt-2 rounded-full bg-slate-950 px-2 py-1 text-[11px] text-slate-500">{row.status}</p>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ModuleToggleStrip() {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-2 flex items-center gap-2 text-xs font-semibold text-slate-300">
+        <Boxes className="h-4 w-4 text-amber-400" />
+        캐릭터 적용 모듈
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {['starting_clue', 'hidden_mission'].map((id) => (
+          <button
+            key={id}
+            type="button"
+            className="rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-200"
+          >
+            켜짐 · {id}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CharacterDetail() {
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-[radial-gradient(circle_at_top_right,rgba(245,158,11,0.12),transparent_30%),linear-gradient(180deg,rgba(15,23,42,0.96),rgba(2,6,23,0.96))] p-4 sm:p-5">
+      <div className="mb-4 space-y-3 sm:flex sm:items-start sm:justify-between sm:gap-3 sm:space-y-0">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-amber-400/80">Character entity</p>
+          <h2 className="mt-1 text-xl font-bold text-slate-100">김철수</h2>
+          <p className="mt-1 text-sm text-slate-500">모바일에서는 위에서 아래로: 선택 → 베이스 → 모듈 → 참조 순서로 읽습니다.</p>
+        </div>
+        <div className="inline-flex rounded-full border border-slate-700 px-3 py-1 text-xs text-slate-400">시스템 ID · char-1</div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-200">
+            <Fingerprint className="h-4 w-4 text-amber-400" />
+            베이스
+          </div>
+          <div className="grid gap-3 sm:grid-cols-[8rem_1fr]">
+            <div className="flex h-28 items-center justify-center rounded-xl border border-dashed border-slate-700 bg-slate-950 text-xs text-slate-600">사진</div>
+            <div className="space-y-2 text-sm">
+              <p className="text-slate-200">김철수 <span className="ml-2 rounded bg-red-500/10 px-2 py-0.5 text-xs text-red-300">범인 후보</span></p>
+              <p className="rounded-xl bg-slate-950 p-3 text-xs leading-5 text-slate-400">
+                오래된 저택의 상속자. 모두에게 친절하지만 사건 당일 행적이 불분명하다.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <ModuleToggleStrip />
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-200">
+              <BookOpen className="h-4 w-4 text-amber-400" />
+              역할지 Markdown
+            </div>
+            <pre className="min-h-36 whitespace-pre-wrap rounded-xl bg-slate-950 p-3 text-xs leading-5 text-slate-400">## 당신의 비밀{`\n`}사건 전날, 당신은 서재에서 피해자와 다퉜다.</pre>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-200">
+              <KeyRound className="h-4 w-4 text-amber-400" />
+              starting_clue
+            </div>
+            <div className="space-y-2 text-xs text-slate-400">
+              <div className="rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-amber-200">피 묻은 칼</div>
+              <div className="rounded-xl border border-slate-800 bg-slate-950 px-3 py-2">+ 단서 entity 목록에서 클릭 추가</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ReferencePanels() {
+  return (
+    <section className="grid gap-3 lg:grid-cols-3">
+      <InfoCard icon={GitBranch} title="참조 상태">
+        <p>시작 단서: 피 묻은 칼</p>
+        <p>장소 접근 제한: 서재 차단</p>
+        <p>미션: 비밀 편지를 보유하세요</p>
+      </InfoCard>
+      <InfoCard icon={MapPin} title="장소 tree-ready">
+        <p>별장</p>
+        <p className="pl-3">└ 1층</p>
+        <p className="pl-6 text-amber-200">└ 서재</p>
+        <p className="pl-6">└ 부엌</p>
+      </InfoCard>
+      <InfoCard icon={Package} title="단서 backlink">
+        {clueRows.map((row) => (
+          <div key={row.code} className="border-b border-slate-800 py-2 last:border-b-0 first:pt-0 last:pb-0">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-slate-600">{row.code}</span>
+              <span className="flex-1 text-slate-200">{row.name}</span>
+              <span className={row.tone === 'unused' ? 'text-slate-600' : 'text-amber-300'}>
+                {row.refs.length || '미사용'}
+              </span>
+            </div>
+            {row.refs.length > 0 && <p className="mt-1 text-slate-500">{row.refs.join(' · ')}</p>}
+          </div>
+        ))}
+      </InfoCard>
+    </section>
+  );
+}
+
+function InfoCard({ icon: Icon, title, children }: { icon: typeof GitBranch; title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/80 p-4 text-xs leading-6 text-slate-400">
+      <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-slate-200">
+        <Icon className="h-4 w-4 text-amber-400" />
+        {title}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function StatusBar() {
+  return (
+    <div className="grid gap-3 text-xs text-slate-400 md:grid-cols-3">
+      <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
+        <ShieldAlert className="mr-1 inline h-3.5 w-3.5 text-red-300" />
+        장소 접근 제한은 기존 CSV API와 호환
+      </div>
+      <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
+        <FileText className="mr-1 inline h-3.5 w-3.5 text-amber-300" />
+        역할지/발견 컨텐츠는 content key로 저장
+      </div>
+      <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
+        <Link2 className="mr-1 inline h-3.5 w-3.5 text-amber-300" />
+        단서 사용처는 config에서 자동 계산
+      </div>
+    </div>
+  );
+}
+
+export function EntityPageMockup() {
+  return (
+    <section className="space-y-4 rounded-3xl border border-slate-800 bg-slate-900/50 p-4 shadow-2xl shadow-slate-950/40 sm:p-5">
+      <div className="space-y-3 border-b border-slate-800 pb-4 sm:flex sm:items-center sm:justify-between sm:gap-3 sm:space-y-0">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-400/80">
+          <Sparkles className="h-4 w-4" />
+          Phase 24 PR-3 entity workspace
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+          <span className="rounded-full border border-slate-800 px-3 py-1">모바일 우선 세로 흐름</span>
+          <span className="rounded-full border border-slate-800 px-3 py-1">저장 shape: canonical config</span>
+        </div>
+      </div>
+
+      <EntityTypeTabs />
+      <CharacterPicker />
+      <CharacterDetail />
+      <ReferencePanels />
+      <StatusBar />
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ApiHttpError } from '@/lib/api-error';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -185,6 +186,80 @@ describe('CharacterAssignPanel', () => {
     expect(useUpsertContentMock).toHaveBeenCalledWith('theme-1', 'role_sheet:char-1');
     expect(upsertContentMutateMock).toHaveBeenCalledWith(
       { body: '## 비밀\n범인은 아직 모른다.' },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+
+  it('저장된 역할지가 없으면 빈 Markdown 초안으로 시작한다', () => {
+    useEditorContentMock.mockReturnValue({
+      data: undefined,
+      error: new ApiHttpError({
+        type: 'about:blank',
+        title: 'Not Found',
+        status: 404,
+        detail: 'role sheet not found',
+      }),
+      isError: true,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    renderPanel();
+    fireEvent.click(screen.getByText('홍길동'));
+
+    expect(screen.getByText('아직 저장된 역할지가 없습니다.')).toBeDefined();
+    expect((screen.getByRole('textbox', { name: '역할지 Markdown' }) as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('역할지 로드 실패 시 재시도 버튼을 표시한다', () => {
+    const refetch = vi.fn();
+    useEditorContentMock.mockReturnValue({
+      data: undefined,
+      error: new ApiHttpError({
+        type: 'about:blank',
+        title: 'Server Error',
+        status: 500,
+        detail: 'server error',
+      }),
+      isError: true,
+      isLoading: false,
+      refetch,
+    });
+
+    renderPanel();
+    fireEvent.click(screen.getByText('홍길동'));
+    fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+
+    expect(screen.getByText('역할지를 불러오지 못했습니다.')).toBeDefined();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('역할지 본문이 바뀌지 않았으면 저장 요청을 보내지 않는다', () => {
+    useEditorContentMock.mockReturnValue({ data: { body: '기존 역할지' }, isLoading: false });
+
+    renderPanel();
+    fireEvent.click(screen.getByText('홍길동'));
+    fireEvent.click(screen.getByRole('button', { name: '역할지 저장' }));
+
+    expect(upsertContentMutateMock).not.toHaveBeenCalled();
+    expect(screen.getByText('저장되었습니다.')).toBeDefined();
+  });
+
+  it('역할지 저장 버튼 클릭 시 blur 자동 저장과 중복 호출하지 않는다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByText('홍길동'));
+
+    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' });
+    const saveButton = screen.getByRole('button', { name: '역할지 저장' });
+    fireEvent.change(roleSheet, { target: { value: '수정된 역할지' } });
+    fireEvent.mouseDown(saveButton);
+    fireEvent.blur(roleSheet);
+    fireEvent.click(saveButton);
+
+    expect(upsertContentMutateMock).toHaveBeenCalledTimes(1);
+    expect(upsertContentMutateMock).toHaveBeenCalledWith(
+      { body: '수정된 역할지' },
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
     );
   });

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -11,11 +11,19 @@ const {
   useEditorCharactersMock,
   useEditorCluesMock,
   useUpdateConfigJsonMock,
+  useEditorContentMock,
+  useUpsertContentMock,
+  upsertContentMutateMock,
+  updateCharacterMutateMock,
 } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
   useEditorCharactersMock: vi.fn(),
   useEditorCluesMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
+  useEditorContentMock: vi.fn(),
+  useUpsertContentMock: vi.fn(),
+  upsertContentMutateMock: vi.fn(),
+  updateCharacterMutateMock: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -34,6 +42,9 @@ vi.mock('@/features/editor/api', () => ({
   useEditorCharacters: () => useEditorCharactersMock(),
   useEditorClues: () => useEditorCluesMock(),
   useUpdateConfigJson: () => useUpdateConfigJsonMock(),
+  useEditorContent: (themeId: string, key: string) => useEditorContentMock(themeId, key),
+  useUpsertContent: (themeId: string, key: string) => useUpsertContentMock(themeId, key),
+  useUpdateCharacter: () => ({ mutate: updateCharacterMutateMock, isPending: false }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -47,8 +58,8 @@ import { CharacterAssignPanel } from '../../design/CharacterAssignPanel';
 // ---------------------------------------------------------------------------
 
 const mockCharacters = [
-  { id: 'char-1', name: '홍길동', is_culprit: true },
-  { id: 'char-2', name: '김철수', is_culprit: false },
+  { id: 'char-1', name: '홍길동', description: null, image_url: null, is_culprit: true, mystery_role: 'culprit' as const, sort_order: 0 },
+  { id: 'char-2', name: '김철수', description: null, image_url: null, is_culprit: false, mystery_role: 'suspect' as const, sort_order: 1 },
 ];
 
 const mockClues = [
@@ -119,6 +130,8 @@ describe('CharacterAssignPanel', () => {
     useEditorCharactersMock.mockReturnValue({ data: mockCharacters, isLoading: false });
     useEditorCluesMock.mockReturnValue({ data: mockClues, isLoading: false });
     useUpdateConfigJsonMock.mockReturnValue({ mutate: mutateMock, isPending: false });
+    useEditorContentMock.mockReturnValue({ data: { body: '' }, isLoading: false });
+    useUpsertContentMock.mockReturnValue({ mutate: upsertContentMutateMock, isPending: false });
   });
 
   it('캐릭터 목록을 렌더링한다', () => {
@@ -132,6 +145,24 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByText('범인')).toBeDefined();
   });
 
+  it('캐릭터 역할을 공범으로 변경한다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByText('홍길동'));
+    fireEvent.click(screen.getByRole('button', { name: /공범/ }));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      body: {
+        name: '홍길동',
+        description: undefined,
+        image_url: undefined,
+        is_culprit: false,
+        mystery_role: 'accomplice',
+        sort_order: 0,
+      },
+    });
+  });
+
   it('캐릭터 선택 시 좌측 전체 단서와 우측 배정 영역이 표시된다', () => {
     renderPanel();
     fireEvent.click(screen.getByText('홍길동'));
@@ -139,6 +170,23 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByText('홍길동의 시작 단서')).toBeDefined();
     expect(screen.getByText('피 묻은 칼')).toBeDefined();
     expect(screen.getByText('비밀 편지')).toBeDefined();
+  });
+
+
+  it('역할지 Markdown을 content API key로 저장한다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByText('홍길동'));
+
+    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' });
+    fireEvent.change(roleSheet, { target: { value: '## 비밀\n범인은 아직 모른다.' } });
+    fireEvent.click(screen.getByRole('button', { name: '역할지 저장' }));
+
+    expect(useEditorContentMock).toHaveBeenCalledWith('theme-1', 'role_sheet:char-1');
+    expect(useUpsertContentMock).toHaveBeenCalledWith('theme-1', 'role_sheet:char-1');
+    expect(upsertContentMutateMock).toHaveBeenCalledWith(
+      { body: '## 비밀\n범인은 아직 모른다.' },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
   });
 
   it('좌측 단서 목록을 장소/태그로 검색할 수 있다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -246,7 +246,7 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByText('저장되었습니다.')).toBeDefined();
   });
 
-  it('역할지 저장 버튼 클릭 시 blur 자동 저장과 중복 호출하지 않는다', () => {
+  it('역할지 저장 버튼 클릭 시 blur 자동 저장과 중복 호출하지 않는다', async () => {
     renderPanel();
     fireEvent.click(screen.getByText('홍길동'));
 
@@ -257,6 +257,8 @@ describe('CharacterAssignPanel', () => {
     fireEvent.blur(roleSheet);
     fireEvent.click(saveButton);
 
+    expect(upsertContentMutateMock).toHaveBeenCalledTimes(1);
+    await act(async () => { vi.advanceTimersByTime(1500); });
     expect(upsertContentMutateMock).toHaveBeenCalledTimes(1);
     expect(upsertContentMutateMock).toHaveBeenCalledWith(
       { body: '수정된 역할지' },

--- a/apps/web/src/features/editor/utils/__tests__/entityMeta.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/entityMeta.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatRestrictedCharacterIds,
+  parseRestrictedCharacterIds,
+  readLocationMeta,
+  writeLocationMeta,
+} from '../entityMeta';
+
+describe('entityMeta', () => {
+  it('reads and writes location meta without legacy config keys', () => {
+    const next = writeLocationMeta(
+      { clue_placement: { old: 'loc-1' }, locationMeta: { 'loc-1': { entryMessage: 'old' } } },
+      'loc-1',
+      { parentLocationId: 'parent-1', entryMessage: '문이 삐걱인다.', imageUrl: 'study.jpg' },
+    );
+
+    expect(next).not.toHaveProperty('clue_placement');
+    expect(readLocationMeta(next, 'loc-1')).toEqual({
+      parentLocationId: 'parent-1',
+      entryMessage: '문이 삐걱인다.',
+      imageUrl: 'study.jpg',
+    });
+  });
+
+  it('does not allow a location to be its own parent', () => {
+    const next = writeLocationMeta({}, 'loc-1', { parentLocationId: 'loc-1' });
+
+    expect(readLocationMeta(next, 'loc-1')).not.toHaveProperty('parentLocationId');
+  });
+
+  it('parses and formats restricted character CSV values', () => {
+    expect(parseRestrictedCharacterIds(' char-1, char-2,,char-1 ')).toEqual([
+      'char-1',
+      'char-2',
+      'char-1',
+    ]);
+    expect(formatRestrictedCharacterIds(['char-1', 'char-2', 'char-1', ''])).toBe('char-1,char-2');
+    expect(formatRestrictedCharacterIds([])).toBeNull();
+  });
+});

--- a/apps/web/src/features/editor/utils/__tests__/entityReferences.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/entityReferences.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { ClueResponse, EditorCharacterResponse, LocationResponse } from '@/features/editor/api';
+import { buildClueUsageMap, getClueBacklinks } from '../entityReferences';
+
+const clues = [
+  { id: 'clue-1', name: '일기장' },
+  { id: 'clue-2', name: '피 묻은 칼' },
+  { id: 'clue-3', name: '담배꽁초' },
+] as ClueResponse[];
+
+const locations = [
+  { id: 'loc-1', name: '서재' },
+  { id: 'loc-2', name: '부엌' },
+] as LocationResponse[];
+
+const characters = [
+  { id: 'char-1', name: '김철수' },
+] as EditorCharacterResponse[];
+
+describe('entityReferences', () => {
+  it('builds clue backlinks from location clue, evidence, and starting clue references', () => {
+    const usage = buildClueUsageMap({
+      clues,
+      locations,
+      characters,
+      configJson: {
+        locations: [
+          {
+            id: 'loc-1',
+            locationClueConfig: { clueIds: ['clue-1'] },
+            evidenceConfig: { clueIds: ['clue-2'] },
+          },
+        ],
+        modules: {
+          starting_clue: {
+            enabled: true,
+            config: { startingClues: { 'char-1': ['clue-1'] } },
+          },
+        },
+      },
+    });
+
+    expect(getClueBacklinks(usage, 'clue-1')).toEqual([
+      { sourceType: 'location', sourceId: 'loc-1', sourceName: '서재', relation: 'location_clue' },
+      { sourceType: 'character', sourceId: 'char-1', sourceName: '김철수', relation: 'starting_clue' },
+    ]);
+    expect(getClueBacklinks(usage, 'clue-2')).toEqual([
+      { sourceType: 'location', sourceId: 'loc-1', sourceName: '서재', relation: 'evidence' },
+    ]);
+    expect(usage['clue-3'].isUnused).toBe(true);
+  });
+
+  it('ignores references to deleted clues', () => {
+    const usage = buildClueUsageMap({
+      clues,
+      locations,
+      characters,
+      configJson: {
+        locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['missing-clue'] } }],
+        modules: {
+          starting_clue: {
+            enabled: true,
+            config: { startingClues: { 'char-1': ['missing-clue'] } },
+          },
+        },
+      },
+    });
+
+    expect(Object.values(usage).every((summary) => summary.references.length === 0)).toBe(true);
+  });
+});

--- a/apps/web/src/features/editor/utils/entityMeta.ts
+++ b/apps/web/src/features/editor/utils/entityMeta.ts
@@ -1,0 +1,64 @@
+import { normalizeConfigForSave, type EditorConfig } from './configShape';
+
+export interface LocationMeta extends Record<string, unknown> {
+  parentLocationId?: string | null;
+  entryMessage?: string;
+  imageUrl?: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readLocationMetaMap(
+  configJson: EditorConfig | null | undefined,
+): Record<string, LocationMeta> {
+  const raw = configJson?.locationMeta;
+  if (!isRecord(raw)) return {};
+  return Object.fromEntries(
+    Object.entries(raw).filter((entry): entry is [string, LocationMeta] => isRecord(entry[1])),
+  );
+}
+
+export function readLocationMeta(
+  configJson: EditorConfig | null | undefined,
+  locationId: string,
+): LocationMeta {
+  return { ...(readLocationMetaMap(configJson)[locationId] ?? {}) };
+}
+
+export function writeLocationMeta(
+  configJson: EditorConfig | null | undefined,
+  locationId: string,
+  patch: LocationMeta,
+): EditorConfig {
+  const next = normalizeConfigForSave(configJson);
+  const map = readLocationMetaMap(next);
+  const current = map[locationId] ?? {};
+  const merged: LocationMeta = { ...current, ...patch };
+
+  if (merged.parentLocationId === locationId) {
+    delete merged.parentLocationId;
+  }
+
+  return {
+    ...next,
+    locationMeta: {
+      ...map,
+      [locationId]: merged,
+    },
+  };
+}
+
+export function parseRestrictedCharacterIds(value: string | null | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function formatRestrictedCharacterIds(ids: string[]): string | null {
+  const unique = Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean)));
+  return unique.length > 0 ? unique.join(',') : null;
+}

--- a/apps/web/src/features/editor/utils/entityReferences.ts
+++ b/apps/web/src/features/editor/utils/entityReferences.ts
@@ -1,0 +1,116 @@
+import type {
+  ClueResponse,
+  EditorCharacterResponse,
+  LocationResponse,
+} from '@/features/editor/api';
+import {
+  readCharacterStartingClueMap,
+  readLocationsConfig,
+  readLocationClueIds,
+  type EditorConfig,
+} from './configShape';
+
+export type EntityReferenceSource = 'location' | 'character' | 'clue' | 'question';
+export type EntityReferenceRelation =
+  | 'evidence'
+  | 'location_clue'
+  | 'starting_clue'
+  | 'combination_input'
+  | 'combination_output'
+  | 'question_choice';
+
+export interface EntityReference {
+  sourceType: EntityReferenceSource;
+  sourceId: string;
+  sourceName: string;
+  relation: EntityReferenceRelation;
+}
+
+export interface ClueUsageSummary {
+  clueId: string;
+  references: EntityReference[];
+  isUnused: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function pushUnique(target: EntityReference[], ref: EntityReference) {
+  const key = `${ref.sourceType}:${ref.sourceId}:${ref.relation}`;
+  if (!target.some((item) => `${item.sourceType}:${item.sourceId}:${item.relation}` === key)) {
+    target.push(ref);
+  }
+}
+
+function readEvidenceClueIds(locationConfig: Record<string, unknown>): string[] {
+  const evidence = locationConfig.evidenceConfig;
+  return isRecord(evidence) ? stringList(evidence.clueIds) : [];
+}
+
+export function buildClueUsageMap(params: {
+  configJson: EditorConfig | null | undefined;
+  clues: ClueResponse[];
+  locations: LocationResponse[];
+  characters: EditorCharacterResponse[];
+}): Record<string, ClueUsageSummary> {
+  const { configJson, clues, locations, characters } = params;
+  const clueIds = new Set(clues.map((clue) => clue.id));
+  const locationNames = new Map(locations.map((location) => [location.id, location.name]));
+  const characterNames = new Map(characters.map((character) => [character.id, character.name]));
+  const usage = Object.fromEntries(
+    clues.map((clue) => [clue.id, { clueId: clue.id, references: [], isUnused: true }]),
+  ) as Record<string, ClueUsageSummary>;
+
+  for (const location of readLocationsConfig(configJson)) {
+    const sourceName = locationNames.get(location.id) ?? location.name ?? location.id;
+    for (const clueId of readLocationClueIds(configJson, location.id)) {
+      if (!clueIds.has(clueId)) continue;
+      pushUnique(usage[clueId].references, {
+        sourceType: 'location',
+        sourceId: location.id,
+        sourceName,
+        relation: 'location_clue',
+      });
+    }
+    for (const clueId of readEvidenceClueIds(location)) {
+      if (!clueIds.has(clueId)) continue;
+      pushUnique(usage[clueId].references, {
+        sourceType: 'location',
+        sourceId: location.id,
+        sourceName,
+        relation: 'evidence',
+      });
+    }
+  }
+
+  for (const [characterId, assignedClueIds] of Object.entries(readCharacterStartingClueMap(configJson))) {
+    const sourceName = characterNames.get(characterId) ?? characterId;
+    for (const clueId of assignedClueIds) {
+      if (!clueIds.has(clueId)) continue;
+      pushUnique(usage[clueId].references, {
+        sourceType: 'character',
+        sourceId: characterId,
+        sourceName,
+        relation: 'starting_clue',
+      });
+    }
+  }
+
+  for (const summary of Object.values(usage)) {
+    summary.isUnused = summary.references.length === 0;
+  }
+
+  return usage;
+}
+
+export function getClueBacklinks(
+  usageMap: Record<string, ClueUsageSummary>,
+  clueId: string,
+): EntityReference[] {
+  return usageMap[clueId]?.references ?? [];
+}

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -21,9 +21,8 @@ export default function EditorPage() {
   const setActiveTab = useEditorUI((state) => state.setActiveTab);
 
   useEffect(() => {
-    if (!tab) return;
-    const nextTab = TAB_SEGMENT_MAP[tab];
-    if (nextTab) setActiveTab(nextTab);
+    const nextTab = tab ? TAB_SEGMENT_MAP[tab] : undefined;
+    setActiveTab(nextTab ?? "overview");
   }, [setActiveTab, tab]);
 
   if (id) {

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -1,12 +1,33 @@
+import { useEffect } from "react";
 import { useParams } from "react-router";
 import { EditorDashboard } from "@/features/editor/components";
 import { ThemeEditor } from "@/features/editor/components";
+import type { EditorTab } from "@/features/editor/constants";
+import { useEditorUI } from "@/features/editor/stores/editorUIStore";
+
+const TAB_SEGMENT_MAP: Record<string, EditorTab> = {
+  characters: "characters",
+  clues: "clues",
+  relations: "clues",
+  modules: "design",
+  flow: "design",
+  locations: "design",
+  templates: "template",
+  template: "template",
+};
 
 export default function EditorPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id, tab } = useParams<{ id: string; tab?: string }>();
+  const setActiveTab = useEditorUI((state) => state.setActiveTab);
+
+  useEffect(() => {
+    if (!tab) return;
+    const nextTab = TAB_SEGMENT_MAP[tab];
+    if (nextTab) setActiveTab(nextTab);
+  }, [setActiveTab, tab]);
 
   if (id) {
-    return <ThemeEditor themeId={id} />;
+    return <ThemeEditor themeId={id} routeSegment={tab} />;
   }
 
   return <EditorDashboard />;

--- a/apps/web/src/pages/Phase24EditorPreviewPage.test.tsx
+++ b/apps/web/src/pages/Phase24EditorPreviewPage.test.tsx
@@ -1,28 +1,34 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Phase24EditorPreviewPage from './Phase24EditorPreviewPage';
+
+function renderPreview() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Phase24EditorPreviewPage />
+    </QueryClientProvider>,
+  );
+}
 
 afterEach(() => {
   cleanup();
 });
 
 describe('Phase24EditorPreviewPage', () => {
-  it('Phase 24 에디터 preview를 렌더링하고 split assigner 변경을 JSON에 반영한다', () => {
-    render(<Phase24EditorPreviewPage />);
+  it('Phase 24 entity page mockup만 렌더링한다', () => {
+    renderPreview();
 
-    expect(screen.getByRole('heading', { name: /에디터 작업 미리보기/ })).toBeDefined();
+    expect(screen.getByRole('heading', { name: /에디터 Entity Page Preview/ })).toBeDefined();
     expect(screen.getByText('DEV ONLY')).toBeDefined();
-    expect(screen.getAllByText('전체 단서 목록').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('홍길동의 시작 단서').length).toBeGreaterThan(0);
-
-    const splitSection = screen.getByText('추천 구조 — split clue assigner').closest('section');
-    expect(splitSection).not.toBeNull();
-
-    fireEvent.change(within(splitSection as HTMLElement).getByRole('textbox', { name: '단서 검색' }), {
-      target: { value: '녹음' },
-    });
-    fireEvent.click(within(splitSection as HTMLElement).getByRole('button', { name: /녹음 파일/ }));
-
-    expect(screen.getByText(/"clue-5"/)).toBeDefined();
+    expect(screen.getByText('Phase 24 PR-3 entity workspace')).toBeDefined();
+    expect(screen.getByRole('button', { name: /캐릭터5/ })).toBeDefined();
+    expect(screen.getByRole('button', { name: /김철수 상속자 범인 후보/ })).toBeDefined();
+    expect(screen.getByText('참조 상태')).toBeDefined();
+    expect(screen.getByText('단서 backlink')).toBeDefined();
+    expect(screen.queryByText('PR-2 추천 구조 — split clue assigner')).toBeNull();
   });
 });

--- a/apps/web/src/pages/Phase24EditorPreviewPage.tsx
+++ b/apps/web/src/pages/Phase24EditorPreviewPage.tsx
@@ -1,199 +1,25 @@
-import { useMemo, useState, type ReactNode } from 'react';
-import { GitBranch, Puzzle, UserRound } from 'lucide-react';
-import { Accordion, Badge } from '@/shared/components/ui';
-import { CharacterDetailPanel } from '@/features/editor/components/design/CharacterDetailPanel';
-import type { Mission } from '@/features/editor/components/design/MissionEditor';
-import { StartingClueAssigner } from '@/features/editor/components/design/StartingClueAssigner';
-import {
-  readCharacterStartingClueMap,
-  readCluePlacement,
-  writeCharacterStartingClueMap,
-  writeCluePlacement,
-  writeModuleEnabled,
-} from '@/features/editor/utils/configShape';
-
-const characters = [
-  { id: 'char-1', name: '홍길동' },
-  { id: 'char-2', name: '김철수' },
-];
-
-const clues = [
-  { id: 'clue-1', name: '피 묻은 칼', location: '서재', round: 1, tag: '물증' },
-  { id: 'clue-2', name: '비밀 편지', location: '부엌', round: 1, tag: '문서' },
-  { id: 'clue-3', name: '찢어진 초대장', location: '현관', round: 2, tag: '문서' },
-  { id: 'clue-4', name: '깨진 시계', location: '거실', round: 2, tag: '물증' },
-  { id: 'clue-5', name: '녹음 파일', location: '서재', round: 3, tag: '미디어' },
-  { id: 'clue-6', name: '검은 장갑', location: '창고', round: 3, tag: '물증' },
-];
-
-const initialConfig = writeCluePlacement(
-  writeCharacterStartingClueMap(
-    writeModuleEnabled({ modules: ['starting_clue'] }, 'hidden_mission', true),
-    { 'char-1': ['clue-1'] },
-  ),
-  { 'clue-1': 'library', 'clue-2': 'kitchen' },
-);
-
-function PreviewCard({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <section className="rounded-xl border border-slate-800 bg-slate-900/80 p-4 shadow-2xl shadow-slate-950/30">
-      <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-amber-400/80">
-        {title}
-      </h2>
-      {children}
-    </section>
-  );
-}
-
-function createMissionId(existingIds: Set<string>) {
-  let id = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-    ? crypto.randomUUID()
-    : `mission-${Date.now()}`;
-  let suffix = 1;
-  while (existingIds.has(id)) {
-    id = `mission-${Date.now()}-${suffix}`;
-    suffix += 1;
-  }
-  return id;
-}
+import { Badge } from '@/shared/components/ui';
+import { EntityPageMockup } from '@/features/editor/components/design/EntityPageMockup';
 
 export default function Phase24EditorPreviewPage() {
-  const [config, setConfig] = useState(initialConfig);
-  const [missions, setMissions] = useState<Mission[]>([
-    {
-      id: 'mission-1',
-      type: 'possess',
-      description: '비밀 편지를 마지막까지 보유하세요',
-      points: 10,
-      targetClueId: 'clue-2',
-    },
-  ]);
-
-  const startingClues = useMemo(() => readCharacterStartingClueMap(config), [config]);
-  const cluePlacement = useMemo(() => readCluePlacement(config), [config]);
-  const charOneClueIds = startingClues['char-1'] ?? [];
-
-  function updateCharOneClues(next: string[]) {
-    setConfig(writeCharacterStartingClueMap(config, { ...startingClues, 'char-1': next }));
-  }
-
-  function toggleStartingClue(clueId: string, checked: boolean) {
-    const next = checked
-      ? Array.from(new Set([...charOneClueIds, clueId]))
-      : charOneClueIds.filter((id) => id !== clueId);
-    updateCharOneClues(next);
-  }
-
-  function addMission() {
-    setMissions((prev) => [
-      ...prev,
-      {
-        id: createMissionId(new Set(prev.map((mission) => mission.id))),
-        type: 'kill',
-        description: '',
-        points: 10,
-      },
-    ]);
-  }
-
-  function changeMission(missionId: string, field: keyof Mission, value: string | number) {
-    setMissions((prev) =>
-      prev.map((mission) =>
-        mission.id === missionId ? { ...mission, [field]: value } : mission,
-      ),
-    );
-  }
-
-  function deleteMission(missionId: string) {
-    setMissions((prev) => prev.filter((mission) => mission.id !== missionId));
-  }
-
   return (
-    <main className="min-h-screen bg-slate-950 px-6 py-8 text-slate-100">
-      <div className="mx-auto max-w-6xl space-y-6">
-        <header className="rounded-2xl border border-amber-500/20 bg-gradient-to-br from-slate-900 via-slate-900 to-amber-950/20 p-6">
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto max-w-5xl px-6 py-6">
+        <header className="mb-4 rounded-2xl border border-amber-500/20 bg-gradient-to-br from-slate-900 via-slate-900 to-amber-950/20 p-5">
           <div className="mb-3 flex flex-wrap items-center gap-2">
             <Badge variant="warning">DEV ONLY</Badge>
-            <Badge variant="default">Phase 24 PR-2</Badge>
+            <Badge variant="default">Phase 24 PR-3</Badge>
           </div>
           <h1 className="text-2xl font-bold tracking-tight text-slate-100">
-            에디터 작업 미리보기 — split 단서 배정 제안
+            에디터 Entity Page Preview
           </h1>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
-            좌측에서 전체 단서를 검색·탐색하고, 클릭하면 우측 캐릭터 시작 단서에 추가됩니다.
-            오른쪽 JSON은 canonical config shape를 즉시 반영합니다.
+            이전 PR-2 비교 UI는 제거하고, 실제 에디터의 캐릭터·장소·단서 entity 화면처럼
+            한 화면에서 탐색·목록·상세·참조 정보를 확인하는 목업만 표시합니다.
           </p>
         </header>
 
-        <PreviewCard title="추천 구조 — split clue assigner">
-          <StartingClueAssigner
-            characterName={characters[0].name}
-            clues={clues}
-            selectedIds={charOneClueIds}
-            onClueToggle={toggleStartingClue}
-          />
-        </PreviewCard>
-
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_26rem]">
-          <PreviewCard title="현재 적용 컴포넌트 비교용">
-            <div className="mb-4 flex items-center gap-2 text-sm text-slate-300">
-              <UserRound className="h-4 w-4 text-amber-400" />
-              기존 checkbox 방식. 단서가 적을 때는 빠르지만, 많아지면 위 split assigner가 유리합니다.
-            </div>
-            <CharacterDetailPanel
-              selectedChar={characters[0]}
-              characters={characters}
-              clues={clues}
-              charClueIds={charOneClueIds}
-              charMissions={missions}
-              onClueToggle={toggleStartingClue}
-              onAddMission={addMission}
-              onChangeMission={changeMission}
-              onDeleteMission={deleteMission}
-            />
-          </PreviewCard>
-
-          <div className="space-y-6">
-            <PreviewCard title="Accordion 독립 상태">
-              <Accordion
-                storageKey="phase24-preview:accordion"
-                items={[
-                  {
-                    id: 'base',
-                    title: '베이스 섹션',
-                    subtitle: 'forceOpen: 항상 펼침',
-                    forceOpen: true,
-                    children: <p className="text-sm text-slate-400">기본 정보 섹션은 닫히지 않습니다.</p>,
-                  },
-                  {
-                    id: 'module',
-                    title: '활성 모듈 섹션',
-                    subtitle: 'localStorage로 펼침 상태 저장',
-                    defaultOpen: true,
-                    children: <p className="text-sm text-slate-400">새로고침해도 접힘 상태가 유지됩니다.</p>,
-                  },
-                ]}
-              />
-            </PreviewCard>
-
-            <PreviewCard title="저장될 canonical config">
-              <div className="mb-3 flex items-center gap-2 text-xs text-slate-400">
-                <Puzzle className="h-3.5 w-3.5 text-amber-400" />
-                legacy key 없이 백엔드 PR-1 shape로 저장됩니다.
-              </div>
-              <pre className="max-h-[26rem] overflow-auto rounded-lg bg-slate-950 p-3 text-[11px] leading-5 text-slate-300">
-                {JSON.stringify(config, null, 2)}
-              </pre>
-            </PreviewCard>
-
-            <PreviewCard title="단서 배치 파생 뷰">
-              <div className="flex items-center gap-2 text-xs text-slate-400">
-                <GitBranch className="h-3.5 w-3.5 text-amber-400" />
-                <span>{Object.keys(cluePlacement).length}개 단서가 장소에 연결됨</span>
-              </div>
-            </PreviewCard>
-          </div>
-        </div>
+        <EntityPageMockup />
       </div>
     </main>
   );

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -55,7 +55,6 @@ describe('EditorPage', () => {
 
     render(<EditorPage />);
 
-    expect(screen.getByText(/테마 에디터 theme-1 modules/)).toBeDefined();
     expect(setActiveTabMock).toHaveBeenCalledWith('design');
   });
 

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { paramsMock, setActiveTabMock } = vi.hoisted(() => ({
+  paramsMock: vi.fn(),
+  setActiveTabMock: vi.fn(),
+}));
+
+vi.mock('react-router', () => ({
+  useParams: () => paramsMock(),
+}));
+
+vi.mock('@/features/editor/stores/editorUIStore', () => ({
+  useEditorUI: (selector: (state: { setActiveTab: typeof setActiveTabMock }) => unknown) =>
+    selector({ setActiveTab: setActiveTabMock }),
+}));
+
+vi.mock('@/features/editor/components', () => ({
+  EditorDashboard: () => <div>에디터 대시보드</div>,
+  ThemeEditor: ({ themeId, routeSegment }: { themeId: string; routeSegment?: string }) => (
+    <div>
+      테마 에디터 {themeId} {routeSegment ?? 'no-segment'}
+    </div>
+  ),
+}));
+
+import EditorPage from '../EditorPage';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('EditorPage', () => {
+  it('id가 없으면 에디터 대시보드를 보여주고 overview 탭을 활성화한다', () => {
+    paramsMock.mockReturnValue({});
+
+    render(<EditorPage />);
+
+    expect(screen.getByText('에디터 대시보드')).toBeDefined();
+    expect(setActiveTabMock).toHaveBeenCalledWith('overview');
+  });
+
+  it('characters 라우트 segment를 characters 탭으로 매핑한다', () => {
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: 'characters' });
+
+    render(<EditorPage />);
+
+    expect(screen.getByText(/테마 에디터 theme-1 characters/)).toBeDefined();
+    expect(setActiveTabMock).toHaveBeenCalledWith('characters');
+  });
+
+  it('modules 라우트 segment를 design 탭으로 매핑한다', () => {
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: 'modules' });
+
+    render(<EditorPage />);
+
+    expect(screen.getByText(/테마 에디터 theme-1 modules/)).toBeDefined();
+    expect(setActiveTabMock).toHaveBeenCalledWith('design');
+  });
+
+  it('알 수 없는 segment는 overview 탭으로 되돌린다', () => {
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: 'unknown' });
+
+    render(<EditorPage />);
+
+    expect(screen.getByText(/테마 에디터 theme-1 unknown/)).toBeDefined();
+    expect(setActiveTabMock).toHaveBeenCalledWith('overview');
+  });
+});

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -67,7 +67,9 @@ parent_phase: "phase-21-editor-ux"
   2. 장소 entity 페이지 (D-07) — Tree 무한 중첩 + 접근 제한 + 단순 사진 + evidence/location_clue 모듈 섹션
   3. 단서 entity 페이지 (D-08) — 단일 진실 위치 + 자동 backlink + 미사용 표시 + conditional_clue/combination/clue_interaction 모듈 섹션
   4. 자동 backlink 백엔드 신설 — derived 쿼리 vs DB 별도 테이블 (writing-plans 단계 결정, refs/10 참조)
-  5. PR-3A~E 확장 — `mystery_role`, voting `candidatePolicy`, typed role sheet, DOCUMENT/PDF, image role sheet viewer
+  5. PR-3A~E 확장 — `mystery_role`, voting `candidatePolicy`, typed role sheet
+     - DOCUMENT/PDF, image role sheet viewer는 후속 PR로 분리 (위 scope update 기준)
+     - PR-3A 테스트 책임: 역할 enum 저장/검증, Markdown 역할지 저장, entity preview 반응형/E2E
 - **상세 task**: `refs/pr-3-tasks.md` (PR-2 머지 후 expand)
 
 ### PR-4 — Entity Pages (페이즈 + 결말)

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -61,11 +61,13 @@ parent_phase: "phase-21-editor-ux"
 ### PR-3 — Entity Pages (캐릭터 + 장소 + 단서)
 - **Effort** L (~7일), **Impact** High (3 entity 첫 출시)
 - **branch**: `feat/phase-24-pr-3-entity-character-location-clue`
+- **2026-05-02 scope update**: 캐릭터 역할 enum, 탐정 투표 후보 정책, PDF/이미지 역할지 지원은 PR-3 계열 후속 PR로 분리. 상세는 `refs/pr-3-expansion-role-pdf-voting.md`.
 - **포함**:
   1. 캐릭터 entity 페이지 (D-06) — 베이스 + 역할지 Markdown + starting_clue/hidden_mission 모듈 섹션
   2. 장소 entity 페이지 (D-07) — Tree 무한 중첩 + 접근 제한 + 단순 사진 + evidence/location_clue 모듈 섹션
   3. 단서 entity 페이지 (D-08) — 단일 진실 위치 + 자동 backlink + 미사용 표시 + conditional_clue/combination/clue_interaction 모듈 섹션
   4. 자동 backlink 백엔드 신설 — derived 쿼리 vs DB 별도 테이블 (writing-plans 단계 결정, refs/10 참조)
+  5. PR-3A~E 확장 — `mystery_role`, voting `candidatePolicy`, typed role sheet, DOCUMENT/PDF, image role sheet viewer
 - **상세 task**: `refs/pr-3-tasks.md` (PR-2 머지 후 expand)
 
 ### PR-4 — Entity Pages (페이즈 + 결말)

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-3-expansion-role-pdf-voting.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-3-expansion-role-pdf-voting.md
@@ -1,0 +1,284 @@
+# Phase 24 PR-3 Expansion — Character Roles, PDF Role Sheet, Voting Candidate Policy
+
+## 배경
+
+PR-3 기존 범위는 캐릭터/장소/단서 entity 화면의 첫 usable slice였다. 진행 중 사용자 결정으로 다음 요구가 추가되었다.
+
+1. 캐릭터가 범인/공범/탐정/일반 용의자 중 어떤 역할인지 에디터에서 명확히 설정한다.
+2. 최종 투표에서 탐정을 후보에 포함할지 제외할지 선택할 수 있어야 한다.
+3. 역할지는 Markdown만이 아니라 PDF 또는 이미지 페이지 묶음도 지원한다.
+4. 모든 프론트 화면은 모바일 우선 반응형 UI로 구현한다.
+
+이 문서는 기존 PR-3를 과도하게 키우지 않기 위해 작업을 작은 PR 단위로 재분할하는 기준 문서다.
+
+## 현재 코드 근거
+
+| 영역 | 현재 상태 | 영향 |
+|---|---|---|
+| 캐릭터 범인 여부 | `theme_characters.is_culprit` 존재 | 범인 단일 boolean은 있으나 공범/탐정 표현 불가 |
+| 공개 캐릭터 API | public response에서 `is_culprit` 숨김 테스트 존재 | 스포일러 보호 방향은 유지 가능 |
+| 에디터 캐릭터 API | `EditorCharacterResponse.is_culprit` 노출 | 제작자 화면에서는 역할 편집 가능 |
+| 투표 후보 | `VotingPanel`이 생존자 중 나 제외만 후보로 사용 | 탐정 제외/포함 정책 추가 필요 |
+| 역할지 | `theme_contents` key-value API 기반 `role_sheet:<characterId>` 계획 | Markdown 외 typed format API 필요 |
+| 미디어 | `theme_media.type` = `BGM/SFX/VOICE/VIDEO` | PDF용 `DOCUMENT` 또는 `PDF` 타입 추가 필요 |
+
+## 결정
+
+### D-PR3X-01 — 캐릭터 역할은 boolean 확장이 아니라 enum으로 관리
+
+`is_culprit`에 `is_detective`, `is_accomplice`를 계속 추가하면 조합 오류가 생긴다. 예를 들어 한 캐릭터가 동시에 범인/탐정이 될 수 있다. 따라서 신규 필드는 enum이 맞다.
+
+```ts
+type MysteryRole = 'suspect' | 'culprit' | 'accomplice' | 'detective';
+```
+
+마이그레이션 기준:
+
+- `is_culprit = true` → `mystery_role = 'culprit'`
+- `is_culprit = false` → `mystery_role = 'suspect'`
+
+`is_culprit`는 호환 기간 동안 남기되, 신규 UI/런타임 판단은 `mystery_role`을 우선한다.
+
+### D-PR3X-02 — 탐정 투표 후보 포함 여부는 voting module config에 둔다
+
+탐정 자체는 캐릭터 속성이지만, “투표 후보에 포함할지”는 게임 룰이므로 voting module 설정이다.
+
+```json
+{
+  "modules": {
+    "voting": {
+      "enabled": true,
+      "config": {
+        "candidatePolicy": {
+          "includeDetective": false,
+          "includeSelf": false,
+          "includeDeadPlayers": false
+        }
+      }
+    }
+  }
+}
+```
+
+초기값:
+
+- `includeDetective: false`
+- `includeSelf: false`
+- `includeDeadPlayers: false`
+
+### D-PR3X-03 — 역할지는 typed model로 추상화한다
+
+기존 `theme_contents` 직접 body 저장만으로는 Markdown/PDF/Images를 안전하게 구분하기 어렵다. API/프론트 모델은 typed role sheet로 설계한다.
+
+```ts
+type RoleSheet =
+  | { format: 'markdown'; markdown: string }
+  | { format: 'pdf'; mediaId: string }
+  | { format: 'images'; imageUrls: string[] };
+```
+
+저장소는 첫 단계에서 `theme_contents`를 재사용할 수 있다. 단, 프론트와 API 경계는 typed model로 둔다.
+
+### D-PR3X-04 — PDF는 document media로 업로드한다
+
+`theme_media`에 문서 타입을 추가한다.
+
+추천 타입:
+
+```txt
+DOCUMENT
+```
+
+허용 MIME 1차 범위:
+
+```txt
+application/pdf
+```
+
+PDF viewer는 모바일에서 한 번에 전체 페이지를 렌더링하지 않고, 현재 페이지 중심으로 렌더링한다.
+
+### D-PR3X-05 — 프론트는 모바일 우선 세로 흐름을 기본으로 한다
+
+`apps/web/AGENTS.md`의 UIUX/반응형 규칙을 따른다.
+
+- 모바일: entity 타입 → 목록 → 상세 → 검수 정보 순서
+- 태블릿: 카드 2열 일부 허용
+- 데스크톱: 핵심 편집 영역 폭을 먼저 확보하고 보조 패널은 아래 또는 우측에 제한적으로 배치
+- 4열 고정 레이아웃 금지
+
+## PR 재분할
+
+### PR-3A — Character Entity + Mystery Role Foundation
+
+목표: 캐릭터 entity에서 범인/공범/탐정/일반 용의자를 설정할 수 있게 한다.
+
+#### Backend
+
+- [x] migration: `theme_characters.mystery_role` 추가
+- [x] 기존 `is_culprit` → `mystery_role` backfill
+- [x] CHECK 제약: `suspect/culprit/accomplice/detective`
+- [x] sqlc query/update 반영
+- [x] editor DTO에 `mystery_role` 추가
+- [x] public character response에는 `mystery_role` 숨김
+- [x] validation: 최소 1명 culprit 필요
+- [ ] validation: detective 2명 이상이면 warning 또는 error 정책 결정 후 적용
+
+#### Frontend
+
+- [x] `EditorCharacterResponse` 타입에 `mystery_role` 추가
+- [x] 캐릭터 베이스 섹션에 role selector 추가
+- [x] 기존 범인 checkbox는 role selector로 대체
+- [ ] dev preview 목업도 role selector 기준으로 갱신
+- [x] focused component/API type test 보강
+
+#### 완료 기준
+
+- [x] 에디터에서 캐릭터 역할을 저장/재조회할 수 있다.
+- [x] public API에는 역할 스포일러가 노출되지 않는다.
+- [x] 기존 `is_culprit` 데이터는 `culprit`로 보존된다.
+
+### PR-3B — Voting Candidate Policy
+
+목표: 최종 투표 후보에서 탐정을 포함/제외하는 옵션을 제공한다.
+
+#### Backend / Config
+
+- [ ] voting module config schema에 `candidatePolicy` 추가
+- [ ] config normalizer 기본값 보강
+- [ ] publish/validate 시 candidatePolicy shape 검증
+- [ ] 게임 런타임 후보 계산 지점 확인 및 정책 적용
+
+#### Frontend
+
+- [ ] voting 설정 UI에 “탐정을 투표 후보에 포함” 토글 추가
+- [ ] `VotingPanel` 후보 필터에서 정책 반영
+- [ ] 탐정 제외 시 빈 후보/적은 후보 상태 문구 추가
+
+#### 완료 기준
+
+- [ ] `includeDetective=false`면 detective 캐릭터는 투표 후보에 보이지 않는다.
+- [ ] `includeDetective=true`면 detective도 후보에 포함된다.
+- [ ] 자기 자신 제외 정책은 유지된다.
+
+### PR-3C — Typed Role Sheet API + Markdown Compatibility
+
+목표: PDF/이미지 확장을 위해 역할지 저장 경계를 typed model로 바꾼다.
+
+#### Backend
+
+- [ ] role sheet DTO 추가
+- [ ] `GET /editor/characters/{id}/role-sheet` 추가
+- [ ] `PUT /editor/characters/{id}/role-sheet` 추가
+- [ ] 내부 저장은 우선 `theme_contents` 재사용 가능
+- [ ] format별 validation 추가
+
+#### Frontend
+
+- [ ] `RoleSheet` 타입 추가
+- [ ] `useCharacterRoleSheet` / `useUpsertCharacterRoleSheet` hook 추가
+- [ ] 기존 Markdown 역할지 섹션을 typed API로 전환
+- [ ] 기존 `role_sheet:<id>` content는 호환 읽기 처리
+
+#### 완료 기준
+
+- [ ] 기존 Markdown 역할지가 깨지지 않는다.
+- [ ] 프론트는 format에 따라 renderer를 분기할 수 있다.
+
+### PR-3D — DOCUMENT/PDF Upload + Page Viewer
+
+목표: 역할지 PDF 업로드와 한 페이지씩 읽는 viewer를 제공한다.
+
+#### Backend
+
+- [ ] migration: `theme_media` valid type에 `DOCUMENT` 추가
+- [ ] upload request에서 `DOCUMENT` 허용
+- [ ] `application/pdf` MIME 검증
+- [ ] role sheet `pdf.mediaId`가 DOCUMENT media인지 검증
+- [ ] media delete 시 role sheet 참조 충돌 처리
+
+#### Frontend
+
+- [ ] PDF 업로드 UI 추가
+- [ ] role sheet format selector: Markdown / PDF / Images
+- [ ] PDF page viewer 추가
+- [ ] 모바일에서 1페이지 단위 읽기 UX 구현
+- [ ] PDF viewer dependency는 lazy load
+
+#### 완료 기준
+
+- [ ] 제작자는 PDF 역할지를 업로드하고 캐릭터에 연결할 수 있다.
+- [ ] 플레이어/preview는 PDF를 한 페이지씩 읽을 수 있다.
+- [ ] 모바일에서 가로 스크롤 없이 조작 가능하다.
+
+### PR-3E — Image Role Sheet Viewer
+
+목표: PDF가 아닌 이미지 페이지 묶음 역할지도 지원한다.
+
+#### Backend
+
+- [ ] image URL 배열 validation
+- [ ] 필요 시 image asset 참조 검증
+
+#### Frontend
+
+- [ ] 이미지 페이지 추가/삭제/순서 변경 UI
+- [ ] image page viewer 추가
+- [ ] 모바일 1페이지 단위 viewer 공유
+
+#### 완료 기준
+
+- [ ] 이미지 여러 장을 역할지처럼 순서대로 볼 수 있다.
+
+## 기존 PR-3와의 관계
+
+현재 PR-3에서 이미 진행한 helper/캐릭터 detail 일부는 유지한다.
+
+- 유지: entityReferences helper
+- 유지: entityMeta helper
+- 유지: 캐릭터 base/detail UI 방향
+- 수정: `CharacterRoleSheetSection`은 Markdown-only에서 typed role sheet로 후속 전환
+- 수정: `is_culprit` UI는 `mystery_role` selector로 후속 전환
+- 유지: 장소/단서 entity 작업은 PR-3A 이후 이어서 진행 가능
+
+## 작업 우선순위
+
+1. PR-3A 캐릭터 역할 모델
+2. PR-3B voting 후보 정책
+3. PR-3C typed role sheet API
+4. PR-3D PDF/DOCUMENT 업로드 + viewer
+5. PR-3E 이미지 역할지 viewer
+6. 기존 PR-3 장소/단서 entity 마무리
+
+## 검증 전략
+
+### Backend
+
+```bash
+cd apps/server && go test ./internal/domain/editor ./internal/domain/theme ./internal/module/... ./internal/db/...
+```
+
+### Frontend
+
+```bash
+cd apps/web && pnpm exec vitest run \
+  src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx \
+  src/pages/Phase24EditorPreviewPage.test.tsx
+
+cd apps/web && pnpm typecheck
+```
+
+### Browser
+
+- `/__dev/phase24-editor-preview`
+- 모바일 폭 390px
+- 데스크톱 폭 1365px
+
+## 리스크
+
+| 리스크 | 대응 |
+|---|---|
+| PR-3 범위 과대 | PR-3A~E로 분리 |
+| 기존 `is_culprit` 호환 깨짐 | backfill + 호환 기간 유지 |
+| public API 스포일러 노출 | public DTO/test 유지 및 확장 |
+| PDF 렌더링 성능 | lazy load + 현재 페이지 중심 렌더 |
+| 모바일 UI 혼잡 | `apps/web/AGENTS.md` 반응형 원칙 강제 |

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-3-tasks.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-3-tasks.md
@@ -1,0 +1,198 @@
+# Phase 24 PR-3 Tasks — Entity Pages: 캐릭터 + 장소 + 단서
+
+## 목표
+
+PR-2에서 정리한 canonical config helper와 Accordion UI를 기반으로, 에디터의 제작 흐름을 **캐릭터·장소·단서 entity 중심**으로 재배치한다. 사용자는 단서를 한 곳에서 정의하고, 캐릭터/장소에서는 단서 ID만 참조한다.
+
+> 2026-05-02 확장 결정: 캐릭터 역할 enum, 탐정 투표 후보 정책, PDF/이미지 역할지를 PR-3 계열 작업에 포함한다. 상세 분할은 `refs/pr-3-expansion-role-pdf-voting.md`가 canonical이다. 본 문서는 현재 브랜치의 기존 PR-3 진행 상태와 장소/단서 entity 작업 추적을 유지한다.
+
+## Branch
+
+- `feat/phase-24-pr-3-entity-character-location-clue`
+
+## Spec 결정 매핑
+
+| 결정 | PR-3 적용 |
+|---|---|
+| D-06 캐릭터 entity | 베이스 + 역할지 Markdown + starting_clue/hidden_mission 섹션 |
+| D-07 장소 entity | 장소 리스트를 tree-ready 구조로 정리 + 접근 제한/장소 단서 섹션 |
+| D-08 단서 entity | 단서 상세 화면 + 발견 컨텐츠 + 자동 backlink + 미사용 표시 |
+| D-09 참조 패턴 | 캐릭터/장소는 단서 객체 복사 금지, ID 참조만 유지 |
+| D-16 모듈 매핑 | 캐릭터 2개, 장소 2~3개, 단서 3개 섹션을 entity 폼에 배치 |
+| D-PR3X-01 | 캐릭터 역할은 `mystery_role` enum으로 확장 |
+| D-PR3X-02 | 탐정 투표 후보 포함 여부는 voting module config로 관리 |
+| D-PR3X-03 | 역할지는 Markdown/PDF/Images typed model로 추상화 |
+| D-PR3X-04 | PDF는 `DOCUMENT` media로 업로드하고 페이지 단위 viewer로 표시 |
+| D-PR3X-05 | 프론트는 모바일 우선 세로 흐름을 기본으로 구현 |
+
+## 현 코드/API 갭
+
+| 영역 | 현재 | PR-3 처리 |
+|---|---|---|
+| 캐릭터 code | `EditorCharacterResponse`에 code 없음 | 이번 PR은 `id`를 시스템 식별자로 표시, 별도 code 컬럼은 Phase 25+ 후보 |
+| 캐릭터 역할 | `is_culprit` boolean만 있음 | PR-3A에서 `mystery_role` enum 추가, `is_culprit`는 호환 기간 유지 |
+| 캐릭터 역할지 | `theme_contents` key-value API 있음 | 현재 slice는 Markdown 저장, PR-3C에서 typed role sheet API로 전환 |
+| PDF 역할지 | `theme_media`가 문서 타입 미지원 | PR-3D에서 `DOCUMENT` media + PDF page viewer 추가 |
+| 투표 후보 정책 | 생존자 중 나 제외만 후보 | PR-3B에서 `candidatePolicy.includeDetective` 추가 |
+| 장소 parent/tree | DB/API에 parent 없음 | UI는 tree-ready 컴포넌트 경계만 만들고 실제 parent 저장은 `config_json.locationMeta[locationId].parentLocationId`에 보존 |
+| 장소 entry message/image | DB/API 필드 없음 | `config_json.locationMeta[locationId]`에 entryMessage/imageUrl 보존 |
+| 접근 제한 | `restricted_characters` CSV 문자열 | 기존 API 유지, 프론트에서 string[]처럼 편집 후 CSV 저장 |
+| 단서 발견 컨텐츠 | clue.description은 짧은 설명 | `clue_content:<clueId>` content key로 Markdown 저장 |
+| Backlink | 백엔드 endpoint 없음 | 이번 PR은 editor 화면용 derived utility로 계산. DB 인덱스는 사용량/성능 확인 후 별도 PR |
+| 삭제 무결성 | API delete는 즉시 삭제 | 이번 PR은 삭제 전 사용처 표시/경고 UI만. 강제 삭제 백엔드 게이트는 별도 hardening 후보 |
+
+## 범위
+
+### 포함
+
+- [ ] PR-3 확장 계획 반영
+  - 캐릭터 역할 enum: `suspect/culprit/accomplice/detective`
+  - voting 후보 정책: `candidatePolicy.includeDetective`
+  - 역할지 typed model: Markdown/PDF/Images
+  - PDF/DOCUMENT 업로드는 별도 PR-3D로 분리
+- [ ] entity 공통 레이아웃 primitive 추가
+  - 좌측 리스트 + 우측 detail 패턴 정리
+  - 빈 상태, 선택 상태, count badge 일관화
+- [ ] 캐릭터 entity 페이지
+  - 기존 `CharacterAssignPanel`을 캐릭터 entity detail로 승격
+  - 베이스 요약 카드: 이름, 시스템 ID, 공개 소개, 사진 상태
+  - 역할지 Markdown 편집 섹션: `role_sheet:<characterId>` content API
+  - starting_clue split assigner 유지
+  - hidden_mission Markdown/mission editor 섹션 유지
+- [ ] 장소 entity 페이지
+  - 기존 `LocationsSubTab` UI를 entity 리스트/상세 패턴으로 정리
+  - map 선택 의존 UI를 유지하되, 장소 리스트가 tree-ready boundary를 갖게 분리
+  - 접근 제한 캐릭터 편집 UI 추가/개선
+  - `locationMeta` helper로 parentLocationId, entryMessage, imageUrl 저장 경계 신설
+  - location_clue 섹션은 기존 canonical helper 유지
+- [ ] 단서 entity 페이지
+  - 단서 리스트 + 상세 패널 추가 또는 기존 `CluesTab`/`ClueForm` 재사용 경계 정리
+  - 발견 컨텐츠 Markdown 편집: `clue_content:<clueId>` content API
+  - 자동 backlink utility 추가
+  - 리스트에 “사용된 곳”/“미사용” 표시
+  - 단서 상세 하단에 backlink 섹션 표시
+- [ ] config helper 확장
+  - `locationMeta` read/write
+  - clue backlink 계산
+  - character/location/clue reference count 계산
+- [ ] 테스트
+  - helper unit test
+  - 캐릭터 역할지 content 저장 테스트
+  - 장소 meta/access 제한 테스트
+  - 단서 backlink/misused 표시 테스트
+  - 기존 PR-2 regression focused tests 유지
+
+### 제외
+
+- DB migration으로 character code/location parent/location image 컬럼 추가
+- Backlink DB 인덱스/전용 API
+- Soft delete/휴지통
+- 순환 조합 validation의 완전한 backend enforcement
+- 페이즈/결말 entity 페이지 (PR-4)
+- ending_branch matrix (PR-5)
+- Playwright 전체 E2E 신규 작성
+
+> 예외: 캐릭터 역할 enum과 DOCUMENT media는 사용자 결정으로 PR-3 계열 후속 PR에 포함한다. 단, 현재 PR-3 단일 PR에 모두 넣지 않고 `refs/pr-3-expansion-role-pdf-voting.md`의 PR-3A~E로 분리한다.
+
+## 작업 순서
+
+### Task 1 — 준비
+
+- [x] main 최신화 후 브랜치 생성
+- [x] PR-3 task 문서 커밋 전 `git diff --check` 확인
+- [x] 기존 PR-2 테스트 baseline 확인
+
+### Task 2 — helper 설계/테스트 우선
+
+- [x] `apps/web/src/features/editor/utils/entityReferences.ts` 추가
+  - clue backlinks derived 계산
+  - unused clue 판단
+  - character/location reference summary 계산
+- [x] `apps/web/src/features/editor/utils/entityMeta.ts` 추가
+  - `locationMeta` read/write
+  - restricted character CSV parse/format helper는 기존 API와 분리
+- [x] unit tests 추가
+
+### Task 3 — 캐릭터 entity detail
+
+- [x] `CharacterDetailPanel`에 베이스 Accordion 섹션 추가
+- [x] `CharacterRoleSheetSection` 추가
+  - `useEditorContent(themeId, role_sheet:<id>)`
+  - `useUpsertContent(themeId, role_sheet:<id>)`
+  - blur/save 버튼으로 저장
+- [x] starting_clue/hidden_mission 섹션은 기존 동작 유지
+- [x] focused component test 추가
+
+### Task 3X — 확장 작업 분리
+
+- [x] PR-3 확장 계획서 작성: `refs/pr-3-expansion-role-pdf-voting.md`
+- [x] PR-3A: `mystery_role` backend/frontend 작업 착수
+- [ ] PR-3B: voting candidate policy 작업 착수
+- [ ] PR-3C: typed role sheet API 작업 착수
+- [ ] PR-3D: DOCUMENT/PDF 업로드 + viewer 작업 착수
+- [ ] PR-3E: image role sheet viewer 작업 착수
+
+### Task 4 — 장소 entity detail
+
+- [ ] `LocationsSubTab`를 list/detail 책임으로 더 분리
+- [ ] `LocationTreeList` 또는 tree-ready list 컴포넌트 추가
+- [ ] `LocationMetaSection` 추가
+  - parentLocationId dropdown boundary
+  - entryMessage Markdown textarea
+  - imageUrl 입력/기존 image upload 재사용 여부 확인
+- [ ] `LocationAccessSection` 추가
+  - 캐릭터 checkbox → `restricted_characters` CSV 저장
+- [ ] location_clue 섹션 regression 유지
+- [ ] focused component test 추가
+
+### Task 5 — 단서 entity detail/backlink
+
+- [ ] `ClueEntitySubTab` 또는 기존 `CluesTab` 내 entity mode 추가
+- [ ] `ClueBacklinkPanel` 추가
+- [ ] `ClueDiscoveryContentSection` 추가
+  - `useEditorContent(themeId, clue_content:<id>)`
+  - Markdown textarea 저장
+- [ ] clue list에 사용처 count와 “미사용” 표시
+- [ ] focused component test 추가
+
+### Task 6 — 통합/검증
+
+- [ ] DesignTab 진입점 정리: 캐릭터/장소/단서 entity 접근 경로 확정
+- [x] `/__dev/phase24-editor-preview`에 PR-3 확인용 샘플 추가 또는 별도 section 추가
+- [x] focused Vitest 실행
+- [x] `cd apps/web && pnpm typecheck`
+- [ ] `cd apps/web && pnpm lint`
+- [x] 브라우저로 캐릭터 → 장소 → 단서 흐름 확인
+
+## 완료 기준
+
+- [ ] 캐릭터 상세에서 역할지 Markdown을 저장/재조회할 수 있다.
+- [ ] 캐릭터 시작 단서는 PR-2 split assigner와 동일하게 canonical shape로 저장된다.
+- [ ] 장소 상세에서 접근 제한 캐릭터와 장소 meta를 편집할 수 있다.
+- [ ] 단서 상세에서 발견 컨텐츠를 저장/재조회할 수 있다.
+- [ ] 단서 리스트/상세에서 자동 backlink와 미사용 표시가 보인다.
+- [ ] 캐릭터/장소가 단서를 복사하지 않고 ID만 참조한다.
+- [ ] 기존 config legacy key write가 재도입되지 않는다.
+- [ ] focused tests/typecheck/lint가 통과한다.
+
+## 검증 명령 후보
+
+```bash
+cd apps/web && pnpm exec vitest run \
+  src/features/editor/utils/__tests__/configShape.test.ts \
+  src/features/editor/utils/__tests__/entityReferences.test.ts \
+  src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx \
+  src/features/editor/components/design/__tests__/StartingClueAssigner.test.tsx \
+  src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx \
+  src/features/editor/components/__tests__/CluesTab.test.tsx
+
+cd apps/web && pnpm typecheck
+cd apps/web && pnpm lint
+```
+
+## PR 노트 초안
+
+- PR-3는 ECS 전체 완성이 아니라 **캐릭터/장소/단서 3 entity의 첫 usable slice**다.
+- DB schema 변경 없이 기존 API와 `theme_contents`, canonical `config_json` helper로 구현한다.
+- Backlink는 editor-only derived 계산으로 시작한다. DB 인덱스는 실제 데이터 크기와 성능을 본 뒤 결정한다.
+- 비관련 `graphify-out/*`, `.codex/`, `AGENTS.md`, `memory/sessions/*`는 PR 범위에서 제외한다.


### PR DESCRIPTION
## Summary
- Add `theme_characters.mystery_role` with legacy `is_culprit` compatibility for Phase 24 editor character roles.
- Add responsive frontend role selection, role-sheet editing, entity-style Phase 24 preview pages, and `/editor/:id/:tab` deep links.
- Add Phase 24 PR-3 planning docs plus focused unit/E2E coverage for the new editor flows.

## Test Plan
- `pnpm --dir apps/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium`
- `pnpm --dir apps/web exec playwright test e2e/phase24-editor-preview.spec.ts e2e/phase24-editor-character-role.spec.ts --project=chromium`
- `pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/pages/Phase24EditorPreviewPage.test.tsx`
- `pnpm --dir apps/web typecheck`
- `cd apps/server && go test ./internal/domain/editor ./internal/domain/theme`
- `git diff --cached --check`

## Scope Guard
- Excludes unrelated dirty workspace files under `.claude`, `.codex`, `graphify-out`, root/server `AGENTS.md`, and `memory`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캐릭터 역할(mystery_role: suspect/culprit/accomplice/detective, 생성 기본 suspect) 지정·저장 기능 추가
  * 캐릭터별 역할지(마크다운) 편집·저장 전용 섹션 및 미리보기 목업 추가
* **개선 사항**
  * 에디터 경로에 탭 세그먼트 지원 추가(탭별 심화 탐색)
  * 캐릭터 목록·상세에서 역할 표시·선택 UI 개선 및 DB 마이그레이션으로 기존값 백필·색인 추가
  * 클루·엔티티 메타 및 참조 계산 유틸 추가(백링크/미사용 단서 탐지)
* **테스트**
  * 단위·E2E(Playwright) 테스트와 접근성 검사 추가
* **문서**
  * 프론트엔드 개발 규칙·PR-3 계획 문서 대폭 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->