### PR TITLE
ci: ready-for-ci 라벨 뒤로 full CI 실행 지연

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - '.github/workflows/**'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
     paths:
       - 'apps/**'
       - 'packages/**'
@@ -24,6 +25,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'turbo.json'
       - '.github/workflows/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,11 +34,19 @@ concurrency:
 jobs:
   go-check:
     name: Go Lint + Test
-    runs-on: arc-runner-set
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     defaults:
       run:
         working-directory: apps/server
     steps:
+      - name: Full CI ready gate
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "::error::Full CI는 CodeRabbit/Codecov 정리 후 'ready-for-ci' 라벨을 붙였을 때 실행합니다."
+          echo "::error::리뷰 대응 중에는 light checks만 사용하고, merge 전 라벨을 붙여 full CI를 다시 실행하세요."
+          exit 1
+
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
@@ -213,8 +223,16 @@ jobs:
 
   ts-check:
     name: TypeScript Lint + Test + Build
-    runs-on: arc-runner-set
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     steps:
+      - name: Full CI ready gate
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "::error::Full CI는 CodeRabbit/Codecov 정리 후 'ready-for-ci' 라벨을 붙였을 때 실행합니다."
+          echo "::error::리뷰 대응 중에는 light checks만 사용하고, merge 전 라벨을 붙여 full CI를 다시 실행하세요."
+          exit 1
+
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -29,6 +29,7 @@ on:
       - '.github/workflows/**'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
     paths:
       - 'apps/**'
       - 'packages/**'
@@ -50,7 +51,7 @@ concurrency:
 jobs:
   e2e:
     name: E2E (${{ matrix.browser }} shard ${{ matrix.shard }})
-    runs-on: arc-runner-set
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     # H-1: fork PR 의 untrusted code 가 shared named volume (playwright-cache/hostedtool-cache) 에
     # 악성 binary 를 심어 4 runner 횡전파하는 cache poisoning 차단.
     # fork PR 은 cache mount runner 를 우회 (skip). main / same-repo PR 만 실행.
@@ -69,6 +70,14 @@ jobs:
       PLAYWRIGHT_BACKEND: "1"
 
     steps:
+      - name: Full CI ready gate
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "::error::Full CI는 CodeRabbit/Codecov 정리 후 'ready-for-ci' 라벨을 붙였을 때 실행합니다."
+          echo "::error::리뷰 대응 중에는 light checks만 사용하고, merge 전 라벨을 붙여 full CI를 다시 실행하세요."
+          exit 1
+
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
@@ -374,7 +383,7 @@ jobs:
   merge-reports:
     name: Merge Playwright reports
     # H-1 consistency: e2e 와 동일 fork PR 게이트 (cache mount runner 일관성).
-    if: (always()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: (always()) && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ready-for-ci')))
     needs: [e2e]
     runs-on: arc-runner-set
     steps:

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -6,6 +6,7 @@ name: Security — Fast Feedback
 on:
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
     paths:
       - 'apps/**'
       - 'packages/**'
@@ -24,6 +25,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.gitleaks.toml'
       - '.github/workflows/security-fast.yml'
+  workflow_dispatch:
 
 concurrency:
   group: security-fast-${{ github.ref }}
@@ -35,12 +37,20 @@ permissions:
 jobs:
   govulncheck:
     name: govulncheck (Go SCA)
-    runs-on: arc-runner-set
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     # Phase 22 W1.5 PR-8 fold-in (PR-170 8ce9c0b run cancelled at 5:13):
     # containerized runner 의 setup-go cache miss + go install govulncheck +
     # scan 이 5분 timeout 초과. 10분 으로 상향 (cache warm-up 후 정상 ~3분).
     timeout-minutes: 10
     steps:
+      - name: Full CI ready gate
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "::error::Full CI는 CodeRabbit/Codecov 정리 후 'ready-for-ci' 라벨을 붙였을 때 실행합니다."
+          echo "::error::리뷰 대응 중에는 light checks만 사용하고, merge 전 라벨을 붙여 full CI를 다시 실행하세요."
+          exit 1
+
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,9 @@
 - `main`을 보호한다. 병합 가능한 변경은 feature branch와 PR을 사용한다.
 - PR 또는 merge 전에는 관련 focused check를 실행하고 `memory/feedback_pre_pr_review_checklist.md` 기준으로 검토한다.
 - PR 제목과 본문은 기본적으로 한글로 작성한다. 코드 식별자, 명령어, 에러 메시지, 공식 API명은 원문을 유지한다.
-- PR 생성 후에는 GitHub Actions CI뿐 아니라 Codecov Report를 확인한다. 커버리지 리포트가 실패하거나 기준 미달 코멘트를 남기면 원인을 확인하고 필요한 테스트 보강 또는 코드 수정을 진행한 뒤 다시 검증한다.
+- Full CI 실행 후에는 GitHub Actions CI뿐 아니라 Codecov Report를 확인한다. 커버리지 리포트가 실패하거나 기준 미달 코멘트를 남기면 원인을 확인하고 필요한 테스트 보강 또는 코드 수정을 진행한 뒤 다시 검증한다.
 - PR 생성 후 CodeRabbit 리뷰를 확인한다. 문제 제기 코멘트는 수정 커밋으로 해결하고, GitHub review thread가 unresolved 상태로 남지 않도록 resolve 상태까지 확인한 뒤 merge한다.
+- Full CI는 리뷰 대응이 끝난 뒤 `ready-for-ci` 라벨을 붙여 실행한다. 리뷰/Codecov/CodeRabbit 수정 중에는 라벨을 제거해 heavy CI 반복 실행을 피하고, merge 전에는 반드시 라벨을 다시 붙여 Go/TypeScript/Coverage/E2E/Docker/Security checks를 통과시킨다.
 - PR/CI/리뷰 상태 확인을 반복할 때는 GitHub/API 호출을 과도하게 하지 않는다. 기본 폴링 간격은 30초~1분으로 두고, 긴 작업은 `--watch --interval 30` 이상 또는 단발 조회를 사용한다.
 - 4-agent review 정책의 canonical 문서는 `memory/feedback_4agent_review_before_admin_merge.md`다. Codex에서 사용 가능한 도구와 사용자 승인 범위에 맞춰 적용한다.
 


### PR DESCRIPTION
## 요약

- PR full CI를 `ready-for-ci` 라벨 뒤로 미루는 게이트를 추가했습니다.
- PR 생성/리뷰 대응 중에는 heavy CI가 ARC runner에서 반복 실행되지 않도록 `ubuntu-latest`에서 빠르게 차단합니다.
- `ready-for-ci` 라벨을 붙이거나 수동 실행하면 기존 Go/TypeScript/Coverage/E2E/Docker/Security checks가 전체 실행됩니다.

## 변경 내용

- `.github/workflows/ci.yml`
  - PR 라벨 이벤트에서 재실행되도록 `labeled/unlabeled` type 추가
  - Go/TypeScript heavy job에 `ready-for-ci` 게이트 추가
  - 수동 `workflow_dispatch` 추가
- `.github/workflows/e2e-stubbed.yml`
  - E2E shard job에 `ready-for-ci` 게이트 추가
  - report merge job은 ready 라벨 이후에만 실행되도록 조정
- `.github/workflows/security-fast.yml`
  - govulncheck도 `ready-for-ci` 이후 실행되도록 게이트 추가
  - 수동 `workflow_dispatch` 추가
- `AGENTS.md`
  - CodeRabbit/Codecov 정리 후 `ready-for-ci` 라벨을 붙여 full CI를 실행하는 운영 규칙 추가

## 운영 방법

1. PR 생성 직후에는 `ready-for-ci` 라벨을 붙이지 않습니다.
2. CodeRabbit/리뷰/Codecov 대응을 마칩니다.
3. merge 직전에 `ready-for-ci` 라벨을 붙입니다.
4. full CI가 통과하면 merge합니다.
5. 리뷰 대응을 다시 해야 하면 라벨을 제거하고 수정합니다.

## 검증

- [x] `python3` + PyYAML로 workflow YAML 파싱 확인
- [x] `git diff --check` 통과
- [x] `actionlint` 실행
  - `arc-runner-set` custom runner label, 기존 `SC2024`는 ignore 처리
  - 신규 expression/YAML 오류 없음
- [x] `ready-for-ci` GitHub label 생성 확인

Closes #216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 워크플로우를 최적화하여 불필요한 전체 검사 실행을 줄임
  * PR 라벨 기반 조건부 검사 메커니즘 추가
  * 개발 프로세스 가이드라인 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->