### PR TITLE
장소 엔티티 이미지/단서 편집 흐름 추가

### DIFF
--- a/apps/server/db/migrations/00031_location_image_url.sql
+++ b/apps/server/db/migrations/00031_location_image_url.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE theme_locations
+  ADD COLUMN image_url TEXT;
+
+-- +goose Down
+ALTER TABLE theme_locations
+  DROP COLUMN IF EXISTS image_url;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -38,13 +38,13 @@ SELECT * FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
 SELECT * FROM theme_locations WHERE id = $1;
 
 -- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
 -- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -108,9 +108,9 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 }
 
 const createLocation = `-- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url
 `
 
 type CreateLocationParams struct {
@@ -121,6 +121,7 @@ type CreateLocationParams struct {
 	SortOrder            int32       `json:"sort_order"`
 	FromRound            pgtype.Int4 `json:"from_round"`
 	UntilRound           pgtype.Int4 `json:"until_round"`
+	ImageUrl             pgtype.Text `json:"image_url"`
 }
 
 func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) (ThemeLocation, error) {
@@ -132,6 +133,7 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		arg.SortOrder,
 		arg.FromRound,
 		arg.UntilRound,
+		arg.ImageUrl,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -144,6 +146,7 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		&i.CreatedAt,
 		&i.FromRound,
 		&i.UntilRound,
+		&i.ImageUrl,
 	)
 	return i, err
 }
@@ -365,7 +368,7 @@ func (q *Queries) GetContent(ctx context.Context, arg GetContentParams) (ThemeCo
 }
 
 const getLocation = `-- name: GetLocation :one
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round FROM theme_locations WHERE id = $1
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url FROM theme_locations WHERE id = $1
 `
 
 func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation, error) {
@@ -381,12 +384,13 @@ func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation,
 		&i.CreatedAt,
 		&i.FromRound,
 		&i.UntilRound,
+		&i.ImageUrl,
 	)
 	return i, err
 }
 
 const getLocationWithOwner = `-- name: GetLocationWithOwner :one
-SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round FROM theme_locations l
+SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round, l.image_url FROM theme_locations l
 JOIN themes t ON l.theme_id = t.id
 WHERE l.id = $1 AND t.creator_id = $2
 `
@@ -409,6 +413,7 @@ func (q *Queries) GetLocationWithOwner(ctx context.Context, arg GetLocationWithO
 		&i.CreatedAt,
 		&i.FromRound,
 		&i.UntilRound,
+		&i.ImageUrl,
 	)
 	return i, err
 }
@@ -578,7 +583,7 @@ func (q *Queries) ListContentsByTheme(ctx context.Context, themeID uuid.UUID) ([
 
 const listLocationsByMap = `-- name: ListLocationsByMap :many
 
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -603,6 +608,7 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 			&i.CreatedAt,
 			&i.FromRound,
 			&i.UntilRound,
+			&i.ImageUrl,
 		); err != nil {
 			return nil, err
 		}
@@ -615,7 +621,7 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 }
 
 const listLocationsByTheme = `-- name: ListLocationsByTheme :many
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeLocation, error) {
@@ -637,6 +643,7 @@ func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) (
 			&i.CreatedAt,
 			&i.FromRound,
 			&i.UntilRound,
+			&i.ImageUrl,
 		); err != nil {
 			return nil, err
 		}
@@ -748,9 +755,9 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 
 const updateLocation = `-- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7
 WHERE id = $1
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url
 `
 
 type UpdateLocationParams struct {
@@ -760,6 +767,7 @@ type UpdateLocationParams struct {
 	SortOrder            int32       `json:"sort_order"`
 	FromRound            pgtype.Int4 `json:"from_round"`
 	UntilRound           pgtype.Int4 `json:"until_round"`
+	ImageUrl             pgtype.Text `json:"image_url"`
 }
 
 func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) (ThemeLocation, error) {
@@ -770,6 +778,7 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		arg.SortOrder,
 		arg.FromRound,
 		arg.UntilRound,
+		arg.ImageUrl,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -782,6 +791,7 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		&i.CreatedAt,
 		&i.FromRound,
 		&i.UntilRound,
+		&i.ImageUrl,
 	)
 	return i, err
 }

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -323,6 +323,7 @@ type ThemeLocation struct {
 	CreatedAt            time.Time   `json:"created_at"`
 	FromRound            pgtype.Int4 `json:"from_round"`
 	UntilRound           pgtype.Int4 `json:"until_round"`
+	ImageUrl             pgtype.Text `json:"image_url"`
 }
 
 type ThemeMap struct {

--- a/apps/server/internal/domain/editor/image_handler.go
+++ b/apps/server/internal/domain/editor/image_handler.go
@@ -19,7 +19,8 @@ func NewImageHandler(svc *ImageService) *ImageHandler {
 }
 
 // RequestUpload handles POST /editor/themes/{id}/images/upload-url.
-// Body: { "target": "character"|"clue"|"location", "target_id": "uuid", "content_type": "image/png", "file_size": 12345 }
+// Body: { "target": "character"|"clue"|"location"|"cover", "target_id": "uuid", "content_type": "image/png", "file_size": 12345 }
+// target_id is optional for cover uploads.
 func (h *ImageHandler) RequestUpload(w http.ResponseWriter, r *http.Request) {
 	creatorID := middleware.UserIDFrom(r.Context())
 	themeID, err := parseUUID(r, "id")

--- a/apps/server/internal/domain/editor/image_handler.go
+++ b/apps/server/internal/domain/editor/image_handler.go
@@ -8,8 +8,7 @@ import (
 	"github.com/mmp-platform/server/internal/middleware"
 )
 
-// ImageHandler handles image upload HTTP endpoints for character avatars and
-// clue images.
+// ImageHandler handles image upload HTTP endpoints for character, clue, location, and cover images.
 type ImageHandler struct {
 	svc *ImageService
 }
@@ -20,7 +19,7 @@ func NewImageHandler(svc *ImageService) *ImageHandler {
 }
 
 // RequestUpload handles POST /editor/themes/{id}/images/upload-url.
-// Body: { "target": "character"|"clue", "target_id": "uuid", "content_type": "image/png", "file_size": 12345 }
+// Body: { "target": "character"|"clue"|"location", "target_id": "uuid", "content_type": "image/png", "file_size": 12345 }
 func (h *ImageHandler) RequestUpload(w http.ResponseWriter, r *http.Request) {
 	creatorID := middleware.UserIDFrom(r.Context())
 	themeID, err := parseUUID(r, "id")

--- a/apps/server/internal/domain/editor/image_service.go
+++ b/apps/server/internal/domain/editor/image_service.go
@@ -24,6 +24,7 @@ const (
 
 	ImageTargetCharacter = "character"
 	ImageTargetClue      = "clue"
+	ImageTargetLocation  = "location"
 	ImageTargetCover     = "cover"
 )
 
@@ -50,8 +51,8 @@ type ImageConfirmResponse struct {
 
 // RequestImageUploadRequest is the body for POST .../images/upload-url.
 type RequestImageUploadRequest struct {
-	Target      string     `json:"target"`       // "character" | "clue" | "cover"
-	TargetID    *uuid.UUID `json:"target_id"`    // character or clue UUID; omitted for "cover"
+	Target      string     `json:"target"`       // "character" | "clue" | "location" | "cover"
+	TargetID    *uuid.UUID `json:"target_id"`    // character, clue, or location UUID; omitted for "cover"
 	ContentType string     `json:"content_type"` // image/jpeg | image/png | image/webp
 	FileSize    int64      `json:"file_size"`    // bytes
 }
@@ -68,10 +69,12 @@ type imageQueries interface {
 	UpdateThemeCharacter(ctx context.Context, arg db.UpdateThemeCharacterParams) (db.ThemeCharacter, error)
 	GetClue(ctx context.Context, id uuid.UUID) (db.ThemeClue, error)
 	UpdateClue(ctx context.Context, arg db.UpdateClueParams) (db.ThemeClue, error)
+	GetLocation(ctx context.Context, id uuid.UUID) (db.ThemeLocation, error)
+	UpdateLocation(ctx context.Context, arg db.UpdateLocationParams) (db.ThemeLocation, error)
 	UpdateThemeCoverImage(ctx context.Context, arg db.UpdateThemeCoverImageParams) error
 }
 
-// ImageService handles image upload flow for character avatars and clue images.
+// ImageService handles image upload flow for character, clue, location, and cover images.
 type ImageService struct {
 	q       imageQueries
 	storage storage.Provider
@@ -120,9 +123,9 @@ func (s *ImageService) RequestImageUpload(
 		return nil, err
 	}
 
-	if req.Target != ImageTargetCharacter && req.Target != ImageTargetClue && req.Target != ImageTargetCover {
+	if req.Target != ImageTargetCharacter && req.Target != ImageTargetClue && req.Target != ImageTargetLocation && req.Target != ImageTargetCover {
 		return nil, apperror.New(apperror.ErrImageInvalidTarget, 400,
-			fmt.Sprintf("target must be %q, %q, or %q", ImageTargetCharacter, ImageTargetClue, ImageTargetCover))
+			fmt.Sprintf("target must be %q, %q, %q, or %q", ImageTargetCharacter, ImageTargetClue, ImageTargetLocation, ImageTargetCover))
 	}
 
 	ext, ok := AllowedImageMIMEs[req.ContentType]
@@ -165,7 +168,7 @@ func (s *ImageService) RequestImageUpload(
 }
 
 // ConfirmImageUpload verifies the upload exists in storage and updates the
-// image_url on the character or clue record.
+// image_url on the target record.
 func (s *ImageService) ConfirmImageUpload(
 	ctx context.Context,
 	userID, themeID uuid.UUID,
@@ -199,6 +202,7 @@ func (s *ImageService) ConfirmImageUpload(
 	// Key format:
 	//   themes/{themeId}/characters/{charId}/avatar.{ext}
 	//   themes/{themeId}/clues/{clueId}/image.{ext}
+	//   themes/{themeId}/locations/{locationId}/image.{ext}
 	target, targetID, err := parseUploadKey(uploadKey)
 	if err != nil {
 		return nil, apperror.BadRequest("invalid upload_key format")
@@ -228,6 +232,7 @@ func (s *ImageService) ConfirmImageUpload(
 			Description: char.Description,
 			ImageUrl:    pgtype.Text{String: downloadURL, Valid: true},
 			IsCulprit:   char.IsCulprit,
+			MysteryRole: char.MysteryRole,
 			SortOrder:   char.SortOrder,
 		})
 		if err != nil {
@@ -256,10 +261,42 @@ func (s *ImageService) ConfirmImageUpload(
 			IsCommon:    clue.IsCommon,
 			Level:       clue.Level,
 			SortOrder:   clue.SortOrder,
+			IsUsable:    clue.IsUsable,
+			UseEffect:   clue.UseEffect,
+			UseTarget:   clue.UseTarget,
+			UseConsumed: clue.UseConsumed,
+			RevealRound: clue.RevealRound,
+			HideRound:   clue.HideRound,
 		})
 		if err != nil {
 			s.logger.Error().Err(err).Str("clue_id", targetID.String()).Msg("failed to update clue image_url")
 			return nil, apperror.Internal("failed to update clue image")
+		}
+
+	case ImageTargetLocation:
+		loc, err := s.q.GetLocation(ctx, targetID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, apperror.NotFound("location not found")
+			}
+			s.logger.Error().Err(err).Str("location_id", targetID.String()).Msg("failed to get location")
+			return nil, apperror.Internal("failed to get location")
+		}
+		if loc.ThemeID != themeID {
+			return nil, apperror.NotFound("location not found")
+		}
+		_, err = s.q.UpdateLocation(ctx, db.UpdateLocationParams{
+			ID:                   loc.ID,
+			Name:                 loc.Name,
+			RestrictedCharacters: loc.RestrictedCharacters,
+			SortOrder:            loc.SortOrder,
+			FromRound:            loc.FromRound,
+			UntilRound:           loc.UntilRound,
+			ImageUrl:             pgtype.Text{String: downloadURL, Valid: true},
+		})
+		if err != nil {
+			s.logger.Error().Err(err).Str("location_id", targetID.String()).Msg("failed to update location image_url")
+			return nil, apperror.Internal("failed to update location image")
 		}
 
 	case ImageTargetCover:
@@ -321,6 +358,20 @@ func (s *ImageService) buildStorageKey(
 		}
 		return fmt.Sprintf("themes/%s/clues/%s/image%s", themeID, targetID, ext), nil
 
+	case ImageTargetLocation:
+		loc, err := s.q.GetLocation(ctx, targetID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return "", apperror.NotFound("location not found")
+			}
+			s.logger.Error().Err(err).Str("location_id", targetID.String()).Msg("failed to get location")
+			return "", apperror.Internal("failed to get location")
+		}
+		if loc.ThemeID != themeID {
+			return "", apperror.NotFound("location not found")
+		}
+		return fmt.Sprintf("themes/%s/locations/%s/image%s", themeID, targetID, ext), nil
+
 	case ImageTargetCover:
 		return fmt.Sprintf("themes/%s/cover%s", themeID, ext), nil
 
@@ -334,6 +385,7 @@ func (s *ImageService) buildStorageKey(
 //
 //	themes/{themeId}/characters/{charId}/avatar.{ext}  → "character", charId
 //	themes/{themeId}/clues/{clueId}/image.{ext}        → "clue", clueId
+//	themes/{themeId}/locations/{locationId}/image.{ext} → "location", locationId
 //	themes/{themeId}/cover.{ext}                       → "cover", themeId
 func parseUploadKey(key string) (target string, id uuid.UUID, err error) {
 	parts := strings.Split(key, "/")
@@ -350,7 +402,7 @@ func parseUploadKey(key string) (target string, id uuid.UUID, err error) {
 		return ImageTargetCover, themeID, nil
 	}
 
-	// characters/clues: themes / {themeId} / characters|clues / {id} / filename
+	// characters/clues/locations: themes / {themeId} / characters|clues|locations / {id} / filename
 	if len(parts) != 5 {
 		return "", uuid.Nil, fmt.Errorf("unexpected key format")
 	}
@@ -359,6 +411,8 @@ func parseUploadKey(key string) (target string, id uuid.UUID, err error) {
 		target = ImageTargetCharacter
 	case "clues":
 		target = ImageTargetClue
+	case "locations":
+		target = ImageTargetLocation
 	default:
 		return "", uuid.Nil, fmt.Errorf("unknown target segment: %s", parts[2])
 	}

--- a/apps/server/internal/domain/editor/image_service_test.go
+++ b/apps/server/internal/domain/editor/image_service_test.go
@@ -1,0 +1,152 @@
+package editor
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog"
+
+	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/infra/storage"
+)
+
+func TestParseUploadKey_Location(t *testing.T) {
+	key := "themes/11111111-1111-1111-1111-111111111111/locations/22222222-2222-2222-2222-222222222222/image.webp"
+	target, id, err := parseUploadKey(key)
+	if err != nil {
+		t.Fatalf("parseUploadKey returned error: %v", err)
+	}
+	if target != ImageTargetLocation {
+		t.Fatalf("target = %q, want %q", target, ImageTargetLocation)
+	}
+	if got := id.String(); got != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("id = %q", got)
+	}
+}
+
+func TestConfirmImageUpload_PreservesExistingTargetFields(t *testing.T) {
+	creatorID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	themeID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	charID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	clueID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	locationID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+
+	cases := []struct {
+		name      string
+		uploadKey string
+		assert    func(*testing.T, *fakeImageQueries)
+	}{
+		{
+			name:      "character mystery role",
+			uploadKey: "themes/11111111-1111-1111-1111-111111111111/characters/22222222-2222-2222-2222-222222222222/avatar.webp",
+			assert: func(t *testing.T, q *fakeImageQueries) {
+				if q.updateCharacterArg.MysteryRole != "detective" {
+					t.Fatalf("MysteryRole = %q", q.updateCharacterArg.MysteryRole)
+				}
+			},
+		},
+		{
+			name:      "clue gameplay fields",
+			uploadKey: "themes/11111111-1111-1111-1111-111111111111/clues/33333333-3333-3333-3333-333333333333/image.webp",
+			assert: func(t *testing.T, q *fakeImageQueries) {
+				arg := q.updateClueArg
+				if !arg.IsUsable || arg.UseEffect.String != "peek" || arg.UseTarget.String != "player" || !arg.UseConsumed || arg.RevealRound.Int32 != 2 || arg.HideRound.Int32 != 5 {
+					t.Fatalf("clue fields not preserved: %+v", arg)
+				}
+			},
+		},
+		{
+			name:      "location metadata fields",
+			uploadKey: "themes/11111111-1111-1111-1111-111111111111/locations/44444444-4444-4444-4444-444444444444/image.webp",
+			assert: func(t *testing.T, q *fakeImageQueries) {
+				arg := q.updateLocationArg
+				if arg.RestrictedCharacters.String != "char-a,char-b" || arg.FromRound.Int32 != 1 || arg.UntilRound.Int32 != 4 {
+					t.Fatalf("location fields not preserved: %+v", arg)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := newFakeImageQueries(creatorID, themeID, charID, clueID, locationID)
+			svc := &ImageService{q: q, storage: fakeImageStorage{}, logger: zerolog.Nop()}
+			_, err := svc.ConfirmImageUpload(context.Background(), creatorID, themeID, ConfirmImageUploadRequest{UploadKey: tc.uploadKey})
+			if err != nil {
+				t.Fatalf("ConfirmImageUpload returned error: %v", err)
+			}
+			tc.assert(t, q)
+		})
+	}
+}
+
+type fakeImageQueries struct {
+	theme              db.Theme
+	character          db.ThemeCharacter
+	clue               db.ThemeClue
+	location           db.ThemeLocation
+	updateCharacterArg db.UpdateThemeCharacterParams
+	updateClueArg      db.UpdateClueParams
+	updateLocationArg  db.UpdateLocationParams
+}
+
+func newFakeImageQueries(creatorID, themeID, charID, clueID, locationID uuid.UUID) *fakeImageQueries {
+	return &fakeImageQueries{
+		theme:     db.Theme{ID: themeID, CreatorID: creatorID},
+		character: db.ThemeCharacter{ID: charID, ThemeID: themeID, Name: "탐정", MysteryRole: "detective", IsCulprit: true},
+		clue:      db.ThemeClue{ID: clueID, ThemeID: themeID, Name: "단서", IsUsable: true, UseEffect: text("peek"), UseTarget: text("player"), UseConsumed: true, RevealRound: int4(2), HideRound: int4(5)},
+		location:  db.ThemeLocation{ID: locationID, ThemeID: themeID, Name: "서재", RestrictedCharacters: text("char-a,char-b"), FromRound: int4(1), UntilRound: int4(4)},
+	}
+}
+
+func (f *fakeImageQueries) GetTheme(context.Context, uuid.UUID) (db.Theme, error) {
+	return f.theme, nil
+}
+func (f *fakeImageQueries) GetThemeCharacter(context.Context, uuid.UUID) (db.ThemeCharacter, error) {
+	return f.character, nil
+}
+func (f *fakeImageQueries) UpdateThemeCharacter(_ context.Context, arg db.UpdateThemeCharacterParams) (db.ThemeCharacter, error) {
+	f.updateCharacterArg = arg
+	return f.character, nil
+}
+func (f *fakeImageQueries) GetClue(context.Context, uuid.UUID) (db.ThemeClue, error) {
+	return f.clue, nil
+}
+func (f *fakeImageQueries) UpdateClue(_ context.Context, arg db.UpdateClueParams) (db.ThemeClue, error) {
+	f.updateClueArg = arg
+	return f.clue, nil
+}
+func (f *fakeImageQueries) GetLocation(context.Context, uuid.UUID) (db.ThemeLocation, error) {
+	return f.location, nil
+}
+func (f *fakeImageQueries) UpdateLocation(_ context.Context, arg db.UpdateLocationParams) (db.ThemeLocation, error) {
+	f.updateLocationArg = arg
+	return f.location, nil
+}
+func (f *fakeImageQueries) UpdateThemeCoverImage(context.Context, db.UpdateThemeCoverImageParams) error {
+	return nil
+}
+
+type fakeImageStorage struct{}
+
+func (fakeImageStorage) GenerateUploadURL(context.Context, string, string, int64, time.Duration) (string, error) {
+	return "https://upload", nil
+}
+func (fakeImageStorage) GenerateDownloadURL(_ context.Context, key string, _ time.Duration) (string, error) {
+	return "https://cdn.example/" + key, nil
+}
+func (fakeImageStorage) HeadObject(_ context.Context, key string) (*storage.ObjectMeta, error) {
+	return &storage.ObjectMeta{Key: key}, nil
+}
+func (fakeImageStorage) GetObjectRange(context.Context, string, int64, int64) (io.ReadCloser, error) {
+	return nil, storage.ErrObjectNotFound
+}
+func (fakeImageStorage) DeleteObject(context.Context, string) error    { return nil }
+func (fakeImageStorage) DeleteObjects(context.Context, []string) error { return nil }
+
+func text(value string) pgtype.Text { return pgtype.Text{String: value, Valid: true} }
+func int4(value int32) pgtype.Int4  { return pgtype.Int4{Int32: value, Valid: true} }

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -141,6 +141,7 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 		SortOrder:            req.SortOrder,
 		FromRound:            int32PtrToPgtype(req.FromRound),
 		UntilRound:           int32PtrToPgtype(req.UntilRound),
+		ImageUrl:             ptrToText(req.ImageURL),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create location")
@@ -162,6 +163,10 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		s.logger.Error().Err(err).Msg("failed to get location")
 		return nil, apperror.Internal("failed to get location")
 	}
+	imageURL := l.ImageUrl
+	if req.ImageURL != nil {
+		imageURL = ptrToText(req.ImageURL)
+	}
 	updated, err := s.q.UpdateLocation(ctx, db.UpdateLocationParams{
 		ID:                   l.ID,
 		Name:                 req.Name,
@@ -169,6 +174,7 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		SortOrder:            req.SortOrder,
 		FromRound:            int32PtrToPgtype(req.FromRound),
 		UntilRound:           int32PtrToPgtype(req.UntilRound),
+		ImageUrl:             imageURL,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update location")
@@ -218,6 +224,7 @@ func toLocationResponse(l db.ThemeLocation) LocationResponse {
 		MapID:                l.MapID,
 		Name:                 l.Name,
 		RestrictedCharacters: textToPtr(l.RestrictedCharacters),
+		ImageURL:             textToPtr(l.ImageUrl),
 		SortOrder:            l.SortOrder,
 		CreatedAt:            l.CreatedAt,
 		FromRound:            pgtypeInt4ToPtr(l.FromRound),

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -34,6 +34,7 @@ type MapResponse struct {
 type CreateLocationRequest struct {
 	Name                 string  `json:"name" validate:"required,min=1,max=100"`
 	RestrictedCharacters *string `json:"restricted_characters"`
+	ImageURL             *string `json:"image_url" validate:"omitempty,url"`
 	SortOrder            int32   `json:"sort_order" validate:"min=0"`
 	FromRound            *int32  `json:"from_round" validate:"omitempty,min=1"`
 	UntilRound           *int32  `json:"until_round" validate:"omitempty,min=1"`
@@ -42,6 +43,7 @@ type CreateLocationRequest struct {
 type UpdateLocationRequest struct {
 	Name                 string  `json:"name" validate:"required,min=1,max=100"`
 	RestrictedCharacters *string `json:"restricted_characters"`
+	ImageURL             *string `json:"image_url" validate:"omitempty,url"`
 	SortOrder            int32   `json:"sort_order" validate:"min=0"`
 	FromRound            *int32  `json:"from_round" validate:"omitempty,min=1"`
 	UntilRound           *int32  `json:"until_round" validate:"omitempty,min=1"`
@@ -53,6 +55,7 @@ type LocationResponse struct {
 	MapID                uuid.UUID `json:"map_id"`
 	Name                 string    `json:"name"`
 	RestrictedCharacters *string   `json:"restricted_characters,omitempty"`
+	ImageURL             *string   `json:"image_url,omitempty"`
 	SortOrder            int32     `json:"sort_order"`
 	CreatedAt            time.Time `json:"created_at"`
 	FromRound            *int32    `json:"from_round,omitempty"`

--- a/apps/web/e2e/phase24-editor-preview.spec.ts
+++ b/apps/web/e2e/phase24-editor-preview.spec.ts
@@ -101,5 +101,14 @@ test.describe("Phase 24 에디터 entity preview", () => {
     await expect
       .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth))
       .toBe(true);
+
+    await page.keyboard.press("Tab");
+    await expect(page.locator(":focus")).toBeVisible();
+
+    const mobileA11y = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(mobileA11y.violations).toEqual([]);
   });
 });

--- a/apps/web/e2e/phase24-editor-preview.spec.ts
+++ b/apps/web/e2e/phase24-editor-preview.spec.ts
@@ -79,4 +79,27 @@ test.describe("Phase 24 에디터 entity preview", () => {
       .analyze();
     expect(a11y.violations).toEqual([]);
   });
+
+  test("장소 entity preview를 모바일과 데스크톱에서 확인한다", async ({ page }) => {
+    await page.goto("/__dev/phase24-location-entity-preview");
+
+    await expect(page.getByRole("heading", { name: "장소 엔티티 설계 목업" })).toBeVisible();
+    await expect(page.getByRole("button", { name: /장소\s*8곳 entity/ })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "서재" })).toBeVisible();
+    await expect(page.getByText("접근 제한", { exact: true })).toBeVisible();
+    await expect(page.getByText("장소 단서 추가", { exact: true })).toBeVisible();
+
+    const desktopA11y = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(desktopA11y.violations).toEqual([]);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.reload();
+    await expect(page.getByText("모바일 흐름")).toBeVisible();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth))
+      .toBe(true);
+  });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -40,6 +40,9 @@ const Phase24EditorPreviewPage = import.meta.env.DEV
 const Phase24ImageRoleSheetPreviewPage = import.meta.env.DEV
   ? lazy(() => import("@/pages/Phase24ImageRoleSheetPreviewPage"))
   : null;
+const Phase24LocationEntityPreviewPage = import.meta.env.DEV
+  ? lazy(() => import("@/pages/Phase24LocationEntityPreviewPage"))
+  : null;
 
 // Shop
 const ShopPage = lazy(() => import("@/pages/ShopPage"));
@@ -233,6 +236,12 @@ export function App() {
                 <Route
                   path="/__dev/phase24-image-role-sheet-preview"
                   element={<Phase24ImageRoleSheetPreviewPage />}
+                />
+              )}
+              {Phase24LocationEntityPreviewPage && (
+                <Route
+                  path="/__dev/phase24-location-entity-preview"
+                  element={<Phase24LocationEntityPreviewPage />}
                 />
               )}
               <Route path="/offline" element={<OfflinePage />} />

--- a/apps/web/src/features/editor/__tests__/imageApi.test.ts
+++ b/apps/web/src/features/editor/__tests__/imageApi.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -13,7 +13,7 @@ const { mockPost, mockInvalidateQueries } = vi.hoisted(() => ({
 // Mock: @/services/api
 // ---------------------------------------------------------------------------
 
-vi.mock("@/services/api", () => ({
+vi.mock('@/services/api', () => ({
   api: { post: mockPost },
 }));
 
@@ -21,11 +21,12 @@ vi.mock("@/services/api", () => ({
 // Mock: @/features/editor/api (for queryClient invalidation)
 // ---------------------------------------------------------------------------
 
-vi.mock("@/features/editor/api", () => ({
+vi.mock('@/features/editor/api', () => ({
   editorKeys: {
-    characters: (id: string) => ["editor", "characters", id],
-    theme: (id: string) => ["editor", "theme", id],
-    clues: (id: string) => ["editor", "clues", id],
+    characters: (id: string) => ['editor', 'characters', id],
+    theme: (id: string) => ['editor', 'theme', id],
+    clues: (id: string) => ['editor', 'clues', id],
+    locations: (id: string) => ['editor', 'locations', id],
   },
 }));
 
@@ -33,7 +34,7 @@ vi.mock("@/features/editor/api", () => ({
 // Mock: @/services/queryClient
 // ---------------------------------------------------------------------------
 
-vi.mock("@/services/queryClient", () => ({
+vi.mock('@/services/queryClient', () => ({
   queryClient: { invalidateQueries: mockInvalidateQueries },
 }));
 
@@ -41,74 +42,81 @@ vi.mock("@/services/queryClient", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { uploadImage, useConfirmImageUpload } from "../imageApi";
-import { renderHook } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import React from "react";
+import { uploadImage, useConfirmImageUpload } from '../imageApi';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("uploadImage", () => {
-  const themeId = "theme-uuid-123";
-  const targetId = "char-uuid-456";
-  const blob = new Blob(["fake"], { type: "image/webp" });
+describe('uploadImage', () => {
+  const themeId = 'theme-uuid-123';
+  const targetId = 'char-uuid-456';
+  const blob = new Blob(['fake'], { type: 'image/webp' });
 
   beforeEach(() => {
     vi.clearAllMocks();
     // fetch mock for S3 PUT
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: true } as Response),
-    );
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true } as Response));
     mockPost
-      .mockResolvedValueOnce({ upload_url: "https://s3/presigned", upload_key: "key-abc" })
-      .mockResolvedValueOnce({ image_url: "https://cdn/image.webp" });
+      .mockResolvedValueOnce({ upload_url: 'https://s3/presigned', upload_key: 'key-abc' })
+      .mockResolvedValueOnce({ image_url: 'https://cdn/image.webp' });
   });
 
-  it("sends target_id when target is character and targetId is non-empty", async () => {
-    await uploadImage(themeId, "character", targetId, blob, "image/webp");
+  it('sends target_id when target is character and targetId is non-empty', async () => {
+    await uploadImage(themeId, 'character', targetId, blob, 'image/webp');
 
     expect(mockPost).toHaveBeenNthCalledWith(
       1,
       `/v1/editor/themes/${themeId}/images/upload-url`,
-      expect.objectContaining({ target_id: targetId }),
+      expect.objectContaining({ target_id: targetId })
     );
   });
 
-  it("omits target_id when target is character and targetId is empty string", async () => {
-    await uploadImage(themeId, "character", "", blob, "image/webp");
+  it('omits target_id when target is character and targetId is empty string', async () => {
+    await uploadImage(themeId, 'character', '', blob, 'image/webp');
 
     const body = mockPost.mock.calls[0][1] as Record<string, unknown>;
-    expect(body).not.toHaveProperty("target_id");
+    expect(body).not.toHaveProperty('target_id');
   });
 
-  it("omits target_id when target is cover regardless of targetId", async () => {
-    await uploadImage(themeId, "cover", themeId, blob, "image/webp");
+  it('omits target_id when target is cover regardless of targetId', async () => {
+    await uploadImage(themeId, 'cover', themeId, blob, 'image/webp');
 
     const body = mockPost.mock.calls[0][1] as Record<string, unknown>;
-    expect(body).not.toHaveProperty("target_id");
+    expect(body).not.toHaveProperty('target_id');
   });
 
-  it("returns the image_url from confirm response", async () => {
-    const url = await uploadImage(themeId, "character", targetId, blob, "image/webp");
-    expect(url).toBe("https://cdn/image.webp");
+  it('sends target_id when target is location', async () => {
+    await uploadImage(themeId, 'location', targetId, blob, 'image/webp');
+
+    expect(mockPost).toHaveBeenNthCalledWith(
+      1,
+      `/v1/editor/themes/${themeId}/images/upload-url`,
+      expect.objectContaining({ target: 'location', target_id: targetId })
+    );
   });
 
-  it("throws when themeId is empty and does not hit the API", async () => {
-    await expect(
-      uploadImage("", "character", targetId, blob, "image/webp"),
-    ).rejects.toThrow(/themeId/);
+  it('returns the image_url from confirm response', async () => {
+    const url = await uploadImage(themeId, 'character', targetId, blob, 'image/webp');
+    expect(url).toBe('https://cdn/image.webp');
+  });
+
+  it('throws when themeId is empty and does not hit the API', async () => {
+    await expect(uploadImage('', 'character', targetId, blob, 'image/webp')).rejects.toThrow(
+      /themeId/
+    );
     expect(mockPost).not.toHaveBeenCalled();
   });
 
-  it("hits the single-prefix path /v1/editor/themes/.../images/upload-url", async () => {
-    await uploadImage(themeId, "clue", targetId, blob, "image/webp");
+  it('hits the single-prefix path /v1/editor/themes/.../images/upload-url', async () => {
+    await uploadImage(themeId, 'clue', targetId, blob, 'image/webp');
     expect(mockPost).toHaveBeenNthCalledWith(
       1,
       `/v1/editor/themes/${themeId}/images/upload-url`,
-      expect.any(Object),
+      expect.any(Object)
     );
     // Guard: no double /v1 prefix
     const calledPath = mockPost.mock.calls[0][0] as string;
@@ -121,8 +129,8 @@ describe("uploadImage", () => {
 // useConfirmImageUpload — cache invalidation
 // ---------------------------------------------------------------------------
 
-describe("useConfirmImageUpload", () => {
-  const themeId = "theme-uuid-123";
+describe('useConfirmImageUpload', () => {
+  const themeId = 'theme-uuid-123';
 
   function wrapper({ children }: { children: React.ReactNode }) {
     const qc = new QueryClient();
@@ -131,23 +139,26 @@ describe("useConfirmImageUpload", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPost.mockResolvedValue({ image_url: "https://cdn/image.webp" });
+    mockPost.mockResolvedValue({ image_url: 'https://cdn/image.webp' });
   });
 
-  it("invalidates characters, theme, and clues caches on success", async () => {
+  it('invalidates characters, theme, clues, and locations caches on success', async () => {
     const { result } = renderHook(() => useConfirmImageUpload(themeId), { wrapper });
 
-    await result.current.mutateAsync({ upload_key: "key-abc" });
+    await result.current.mutateAsync({ upload_key: 'key-abc' });
 
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["editor", "characters", themeId],
+      queryKey: ['editor', 'characters', themeId],
     });
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["editor", "theme", themeId],
+      queryKey: ['editor', 'theme', themeId],
     });
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["editor", "clues", themeId],
+      queryKey: ['editor', 'clues', themeId],
     });
-    expect(mockInvalidateQueries).toHaveBeenCalledTimes(3);
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['editor', 'locations', themeId],
+    });
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(4);
   });
 });

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -2,7 +2,13 @@
 // Editor API — shared types
 // ---------------------------------------------------------------------------
 
-export type ThemeStatus = "DRAFT" | "PENDING_REVIEW" | "PUBLISHED" | "REJECTED" | "UNPUBLISHED" | "SUSPENDED";
+export type ThemeStatus =
+  | 'DRAFT'
+  | 'PENDING_REVIEW'
+  | 'PUBLISHED'
+  | 'REJECTED'
+  | 'UNPUBLISHED'
+  | 'SUSPENDED';
 
 export interface EditorThemeSummary {
   id: string;
@@ -46,7 +52,7 @@ export interface EditorCharacterResponse {
   sort_order: number;
 }
 
-export type MysteryRole = "suspect" | "culprit" | "accomplice" | "detective";
+export type MysteryRole = 'suspect' | 'culprit' | 'accomplice' | 'detective';
 
 export interface CreateThemeRequest {
   title: string;
@@ -145,6 +151,7 @@ export interface LocationResponse {
   map_id: string;
   name: string;
   restricted_characters: string | null;
+  image_url: string | null;
   sort_order: number;
   created_at: string;
   from_round?: number | null;
@@ -178,7 +185,7 @@ export interface ContentResponse {
   updated_at: string;
 }
 
-export type RoleSheetFormat = "markdown" | "pdf" | "images";
+export type RoleSheetFormat = 'markdown' | 'pdf' | 'images';
 
 export interface RoleSheetMarkdown {
   body: string;
@@ -204,15 +211,15 @@ export interface RoleSheetResponse {
 
 export type UpsertRoleSheetRequest =
   | {
-      format: "markdown";
+      format: 'markdown';
       markdown: RoleSheetMarkdown;
     }
   | {
-      format: "pdf";
+      format: 'pdf';
       pdf: RoleSheetPDF;
     }
   | {
-      format: "images";
+      format: 'images';
       images: RoleSheetImages;
     };
 
@@ -227,7 +234,7 @@ export interface ValidationResponse {
   };
 }
 
-export type JSONSchema = import("@/features/editor/templateApi").JSONSchemaProperty;
+export type JSONSchema = import('@/features/editor/templateApi').JSONSchemaProperty;
 
 export interface ModuleSchemasResponse {
   schemas: Record<string, JSONSchema>;

--- a/apps/web/src/features/editor/components/ImageCropUpload.tsx
+++ b/apps/web/src/features/editor/components/ImageCropUpload.tsx
@@ -15,7 +15,7 @@ import { getCroppedBlob, makeInitialCrop } from './cropUtils';
 export interface ImageCropUploadProps {
   themeId: string;
   targetId: string;
-  target: 'character' | 'clue';
+  target: 'character' | 'clue' | 'location';
   currentImageUrl?: string | null;
   onUploaded: (url: string) => void;
   size?: 'sm' | 'md' | 'lg';

--- a/apps/web/src/features/editor/components/ImageUpload.tsx
+++ b/apps/web/src/features/editor/components/ImageUpload.tsx
@@ -10,7 +10,7 @@ import { uploadImage } from '@/features/editor/imageApi';
 export interface ImageUploadProps {
   themeId: string;
   targetId: string;
-  target: 'character' | 'clue' | 'cover';
+  target: 'character' | 'clue' | 'location' | 'cover';
   currentImageUrl?: string | null;
   onUploaded: (url: string) => void;
   aspectRatio?: string;

--- a/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
@@ -1,0 +1,95 @@
+import { LockKeyhole } from 'lucide-react';
+import { toast } from 'sonner';
+import { Spinner } from '@/shared/components/ui/Spinner';
+import type { LocationResponse } from '@/features/editor/api';
+import { useEditorCharacters, useUpdateLocation } from '@/features/editor/api';
+
+interface LocationAccessPolicyPanelProps {
+  themeId: string;
+  location: LocationResponse;
+}
+
+function parseRestrictedCharacters(value: string | null) {
+  if (!value) return new Set<string>();
+  return new Set(
+    value
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)
+  );
+}
+
+function stringifyRestrictedCharacters(ids: Set<string>) {
+  return ids.size > 0 ? Array.from(ids).join(',') : null;
+}
+
+export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessPolicyPanelProps) {
+  const { data: characters, isLoading } = useEditorCharacters(themeId);
+  const updateLocation = useUpdateLocation(themeId);
+  const restrictedSet = parseRestrictedCharacters(location.restricted_characters);
+
+  function toggleCharacter(characterId: string, restricted: boolean) {
+    const next = new Set(restrictedSet);
+    if (restricted) next.add(characterId);
+    else next.delete(characterId);
+
+    updateLocation.mutate(
+      {
+        locationId: location.id,
+        body: {
+          name: location.name,
+          restricted_characters: stringifyRestrictedCharacters(next),
+          image_url: location.image_url,
+          sort_order: location.sort_order,
+          from_round: location.from_round ?? null,
+          until_round: location.until_round ?? null,
+        },
+      },
+      { onError: () => toast.error('접근 제한 저장에 실패했습니다') }
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-3 flex items-start gap-2">
+        <LockKeyhole className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+        <div>
+          <p className="text-xs font-semibold text-slate-200">접근 제한</p>
+          <p className="mt-1 text-xs leading-5 text-slate-500">
+            체크한 캐릭터는 이 장소에 들어오지 못합니다.
+          </p>
+        </div>
+      </div>
+      {isLoading ? (
+        <div className="flex justify-center py-4">
+          <Spinner size="sm" />
+        </div>
+      ) : !characters || characters.length === 0 ? (
+        <p className="rounded-md border border-dashed border-slate-800 px-3 py-4 text-center text-xs text-slate-600">
+          캐릭터가 없습니다.
+        </p>
+      ) : (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {characters.map((character) => (
+            <label
+              key={character.id}
+              className="flex items-start gap-2 rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                checked={restrictedSet.has(character.id)}
+                disabled={updateLocation.isPending}
+                onChange={(event) => toggleCharacter(character.id, event.target.checked)}
+                className="mt-1 accent-amber-500"
+              />
+              <span className="min-w-0">
+                <span className="block truncate font-medium text-slate-200">{character.name}</span>
+                <span className="block text-xs text-slate-500">{character.mystery_role}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
@@ -24,7 +24,7 @@ function stringifyRestrictedCharacters(ids: Set<string>) {
 }
 
 export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessPolicyPanelProps) {
-  const { data: characters, isLoading } = useEditorCharacters(themeId);
+  const { data: characters, isLoading, isError, error, refetch } = useEditorCharacters(themeId);
   const updateLocation = useUpdateLocation(themeId);
   const restrictedSet = parseRestrictedCharacters(location.restricted_characters);
 
@@ -63,6 +63,17 @@ export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessP
       {isLoading ? (
         <div className="flex justify-center py-4">
           <Spinner size="sm" />
+        </div>
+      ) : isError ? (
+        <div className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-4 text-center text-xs text-red-100">
+          <p>{error instanceof Error ? error.message : '캐릭터 목록을 불러오지 못했습니다.'}</p>
+          <button
+            type="button"
+            onClick={() => refetch?.()}
+            className="mt-2 rounded-md border border-red-300/30 px-2 py-1 text-red-50 hover:bg-red-500/20"
+          >
+            다시 불러오기
+          </button>
         </div>
       ) : !characters || characters.length === 0 ? (
         <p className="rounded-md border border-dashed border-slate-800 px-3 py-4 text-center text-xs text-slate-600">

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -1,38 +1,29 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { Package, MapPin, Check } from 'lucide-react';
+import { Check, MapPin, Package, Plus, Search, X } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Spinner } from '@/shared/components/ui/Spinner';
-import type {
-  EditorThemeResponse,
-  LocationResponse,
-  ClueResponse,
-} from '@/features/editor/api';
+import type { EditorThemeResponse, LocationResponse, ClueResponse } from '@/features/editor/api';
 import { editorKeys, useEditorClues, useUpdateConfigJson } from '@/features/editor/api';
 import { readLocationClueIds, writeLocationClueIds } from '@/features/editor/editorTypes';
-
-// ---------------------------------------------------------------------------
-// Props
-// ---------------------------------------------------------------------------
 
 interface LocationClueAssignPanelProps {
   themeId: string;
   theme: EditorThemeResponse;
   location: LocationResponse;
-  /** Override clue list (mainly for tests); defaults to `useEditorClues`. */
   allClues?: ClueResponse[];
-  /** Optional callback after a successful config update. */
   onChange?: (clueIds: string[]) => void;
 }
 
-// ---------------------------------------------------------------------------
-// LocationClueAssignPanel
-//
-// Renders every clue in the theme as a toggleable chip. Selected chips are
-// the ones currently assigned to `location.id` inside
-// `theme.config_json.locations[].locationClueConfig.clueIds`. Toggling a chip rewrites the
-// config blob via `useUpdateConfigJson`.
-// ---------------------------------------------------------------------------
+function clueMeta(clue: ClueResponse) {
+  return [clue.location_id ? '장소 단서' : '미배치', clue.is_common ? '공용' : null]
+    .filter(Boolean)
+    .join(' · ');
+}
+
+function roundLabel(clue: ClueResponse) {
+  return typeof clue.reveal_round === 'number' ? `R${clue.reveal_round}` : 'CL';
+}
 
 export function LocationClueAssignPanel({
   themeId,
@@ -42,51 +33,57 @@ export function LocationClueAssignPanel({
   onChange,
 }: LocationClueAssignPanelProps) {
   const { data: fetchedClues, isLoading } = useEditorClues(themeId);
-  const clues = allClues ?? fetchedClues ?? [];
+  const clues = useMemo(() => allClues ?? fetchedClues ?? [], [allClues, fetchedClues]);
   const updateConfig = useUpdateConfigJson(themeId);
   const queryClient = useQueryClient();
+  const [query, setQuery] = useState('');
 
   const assignedIds = useMemo(
     () => readLocationClueIds(theme.config_json, location.id),
-    [theme.config_json, location.id],
+    [theme.config_json, location.id]
   );
   const assignedSet = useMemo(() => new Set(assignedIds), [assignedIds]);
+  const selectedClues = clues.filter((clue) => assignedSet.has(clue.id));
+  const visibleClues = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return clues;
+    return clues.filter((clue) =>
+      [clue.name, clue.description, clueMeta(clue), clue.reveal_round?.toString()]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(q)
+    );
+  }, [clues, query]);
 
   function commit(next: string[]) {
     const nextConfig = writeLocationClueIds(theme.config_json, location.id, next);
-
-    // Optimistic cache write: merge the next config into the theme snapshot so
-    // the chip state reflects immediately without waiting for the PATCH round-trip.
-    // Capture `previous` in closure per mutation so concurrent toggles each
-    // rollback to their own pre-state instead of sharing a single ref slot.
     const cacheKey = editorKeys.theme(themeId);
     const previous = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
-    if (previous) {
+    if (previous)
       queryClient.setQueryData<EditorThemeResponse>(cacheKey, {
         ...previous,
         config_json: nextConfig,
       });
-    }
-
     updateConfig.mutate(nextConfig, {
       onSuccess: () => {
         toast.success('단서 배정이 저장되었습니다');
         onChange?.(next);
       },
       onError: () => {
-        if (previous) {
-          queryClient.setQueryData(cacheKey, previous);
-        }
+        if (previous) queryClient.setQueryData(cacheKey, previous);
         toast.error('단서 배정 저장에 실패했습니다');
       },
     });
   }
 
-  function toggle(clueId: string) {
-    const next = assignedSet.has(clueId)
-      ? assignedIds.filter((id) => id !== clueId)
-      : [...assignedIds, clueId];
-    commit(next);
+  function addClue(clueId: string) {
+    if (assignedSet.has(clueId)) return;
+    commit([...assignedIds, clueId]);
+  }
+
+  function removeClue(clueId: string) {
+    commit(assignedIds.filter((id) => id !== clueId));
   }
 
   if (!allClues && isLoading) {
@@ -100,56 +97,158 @@ export function LocationClueAssignPanel({
   return (
     <section
       aria-label={`${location.name} 단서 배정`}
-      className="rounded-sm border border-slate-800 bg-slate-950 p-3"
+      className="rounded-lg border border-slate-800 bg-slate-950/70 p-3"
     >
-      <header className="mb-3 flex items-center gap-2">
+      <header className="mb-3 flex flex-wrap items-center gap-2">
         <MapPin className="h-3.5 w-3.5 text-amber-500/70" />
-        <h4 className="text-xs font-semibold text-slate-300">
-          {location.name} — 단서 배정
-        </h4>
-        <span className="ml-1 text-[10px] text-slate-600">
+        <h4 className="text-sm font-semibold text-slate-200">{location.name} 단서 추가</h4>
+        <span className="text-xs text-slate-600">
           ({assignedIds.length}/{clues.length})
         </span>
       </header>
-
       {clues.length === 0 ? (
-        <div className="rounded-sm border border-dashed border-slate-800 py-6 text-center">
-          <Package className="mx-auto mb-2 h-5 w-5 text-slate-800" />
-          <p className="text-[10px] font-mono uppercase tracking-widest text-slate-700">
-            단서가 없습니다
-          </p>
-        </div>
+        <EmptyClues />
       ) : (
-        <ul className="flex flex-wrap gap-1.5" role="list">
-          {clues.map((clue) => {
-            const selected = assignedSet.has(clue.id);
-            return (
-              <li key={clue.id}>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={selected}
-                  aria-label={`${clue.name} 배정 토글`}
-                  disabled={updateConfig.isPending}
-                  onClick={() => toggle(clue.id)}
-                  className={`group inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
-                    selected
-                      ? 'border-amber-500/50 bg-amber-500/10 text-amber-300 hover:bg-amber-500/20'
-                      : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-200'
-                  }`}
-                >
-                  {selected ? (
-                    <Check className="h-3 w-3 shrink-0" />
-                  ) : (
-                    <Package className="h-3 w-3 shrink-0" />
-                  )}
-                  <span className="truncate max-w-[10rem]">{clue.name}</span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(13rem,0.65fr)]">
+          <section className="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                전체 단서 목록
+              </p>
+              <span className="text-[10px] text-slate-600">
+                {visibleClues.length}/{clues.length}개 표시
+              </span>
+            </div>
+            <label className="relative mb-3 block">
+              <span className="sr-only">단서 검색</span>
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-600" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="단서명, 설명, 라운드 검색"
+                aria-label="단서 검색"
+                className="w-full rounded-lg border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+              />
+            </label>
+            <div className="max-h-80 space-y-1 overflow-auto pr-1">
+              {visibleClues.length === 0 ? (
+                <p className="rounded-md border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
+                  검색 결과가 없습니다.
+                </p>
+              ) : (
+                visibleClues.map((clue) => (
+                  <ClueOption
+                    key={clue.id}
+                    clue={clue}
+                    selected={assignedSet.has(clue.id)}
+                    disabled={updateConfig.isPending}
+                    onAdd={addClue}
+                  />
+                ))
+              )}
+            </div>
+          </section>
+          <section className="rounded-lg border border-amber-500/20 bg-amber-950/10 p-2.5">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
+                이 장소의 단서
+              </p>
+              <span className="text-[10px] text-slate-600">클릭 추가</span>
+            </div>
+            {selectedClues.length === 0 ? (
+              <p className="rounded-md border border-dashed border-slate-800 px-2.5 py-5 text-center text-xs text-slate-600">
+                아직 배정된 단서가 없습니다. 좌측 목록에서 단서를 클릭하세요.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {selectedClues.map((clue) => (
+                  <SelectedClue
+                    key={clue.id}
+                    clue={clue}
+                    disabled={updateConfig.isPending}
+                    onRemove={removeClue}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
       )}
     </section>
+  );
+}
+
+function ClueOption({
+  clue,
+  selected,
+  disabled,
+  onAdd,
+}: {
+  clue: ClueResponse;
+  selected: boolean;
+  disabled: boolean;
+  onAdd: (id: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onAdd(clue.id)}
+      disabled={disabled || selected}
+      aria-label={`${clue.name} 추가`}
+      className="group flex w-full items-center gap-3 rounded-md border border-transparent px-2 py-2 text-left transition hover:border-amber-500/30 hover:bg-slate-800/80 disabled:cursor-default disabled:border-amber-500/10 disabled:bg-amber-950/10"
+    >
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-800 text-[10px] font-semibold text-amber-400">
+        {roundLabel(clue)}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-slate-200">{clue.name}</span>
+        <span className="mt-0.5 block truncate text-xs text-slate-500">{clueMeta(clue)}</span>
+      </span>
+      <span className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-slate-700 px-2 text-[10px] font-semibold text-slate-500 group-hover:border-amber-500 group-hover:text-amber-300 group-disabled:border-amber-500/20 group-disabled:text-amber-300/70">
+        {selected ? <Check className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+      </span>
+    </button>
+  );
+}
+
+function SelectedClue({
+  clue,
+  disabled,
+  onRemove,
+}: {
+  clue: ClueResponse;
+  disabled: boolean;
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-slate-950/80 px-2.5 py-1.5">
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-amber-500/10 text-[9px] font-semibold text-amber-300">
+        {roundLabel(clue)}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-xs font-medium text-slate-200">{clue.name}</span>
+        <span className="block truncate text-[10px] text-slate-600">{clueMeta(clue)}</span>
+      </span>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onRemove(clue.id)}
+        aria-label={`${clue.name} 제거`}
+        className="rounded-full p-1 text-slate-600 hover:bg-red-950/40 hover:text-red-300 disabled:opacity-50"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+function EmptyClues() {
+  return (
+    <div className="rounded-md border border-dashed border-slate-800 py-6 text-center">
+      <Package className="mx-auto mb-2 h-5 w-5 text-slate-800" />
+      <p className="text-[10px] font-mono uppercase tracking-widest text-slate-700">
+        단서가 없습니다
+      </p>
+    </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -32,7 +32,7 @@ export function LocationClueAssignPanel({
   allClues,
   onChange,
 }: LocationClueAssignPanelProps) {
-  const { data: fetchedClues, isLoading } = useEditorClues(themeId);
+  const { data: fetchedClues, isLoading, isError, error, refetch } = useEditorClues(themeId);
   const clues = useMemo(() => allClues ?? fetchedClues ?? [], [allClues, fetchedClues]);
   const updateConfig = useUpdateConfigJson(themeId);
   const queryClient = useQueryClient();
@@ -91,6 +91,24 @@ export function LocationClueAssignPanel({
       <div className="flex items-center justify-center py-6">
         <Spinner size="sm" />
       </div>
+    );
+  }
+
+  if (!allClues && isError) {
+    return (
+      <section
+        aria-label={`${location.name} 단서 배정`}
+        className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-center text-xs text-red-100"
+      >
+        <p>{error instanceof Error ? error.message : '단서 목록을 불러오지 못했습니다.'}</p>
+        <button
+          type="button"
+          onClick={() => refetch?.()}
+          className="mt-2 rounded-md border border-red-300/30 px-2 py-1 text-red-50 hover:bg-red-500/20"
+        >
+          다시 불러오기
+        </button>
+      </section>
     );
   }
 
@@ -153,7 +171,7 @@ export function LocationClueAssignPanel({
               <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
                 이 장소의 단서
               </p>
-              <span className="text-[10px] text-slate-600">클릭 추가</span>
+              <span className="text-[10px] text-slate-600">클릭 제거</span>
             </div>
             {selectedClues.length === 0 ? (
               <p className="rounded-md border border-dashed border-slate-800 px-2.5 py-5 text-center text-xs text-slate-600">

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -25,12 +25,16 @@ interface LocationDetailPanelProps {
   onDeleteLocation: (locationId: string) => void;
 }
 
-function parseRound(raw: string): number | null {
+function parseRound(raw: string): number | null | undefined {
   const trimmed = raw.trim();
   if (trimmed === '') return null;
   const n = Number(trimmed);
-  if (!Number.isFinite(n) || n < 1) return null;
+  if (!Number.isFinite(n) || n < 1) return undefined;
   return Math.floor(n);
+}
+
+function roundToInput(value: number | null | undefined) {
+  return value == null ? '' : String(value);
 }
 
 function getPathLabel(map: MapResponse, location: LocationResponse) {
@@ -83,7 +87,7 @@ export function LocationDetailPanel({
         {mapLocations.length === 0 ? (
           <LocationEmptyState message="장소 없음" compact />
         ) : (
-          <ul className="space-y-1" role="listbox" aria-label={`${selectedMap.name} 장소 목록`}>
+          <ul className="space-y-1" aria-label={`${selectedMap.name} 장소 목록`}>
             {mapLocations.map((loc) => (
               <LocationListItem
                 key={loc.id}
@@ -125,8 +129,7 @@ function LocationListItem({
     <li className="group flex items-center gap-1">
       <button
         type="button"
-        role="option"
-        aria-selected={selected}
+        aria-pressed={selected}
         onClick={() => onSelect(location.id)}
         className={`flex min-w-0 flex-1 items-center gap-2 rounded-md border px-3 py-2 text-left transition ${selected ? 'border-amber-500/50 bg-amber-500/10 text-amber-200' : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-200'}`}
       >
@@ -135,7 +138,9 @@ function LocationListItem({
       </button>
       <button
         type="button"
-        onClick={() => onDelete(location.id)}
+        onClick={() => {
+          if (window.confirm(`${location.name} 장소를 삭제할까요?`)) onDelete(location.id);
+        }}
         aria-label={`${location.name} 삭제`}
         className="rounded-md p-2 text-slate-700 opacity-100 transition hover:bg-red-950/40 hover:text-red-300 md:opacity-0 md:group-hover:opacity-100"
       >
@@ -157,25 +162,37 @@ function SelectedLocationDetail({
   location: LocationResponse;
 }) {
   const updateLocation = useUpdateLocation(themeId);
-  const [fromRound, setFromRound] = useState<number | null>(location.from_round ?? null);
-  const [untilRound, setUntilRound] = useState<number | null>(location.until_round ?? null);
+  const [fromRoundInput, setFromRoundInput] = useState(roundToInput(location.from_round));
+  const [untilRoundInput, setUntilRoundInput] = useState(roundToInput(location.until_round));
   const assignedCount = useMemo(
     () => readLocationClueIds(theme.config_json, location.id).length,
     [theme.config_json, location.id]
   );
 
   useEffect(() => {
-    setFromRound(location.from_round ?? null);
-    setUntilRound(location.until_round ?? null);
+    setFromRoundInput(roundToInput(location.from_round));
+    setUntilRoundInput(roundToInput(location.until_round));
   }, [location.id, location.from_round, location.until_round]);
 
   function saveLocation(patch: Partial<LocationResponse>) {
-    const nextFrom = patch.from_round !== undefined ? patch.from_round : fromRound;
-    const nextUntil = patch.until_round !== undefined ? patch.until_round : untilRound;
+    const currentFrom = parseRound(fromRoundInput);
+    const currentUntil = parseRound(untilRoundInput);
+    const nextFrom =
+      patch.from_round !== undefined
+        ? patch.from_round
+        : currentFrom === undefined
+          ? (location.from_round ?? null)
+          : currentFrom;
+    const nextUntil =
+      patch.until_round !== undefined
+        ? patch.until_round
+        : currentUntil === undefined
+          ? (location.until_round ?? null)
+          : currentUntil;
     if (nextFrom != null && nextUntil != null && nextFrom > nextUntil) {
       toast.error('등장 라운드는 퇴장 라운드보다 클 수 없습니다');
-      setFromRound(location.from_round ?? null);
-      setUntilRound(location.until_round ?? null);
+      setFromRoundInput(roundToInput(location.from_round));
+      setUntilRoundInput(roundToInput(location.until_round));
       return;
     }
     const nextImageUrl = Object.prototype.hasOwnProperty.call(patch, 'image_url')
@@ -230,10 +247,10 @@ function SelectedLocationDetail({
           <div className="space-y-3">
             <RoundFields
               location={location}
-              fromRound={fromRound}
-              untilRound={untilRound}
-              setFromRound={setFromRound}
-              setUntilRound={setUntilRound}
+              fromRoundInput={fromRoundInput}
+              untilRoundInput={untilRoundInput}
+              setFromRoundInput={setFromRoundInput}
+              setUntilRoundInput={setUntilRoundInput}
               onCommit={saveLocation}
             />
             <InfoBox />
@@ -248,19 +265,30 @@ function SelectedLocationDetail({
 
 function RoundFields({
   location,
-  fromRound,
-  untilRound,
-  setFromRound,
-  setUntilRound,
+  fromRoundInput,
+  untilRoundInput,
+  setFromRoundInput,
+  setUntilRoundInput,
   onCommit,
 }: {
   location: LocationResponse;
-  fromRound: number | null;
-  untilRound: number | null;
-  setFromRound: (value: number | null) => void;
-  setUntilRound: (value: number | null) => void;
+  fromRoundInput: string;
+  untilRoundInput: string;
+  setFromRoundInput: (value: string) => void;
+  setUntilRoundInput: (value: string) => void;
   onCommit: (patch: Partial<LocationResponse>) => void;
 }) {
+  function commitRound(kind: 'from_round' | 'until_round', raw: string) {
+    const parsed = parseRound(raw);
+    if (parsed === undefined) {
+      toast.error('라운드는 1 이상의 숫자로 입력해 주세요');
+      if (kind === 'from_round') setFromRoundInput(roundToInput(location.from_round));
+      else setUntilRoundInput(roundToInput(location.until_round));
+      return;
+    }
+    onCommit({ [kind]: parsed });
+  }
+
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
       <p className="mb-2 text-xs font-semibold text-slate-300">라운드 노출</p>
@@ -271,9 +299,9 @@ function RoundFields({
             type="number"
             min={1}
             aria-label={`${location.name} 등장 라운드`}
-            value={fromRound ?? ''}
-            onChange={(e) => setFromRound(parseRound(e.target.value))}
-            onBlur={() => onCommit({ from_round: fromRound, until_round: untilRound })}
+            value={fromRoundInput}
+            onChange={(e) => setFromRoundInput(e.target.value)}
+            onBlur={() => commitRound('from_round', fromRoundInput)}
             className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
           />
         </label>
@@ -283,9 +311,9 @@ function RoundFields({
             type="number"
             min={1}
             aria-label={`${location.name} 퇴장 라운드`}
-            value={untilRound ?? ''}
-            onChange={(e) => setUntilRound(parseRound(e.target.value))}
-            onBlur={() => onCommit({ from_round: fromRound, until_round: untilRound })}
+            value={untilRoundInput}
+            onChange={(e) => setUntilRoundInput(e.target.value)}
+            onBlur={() => commitRound('until_round', untilRoundInput)}
             className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
           />
         </label>

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -1,96 +1,320 @@
-import { Plus } from 'lucide-react';
-import { MapPin } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Image, Info, MapPin, Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/shared/components/ui/Button';
-import type { MapResponse, LocationResponse } from '@/features/editor/api';
+import type { EditorThemeResponse, MapResponse, LocationResponse } from '@/features/editor/api';
+import { useUpdateLocation } from '@/features/editor/api';
+import { ImageUpload } from '@/features/editor/components/ImageUpload';
+import { readLocationClueIds } from '@/features/editor/editorTypes';
 import { AddNameInput } from './AddNameInput';
-import { LocationRow } from './LocationRow';
-
-// ---------------------------------------------------------------------------
-// Props
-// ---------------------------------------------------------------------------
+import { LocationAccessPolicyPanel } from './LocationAccessPolicyPanel';
+import { LocationClueAssignPanel } from './LocationClueAssignPanel';
 
 interface LocationDetailPanelProps {
   themeId: string;
+  theme: EditorThemeResponse;
   selectedMap: MapResponse | null;
+  selectedLocation: LocationResponse | null;
   mapLocations: LocationResponse[];
   addingLocation: boolean;
   isCreatingLocation: boolean;
   onStartAdd: () => void;
   onCancelAdd: () => void;
   onAddLocation: (name: string) => void;
+  onSelectLocation: (locationId: string) => void;
   onDeleteLocation: (locationId: string) => void;
 }
 
-// ---------------------------------------------------------------------------
-// LocationDetailPanel
-// ---------------------------------------------------------------------------
+function parseRound(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return Math.floor(n);
+}
+
+function getPathLabel(map: MapResponse, location: LocationResponse) {
+  return `${map.name} / ${location.name}`;
+}
 
 export function LocationDetailPanel({
   themeId,
+  theme,
   selectedMap,
+  selectedLocation,
   mapLocations,
   addingLocation,
   isCreatingLocation,
   onStartAdd,
   onCancelAdd,
   onAddLocation,
+  onSelectLocation,
   onDeleteLocation,
 }: LocationDetailPanelProps) {
-  if (!selectedMap) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <MapPin className="mx-auto mb-2 h-8 w-8 text-slate-800" />
-          <p className="text-xs font-mono uppercase tracking-widest text-slate-700">
-            좌측에서 맵을 선택하세요
-          </p>
+  if (!selectedMap) return <LocationEmptyState message="좌측에서 맵을 선택하세요" />;
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(16rem,0.42fr)_minmax(0,1fr)]">
+      <section className="rounded-lg border border-slate-800 bg-slate-950/70 p-3">
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-600">
+              장소 트리
+            </p>
+            <h3 className="mt-1 truncate text-sm font-semibold text-slate-200">
+              {selectedMap.name}
+            </h3>
+          </div>
+          <Button size="sm" onClick={onStartAdd}>
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            장소 추가
+          </Button>
         </div>
-      </div>
+        {addingLocation && (
+          <div className="mb-3 rounded-md border border-amber-500/30 bg-slate-900 p-2">
+            <AddNameInput
+              placeholder="장소 이름"
+              onAdd={onAddLocation}
+              onCancel={onCancelAdd}
+              isPending={isCreatingLocation}
+            />
+          </div>
+        )}
+        {mapLocations.length === 0 ? (
+          <LocationEmptyState message="장소 없음" compact />
+        ) : (
+          <ul className="space-y-1" role="listbox" aria-label={`${selectedMap.name} 장소 목록`}>
+            {mapLocations.map((loc) => (
+              <LocationListItem
+                key={loc.id}
+                location={loc}
+                selected={selectedLocation?.id === loc.id}
+                onSelect={onSelectLocation}
+                onDelete={onDeleteLocation}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+      {selectedLocation ? (
+        <SelectedLocationDetail
+          themeId={themeId}
+          theme={theme}
+          map={selectedMap}
+          location={selectedLocation}
+        />
+      ) : (
+        <LocationEmptyState message="장소를 추가하거나 선택하세요" />
+      )}
+    </div>
+  );
+}
+
+function LocationListItem({
+  location,
+  selected,
+  onSelect,
+  onDelete,
+}: {
+  location: LocationResponse;
+  selected: boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <li className="group flex items-center gap-1">
+      <button
+        type="button"
+        role="option"
+        aria-selected={selected}
+        onClick={() => onSelect(location.id)}
+        className={`flex min-w-0 flex-1 items-center gap-2 rounded-md border px-3 py-2 text-left transition ${selected ? 'border-amber-500/50 bg-amber-500/10 text-amber-200' : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-200'}`}
+      >
+        <MapPin className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate text-sm font-medium">{location.name}</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onDelete(location.id)}
+        aria-label={`${location.name} 삭제`}
+        className="rounded-md p-2 text-slate-700 opacity-100 transition hover:bg-red-950/40 hover:text-red-300 md:opacity-0 md:group-hover:opacity-100"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </li>
+  );
+}
+
+function SelectedLocationDetail({
+  themeId,
+  theme,
+  map,
+  location,
+}: {
+  themeId: string;
+  theme: EditorThemeResponse;
+  map: MapResponse;
+  location: LocationResponse;
+}) {
+  const updateLocation = useUpdateLocation(themeId);
+  const [fromRound, setFromRound] = useState<number | null>(location.from_round ?? null);
+  const [untilRound, setUntilRound] = useState<number | null>(location.until_round ?? null);
+  const assignedCount = useMemo(
+    () => readLocationClueIds(theme.config_json, location.id).length,
+    [theme.config_json, location.id]
+  );
+
+  useEffect(() => {
+    setFromRound(location.from_round ?? null);
+    setUntilRound(location.until_round ?? null);
+  }, [location.id, location.from_round, location.until_round]);
+
+  function saveLocation(patch: Partial<LocationResponse>) {
+    const nextFrom = patch.from_round !== undefined ? patch.from_round : fromRound;
+    const nextUntil = patch.until_round !== undefined ? patch.until_round : untilRound;
+    if (nextFrom != null && nextUntil != null && nextFrom > nextUntil) {
+      toast.error('등장 라운드는 퇴장 라운드보다 클 수 없습니다');
+      setFromRound(location.from_round ?? null);
+      setUntilRound(location.until_round ?? null);
+      return;
+    }
+    const nextImageUrl = Object.prototype.hasOwnProperty.call(patch, 'image_url')
+      ? (patch.image_url ?? null)
+      : location.image_url;
+    updateLocation.mutate(
+      {
+        locationId: location.id,
+        body: {
+          name: patch.name ?? location.name,
+          restricted_characters: patch.restricted_characters ?? location.restricted_characters,
+          image_url: nextImageUrl,
+          sort_order: patch.sort_order ?? location.sort_order,
+          from_round: nextFrom,
+          until_round: nextUntil,
+        },
+      },
+      { onError: () => toast.error('장소 저장에 실패했습니다') }
     );
   }
 
   return (
-    <div className="max-w-lg">
-      <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-mono font-semibold text-slate-300">
-          {selectedMap.name}
-        </h3>
-        <Button size="sm" onClick={onStartAdd}>
-          <Plus className="mr-1 h-3.5 w-3.5" />
-          장소 추가
-        </Button>
-      </div>
-
-      {addingLocation && (
-        <div className="mb-3 rounded-sm border border-amber-500/30 bg-slate-900 p-2">
-          <AddNameInput
-            placeholder="장소 이름"
-            onAdd={onAddLocation}
-            onCancel={onCancelAdd}
-            isPending={isCreatingLocation}
-          />
+    <div className="space-y-4">
+      <section className="rounded-lg border border-slate-800 bg-slate-950/70 p-4">
+        <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-amber-300/80">
+              Selected location
+            </p>
+            <h3 className="mt-1 text-xl font-semibold text-slate-100">{location.name}</h3>
+            <p className="mt-1 text-xs text-slate-500">트리 경로: {getPathLabel(map, location)}</p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-900/80 px-3 py-2 text-xs text-slate-400">
+            단서 연결 <span className="font-semibold text-amber-300">{assignedCount}개</span>
+          </div>
         </div>
-      )}
-
-      {mapLocations.length === 0 ? (
-        <div className="rounded-sm border border-dashed border-slate-800 py-10 text-center">
-          <MapPin className="mx-auto mb-2 h-5 w-5 text-slate-800" />
-          <p className="text-[10px] font-mono uppercase tracking-widest text-slate-700">
-            장소 없음
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {mapLocations.map((loc) => (
-            <LocationRow
-              key={loc.id}
+        <div className="grid gap-4 lg:grid-cols-[minmax(12rem,0.42fr)_minmax(0,1fr)]">
+          <div>
+            <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-slate-300">
+              <Image className="h-3.5 w-3.5 text-amber-400" />
+              장소 이미지
+            </div>
+            <ImageUpload
               themeId={themeId}
-              location={loc}
-              onDelete={onDeleteLocation}
+              target="location"
+              targetId={location.id}
+              currentImageUrl={location.image_url}
+              aspectRatio="16 / 10"
+              onUploaded={(url) => saveLocation({ image_url: url || null })}
             />
-          ))}
+          </div>
+          <div className="space-y-3">
+            <RoundFields
+              location={location}
+              fromRound={fromRound}
+              untilRound={untilRound}
+              setFromRound={setFromRound}
+              setUntilRound={setUntilRound}
+              onCommit={saveLocation}
+            />
+            <InfoBox />
+          </div>
         </div>
-      )}
+      </section>
+      <LocationAccessPolicyPanel themeId={themeId} location={location} />
+      <LocationClueAssignPanel themeId={themeId} theme={theme} location={location} />
+    </div>
+  );
+}
+
+function RoundFields({
+  location,
+  fromRound,
+  untilRound,
+  setFromRound,
+  setUntilRound,
+  onCommit,
+}: {
+  location: LocationResponse;
+  fromRound: number | null;
+  untilRound: number | null;
+  setFromRound: (value: number | null) => void;
+  setUntilRound: (value: number | null) => void;
+  onCommit: (patch: Partial<LocationResponse>) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <p className="mb-2 text-xs font-semibold text-slate-300">라운드 노출</p>
+      <div className="grid grid-cols-2 gap-2">
+        <label className="text-xs text-slate-500">
+          등장 라운드
+          <input
+            type="number"
+            min={1}
+            aria-label={`${location.name} 등장 라운드`}
+            value={fromRound ?? ''}
+            onChange={(e) => setFromRound(parseRound(e.target.value))}
+            onBlur={() => onCommit({ from_round: fromRound, until_round: untilRound })}
+            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          />
+        </label>
+        <label className="text-xs text-slate-500">
+          퇴장 라운드
+          <input
+            type="number"
+            min={1}
+            aria-label={`${location.name} 퇴장 라운드`}
+            value={untilRound ?? ''}
+            onChange={(e) => setUntilRound(parseRound(e.target.value))}
+            onBlur={() => onCommit({ from_round: fromRound, until_round: untilRound })}
+            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function InfoBox() {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-xs leading-5 text-slate-500">
+      <div className="mb-1 flex items-center gap-1.5 font-semibold text-slate-300">
+        <Info className="h-3.5 w-3.5 text-amber-400" />
+        기본정보
+      </div>
+      부모 장소는 별도 입력하지 않습니다. 현재 구조에서는 맵과 장소 트리 위치가 곧 경로입니다.
+    </div>
+  );
+}
+
+function LocationEmptyState({ message, compact = false }: { message: string; compact?: boolean }) {
+  return (
+    <div
+      className={`flex items-center justify-center rounded-lg border border-dashed border-slate-800 ${compact ? 'py-8' : 'min-h-64 py-12'}`}
+    >
+      <div className="text-center">
+        <MapPin className="mx-auto mb-2 h-6 w-6 text-slate-800" />
+        <p className="text-xs font-mono uppercase tracking-widest text-slate-700">{message}</p>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -13,7 +13,6 @@ import {
 } from '@/features/editor/api';
 import { AddNameInput } from './AddNameInput';
 import { LocationDetailPanel } from './LocationDetailPanel';
-import { LocationClueAssignPanel } from './LocationClueAssignPanel';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -44,7 +43,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   const selectedMap = maps?.find((m) => m.id === selectedMapId) ?? null;
   const mapLocations = locations?.filter((l) => l.map_id === selectedMapId) ?? [];
   const selectedLocation =
-    mapLocations.find((l) => l.id === selectedLocationId) ?? null;
+    mapLocations.find((l) => l.id === selectedLocationId) ?? mapLocations[0] ?? null;
 
   function handleAddMap(name: string) {
     createMap.mutate(
@@ -54,9 +53,10 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           toast.success('맵이 추가되었습니다');
           setAddingMap(false);
           setSelectedMapId(newMap.id);
+          setSelectedLocationId(null);
         },
         onError: () => toast.error('맵 추가에 실패했습니다'),
-      },
+      }
     );
   }
 
@@ -78,18 +78,22 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
     createLocation.mutate(
       { mapId: selectedMapId, body: { name } },
       {
-        onSuccess: () => {
+        onSuccess: (newLocation) => {
           toast.success('장소가 추가되었습니다');
           setAddingLocation(false);
+          setSelectedLocationId(newLocation.id);
         },
         onError: () => toast.error('장소 추가에 실패했습니다'),
-      },
+      }
     );
   }
 
   function handleDeleteLocation(locationId: string) {
     deleteLocation.mutate(locationId, {
-      onSuccess: () => toast.success('장소가 삭제되었습니다'),
+      onSuccess: () => {
+        toast.success('장소가 삭제되었습니다');
+        if (selectedLocationId === locationId) setSelectedLocationId(null);
+      },
       onError: () => toast.error('장소 삭제에 실패했습니다'),
     });
   }
@@ -164,7 +168,10 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
                 <span className="flex-1 truncate text-xs font-medium">{map.name}</span>
                 <button
                   type="button"
-                  onClick={(e) => { e.stopPropagation(); handleDeleteMap(map.id); }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDeleteMap(map.id);
+                  }}
                   aria-label={`${map.name} 삭제`}
                   className="p-0.5 text-slate-700 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all shrink-0"
                 >
@@ -180,54 +187,18 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
       <div className="flex-1 overflow-y-auto px-5 py-5">
         <LocationDetailPanel
           themeId={themeId}
+          theme={theme}
           selectedMap={selectedMap}
+          selectedLocation={selectedLocation}
           mapLocations={mapLocations}
           addingLocation={addingLocation}
           isCreatingLocation={createLocation.isPending}
           onStartAdd={() => setAddingLocation(true)}
           onCancelAdd={() => setAddingLocation(false)}
           onAddLocation={handleAddLocation}
+          onSelectLocation={setSelectedLocationId}
           onDeleteLocation={handleDeleteLocation}
         />
-
-        {/* ── Location → Clue assignment ── */}
-        {selectedMap && mapLocations.length > 0 && (
-          <div className="mt-5 max-w-lg">
-            <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-600">
-              <span>단서 배정 — 장소 선택</span>
-            </div>
-            <div className="mb-3 flex flex-wrap gap-1.5" role="listbox" aria-label="단서 배정할 장소 선택">
-              {mapLocations.map((loc) => {
-                const selected = selectedLocationId === loc.id;
-                return (
-                  <button
-                    type="button"
-                    key={loc.id}
-                    role="option"
-                    aria-selected={selected}
-                    onClick={() =>
-                      setSelectedLocationId(selected ? null : loc.id)
-                    }
-                    className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs transition-colors ${
-                      selected
-                        ? 'border-amber-500/50 bg-amber-500/10 text-amber-300'
-                        : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-200'
-                    }`}
-                  >
-                    {loc.name}
-                  </button>
-                );
-              })}
-            </div>
-            {selectedLocation && (
-              <LocationClueAssignPanel
-                themeId={themeId}
-                theme={theme}
-                location={selectedLocation}
-              />
-            )}
-          </div>
-        )}
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -170,7 +170,9 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleDeleteMap(map.id);
+                    if (window.confirm(`${map.name} 맵을 삭제할까요? 하위 장소 편집 흐름도 함께 영향을 받습니다.`)) {
+                      handleDeleteMap(map.id);
+                    }
                   }}
                   aria-label={`${map.name} 삭제`}
                   className="p-0.5 text-slate-700 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all shrink-0"

--- a/apps/web/src/features/editor/components/design/StartingClueAssigner.tsx
+++ b/apps/web/src/features/editor/components/design/StartingClueAssigner.tsx
@@ -14,6 +14,7 @@ interface StartingClueAssignerProps {
   clues: ClueItem[];
   selectedIds: string[];
   onClueToggle: (clueId: string, checked: boolean) => void;
+  selectedTitle?: string;
 }
 
 function getClueMeta(clue: ClueItem) {
@@ -29,6 +30,7 @@ export function StartingClueAssigner({
   clues,
   selectedIds,
   onClueToggle,
+  selectedTitle,
 }: StartingClueAssignerProps) {
   const [query, setQuery] = useState('');
   const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
@@ -36,12 +38,7 @@ export function StartingClueAssigner({
   const selectedClues = clues.filter((clue) => selectedSet.has(clue.id));
   const visibleClues = clues.filter((clue) => {
     if (!normalizedQuery) return true;
-    const haystack = [
-      clue.name,
-      clue.location,
-      clue.tag,
-      clue.round?.toString(),
-    ]
+    const haystack = [clue.name, clue.location, clue.tag, clue.round?.toString()]
       .filter(Boolean)
       .join(' ')
       .toLowerCase();
@@ -117,7 +114,7 @@ export function StartingClueAssigner({
       <section className="rounded-lg border border-amber-500/20 bg-amber-950/10 p-2.5">
         <div className="mb-2 flex items-center justify-between gap-2">
           <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
-            {characterName}의 시작 단서
+            {selectedTitle ?? `${characterName}의 시작 단서`}
           </p>
           <span className="text-[10px] text-slate-600">클릭 추가</span>
         </div>

--- a/apps/web/src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { LocationAccessPolicyPanel } from '../LocationAccessPolicyPanel';
+import type { EditorCharacterResponse, LocationResponse } from '@/features/editor/api';
+
+const { useEditorCharactersMock, useUpdateLocationMock, mutateMock, toastError } = vi.hoisted(
+  () => ({
+    useEditorCharactersMock: vi.fn(),
+    useUpdateLocationMock: vi.fn(),
+    mutateMock: vi.fn(),
+    toastError: vi.fn(),
+  }),
+);
+
+vi.mock('sonner', () => ({
+  toast: { error: toastError },
+}));
+
+vi.mock('@/features/editor/api', () => ({
+  useEditorCharacters: () => useEditorCharactersMock(),
+  useUpdateLocation: () => useUpdateLocationMock(),
+}));
+
+const characters: EditorCharacterResponse[] = [
+  {
+    id: 'char-1',
+    theme_id: 'theme-1',
+    name: '김철수',
+    description: null,
+    image_url: null,
+    is_culprit: false,
+    mystery_role: 'suspect',
+    sort_order: 0,
+  },
+  {
+    id: 'char-2',
+    theme_id: 'theme-1',
+    name: '이영희',
+    description: null,
+    image_url: null,
+    is_culprit: false,
+    mystery_role: 'detective',
+    sort_order: 1,
+  },
+];
+
+const location: LocationResponse = {
+  id: 'loc-1',
+  theme_id: 'theme-1',
+  map_id: 'map-1',
+  name: '서재',
+  description: '낡은 서재',
+  restricted_characters: 'char-1',
+  image_url: '/images/study.webp',
+  from_round: 1,
+  until_round: 3,
+  sort_order: 7,
+  created_at: '2026-05-02T00:00:00Z',
+};
+
+beforeEach(() => {
+  useEditorCharactersMock.mockReturnValue({ data: characters, isLoading: false });
+  useUpdateLocationMock.mockReturnValue({ mutate: mutateMock, isPending: false });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('LocationAccessPolicyPanel', () => {
+  it('기존 restricted_characters CSV를 체크박스 상태로 표시한다', () => {
+    render(<LocationAccessPolicyPanel themeId="theme-1" location={location} />);
+
+    expect(screen.getByText('접근 제한')).toBeDefined();
+    expect((screen.getByLabelText(/김철수/) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByLabelText(/이영희/) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('캐릭터를 제한 목록에 추가할 때 기존 장소 필드를 보존해 저장한다', () => {
+    render(<LocationAccessPolicyPanel themeId="theme-1" location={location} />);
+
+    fireEvent.click(screen.getByLabelText(/이영희/));
+
+    expect(mutateMock).toHaveBeenCalledOnce();
+    expect(mutateMock.mock.calls[0][0]).toEqual({
+      locationId: 'loc-1',
+      body: {
+        name: '서재',
+        restricted_characters: 'char-1,char-2',
+        image_url: '/images/study.webp',
+        sort_order: 7,
+        from_round: 1,
+        until_round: 3,
+      },
+    });
+  });
+
+  it('마지막 제한 캐릭터를 해제하면 null로 저장하고 실패 시 토스트를 띄운다', () => {
+    mutateMock.mockImplementation((_body, options) => options?.onError?.(new Error('fail')));
+    render(
+      <LocationAccessPolicyPanel
+        themeId="theme-1"
+        location={{ ...location, restricted_characters: 'char-1' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/김철수/));
+
+    expect(mutateMock.mock.calls[0][0].body.restricted_characters).toBeNull();
+    expect(toastError).toHaveBeenCalledWith('접근 제한 저장에 실패했습니다');
+  });
+
+  it('캐릭터 로딩/빈 상태와 저장 중 disabled 상태를 보여준다', () => {
+    useEditorCharactersMock.mockReturnValueOnce({ data: undefined, isLoading: true });
+    const { rerender } = render(<LocationAccessPolicyPanel themeId="theme-1" location={location} />);
+    expect(document.querySelector('.animate-spin')).toBeDefined();
+
+    useEditorCharactersMock.mockReturnValueOnce({ data: [], isLoading: false });
+    rerender(<LocationAccessPolicyPanel themeId="theme-1" location={location} />);
+    expect(screen.getByText('캐릭터가 없습니다.')).toBeDefined();
+
+    useEditorCharactersMock.mockReturnValueOnce({ data: characters, isLoading: false });
+    useUpdateLocationMock.mockReturnValueOnce({ mutate: mutateMock, isPending: true });
+    rerender(<LocationAccessPolicyPanel themeId="theme-1" location={location} />);
+    expect((screen.getByLabelText(/김철수/) as HTMLInputElement).disabled).toBe(true);
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -163,7 +163,7 @@ describe('LocationClueAssignPanel', () => {
     expect(screen.getByText('(1/2)')).toBeDefined();
   });
 
-  it('배정된 clue는 aria-checked=true 로 표시된다', () => {
+  it('배정된 clue는 전체 목록에서 비활성화되고 우측 목록에 표시된다', () => {
     const theme: EditorThemeResponse = {
       ...baseTheme,
       config_json: { locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }] },
@@ -171,10 +171,9 @@ describe('LocationClueAssignPanel', () => {
     renderQC(
       <LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />,
     );
-    const chip1 = screen.getByLabelText('단검 배정 토글');
-    const chip2 = screen.getByLabelText('편지 배정 토글');
-    expect(chip1.getAttribute('aria-checked')).toBe('true');
-    expect(chip2.getAttribute('aria-checked')).toBe('false');
+    expect((screen.getByLabelText('단검 추가') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText('편지 추가') as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByLabelText('단검 제거')).toBeDefined();
   });
 
   it('배정되지 않은 clue 클릭 시 clueIds에 추가되어 mutate가 호출된다', () => {
@@ -185,7 +184,7 @@ describe('LocationClueAssignPanel', () => {
         location={mockLocation}
       />,
     );
-    fireEvent.click(screen.getByLabelText('단검 배정 토글'));
+    fireEvent.click(screen.getByLabelText('단검 추가'));
     expect(mutateMock).toHaveBeenCalledOnce();
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
     const locs = config.locations as Array<{ id: string; locationClueConfig: { clueIds: string[] } }>;
@@ -201,7 +200,7 @@ describe('LocationClueAssignPanel', () => {
     renderQC(
       <LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />,
     );
-    fireEvent.click(screen.getByLabelText('단검 배정 토글'));
+    fireEvent.click(screen.getByLabelText('단검 제거'));
     expect(mutateMock).toHaveBeenCalledOnce();
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
     const locs = config.locations as Array<{ id: string; locationClueConfig: { clueIds: string[] } }>;
@@ -220,7 +219,7 @@ describe('LocationClueAssignPanel', () => {
         onChange={onChange}
       />,
     );
-    fireEvent.click(screen.getByLabelText('단검 배정 토글'));
+    fireEvent.click(screen.getByLabelText('단검 추가'));
     expect(onChange).toHaveBeenCalledWith(['clue-1']);
   });
 
@@ -258,7 +257,7 @@ describe('LocationClueAssignPanel', () => {
         location={mockLocation}
       />,
     );
-    const chip = screen.getByLabelText('단검 배정 토글') as HTMLButtonElement;
+    const chip = screen.getByLabelText('단검 추가') as HTMLButtonElement;
     expect(chip.disabled).toBe(true);
   });
 });
@@ -280,7 +279,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     );
     qc.setQueryData(cacheKey, baseTheme);
 
-    fireEvent.click(screen.getByLabelText('단검 배정 토글'));
+    fireEvent.click(screen.getByLabelText('단검 추가'));
 
     const cached = qc.getQueryData<EditorThemeResponse>(cacheKey);
     const locs = (cached?.config_json as {
@@ -305,7 +304,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     );
     qc.setQueryData(cacheKey, baseTheme);
 
-    fireEvent.click(screen.getByLabelText('단검 배정 토글'));
+    fireEvent.click(screen.getByLabelText('단검 추가'));
 
     const cached = qc.getQueryData<EditorThemeResponse>(cacheKey);
     expect(cached?.config_json).toEqual({}); // rolled back to baseTheme.config_json
@@ -339,12 +338,12 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     qc.setQueryData(cacheKey, baseTheme);
 
     // 1st toggle: clue-1 추가 → 캐시 optimistic = {locations:[{loc-1,[clue-1]}]}
-    fireEvent.click(screen.getByLabelText('단검 배정 토글'));
+    fireEvent.click(screen.getByLabelText('단검 추가'));
 
     // 2nd toggle: 같은 컴포넌트의 `theme` prop 은 불변이므로 여전히 baseTheme 기준이지만,
     // queryClient 캐시는 1차 optimistic 결과를 반영 중. 두 번째 commit 이 이 시점 캐시를
     // previous 로 캡처하도록 fire.
-    fireEvent.click(screen.getByLabelText('편지 배정 토글'));
+    fireEvent.click(screen.getByLabelText('편지 추가'));
 
     expect(deferred).toHaveLength(2);
 
@@ -369,7 +368,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     );
     // no setQueryData
 
-    fireEvent.click(screen.getByLabelText('단검 배정 토글'));
+    fireEvent.click(screen.getByLabelText('단검 추가'));
 
     expect(mutateMock).toHaveBeenCalledOnce();
     expect(qc.getQueryData(cacheKey)).toBeUndefined();

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -11,6 +11,7 @@ const {
   mutateMock,
   updateConfigMutateMock,
   updateLocationMutateMock,
+  useEditorCharactersMock,
   useEditorMapsMock,
   useCreateMapMock,
   useDeleteMapMock,
@@ -26,6 +27,7 @@ const {
   mutateMock: vi.fn(),
   updateConfigMutateMock: vi.fn(),
   updateLocationMutateMock: vi.fn(),
+  useEditorCharactersMock: vi.fn(),
   useEditorMapsMock: vi.fn(),
   useCreateMapMock: vi.fn(),
   useDeleteMapMock: vi.fn(),
@@ -41,7 +43,7 @@ const {
 // Mock: sonner
 // ---------------------------------------------------------------------------
 
-vi.mock("sonner", () => ({
+vi.mock('sonner', () => ({
   toast: { success: toastSuccess, error: toastError },
 }));
 
@@ -49,7 +51,8 @@ vi.mock("sonner", () => ({
 // Mock: @/features/editor/api
 // ---------------------------------------------------------------------------
 
-vi.mock("@/features/editor/api", () => ({
+vi.mock('@/features/editor/api', () => ({
+  useEditorCharacters: () => useEditorCharactersMock(),
   useEditorMaps: () => useEditorMapsMock(),
   useCreateMap: () => useCreateMapMock(),
   useDeleteMap: () => useDeleteMapMock(),
@@ -60,17 +63,15 @@ vi.mock("@/features/editor/api", () => ({
   useEditorClues: () => useEditorCluesMock(),
   useUpdateConfigJson: () => useUpdateConfigJsonMock(),
   editorKeys: {
-    theme: (id: string) => ["editor", "themes", id] as const,
+    theme: (id: string) => ['editor', 'themes', id] as const,
   },
 }));
 
 // LocationClueAssignPanel (via LocationsSubTab) now calls `useQueryClient`; stub
 // it so the existing tests don't need a real provider.
-vi.mock("@tanstack/react-query", async () => {
+vi.mock('@tanstack/react-query', async () => {
   const actual =
-    await vi.importActual<typeof import("@tanstack/react-query")>(
-      "@tanstack/react-query",
-    );
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
   return {
     ...actual,
     useQueryClient: () => ({
@@ -84,39 +85,15 @@ vi.mock("@tanstack/react-query", async () => {
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { LocationsSubTab } from "../LocationsSubTab";
+import { LocationsSubTab } from '../LocationsSubTab';
 
-// ---------------------------------------------------------------------------
-// Mock data
-// ---------------------------------------------------------------------------
-
-const mockTheme = {
-  id: "theme-1",
-  title: "테스트 테마",
-  slug: "test-theme",
-  description: null,
-  cover_image: null,
-  min_players: 4,
-  max_players: 6,
-  duration_min: 90,
-  price: 0,
-  coin_price: 0,
-  status: "DRAFT" as const,
-  config_json: null,
-  version: 1,
-  created_at: "2026-04-13T00:00:00Z",
-};
-
-const mockMaps = [
-  { id: "map-1", theme_id: "theme-1", name: "저택 1층", image_url: null, sort_order: 1, created_at: "2026-04-13T00:00:00Z" },
-  { id: "map-2", theme_id: "theme-1", name: "저택 2층", image_url: null, sort_order: 2, created_at: "2026-04-13T00:00:00Z" },
-];
-
-const mockLocations = [
-  { id: "loc-1", theme_id: "theme-1", map_id: "map-1", name: "거실", restricted_characters: null, sort_order: 1, created_at: "2026-04-13T00:00:00Z" },
-  { id: "loc-2", theme_id: "theme-1", map_id: "map-1", name: "주방", restricted_characters: null, sort_order: 2, created_at: "2026-04-13T00:00:00Z" },
-  { id: "loc-3", theme_id: "theme-1", map_id: "map-2", name: "침실", restricted_characters: null, sort_order: 1, created_at: "2026-04-13T00:00:00Z" },
-];
+import {
+  mockCharacters,
+  mockClues,
+  mockLocations,
+  mockMaps,
+  mockTheme,
+} from './locationsSubTabTestData';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -128,16 +105,16 @@ function defaultMutation() {
 
 const mockClues = [
   {
-    id: "clue-1",
-    theme_id: "theme-1",
+    id: 'clue-1',
+    theme_id: 'theme-1',
     location_id: null,
-    name: "단검",
+    name: '단검',
     description: null,
     image_url: null,
     is_common: false,
     level: 1,
     sort_order: 0,
-    created_at: "2026-04-13T00:00:00Z",
+    created_at: '2026-04-13T00:00:00Z',
     is_usable: false,
     use_effect: null,
     use_target: null,
@@ -146,6 +123,7 @@ const mockClues = [
 ];
 
 function setupDefaultMocks() {
+  useEditorCharactersMock.mockReturnValue({ data: mockCharacters, isLoading: false });
   useEditorMapsMock.mockReturnValue({ data: mockMaps, isLoading: false });
   useEditorLocationsMock.mockReturnValue({ data: mockLocations, isLoading: false });
   useCreateMapMock.mockReturnValue(defaultMutation());
@@ -176,9 +154,10 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("LocationsSubTab", () => {
-  describe("로딩 상태", () => {
-    it("맵 로딩 중일 때 스피너를 표시한다", () => {
+describe('LocationsSubTab', () => {
+  describe('로딩 상태', () => {
+    it('맵 로딩 중일 때 스피너를 표시한다', () => {
+      useEditorCharactersMock.mockReturnValue({ data: mockCharacters, isLoading: false });
       useEditorMapsMock.mockReturnValue({ data: undefined, isLoading: true });
       useEditorLocationsMock.mockReturnValue({ data: undefined, isLoading: false });
       useCreateMapMock.mockReturnValue(defaultMutation());
@@ -195,237 +174,220 @@ describe("LocationsSubTab", () => {
         isPending: false,
       });
 
-      const { container } = render(
-        <LocationsSubTab themeId="theme-1" theme={mockTheme} />,
-      );
+      const { container } = render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       const spinner = container.querySelector('[role="status"]');
       expect(spinner).not.toBeNull();
     });
   });
 
-  describe("맵 목록 렌더링", () => {
+  describe('맵 목록 렌더링', () => {
     beforeEach(setupDefaultMocks);
 
-    it("맵 이름들을 렌더링한다", () => {
+    it('맵 이름들을 렌더링한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      expect(screen.getByText("저택 1층")).toBeDefined();
-      expect(screen.getByText("저택 2층")).toBeDefined();
+      expect(screen.getByText('저택 1층')).toBeDefined();
+      expect(screen.getByText('저택 2층')).toBeDefined();
     });
 
-    it("맵이 없을 때 빈 상태를 표시한다", () => {
+    it('맵이 없을 때 빈 상태를 표시한다', () => {
       useEditorMapsMock.mockReturnValue({ data: [], isLoading: false });
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      expect(screen.getByText("맵 없음")).toBeDefined();
+      expect(screen.getByText('맵 없음')).toBeDefined();
     });
 
-    it("맵 추가 버튼이 존재한다", () => {
+    it('맵 추가 버튼이 존재한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      const addBtn = screen.getByLabelText("맵 추가");
+      const addBtn = screen.getByLabelText('맵 추가');
       expect(addBtn).toBeDefined();
     });
   });
 
-  describe("맵 추가 UI", () => {
+  describe('맵 추가 UI', () => {
     beforeEach(setupDefaultMocks);
 
-    it("맵 추가 버튼 클릭 시 인라인 입력이 나타난다", () => {
+    it('맵 추가 버튼 클릭 시 인라인 입력이 나타난다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByLabelText("맵 추가"));
-      expect(screen.getByPlaceholderText("맵 이름")).toBeDefined();
+      fireEvent.click(screen.getByLabelText('맵 추가'));
+      expect(screen.getByPlaceholderText('맵 이름')).toBeDefined();
     });
 
-    it("취소 버튼 클릭 시 입력 필드가 사라진다", () => {
+    it('취소 버튼 클릭 시 입력 필드가 사라진다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByLabelText("맵 추가"));
-      expect(screen.getByPlaceholderText("맵 이름")).toBeDefined();
-      fireEvent.click(screen.getByText("취소"));
-      expect(screen.queryByPlaceholderText("맵 이름")).toBeNull();
+      fireEvent.click(screen.getByLabelText('맵 추가'));
+      expect(screen.getByPlaceholderText('맵 이름')).toBeDefined();
+      fireEvent.click(screen.getByText('취소'));
+      expect(screen.queryByPlaceholderText('맵 이름')).toBeNull();
     });
 
-    it("Enter 키로 맵을 추가하면 mutate가 호출된다", () => {
+    it('Enter 키로 맵을 추가하면 mutate가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByLabelText("맵 추가"));
-      const input = screen.getByPlaceholderText("맵 이름");
-      fireEvent.change(input, { target: { value: "새 맵" } });
-      fireEvent.keyDown(input, { key: "Enter" });
-      expect(mutateMock).toHaveBeenCalledWith(
-        { name: "새 맵" },
-        expect.any(Object),
-      );
+      fireEvent.click(screen.getByLabelText('맵 추가'));
+      const input = screen.getByPlaceholderText('맵 이름');
+      fireEvent.change(input, { target: { value: '새 맵' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(mutateMock).toHaveBeenCalledWith({ name: '새 맵' }, expect.any(Object));
     });
   });
 
-  describe("맵 삭제 UI", () => {
+  describe('맵 삭제 UI', () => {
     beforeEach(setupDefaultMocks);
 
-    it("맵 삭제 버튼이 각 맵에 존재한다", () => {
+    it('맵 삭제 버튼이 각 맵에 존재한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      const deleteBtn = screen.getByLabelText("저택 1층 삭제");
+      const deleteBtn = screen.getByLabelText('저택 1층 삭제');
       expect(deleteBtn).toBeDefined();
     });
 
-    it("맵 삭제 버튼 클릭 시 mutate가 호출된다", () => {
+    it('맵 삭제 버튼 클릭 시 mutate가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByLabelText("저택 1층 삭제"));
-      expect(mutateMock).toHaveBeenCalledWith("map-1", expect.any(Object));
+      fireEvent.click(screen.getByLabelText('저택 1층 삭제'));
+      expect(mutateMock).toHaveBeenCalledWith('map-1', expect.any(Object));
     });
   });
 
-  describe("장소 목록 렌더링", () => {
+  describe('장소 목록 렌더링', () => {
     beforeEach(setupDefaultMocks);
 
-    it("맵 미선택 시 empty state를 표시한다", () => {
+    it('맵 미선택 시 empty state를 표시한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      expect(screen.getByText("좌측에서 맵을 선택하세요")).toBeDefined();
+      expect(screen.getByText('좌측에서 맵을 선택하세요')).toBeDefined();
     });
 
-    it("맵 선택 시 해당 맵의 장소만 표시한다", () => {
+    it('맵 선택 시 해당 맵의 장소만 표시한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
+      fireEvent.click(screen.getByText('저택 1층'));
       // LocationDetailPanel row + clue-assignment picker option 두 곳에서 렌더됨
-      expect(screen.getAllByText("거실").length).toBeGreaterThan(0);
-      expect(screen.getAllByText("주방").length).toBeGreaterThan(0);
+      expect(screen.getAllByText('거실').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('주방').length).toBeGreaterThan(0);
       // 다른 맵의 장소는 표시되지 않아야 함
-      expect(screen.queryByText("침실")).toBeNull();
+      expect(screen.queryByText('침실')).toBeNull();
     });
 
-    it("선택한 맵에 장소가 없을 때 빈 상태를 표시한다", () => {
+    it('선택한 맵에 장소가 없을 때 빈 상태를 표시한다', () => {
       useEditorLocationsMock.mockReturnValue({ data: [], isLoading: false });
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      expect(screen.getByText("장소 없음")).toBeDefined();
+      fireEvent.click(screen.getByText('저택 1층'));
+      expect(screen.getByText('장소 없음')).toBeDefined();
     });
   });
 
-  describe("장소 추가 UI", () => {
+  describe('장소 추가 UI', () => {
     beforeEach(setupDefaultMocks);
 
-    it("맵 선택 후 장소 추가 버튼이 나타난다", () => {
+    it('맵 선택 후 장소 추가 버튼이 나타난다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      expect(screen.getByText("장소 추가")).toBeDefined();
+      fireEvent.click(screen.getByText('저택 1층'));
+      expect(screen.getByText('장소 추가')).toBeDefined();
     });
 
-    it("장소 추가 버튼 클릭 시 인라인 입력이 나타난다", () => {
+    it('장소 추가 버튼 클릭 시 인라인 입력이 나타난다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      fireEvent.click(screen.getByText("장소 추가"));
-      expect(screen.getByPlaceholderText("장소 이름")).toBeDefined();
+      fireEvent.click(screen.getByText('저택 1층'));
+      fireEvent.click(screen.getByText('장소 추가'));
+      expect(screen.getByPlaceholderText('장소 이름')).toBeDefined();
     });
 
-    it("Enter 키로 장소를 추가하면 mutate가 호출된다", () => {
+    it('Enter 키로 장소를 추가하면 mutate가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      fireEvent.click(screen.getByText("장소 추가"));
-      const input = screen.getByPlaceholderText("장소 이름");
-      fireEvent.change(input, { target: { value: "서재" } });
-      fireEvent.keyDown(input, { key: "Enter" });
+      fireEvent.click(screen.getByText('저택 1층'));
+      fireEvent.click(screen.getByText('장소 추가'));
+      const input = screen.getByPlaceholderText('장소 이름');
+      fireEvent.change(input, { target: { value: '서재' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
       expect(mutateMock).toHaveBeenCalledWith(
-        { mapId: "map-1", body: { name: "서재" } },
-        expect.any(Object),
+        { mapId: 'map-1', body: { name: '서재' } },
+        expect.any(Object)
       );
     });
   });
 
-  describe("단서 배정 패널", () => {
+  describe('단서 배정 패널', () => {
     beforeEach(setupDefaultMocks);
 
-    it("맵 선택 시 장소 선택 picker 가 표시된다", () => {
+    it('맵 선택 시 장소 선택 picker 가 표시된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      expect(screen.getByText(/단서 배정 — 장소 선택/)).toBeDefined();
+      fireEvent.click(screen.getByText('저택 1층'));
+      expect(screen.getByText('전체 단서 목록')).toBeDefined();
     });
 
-    it("location picker 를 통해 선택한 location 에 대해 LocationClueAssignPanel 이 렌더된다", () => {
+    it('location picker 를 통해 선택한 location 에 대해 LocationClueAssignPanel 이 렌더된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      // location picker 의 "거실" 옵션 (option role). LocationDetailPanel 의 row 와
-      // 구분하기 위해 role=option 만 타겟.
-      const options = screen.getAllByRole("option", { name: "거실" });
-      fireEvent.click(options[0]);
-      expect(screen.getByLabelText("거실 단서 배정")).toBeDefined();
-      expect(screen.getByLabelText("단검 배정 토글")).toBeDefined();
+      fireEvent.click(screen.getByText('저택 1층'));
+      fireEvent.click(screen.getByRole('option', { name: '주방' }));
+      expect(screen.getByLabelText('주방 단서 배정')).toBeDefined();
+      expect(screen.getByLabelText('단검 추가')).toBeDefined();
     });
 
-    it("chip 토글 시 useUpdateConfigJson.mutate 가 호출된다", () => {
+    it('chip 토글 시 useUpdateConfigJson.mutate 가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      const options = screen.getAllByRole("option", { name: "거실" });
-      fireEvent.click(options[0]);
-      fireEvent.click(screen.getByLabelText("단검 배정 토글"));
+      fireEvent.click(screen.getByText('저택 1층'));
+      fireEvent.click(screen.getByLabelText('단검 추가'));
       expect(updateConfigMutateMock).toHaveBeenCalledOnce();
-      const [config] = updateConfigMutateMock.mock.calls[0] as [
-        Record<string, unknown>,
-      ];
+      const [config] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
       const locs = config.locations as Array<{
         id: string;
         locationClueConfig: { clueIds: string[] };
       }>;
       expect(locs[0]).toEqual({
-        id: "loc-1",
-        locationClueConfig: { clueIds: ["clue-1"] },
+        id: 'loc-1',
+        locationClueConfig: { clueIds: ['clue-1'] },
       });
     });
 
-    it("맵 미선택 상태에서는 단서 배정 picker 가 표시되지 않는다", () => {
+    it('맵 미선택 상태에서는 단서 배정 picker 가 표시되지 않는다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      expect(screen.queryByText(/단서 배정 — 장소 선택/)).toBeNull();
+      expect(screen.queryByText('전체 단서 목록')).toBeNull();
     });
   });
 
-  describe("LocationRow 라운드 편집", () => {
+  describe('LocationRow 라운드 편집', () => {
     beforeEach(setupDefaultMocks);
 
-    it("등장/퇴장 라운드 입력이 각 장소 행마다 존재한다", () => {
+    it('등장/퇴장 라운드 입력이 각 장소 행마다 존재한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      expect(screen.getByLabelText("거실 등장 라운드")).toBeDefined();
-      expect(screen.getByLabelText("거실 퇴장 라운드")).toBeDefined();
+      fireEvent.click(screen.getByText('저택 1층'));
+      expect(screen.getByLabelText('거실 등장 라운드')).toBeDefined();
+      expect(screen.getByLabelText('거실 퇴장 라운드')).toBeDefined();
     });
 
-    it("라운드 값 입력 후 blur 하면 useUpdateLocation.mutate 가 호출된다", () => {
+    it('라운드 값 입력 후 blur 하면 useUpdateLocation.mutate 가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      const fromInput = screen.getByLabelText("거실 등장 라운드") as HTMLInputElement;
-      fireEvent.change(fromInput, { target: { value: "2" } });
+      fireEvent.click(screen.getByText('저택 1층'));
+      const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
+      fireEvent.change(fromInput, { target: { value: '2' } });
       fireEvent.blur(fromInput);
       expect(updateLocationMutateMock).toHaveBeenCalledOnce();
       const [payload] = updateLocationMutateMock.mock.calls[0] as [
         { locationId: string; body: Record<string, unknown> },
       ];
-      expect(payload.locationId).toBe("loc-1");
+      expect(payload.locationId).toBe('loc-1');
       expect(payload.body.from_round).toBe(2);
-      expect(payload.body.name).toBe("거실");
+      expect(payload.body.name).toBe('거실');
     });
 
-    it("등장 > 퇴장 조합은 에러 토스트 후 저장되지 않는다", () => {
+    it('등장 > 퇴장 조합은 에러 토스트 후 저장되지 않는다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      const fromInput = screen.getByLabelText("거실 등장 라운드") as HTMLInputElement;
-      const untilInput = screen.getByLabelText("거실 퇴장 라운드") as HTMLInputElement;
-      fireEvent.change(untilInput, { target: { value: "2" } });
+      fireEvent.click(screen.getByText('저택 1층'));
+      const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
+      const untilInput = screen.getByLabelText('거실 퇴장 라운드') as HTMLInputElement;
+      fireEvent.change(untilInput, { target: { value: '2' } });
       fireEvent.blur(untilInput);
       updateLocationMutateMock.mockClear();
-      fireEvent.change(fromInput, { target: { value: "5" } });
+      fireEvent.change(fromInput, { target: { value: '5' } });
       fireEvent.blur(fromInput);
       expect(updateLocationMutateMock).not.toHaveBeenCalled();
-      expect(toastError).toHaveBeenCalledWith(
-        "등장 라운드는 퇴장 라운드보다 클 수 없습니다",
-      );
+      expect(toastError).toHaveBeenCalledWith('등장 라운드는 퇴장 라운드보다 클 수 없습니다');
     });
 
-    it("값을 비우면 from_round 가 null 로 저장된다", () => {
+    it('값을 비우면 from_round 가 null 로 저장된다', () => {
       useEditorLocationsMock.mockReturnValue({
-        data: [
-          { ...mockLocations[0], from_round: 2, until_round: 5 },
-          ...mockLocations.slice(1),
-        ],
+        data: [{ ...mockLocations[0], from_round: 2, until_round: 5 }, ...mockLocations.slice(1)],
         isLoading: false,
       });
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText("저택 1층"));
-      const fromInput = screen.getByLabelText("거실 등장 라운드") as HTMLInputElement;
-      fireEvent.change(fromInput, { target: { value: "" } });
+      fireEvent.click(screen.getByText('저택 1층'));
+      const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
+      fireEvent.change(fromInput, { target: { value: '' } });
       fireEvent.blur(fromInput);
       expect(updateLocationMutateMock).toHaveBeenCalledOnce();
       const [payload] = updateLocationMutateMock.mock.calls[0] as [

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -103,25 +103,6 @@ function defaultMutation() {
   return { mutate: mutateMock, isPending: false };
 }
 
-const mockClues = [
-  {
-    id: 'clue-1',
-    theme_id: 'theme-1',
-    location_id: null,
-    name: '단검',
-    description: null,
-    image_url: null,
-    is_common: false,
-    level: 1,
-    sort_order: 0,
-    created_at: '2026-04-13T00:00:00Z',
-    is_usable: false,
-    use_effect: null,
-    use_target: null,
-    use_consumed: false,
-  },
-];
-
 function setupDefaultMocks() {
   useEditorCharactersMock.mockReturnValue({ data: mockCharacters, isLoading: false });
   useEditorMapsMock.mockReturnValue({ data: mockMaps, isLoading: false });
@@ -239,6 +220,7 @@ describe('LocationsSubTab', () => {
     });
 
     it('맵 삭제 버튼 클릭 시 mutate가 호출된다', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       fireEvent.click(screen.getByLabelText('저택 1층 삭제'));
       expect(mutateMock).toHaveBeenCalledWith('map-1', expect.any(Object));
@@ -313,7 +295,7 @@ describe('LocationsSubTab', () => {
     it('location picker 를 통해 선택한 location 에 대해 LocationClueAssignPanel 이 렌더된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       fireEvent.click(screen.getByText('저택 1층'));
-      fireEvent.click(screen.getByRole('option', { name: '주방' }));
+      fireEvent.click(screen.getByRole('button', { name: '주방' }));
       expect(screen.getByLabelText('주방 단서 배정')).toBeDefined();
       expect(screen.getByLabelText('단검 추가')).toBeDefined();
     });

--- a/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestData.ts
+++ b/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestData.ts
@@ -1,0 +1,110 @@
+export const mockTheme = {
+  id: 'theme-1',
+  title: '테스트 테마',
+  slug: 'test-theme',
+  description: null,
+  cover_image: null,
+  min_players: 4,
+  max_players: 6,
+  duration_min: 90,
+  price: 0,
+  coin_price: 0,
+  status: 'DRAFT' as const,
+  config_json: null,
+  version: 1,
+  created_at: '2026-04-13T00:00:00Z',
+};
+
+export const mockMaps = [
+  {
+    id: 'map-1',
+    theme_id: 'theme-1',
+    name: '저택 1층',
+    image_url: null,
+    sort_order: 1,
+    created_at: '2026-04-13T00:00:00Z',
+  },
+  {
+    id: 'map-2',
+    theme_id: 'theme-1',
+    name: '저택 2층',
+    image_url: null,
+    sort_order: 2,
+    created_at: '2026-04-13T00:00:00Z',
+  },
+];
+
+export const mockLocations = [
+  {
+    id: 'loc-1',
+    theme_id: 'theme-1',
+    map_id: 'map-1',
+    name: '거실',
+    restricted_characters: null,
+    image_url: null,
+    sort_order: 1,
+    created_at: '2026-04-13T00:00:00Z',
+  },
+  {
+    id: 'loc-2',
+    theme_id: 'theme-1',
+    map_id: 'map-1',
+    name: '주방',
+    restricted_characters: null,
+    image_url: null,
+    sort_order: 2,
+    created_at: '2026-04-13T00:00:00Z',
+  },
+  {
+    id: 'loc-3',
+    theme_id: 'theme-1',
+    map_id: 'map-2',
+    name: '침실',
+    restricted_characters: null,
+    image_url: null,
+    sort_order: 1,
+    created_at: '2026-04-13T00:00:00Z',
+  },
+];
+
+export const mockClues = [
+  {
+    id: 'clue-1',
+    theme_id: 'theme-1',
+    location_id: null,
+    name: '단검',
+    description: null,
+    image_url: null,
+    is_common: false,
+    level: 1,
+    sort_order: 0,
+    created_at: '2026-04-13T00:00:00Z',
+    is_usable: false,
+    use_effect: null,
+    use_target: null,
+    use_consumed: false,
+  },
+];
+
+export const mockCharacters = [
+  {
+    id: 'char-1',
+    theme_id: 'theme-1',
+    name: '홍길동',
+    description: null,
+    image_url: null,
+    is_culprit: false,
+    mystery_role: 'detective' as const,
+    sort_order: 1,
+  },
+  {
+    id: 'char-2',
+    theme_id: 'theme-1',
+    name: '김철수',
+    description: null,
+    image_url: null,
+    is_culprit: true,
+    mystery_role: 'culprit' as const,
+    sort_order: 2,
+  },
+];

--- a/apps/web/src/features/editor/editorMapApi.ts
+++ b/apps/web/src/features/editor/editorMapApi.ts
@@ -1,8 +1,8 @@
-import { useQuery, useMutation } from "@tanstack/react-query";
-import { api } from "@/services/api";
-import { queryClient } from "@/services/queryClient";
-import { editorKeys } from "./api";
-import type { MapResponse, LocationResponse } from "./api";
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { api } from '@/services/api';
+import { queryClient } from '@/services/queryClient';
+import { editorKeys } from './api';
+import type { MapResponse, LocationResponse } from './api';
 
 // ---------------------------------------------------------------------------
 // Map Types
@@ -16,7 +16,8 @@ export interface UpdateMapRequest {
 export interface CreateLocationRequest {
   name: string;
   description?: string;
-  restricted_characters?: string[];
+  restricted_characters?: string | null;
+  image_url?: string | null;
   from_round?: number | null;
   until_round?: number | null;
 }
@@ -24,7 +25,8 @@ export interface CreateLocationRequest {
 export interface UpdateLocationRequest {
   name?: string;
   description?: string;
-  restricted_characters?: string[];
+  restricted_characters?: string | null;
+  image_url?: string | null;
   sort_order?: number;
   from_round?: number | null;
   until_round?: number | null;
@@ -48,8 +50,7 @@ export function useEditorMaps(themeId: string) {
 
 export function useCreateMap(themeId: string) {
   return useMutation<MapResponse, Error, { name: string; image_url?: string }>({
-    mutationFn: (body) =>
-      api.post<MapResponse>(`/v1/editor/themes/${themeId}/maps`, body),
+    mutationFn: (body) => api.post<MapResponse>(`/v1/editor/themes/${themeId}/maps`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: editorKeys.maps(themeId) });
     },
@@ -58,8 +59,7 @@ export function useCreateMap(themeId: string) {
 
 export function useUpdateMap(themeId: string) {
   return useMutation<MapResponse, Error, { mapId: string; body: UpdateMapRequest }>({
-    mutationFn: ({ mapId, body }) =>
-      api.put<MapResponse>(`/v1/editor/maps/${mapId}`, body),
+    mutationFn: ({ mapId, body }) => api.put<MapResponse>(`/v1/editor/maps/${mapId}`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: editorKeys.maps(themeId) });
     },
@@ -83,8 +83,7 @@ export function useDeleteMap(themeId: string) {
 export function useEditorLocations(themeId: string) {
   return useQuery<LocationResponse[]>({
     queryKey: editorKeys.locations(themeId),
-    queryFn: () =>
-      api.get<LocationResponse[]>(`/v1/editor/themes/${themeId}/locations`),
+    queryFn: () => api.get<LocationResponse[]>(`/v1/editor/themes/${themeId}/locations`),
     enabled: !!themeId,
   });
 }
@@ -96,10 +95,7 @@ export function useEditorLocations(themeId: string) {
 export function useCreateLocation(themeId: string) {
   return useMutation<LocationResponse, Error, { mapId: string; body: CreateLocationRequest }>({
     mutationFn: ({ mapId, body }) =>
-      api.post<LocationResponse>(
-        `/v1/editor/themes/${themeId}/maps/${mapId}/locations`,
-        body,
-      ),
+      api.post<LocationResponse>(`/v1/editor/themes/${themeId}/maps/${mapId}/locations`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: editorKeys.locations(themeId) });
     },
@@ -118,8 +114,7 @@ export function useUpdateLocation(themeId: string) {
 
 export function useDeleteLocation(themeId: string) {
   return useMutation<void, Error, string>({
-    mutationFn: (locationId) =>
-      api.deleteVoid(`/v1/editor/locations/${locationId}`),
+    mutationFn: (locationId) => api.deleteVoid(`/v1/editor/locations/${locationId}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: editorKeys.locations(themeId) });
     },

--- a/apps/web/src/features/editor/imageApi.ts
+++ b/apps/web/src/features/editor/imageApi.ts
@@ -1,14 +1,14 @@
-import { useMutation } from "@tanstack/react-query";
-import { api } from "@/services/api";
-import { queryClient } from "@/services/queryClient";
-import { editorKeys } from "@/features/editor/api";
+import { useMutation } from '@tanstack/react-query';
+import { api } from '@/services/api';
+import { queryClient } from '@/services/queryClient';
+import { editorKeys } from '@/features/editor/api';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export interface UploadUrlRequest {
-  target: "character" | "clue" | "cover";
+  target: 'character' | 'clue' | 'location' | 'cover';
   target_id?: string;
   content_type: string;
   file_size: number;
@@ -30,24 +30,19 @@ interface ConfirmResponse {
 export function useRequestImageUpload(themeId: string) {
   return useMutation<UploadUrlResponse, Error, UploadUrlRequest>({
     mutationFn: (body) =>
-      api.post<UploadUrlResponse>(
-        `/v1/editor/themes/${themeId}/images/upload-url`,
-        body,
-      ),
+      api.post<UploadUrlResponse>(`/v1/editor/themes/${themeId}/images/upload-url`, body),
   });
 }
 
 export function useConfirmImageUpload(themeId: string) {
   return useMutation<ConfirmResponse, Error, { upload_key: string }>({
     mutationFn: (body) =>
-      api.post<ConfirmResponse>(
-        `/v1/editor/themes/${themeId}/images/confirm`,
-        body,
-      ),
+      api.post<ConfirmResponse>(`/v1/editor/themes/${themeId}/images/confirm`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: editorKeys.characters(themeId) });
       queryClient.invalidateQueries({ queryKey: editorKeys.theme(themeId) });
       queryClient.invalidateQueries({ queryKey: editorKeys.clues(themeId) });
+      queryClient.invalidateQueries({ queryKey: editorKeys.locations(themeId) });
     },
   });
 }
@@ -58,15 +53,15 @@ export function useConfirmImageUpload(themeId: string) {
 
 export async function uploadImage(
   themeId: string,
-  target: "character" | "clue" | "cover",
+  target: 'character' | 'clue' | 'location' | 'cover',
   targetId: string,
   file: Blob,
-  contentType: string,
+  contentType: string
 ): Promise<string> {
   // Guard: caller must pass a concrete themeId. Without this, path becomes
   // `/v1/editor/themes/undefined/images/upload-url` → 404.
   if (!themeId) {
-    throw new Error("themeId is required for image upload");
+    throw new Error('themeId is required for image upload');
   }
 
   // 1. Get presigned URL
@@ -79,22 +74,22 @@ export async function uploadImage(
       target,
       content_type: contentType,
       file_size: file.size,
-      ...(target !== "cover" && targetId ? { target_id: targetId } : {}),
-    },
+      ...(target !== 'cover' && targetId ? { target_id: targetId } : {}),
+    }
   );
 
   // 2. PUT to presigned URL (bypass api client — no auth header needed for S3)
   const putRes = await fetch(upload_url, {
-    method: "PUT",
-    headers: { "Content-Type": contentType },
+    method: 'PUT',
+    headers: { 'Content-Type': contentType },
     body: file,
   });
-  if (!putRes.ok) throw new Error("Failed to upload image to storage");
+  if (!putRes.ok) throw new Error('Failed to upload image to storage');
 
   // 3. Confirm upload and get final URL
   const { image_url } = await api.post<ConfirmResponse>(
     `/v1/editor/themes/${themeId}/images/confirm`,
-    { upload_key },
+    { upload_key }
   );
 
   return image_url;

--- a/apps/web/src/pages/Phase24LocationEntityPreviewData.ts
+++ b/apps/web/src/pages/Phase24LocationEntityPreviewData.ts
@@ -1,0 +1,21 @@
+export const locationRows = [
+  { id: 'estate', name: '별장', depth: 0, count: 5, status: 'root' },
+  { id: 'floor-1', name: '1층', depth: 1, count: 3, status: 'group' },
+  { id: 'study', name: '서재', depth: 2, count: 4, status: 'selected' },
+  { id: 'kitchen', name: '부엌', depth: 2, count: 2, status: 'normal' },
+  { id: 'floor-2', name: '2층', depth: 1, count: 1, status: 'warning' },
+];
+
+export const restrictedCharacters = [
+  { name: '홍길동', role: '탐정', checked: false },
+  { name: '김철수', role: '상속자', checked: true },
+  { name: '이영희', role: '비서', checked: true },
+];
+
+export const allLocationClues = [
+  { id: 'knife', name: '피 묻은 칼', location: '서재', round: 2, tag: 'location_clue' },
+  { id: 'receipt', name: '찢어진 영수증', location: '서재', round: 1, tag: 'evidence' },
+  { id: 'safe-code', name: '비밀 금고 암호', location: '서재', round: 3, tag: 'conditional_clue' },
+  { id: 'ash', name: '담배꽁초', location: '정원', round: 1, tag: '미사용 후보' },
+  { id: 'letter', name: '비밀 편지', location: '침실', round: 2, tag: 'character_clue' },
+];

--- a/apps/web/src/pages/Phase24LocationEntityPreviewPage.test.tsx
+++ b/apps/web/src/pages/Phase24LocationEntityPreviewPage.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import Phase24LocationEntityPreviewPage from './Phase24LocationEntityPreviewPage';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('Phase24LocationEntityPreviewPage', () => {
+  it('장소 엔티티 목업을 렌더링하고 새 장소 추가 동작을 보여준다', () => {
+    render(<Phase24LocationEntityPreviewPage />);
+
+    expect(screen.getByRole('heading', { name: '장소 엔티티 설계 목업' })).toBeDefined();
+    expect(screen.getByText('DEV ONLY')).toBeDefined();
+    expect(screen.getByRole('group', { name: 'entity 타입 선택' })).toBeDefined();
+    expect(screen.getByLabelText('장소 목록')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: '장소 추가' }));
+    fireEvent.change(screen.getByLabelText('새 장소 이름'), { target: { value: '응접실' } });
+    fireEvent.click(screen.getByRole('button', { name: '목업에 추가되는 동작 보기' }));
+
+    expect(screen.getByText('응접실')).toBeDefined();
+    expect(screen.getByText('new')).toBeDefined();
+  });
+
+  it('장소 이미지 업로드와 장소 단서 선택 목록을 한 화면에서 확인한다', () => {
+    vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:study') });
+    render(<Phase24LocationEntityPreviewPage />);
+
+    const file = new File(['mock'], 'library.png', { type: 'image/png' });
+    fireEvent.change(screen.getByLabelText('장소 이미지 파일 선택'), {
+      target: { files: [file] },
+    });
+
+    expect(screen.getByText('library.png')).toBeDefined();
+    expect(screen.getByAltText('업로드한 장소 이미지 미리보기')).toBeDefined();
+    expect(screen.getByText('이 장소의 단서')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: /담배꽁초/ }));
+    expect(screen.getAllByText('담배꽁초').length).toBeGreaterThan(1);
+    expect(screen.getByText('4개')).toBeDefined();
+  });
+});

--- a/apps/web/src/pages/Phase24LocationEntityPreviewPage.tsx
+++ b/apps/web/src/pages/Phase24LocationEntityPreviewPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ChevronDown, ChevronRight, MapPin, Plus, Search, Sparkles } from 'lucide-react';
 import { Badge } from '@/shared/components/ui';
 import { locationRows } from './Phase24LocationEntityPreviewData';
@@ -61,6 +61,14 @@ function LocationEntityWorkspace() {
   const [locationImageName, setLocationImageName] = useState('study.webp');
   const [locationImagePreview, setLocationImagePreview] = useState<string | null>(null);
   const [selectedClueIds, setSelectedClueIds] = useState(['knife', 'receipt', 'safe-code']);
+
+  useEffect(() => {
+    return () => {
+      if (locationImagePreview && typeof URL.revokeObjectURL === 'function') {
+        URL.revokeObjectURL(locationImagePreview);
+      }
+    };
+  }, [locationImagePreview]);
 
   function handleCreateDraftLocation() {
     const next = draftLocationName.trim();

--- a/apps/web/src/pages/Phase24LocationEntityPreviewPage.tsx
+++ b/apps/web/src/pages/Phase24LocationEntityPreviewPage.tsx
@@ -1,0 +1,230 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, MapPin, Plus, Search, Sparkles } from 'lucide-react';
+import { Badge } from '@/shared/components/ui';
+import { locationRows } from './Phase24LocationEntityPreviewData';
+import {
+  LocationDetailPanel,
+  LocationInspectorPanel,
+  MobileFlowNote,
+} from './Phase24LocationEntityPreviewSections';
+export default function Phase24LocationEntityPreviewPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(245,158,11,0.14),transparent_32%),radial-gradient(circle_at_80%_0%,rgba(14,165,233,0.10),transparent_28%)]" />
+      <div className="relative mx-auto max-w-7xl px-4 py-5 sm:px-6 lg:px-8">
+        <PageHeader />
+        <LocationEntityWorkspace />
+      </div>
+    </main>
+  );
+}
+function PageHeader() {
+  return (
+    <header className="mb-5 overflow-hidden rounded-3xl border border-amber-500/20 bg-slate-900/80 shadow-2xl shadow-slate-950/40">
+      <div className="border-b border-slate-800 bg-gradient-to-r from-amber-500/10 via-slate-900 to-sky-500/10 px-5 py-4">
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <Badge variant="warning">DEV ONLY</Badge>
+          <Badge variant="default">Phase 24 PR-3F</Badge>
+          <span className="rounded-full border border-slate-700 px-3 py-1 text-xs text-slate-400">
+            모바일 우선 장소 entity
+          </span>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-end">
+          <div>
+            <p className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.28em] text-amber-300/80">
+              <Sparkles className="h-4 w-4" /> Location Entity Preview
+            </p>
+            <h1 className="mt-2 text-2xl font-bold tracking-tight text-slate-50 sm:text-3xl">
+              장소 엔티티 설계 목업
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
+              장소를 트리로 찾고, 상세에서 입장 메시지·장소 이미지·접근 제한·장소 단서를 한 흐름으로
+              편집하는 화면입니다.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3 text-xs leading-5 text-slate-400">
+            <p className="font-semibold text-slate-200">변경 반영</p>
+            <p className="mt-1">
+              부모 장소 입력은 제거했습니다. 위치 관계는 장소 트리와 경로에서만 확인하고, +
+              버튼/이미지 업로드/단서 추가 동작을 볼 수 있습니다.
+            </p>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+function LocationEntityWorkspace() {
+  const [isAddingLocation, setIsAddingLocation] = useState(false);
+  const [draftLocationName, setDraftLocationName] = useState('');
+  const [mockLocationName, setMockLocationName] = useState<string | null>(null);
+  const [locationImageName, setLocationImageName] = useState('study.webp');
+  const [locationImagePreview, setLocationImagePreview] = useState<string | null>(null);
+  const [selectedClueIds, setSelectedClueIds] = useState(['knife', 'receipt', 'safe-code']);
+
+  function handleCreateDraftLocation() {
+    const next = draftLocationName.trim();
+    if (!next) return;
+    setMockLocationName(next);
+    setDraftLocationName('');
+    setIsAddingLocation(false);
+  }
+
+  function handleClueToggle(clueId: string, checked: boolean) {
+    setSelectedClueIds((current) => {
+      if (checked && !current.includes(clueId)) return [...current, clueId];
+      if (!checked) return current.filter((id) => id !== clueId);
+      return current;
+    });
+  }
+  return (
+    <section className="space-y-4 rounded-3xl border border-slate-800 bg-slate-900/60 p-3 shadow-2xl shadow-slate-950/30 sm:p-4">
+      <EntityModeBar />
+      <div className="grid gap-4 lg:grid-cols-[20rem_minmax(0,1fr)_22rem]">
+        <LocationTreePanel
+          isAddingLocation={isAddingLocation}
+          draftLocationName={draftLocationName}
+          mockLocationName={mockLocationName}
+          onAddClick={() => setIsAddingLocation((current) => !current)}
+          onDraftLocationNameChange={setDraftLocationName}
+          onCreateDraftLocation={handleCreateDraftLocation}
+        />
+        <LocationDetailPanel
+          locationImageName={locationImageName}
+          locationImagePreview={locationImagePreview}
+          selectedClueIds={selectedClueIds}
+          onLocationImageChange={(name, preview) => {
+            setLocationImageName(name);
+            setLocationImagePreview(preview);
+          }}
+          onClueToggle={handleClueToggle}
+        />
+        <LocationInspectorPanel selectedClueCount={selectedClueIds.length} />
+      </div>
+      <MobileFlowNote />
+    </section>
+  );
+}
+function EntityModeBar() {
+  return (
+    <div className="grid gap-2 sm:grid-cols-3" role="group" aria-label="entity 타입 선택">
+      {[
+        { label: '캐릭터', count: '5명', active: false },
+        { label: '장소', count: '8곳', active: true },
+        { label: '단서', count: '12개', active: false },
+      ].map((item) => (
+        <button
+          key={item.label}
+          type="button"
+          className={`rounded-2xl border px-4 py-3 text-left transition ${item.active ? 'border-amber-500/40 bg-amber-500/10 text-amber-100 shadow-lg shadow-amber-950/20' : 'border-slate-800 bg-slate-950/70 text-slate-400 hover:border-slate-700'}`}
+        >
+          <span className="block text-sm font-semibold">{item.label}</span>
+          <span className="mt-1 block text-xs text-slate-500">{item.count} entity</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+function LocationTreePanel({
+  isAddingLocation,
+  draftLocationName,
+  mockLocationName,
+  onAddClick,
+  onDraftLocationNameChange,
+  onCreateDraftLocation,
+}: {
+  isAddingLocation: boolean;
+  draftLocationName: string;
+  mockLocationName: string | null;
+  onAddClick: () => void;
+  onDraftLocationNameChange: (value: string) => void;
+  onCreateDraftLocation: () => void;
+}) {
+  return (
+    <aside className="min-w-0 space-y-3 rounded-2xl border border-slate-800 bg-slate-950/80 p-3 lg:sticky lg:top-4 lg:self-start">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300/80">
+            장소 트리
+          </p>
+          <p className="mt-1 text-xs text-slate-500">중첩 장소를 접고 펼치며 선택합니다.</p>
+        </div>
+        <button
+          type="button"
+          className="rounded-xl bg-amber-500/10 p-2 text-amber-300 hover:bg-amber-500/20"
+          aria-label="장소 추가"
+          onClick={onAddClick}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+
+      <label className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-xs text-slate-500">
+        <Search className="h-3.5 w-3.5 shrink-0" />
+        <input
+          className="min-w-0 flex-1 bg-transparent text-slate-200 outline-none placeholder:text-slate-600"
+          placeholder="장소 검색"
+        />
+      </label>
+
+      {isAddingLocation && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">
+          <p className="text-xs font-semibold text-amber-100">새 장소 추가</p>
+          <p className="mt-1 text-[11px] leading-4 text-amber-100/70">
+            현재 목업에서는 ‘1층’ 아래에 추가되는 동작만 보여줍니다.
+          </p>
+          <input
+            value={draftLocationName}
+            onChange={(event) => onDraftLocationNameChange(event.target.value)}
+            placeholder="예: 응접실"
+            aria-label="새 장소 이름"
+            className="mt-2 w-full rounded-lg border border-amber-500/30 bg-slate-950 px-3 py-2 text-xs text-slate-100 outline-none placeholder:text-slate-600 focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          />
+          <button
+            type="button"
+            onClick={onCreateDraftLocation}
+            disabled={!draftLocationName.trim()}
+            className="mt-2 w-full rounded-lg bg-amber-500 px-3 py-2 text-xs font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            목업에 추가되는 동작 보기
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-1" aria-label="장소 목록">
+        {locationRows.map((row) => (
+          <button
+            key={row.id}
+            type="button"
+            className={`flex w-full min-w-0 items-center gap-2 rounded-xl border px-3 py-2 text-left text-sm transition ${row.status === 'selected' ? 'border-amber-500/40 bg-amber-500/10 text-amber-100' : 'border-transparent bg-slate-900/50 text-slate-300 hover:border-slate-700'}`}
+            style={{ paddingLeft: `${12 + row.depth * 18}px` }}
+          >
+            {row.depth < 2 ? (
+              <ChevronDown className="h-3.5 w-3.5 shrink-0 text-slate-500" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 shrink-0 text-slate-600" />
+            )}
+            <MapPin className="h-3.5 w-3.5 shrink-0 text-amber-400/80" />
+            <span className="min-w-0 flex-1 truncate">{row.name}</span>
+            <span className="rounded-full bg-slate-950 px-2 py-0.5 text-[11px] text-slate-500">
+              {row.count}
+            </span>
+          </button>
+        ))}
+        {mockLocationName && (
+          <button
+            type="button"
+            className="flex w-full min-w-0 items-center gap-2 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 pl-[48px] text-left text-sm text-emerald-100"
+          >
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+            <MapPin className="h-3.5 w-3.5 shrink-0 text-emerald-300" />
+            <span className="min-w-0 flex-1 truncate">{mockLocationName}</span>
+            <span className="rounded-full bg-slate-950 px-2 py-0.5 text-[11px] text-emerald-300">
+              new
+            </span>
+          </button>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/pages/Phase24LocationEntityPreviewSections.tsx
+++ b/apps/web/src/pages/Phase24LocationEntityPreviewSections.tsx
@@ -1,0 +1,317 @@
+import { useRef, type ChangeEvent, type ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Building2,
+  CheckCircle2,
+  EyeOff,
+  Image,
+  KeyRound,
+  Layers3,
+  Link2,
+  LockKeyhole,
+  ShieldCheck,
+  TreePine,
+} from 'lucide-react';
+import { StartingClueAssigner } from '@/features/editor/components/design/StartingClueAssigner';
+import { allLocationClues, restrictedCharacters } from './Phase24LocationEntityPreviewData';
+
+const auditItems = [
+  { icon: CheckCircle2, text: '부모 장소가 자기 자신을 가리키지 않음', tone: 'ok' },
+  { icon: AlertTriangle, text: '2층 하위 장소 1개가 아직 단서 없음', tone: 'warn' },
+  { icon: ShieldCheck, text: '접근 제한 캐릭터 2명 설정됨', tone: 'ok' },
+];
+
+export function LocationDetailPanel({
+  locationImageName,
+  locationImagePreview,
+  selectedClueIds,
+  onLocationImageChange,
+  onClueToggle,
+}: {
+  locationImageName: string;
+  locationImagePreview: string | null;
+  selectedClueIds: string[];
+  onLocationImageChange: (name: string, preview: string | null) => void;
+  onClueToggle: (clueId: string, checked: boolean) => void;
+}) {
+  return (
+    <section className="min-w-0 space-y-4">
+      <div className="rounded-2xl border border-slate-800 bg-[linear-gradient(180deg,rgba(15,23,42,0.98),rgba(2,6,23,0.96))] p-4 sm:p-5">
+        <div className="space-y-3 sm:flex sm:items-start sm:justify-between sm:gap-4 sm:space-y-0">
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-amber-300/80">
+              Selected location
+            </p>
+            <h2 className="mt-1 text-2xl font-bold text-slate-50">서재</h2>
+            <p className="mt-1 text-sm leading-6 text-slate-500">
+              별장 / 1층 / 서재 — 플레이어가 조사와 단서 발견을 수행하는 핵심 공간
+            </p>
+          </div>
+          <span className="inline-flex rounded-full border border-slate-700 px-3 py-1 text-xs text-slate-400">
+            ID · loc-study
+          </span>
+        </div>
+      </div>
+
+      <BaseLocationForm
+        locationImageName={locationImageName}
+        locationImagePreview={locationImagePreview}
+        onLocationImageChange={onLocationImageChange}
+      />
+      <AccessPolicyCard />
+      <LocationClueCard selectedClueIds={selectedClueIds} onClueToggle={onClueToggle} />
+    </section>
+  );
+}
+function BaseLocationForm({
+  locationImageName,
+  locationImagePreview,
+  onLocationImageChange,
+}: {
+  locationImageName: string;
+  locationImagePreview: string | null;
+  onLocationImageChange: (name: string, preview: string | null) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  function handleImageFile(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    onLocationImageChange(file.name, URL.createObjectURL(file));
+    event.target.value = '';
+  }
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/80 p-4">
+      <SectionTitle
+        icon={Building2}
+        title="장소 기본 정보"
+        description="이름, 입장 메시지, 장소 이미지를 편집합니다. 부모 관계는 좌측 장소 트리에서만 관리합니다."
+      />
+      <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_14rem]">
+        <label className="space-y-1 text-xs text-slate-400">
+          <span>장소 이름</span>
+          <input
+            value="서재"
+            readOnly
+            className="w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+          />
+        </label>
+        <div className="rounded-xl border border-slate-800 bg-slate-900 px-3 py-2">
+          <p className="text-xs text-slate-500">트리 경로</p>
+          <p className="mt-1 truncate text-sm text-slate-200">별장 / 1층 / 서재</p>
+        </div>
+      </div>
+      <label className="mt-3 block space-y-1 text-xs text-slate-400">
+        <span>입장 메시지 Markdown</span>
+        <textarea
+          readOnly
+          value="문을 열자 낡은 책 냄새가 밀려옵니다. 책상 위에는 아직 식지 않은 홍차가 놓여 있습니다."
+          className="min-h-28 w-full rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-200"
+        />
+      </label>
+      <div className="mt-3 grid gap-3 sm:grid-cols-[10rem_minmax(0,1fr)]">
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="group relative flex min-h-36 items-center justify-center overflow-hidden rounded-xl border border-dashed border-slate-700 bg-slate-900 text-slate-600 hover:border-amber-500/50 hover:text-amber-200"
+          aria-label="장소 이미지 업로드"
+        >
+          {locationImagePreview ? (
+            <img
+              src={locationImagePreview}
+              alt="업로드한 장소 이미지 미리보기"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="flex flex-col items-center gap-2 text-xs">
+              <Image className="h-8 w-8" />
+              장소 이미지 업로드
+            </span>
+          )}
+          <span className="absolute inset-x-2 bottom-2 rounded-lg bg-slate-950/80 px-2 py-1 text-center text-[11px] text-slate-300 opacity-0 transition group-hover:opacity-100">
+            클릭해서 변경
+          </span>
+        </button>
+        <div className="space-y-2 text-xs text-slate-400">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="sr-only"
+            onChange={handleImageFile}
+            aria-label="장소 이미지 파일 선택"
+          />
+          <p className="font-semibold text-slate-200">장소 이미지</p>
+          <p className="rounded-xl border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100">
+            {locationImageName}
+          </p>
+          <p className="leading-5 text-slate-500">
+            실제 구현에서는 장소 이미지도 기존 이미지 업로드 API 흐름으로 저장합니다. 여기서는 선택
+            즉시 미리보기만 보여줍니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+function AccessPolicyCard() {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/80 p-4">
+      <SectionTitle
+        icon={LockKeyhole}
+        title="접근 제한"
+        description="특정 캐릭터만 이 장소에 들어오지 못하게 막습니다."
+      />
+      <div className="mt-4 grid gap-2 sm:grid-cols-3">
+        {restrictedCharacters.map((character) => (
+          <label
+            key={character.name}
+            className="rounded-xl border border-slate-800 bg-slate-900/80 p-3 text-sm"
+          >
+            <span className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={character.checked}
+                readOnly
+                className="mt-1 accent-amber-500"
+              />
+              <span className="min-w-0">
+                <span className="block truncate font-semibold text-slate-200">
+                  {character.name}
+                </span>
+                <span className="block text-xs text-slate-500">{character.role}</span>
+              </span>
+            </span>
+          </label>
+        ))}
+      </div>
+      <p className="mt-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-100">
+        저장 shape 후보: 기존 restricted_characters CSV와 호환하되, UI에서는 체크박스로 보여줍니다.
+      </p>
+    </div>
+  );
+}
+function LocationClueCard({
+  selectedClueIds,
+  onClueToggle,
+}: {
+  selectedClueIds: string[];
+  onClueToggle: (clueId: string, checked: boolean) => void;
+}) {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/80 p-4">
+      <SectionTitle
+        icon={KeyRound}
+        title="장소 단서 추가"
+        description="캐릭터 시작 단서와 같은 좌측 전체 목록 + 우측 선택 목록 패턴으로 연결합니다."
+      />
+      <div className="mt-4">
+        <StartingClueAssigner
+          characterName="서재"
+          selectedTitle="이 장소의 단서"
+          clues={allLocationClues}
+          selectedIds={selectedClueIds}
+          onClueToggle={onClueToggle}
+        />
+      </div>
+    </div>
+  );
+}
+export function LocationInspectorPanel({ selectedClueCount }: { selectedClueCount: number }) {
+  return (
+    <aside className="min-w-0 space-y-3 lg:sticky lg:top-4 lg:self-start">
+      <InspectorCard icon={TreePine} title="트리 미리보기">
+        <div className="space-y-1 text-xs text-slate-400">
+          <p>별장</p>
+          <p className="pl-4">└ 1층</p>
+          <p className="pl-8 text-amber-200">└ 서재</p>
+          <p className="pl-8">└ 부엌</p>
+        </div>
+      </InspectorCard>
+      <InspectorCard icon={Link2} title="Backlink / 사용처">
+        <div className="space-y-2 text-xs">
+          <BacklinkRow label="캐릭터 접근 제한" value="김철수 · 이영희" />
+          <BacklinkRow label="단서 연결" value={`${selectedClueCount}개`} />
+          <BacklinkRow label="진행 조건" value="round_clue 후보" />
+        </div>
+      </InspectorCard>
+      <InspectorCard icon={EyeOff} title="검수 상태">
+        <div className="space-y-2">
+          {auditItems.map(({ icon: Icon, text, tone }) => (
+            <div
+              key={text}
+              className="flex gap-2 rounded-xl border border-slate-800 bg-slate-950 px-3 py-2 text-xs leading-5 text-slate-400"
+            >
+              <Icon
+                className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${tone === 'ok' ? 'text-emerald-300' : 'text-amber-300'}`}
+              />
+              <span>{text}</span>
+            </div>
+          ))}
+        </div>
+      </InspectorCard>
+    </aside>
+  );
+}
+export function MobileFlowNote() {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-4 text-xs leading-6 text-slate-400">
+      <p className="flex items-center gap-2 font-semibold text-slate-200">
+        <Layers3 className="h-4 w-4 text-amber-400" /> 모바일 흐름
+      </p>
+      <p className="mt-1 flex flex-wrap items-center gap-2">
+        장소 검색 <ArrowRight className="h-3.5 w-3.5" /> 상세 편집{' '}
+        <ArrowRight className="h-3.5 w-3.5" /> 접근 제한 <ArrowRight className="h-3.5 w-3.5" /> 연결
+        단서 <ArrowRight className="h-3.5 w-3.5" /> 검수
+      </p>
+    </div>
+  );
+}
+function SectionTitle({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <Icon className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+      <div>
+        <p className="text-sm font-semibold text-slate-100">{title}</p>
+        <p className="mt-1 text-xs leading-5 text-slate-500">{description}</p>
+      </div>
+    </div>
+  );
+}
+function InspectorCard({
+  icon: Icon,
+  title,
+  children,
+}: {
+  icon: LucideIcon;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-950/80 p-4">
+      <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-100">
+        <Icon className="h-4 w-4 text-amber-400" />
+        {title}
+      </div>
+      {children}
+    </section>
+  );
+}
+function BacklinkRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950 px-3 py-2">
+      <p className="text-slate-500">{label}</p>
+      <p className="mt-1 text-slate-200">{value}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 요약
- 장소 엔티티에 `image_url`을 추가하고 백엔드 이미지 업로드/확정 흐름에서 `location` target을 지원했습니다.
- 프론트 장소 상세 화면을 이미지 업로드, 라운드, 접근 제한, 장소 단서 배정 중심으로 개편했습니다.
- 장소 엔티티 dev preview와 Vitest/E2E/커버리지 보강을 추가했습니다.

## 검증
- [x] `cd apps/web && pnpm test:coverage`
- [x] `cd apps/web && pnpm typecheck`
- [x] `cd apps/web && pnpm exec eslint . --quiet`
- [x] `cd apps/web && pnpm exec playwright test e2e/phase24-editor-preview.spec.ts --project=chromium`
- [x] `cd apps/server && go test -coverprofile=coverage.out ./...`
- [x] `cd apps/server && go test ./internal/domain/editor ./internal/db`
- [x] `git diff --check`
- [x] GitHub CI 전체 통과 (`ready-for-ci` 라벨 적용 후 실행)

## 리뷰/커버리지
- [x] CodeRabbit 1차 리뷰 반영 및 스레드 resolve
- [x] CodeRabbit 재리뷰 승인 확인
- [x] Codecov Report 확인: patch coverage `91.43389%`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장소 이미지 업로드/저장(image_url) 전반 지원 추가 (업로드, 저장·조회, 이미지 편집)
  * 장소 접근 제한 UI 패널 추가 (체크박스로 접근 캐릭터 관리)
  * 장소 단서 할당 UI 개선: 검색 가능 목록과 추가/제거 흐름 도입
  * 개발용 장소 엔티티 미리보기 페이지 및 관련 모듈 추가

* **변경**
  * 이미지 업로드 흐름이 장소 대상('location')을 지원하고 관련 캐시 무효화 대상에 장소 추가

* **테스트**
  * 장소 이미지/접근제한/단서 할당 관련 단위 및 E2E 테스트 추가/갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
