### PR TITLE
Phase 24 페이즈·결말 entity 구현

### DIFF
--- a/apps/web/e2e/editor-phase-ending.spec.ts
+++ b/apps/web/e2e/editor-phase-ending.spec.ts
@@ -63,8 +63,8 @@ test.describe("Phase 24 페이즈/결말 entity smoke", () => {
     await expect(page.getByLabel("결말 본문")).toHaveValue("범인은 밝혀졌다.");
 
     const a11y = await new AxeBuilder({ page })
+      .include('[data-testid="ending-entity-panel"]')
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-      .disableRules(["color-contrast"])
       .analyze();
     expect(a11y.violations).toEqual([]);
   });

--- a/apps/web/e2e/editor-phase-ending.spec.ts
+++ b/apps/web/e2e/editor-phase-ending.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import {
+  BASE,
+  THEME_ID,
+  FLOW_NODE_ID,
+  freshState,
+  mockCommonApis,
+  loginAsE2EUser,
+  type MockState,
+} from "./helpers/editor-golden-path-fixtures";
+
+test.describe("Phase 24 페이즈/결말 entity smoke", () => {
+  let state: MockState;
+
+  test.beforeEach(async ({ page }) => {
+    state = freshState();
+    await mockCommonApis(page, state);
+    await page.route(`**/v1/editor/themes/${THEME_ID}/flow`, async (route) => {
+      if (route.request().method() === "GET") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            nodes: [
+              {
+                id: FLOW_NODE_ID,
+                theme_id: THEME_ID,
+                type: "ending",
+                data: {
+                  label: "진실",
+                  icon: "🎭",
+                  color: "amber",
+                  description: "사건의 전말",
+                  endingContent: "범인은 밝혀졌다.",
+                },
+                position_x: 320,
+                position_y: 200,
+                created_at: "2026-05-03T00:00:00Z",
+                updated_at: "2026-05-03T00:00:00Z",
+              },
+            ],
+            edges: [],
+          }),
+        });
+      }
+      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ nodes: [], edges: [] }) });
+    });
+    await loginAsE2EUser(page);
+  });
+
+  test("페이즈 흐름 안내와 결말 목록을 볼 수 있다", async ({ page }) => {
+    await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
+
+    await expect(page.getByText("페이즈 흐름")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/페이즈는 게임 진행 순서를 화살표로 연결합니다/)).toBeVisible();
+
+    await page.getByRole("button", { name: /결말/ }).click();
+
+    await expect(page.getByRole("heading", { name: "결말 목록" })).toBeVisible();
+    await expect(page.getByText("진실").first()).toBeVisible();
+    await expect(page.getByLabel("결말 이름")).toHaveValue("진실");
+    await expect(page.getByLabel("결말 본문")).toHaveValue("범인은 밝혀졌다.");
+  });
+});

--- a/apps/web/e2e/editor-phase-ending.spec.ts
+++ b/apps/web/e2e/editor-phase-ending.spec.ts
@@ -1,3 +1,4 @@
+import AxeBuilder from "@axe-core/playwright";
 import { test, expect } from "@playwright/test";
 import {
   BASE,
@@ -60,5 +61,11 @@ test.describe("Phase 24 페이즈/결말 entity smoke", () => {
     await expect(page.getByText("진실").first()).toBeVisible();
     await expect(page.getByLabel("결말 이름")).toHaveValue("진실");
     await expect(page.getByLabel("결말 본문")).toHaveValue("범인은 밝혀졌다.");
+
+    const a11y = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(a11y.violations).toEqual([]);
   });
 });

--- a/apps/web/src/features/editor/components/DesignTab.tsx
+++ b/apps/web/src/features/editor/components/DesignTab.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
-import { Puzzle, GitBranch, MapPin } from 'lucide-react';
+import { Puzzle, GitBranch, MapPin, Drama } from 'lucide-react';
 import type { EditorThemeResponse } from '@/features/editor/api';
 import { ModulesSubTab } from './design/ModulesSubTab';
 import { FlowSubTab } from './design/FlowSubTab';
 import { LocationsSubTab } from './design/LocationsSubTab';
+import { EndingEntitySubTab } from './design/EndingEntitySubTab';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type SubTab = 'modules' | 'flow' | 'locations';
+type SubTab = 'modules' | 'flow' | 'locations' | 'endings';
 
 interface DesignTabProps {
   themeId: string;
@@ -20,6 +21,7 @@ interface DesignTabProps {
 const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
   { key: 'modules', label: '모듈', icon: Puzzle },
   { key: 'flow', label: '흐름', icon: GitBranch },
+  { key: 'endings', label: '결말', icon: Drama },
   { key: 'locations', label: '장소', icon: MapPin },
 ];
 
@@ -30,6 +32,7 @@ const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
 function readInitialSubTab(routeSegment?: string): SubTab {
   if (routeSegment === 'flow') return 'flow';
   if (routeSegment === 'locations') return 'locations';
+  if (routeSegment === 'endings') return 'endings';
   return 'modules';
 }
 
@@ -68,6 +71,9 @@ export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
         )}
         {activeSubTab === 'flow' && (
           <FlowSubTab themeId={themeId} />
+        )}
+        {activeSubTab === 'endings' && (
+          <EndingEntitySubTab themeId={themeId} />
         )}
         {activeSubTab === 'locations' && (
           <LocationsSubTab themeId={themeId} theme={theme} />

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import type { Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -14,6 +15,7 @@ interface EndingEntityDetailProps {
 const SAVE_DEBOUNCE_MS = 1000;
 
 export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDetailProps) {
+  const fieldIdPrefix = useId();
   const data = node.data as FlowNodeData;
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
@@ -63,11 +65,11 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
       </div>
 
       <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
-        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-icon-${node.id}`}>
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-icon`}>
           아이콘
         </label>
         <input
-          id={`ending-icon-${node.id}`}
+          id={`${fieldIdPrefix}-icon`}
           type="text"
           value={data.icon ?? ""}
           onChange={(event) => handleChange({ icon: event.target.value })}
@@ -78,11 +80,11 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
       </div>
 
       <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
-        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-label-${node.id}`}>
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-label`}>
           결말 이름
         </label>
         <input
-          id={`ending-label-${node.id}`}
+          id={`${fieldIdPrefix}-label`}
           type="text"
           value={data.label ?? ""}
           onChange={(event) => handleChange({ label: event.target.value })}
@@ -93,11 +95,11 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
       </div>
 
       <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
-        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-color-${node.id}`}>
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-color`}>
           표시 색상
         </label>
         <input
-          id={`ending-color-${node.id}`}
+          id={`${fieldIdPrefix}-color`}
           type="text"
           value={data.color ?? ""}
           onChange={(event) => handleChange({ color: event.target.value })}
@@ -108,11 +110,11 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
       </div>
 
       <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
-        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-description-${node.id}`}>
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-description`}>
           공개 설명
         </label>
         <textarea
-          id={`ending-description-${node.id}`}
+          id={`${fieldIdPrefix}-description`}
           value={data.description ?? ""}
           onChange={(event) => handleChange({ description: event.target.value })}
           onBlur={debouncer.flush}
@@ -123,11 +125,11 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
       </div>
 
       <div className="space-y-2">
-        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-content-${node.id}`}>
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-content`}>
           결말 본문
         </label>
         <textarea
-          id={`ending-content-${node.id}`}
+          id={`${fieldIdPrefix}-content`}
           value={data.endingContent ?? ""}
           onChange={(event) => handleChange({ endingContent: event.target.value })}
           onBlur={debouncer.flush}

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -1,16 +1,50 @@
 import type { Node } from "@xyflow/react";
-import type { FlowNodeData } from "../../flowTypes";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+import { useUpdateFlowNode } from "../../flowApi";
+import { flowKeys, type FlowGraphResponse, type FlowNodeData } from "../../flowTypes";
 
 interface EndingEntityDetailProps {
   node: Node;
+  themeId: string;
   onChange: (nodeId: string, patch: Partial<FlowNodeData>) => void;
 }
 
-export function EndingEntityDetail({ node, onChange }: EndingEntityDetailProps) {
+const SAVE_DEBOUNCE_MS = 1000;
+
+export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDetailProps) {
   const data = node.data as FlowNodeData;
+  const updateNode = useUpdateFlowNode(themeId);
+  const queryClient = useQueryClient();
+
+  const debouncer = useDebouncedMutation<FlowNodeData>({
+    debounceMs: SAVE_DEBOUNCE_MS,
+    mutate: (body, opts) =>
+      updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
+    applyOptimistic: (body) => {
+      const cacheKey = flowKeys.graph(themeId);
+      const previous = queryClient.getQueryData<FlowGraphResponse>(cacheKey);
+      if (!previous) return null;
+      queryClient.setQueryData<FlowGraphResponse>(cacheKey, {
+        ...previous,
+        nodes: previous.nodes.map((flowNode) =>
+          flowNode.id === node.id
+            ? { ...flowNode, data: { ...flowNode.data, ...body } }
+            : flowNode,
+        ),
+      });
+      return () => queryClient.setQueryData(cacheKey, previous);
+    },
+    onError: () => toast.error("결말 저장에 실패했습니다"),
+  });
 
   const handleChange = (patch: Partial<FlowNodeData>) => {
     onChange(node.id, patch);
+    debouncer.schedule(
+      { ...data, ...patch },
+      (prev) => ({ ...data, ...(prev ?? {}), ...patch }),
+    );
   };
 
   return (
@@ -37,6 +71,7 @@ export function EndingEntityDetail({ node, onChange }: EndingEntityDetailProps) 
           type="text"
           value={data.icon ?? ""}
           onChange={(event) => handleChange({ icon: event.target.value })}
+          onBlur={debouncer.flush}
           placeholder="예: 🎭"
           className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
         />
@@ -51,6 +86,7 @@ export function EndingEntityDetail({ node, onChange }: EndingEntityDetailProps) 
           type="text"
           value={data.label ?? ""}
           onChange={(event) => handleChange({ label: event.target.value })}
+          onBlur={debouncer.flush}
           placeholder="예: 진실, 자비, 오판"
           className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
         />
@@ -65,6 +101,7 @@ export function EndingEntityDetail({ node, onChange }: EndingEntityDetailProps) 
           type="text"
           value={data.color ?? ""}
           onChange={(event) => handleChange({ color: event.target.value })}
+          onBlur={debouncer.flush}
           placeholder="예: amber, emerald, rose"
           className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
         />
@@ -78,6 +115,7 @@ export function EndingEntityDetail({ node, onChange }: EndingEntityDetailProps) 
           id={`ending-description-${node.id}`}
           value={data.description ?? ""}
           onChange={(event) => handleChange({ description: event.target.value })}
+          onBlur={debouncer.flush}
           placeholder="결말 목록에서 제작자가 구분하기 쉬운 짧은 설명"
           rows={3}
           className="resize-y rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
@@ -92,6 +130,7 @@ export function EndingEntityDetail({ node, onChange }: EndingEntityDetailProps) 
           id={`ending-content-${node.id}`}
           value={data.endingContent ?? ""}
           onChange={(event) => handleChange({ endingContent: event.target.value })}
+          onBlur={debouncer.flush}
           placeholder="사건의 전말을 Markdown으로 작성하세요. 플레이어에게 공개되는 내용입니다."
           rows={8}
           className="min-h-44 w-full resize-y rounded-xl border border-slate-700 bg-slate-900 px-3 py-3 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -1,0 +1,105 @@
+import type { Node } from "@xyflow/react";
+import type { FlowNodeData } from "../../flowTypes";
+
+interface EndingEntityDetailProps {
+  node: Node;
+  onChange: (nodeId: string, patch: Partial<FlowNodeData>) => void;
+}
+
+export function EndingEntityDetail({ node, onChange }: EndingEntityDetailProps) {
+  const data = node.data as FlowNodeData;
+
+  const handleChange = (patch: Partial<FlowNodeData>) => {
+    onChange(node.id, patch);
+  };
+
+  return (
+    <section className="flex min-w-0 flex-col gap-4 rounded-2xl border border-slate-800 bg-slate-950/80 p-4 lg:p-5">
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
+          결말 상세
+        </p>
+        <h3 className="text-lg font-semibold text-slate-100">
+          {data.label || "새 결말"}
+        </h3>
+        <p className="text-sm leading-6 text-slate-400">
+          게임이 끝났을 때 모두에게 공개할 결말 이름과 본문을 작성합니다.
+          점수 배율은 사용하지 않고 모든 결말은 같은 기준으로 계산됩니다.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-icon-${node.id}`}>
+          아이콘
+        </label>
+        <input
+          id={`ending-icon-${node.id}`}
+          type="text"
+          value={data.icon ?? ""}
+          onChange={(event) => handleChange({ icon: event.target.value })}
+          placeholder="예: 🎭"
+          className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-label-${node.id}`}>
+          결말 이름
+        </label>
+        <input
+          id={`ending-label-${node.id}`}
+          type="text"
+          value={data.label ?? ""}
+          onChange={(event) => handleChange({ label: event.target.value })}
+          placeholder="예: 진실, 자비, 오판"
+          className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-color-${node.id}`}>
+          표시 색상
+        </label>
+        <input
+          id={`ending-color-${node.id}`}
+          type="text"
+          value={data.color ?? ""}
+          onChange={(event) => handleChange({ color: event.target.value })}
+          placeholder="예: amber, emerald, rose"
+          className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-description-${node.id}`}>
+          공개 설명
+        </label>
+        <textarea
+          id={`ending-description-${node.id}`}
+          value={data.description ?? ""}
+          onChange={(event) => handleChange({ description: event.target.value })}
+          placeholder="결말 목록에서 제작자가 구분하기 쉬운 짧은 설명"
+          rows={3}
+          className="resize-y rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`ending-content-${node.id}`}>
+          결말 본문
+        </label>
+        <textarea
+          id={`ending-content-${node.id}`}
+          value={data.endingContent ?? ""}
+          onChange={(event) => handleChange({ endingContent: event.target.value })}
+          placeholder="사건의 전말을 Markdown으로 작성하세요. 플레이어에게 공개되는 내용입니다."
+          rows={8}
+          className="min-h-44 w-full resize-y rounded-xl border border-slate-700 bg-slate-900 px-3 py-3 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+        <p className="text-xs leading-5 text-slate-500">
+          Markdown 문법을 사용할 수 있습니다. 플레이어에게 보일 문장만 작성하고 내부 코드나 저장 키는 쓰지 않아도 됩니다.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -41,7 +41,7 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
   }, [endingNodes, query]);
 
   const selectedNode =
-    endingNodes.find((node) => node.id === selectedId) ?? filteredNodes[0] ?? null;
+    filteredNodes.find((node) => node.id === selectedId) ?? filteredNodes[0] ?? null;
 
   const handleAddEnding = () => {
     addNode("ending", { x: 360 + endingNodes.length * 40, y: 220 });
@@ -137,7 +137,7 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
           </aside>
 
           {selectedNode && (
-            <EndingEntityDetail node={selectedNode} onChange={updateNodeData} />
+            <EndingEntityDetail node={selectedNode} themeId={themeId} onChange={updateNodeData} />
           )}
         </div>
       )}

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -95,6 +95,7 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
               <input
                 type="search"
+                aria-label="결말 검색"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="결말 검색"

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from "react";
+import { Plus, Search } from "lucide-react";
+import type { Node } from "@xyflow/react";
+import { useFlowData } from "../../hooks/useFlowData";
+import type { FlowNodeData } from "../../flowTypes";
+import { EndingEntityDetail } from "./EndingEntityDetail";
+
+interface EndingEntitySubTabProps {
+  themeId: string;
+}
+
+function getEndingLabel(node: Node) {
+  const data = node.data as FlowNodeData;
+  return data.label || "이름 없는 결말";
+}
+
+function getEndingDescription(node: Node) {
+  const data = node.data as FlowNodeData;
+  return data.description || "결말 설명을 작성해 주세요.";
+}
+
+export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const { nodes, isLoading, addNode, updateNodeData } = useFlowData(themeId);
+
+  const endingNodes = useMemo(
+    () => nodes.filter((node) => node.type === "ending"),
+    [nodes],
+  );
+
+  const filteredNodes = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return endingNodes;
+    return endingNodes.filter((node) => {
+      const data = node.data as FlowNodeData;
+      return [data.label, data.description, data.endingContent]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(needle));
+    });
+  }, [endingNodes, query]);
+
+  const selectedNode =
+    endingNodes.find((node) => node.id === selectedId) ?? filteredNodes[0] ?? null;
+
+  const handleAddEnding = () => {
+    addNode("ending", { x: 360 + endingNodes.length * 40, y: 220 });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-slate-400">
+        결말 목록을 불러오는 중입니다...
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6">
+      <header className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
+            결말 entity
+          </p>
+          <h2 className="text-xl font-semibold text-slate-100">결말 목록</h2>
+          <p className="max-w-3xl text-sm leading-6 text-slate-400">
+            Flow의 엔딩 노드를 결말 목록으로 모아 보여줍니다. 분기 매트릭스는 다음 PR에서 연결하고,
+            여기서는 플레이어에게 공개될 결말 이름과 본문을 먼저 정리합니다.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleAddEnding}
+          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-amber-500/50 bg-amber-500/10 px-4 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-400/60"
+        >
+          <Plus className="h-4 w-4" />
+          결말 추가
+        </button>
+      </header>
+
+      {endingNodes.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-700 bg-slate-900/50 p-8 text-center">
+          <div className="max-w-md space-y-3">
+            <h3 className="text-lg font-semibold text-slate-100">아직 결말이 없습니다</h3>
+            <p className="text-sm leading-6 text-slate-400">
+              Flow에서 결말 노드를 추가하면 이곳에서 결말 내용을 작성할 수 있어요.
+              바로 시작하려면 위의 “결말 추가” 버튼을 눌러도 됩니다.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(260px,360px)_minmax(0,1fr)]">
+          <aside className="flex min-h-0 flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
+            <label className="relative block">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="결말 검색"
+                className="min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+              />
+            </label>
+
+            <div className="flex min-h-0 flex-col gap-2 overflow-y-auto">
+              {filteredNodes.length === 0 ? (
+                <p className="rounded-xl border border-slate-800 bg-slate-950 p-4 text-sm text-slate-400">
+                  검색 결과가 없습니다.
+                </p>
+              ) : (
+                filteredNodes.map((node) => {
+                  const data = node.data as FlowNodeData;
+                  const selected = selectedNode?.id === node.id;
+                  return (
+                    <button
+                      key={node.id}
+                      type="button"
+                      onClick={() => setSelectedId(node.id)}
+                      className={`rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-400/60 ${
+                        selected
+                          ? "border-amber-500/70 bg-amber-500/10"
+                          : "border-slate-800 bg-slate-950 hover:border-slate-600"
+                      }`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span aria-hidden="true">{data.icon || "🎭"}</span>
+                        <span className="font-medium text-slate-100">{getEndingLabel(node)}</span>
+                      </div>
+                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-400">
+                        {getEndingDescription(node)}
+                      </p>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </aside>
+
+          {selectedNode && (
+            <EndingEntityDetail node={selectedNode} onChange={updateNodeData} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -22,7 +22,7 @@ function getEndingDescription(node: Node) {
 export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const { nodes, isLoading, addNode, updateNodeData } = useFlowData(themeId);
+  const { nodes, isLoading, isError, error, refetch, addNode, updateNodeData } = useFlowData(themeId);
 
   const endingNodes = useMemo(
     () => nodes.filter((node) => node.type === "ending"),
@@ -55,8 +55,33 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
     );
   }
 
+  if (isError) {
+    return (
+      <div className="flex h-full items-center justify-center bg-slate-950 p-6 text-center">
+        <div className="max-w-md rounded-2xl border border-rose-500/30 bg-rose-950/20 p-6">
+          <h3 className="text-lg font-semibold text-rose-100">결말 목록을 불러오지 못했습니다</h3>
+          <p className="mt-2 text-sm leading-6 text-rose-200/80">
+            네트워크나 권한 문제일 수 있습니다. 잠시 후 다시 시도해 주세요.
+          </p>
+          {error instanceof Error && error.message && (
+            <p className="mt-3 rounded-xl bg-slate-950/60 p-3 text-left text-xs leading-5 text-rose-100/80">
+              {error.message}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="mt-4 inline-flex min-h-11 items-center justify-center rounded-xl border border-rose-300/40 bg-rose-300/10 px-4 text-sm font-medium text-rose-100 transition hover:bg-rose-300/20 focus:outline-none focus:ring-2 focus:ring-rose-300/60"
+          >
+            다시 불러오기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6">
+    <div data-testid="ending-entity-panel" className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6">
       <header className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-1">
           <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
@@ -117,6 +142,7 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
                       key={node.id}
                       type="button"
                       onClick={() => setSelectedId(node.id)}
+                      aria-pressed={selected}
                       className={`rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-400/60 ${
                         selected
                           ? "border-amber-500/70 bg-amber-500/10"

--- a/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
@@ -91,23 +91,28 @@ export function EndingNodePanel({
         />
       </div>
 
-      {/* Score multiplier */}
+      {/* Icon */}
       <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">점수 배율</label>
+        <label className="text-[11px] text-slate-400">아이콘</label>
         <input
-          type="number"
-          min={0}
-          step={0.1}
-          value={data.score_multiplier ?? ""}
-          onChange={(e) =>
-            handleChange({
-              score_multiplier: e.target.value
-                ? Number(e.target.value)
-                : undefined,
-            })
-          }
+          type="text"
+          value={data.icon ?? ""}
+          onChange={(e) => handleChange({ icon: e.target.value })}
           onBlur={flush}
-          placeholder="1.0"
+          placeholder="예: 🎭"
+          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+        />
+      </div>
+
+      {/* Color */}
+      <div className="flex flex-col gap-1">
+        <label className="text-[11px] text-slate-400">표시 색상</label>
+        <input
+          type="text"
+          value={data.color ?? ""}
+          onChange={(e) => handleChange({ color: e.target.value })}
+          onBlur={flush}
+          placeholder="예: amber, emerald, rose"
           className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>

--- a/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import type { Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -27,6 +28,10 @@ export function EndingNodePanel({
   themeId,
   onUpdate,
 }: EndingNodePanelProps) {
+  const labelInputId = useId();
+  const descriptionInputId = useId();
+  const iconInputId = useId();
+  const colorInputId = useId();
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
   const data = node.data as FlowNodeData;
@@ -67,8 +72,9 @@ export function EndingNodePanel({
 
       {/* Label */}
       <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">라벨</label>
+        <label htmlFor={labelInputId} className="text-[11px] text-slate-400">라벨</label>
         <input
+          id={labelInputId}
           type="text"
           value={data.label ?? ""}
           onChange={(e) => handleChange({ label: e.target.value })}
@@ -80,8 +86,9 @@ export function EndingNodePanel({
 
       {/* Description */}
       <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">설명</label>
+        <label htmlFor={descriptionInputId} className="text-[11px] text-slate-400">설명</label>
         <textarea
+          id={descriptionInputId}
           value={data.description ?? ""}
           onChange={(e) => handleChange({ description: e.target.value })}
           onBlur={flush}
@@ -93,8 +100,9 @@ export function EndingNodePanel({
 
       {/* Icon */}
       <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">아이콘</label>
+        <label htmlFor={iconInputId} className="text-[11px] text-slate-400">아이콘</label>
         <input
+          id={iconInputId}
           type="text"
           value={data.icon ?? ""}
           onChange={(e) => handleChange({ icon: e.target.value })}
@@ -106,8 +114,9 @@ export function EndingNodePanel({
 
       {/* Color */}
       <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-slate-400">표시 색상</label>
+        <label htmlFor={colorInputId} className="text-[11px] text-slate-400">표시 색상</label>
         <input
+          id={colorInputId}
           type="text"
           value={data.color ?? ""}
           onChange={(e) => handleChange({ color: e.target.value })}

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -158,6 +158,11 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
 
         {/* Side panels */}
         <div className="flex max-h-[55vh] w-full shrink-0 flex-col overflow-y-auto border-t border-slate-800 bg-slate-900 lg:max-h-none lg:w-72 lg:border-l lg:border-t-0">
+          {!showSim && !selectedNode && (
+            <div className="p-4 text-sm leading-6 text-slate-400">
+              페이즈나 결말 노드를 선택하면 세부 설정을 편집할 수 있습니다.
+            </div>
+          )}
           {showSim && (
             <div className="border-b border-slate-800 p-3">
               <FlowSimulationPanel

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -126,11 +126,11 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
         onToggleSimulation={() => setShowSim((v) => !v)}
         isSimulating={showSim}
       />
-      <div className="flex flex-1 overflow-hidden">
+      <div data-testid="flow-workspace" className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
         {/* Canvas */}
         <div
           ref={reactFlowWrapper}
-          className="flex-1"
+          className="min-h-[420px] flex-1 lg:min-h-0"
           onDragOver={handleDragOver}
           onDrop={handleDrop}
         >
@@ -157,7 +157,7 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
         </div>
 
         {/* Side panels */}
-        <div className="flex w-56 shrink-0 flex-col border-l border-slate-800 bg-slate-900 overflow-y-auto">
+        <div className="flex max-h-[55vh] w-full shrink-0 flex-col overflow-y-auto border-t border-slate-800 bg-slate-900 lg:max-h-none lg:w-72 lg:border-l lg:border-t-0">
           {showSim && (
             <div className="border-b border-slate-800 p-3">
               <FlowSimulationPanel

--- a/apps/web/src/features/editor/components/design/FlowSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/FlowSubTab.tsx
@@ -5,5 +5,20 @@ interface FlowSubTabProps {
 }
 
 export function FlowSubTab({ themeId }: FlowSubTabProps) {
-  return <FlowCanvas themeId={themeId} />;
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-slate-950">
+      <header className="shrink-0 border-b border-slate-800 bg-slate-900/70 px-4 py-3 lg:px-6">
+        <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
+          페이즈 entity
+        </p>
+        <h2 className="mt-1 text-lg font-semibold text-slate-100">페이즈 흐름</h2>
+        <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
+          페이즈는 게임 진행 순서를 화살표로 연결합니다. 노드를 선택하면 아래 또는 오른쪽에서 세부 설정을 편집할 수 있습니다.
+        </p>
+      </header>
+      <div className="min-h-0 flex-1">
+        <FlowCanvas themeId={themeId} />
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
@@ -33,7 +33,7 @@ export function NodeDetailPanel({
   if (!node) {
     return (
       <div className="flex h-full items-center justify-center p-4">
-        <span className="text-xs text-slate-500">노드를 선택하세요</span>
+        <span className="text-xs text-slate-500">편집할 페이즈나 결말 노드를 선택하세요</span>
       </div>
     );
   }
@@ -54,7 +54,7 @@ export function NodeDetailPanel({
         {isStart ? (
           <div className="flex h-full items-center justify-center p-4">
             <span className="text-xs text-slate-500">
-              시작 노드는 편집할 수 없습니다
+              시작 지점은 고정되어 있어 편집할 수 없습니다
             </span>
           </div>
         ) : node.type === "phase" ? (
@@ -87,7 +87,7 @@ export function NodeDetailPanel({
             className="flex w-full items-center justify-center gap-1.5 rounded border border-red-800 bg-red-950/30 px-3 py-1.5 text-xs text-red-400 transition-colors hover:border-red-600 hover:bg-red-900/30"
           >
             <Trash2 className="h-3.5 w-3.5" />
-            노드 삭제
+            선택 항목 삭제
           </button>
         </div>
       )}

--- a/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
@@ -49,6 +49,9 @@ vi.mock('../../design/FlowSubTab', () => ({
 vi.mock('../../design/LocationsSubTab', () => ({
   LocationsSubTab: () => <div>LocationsSubTab 콘텐츠</div>,
 }));
+vi.mock('../../design/EndingEntitySubTab', () => ({
+  EndingEntitySubTab: () => <div>EndingEntitySubTab 콘텐츠</div>,
+}));
 
 vi.mock('@/features/editor/constants', () => ({
   MODULE_CATEGORIES: [
@@ -124,12 +127,13 @@ describe('DesignTab', () => {
     useModuleSchemasMock.mockReturnValue({ data: null, isLoading: false });
   });
 
-  it('서브탭 3개를 모두 렌더링한다', () => {
+  it('서브탭 4개를 모두 렌더링한다', () => {
     render(<DesignTab themeId="theme-1" theme={mockTheme} />);
 
     expect(screen.getByText('모듈')).toBeDefined();
     expect(screen.getByText('흐름')).toBeDefined();
     expect(screen.getByText('장소')).toBeDefined();
+    expect(screen.getByText('결말')).toBeDefined();
   });
 
   it('배치, 설정 탭이 없다', () => {
@@ -158,6 +162,13 @@ describe('DesignTab', () => {
 
     fireEvent.click(screen.getByText('장소'));
     expect(screen.getByText('LocationsSubTab 콘텐츠')).toBeDefined();
+  });
+
+  it('결말 탭 클릭 시 결말 entity 콘텐츠로 전환된다', () => {
+    render(<DesignTab themeId="theme-1" theme={mockTheme} />);
+
+    fireEvent.click(screen.getByText('결말'));
+    expect(screen.getByText('EndingEntitySubTab 콘텐츠')).toBeDefined();
   });
 
   it('모듈 탭이 기본 선택되어 모듈 사이드바가 표시된다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+const { useFlowDataMock, addNodeMock, updateNodeDataMock } = vi.hoisted(() => ({
+  useFlowDataMock: vi.fn(),
+  addNodeMock: vi.fn(),
+  updateNodeDataMock: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useFlowData", () => ({
+  useFlowData: () => useFlowDataMock(),
+}));
+
+import { EndingEntitySubTab } from "../EndingEntitySubTab";
+
+const makeNode = (id: string, data: Record<string, unknown> = {}, type = "ending") => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: { label: "진실", description: "사건의 전말", ...data },
+});
+
+beforeEach(() => {
+  useFlowDataMock.mockReturnValue({
+    nodes: [
+      makeNode("ending-1", { label: "진실", icon: "🎭", endingContent: "범인은 밝혀졌다." }),
+      makeNode("phase-1", { label: "1막" }, "phase"),
+      makeNode("ending-2", { label: "오판", description: "잘못된 선택" }),
+    ],
+    isLoading: false,
+    addNode: addNodeMock,
+    updateNodeData: updateNodeDataMock,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("EndingEntitySubTab", () => {
+  it("Flow의 ending 노드만 결말 목록에 표시한다", () => {
+    render(<EndingEntitySubTab themeId="theme-1" />);
+
+    expect(screen.getByText("결말 목록")).toBeDefined();
+    expect(screen.getAllByText("진실").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
+    expect(screen.queryByText("1막")).toBeNull();
+  });
+
+  it("결말이 없으면 제작자가 이해할 수 있는 빈 상태를 보여준다", () => {
+    useFlowDataMock.mockReturnValue({
+      nodes: [],
+      isLoading: false,
+      addNode: addNodeMock,
+      updateNodeData: updateNodeDataMock,
+    });
+
+    render(<EndingEntitySubTab themeId="theme-1" />);
+
+    expect(screen.getByText("아직 결말이 없습니다")).toBeDefined();
+    expect(screen.getByText(/Flow에서 결말 노드를 추가하면/)).toBeDefined();
+  });
+
+  it("결말 추가 버튼은 ending 노드 생성을 요청한다", () => {
+    render(<EndingEntitySubTab themeId="theme-1" />);
+
+    fireEvent.click(screen.getByText("결말 추가"));
+
+    expect(addNodeMock).toHaveBeenCalledWith("ending", expect.objectContaining({ x: expect.any(Number), y: 220 }));
+  });
+
+  it("검색어로 결말 목록을 좁힌다", () => {
+    render(<EndingEntitySubTab themeId="theme-1" />);
+
+    fireEvent.change(screen.getByPlaceholderText("결말 검색"), { target: { value: "오판" } });
+
+    expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
+    expect(screen.queryByText("진실")).toBeNull();
+  });
+
+  it("상세 입력을 변경하면 선택한 결말 노드 데이터만 갱신한다", () => {
+    render(<EndingEntitySubTab themeId="theme-1" />);
+
+    fireEvent.change(screen.getByLabelText("결말 이름"), { target: { value: "자비" } });
+
+    expect(updateNodeDataMock).toHaveBeenCalledWith("ending-1", { label: "자비" });
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -1,17 +1,36 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 
-const { useFlowDataMock, addNodeMock, updateNodeDataMock } = vi.hoisted(() => ({
+const { useFlowDataMock, addNodeMock, updateNodeDataMock, mutateMock, useUpdateFlowNodeMock } = vi.hoisted(() => ({
   useFlowDataMock: vi.fn(),
   addNodeMock: vi.fn(),
   updateNodeDataMock: vi.fn(),
+  mutateMock: vi.fn(),
+  useUpdateFlowNodeMock: vi.fn(),
 }));
 
 vi.mock("../../../hooks/useFlowData", () => ({
   useFlowData: () => useFlowDataMock(),
 }));
 
+vi.mock("../../../flowApi", () => ({
+  useUpdateFlowNode: () => useUpdateFlowNodeMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
 import { EndingEntitySubTab } from "../EndingEntitySubTab";
+
+function renderWithClient(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
 
 const makeNode = (id: string, data: Record<string, unknown> = {}, type = "ending") => ({
   id,
@@ -21,6 +40,7 @@ const makeNode = (id: string, data: Record<string, unknown> = {}, type = "ending
 });
 
 beforeEach(() => {
+  useUpdateFlowNodeMock.mockReturnValue({ mutate: mutateMock });
   useFlowDataMock.mockReturnValue({
     nodes: [
       makeNode("ending-1", { label: "진실", icon: "🎭", endingContent: "범인은 밝혀졌다." }),
@@ -40,7 +60,7 @@ afterEach(() => {
 
 describe("EndingEntitySubTab", () => {
   it("Flow의 ending 노드만 결말 목록에 표시한다", () => {
-    render(<EndingEntitySubTab themeId="theme-1" />);
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" />);
 
     expect(screen.getByText("결말 목록")).toBeDefined();
     expect(screen.getAllByText("진실").length).toBeGreaterThan(0);
@@ -56,14 +76,14 @@ describe("EndingEntitySubTab", () => {
       updateNodeData: updateNodeDataMock,
     });
 
-    render(<EndingEntitySubTab themeId="theme-1" />);
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" />);
 
     expect(screen.getByText("아직 결말이 없습니다")).toBeDefined();
     expect(screen.getByText(/Flow에서 결말 노드를 추가하면/)).toBeDefined();
   });
 
   it("결말 추가 버튼은 ending 노드 생성을 요청한다", () => {
-    render(<EndingEntitySubTab themeId="theme-1" />);
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" />);
 
     fireEvent.click(screen.getByText("결말 추가"));
 
@@ -71,7 +91,7 @@ describe("EndingEntitySubTab", () => {
   });
 
   it("검색어로 결말 목록을 좁힌다", () => {
-    render(<EndingEntitySubTab themeId="theme-1" />);
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" />);
 
     fireEvent.change(screen.getByPlaceholderText("결말 검색"), { target: { value: "오판" } });
 
@@ -80,10 +100,16 @@ describe("EndingEntitySubTab", () => {
   });
 
   it("상세 입력을 변경하면 선택한 결말 노드 데이터만 갱신한다", () => {
-    render(<EndingEntitySubTab themeId="theme-1" />);
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" />);
 
     fireEvent.change(screen.getByLabelText("결말 이름"), { target: { value: "자비" } });
 
     expect(updateNodeDataMock).toHaveBeenCalledWith("ending-1", { label: "자비" });
+
+    fireEvent.blur(screen.getByLabelText("결말 이름"));
+    expect(mutateMock).toHaveBeenCalledWith(
+      { nodeId: "ending-1", body: { data: expect.objectContaining({ label: "자비" }) } },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -3,12 +3,13 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
-const { useFlowDataMock, addNodeMock, updateNodeDataMock, mutateMock, useUpdateFlowNodeMock } = vi.hoisted(() => ({
+const { useFlowDataMock, addNodeMock, updateNodeDataMock, mutateMock, useUpdateFlowNodeMock, refetchMock } = vi.hoisted(() => ({
   useFlowDataMock: vi.fn(),
   addNodeMock: vi.fn(),
   updateNodeDataMock: vi.fn(),
   mutateMock: vi.fn(),
   useUpdateFlowNodeMock: vi.fn(),
+  refetchMock: vi.fn(),
 }));
 
 vi.mock("../../../hooks/useFlowData", () => ({
@@ -48,6 +49,9 @@ beforeEach(() => {
       makeNode("ending-2", { label: "오판", description: "잘못된 선택" }),
     ],
     isLoading: false,
+    isError: false,
+    error: null,
+    refetch: refetchMock,
     addNode: addNodeMock,
     updateNodeData: updateNodeDataMock,
   });
@@ -72,6 +76,9 @@ describe("EndingEntitySubTab", () => {
     useFlowDataMock.mockReturnValue({
       nodes: [],
       isLoading: false,
+      isError: false,
+      error: null,
+      refetch: refetchMock,
       addNode: addNodeMock,
       updateNodeData: updateNodeDataMock,
     });
@@ -80,6 +87,27 @@ describe("EndingEntitySubTab", () => {
 
     expect(screen.getByText("아직 결말이 없습니다")).toBeDefined();
     expect(screen.getByText(/Flow에서 결말 노드를 추가하면/)).toBeDefined();
+  });
+
+
+  it("결말 목록을 불러오지 못하면 에러 안내와 재시도 버튼을 보여준다", () => {
+    useFlowDataMock.mockReturnValue({
+      nodes: [],
+      isLoading: false,
+      isError: true,
+      error: new Error("권한이 없습니다"),
+      refetch: refetchMock,
+      addNode: addNodeMock,
+      updateNodeData: updateNodeDataMock,
+    });
+
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" />);
+
+    expect(screen.getByText("결말 목록을 불러오지 못했습니다")).toBeDefined();
+    expect(screen.getByText("권한이 없습니다")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
+    expect(refetchMock).toHaveBeenCalled();
   });
 
   it("결말 추가 버튼은 ending 노드 생성을 요청한다", () => {
@@ -96,6 +124,7 @@ describe("EndingEntitySubTab", () => {
     fireEvent.change(screen.getByPlaceholderText("결말 검색"), { target: { value: "오판" } });
 
     expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /오판/ }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.queryByText("진실")).toBeNull();
   });
 

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -115,7 +115,10 @@ describe("EndingEntitySubTab", () => {
 
     fireEvent.click(screen.getByText("결말 추가"));
 
-    expect(addNodeMock).toHaveBeenCalledWith("ending", expect.objectContaining({ x: expect.any(Number), y: 220 }));
+    expect(addNodeMock).toHaveBeenCalledWith("ending", expect.objectContaining({
+      x: expect.any(Number),
+      y: expect.any(Number),
+    }));
   });
 
   it("검색어로 결말 목록을 좁힌다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
@@ -79,6 +79,29 @@ afterEach(() => {
 });
 
 describe("EndingNodePanel debounce + onBlur flush", () => {
+
+  it("Phase 24 정책에 따라 점수 배율 입력을 표시하지 않는다", () => {
+    renderWithClient(
+      <EndingNodePanel node={makeNode({ score_multiplier: 2 })} themeId="t1" onUpdate={vi.fn()} />,
+    );
+
+    expect(screen.queryByText("점수 배율")).toBeNull();
+  });
+
+  it("아이콘과 표시 색상을 저장할 수 있다", () => {
+    renderWithClient(
+      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("예: 🎭"), { target: { value: "💚" } });
+    fireEvent.blur(screen.getByPlaceholderText("예: 🎭"));
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    const [arg] = mutateMock.mock.calls[0] as [
+      { nodeId: string; body: { data: { icon: string } } },
+    ];
+    expect(arg.body.data.icon).toBe("💚");
+  });
   it("debounce 500ms 후에 mutate가 1회 호출된다", async () => {
     renderWithClient(
       <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -85,6 +85,13 @@ describe('FlowCanvas', () => {
     expect(screen.getByTestId('react-flow')).toBeDefined();
   });
 
+  it('모바일 우선 세로 레이아웃을 사용하고 데스크톱에서만 2열로 바뀐다', () => {
+    render(<FlowCanvas themeId="theme-1" />);
+    const workspace = screen.getByTestId('flow-workspace');
+    expect(workspace.className).toContain('flex-col');
+    expect(workspace.className).toContain('lg:flex-row');
+  });
+
   it('ReactFlow 보조 컴포넌트들이 렌더링된다', () => {
     render(<FlowCanvas themeId="theme-1" />);
     expect(screen.getByTestId('rf-background')).toBeDefined();

--- a/apps/web/src/features/editor/components/design/__tests__/FlowSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowSubTab.test.tsx
@@ -33,6 +33,8 @@ afterEach(() => {
 describe('FlowSubTab', () => {
   it('FlowCanvas를 렌더링한다', () => {
     render(<FlowSubTab themeId="theme-1" />);
+    expect(screen.getByText('페이즈 흐름')).toBeDefined();
+    expect(screen.getByText(/페이즈는 게임 진행 순서를 화살표로 연결합니다/)).toBeDefined();
     expect(screen.getByTestId('flow-canvas')).toBeDefined();
   });
 

--- a/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
@@ -43,7 +43,7 @@ function makeNode(type: string, data: Record<string, unknown> = {}): Node {
 // ---------------------------------------------------------------------------
 
 describe("NodeDetailPanel", () => {
-  it("node가 null이면 '노드를 선택하세요' 를 표시한다", () => {
+  it("node가 null이면 '편집할 페이즈나 결말 노드를 선택하세요' 를 표시한다", () => {
     render(
       <NodeDetailPanel
         node={null}
@@ -52,7 +52,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText("노드를 선택하세요")).toBeDefined();
+    expect(screen.getByText("편집할 페이즈나 결말 노드를 선택하세요")).toBeDefined();
   });
 
   it("start 노드이면 편집 불가 메시지를 표시한다", () => {
@@ -64,7 +64,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText("시작 노드는 편집할 수 없습니다")).toBeDefined();
+    expect(screen.getByText("시작 지점은 고정되어 있어 편집할 수 없습니다")).toBeDefined();
   });
 
   it("start 노드에는 삭제 버튼이 없다", () => {
@@ -76,7 +76,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.queryByText("노드 삭제")).toBeNull();
+    expect(screen.queryByText("선택 항목 삭제")).toBeNull();
   });
 
   it("phase 노드이면 PhaseNodePanel을 렌더링한다", () => {
@@ -100,7 +100,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText("노드 삭제")).toBeDefined();
+    expect(screen.getByText("선택 항목 삭제")).toBeDefined();
   });
 
   it("삭제 버튼 클릭 시 onDelete가 노드 id와 함께 호출된다", () => {
@@ -113,7 +113,7 @@ describe("NodeDetailPanel", () => {
         onDelete={onDelete}
       />,
     );
-    fireEvent.click(screen.getByText("노드 삭제"));
+    fireEvent.click(screen.getByText("선택 항목 삭제"));
     expect(onDelete).toHaveBeenCalledWith("node-1");
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import type { Node } from "@xyflow/react";
 

--- a/apps/web/src/features/editor/flowTypes.ts
+++ b/apps/web/src/features/editor/flowTypes.ts
@@ -16,6 +16,9 @@ export interface FlowNodeData {
   duration?: number;
   rounds?: number;
   description?: string;
+  icon?: string;
+  color?: string;
+  endingContent?: string;
   score_multiplier?: number;
   default_edge_id?: string;
   autoAdvance?: boolean;

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -21,7 +21,7 @@ import { useEdgeCondition } from "./useEdgeCondition";
 import { useApplyPreset } from "./useApplyPreset";
 
 export function useFlowData(themeId: string) {
-  const { data, isLoading } = useFlowGraph(themeId);
+  const { data, isLoading, isError, error, refetch } = useFlowGraph(themeId);
   const saveFlow = useSaveFlow(themeId);
   const createNode = useCreateFlowNode(themeId);
   const deleteNodeMutation = useDeleteFlowNode(themeId);
@@ -188,7 +188,7 @@ export function useFlowData(themeId: string) {
   return {
     nodes, edges,
     onNodesChange: handleNodesChange, onEdgesChange: handleEdgesChange,
-    onConnect, isLoading, isSaving: saveFlow.isPending, save,
+    onConnect, isLoading, isError, error, refetch, isSaving: saveFlow.isPending, save,
     selectedNode, addNode, updateNodeData, deleteNode,
     onSelectionChange, updateEdgeCondition, applyPreset,
   };

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-4-tasks.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-4-tasks.md
@@ -1,0 +1,220 @@
+# Phase 24 PR-4 — 페이즈 + 결말 Entity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 기존 Flow 편집 화면을 Phase 24 entity 체계에 맞게 정리하고, 결말 목록 탭을 별도 entity 화면으로 추가한다.
+
+**Architecture:** 페이즈는 다른 entity처럼 단순 좌측 리스트로 만들지 않고 기존 React Flow 기반 `FlowCanvas`를 유지한다. 대신 선택 노드 편집 패널을 모바일 친화적 세로 흐름과 제작자 친화 문구로 정리하고, 결말 노드는 별도 결말 entity 목록과 1:1로 연결할 수 있는 경계를 만든다. 결말 분기 매트릭스는 PR-5 범위이므로 이번 PR은 목록/콘텐츠/Flow 노드 연결까지만 구현한다.
+
+**Tech Stack:** React 19, TypeScript, Vite, TanStack Query, React Flow, Tailwind CSS, Vitest + Testing Library, Playwright E2E, Go editor flow API는 기존 `flow_nodes`/`flow_edges`를 재사용한다.
+
+---
+
+## 1. 범위와 비범위
+
+### 포함
+
+- 페이즈 entity 화면: 기존 `FlowSubTab`/`FlowCanvas`를 Phase 24 표현으로 정리한다.
+- 페이즈 노드 편집: 기본 정보, 시간/라운드, 자동 진행, 액션 편집을 제작자가 이해하기 쉬운 이름으로 유지한다.
+- 결말 entity 목록 탭: Flow의 `ending` 노드들을 목록/상세 형태로 보여주고 라벨·아이콘·색상·공개 설명·결말 본문 Markdown 저장 경계를 제공한다.
+- `EndingNodePanel`에서 Phase 24 결정과 충돌하는 “점수 배율” UI를 제거한다. 모든 결말 점수 배율은 1.0 고정이다.
+- Flow 결말 노드와 결말 entity 상세가 같은 `flow_node.id`를 기준으로 동작하도록 한다.
+- 모바일에서는 세로 흐름, 데스크톱에서는 Flow + 상세 패널 2열을 유지한다.
+- 테스트: 페이즈/결말 focused unit + E2E smoke + typecheck/lint.
+
+### 제외
+
+- 결말 분기 질문/매트릭스 UI와 평가기: PR-5.
+- 신규 DB 테이블 기반 ending CRUD: 이번 PR은 기존 `flow_nodes(type='ending')`를 entity source로 사용한다.
+- 게임 종료 화면의 결말/점수 breakdown: PR-5 또는 런타임 후속 PR.
+- 복잡한 모듈 설정 폼 자동 생성: PR-4에서는 섹션 경계와 기본 저장만 만든다.
+
+## 2. 파일 구조
+
+### 생성
+
+- `apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx`
+  - 결말 목록 탭 컨테이너. Flow graph에서 ending node만 추출해 목록/상세를 렌더링한다.
+- `apps/web/src/features/editor/components/design/EndingEntityDetail.tsx`
+  - 결말 라벨, 아이콘/색상, 짧은 공개 설명, Markdown 본문 입력 UI.
+- `apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx`
+  - 결말 목록/빈 상태/선택/저장 동작 테스트.
+- `apps/web/e2e/editor-phase-ending.spec.ts`
+  - 에디터 디자인 탭에서 Flow와 결말 목록을 확인하는 smoke 테스트.
+
+### 수정
+
+- `apps/web/src/features/editor/components/design/FlowSubTab.tsx`
+  - 상단에 “페이즈 흐름” 설명과 결말 목록 탭 진입 UI를 추가하거나 `DesignTab` 탭 구조에 맞게 분리한다.
+- `apps/web/src/features/editor/components/design/FlowCanvas.tsx`
+  - 모바일에서 Flow와 상세 패널이 세로로 쌓이도록 반응형 class를 조정한다.
+- `apps/web/src/features/editor/components/design/NodeDetailPanel.tsx`
+  - 삭제 버튼 문구와 빈 상태 문구를 제작자 친화적으로 정리한다.
+- `apps/web/src/features/editor/components/design/PhaseNodePanel.tsx`
+  - Phase 24 페이즈 entity 문구와 섹션 구분을 추가한다.
+- `apps/web/src/features/editor/components/design/EndingNodePanel.tsx`
+  - 점수 배율 입력 제거, `icon`/`color`/`contentKey` 저장 필드 추가.
+- `apps/web/src/features/editor/flowTypes.ts`
+  - `FlowNodeData`에 `icon`, `color`, `endingContent` 또는 `contentKey` 타입 필드 추가.
+- `apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx`
+  - 점수 배율 제거와 새 필드 저장 테스트 갱신.
+- `apps/web/src/features/editor/components/design/__tests__/FlowSubTab.test.tsx`
+  - 페이즈/결말 안내 문구 또는 탭 표시 테스트 갱신.
+- `docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md`
+  - PR-4 상세 task 링크 상태 갱신.
+
+## 3. 데이터 원칙
+
+- 결말 entity의 1차 source는 `flow_nodes` 중 `type === "ending"`인 노드다.
+- `label`, `description`, `icon`, `color`는 `flow_nodes.data`에 저장한다.
+- 결말 본문 Markdown은 이번 PR에서 `flow_nodes.data.endingContent`로 시작한다. 추후 런타임 공개/다국어가 필요하면 `theme_contents` 기반 typed content로 옮길 수 있도록 `EndingEntityDetail` 내부 handler 경계를 분리한다.
+- `score_multiplier`는 UI에서 제거하고, 기존 데이터에 값이 있어도 표시하지 않는다. PR-5 평가에서도 결말 배율은 1.0으로 취급한다.
+
+## 4. 작업 순서
+
+### Task 1 — 계획/기준선
+
+- [x] **Step 1:** 새 worktree 생성
+
+```bash
+git worktree add .worktrees/phase-24-pr-4-phase-ending -b feat/phase-24-pr-4-phase-ending main
+```
+
+- [ ] **Step 2:** focused baseline 테스트 실행
+
+```bash
+pnpm --dir apps/web exec vitest run \
+  src/features/editor/components/design/__tests__/FlowSubTab.test.tsx \
+  src/features/editor/components/design/__tests__/FlowCanvas.test.tsx \
+  src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx \
+  src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+```
+
+Expected: PASS. 실패하면 구현 전에 원인을 기록하고 기존 실패/신규 실패를 구분한다.
+
+### Task 2 — 결말 entity 상세 테스트 RED
+
+- [ ] **Step 1:** `EndingEntitySubTab.test.tsx`에 빈 상태와 목록 선택 테스트를 작성한다.
+- [ ] **Step 2:** 테스트를 실행해 `EndingEntitySubTab` 미정의 실패를 확인한다.
+- [ ] **Step 3:** `EndingEntitySubTab.tsx`와 `EndingEntityDetail.tsx` 최소 구현으로 테스트를 통과시킨다.
+- [ ] **Step 4:** 결말 노드가 없을 때 “Flow에서 결말 노드를 추가하면 이곳에서 결말 내용을 작성할 수 있어요.” 문구가 보이게 한다.
+- [ ] **Step 5:** Commit
+
+```bash
+git add apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx \
+  apps/web/src/features/editor/components/design/EndingEntityDetail.tsx \
+  apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+git commit -m "feat(editor): add ending entity list tab"
+```
+
+### Task 3 — EndingNodePanel Phase 24 정합성
+
+- [ ] **Step 1:** `EndingNodePanel.test.tsx`에 “점수 배율 입력이 보이지 않는다” 테스트를 추가한다.
+- [ ] **Step 2:** 테스트 실패를 확인한다.
+- [ ] **Step 3:** `EndingNodePanel.tsx`에서 점수 배율 입력을 제거하고 아이콘/색상/설명 필드를 유지한다.
+- [ ] **Step 4:** `FlowNodeData` 타입에 `icon?: string`, `color?: string`, `endingContent?: string`를 추가한다.
+- [ ] **Step 5:** focused 테스트 통과 확인 후 commit.
+
+```bash
+pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+git add apps/web/src/features/editor/components/design/EndingNodePanel.tsx apps/web/src/features/editor/flowTypes.ts apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+git commit -m "fix(editor): align ending node fields with phase 24"
+```
+
+### Task 4 — 페이즈 Flow 반응형/문구 정리
+
+- [ ] **Step 1:** `FlowCanvas.test.tsx` 또는 `FlowSubTab.test.tsx`에 모바일 세로 레이아웃 기준 class/문구 테스트를 추가한다.
+- [ ] **Step 2:** `FlowCanvas.tsx`의 본문을 `flex-col lg:flex-row`로 조정하고 상세 패널 폭을 모바일 `w-full`, 데스크톱 `lg:w-72`로 조정한다.
+- [ ] **Step 3:** `FlowSubTab.tsx` 상단에 제작자용 안내를 추가한다: “페이즈는 게임 진행 순서를 화살표로 연결합니다.”
+- [ ] **Step 4:** `NodeDetailPanel.tsx` 빈 상태/삭제 문구를 제작자 친화적으로 바꾼다.
+- [ ] **Step 5:** focused 테스트 통과 후 commit.
+
+```bash
+pnpm --dir apps/web exec vitest run \
+  src/features/editor/components/design/__tests__/FlowSubTab.test.tsx \
+  src/features/editor/components/design/__tests__/FlowCanvas.test.tsx \
+  src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+git add apps/web/src/features/editor/components/design/FlowSubTab.tsx \
+  apps/web/src/features/editor/components/design/FlowCanvas.tsx \
+  apps/web/src/features/editor/components/design/NodeDetailPanel.tsx \
+  apps/web/src/features/editor/components/design/__tests__/FlowSubTab.test.tsx \
+  apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx \
+  apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+git commit -m "refactor(editor): polish phase flow entity layout"
+```
+
+### Task 5 — DesignTab 연결
+
+- [ ] **Step 1:** 현재 `DesignTab`의 하위 탭 구조를 확인한다.
+- [ ] **Step 2:** 페이즈/결말 접근이 같은 디자인 영역에서 가능하도록 결말 탭을 추가한다. 기존 탭 이름은 비개발자 기준으로 유지한다.
+- [ ] **Step 3:** `DesignTab.test.tsx`에 결말 탭 진입 테스트를 추가한다.
+- [ ] **Step 4:** focused 테스트 통과 후 commit.
+
+```bash
+pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+git add apps/web/src/features/editor/components/DesignTab.tsx apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+git commit -m "feat(editor): wire ending entity tab into design editor"
+```
+
+### Task 6 — E2E smoke
+
+- [ ] **Step 1:** `apps/web/e2e/editor-phase-ending.spec.ts` 작성.
+- [ ] **Step 2:** mock/stub 기반으로 에디터 디자인 탭 진입 → 페이즈 Flow 안내 표시 → 결말 탭 빈 상태 또는 결말 목록 표시를 검증한다.
+- [ ] **Step 3:** chromium focused E2E 실행.
+
+```bash
+pnpm --dir apps/web exec playwright test e2e/editor-phase-ending.spec.ts --project=chromium
+```
+
+- [ ] **Step 4:** Commit.
+
+```bash
+git add apps/web/e2e/editor-phase-ending.spec.ts
+git commit -m "test(editor): cover phase and ending entity smoke"
+```
+
+### Task 7 — 최종 검증/PR
+
+- [ ] **Step 1:** focused unit test 실행.
+
+```bash
+pnpm --dir apps/web exec vitest run \
+  src/features/editor/components/design/__tests__/FlowSubTab.test.tsx \
+  src/features/editor/components/design/__tests__/FlowCanvas.test.tsx \
+  src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx \
+  src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx \
+  src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx \
+  src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx \
+  src/features/editor/components/design/__tests__/DesignTab.test.tsx
+```
+
+- [ ] **Step 2:** typecheck/lint 실행.
+
+```bash
+pnpm --dir apps/web typecheck
+pnpm --dir apps/web exec eslint src/features/editor/components/DesignTab.tsx src/features/editor/components/design apps/web/e2e/editor-phase-ending.spec.ts
+```
+
+- [ ] **Step 3:** diff whitespace 검사.
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 4:** PR 전 코드리뷰 수행. 타당한 지적만 반영한다.
+- [ ] **Step 5:** PR 생성. 제목/본문은 한국어로 작성하고, `ready-for-ci` 라벨은 CodeRabbit/Codecov 검토 후에만 붙인다.
+
+## 5. 완료 조건
+
+- [ ] 페이즈 탭은 기존 Flow 편집 기능을 잃지 않고 Phase 24 안내/반응형 레이아웃을 제공한다.
+- [ ] 결말 목록 탭에서 ending 노드 목록을 보고 상세 내용을 편집할 수 있다.
+- [ ] 제작자 화면에 점수 배율처럼 정책상 제거된 항목이 보이지 않는다.
+- [ ] 결말 entity와 Flow ending 노드는 같은 node id를 기준으로 연결된다.
+- [ ] 모바일에서 Flow와 상세 패널이 세로로 쌓인다.
+- [ ] focused unit, E2E smoke, typecheck, lint, `git diff --check`가 통과한다.
+- [ ] Codecov patch coverage 70% 이상 또는 “수정된 커버 가능 라인 모두 테스트됨” 확인 후 merge한다.
+
+## 6. 다음 PR 경계
+
+- PR-5: 결말 분기 질문/매트릭스/JSONLogic 평가기/게임 종료 breakdown.
+- PR-6: migration sweep, telemetry, legacy key 제거.

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-4-tasks.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-4-tasks.md
@@ -80,7 +80,7 @@
 git worktree add .worktrees/phase-24-pr-4-phase-ending -b feat/phase-24-pr-4-phase-ending main
 ```
 
-- [ ] **Step 2:** focused baseline 테스트 실행
+- [x] **Step 2:** focused baseline 테스트 실행
 
 ```bash
 pnpm --dir apps/web exec vitest run \
@@ -94,11 +94,11 @@ Expected: PASS. 실패하면 구현 전에 원인을 기록하고 기존 실패/
 
 ### Task 2 — 결말 entity 상세 테스트 RED
 
-- [ ] **Step 1:** `EndingEntitySubTab.test.tsx`에 빈 상태와 목록 선택 테스트를 작성한다.
-- [ ] **Step 2:** 테스트를 실행해 `EndingEntitySubTab` 미정의 실패를 확인한다.
-- [ ] **Step 3:** `EndingEntitySubTab.tsx`와 `EndingEntityDetail.tsx` 최소 구현으로 테스트를 통과시킨다.
-- [ ] **Step 4:** 결말 노드가 없을 때 “Flow에서 결말 노드를 추가하면 이곳에서 결말 내용을 작성할 수 있어요.” 문구가 보이게 한다.
-- [ ] **Step 5:** Commit
+- [x] **Step 1:** `EndingEntitySubTab.test.tsx`에 빈 상태와 목록 선택 테스트를 작성한다.
+- [x] **Step 2:** 테스트를 실행해 `EndingEntitySubTab` 미정의 실패를 확인한다.
+- [x] **Step 3:** `EndingEntitySubTab.tsx`와 `EndingEntityDetail.tsx` 최소 구현으로 테스트를 통과시킨다.
+- [x] **Step 4:** 결말 노드가 없을 때 “Flow에서 결말 노드를 추가하면 이곳에서 결말 내용을 작성할 수 있어요.” 문구가 보이게 한다.
+- [x] **Step 5:** Commit
 
 ```bash
 git add apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx \
@@ -109,11 +109,11 @@ git commit -m "feat(editor): add ending entity list tab"
 
 ### Task 3 — EndingNodePanel Phase 24 정합성
 
-- [ ] **Step 1:** `EndingNodePanel.test.tsx`에 “점수 배율 입력이 보이지 않는다” 테스트를 추가한다.
-- [ ] **Step 2:** 테스트 실패를 확인한다.
-- [ ] **Step 3:** `EndingNodePanel.tsx`에서 점수 배율 입력을 제거하고 아이콘/색상/설명 필드를 유지한다.
-- [ ] **Step 4:** `FlowNodeData` 타입에 `icon?: string`, `color?: string`, `endingContent?: string`를 추가한다.
-- [ ] **Step 5:** focused 테스트 통과 확인 후 commit.
+- [x] **Step 1:** `EndingNodePanel.test.tsx`에 “점수 배율 입력이 보이지 않는다” 테스트를 추가한다.
+- [x] **Step 2:** 테스트 실패를 확인한다.
+- [x] **Step 3:** `EndingNodePanel.tsx`에서 점수 배율 입력을 제거하고 아이콘/색상/설명 필드를 유지한다.
+- [x] **Step 4:** `FlowNodeData` 타입에 `icon?: string`, `color?: string`, `endingContent?: string`를 추가한다.
+- [x] **Step 5:** focused 테스트 통과 확인 후 commit.
 
 ```bash
 pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
@@ -123,11 +123,11 @@ git commit -m "fix(editor): align ending node fields with phase 24"
 
 ### Task 4 — 페이즈 Flow 반응형/문구 정리
 
-- [ ] **Step 1:** `FlowCanvas.test.tsx` 또는 `FlowSubTab.test.tsx`에 모바일 세로 레이아웃 기준 class/문구 테스트를 추가한다.
-- [ ] **Step 2:** `FlowCanvas.tsx`의 본문을 `flex-col lg:flex-row`로 조정하고 상세 패널 폭을 모바일 `w-full`, 데스크톱 `lg:w-72`로 조정한다.
-- [ ] **Step 3:** `FlowSubTab.tsx` 상단에 제작자용 안내를 추가한다: “페이즈는 게임 진행 순서를 화살표로 연결합니다.”
-- [ ] **Step 4:** `NodeDetailPanel.tsx` 빈 상태/삭제 문구를 제작자 친화적으로 바꾼다.
-- [ ] **Step 5:** focused 테스트 통과 후 commit.
+- [x] **Step 1:** `FlowCanvas.test.tsx` 또는 `FlowSubTab.test.tsx`에 모바일 세로 레이아웃 기준 class/문구 테스트를 추가한다.
+- [x] **Step 2:** `FlowCanvas.tsx`의 본문을 `flex-col lg:flex-row`로 조정하고 상세 패널 폭을 모바일 `w-full`, 데스크톱 `lg:w-72`로 조정한다.
+- [x] **Step 3:** `FlowSubTab.tsx` 상단에 제작자용 안내를 추가한다: “페이즈는 게임 진행 순서를 화살표로 연결합니다.”
+- [x] **Step 4:** `NodeDetailPanel.tsx` 빈 상태/삭제 문구를 제작자 친화적으로 바꾼다.
+- [x] **Step 5:** focused 테스트 통과 후 commit.
 
 ```bash
 pnpm --dir apps/web exec vitest run \
@@ -145,10 +145,10 @@ git commit -m "refactor(editor): polish phase flow entity layout"
 
 ### Task 5 — DesignTab 연결
 
-- [ ] **Step 1:** 현재 `DesignTab`의 하위 탭 구조를 확인한다.
-- [ ] **Step 2:** 페이즈/결말 접근이 같은 디자인 영역에서 가능하도록 결말 탭을 추가한다. 기존 탭 이름은 비개발자 기준으로 유지한다.
-- [ ] **Step 3:** `DesignTab.test.tsx`에 결말 탭 진입 테스트를 추가한다.
-- [ ] **Step 4:** focused 테스트 통과 후 commit.
+- [x] **Step 1:** 현재 `DesignTab`의 하위 탭 구조를 확인한다.
+- [x] **Step 2:** 페이즈/결말 접근이 같은 디자인 영역에서 가능하도록 결말 탭을 추가한다. 기존 탭 이름은 비개발자 기준으로 유지한다.
+- [x] **Step 3:** `DesignTab.test.tsx`에 결말 탭 진입 테스트를 추가한다.
+- [x] **Step 4:** focused 테스트 통과 후 commit.
 
 ```bash
 pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -158,15 +158,15 @@ git commit -m "feat(editor): wire ending entity tab into design editor"
 
 ### Task 6 — E2E smoke
 
-- [ ] **Step 1:** `apps/web/e2e/editor-phase-ending.spec.ts` 작성.
-- [ ] **Step 2:** mock/stub 기반으로 에디터 디자인 탭 진입 → 페이즈 Flow 안내 표시 → 결말 탭 빈 상태 또는 결말 목록 표시를 검증한다.
-- [ ] **Step 3:** chromium focused E2E 실행.
+- [x] **Step 1:** `apps/web/e2e/editor-phase-ending.spec.ts` 작성.
+- [x] **Step 2:** mock/stub 기반으로 에디터 디자인 탭 진입 → 페이즈 Flow 안내 표시 → 결말 탭 빈 상태 또는 결말 목록 표시를 검증한다.
+- [x] **Step 3:** chromium focused E2E 실행.
 
 ```bash
 pnpm --dir apps/web exec playwright test e2e/editor-phase-ending.spec.ts --project=chromium
 ```
 
-- [ ] **Step 4:** Commit.
+- [x] **Step 4:** Commit.
 
 ```bash
 git add apps/web/e2e/editor-phase-ending.spec.ts


### PR DESCRIPTION
## 목표

Phase 24 에디터 ECS 재설계 기준으로 페이즈/결말 entity의 첫 usable slice를 추가합니다.

## 변경 내용

- 페이즈 Flow 탭에 제작자 친화 안내와 모바일 우선 반응형 레이아웃을 적용했습니다.
- 결말 탭을 추가해 Flow의 ending 노드를 결말 목록/상세 entity처럼 편집할 수 있게 했습니다.
- 결말 상세에서 아이콘, 표시 색상, 공개 설명, 결말 본문 Markdown을 편집합니다.
- Phase 24 결정과 충돌하던 `점수 배율` 입력을 제거했습니다. 결말 점수 배율은 1.0 고정입니다.
- 결말 상세 저장은 `useDebouncedMutation` 기반으로 `onBlur`/unmount flush가 동작해 마지막 입력 유실을 막습니다.
- 페이즈/결말 entity smoke E2E를 추가했습니다.
- PR-4 작업 계획 문서를 추가/갱신했습니다.

## 검증

- `pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/FlowSubTab.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/components/design/__tests__/DesignTab.test.tsx` — 7 files, 47 tests passed
- `pnpm --dir apps/web typecheck` — passed
- `pnpm --dir apps/web exec eslint ...changed files... e2e/editor-phase-ending.spec.ts` — passed
- `pnpm --dir apps/web exec playwright test e2e/editor-phase-ending.spec.ts --project=chromium` — 1 passed
- `git diff --check` — passed

## CI 운영

`ready-for-ci` 라벨은 CodeRabbit/Codecov 검토와 타당한 리뷰 반영 후 별도로 붙입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 테마 플로우 에디터에 "결말" 탭 및 결말 목록/상세 편집 추가(아이콘, 라벨, 색상, 설명, 본문)
  * 결말 생성 및 검색, 선택 기능 제공

* **UI 개선**
  * 플로우 에디터 한글 문구 갱신 및 반응형 레이아웃(모바일 세로 / 데스크톱 2열) 적용
  * 점수 배율 입력 UI 제거
  * 편집 시 블러에 즉시 저장(지연 적용 플러시) 및 저장 실패 토스트 알림

* **테스트**
  * 결말 관련 단위·E2E 테스트 추가(접근성 감사 포함, WCAG 규칙 위반 없음)

* **문서**
  * Phase 24 에디터 구현 계획 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->