### PR TITLE
Security Deep Scan의 osv-scanner Go 버전 불일치 수정

### DIFF
--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -86,11 +86,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup Go
+      - name: Setup Go for osv-scanner
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version-file: apps/server/go.mod
-          cache-dependency-path: apps/server/go.sum
+          # osv-scanner v2.3.5 requires Go >= 1.26.1.
+          # Keep the project Go version in apps/server/go.mod; this job only
+          # uses Go to install the scanner CLI.
+          go-version: '1.26.2'
+          cache: false
 
       - name: Install osv-scanner
         run: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5


### PR DESCRIPTION
## 요약
- 머지 후 `main`의 `Security — Deep Scan (SARIF)` 실패 원인을 수정했습니다.
- `osv-scanner v2.3.5`가 Go `1.26.1+`을 요구하지만, 기존 workflow는 `apps/server/go.mod`의 Go `1.25.0`으로 CLI를 설치하고 있었습니다.
- 프로젝트 Go 버전은 유지하고, `osv-scanner` CLI 설치 단계에만 Go `1.26.2`를 사용하도록 분리했습니다.

## 검증
- [x] `git diff --check`

## CI 운영
- `ready-for-ci` 라벨은 아직 붙이지 않습니다.
- CodeRabbit 리뷰를 확인하고 타당한 지적을 반영한 뒤 라벨을 붙여 CI를 실행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 기타 (Chores)

* **보안 스캐너 도구 업데이트**
  * OSV 스캐너의 Go 버전을 1.26.2로 명시적으로 업데이트하여 보안 검사 도구의 호환성을 보장합니다.
  * CI/CD 워크플로우 설정을 개선하여 보안 검사 프로세스의 안정성을 강화했습니다.
  * 스캐너 CLI 설치 관련 문서를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->