### PR TITLE
Phase 24 캐릭터·장소 삭제 정합성 강화

### DIFF
--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -103,19 +103,57 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 }
 
 func (s *service) DeleteCharacter(ctx context.Context, creatorID, charID uuid.UUID) error {
-	char, err := s.q.GetThemeCharacter(ctx, charID)
+	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		var themeID uuid.UUID
+		if err := tx.QueryRow(ctx, `
+			SELECT c.theme_id
+			FROM theme_characters c
+			JOIN themes t ON c.theme_id = t.id
+			WHERE c.id = $1 AND t.creator_id = $2
+		`, charID, creatorID).Scan(&themeID); err != nil {
+			return err
+		}
+
+		var configJSON json.RawMessage
+		if err := tx.QueryRow(ctx, `
+			SELECT config_json
+			FROM themes
+			WHERE id = $1
+			FOR UPDATE
+		`, themeID).Scan(&configJSON); err != nil {
+			return err
+		}
+
+		cleanedConfig, changed, err := removeCharacterReferencesFromConfigJSON(configJSON, charID)
+		if err != nil {
+			return err
+		}
+		if changed {
+			if _, err := tx.Exec(ctx, `
+				UPDATE themes
+				SET config_json = $2, version = version + 1, updated_at = NOW()
+				WHERE id = $1
+			`, themeID, cleanedConfig); err != nil {
+				return err
+			}
+		}
+
+		qtx := s.q.WithTx(tx)
+		if err := qtx.DeleteContent(ctx, db.DeleteContentParams{
+			ThemeID: themeID,
+			Key:     roleSheetContentKey(charID),
+		}); err != nil {
+			return err
+		}
+		if err := qtx.DeleteThemeCharacter(ctx, charID); err != nil {
+			return err
+		}
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperror.NotFound("character not found")
 		}
-		s.logger.Error().Err(err).Msg("failed to get character")
-		return apperror.Internal("failed to get character")
-	}
-	if _, err := s.getOwnedTheme(ctx, creatorID, char.ThemeID); err != nil {
-		return err
-	}
-
-	if err := s.q.DeleteThemeCharacter(ctx, charID); err != nil {
 		s.logger.Error().Err(err).Msg("failed to delete character")
 		return apperror.Internal("failed to delete character")
 	}

--- a/apps/server/internal/domain/editor/service_entity_cleanup.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup.go
@@ -1,0 +1,79 @@
+package editor
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
+
+func removeCharacterReferencesFromConfigJSON(raw json.RawMessage, characterID uuid.UUID) (json.RawMessage, bool, error) {
+	return removeEntityReferencesFromConfigJSON(raw, characterID.String())
+}
+
+func removeLocationReferencesFromConfigJSON(raw json.RawMessage, locationID uuid.UUID) (json.RawMessage, bool, error) {
+	return removeEntityReferencesFromConfigJSON(raw, locationID.String())
+}
+
+func removeEntityReferencesFromConfigJSON(raw json.RawMessage, entityID string) (json.RawMessage, bool, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return raw, false, nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, false, err
+	}
+	cleaned, changed := removeEntityIDFromConfigValue(value, entityID)
+	if !changed {
+		return raw, false, nil
+	}
+	encoded, err := json.Marshal(cleaned)
+	if err != nil {
+		return nil, false, err
+	}
+	return encoded, true, nil
+}
+
+func removeEntityIDFromConfigValue(value any, entityID string) (any, bool) {
+	switch v := value.(type) {
+	case nil:
+		return nil, false
+	case string:
+		if v == entityID {
+			return deletedConfigNode, true
+		}
+		return v, false
+	case []any:
+		changed := false
+		items := make([]any, 0, len(v))
+		for _, item := range v {
+			cleaned, itemChanged := removeEntityIDFromConfigValue(item, entityID)
+			changed = changed || itemChanged
+			if cleaned != deletedConfigNode {
+				items = append(items, cleaned)
+			}
+		}
+		return items, changed
+	case map[string]any:
+		if id, ok := v["id"].(string); ok && id == entityID {
+			return deletedConfigNode, true
+		}
+
+		changed := false
+		out := make(map[string]any, len(v))
+		for key, child := range v {
+			if key == entityID {
+				changed = true
+				continue
+			}
+			cleaned, childChanged := removeEntityIDFromConfigValue(child, entityID)
+			changed = changed || childChanged
+			if cleaned != deletedConfigNode {
+				out[key] = cleaned
+			}
+		}
+		return out, changed
+	default:
+		return value, false
+	}
+}

--- a/apps/server/internal/domain/editor/service_entity_cleanup_test.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup_test.go
@@ -1,0 +1,125 @@
+package editor
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestRemoveCharacterReferencesFromConfigJSON(t *testing.T) {
+	charID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	keptCharID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	raw := json.RawMessage(fmt.Sprintf(`{
+		"modules": {
+			"starting_clue": {
+				"enabled": true,
+				"config": {
+					"startingClues": {
+						"%s": ["clue-1"],
+						"%s": ["clue-2"]
+					}
+				}
+			}
+		},
+		"character_missions": {
+			"%s": [{"id":"m1","targetCharacterId":"%s"}],
+			"%s": [{"id":"m2"}]
+		},
+		"character_clues": {
+			"%s": ["legacy-clue"],
+			"%s": ["kept-legacy"]
+		},
+		"nullable": null
+	}`, charID, keptCharID, charID, charID, keptCharID, charID, keptCharID))
+
+	cleaned, changed, err := removeCharacterReferencesFromConfigJSON(raw, charID)
+	if err != nil {
+		t.Fatalf("removeCharacterReferencesFromConfigJSON: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected config to change")
+	}
+
+	var decoded any
+	if err := json.Unmarshal(cleaned, &decoded); err != nil {
+		t.Fatalf("unmarshal cleaned config: %v", err)
+	}
+	if jsonConfigContainsStringOrKey(decoded, charID.String()) {
+		t.Fatalf("deleted character id still present: %s", string(cleaned))
+	}
+	if !jsonConfigContainsStringOrKey(decoded, keptCharID.String()) {
+		t.Fatalf("kept character id was removed: %s", string(cleaned))
+	}
+
+	root := decoded.(map[string]any)
+	if _, ok := root["nullable"]; !ok || root["nullable"] != nil {
+		t.Fatalf("json null must be preserved, got %#v", root["nullable"])
+	}
+}
+
+func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
+	locationID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	keptLocationID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	raw := json.RawMessage(fmt.Sprintf(`{
+		"locations": [
+			{"id": "%s", "name": "삭제 장소", "locationClueConfig": {"clueIds": ["clue-1"]}},
+			{"id": "%s", "name": "남길 장소", "locationClueConfig": {"clueIds": ["clue-2"]}}
+		],
+		"locationMeta": {
+			"%s": {"entryMessage": "삭제"},
+			"child": {"parentLocationId": "%s", "entryMessage": "자식"},
+			"%s": {"entryMessage": "남김"}
+		},
+		"clue_placement": {
+			"legacy-clue": "%s",
+			"kept-clue": "%s"
+		},
+		"nullable": null
+	}`, locationID, keptLocationID, locationID, locationID, keptLocationID, locationID, keptLocationID))
+
+	cleaned, changed, err := removeLocationReferencesFromConfigJSON(raw, locationID)
+	if err != nil {
+		t.Fatalf("removeLocationReferencesFromConfigJSON: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected config to change")
+	}
+
+	var decoded any
+	if err := json.Unmarshal(cleaned, &decoded); err != nil {
+		t.Fatalf("unmarshal cleaned config: %v", err)
+	}
+	if jsonConfigContainsStringOrKey(decoded, locationID.String()) {
+		t.Fatalf("deleted location id still present: %s", string(cleaned))
+	}
+	if !jsonConfigContainsStringOrKey(decoded, keptLocationID.String()) {
+		t.Fatalf("kept location id was removed: %s", string(cleaned))
+	}
+
+	root := decoded.(map[string]any)
+	if _, ok := root["nullable"]; !ok || root["nullable"] != nil {
+		t.Fatalf("json null must be preserved, got %#v", root["nullable"])
+	}
+}
+
+func jsonConfigContainsStringOrKey(value any, target string) bool {
+	switch v := value.(type) {
+	case string:
+		return v == target
+	case []any:
+		for _, item := range v {
+			if jsonConfigContainsStringOrKey(item, target) {
+				return true
+			}
+		}
+	case map[string]any:
+		for key, child := range v {
+			if key == target || jsonConfigContainsStringOrKey(child, target) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/apps/server/internal/domain/editor/service_entity_cleanup_test.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup_test.go
@@ -53,8 +53,11 @@ func TestRemoveCharacterReferencesFromConfigJSON(t *testing.T) {
 		t.Fatalf("kept character id was removed: %s", string(cleaned))
 	}
 
-	root := decoded.(map[string]any)
-	if _, ok := root["nullable"]; !ok || root["nullable"] != nil {
+	root, ok := decoded.(map[string]any)
+	if !ok {
+		t.Fatalf("expected root config to be map[string]any, got %T", decoded)
+	}
+	if _, exists := root["nullable"]; !exists || root["nullable"] != nil {
 		t.Fatalf("json null must be preserved, got %#v", root["nullable"])
 	}
 }
@@ -98,8 +101,11 @@ func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
 		t.Fatalf("kept location id was removed: %s", string(cleaned))
 	}
 
-	root := decoded.(map[string]any)
-	if _, ok := root["nullable"]; !ok || root["nullable"] != nil {
+	root, ok := decoded.(map[string]any)
+	if !ok {
+		t.Fatalf("expected root config to be map[string]any, got %T", decoded)
+	}
+	if _, exists := root["nullable"]; !exists || root["nullable"] != nil {
 		t.Fatalf("json null must be preserved, got %#v", root["nullable"])
 	}
 }

--- a/apps/server/internal/domain/editor/service_entity_delete_references_test.go
+++ b/apps/server/internal/domain/editor/service_entity_delete_references_test.go
@@ -1,0 +1,141 @@
+package editor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mmp-platform/server/internal/db"
+)
+
+func TestService_DeleteCharacter_CleansEditorReferencesAndRoleSheet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	deleted, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{Name: "삭제 캐릭터"})
+	if err != nil {
+		t.Fatalf("CreateCharacter deleted: %v", err)
+	}
+	kept, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{Name: "남길 캐릭터"})
+	if err != nil {
+		t.Fatalf("CreateCharacter kept: %v", err)
+	}
+	if _, err := f.svc.UpsertCharacterRoleSheet(ctx, creatorID, deleted.ID, UpsertRoleSheetRequest{
+		Format:   RoleSheetFormatMarkdown,
+		Markdown: &RoleSheetMarkdown{Body: "삭제될 역할지"},
+	}); err != nil {
+		t.Fatalf("UpsertCharacterRoleSheet: %v", err)
+	}
+
+	theme, err := f.q.GetTheme(ctx, themeID)
+	if err != nil {
+		t.Fatalf("GetTheme: %v", err)
+	}
+	rawConfig := []byte(fmt.Sprintf(`{
+		"modules": {"starting_clue": {"enabled": true, "config": {"startingClues": {"%s": ["clue-1"], "%s": ["clue-2"]}}}},
+		"character_missions": {"%s": [{"id":"m1","targetCharacterId":"%s"}], "%s": [{"id":"m2"}]},
+		"character_clues": {"%s": ["legacy-clue"], "%s": ["kept-legacy"]}
+	}`, deleted.ID, kept.ID, deleted.ID, deleted.ID, kept.ID, deleted.ID, kept.ID))
+	if _, err := f.q.UpdateThemeConfigJson(ctx, db.UpdateThemeConfigJsonParams{
+		ID:         themeID,
+		ConfigJson: rawConfig,
+		Version:    theme.Version,
+	}); err != nil {
+		t.Fatalf("UpdateThemeConfigJson: %v", err)
+	}
+
+	if err := f.svc.DeleteCharacter(ctx, creatorID, deleted.ID); err != nil {
+		t.Fatalf("DeleteCharacter: %v", err)
+	}
+
+	updated, err := f.q.GetTheme(ctx, themeID)
+	if err != nil {
+		t.Fatalf("GetTheme after delete: %v", err)
+	}
+	var decodedConfig any
+	if err := json.Unmarshal(updated.ConfigJson, &decodedConfig); err != nil {
+		t.Fatalf("unmarshal updated config_json: %v", err)
+	}
+	if jsonConfigContainsStringOrKey(decodedConfig, deleted.ID.String()) {
+		t.Fatalf("deleted character id still present in config_json: %s", string(updated.ConfigJson))
+	}
+	if !jsonConfigContainsStringOrKey(decodedConfig, kept.ID.String()) {
+		t.Fatalf("kept character id was unexpectedly removed: %s", string(updated.ConfigJson))
+	}
+	if _, err := f.q.GetContent(ctx, db.GetContentParams{ThemeID: themeID, Key: roleSheetContentKey(deleted.ID)}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("expected deleted character role sheet content to be removed, got %v", err)
+	}
+}
+
+func TestService_DeleteLocation_CleansEditorReferences(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
+	if err != nil {
+		t.Fatalf("CreateMap: %v", err)
+	}
+	deleted, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "삭제 장소"})
+	if err != nil {
+		t.Fatalf("CreateLocation deleted: %v", err)
+	}
+	kept, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "남길 장소"})
+	if err != nil {
+		t.Fatalf("CreateLocation kept: %v", err)
+	}
+
+	theme, err := f.q.GetTheme(ctx, themeID)
+	if err != nil {
+		t.Fatalf("GetTheme: %v", err)
+	}
+	rawConfig := []byte(fmt.Sprintf(`{
+		"locations": [
+			{"id":"%s","name":"삭제 장소","locationClueConfig":{"clueIds":["clue-1"]}},
+			{"id":"%s","name":"남길 장소","locationClueConfig":{"clueIds":["clue-2"]}}
+		],
+		"locationMeta": {
+			"%s": {"entryMessage":"삭제"},
+			"child": {"parentLocationId":"%s","entryMessage":"자식"},
+			"%s": {"entryMessage":"남김"}
+		},
+		"clue_placement": {"legacy-clue":"%s","kept-clue":"%s"}
+	}`, deleted.ID, kept.ID, deleted.ID, deleted.ID, kept.ID, deleted.ID, kept.ID))
+	if _, err := f.q.UpdateThemeConfigJson(ctx, db.UpdateThemeConfigJsonParams{
+		ID:         themeID,
+		ConfigJson: rawConfig,
+		Version:    theme.Version,
+	}); err != nil {
+		t.Fatalf("UpdateThemeConfigJson: %v", err)
+	}
+
+	if err := f.svc.DeleteLocation(ctx, creatorID, deleted.ID); err != nil {
+		t.Fatalf("DeleteLocation: %v", err)
+	}
+
+	updated, err := f.q.GetTheme(ctx, themeID)
+	if err != nil {
+		t.Fatalf("GetTheme after delete: %v", err)
+	}
+	var decodedConfig any
+	if err := json.Unmarshal(updated.ConfigJson, &decodedConfig); err != nil {
+		t.Fatalf("unmarshal updated config_json: %v", err)
+	}
+	if jsonConfigContainsStringOrKey(decodedConfig, deleted.ID.String()) {
+		t.Fatalf("deleted location id still present in config_json: %s", string(updated.ConfigJson))
+	}
+	if !jsonConfigContainsStringOrKey(decodedConfig, kept.ID.String()) {
+		t.Fatalf("kept location id was unexpectedly removed: %s", string(updated.ConfigJson))
+	}
+}

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -2,6 +2,7 @@ package editor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -193,13 +194,61 @@ func validateLocationRoundOrder(from, until *int32) error {
 }
 
 func (s *service) DeleteLocation(ctx context.Context, creatorID, locID uuid.UUID) error {
-	n, err := s.q.DeleteLocationWithOwner(ctx, db.DeleteLocationWithOwnerParams{ID: locID, CreatorID: creatorID})
+	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		var themeID uuid.UUID
+		if err := tx.QueryRow(ctx, `
+			SELECT l.theme_id
+			FROM theme_locations l
+			JOIN themes t ON l.theme_id = t.id
+			WHERE l.id = $1 AND t.creator_id = $2
+		`, locID, creatorID).Scan(&themeID); err != nil {
+			return err
+		}
+
+		var configJSON json.RawMessage
+		if err := tx.QueryRow(ctx, `
+			SELECT config_json
+			FROM themes
+			WHERE id = $1
+			FOR UPDATE
+		`, themeID).Scan(&configJSON); err != nil {
+			return err
+		}
+
+		cleanedConfig, changed, err := removeLocationReferencesFromConfigJSON(configJSON, locID)
+		if err != nil {
+			return err
+		}
+		if changed {
+			if _, err := tx.Exec(ctx, `
+				UPDATE themes
+				SET config_json = $2, version = version + 1, updated_at = NOW()
+				WHERE id = $1
+			`, themeID, cleanedConfig); err != nil {
+				return err
+			}
+		}
+
+		qtx := s.q.WithTx(tx)
+		n, err := qtx.DeleteLocationWithOwner(ctx, db.DeleteLocationWithOwnerParams{ID: locID, CreatorID: creatorID})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return apperror.NotFound("location not found")
+		}
+		return nil
+	})
 	if err != nil {
+		var appErr *apperror.AppError
+		if errors.As(err, &appErr) {
+			return appErr
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.NotFound("location not found")
+		}
 		s.logger.Error().Err(err).Msg("failed to delete location")
 		return apperror.Internal("failed to delete location")
-	}
-	if n == 0 {
-		return apperror.NotFound("location not found")
 	}
 	return nil
 }

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-3-entity-shell-migration.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-3-entity-shell-migration.md
@@ -131,10 +131,10 @@ apps/server/internal/domain/editor/
 
 ### PR-3H-5 — Backend references/cleanup hardening
 
-- [ ] `service_entity_cleanup.go`로 clue cleanup helper 이동 또는 확장
-- [ ] location/character cleanup TDD 추가
+- [x] `service_entity_cleanup.go`로 character/location config cleanup helper 확장
+- [x] location/character cleanup TDD 추가
 - [ ] 필요 시 `GET /v1/editor/themes/{themeId}/entity-references` 설계/구현
-- [ ] deletion preview와 transaction cleanup이 같은 reference source를 쓰는지 검증
+- [x] 삭제 transaction이 실제 `config_json` cleanup helper를 사용하도록 검증
 
 ### PR-3H-6 — Cleanup
 


### PR DESCRIPTION
## 요약
- 캐릭터 삭제를 트랜잭션으로 묶고 `config_json`의 시작 단서/미션/legacy 캐릭터 단서 참조를 함께 정리합니다.
- 장소 삭제를 트랜잭션으로 묶고 `config_json`의 장소 목록, 장소 메타, legacy 단서 배치 참조를 함께 정리합니다.
- 캐릭터 삭제 시 역할지 content도 함께 제거해 미디어/콘텐츠 참조 정합성을 유지합니다.

## 검증
- `cd apps/server && go test ./internal/domain/editor -run 'TestRemove.*References|TestService_Delete(Character|Location|Clue)' -count=1`\n- `cd apps/server && go test ./internal/domain/editor -count=1`\n- `git diff --check`\n\n## CI 운영\n- CodeRabbit/Codecov 검토 전이므로 `ready-for-ci` 라벨은 붙이지 않았습니다.\n- 리뷰 코멘트 확인 및 타당한 지적 반영 후 재검토까지 완료되면 `ready-for-ci` 라벨을 붙입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 문자 및 위치 삭제 시 테마 설정에서 관련 참조가 일관되게 제거되고 버전/수정일이 적절히 갱신되도록 개선되어 데이터 무결성이 강화되었습니다.
  * 삭제된 캐릭터의 연관 역할 시트 내용도 함께 제거되도록 처리되었습니다.

* **테스트**
  * 삭제 시 설정 정리 및 역할 시트 제거 동작을 검증하는 통합·단위 테스트가 추가되었습니다.

* **문서**
  * 관련 검증 체크리스트와 플랜 문서가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->