### PR TITLE
Phase 24 에디터 작업용 Codex 운영 규칙과 자동화 추가

### DIFF
--- a/.codex/agents/mmp-backend-engine-reviewer.toml
+++ b/.codex/agents/mmp-backend-engine-reviewer.toml
@@ -1,0 +1,24 @@
+name = "mmp-backend-engine-reviewer"
+description = "Review MMP backend entity, API, persistence, and runtime engine changes for Phase 24 editor/runtime consistency."
+instructions = """
+You are the MMP backend engine reviewer.
+
+Review scope:
+- Go backend under apps/server.
+- Entity persistence, API handlers, service layer, migrations, runtime engines, and deletion consistency.
+- Character, clue, location, phase, ending, role sheet, voting role, information delivery, and clue-effect behavior.
+
+Check:
+1. Backend engine is the source of runtime truth; frontend adapter must not own runtime decisions.
+2. Persistence schema, service validation, API DTO, and runtime engine behavior are aligned.
+3. Deleting an entity preserves data consistency through explicit cascade, backlink cleanup, or safe blocking with creator-facing explanation.
+4. Legacy data paths are preserved or migrated with tests; no silent data loss.
+5. Errors use project error conventions and do not leak internal details.
+6. Unit/integration tests cover runtime decisions and edge cases before relying on E2E.
+
+Output in Korean, under 500 words, with exactly these sections:
+- 발견
+- 수행
+- 판단
+- 미해결
+"""

--- a/.codex/agents/mmp-frontend-editor-reviewer.toml
+++ b/.codex/agents/mmp-frontend-editor-reviewer.toml
@@ -1,0 +1,24 @@
+name = "mmp-frontend-editor-reviewer"
+description = "Review MMP editor frontend changes for creator usability, responsive UI, adapter boundaries, reusable components, accessibility, and E2E coverage readiness."
+instructions = """
+You are the MMP frontend editor reviewer.
+
+Review scope:
+- React editor UI under apps/web.
+- Creator workflows for character, clue, location, phase, ending, role sheet, information delivery, and related dev preview pages.
+- Frontend adapter boundaries between API DTOs and creator-facing ViewModels.
+
+Check:
+1. Creator UI shows only information creators need; hide internal IDs, raw JSON, debug state, and system codes.
+2. Layout is responsive and mobile-readable; do not approve desktop-only dense panels.
+3. Components are reusable where the same search/select, entity picker, upload, or relation workflow appears more than once.
+4. Frontend does not fake backend runtime truth such as permissions, phase transitions, or clue effects.
+5. Use existing project UI conventions, Tailwind 4 direct styling, and lucide-react icons only.
+6. User-facing flows have E2E coverage or a documented substitute when E2E is not appropriate.
+
+Output in Korean, under 500 words, with exactly these sections:
+- 발견
+- 수행
+- 판단
+- 미해결
+"""

--- a/.codex/agents/mmp-test-coverage-reviewer.toml
+++ b/.codex/agents/mmp-test-coverage-reviewer.toml
@@ -1,0 +1,22 @@
+name = "mmp-test-coverage-reviewer"
+description = "Review MMP test strategy, E2E coverage, Codecov patch coverage, and CI readiness before PR labeling or merge."
+instructions = """
+You are the MMP test and coverage reviewer.
+
+Review scope:
+- Playwright E2E, Vitest/frontend tests, Go unit/integration tests, coverage scripts, PR/CI readiness.
+
+Check:
+1. Every code change has user-facing E2E coverage, or a documented reason plus substitute unit/integration coverage.
+2. Patch coverage target is at least 70%; identify likely Codecov gaps before CI.
+3. Tests validate real behavior, not implementation-only snapshots or mock-only success paths.
+4. Failed tests are root-caused; do not recommend skipping or weakening tests.
+5. Heavy CI should run only after CodeRabbit review cleanup and `ready-for-ci` guard passes.
+6. Report exact commands that were run or should be run next.
+
+Output in Korean, under 500 words, with exactly these sections:
+- 발견
+- 수행
+- 판단
+- 미해결
+"""

--- a/.codex/skills/mmp-adapter-engine-design/SKILL.md
+++ b/.codex/skills/mmp-adapter-engine-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: mmp-adapter-engine-design
+description: Use when designing or implementing MMP editor frontend adapters, backend runtime engines, entity migration, phase automation, or boundaries between creator-facing UI and game runtime behavior.
+---
+
+# MMP Adapter / Engine Design
+
+## When
+- When editor UI data differs from runtime behavior.
+- When migrating character, clue, location, phase, ending, role sheet, or information delivery entities.
+- When deciding what belongs in frontend adapter vs backend engine.
+
+## Do
+1. Separate responsibilities:
+   - Frontend adapter: creator-friendly form state, validation hints, search/select UI, responsive layout, API payload mapping.
+   - Backend engine: runtime truth, rule execution, phase transitions, clue effects, role/vote eligibility, entity deletion consistency.
+2. Keep boundaries explicit:
+   - UI should not know hidden engine implementation details.
+   - Engine should not depend on UI labels/layout.
+   - Shared contracts should be typed and versionable.
+3. Migration approach:
+   - preserve legacy data path until replacement is validated
+   - add adapter mapping tests for old/new payloads
+   - add engine tests for runtime decisions
+   - add E2E coverage for creator workflows
+4. Deletion/data consistency:
+   - define backlinks and cascading cleanup in backend service layer
+   - surface creator-safe warnings, not raw relation tables
+5. Future entities:
+   - expose minimal extension points now
+   - avoid premature plugin systems unless current Phase 24 requires them
+
+## Done
+- Each new field has an owner: adapter, API contract, engine, or persistence.
+- Runtime decisions are testable without rendering React.
+- Creator workflows are testable through E2E or documented substitute coverage.
+- Maintenance impact and deferred boundaries are documented in the active plan.
+
+## Avoid
+- Do not let frontend-only mock logic become runtime truth.
+- Do not leak engine internals into creator UI.
+- Do not migrate every entity in one risky PR unless explicitly approved.

--- a/.codex/skills/mmp-editor-uzu-briefing/SKILL.md
+++ b/.codex/skills/mmp-editor-uzu-briefing/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: mmp-editor-uzu-briefing
+description: Use when designing, reviewing, or implementing MMP Phase 24 editor features, especially character, clue, location, phase, ending, role sheet, information delivery, or creator workflow changes that should reference Uzu studio docs and MMP's own editor direction.
+---
+
+# MMP Editor Uzu Briefing
+
+## When
+- Before changing MMP editor UX, entity screens, phase routing, ending rules, clue/location/character workflows, role sheets, or information delivery.
+- Before presenting UI/API/data-model options for editor work.
+
+## Do
+1. Read project routing first:
+   - `AGENTS.md`
+   - `apps/web/AGENTS.md` for frontend work
+   - `apps/server/AGENTS.md` for backend work
+   - active `docs/plans/**/checklist.md` when present
+2. Inspect Uzu references only enough for the current entity/workflow:
+   - `/Users/sabyun/goinfre/muder_platform/docs/uzu-studio-docs`
+3. Extract patterns, not a copy:
+   - creator mental model
+   - entity relation workflow
+   - runtime progression logic
+   - usability safeguards
+4. Compare against MMP requirements:
+   - multiplayer murder-mystery runtime
+   - adapter-first frontend editor
+   - backend engine as source of runtime truth
+   - creator-facing UI that hides internal IDs and irrelevant config
+5. Report with:
+   - `원인`: why this design decision exists
+   - `결과`: impact on creator/runtime/maintenance
+   - `권장`: one recommended path and explicit deferrals
+
+## Done
+- The proposal names which Uzu pattern was referenced and how MMP intentionally differs.
+- The UI keeps only creator-needed information visible.
+- Mobile/responsive behavior is considered.
+- Deferred entities are represented through clear adapter/engine interfaces, not hard-coded dead ends.
+
+## Avoid
+- Do not blindly clone Uzu behavior.
+- Do not expose system codes, raw JSON, internal IDs, or debug-only fields to creators.
+- Do not add over-general enterprise abstractions before Phase 24 needs them.

--- a/.codex/skills/mmp-editor-uzu-briefing/SKILL.md
+++ b/.codex/skills/mmp-editor-uzu-briefing/SKILL.md
@@ -16,7 +16,7 @@ description: Use when designing, reviewing, or implementing MMP Phase 24 editor 
    - `apps/server/AGENTS.md` for backend work
    - active `docs/plans/**/checklist.md` when present
 2. Inspect Uzu references only enough for the current entity/workflow:
-   - `/Users/sabyun/goinfre/muder_platform/docs/uzu-studio-docs`
+   - `docs/uzu-studio-docs`
 3. Extract patterns, not a copy:
    - creator mental model
    - entity relation workflow

--- a/.codex/skills/mmp-pr-lifecycle/SKILL.md
+++ b/.codex/skills/mmp-pr-lifecycle/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: mmp-pr-lifecycle
+description: Use when creating, reviewing, updating, labeling, checking, or merging MMP pull requests, especially when CodeRabbit, Codecov, ready-for-ci labels, CI checks, or Korean PR descriptions are involved.
+---
+
+# MMP PR Lifecycle
+
+## When
+- Before opening a PR, adding `ready-for-ci`, resolving CodeRabbit feedback, checking Codecov, or merging.
+
+## Do
+1. Work on a feature branch or dedicated worktree; never commit directly to `main`.
+2. Before PR creation:
+   - run focused checks for the changed scope
+   - run/perform code review using available review skill or manual review
+   - write PR title/body in Korean
+   - do **not** add `ready-for-ci`
+3. PR sequence:
+   - create PR without CI label
+   - inspect CodeRabbit review threads
+   - fix only valid comments and resolve/address them
+   - wait for or request CodeRabbit re-review
+   - repeat once more when new valid comments appear
+   - confirm unresolved review threads are zero
+   - add `ready-for-ci`
+   - check CI and Codecov
+   - fix failures without skipping tests
+   - merge only when checks and required reviews are satisfied
+4. API polling cadence: 30-60 seconds unless user explicitly asks for faster status.
+5. For Codecov: treat patch coverage under 70% as a blocker unless the user approves an exception and the PR documents why.
+
+## Done
+- PR has Korean title/body.
+- CodeRabbit valid feedback is fixed or explicitly rejected with reason.
+- `ready-for-ci` was added only after review cleanup.
+- CI and Codecov evidence is reported before merge.
+
+## Avoid
+- Do not add `ready-for-ci` at PR creation.
+- Do not treat all bot comments as automatically correct.
+- Do not trigger repeated CI runs while review threads are still unresolved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,46 @@
 - 충돌 시 우선순위: 이 파일 및 하위 `apps/*/AGENTS.md` > repo `CLAUDE.md` > 글로벌 Claude 설정.
 - Claude 전용 `@import`, hooks, status line, permission allowlist, plugin command는 Codex 네이티브 기능이 아니다. 필요한 경우 명시적 지시문이나 Codex MCP/plugin 설정으로 변환한다.
 
+## 작업 실행 카드
+
+AGENTS.md 규칙은 모델이 바로 행동으로 옮길 수 있도록 `When / Do / Done when / Avoid` 구조로 해석한다. 새 규칙을 추가할 때도 추상 선언보다 실행 단계와 완료 조건을 우선한다.
+
+### 새 작업 시작
+
+When:
+- 새 기능, 기존 구현 개선, 버그 수정, 에디터 프론트/백엔드 작업, 문서화 이상의 코드 작업을 시작할 때
+
+Do:
+1. `main` 최신 상태를 확인한다.
+2. 현재 브랜치에 미정리 변경이 있으면 새 작업을 섞지 말고 commit/stash/worktree 중 하나로 분리한다.
+3. 작업마다 새 feature branch 또는 별도 worktree를 만든다.
+4. 관련 GitHub Issue와 `docs/plans/<phase>/checklist.md`를 확인한다.
+5. Issue가 없고 작업이 추적 가능한 단위라면 먼저 Issue를 생성하거나 사용자에게 Issue 생성 계획을 보고한다.
+
+Done when:
+- 현재 branch/worktree, 관련 Issue, 구현 범위, 검증 범위가 보고되어 있다.
+
+Avoid:
+- 기존 feature branch에 무관한 새 작업을 섞지 않는다.
+- `main`에 직접 커밋하거나 push하지 않는다.
+
+### Issue 기반 진행
+
+When:
+- Phase 단위 작업, PR 분할 작업, 여러 세션에 걸치는 작업을 진행할 때
+
+Do:
+1. 작업 계획 문서와 GitHub Issue를 상호 링크한다.
+2. PR 본문에 `Closes #번호` 또는 `Refs #번호`를 명시한다.
+3. 작업 중 scope가 바뀌면 Issue checklist 또는 plan 문서를 먼저 갱신한다.
+4. 완료 보고에는 닫힌 Issue, 남은 Issue, 다음 권장 Issue를 포함한다.
+
+Done when:
+- PR/commit/보고에서 어떤 Issue를 해결했는지 추적 가능하다.
+
+Avoid:
+- 계획 없는 대형 PR로 여러 Issue를 한 번에 섞지 않는다. 단, 사용자가 명시적으로 묶기를 승인한 경우는 예외다.
+
 ## 작업 루틴
 
 - 비단순 작업을 시작할 때는 관련 `memory/MEMORY.md` 포인터와 활성 plan checklist를 먼저 확인한다.
@@ -50,7 +90,74 @@
 - PR/CI/리뷰 상태 확인을 반복할 때는 GitHub/API 호출을 과도하게 하지 않는다. 기본 폴링 간격은 30초~1분으로 두고, 긴 작업은 `--watch --interval 30` 이상 또는 단발 조회를 사용한다.
 - 4-agent review 정책의 canonical 문서는 `memory/feedback_4agent_review_before_admin_merge.md`다. Codex에서 사용 가능한 도구와 사용자 승인 범위에 맞춰 적용한다.
 
+### PR 리뷰와 CI 상태 전이
+
+When:
+- 코드 변경 PR을 생성하거나 merge할 때
+
+Do:
+1. 로컬 구현 후 focused test와 가능한 로컬 리뷰를 먼저 수행한다.
+2. PR은 라벨 없이 생성한다. 특히 생성 시 `ready-for-ci`를 붙이지 않는다.
+3. CodeRabbit 1차 리뷰를 확인한다.
+4. 타당한 리뷰만 수정하고 push한다. 타당하지 않은 리뷰는 근거를 남기고 resolve한다.
+5. CodeRabbit 재리뷰를 기다린다.
+6. 추가 타당 리뷰가 있으면 다시 수정하고 push한다.
+7. 마지막 리뷰 대응 push 이후 unresolved review thread가 0인지 확인한다.
+8. 그 후 `ready-for-ci` 라벨을 붙여 full CI를 실행한다.
+9. CI 실패나 Codecov Report 문제가 있으면 원인을 수정하고 다시 검증한다.
+10. required checks와 Codecov 기준을 통과한 뒤 merge한다.
+
+Done when:
+- CodeRabbit unresolved thread 0
+- Codecov patch coverage 70% 이상
+- required CI green
+- PR merged 또는 명확한 blocker 보고
+
+Avoid:
+- CodeRabbit 재검토 전 `ready-for-ci` 라벨을 붙이지 않는다.
+- 새 커밋 push 직후 CodeRabbit 재검토 가능성을 무시하고 CI를 먼저 돌리지 않는다.
+- GitHub/API 상태 조회를 30초보다 촘촘히 반복하지 않는다.
+
+### 코드 작업 테스트 기준
+
+When:
+- 기능 구현, 버그 수정, 리팩터링, 에디터 UI/백엔드 engine 동작 변경이 있을 때
+
+Do:
+1. 사용자 관점의 E2E 테스트를 추가하거나 기존 E2E를 갱신한다.
+2. E2E로 직접 검증하기 어려운 내부 분기와 에러 처리는 unit/integration test로 보강한다.
+3. Codecov patch coverage 70% 이상을 merge 기준으로 맞춘다.
+4. E2E가 부적합한 순수 내부 변경이면 PR/보고에 E2E 미작성 사유와 대체 테스트를 명시한다.
+
+Done when:
+- 변경된 사용자 흐름 또는 런타임 동작을 E2E/integration/unit 조합으로 검증했다.
+- patch coverage가 70% 이상이다.
+
+Avoid:
+- 테스트 스킵, mock-only 우회, coverage 기준 미달 상태로 merge하지 않는다.
+
 ## 코드 및 아키텍처 규칙
+
+### 설계 품질과 Adapter/Engine 경계
+
+When:
+- 새 기능을 만들거나 기존 구현을 개선할 때
+
+Do:
+1. 변경 이유가 다른 책임은 분리한다.
+2. 같은 패턴이 2곳 이상 반복되거나 곧 다른 entity에 적용될 가능성이 높으면 helper/component/adapter로 추출한다.
+3. 현재는 한 구현에 두더라도 추후 분리 비용이 낮도록 함수, 타입, interface 경계를 명확히 둔다.
+4. 에디터 frontend는 API/저장 DTO를 제작자용 ViewModel로 바꾸는 Adapter 경계를 둔다.
+5. backend는 저장된 설정을 실제 게임 진행 중 해석하는 Engine 경계를 둔다.
+
+Done when:
+- UI, adapter, backend engine, persistence 책임이 어디에 있는지 코드와 문서에서 추적 가능하다.
+
+Avoid:
+- 미래 가능성만으로 큰 framework나 범용 abstraction을 만들지 않는다.
+- 1회성 UI를 무리하게 공용 컴포넌트로 만들지 않는다.
+- 프론트가 backend runtime 판단, 권한, 공개 상태를 흉내 내지 않는다.
+
 
 | 규칙 | Master |
 | ---- | ------ |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,26 @@ Avoid:
 - 여러 단계가 필요한 작업은 간결한 계획을 유지하고 진행 상태가 바뀔 때 갱신한다.
 - Codex sub-agent는 사용자가 명시적으로 위임이나 병렬 agent 작업을 요청한 경우에만 사용한다. Claude 시대의 자동 위임 규칙은 Codex에서는 로컬 계획으로 해석한다.
 
+### Sub-agent 사용 규칙
+
+When:
+- 사용자가 위임, 병렬 agent 작업, sub-agent 사용을 명시적으로 승인했을 때
+- 또는 이번 Phase 24처럼 사용자가 MMP subagent 생성/활용 규칙을 명시적으로 요청한 범위 안에서 작업할 때
+
+Do:
+1. 메인 Codex는 의도 파악, scope 결정, 위험 판단, 최종 통합, PR/label/merge 결정을 맡는다.
+2. Sub-agent는 독립적으로 처리 가능한 탐색, 리뷰, 테스트 커버리지 점검, 반복 컴포넌트/테스트 작성, 긴 로그 분석에만 맡긴다.
+3. 코드 수정 sub-agent에는 소유 파일/모듈을 명확히 지정하고, 다른 작업자가 있을 수 있으니 기존 변경을 되돌리지 말라고 지시한다.
+4. 리뷰 sub-agent 결과는 사용자에게 raw output으로 붙이지 말고 `발견 / 수행 / 판단 / 미해결` 4섹션으로 압축한다.
+5. MMP 전용 리뷰에는 가능한 경우 `.codex/agents/mmp-frontend-editor-reviewer.toml`, `.codex/agents/mmp-backend-engine-reviewer.toml`, `.codex/agents/mmp-test-coverage-reviewer.toml` 역할을 사용한다.
+
+Done when:
+- 위임한 범위, sub-agent 결과 요약, 메인 Codex의 최종 판단이 분리되어 보고된다.
+
+Avoid:
+- secret 조회, destructive command, PR 생성, label 부착, merge, 배포 트리거를 sub-agent에 맡기지 않는다.
+- 다음 로컬 작업이 바로 막히는 critical path를 불필요하게 위임하지 않는다.
+
 ## Git 및 PR 규율
 
 - `main`을 보호한다. 병합 가능한 변경은 feature branch와 PR을 사용한다.

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -19,6 +19,44 @@ Go 1.25 + gorilla/websocket + sqlc + pgx + asynq + go-redis. PostgreSQL + Redis.
 - 커버리지 목표: 75%+. 현재 enforcement gate가 더 낮아도 gate를 낮추지 않는다.
 - 테스트 위치: `apps/server/internal/<pkg>/*_test.go`.
 
+## Runtime Engine 원칙
+
+When:
+- 에디터 설정을 실제 게임 진행, 권한, 공개 상태, 조건 판정, 결말 판정에 연결할 때
+
+Do:
+1. 저장된 editor config를 backend engine/service가 해석한다.
+2. player-aware state, redaction, permission, condition evaluation은 backend에서 결정한다.
+3. phase enter/reconnect/retry 상황에서 같은 이벤트가 중복 적용되지 않도록 idempotency를 보장한다.
+4. frontend가 보낸 값은 신뢰하지 않고 backend validation과 authorization을 거친다.
+5. config validation, player-aware redaction, reconnect/idempotency를 Go unit/integration test로 검증한다.
+
+Done when:
+- 같은 저장 설정이 모든 플레이어에게 동일하게 노출되지 않고, 캐릭터/권한/진행 상태별로 올바르게 분리된다.
+- 재접속 또는 phase 재진입에도 중복 지급/중복 공개가 발생하지 않는다.
+
+Avoid:
+- 프론트 UI의 표시 상태를 runtime truth로 취급하지 않는다.
+- 권한 없는 플레이어에게 스포일러 필드, 범인/공범/탐정 정보, 비공개 단서/역할지를 노출하지 않는다.
+
+## Entity 삭제 정합성
+
+When:
+- 캐릭터, 장소, 단서, 페이즈, 결말 등 editor entity 삭제 로직을 만들거나 수정할 때
+
+Do:
+1. 삭제 대상이 참조되는 config/module/edge/content/media 관계를 먼저 확인한다.
+2. DB row와 config JSON 참조 정리는 가능하면 하나의 transaction 안에서 처리한다.
+3. 삭제 후 고아 참조가 남지 않는지 테스트한다.
+4. cascade가 위험한 경우 사용자에게 삭제 영향 요약을 제공할 수 있는 API/서비스 경계를 둔다.
+
+Done when:
+- 삭제 후 재조회, 런타임 state build, editor load가 실패하지 않는다.
+- 관련 참조 정리 테스트가 있다.
+
+Avoid:
+- 화면에서만 사라지고 backend config에는 남는 soft orphan을 만들지 않는다.
+
 ## Dev Compose
 
 ```bash

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -53,9 +53,46 @@ React 19 + Vite SPA + Zustand + Tailwind CSS 4 직접 사용 + `lucide-react`.
 - 터치 조작 기준으로 버튼/클릭 영역은 충분한 높이와 간격을 둔다.
 - 브라우저 확인 시 최소 1개 모바일 폭(예: 390px)과 데스크톱 폭을 같이 본다.
 
+## 에디터 기능 설계 전 Uzu 참고
+
+When:
+- 캐릭터, 단서, 장소, 페이즈, 결말 등 에디터 기능을 새로 만들거나 개선할 때
+
+Do:
+1. `docs/uzu-studio-docs`에서 관련 문서를 먼저 확인한다.
+2. Uzu가 어떤 제작 문제를 어떤 UI/흐름으로 해결하는지 요약한다.
+3. MMP의 실시간 멀티플레이, 권한, R2 미디어, backend engine 구조에 맞게 반영할 점과 제외할 점을 나눈다.
+4. 구현 전 브리핑에 `Uzu 참고점`, `MMP 적용 방식`, `제외/후순위`를 포함한다.
+
+Done when:
+- 에디터 기능 제안 또는 구현 계획에 Uzu 참고 결과와 MMP식 재해석이 포함되어 있다.
+
+Avoid:
+- Uzu 구조를 그대로 복제하지 않는다.
+- Uzu에 있다는 이유만으로 MMP에 필요 없는 정보나 설정을 노출하지 않는다.
+
 ## 에디터 UI 원칙
 
 - 제작자 에디터와 플레이어 런타임 UI를 분리한다.
+
+### 제작자에게 필요한 정보만 표시
+
+When:
+- 에디터 화면, 검수 패널, 상세 패널, dev preview를 만들거나 수정할 때
+
+Do:
+1. 제작자가 지금 결정을 내리는 데 필요한 정보만 우선 표시한다.
+2. internal ID, DB 필드명, config key, engine module key, 저장 JSON shape, legacy code는 기본 화면에서 숨긴다.
+3. 필요한 검수 정보는 제작자 언어로 요약한다. 예: “이 단서는 아직 어디에도 연결되지 않았어요.”
+4. 개발자용 원문 데이터는 필요할 때만 dev-only/debug 접힘 영역에 격리한다.
+
+Done when:
+- 화면을 보는 제작자가 다음 행동을 이해할 수 있고, 내부 구현 정보를 몰라도 작업을 완료할 수 있다.
+
+Avoid:
+- “혹시 필요할 수 있다”는 이유로 시스템 정보를 기본 화면에 늘어놓지 않는다.
+- 검수 패널을 개발자 로그나 JSON viewer처럼 만들지 않는다.
+
 - 에디터에는 제작자가 실제로 판단해야 하는 검수용 정보만 보일 수 있다. 예: 참조상태, 미사용 단서, backlink, 장소 tree-ready, validation warning. 내부 ID나 저장 구조처럼 제작자가 몰라도 되는 정보는 기본 검수 패널에서도 제외한다.
 - 플레이어 화면에는 스포일러성 제작 정보가 노출되면 안 된다. 예: 범인 여부, 공범 여부, 단서 backlink, 다른 캐릭터 역할지.
 - 캐릭터/장소/단서 entity 화면은 세로 흐름을 기본으로 한다.
@@ -73,6 +110,26 @@ React 19 + Vite SPA + Zustand + Tailwind CSS 4 직접 사용 + `lucide-react`.
 
 ## React 구조 원칙
 
+### Frontend Adapter와 재사용 컴포넌트
+
+When:
+- 에디터 entity, phase, ending, role sheet, clue/location/character UI를 만들거나 개선할 때
+
+Do:
+1. API DTO와 저장 config를 화면 컴포넌트에 직접 흘리지 않고 제작자용 ViewModel로 변환한다.
+2. 변환 책임은 `*Adapter`, mapper, feature-local helper에 둔다.
+3. 반복되는 검색, 선택, 다중 선택, 업로드, 삭제 확인, 검수 패널은 재사용 가능한 컴포넌트로 분리한다.
+4. 컴포넌트는 view, interaction, data adapter, persistence 책임을 섞지 않는다.
+5. props가 과하게 늘어나면 compound component, hook, adapter 분리를 검토한다.
+
+Done when:
+- 같은 UI 패턴을 다른 entity에 옮길 때 복사/붙여넣기보다 재사용 또는 작은 adapter 교체로 대응 가능하다.
+
+Avoid:
+- 1회성 UI를 성급하게 범용 컴포넌트로 만들지 않는다.
+- 컴포넌트가 backend engine config key나 JSON shape를 직접 표시/편집하게 하지 않는다.
+
+
 - 컴포넌트는 변경 이유별로 분리한다. 긴 단일 TSX에 검색/list/detail/inspector/save 로직을 모두 넣지 않는다.
 - 데이터 로직과 view를 분리한다. 서버 상태는 query hook, 화면 상태는 가까운 컴포넌트에 둔다.
 - 단순 파생값은 `useEffect + setState`로 동기화하지 말고 render 중 계산한다.
@@ -86,12 +143,12 @@ React 19 + Vite SPA + Zustand + Tailwind CSS 4 직접 사용 + `lucide-react`.
 - 현재 커버리지 gate: Lines 49%, Branches 77%, Functions 53%.
 - 목표: Phase 21에서 75%+ coverage.
 - E2E: `apps/web/e2e/` 아래 Playwright.
-- 코드 작성/수정 시 사용자 흐름이 바뀌면 E2E 테스트 작성 여부를 반드시 검토한다.
-  - 새 페이지, 라우트, 핵심 버튼/폼, 저장/업로드/권한/리다이렉트 흐름은 Playwright E2E를 추가하거나 기존 E2E를 갱신한다.
+- 모든 코드 작성/수정 PR은 사용자 관점의 E2E 테스트를 필수로 작성하거나 기존 E2E를 갱신한다.
+  - 새 페이지, 라우트, 핵심 버튼/폼, 저장/업로드/권한/리다이렉트 흐름은 Playwright E2E로 검증한다.
   - 백엔드 의존 흐름은 `localhost:8080/health` 같은 사전 확인으로 실행 불가 환경에서 자동 skip되게 작성한다.
-  - 순수 컴포넌트 내부 동작만 바뀌고 실제 라우트/사용자 여정이 변하지 않으면 focused Vitest로 대체할 수 있으나, PR/보고에 “E2E 미작성 사유”를 남긴다.
+  - 순수 내부 로직처럼 Playwright E2E가 부적합한 경우에도 integration/unit test로 대체하고, PR/보고에 “E2E 미작성 사유”와 대체 테스트를 명시한다.
   - dev-only preview를 만든 경우 최소 1개 E2E 또는 브라우저 확인으로 모바일 폭과 데스크톱 폭의 핵심 표시를 검증한다.
-- 코드 작성/수정 PR은 Codecov patch coverage 70% 이상을 달성해야 한다. 사용자 흐름이 바뀐 경우에는 Playwright E2E로 핵심 여정을 보강하고, E2E로 커버하기 어려운 분기/에러 처리는 Vitest 단위 테스트로 보강해 70% 기준을 맞춘다.
+- 코드 작성/수정 PR은 Codecov patch coverage 70% 이상을 merge 기준으로 달성해야 한다. E2E로 커버하기 어려운 분기/에러 처리는 Vitest 단위 테스트로 보강한다.
 - 백엔드가 없으면 lobby flow E2E는 자동 skip되어야 한다.
 - 접근성 smoke: `@axe-core/playwright`, focus-visible, WCAG 2.1 AA 기본 항목.
 - UI 변경 후 가능하면 focused Vitest + typecheck를 실행한다.

--- a/scripts/mmp-pr-status.sh
+++ b/scripts/mmp-pr-status.sh
@@ -52,16 +52,38 @@ review_decision="$(printf '%s' "$pr_json" | jq -r '.reviewDecision // "UNKNOWN"'
 labels="$(printf '%s' "$pr_json" | jq -r '[.labels[].name] | if length == 0 then "없음" else join(", ") end')"
 
 # shellcheck disable=SC2016
-graphql_query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }'
-threads_json="$(gh api graphql \
-  -F owner="$owner" \
-  -F repo="$repo" \
-  -F number="$pr_number" \
-  -f query="$graphql_query")"
-unresolved_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
-total_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]] | length')"
+graphql_query='query($owner:String!, $repo:String!, $number:Int!, $after:String) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100, after:$after) { nodes { isResolved } pageInfo { hasNextPage endCursor } } } } }'
+unresolved_threads=0
+total_threads=0
+after_cursor=""
+while :; do
+  if [[ -z "$after_cursor" ]]; then
+    threads_json="$(gh api graphql \
+      -F owner="$owner" \
+      -F repo="$repo" \
+      -F number="$pr_number" \
+      -f query="$graphql_query")"
+  else
+    threads_json="$(gh api graphql \
+      -F owner="$owner" \
+      -F repo="$repo" \
+      -F number="$pr_number" \
+      -F after="$after_cursor" \
+      -f query="$graphql_query")"
+  fi
 
-latest_coderabbit="$(gh pr view "$pr_number" --json reviews --jq '[.reviews[] | select(.author.login == "coderabbitai[bot]")] | last | if . then (.state + " @ " + .submittedAt) else "없음" end')"
+  page_unresolved="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+  page_total="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]] | length')"
+  unresolved_threads=$((unresolved_threads + page_unresolved))
+  total_threads=$((total_threads + page_total))
+
+  has_next="$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')"
+  [[ "$has_next" == "true" ]] || break
+  after_cursor="$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')"
+done
+
+# shellcheck disable=SC2016
+latest_coderabbit="$(gh pr view "$pr_number" --json reviews,comments --jq '([.reviews[] | select((.author.login == "coderabbitai[bot]") or (.author.login == "coderabbitai"))] | last) as $review | if $review then ($review.state + " @ " + $review.submittedAt) else (([.comments[] | select((.author.login == "coderabbitai") or (.author.login == "coderabbitai[bot]") or (.body | contains("coderabbit.ai")))] | last) as $comment | if $comment then ("comment @ " + $comment.createdAt) else "없음" end) end')"
 codecov_summary="$(gh pr view "$pr_number" --json comments --jq '[.comments[] | select((.author.login == "codecov-commenter") or (.body | contains("Codecov Report")))] | last | if . then (.body | split("\n") | .[0:6] | join("\n")) else "없음" end')"
 
 cat <<MSG

--- a/scripts/mmp-pr-status.sh
+++ b/scripts/mmp-pr-status.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Summarize MMP PR review, label, CI, CodeRabbit, and Codecov state.
+
+set -euo pipefail
+
+usage() {
+  cat <<'MSG'
+Usage: scripts/mmp-pr-status.sh [PR_NUMBER]
+
+현재 브랜치의 PR 또는 지정한 PR 번호에 대해 다음을 요약합니다.
+- labels / merge state / review decision
+- CodeRabbit 최신 리뷰와 unresolved review thread 수
+- Codecov Report 최신 코멘트 요약
+- GitHub checks 상태
+
+반복 조회가 필요하면 30초 이상 간격으로 실행하세요.
+MSG
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "필수 명령을 찾을 수 없습니다: $1" >&2
+    exit 127
+  fi
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+require_cmd gh
+require_cmd jq
+
+pr_number="${1:-}"
+if [[ -z "$pr_number" ]]; then
+  pr_number="$(gh pr view --json number --jq '.number')"
+fi
+
+owner="$(gh repo view --json owner --jq '.owner.login')"
+repo="$(gh repo view --json name --jq '.name')"
+
+pr_json="$(gh pr view "$pr_number" --json number,title,url,headRefName,baseRefName,mergeStateStatus,reviewDecision,labels)"
+
+number="$(printf '%s' "$pr_json" | jq -r '.number')"
+title="$(printf '%s' "$pr_json" | jq -r '.title')"
+url="$(printf '%s' "$pr_json" | jq -r '.url')"
+head="$(printf '%s' "$pr_json" | jq -r '.headRefName')"
+base="$(printf '%s' "$pr_json" | jq -r '.baseRefName')"
+merge_state="$(printf '%s' "$pr_json" | jq -r '.mergeStateStatus // "UNKNOWN"')"
+review_decision="$(printf '%s' "$pr_json" | jq -r '.reviewDecision // "UNKNOWN"')"
+labels="$(printf '%s' "$pr_json" | jq -r '[.labels[].name] | if length == 0 then "없음" else join(", ") end')"
+
+threads_json="$(gh api graphql \
+  -F owner="$owner" \
+  -F repo="$repo" \
+  -F number="$pr_number" \
+  -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }')"
+unresolved_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+total_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]] | length')"
+
+latest_coderabbit="$(gh pr view "$pr_number" --json reviews --jq '[.reviews[] | select(.author.login == "coderabbitai[bot]")] | last | if . then (.state + " @ " + .submittedAt) else "없음" end')"
+codecov_summary="$(gh pr view "$pr_number" --json comments --jq '[.comments[] | select((.author.login == "codecov-commenter") or (.body | contains("Codecov Report")))] | last | if . then (.body | split("\n") | .[0:6] | join("\n")) else "없음" end')"
+
+cat <<MSG
+# PR 상태 요약
+
+- PR: #$number $title
+- URL: $url
+- Branch: $head -> $base
+- Labels: $labels
+- Merge state: $merge_state
+- Review decision: $review_decision
+- CodeRabbit latest review: $latest_coderabbit
+- Review threads: unresolved $unresolved_threads / total $total_threads
+
+# Codecov 최신 코멘트 요약
+$codecov_summary
+
+# Checks
+MSG
+
+gh pr checks "$pr_number" || true

--- a/scripts/mmp-pr-status.sh
+++ b/scripts/mmp-pr-status.sh
@@ -51,11 +51,13 @@ merge_state="$(printf '%s' "$pr_json" | jq -r '.mergeStateStatus // "UNKNOWN"')"
 review_decision="$(printf '%s' "$pr_json" | jq -r '.reviewDecision // "UNKNOWN"')"
 labels="$(printf '%s' "$pr_json" | jq -r '[.labels[].name] | if length == 0 then "없음" else join(", ") end')"
 
+# shellcheck disable=SC2016
+graphql_query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }'
 threads_json="$(gh api graphql \
   -F owner="$owner" \
   -F repo="$repo" \
   -F number="$pr_number" \
-  -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }')"
+  -f query="$graphql_query")"
 unresolved_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
 total_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]] | length')"
 

--- a/scripts/mmp-start-issue-work.sh
+++ b/scripts/mmp-start-issue-work.sh
@@ -67,6 +67,10 @@ if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
   echo "🚫 이미 존재하는 branch입니다: $branch_name" >&2
   exit 3
 fi
+if git ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1; then
+  echo "🚫 origin에 이미 존재하는 branch입니다: $branch_name" >&2
+  exit 3
+fi
 if [[ -e "$worktree_path" ]]; then
   echo "🚫 이미 존재하는 worktree path입니다: $worktree_path" >&2
   exit 4

--- a/scripts/mmp-start-issue-work.sh
+++ b/scripts/mmp-start-issue-work.sh
@@ -28,7 +28,7 @@ require_cmd() {
 slugify() {
   printf '%s' "$1" \
     | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[^a-z0-9가-힣]+/-/g; s/^-+//; s/-+$//' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
     | cut -c 1-64
 }
 

--- a/scripts/mmp-start-issue-work.sh
+++ b/scripts/mmp-start-issue-work.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Start isolated MMP issue work from latest origin/main.
+
+set -euo pipefail
+
+usage() {
+  cat <<'MSG'
+Usage: scripts/mmp-start-issue-work.sh ISSUE_NUMBER [BRANCH_SLUG]
+
+GitHub Issue 기준으로 새 worktree와 feature branch를 생성합니다.
+- 기본 branch prefix: feat (BRANCH_PREFIX=docs 로 변경 가능)
+- 기본 worktree 위치: .worktrees/<branch-name>
+- 현재 worktree가 dirty면 중단합니다. 필요 시 ALLOW_DIRTY=1 로 우회하세요.
+
+Example:
+  scripts/mmp-start-issue-work.sh 248 phase-24-pr-6-phase-entity
+  BRANCH_PREFIX=docs scripts/mmp-start-issue-work.sh 250 agent-workflow
+MSG
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "필수 명령을 찾을 수 없습니다: $1" >&2
+    exit 127
+  fi
+}
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9가-힣]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c 1-64
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 ]]; then
+  usage
+  exit 0
+fi
+
+require_cmd git
+require_cmd gh
+
+issue_number="$1"
+manual_slug="${2:-}"
+branch_prefix="${BRANCH_PREFIX:-feat}"
+
+if [[ "${ALLOW_DIRTY:-}" != "1" && -n "$(git status --porcelain)" ]]; then
+  echo "🚫 현재 worktree에 미정리 변경이 있습니다. 먼저 commit/stash/worktree 분리 후 다시 실행하세요." >&2
+  exit 2
+fi
+
+issue_title="$(gh issue view "$issue_number" --json title --jq '.title')"
+if [[ -n "$manual_slug" ]]; then
+  slug="$(slugify "$manual_slug")"
+else
+  slug="$(slugify "$issue_title")"
+fi
+if [[ -z "$slug" ]]; then
+  slug="issue-$issue_number"
+fi
+
+branch_name="$branch_prefix/issue-$issue_number-$slug"
+worktree_path=".worktrees/${branch_name//\//-}"
+
+git fetch origin main
+if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+  echo "🚫 이미 존재하는 branch입니다: $branch_name" >&2
+  exit 3
+fi
+if [[ -e "$worktree_path" ]]; then
+  echo "🚫 이미 존재하는 worktree path입니다: $worktree_path" >&2
+  exit 4
+fi
+
+git worktree add -b "$branch_name" "$worktree_path" origin/main
+
+cat <<MSG
+✅ Issue 작업 worktree 생성 완료
+
+- Issue: #$issue_number $issue_title
+- Branch: $branch_name
+- Worktree: $worktree_path
+
+다음 단계:
+1. cd "$worktree_path"
+2. 관련 AGENTS.md와 docs/plans checklist 확인
+3. 구현/검증 후 PR은 라벨 없이 생성
+MSG

--- a/scripts/mmp-start-issue-work.sh
+++ b/scripts/mmp-start-issue-work.sh
@@ -32,9 +32,14 @@ slugify() {
     | cut -c 1-64
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
+fi
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 2
 fi
 
 require_cmd git

--- a/scripts/pr-create-guard.sh
+++ b/scripts/pr-create-guard.sh
@@ -9,8 +9,8 @@ contains_ready_for_ci() {
   local value="$1"
   IFS=',' read -ra labels <<< "$value"
   for label in "${labels[@]}"; do
-    label="${label#${label%%[![:space:]]*}}"
-    label="${label%${label##*[![:space:]]}}"
+    label="${label#"${label%%[![:space:]]*}"}"
+    label="${label%"${label##*[![:space:]]}"}"
     if [[ "$label" == "ready-for-ci" ]]; then
       return 0
     fi

--- a/scripts/pr-ready-for-ci-guard.sh
+++ b/scripts/pr-ready-for-ci-guard.sh
@@ -55,11 +55,13 @@ fi
 owner="$(gh repo view --json owner --jq '.owner.login')"
 repo="$(gh repo view --json name --jq '.name')"
 
+# shellcheck disable=SC2016
+graphql_query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }'
 threads_json="$(gh api graphql \
   -F owner="$owner" \
   -F repo="$repo" \
   -F number="$pr_number" \
-  -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }')"
+  -f query="$graphql_query")"
 unresolved_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
 
 if [[ "$unresolved_threads" != "0" ]]; then

--- a/scripts/pr-ready-for-ci-guard.sh
+++ b/scripts/pr-ready-for-ci-guard.sh
@@ -38,7 +38,17 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
+    -*)
+      echo "알 수 없는 옵션: $1" >&2
+      usage >&2
+      exit 64
+      ;;
     *)
+      if [[ -n "$pr_number" ]]; then
+        echo "PR_NUMBER는 하나만 지정할 수 있습니다." >&2
+        usage >&2
+        exit 64
+      fi
       pr_number="$1"
       shift
       ;;
@@ -56,20 +66,40 @@ owner="$(gh repo view --json owner --jq '.owner.login')"
 repo="$(gh repo view --json name --jq '.name')"
 
 # shellcheck disable=SC2016
-graphql_query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }'
-threads_json="$(gh api graphql \
-  -F owner="$owner" \
-  -F repo="$repo" \
-  -F number="$pr_number" \
-  -f query="$graphql_query")"
-unresolved_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+graphql_query='query($owner:String!, $repo:String!, $number:Int!, $after:String) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100, after:$after) { nodes { isResolved } pageInfo { hasNextPage endCursor } } } } }'
+unresolved_threads=0
+after_cursor=""
+while :; do
+  if [[ -z "$after_cursor" ]]; then
+    threads_json="$(gh api graphql \
+      -F owner="$owner" \
+      -F repo="$repo" \
+      -F number="$pr_number" \
+      -f query="$graphql_query")"
+  else
+    threads_json="$(gh api graphql \
+      -F owner="$owner" \
+      -F repo="$repo" \
+      -F number="$pr_number" \
+      -F after="$after_cursor" \
+      -f query="$graphql_query")"
+  fi
+
+  page_unresolved="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+  unresolved_threads=$((unresolved_threads + page_unresolved))
+
+  has_next="$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')"
+  [[ "$has_next" == "true" ]] || break
+  after_cursor="$(printf '%s' "$threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')"
+done
 
 if [[ "$unresolved_threads" != "0" ]]; then
-  echo "🚫 ready-for-ci 차단: unresolved review thread가 $unresolved_threads개 남아 있습니다." >&2
+  echo "🚫 ready-for-ci 차단: unresolved review thread가 ${unresolved_threads}개 남아 있습니다." >&2
   exit 2
 fi
 
-latest_state="$(gh pr view "$pr_number" --json reviews --jq '[.reviews[] | select(.author.login == "coderabbitai[bot]")] | last | if . then .state else "NONE" end')"
+# shellcheck disable=SC2016
+latest_state="$(gh pr view "$pr_number" --json reviews --jq '[.reviews[] | select((.author.login == "coderabbitai[bot]") or (.author.login == "coderabbitai"))] | last | if . then .state else "NONE" end')"
 if [[ "$latest_state" == "NONE" && "${ALLOW_NO_CODERABBIT:-}" != "1" ]]; then
   echo "🚫 ready-for-ci 차단: CodeRabbit 리뷰가 아직 없습니다." >&2
   echo "   필요 시 ALLOW_NO_CODERABBIT=1 로 예외 처리할 수 있지만, 기본 정책은 리뷰 후 CI입니다." >&2

--- a/scripts/pr-ready-for-ci-guard.sh
+++ b/scripts/pr-ready-for-ci-guard.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Guard for adding ready-for-ci only after review cleanup.
+
+set -euo pipefail
+
+usage() {
+  cat <<'MSG'
+Usage: scripts/pr-ready-for-ci-guard.sh [--apply] [PR_NUMBER]
+
+기본은 dry-run입니다. 조건을 통과하면 라벨 추가 명령만 출력합니다.
+--apply를 주면 `ready-for-ci` 라벨을 실제로 붙입니다.
+
+차단 조건:
+- unresolved review thread가 1개 이상
+- CodeRabbit 리뷰가 없거나 최신 CodeRabbit review가 CHANGES_REQUESTED
+
+예외:
+- ALLOW_NO_CODERABBIT=1 이면 CodeRabbit 리뷰 없음은 경고만 출력합니다.
+MSG
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "필수 명령을 찾을 수 없습니다: $1" >&2
+    exit 127
+  fi
+}
+
+apply="0"
+pr_number=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      apply="1"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      pr_number="$1"
+      shift
+      ;;
+  esac
+done
+
+require_cmd gh
+require_cmd jq
+
+if [[ -z "$pr_number" ]]; then
+  pr_number="$(gh pr view --json number --jq '.number')"
+fi
+
+owner="$(gh repo view --json owner --jq '.owner.login')"
+repo="$(gh repo view --json name --jq '.name')"
+
+threads_json="$(gh api graphql \
+  -F owner="$owner" \
+  -F repo="$repo" \
+  -F number="$pr_number" \
+  -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }')"
+unresolved_threads="$(printf '%s' "$threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+
+if [[ "$unresolved_threads" != "0" ]]; then
+  echo "🚫 ready-for-ci 차단: unresolved review thread가 $unresolved_threads개 남아 있습니다." >&2
+  exit 2
+fi
+
+latest_state="$(gh pr view "$pr_number" --json reviews --jq '[.reviews[] | select(.author.login == "coderabbitai[bot]")] | last | if . then .state else "NONE" end')"
+if [[ "$latest_state" == "NONE" && "${ALLOW_NO_CODERABBIT:-}" != "1" ]]; then
+  echo "🚫 ready-for-ci 차단: CodeRabbit 리뷰가 아직 없습니다." >&2
+  echo "   필요 시 ALLOW_NO_CODERABBIT=1 로 예외 처리할 수 있지만, 기본 정책은 리뷰 후 CI입니다." >&2
+  exit 3
+fi
+
+if [[ "$latest_state" == "CHANGES_REQUESTED" ]]; then
+  echo "🚫 ready-for-ci 차단: 최신 CodeRabbit review가 CHANGES_REQUESTED 입니다." >&2
+  exit 4
+fi
+
+if [[ "$apply" == "1" ]]; then
+  gh pr edit "$pr_number" --add-label ready-for-ci
+  echo "✅ ready-for-ci 라벨을 추가했습니다: PR #$pr_number"
+else
+  echo "✅ ready-for-ci 가드 통과: PR #$pr_number"
+  echo "   실제 라벨 추가: scripts/pr-ready-for-ci-guard.sh --apply $pr_number"
+fi


### PR DESCRIPTION
## 요약

- Phase 24 에디터 작업에 필요한 MMP 전용 Codex skills 3개를 추가했습니다.
- 프론트/백엔드/테스트 리뷰용 native subagent 정의 3개와 사용 규칙을 추가했습니다.
- PR 상태 확인, ready-for-ci 라벨 가드, Issue 기반 worktree 시작 스크립트를 추가했습니다.
- 기존 `pr-create-guard.sh` 실행 권한과 shellcheck 지적 사항을 보강했습니다.

## 배경

Phase 24는 에디터 엔티티와 런타임 engine/adapter 경계가 반복적으로 등장합니다. 매 세션마다 같은 운영 규칙을 다시 설명하지 않도록, Codex가 직접 읽고 적용할 수 있는 skill, subagent, script 형태로 분리했습니다.

## 검증

- `bash -n scripts/mmp-pr-status.sh scripts/pr-ready-for-ci-guard.sh scripts/mmp-start-issue-work.sh scripts/pr-create-guard.sh`
- `shellcheck scripts/mmp-pr-status.sh scripts/pr-ready-for-ci-guard.sh scripts/mmp-start-issue-work.sh scripts/pr-create-guard.sh`
- `scripts/mmp-pr-status.sh --help`
- `scripts/pr-ready-for-ci-guard.sh --help`
- `scripts/mmp-start-issue-work.sh --help`
- `PR_CREATE_GUARD_DRY_RUN=1 scripts/pr-create-guard.sh --label ready-for-ci` 차단 확인

## CI 운영

이 PR은 운영 문서와 로컬 보조 스크립트 중심 변경입니다. 요청된 운영 순서에 따라 `ready-for-ci` 라벨은 PR 생성 단계에서 붙이지 않습니다. CodeRabbit 리뷰를 먼저 확인한 뒤 필요한 경우에만 라벨을 붙입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 에디터·런타임 경계, 삭제·마이그레이션, 테스트·PR 정책 등 개발 워크플로우 문서를 대규모로 보강하고 런타임 엔진 및 편집기 설계 원칙을 추가했습니다.
* **Chores**
  * 프론트엔드/백엔드/테스트 전담 검토 에이전트 구성 및 관련 스킬/브리핑 문서 추가로 리뷰 일관성 강화.
  * PR 상태 조회, 이슈 작업용 워크트리 생성, `ready-for-ci` 라벨 가드 등 개발자용 CLI 유틸리티를 도입해 작업 흐름을 자동화하고 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->