### PR TITLE
feat(editor): 페이즈 정보 전달 Adapter UI 추가

### DIFF
--- a/apps/web/e2e/phase24-editor-information-delivery.spec.ts
+++ b/apps/web/e2e/phase24-editor-information-delivery.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import {
+  BASE,
+  THEME_ID,
+  FLOW_NODE_ID,
+  freshState,
+  loginAsE2EUser,
+  mockCommonApis,
+  type MockState,
+} from "./helpers/editor-golden-path-fixtures";
+
+test.describe("Phase 24 페이즈 정보 전달 Frontend Adapter", () => {
+  let state: MockState;
+
+  test.beforeEach(async ({ page }) => {
+    state = freshState();
+    await mockCommonApis(page, state);
+
+    await page.route(`**/v1/editor/themes/${THEME_ID}/characters`, (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "char-1",
+            theme_id: THEME_ID,
+            name: "탐정 A",
+            description: "사건을 추적하는 탐정입니다.",
+            image_url: null,
+            is_culprit: false,
+            mystery_role: "detective",
+            sort_order: 0,
+            created_at: "2026-05-03T00:00:00Z",
+          },
+          {
+            id: "char-2",
+            theme_id: THEME_ID,
+            name: "용의자 B",
+            description: "저택의 비밀을 알고 있습니다.",
+            image_url: null,
+            is_culprit: false,
+            mystery_role: "suspect",
+            sort_order: 1,
+            created_at: "2026-05-03T00:00:00Z",
+          },
+        ]),
+      });
+    });
+
+    await page.route(`**/v1/editor/themes/${THEME_ID}/reading-sections`, (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "rs-1",
+            themeId: THEME_ID,
+            name: "비밀 편지",
+            bgmMediaId: null,
+            lines: [{ Index: 0, Text: "편지의 첫 문장" }],
+            sortOrder: 0,
+            version: 1,
+            createdAt: "2026-05-03T00:00:00Z",
+            updatedAt: "2026-05-03T00:00:00Z",
+          },
+          {
+            id: "rs-2",
+            themeId: THEME_ID,
+            name: "저택 소문",
+            bgmMediaId: null,
+            lines: [{ Index: 0, Text: "소문" }, { Index: 1, Text: "증언" }],
+            sortOrder: 1,
+            version: 1,
+            createdAt: "2026-05-03T00:00:00Z",
+            updatedAt: "2026-05-03T00:00:00Z",
+          },
+        ]),
+      });
+    });
+
+    await page.route(`**/v1/editor/themes/${THEME_ID}/flow`, async (route) => {
+      if (route.request().method() === "GET") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            nodes: [
+              {
+                id: FLOW_NODE_ID,
+                theme_id: THEME_ID,
+                type: "phase",
+                data: {
+                  label: "1차 조사",
+                  phase_type: "investigation",
+                  duration: 25,
+                  rounds: 3,
+                },
+                position_x: 240,
+                position_y: 180,
+                created_at: "2026-05-03T00:00:00Z",
+                updated_at: "2026-05-03T00:00:00Z",
+              },
+            ],
+            edges: [],
+          }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ nodes: [], edges: [] }),
+      });
+    });
+
+    await loginAsE2EUser(page);
+  });
+
+  test("페이즈 선택 후 캐릭터별 전달 정보를 여러 개 선택해 저장한다", async ({ page }) => {
+    await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
+
+    await expect(page.getByText("페이즈 흐름")).toBeVisible({ timeout: 10_000 });
+    await page.getByText("1차 조사").click();
+    await expect(page.getByRole("heading", { name: "정보 전달" })).toBeVisible();
+
+    await page.getByRole("button", { name: "캐릭터별 추가" }).click();
+    await page.getByRole("searchbox", { name: "캐릭터 검색" }).fill("용의자");
+    await page.getByRole("button", { name: /용의자 B/ }).click();
+
+    await page.getByRole("searchbox", { name: "전달 정보 검색" }).fill("비밀");
+    await page.getByRole("button", { name: /비밀 편지/ }).click();
+    await page.getByRole("searchbox", { name: "전달 정보 검색" }).fill("");
+    await page.getByRole("button", { name: /저택 소문/ }).click();
+
+    await expect(page.getByText("용의자 B · 2개 정보")).toBeVisible();
+
+    const patchRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "PATCH" &&
+        request.url().includes(`/v1/editor/themes/${THEME_ID}/flow/nodes/${FLOW_NODE_ID}`),
+    );
+    await page.waitForTimeout(1700);
+    const request = await patchRequest;
+
+    expect(request.postDataJSON()).toMatchObject({
+      data: {
+        onEnter: [
+          {
+            type: "DELIVER_INFORMATION",
+            params: {
+              deliveries: [
+                {
+                  target: { type: "character", character_id: "char-2" },
+                  reading_section_ids: ["rs-1", "rs-2"],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const a11y = await new AxeBuilder({ page })
+      .include('[data-testid="flow-workspace"]')
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(a11y.violations).toEqual([]);
+  });
+});

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -91,6 +91,7 @@ export function ActionListEditor({
           <button
             type="button"
             onClick={() => handleRemove(idx)}
+            aria-label={`${label} ${idx + 1} 삭제`}
             className="text-slate-500 transition-colors hover:text-red-400"
           >
             <Trash2 className="h-3 w-3" />

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -39,6 +39,7 @@ export function ActionListEditor({
   const visibleActions = actions
     .map((action, index) => ({ action, index }))
     .filter(({ action }) => !hiddenTypes.includes(action.type));
+  const visibleActionTypes = ACTION_TYPES.filter((type) => !hiddenTypes.includes(type.value));
   const handleAdd = () => {
     onChange([...actions, { id: crypto.randomUUID(), type: "broadcast" }]);
   };
@@ -80,9 +81,10 @@ export function ActionListEditor({
           <select
             value={action.type}
             onChange={(e) => handleTypeChange(idx, e.target.value)}
+            aria-label={`${label} ${idx + 1} 액션 타입`}
             className="flex-1 bg-transparent text-xs text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
           >
-            {ACTION_TYPES.map((at) => (
+            {visibleActionTypes.map((at) => (
               <option key={at.value} value={at.value}>
                 {at.label}
               </option>

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -23,6 +23,7 @@ interface ActionListEditorProps {
   label: string;
   actions: PhaseAction[];
   onChange: (actions: PhaseAction[]) => void;
+  hiddenTypes?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -33,7 +34,11 @@ export function ActionListEditor({
   label,
   actions,
   onChange,
+  hiddenTypes = [],
 }: ActionListEditorProps) {
+  const visibleActions = actions
+    .map((action, index) => ({ action, index }))
+    .filter(({ action }) => !hiddenTypes.includes(action.type));
   const handleAdd = () => {
     onChange([...actions, { id: crypto.randomUUID(), type: "broadcast" }]);
   };
@@ -63,11 +68,11 @@ export function ActionListEditor({
         </button>
       </div>
 
-      {actions.length === 0 && (
+      {visibleActions.length === 0 && (
         <p className="text-[10px] text-slate-600">액션 없음</p>
       )}
 
-      {actions.map((action, idx) => (
+      {visibleActions.map(({ action, index: idx }) => (
         <div
           key={action.id ?? idx}
           className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-900 px-2 py-1.5"

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
@@ -1,11 +1,12 @@
 import { Plus, Search, Trash2, Users, UserRound } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useEditorCharacters } from "../../api";
 import { useReadingSections } from "../../readingApi";
 import type { FlowNodeData } from "../../flowTypes";
 import {
   flowNodeToInformationDeliveries,
   informationDeliveriesToFlowNodePatch,
+  isCompleteInformationDelivery,
   makeEmptyInformationDelivery,
   type InformationDeliveryViewModel,
 } from "./phaseEditorAdapter";
@@ -21,13 +22,35 @@ export function InformationDeliveryPanel({
   phaseData,
   onChange,
 }: InformationDeliveryPanelProps) {
-  const { data: characters = [], isLoading: charactersLoading } = useEditorCharacters(themeId);
-  const { data: sections = [], isLoading: sectionsLoading } = useReadingSections(themeId);
+  const {
+    data: characters = [],
+    isLoading: charactersLoading,
+    isError: charactersError,
+    refetch: refetchCharacters,
+  } = useEditorCharacters(themeId);
+  const {
+    data: sections = [],
+    isLoading: sectionsLoading,
+    isError: sectionsError,
+    refetch: refetchSections,
+  } = useReadingSections(themeId);
   const [characterQuery, setCharacterQuery] = useState("");
   const [sectionQuery, setSectionQuery] = useState("");
-  const [draftDeliveries, setDraftDeliveries] = useState(() =>
-    flowNodeToInformationDeliveries(phaseData),
+  const savedDeliveries = useMemo(
+    () => flowNodeToInformationDeliveries(phaseData),
+    [phaseData.onEnter],
   );
+  const [draftDeliveries, setDraftDeliveries] = useState(() => savedDeliveries);
+
+  useEffect(() => {
+    setDraftDeliveries((current) => {
+      const savedIds = new Set(savedDeliveries.map((delivery) => delivery.id));
+      const incompleteDrafts = current.filter(
+        (delivery) => !savedIds.has(delivery.id) && !isCompleteInformationDelivery(delivery),
+      );
+      return [...savedDeliveries, ...incompleteDrafts];
+    });
+  }, [savedDeliveries]);
 
   const filteredCharacters = useMemo(() => {
     const query = characterQuery.trim().toLowerCase();
@@ -77,6 +100,12 @@ export function InformationDeliveryPanel({
 
   const isStoryProgression = phaseData.phase_type === "story_progression";
   const loading = charactersLoading || sectionsLoading;
+  const hasLoadError = charactersError || sectionsError;
+
+  const retryLoad = () => {
+    if (charactersError) void refetchCharacters();
+    if (sectionsError) void refetchSections();
+  };
 
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
@@ -113,6 +142,17 @@ export function InformationDeliveryPanel({
         <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-500">
           캐릭터와 스토리 정보를 불러오는 중입니다.
         </p>
+      ) : hasLoadError ? (
+        <div className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-3 text-xs text-red-100">
+          <p>정보 전달에 필요한 캐릭터와 스토리 정보를 불러오지 못했습니다.</p>
+          <button
+            type="button"
+            onClick={retryLoad}
+            className="mt-2 rounded border border-red-300/30 px-2 py-1 text-red-50 hover:bg-red-500/20"
+          >
+            다시 불러오기
+          </button>
+        </div>
       ) : sections.length === 0 ? (
         <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-500">
           전달할 정보가 없습니다. 먼저 스토리 탭의 리딩 섹션에서 플레이어에게 보여줄 정보를 만들어 주세요.

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
@@ -1,7 +1,7 @@
-import { Plus, Search, Trash2, Users, UserRound } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useEditorCharacters } from "../../api";
 import { useReadingSections } from "../../readingApi";
+import { InformationDeliveryContent, InformationDeliveryHeader } from "./InformationDeliveryPanelViews";
 import type { FlowNodeData } from "../../flowTypes";
 import {
   flowNodeToInformationDeliveries,
@@ -101,6 +101,7 @@ export function InformationDeliveryPanel({
   const isStoryProgression = phaseData.phase_type === "story_progression";
   const loading = charactersLoading || sectionsLoading;
   const hasLoadError = charactersError || sectionsError;
+  const canAddCharacterDelivery = characters.length > 0;
 
   const retryLoad = () => {
     if (charactersError) void refetchCharacters();
@@ -109,278 +110,33 @@ export function InformationDeliveryPanel({
 
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h4 className="text-sm font-semibold text-slate-100">정보 전달</h4>
-          <p className="mt-1 text-xs leading-5 text-slate-500">
-            이 페이즈가 시작될 때 캐릭터별로 보여줄 스토리 정보를 선택합니다.
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {isStoryProgression && (
-            <button
-              type="button"
-              onClick={addAllPlayersDelivery}
-              className="inline-flex items-center justify-center gap-1 rounded border border-amber-500/40 px-2.5 py-1.5 text-xs text-amber-200 hover:bg-amber-500/10"
-            >
-              <Users className="h-3.5 w-3.5" />
-              전체 전달
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={addCharacterDelivery}
-            className="inline-flex items-center justify-center gap-1 rounded bg-amber-500 px-2.5 py-1.5 text-xs font-medium text-slate-950 hover:bg-amber-400"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            캐릭터별 추가
-          </button>
-        </div>
-      </div>
+      <InformationDeliveryHeader
+        isStoryProgression={isStoryProgression}
+        canAddCharacterDelivery={canAddCharacterDelivery}
+        onAddAllPlayers={addAllPlayersDelivery}
+        onAddCharacter={addCharacterDelivery}
+      />
 
-      {loading ? (
-        <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-500">
-          캐릭터와 스토리 정보를 불러오는 중입니다.
-        </p>
-      ) : hasLoadError ? (
-        <div className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-3 text-xs text-red-100">
-          <p>정보 전달에 필요한 캐릭터와 스토리 정보를 불러오지 못했습니다.</p>
-          <button
-            type="button"
-            onClick={retryLoad}
-            className="mt-2 rounded border border-red-300/30 px-2 py-1 text-red-50 hover:bg-red-500/20"
-          >
-            다시 불러오기
-          </button>
-        </div>
-      ) : sections.length === 0 ? (
-        <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-500">
-          전달할 정보가 없습니다. 먼저 스토리 탭의 리딩 섹션에서 플레이어에게 보여줄 정보를 만들어 주세요.
-        </p>
-      ) : (
-        <>
-          <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            <SearchField
-              label="캐릭터 검색"
-              value={characterQuery}
-              onChange={setCharacterQuery}
-              placeholder="이름으로 찾기"
-            />
-            <SearchField
-              label="전달 정보 검색"
-              value={sectionQuery}
-              onChange={setSectionQuery}
-              placeholder="정보 이름으로 찾기"
-            />
-          </div>
-
-          {draftDeliveries.length === 0 ? (
-            <p className="mt-4 rounded border border-dashed border-slate-700 px-3 py-4 text-center text-xs leading-5 text-slate-500">
-              아직 전달 설정이 없습니다. 캐릭터별 추가를 눌러 누구에게 어떤 정보를 줄지 정해 주세요.
-            </p>
-          ) : (
-            <div className="mt-4 space-y-3">
-              {draftDeliveries.map((delivery, index) => (
-                <DeliveryCard
-                  key={delivery.id}
-                  index={index}
-                  delivery={delivery}
-                  characters={filteredCharacters}
-                  allCharacters={characters}
-                  sections={filteredSections}
-                  allSections={sections}
-                  onSelectCharacter={(characterId) => updateDelivery(delivery.id, { characterId })}
-                  onToggleSection={(sectionId) => toggleSection(delivery, sectionId)}
-                  onRemove={() => removeDelivery(delivery.id)}
-                />
-              ))}
-            </div>
-          )}
-        </>
-      )}
+      <InformationDeliveryContent
+        loading={loading}
+        hasLoadError={hasLoadError}
+        isStoryProgression={isStoryProgression}
+        hasCharacters={characters.length > 0}
+        hasSections={sections.length > 0}
+        characterQuery={characterQuery}
+        sectionQuery={sectionQuery}
+        deliveries={draftDeliveries}
+        characters={filteredCharacters}
+        allCharacters={characters}
+        sections={filteredSections}
+        allSections={sections}
+        onRetryLoad={retryLoad}
+        onCharacterQueryChange={setCharacterQuery}
+        onSectionQueryChange={setSectionQuery}
+        onSelectCharacter={(deliveryId, characterId) => updateDelivery(deliveryId, { characterId })}
+        onToggleSection={toggleSection}
+        onRemoveDelivery={removeDelivery}
+      />
     </section>
-  );
-}
-
-interface SearchFieldProps {
-  label: string;
-  value: string;
-  placeholder: string;
-  onChange: (value: string) => void;
-}
-
-function SearchField({ label, value, placeholder, onChange }: SearchFieldProps) {
-  return (
-    <label className="flex flex-col gap-1 text-[11px] text-slate-400">
-      {label}
-      <span className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-2 py-1.5 focus-within:border-amber-500 focus-within:ring-2 focus-within:ring-amber-500/40">
-        <Search className="h-3.5 w-3.5 text-slate-500" />
-        <input
-          type="search"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          className="min-w-0 flex-1 bg-transparent text-xs text-slate-200 placeholder-slate-600 focus:outline-none"
-        />
-      </span>
-    </label>
-  );
-}
-
-interface DeliveryCardProps {
-  index: number;
-  delivery: InformationDeliveryViewModel;
-  characters: { id: string; name: string }[];
-  allCharacters: { id: string; name: string }[];
-  sections: { id: string; name: string; lines: unknown[] }[];
-  allSections: { id: string; name: string; lines: unknown[] }[];
-  onSelectCharacter: (characterId: string) => void;
-  onToggleSection: (sectionId: string) => void;
-  onRemove: () => void;
-}
-
-function DeliveryCard({
-  index,
-  delivery,
-  characters,
-  allCharacters,
-  sections,
-  allSections,
-  onSelectCharacter,
-  onToggleSection,
-  onRemove,
-}: DeliveryCardProps) {
-  const selectedCharacterName =
-    delivery.recipientType === "all_players"
-      ? "모든 플레이어"
-      : allCharacters.find((character) => character.id === delivery.characterId)?.name;
-
-  return (
-    <article className="rounded-lg border border-slate-800 bg-slate-900/80 p-3">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="text-xs font-semibold text-slate-200">전달 설정 {index + 1}</p>
-          <p className="mt-1 text-[11px] text-slate-500">
-            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · {delivery.readingSectionIds.length}개 정보
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onRemove}
-          aria-label={`전달 설정 ${index + 1} 삭제`}
-          className="rounded p-1 text-slate-500 hover:bg-red-500/10 hover:text-red-300"
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="mt-3 grid gap-3">
-        {delivery.recipientType === "all_players" ? (
-          <div className="flex items-center gap-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-            <Users className="h-4 w-4" />
-            스토리 진행용 공통 정보로 모든 플레이어에게 전달됩니다.
-          </div>
-        ) : (
-          <OptionList
-            title="받을 캐릭터"
-            emptyText="검색 결과가 없습니다."
-            items={characters}
-            selectedIds={delivery.characterId ? [delivery.characterId] : []}
-            getMeta={() => undefined}
-            onToggle={(id) => onSelectCharacter(id)}
-            single
-          />
-        )}
-
-        <OptionList
-          title="전달할 정보"
-          emptyText="검색 결과가 없습니다."
-          items={sections}
-          selectedIds={delivery.readingSectionIds}
-          getMeta={(section) => `${section.lines.length}줄`}
-          onToggle={onToggleSection}
-          allItems={allSections}
-        />
-      </div>
-    </article>
-  );
-}
-
-interface OptionItem {
-  id: string;
-  name: string;
-}
-
-interface OptionListProps<T extends OptionItem> {
-  title: string;
-  emptyText: string;
-  items: T[];
-  allItems?: T[];
-  selectedIds: string[];
-  single?: boolean;
-  getMeta: (item: T) => string | undefined;
-  onToggle: (id: string) => void;
-}
-
-function OptionList<T extends OptionItem>({
-  title,
-  emptyText,
-  items,
-  allItems,
-  selectedIds,
-  single = false,
-  getMeta,
-  onToggle,
-}: OptionListProps<T>) {
-  const selectedItems = (allItems ?? items).filter((item) => selectedIds.includes(item.id));
-
-  return (
-    <div className="rounded border border-slate-800 bg-slate-950/70 p-2">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <span className="text-[11px] font-medium text-slate-400">{title}</span>
-        {selectedItems.length > 0 && (
-          <span className="text-[10px] text-amber-300">{selectedItems.length}개 선택</span>
-        )}
-      </div>
-      {selectedItems.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-1.5">
-          {selectedItems.map((item) => (
-            <span
-              key={item.id}
-              className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-[10px] text-amber-100"
-            >
-              {single ? <UserRound className="h-3 w-3" /> : null}
-              {item.name}
-            </span>
-          ))}
-        </div>
-      )}
-      {items.length === 0 ? (
-        <p className="px-2 py-3 text-center text-xs text-slate-600">{emptyText}</p>
-      ) : (
-        <div className="grid max-h-44 gap-1 overflow-y-auto pr-1">
-          {items.map((item) => {
-            const selected = selectedIds.includes(item.id);
-            const meta = getMeta(item);
-            return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => onToggle(item.id)}
-                aria-pressed={selected}
-                className={`flex min-h-10 items-center justify-between gap-2 rounded px-2 py-2 text-left text-xs transition-colors ${
-                  selected
-                    ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40"
-                    : "bg-slate-900 text-slate-300 hover:bg-slate-800"
-                }`}
-              >
-                <span className="min-w-0 flex-1 truncate">{item.name}</span>
-                {meta && <span className="shrink-0 text-[10px] text-slate-500">{meta}</span>}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
@@ -1,0 +1,346 @@
+import { Plus, Search, Trash2, Users, UserRound } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useEditorCharacters } from "../../api";
+import { useReadingSections } from "../../readingApi";
+import type { FlowNodeData } from "../../flowTypes";
+import {
+  flowNodeToInformationDeliveries,
+  informationDeliveriesToFlowNodePatch,
+  makeEmptyInformationDelivery,
+  type InformationDeliveryViewModel,
+} from "./phaseEditorAdapter";
+
+interface InformationDeliveryPanelProps {
+  themeId: string;
+  phaseData: FlowNodeData;
+  onChange: (patch: Partial<FlowNodeData>) => void;
+}
+
+export function InformationDeliveryPanel({
+  themeId,
+  phaseData,
+  onChange,
+}: InformationDeliveryPanelProps) {
+  const { data: characters = [], isLoading: charactersLoading } = useEditorCharacters(themeId);
+  const { data: sections = [], isLoading: sectionsLoading } = useReadingSections(themeId);
+  const [characterQuery, setCharacterQuery] = useState("");
+  const [sectionQuery, setSectionQuery] = useState("");
+  const [draftDeliveries, setDraftDeliveries] = useState(() =>
+    flowNodeToInformationDeliveries(phaseData),
+  );
+
+  const filteredCharacters = useMemo(() => {
+    const query = characterQuery.trim().toLowerCase();
+    if (!query) return characters;
+    return characters.filter((character) => character.name.toLowerCase().includes(query));
+  }, [characters, characterQuery]);
+
+  const filteredSections = useMemo(() => {
+    const query = sectionQuery.trim().toLowerCase();
+    if (!query) return sections;
+    return sections.filter((section) => section.name.toLowerCase().includes(query));
+  }, [sections, sectionQuery]);
+
+  const updateDeliveries = (next: InformationDeliveryViewModel[]) => {
+    setDraftDeliveries(next);
+    onChange(informationDeliveriesToFlowNodePatch(phaseData, next));
+  };
+
+  const addCharacterDelivery = () => {
+    updateDeliveries([...draftDeliveries, makeEmptyInformationDelivery("character")]);
+  };
+
+  const addAllPlayersDelivery = () => {
+    updateDeliveries([...draftDeliveries, makeEmptyInformationDelivery("all_players")]);
+  };
+
+  const updateDelivery = (deliveryId: string, patch: Partial<InformationDeliveryViewModel>) => {
+    updateDeliveries(
+      draftDeliveries.map((delivery) =>
+        delivery.id === deliveryId ? { ...delivery, ...patch } : delivery,
+      ),
+    );
+  };
+
+  const removeDelivery = (deliveryId: string) => {
+    updateDeliveries(draftDeliveries.filter((delivery) => delivery.id !== deliveryId));
+  };
+
+  const toggleSection = (delivery: InformationDeliveryViewModel, sectionId: string) => {
+    const hasSection = delivery.readingSectionIds.includes(sectionId);
+    updateDelivery(delivery.id, {
+      readingSectionIds: hasSection
+        ? delivery.readingSectionIds.filter((id) => id !== sectionId)
+        : [...delivery.readingSectionIds, sectionId],
+    });
+  };
+
+  const isStoryProgression = phaseData.phase_type === "story_progression";
+  const loading = charactersLoading || sectionsLoading;
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h4 className="text-sm font-semibold text-slate-100">정보 전달</h4>
+          <p className="mt-1 text-xs leading-5 text-slate-500">
+            이 페이즈가 시작될 때 캐릭터별로 보여줄 스토리 정보를 선택합니다.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {isStoryProgression && (
+            <button
+              type="button"
+              onClick={addAllPlayersDelivery}
+              className="inline-flex items-center justify-center gap-1 rounded border border-amber-500/40 px-2.5 py-1.5 text-xs text-amber-200 hover:bg-amber-500/10"
+            >
+              <Users className="h-3.5 w-3.5" />
+              전체 전달
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={addCharacterDelivery}
+            className="inline-flex items-center justify-center gap-1 rounded bg-amber-500 px-2.5 py-1.5 text-xs font-medium text-slate-950 hover:bg-amber-400"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            캐릭터별 추가
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-500">
+          캐릭터와 스토리 정보를 불러오는 중입니다.
+        </p>
+      ) : sections.length === 0 ? (
+        <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-500">
+          전달할 정보가 없습니다. 먼저 스토리 탭의 리딩 섹션에서 플레이어에게 보여줄 정보를 만들어 주세요.
+        </p>
+      ) : (
+        <>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            <SearchField
+              label="캐릭터 검색"
+              value={characterQuery}
+              onChange={setCharacterQuery}
+              placeholder="이름으로 찾기"
+            />
+            <SearchField
+              label="전달 정보 검색"
+              value={sectionQuery}
+              onChange={setSectionQuery}
+              placeholder="정보 이름으로 찾기"
+            />
+          </div>
+
+          {draftDeliveries.length === 0 ? (
+            <p className="mt-4 rounded border border-dashed border-slate-700 px-3 py-4 text-center text-xs leading-5 text-slate-500">
+              아직 전달 설정이 없습니다. 캐릭터별 추가를 눌러 누구에게 어떤 정보를 줄지 정해 주세요.
+            </p>
+          ) : (
+            <div className="mt-4 space-y-3">
+              {draftDeliveries.map((delivery, index) => (
+                <DeliveryCard
+                  key={delivery.id}
+                  index={index}
+                  delivery={delivery}
+                  characters={filteredCharacters}
+                  allCharacters={characters}
+                  sections={filteredSections}
+                  allSections={sections}
+                  onSelectCharacter={(characterId) => updateDelivery(delivery.id, { characterId })}
+                  onToggleSection={(sectionId) => toggleSection(delivery, sectionId)}
+                  onRemove={() => removeDelivery(delivery.id)}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+interface SearchFieldProps {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}
+
+function SearchField({ label, value, placeholder, onChange }: SearchFieldProps) {
+  return (
+    <label className="flex flex-col gap-1 text-[11px] text-slate-400">
+      {label}
+      <span className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-2 py-1.5 focus-within:border-amber-500 focus-within:ring-2 focus-within:ring-amber-500/40">
+        <Search className="h-3.5 w-3.5 text-slate-500" />
+        <input
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="min-w-0 flex-1 bg-transparent text-xs text-slate-200 placeholder-slate-600 focus:outline-none"
+        />
+      </span>
+    </label>
+  );
+}
+
+interface DeliveryCardProps {
+  index: number;
+  delivery: InformationDeliveryViewModel;
+  characters: { id: string; name: string }[];
+  allCharacters: { id: string; name: string }[];
+  sections: { id: string; name: string; lines: unknown[] }[];
+  allSections: { id: string; name: string; lines: unknown[] }[];
+  onSelectCharacter: (characterId: string) => void;
+  onToggleSection: (sectionId: string) => void;
+  onRemove: () => void;
+}
+
+function DeliveryCard({
+  index,
+  delivery,
+  characters,
+  allCharacters,
+  sections,
+  allSections,
+  onSelectCharacter,
+  onToggleSection,
+  onRemove,
+}: DeliveryCardProps) {
+  const selectedCharacterName =
+    delivery.recipientType === "all_players"
+      ? "모든 플레이어"
+      : allCharacters.find((character) => character.id === delivery.characterId)?.name;
+
+  return (
+    <article className="rounded-lg border border-slate-800 bg-slate-900/80 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold text-slate-200">전달 설정 {index + 1}</p>
+          <p className="mt-1 text-[11px] text-slate-500">
+            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · {delivery.readingSectionIds.length}개 정보
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`전달 설정 ${index + 1} 삭제`}
+          className="rounded p-1 text-slate-500 hover:bg-red-500/10 hover:text-red-300"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="mt-3 grid gap-3">
+        {delivery.recipientType === "all_players" ? (
+          <div className="flex items-center gap-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+            <Users className="h-4 w-4" />
+            스토리 진행용 공통 정보로 모든 플레이어에게 전달됩니다.
+          </div>
+        ) : (
+          <OptionList
+            title="받을 캐릭터"
+            emptyText="검색 결과가 없습니다."
+            items={characters}
+            selectedIds={delivery.characterId ? [delivery.characterId] : []}
+            getMeta={() => undefined}
+            onToggle={(id) => onSelectCharacter(id)}
+            single
+          />
+        )}
+
+        <OptionList
+          title="전달할 정보"
+          emptyText="검색 결과가 없습니다."
+          items={sections}
+          selectedIds={delivery.readingSectionIds}
+          getMeta={(section) => `${section.lines.length}줄`}
+          onToggle={onToggleSection}
+          allItems={allSections}
+        />
+      </div>
+    </article>
+  );
+}
+
+interface OptionItem {
+  id: string;
+  name: string;
+}
+
+interface OptionListProps<T extends OptionItem> {
+  title: string;
+  emptyText: string;
+  items: T[];
+  allItems?: T[];
+  selectedIds: string[];
+  single?: boolean;
+  getMeta: (item: T) => string | undefined;
+  onToggle: (id: string) => void;
+}
+
+function OptionList<T extends OptionItem>({
+  title,
+  emptyText,
+  items,
+  allItems,
+  selectedIds,
+  single = false,
+  getMeta,
+  onToggle,
+}: OptionListProps<T>) {
+  const selectedItems = (allItems ?? items).filter((item) => selectedIds.includes(item.id));
+
+  return (
+    <div className="rounded border border-slate-800 bg-slate-950/70 p-2">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[11px] font-medium text-slate-400">{title}</span>
+        {selectedItems.length > 0 && (
+          <span className="text-[10px] text-amber-300">{selectedItems.length}개 선택</span>
+        )}
+      </div>
+      {selectedItems.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {selectedItems.map((item) => (
+            <span
+              key={item.id}
+              className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-[10px] text-amber-100"
+            >
+              {single ? <UserRound className="h-3 w-3" /> : null}
+              {item.name}
+            </span>
+          ))}
+        </div>
+      )}
+      {items.length === 0 ? (
+        <p className="px-2 py-3 text-center text-xs text-slate-600">{emptyText}</p>
+      ) : (
+        <div className="grid max-h-44 gap-1 overflow-y-auto pr-1">
+          {items.map((item) => {
+            const selected = selectedIds.includes(item.id);
+            const meta = getMeta(item);
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onToggle(item.id)}
+                aria-pressed={selected}
+                className={`flex min-h-10 items-center justify-between gap-2 rounded px-2 py-2 text-left text-xs transition-colors ${
+                  selected
+                    ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40"
+                    : "bg-slate-900 text-slate-300 hover:bg-slate-800"
+                }`}
+              >
+                <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                {meta && <span className="shrink-0 text-[10px] text-slate-500">{meta}</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
@@ -150,7 +150,7 @@ export function InformationDeliveryContent({
 
       {deliveries.length === 0 ? (
         <p className="mt-4 rounded border border-dashed border-slate-700 px-3 py-4 text-center text-xs leading-5 text-slate-500">
-          아직 전달 설정이 없습니다. 캐릭터별 추가를 눌러 누구에게 어떤 정보를 줄지 정해 주세요.
+          {getEmptyDeliveryMessage(isStoryProgression, hasCharacters)}
         </p>
       ) : (
         <div className="mt-4 space-y-3">
@@ -172,6 +172,17 @@ export function InformationDeliveryContent({
       )}
     </>
   );
+}
+
+
+function getEmptyDeliveryMessage(isStoryProgression: boolean, hasCharacters: boolean): string {
+  if (!isStoryProgression) {
+    return "아직 전달 설정이 없습니다. 캐릭터별 추가를 눌러 누구에게 어떤 정보를 줄지 정해 주세요.";
+  }
+  if (!hasCharacters) {
+    return "아직 전달 설정이 없습니다. 전체 전달을 눌러 모든 플레이어에게 줄 공통 정보를 설정해 주세요.";
+  }
+  return "아직 전달 설정이 없습니다. 전체 전달 또는 캐릭터별 추가를 눌러 전달 대상을 정해 주세요.";
 }
 
 interface SearchFieldProps {

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
@@ -1,0 +1,358 @@
+import { Plus, Search, Trash2, Users, UserRound } from "lucide-react";
+import type { InformationDeliveryViewModel } from "./phaseEditorAdapter";
+
+interface InformationDeliveryHeaderProps {
+  isStoryProgression: boolean;
+  canAddCharacterDelivery: boolean;
+  onAddAllPlayers: () => void;
+  onAddCharacter: () => void;
+}
+
+export function InformationDeliveryHeader({
+  isStoryProgression,
+  canAddCharacterDelivery,
+  onAddAllPlayers,
+  onAddCharacter,
+}: InformationDeliveryHeaderProps) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h4 className="text-sm font-semibold text-slate-100">정보 전달</h4>
+        <p className="mt-1 text-xs leading-5 text-slate-500">
+          이 페이즈가 시작될 때 캐릭터별로 보여줄 스토리 정보를 선택합니다.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {isStoryProgression && (
+          <button
+            type="button"
+            onClick={onAddAllPlayers}
+            className="inline-flex items-center justify-center gap-1 rounded border border-amber-500/40 px-2.5 py-1.5 text-xs text-amber-200 hover:bg-amber-500/10"
+          >
+            <Users className="h-3.5 w-3.5" />
+            전체 전달
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onAddCharacter}
+          disabled={!canAddCharacterDelivery}
+          className={`inline-flex items-center justify-center gap-1 rounded px-2.5 py-1.5 text-xs font-medium ${
+            canAddCharacterDelivery
+              ? "bg-amber-500 text-slate-950 hover:bg-amber-400"
+              : "cursor-not-allowed border border-slate-700 text-slate-500"
+          }`}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          캐릭터별 추가
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface InformationDeliveryContentProps {
+  loading: boolean;
+  hasLoadError: boolean;
+  isStoryProgression: boolean;
+  hasCharacters: boolean;
+  hasSections: boolean;
+  characterQuery: string;
+  sectionQuery: string;
+  deliveries: InformationDeliveryViewModel[];
+  characters: { id: string; name: string }[];
+  allCharacters: { id: string; name: string }[];
+  sections: { id: string; name: string; lines: unknown[] }[];
+  allSections: { id: string; name: string; lines: unknown[] }[];
+  onRetryLoad: () => void;
+  onCharacterQueryChange: (value: string) => void;
+  onSectionQueryChange: (value: string) => void;
+  onSelectCharacter: (deliveryId: string, characterId: string) => void;
+  onToggleSection: (delivery: InformationDeliveryViewModel, sectionId: string) => void;
+  onRemoveDelivery: (deliveryId: string) => void;
+}
+
+export function InformationDeliveryContent({
+  loading,
+  hasLoadError,
+  isStoryProgression,
+  hasCharacters,
+  hasSections,
+  characterQuery,
+  sectionQuery,
+  deliveries,
+  characters,
+  allCharacters,
+  sections,
+  allSections,
+  onRetryLoad,
+  onCharacterQueryChange,
+  onSectionQueryChange,
+  onSelectCharacter,
+  onToggleSection,
+  onRemoveDelivery,
+}: InformationDeliveryContentProps) {
+  if (loading) {
+    return (
+      <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-500">
+        캐릭터와 스토리 정보를 불러오는 중입니다.
+      </p>
+    );
+  }
+
+  if (hasLoadError) {
+    return (
+      <div className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-3 text-xs text-red-100">
+        <p>정보 전달에 필요한 캐릭터와 스토리 정보를 불러오지 못했습니다.</p>
+        <button
+          type="button"
+          onClick={onRetryLoad}
+          className="mt-2 rounded border border-red-300/30 px-2 py-1 text-red-50 hover:bg-red-500/20"
+        >
+          다시 불러오기
+        </button>
+      </div>
+    );
+  }
+
+  if (!hasSections) {
+    return (
+      <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-500">
+        전달할 정보가 없습니다. 먼저 스토리 탭의 리딩 섹션에서 플레이어에게 보여줄 정보를 만들어 주세요.
+      </p>
+    );
+  }
+
+  if (!hasCharacters && !isStoryProgression) {
+    return (
+      <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-500">
+        받을 캐릭터가 없습니다. 먼저 캐릭터를 만든 뒤 캐릭터별 정보 전달을 설정해 주세요.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <SearchField
+          label="캐릭터 검색"
+          value={characterQuery}
+          onChange={onCharacterQueryChange}
+          placeholder="이름으로 찾기"
+        />
+        <SearchField
+          label="전달 정보 검색"
+          value={sectionQuery}
+          onChange={onSectionQueryChange}
+          placeholder="정보 이름으로 찾기"
+        />
+      </div>
+
+      {deliveries.length === 0 ? (
+        <p className="mt-4 rounded border border-dashed border-slate-700 px-3 py-4 text-center text-xs leading-5 text-slate-500">
+          아직 전달 설정이 없습니다. 캐릭터별 추가를 눌러 누구에게 어떤 정보를 줄지 정해 주세요.
+        </p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {deliveries.map((delivery, index) => (
+            <DeliveryCard
+              key={delivery.id}
+              index={index}
+              delivery={delivery}
+              characters={characters}
+              allCharacters={allCharacters}
+              sections={sections}
+              allSections={allSections}
+              onSelectCharacter={(characterId) => onSelectCharacter(delivery.id, characterId)}
+              onToggleSection={(sectionId) => onToggleSection(delivery, sectionId)}
+              onRemove={() => onRemoveDelivery(delivery.id)}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+interface SearchFieldProps {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}
+
+function SearchField({ label, value, placeholder, onChange }: SearchFieldProps) {
+  return (
+    <label className="flex flex-col gap-1 text-[11px] text-slate-400">
+      {label}
+      <span className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-2 py-1.5 focus-within:border-amber-500 focus-within:ring-2 focus-within:ring-amber-500/40">
+        <Search className="h-3.5 w-3.5 text-slate-500" />
+        <input
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="min-w-0 flex-1 bg-transparent text-xs text-slate-200 placeholder-slate-600 focus:outline-none"
+        />
+      </span>
+    </label>
+  );
+}
+
+interface DeliveryCardProps {
+  index: number;
+  delivery: InformationDeliveryViewModel;
+  characters: { id: string; name: string }[];
+  allCharacters: { id: string; name: string }[];
+  sections: { id: string; name: string; lines: unknown[] }[];
+  allSections: { id: string; name: string; lines: unknown[] }[];
+  onSelectCharacter: (characterId: string) => void;
+  onToggleSection: (sectionId: string) => void;
+  onRemove: () => void;
+}
+
+function DeliveryCard({
+  index,
+  delivery,
+  characters,
+  allCharacters,
+  sections,
+  allSections,
+  onSelectCharacter,
+  onToggleSection,
+  onRemove,
+}: DeliveryCardProps) {
+  const selectedCharacterName =
+    delivery.recipientType === "all_players"
+      ? "모든 플레이어"
+      : allCharacters.find((character) => character.id === delivery.characterId)?.name;
+
+  return (
+    <article className="rounded-lg border border-slate-800 bg-slate-900/80 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold text-slate-200">전달 설정 {index + 1}</p>
+          <p className="mt-1 text-[11px] text-slate-500">
+            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · {delivery.readingSectionIds.length}개 정보
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`전달 설정 ${index + 1} 삭제`}
+          className="rounded p-1 text-slate-500 hover:bg-red-500/10 hover:text-red-300"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="mt-3 grid gap-3">
+        {delivery.recipientType === "all_players" ? (
+          <div className="flex items-center gap-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+            <Users className="h-4 w-4" />
+            스토리 진행용 공통 정보로 모든 플레이어에게 전달됩니다.
+          </div>
+        ) : (
+          <OptionList
+            title="받을 캐릭터"
+            emptyText="검색 결과가 없습니다."
+            items={characters}
+            selectedIds={delivery.characterId ? [delivery.characterId] : []}
+            getMeta={() => undefined}
+            onToggle={(id) => onSelectCharacter(id)}
+            single
+          />
+        )}
+
+        <OptionList
+          title="전달할 정보"
+          emptyText="검색 결과가 없습니다."
+          items={sections}
+          selectedIds={delivery.readingSectionIds}
+          getMeta={(section) => `${section.lines.length}줄`}
+          onToggle={onToggleSection}
+          allItems={allSections}
+        />
+      </div>
+    </article>
+  );
+}
+
+interface OptionItem {
+  id: string;
+  name: string;
+}
+
+interface OptionListProps<T extends OptionItem> {
+  title: string;
+  emptyText: string;
+  items: T[];
+  allItems?: T[];
+  selectedIds: string[];
+  single?: boolean;
+  getMeta: (item: T) => string | undefined;
+  onToggle: (id: string) => void;
+}
+
+function OptionList<T extends OptionItem>({
+  title,
+  emptyText,
+  items,
+  allItems,
+  selectedIds,
+  single = false,
+  getMeta,
+  onToggle,
+}: OptionListProps<T>) {
+  const selectedItems = (allItems ?? items).filter((item) => selectedIds.includes(item.id));
+
+  return (
+    <div className="rounded border border-slate-800 bg-slate-950/70 p-2">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[11px] font-medium text-slate-400">{title}</span>
+        {selectedItems.length > 0 && (
+          <span className="text-[10px] text-amber-300">{selectedItems.length}개 선택</span>
+        )}
+      </div>
+      {selectedItems.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {selectedItems.map((item) => (
+            <span
+              key={item.id}
+              className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-[10px] text-amber-100"
+            >
+              {single ? <UserRound className="h-3 w-3" /> : null}
+              {item.name}
+            </span>
+          ))}
+        </div>
+      )}
+      {items.length === 0 ? (
+        <p className="px-2 py-3 text-center text-xs text-slate-600">{emptyText}</p>
+      ) : (
+        <div className="grid max-h-44 gap-1 overflow-y-auto pr-1">
+          {items.map((item) => {
+            const selected = selectedIds.includes(item.id);
+            const meta = getMeta(item);
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onToggle(item.id)}
+                aria-pressed={selected}
+                className={`flex min-h-10 items-center justify-between gap-2 rounded px-2 py-2 text-left text-xs transition-colors ${
+                  selected
+                    ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40"
+                    : "bg-slate-900 text-slate-300 hover:bg-slate-800"
+                }`}
+              >
+                <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                {meta && <span className="shrink-0 text-[10px] text-slate-500">{meta}</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/PhaseNode.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNode.tsx
@@ -12,6 +12,7 @@ const PHASE_TYPE_LABELS: Record<string, string> = {
   voting: "투표",
   free: "자유",
   intermission: "인터미션",
+  story_progression: "스토리 진행",
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -10,6 +10,8 @@ import type {
 import { flowKeys } from "../../flowTypes";
 import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
 import { ActionListEditor } from "./ActionListEditor";
+import { InformationDeliveryPanel } from "./InformationDeliveryPanel";
+import { DELIVER_INFORMATION_ACTION } from "./phaseEditorAdapter";
 import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
 import { PhasePanelTimerSettings } from "./PhasePanelTimerSettings";
 import { PhasePanelAdvanceToggle } from "./PhasePanelAdvanceToggle";
@@ -83,10 +85,20 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
 
       <div className="border-t border-slate-800" />
 
+      <InformationDeliveryPanel
+        key={node.id}
+        themeId={themeId}
+        phaseData={data}
+        onChange={handleChange}
+      />
+
+      <div className="border-t border-slate-800" />
+
       <ActionListEditor
         label="진입 액션 (onEnter)"
         actions={(data.onEnter as PhaseAction[]) ?? []}
         onChange={(actions) => handleChange({ onEnter: actions })}
+        hiddenTypes={[DELIVER_INFORMATION_ACTION, "deliver_information"]}
       />
       <ActionListEditor
         label="퇴장 액션 (onExit)"

--- a/apps/web/src/features/editor/components/design/PhasePanelBasicInfo.tsx
+++ b/apps/web/src/features/editor/components/design/PhasePanelBasicInfo.tsx
@@ -11,6 +11,7 @@ const PHASE_TYPES = [
   { value: "investigation", label: "수사" },
   { value: "discussion", label: "토론" },
   { value: "voting", label: "투표" },
+  { value: "story_progression", label: "스토리 진행" },
   { value: "free", label: "자유" },
   { value: "intermission", label: "인터미션" },
 ];

--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -30,8 +30,18 @@ const sections = [
 ];
 
 beforeEach(() => {
-  useEditorCharactersMock.mockReturnValue({ data: characters, isLoading: false });
-  useReadingSectionsMock.mockReturnValue({ data: sections, isLoading: false });
+  useEditorCharactersMock.mockReturnValue({
+    data: characters,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  useReadingSectionsMock.mockReturnValue({
+    data: sections,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
 });
 
 afterEach(() => {
@@ -122,12 +132,83 @@ describe("InformationDeliveryPanel", () => {
     expect(onChange).toHaveBeenLastCalledWith({ onEnter: [] });
   });
 
+
+  it("캐릭터 또는 스토리 정보 조회 실패를 빈 상태와 구분하고 재시도할 수 있다", () => {
+    const refetchCharacters = vi.fn();
+    const refetchSections = vi.fn();
+    useEditorCharactersMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+      refetch: refetchCharacters,
+    });
+    useReadingSectionsMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+      refetch: refetchSections,
+    });
+
+    render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
+
+    expect(screen.getByText("정보 전달에 필요한 캐릭터와 스토리 정보를 불러오지 못했습니다.")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
+
+    expect(refetchCharacters).toHaveBeenCalledTimes(1);
+    expect(refetchSections).toHaveBeenCalledTimes(1);
+  });
+
+  it("phaseData onEnter 변경이 들어오면 저장된 전달 설정을 다시 반영한다", () => {
+    const firstPhaseData: FlowNodeData = {
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-1" },
+                reading_section_ids: ["rs-1"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const nextPhaseData: FlowNodeData = {
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d2",
+                target: { type: "character", character_id: "char-2" },
+                reading_section_ids: ["rs-2"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const { rerender } = render(
+      <InformationDeliveryPanel themeId="theme-1" phaseData={firstPhaseData} onChange={vi.fn()} />,
+    );
+    expect(screen.getByText("탐정 A · 1개 정보")).toBeDefined();
+
+    rerender(<InformationDeliveryPanel themeId="theme-1" phaseData={nextPhaseData} onChange={vi.fn()} />);
+
+    expect(screen.getByText("용의자 B · 1개 정보")).toBeDefined();
+  });
+
   it("스토리 진행 페이즈에서는 모든 플레이어 공통 전달을 추가할 수 있다", () => {
     const onChange = vi.fn();
     render(
       <InformationDeliveryPanel
         themeId="theme-1"
-
         phaseData={{ phase_type: "story_progression" }}
         onChange={onChange}
       />,

--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -204,6 +204,21 @@ describe("InformationDeliveryPanel", () => {
     expect(screen.getByText("용의자 B · 1개 정보")).toBeDefined();
   });
 
+
+  it("캐릭터가 없으면 캐릭터별 추가를 비활성화하고 안내한다", () => {
+    useEditorCharactersMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
+
+    expect((screen.getByRole("button", { name: "캐릭터별 추가" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("받을 캐릭터가 없습니다. 먼저 캐릭터를 만든 뒤 캐릭터별 정보 전달을 설정해 주세요.")).toBeDefined();
+  });
+
   it("스토리 진행 페이즈에서는 모든 플레이어 공통 전달을 추가할 수 있다", () => {
     const onChange = vi.fn();
     render(

--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { FlowNodeData } from "../../../flowTypes";
+import { InformationDeliveryPanel } from "../InformationDeliveryPanel";
+import { DELIVER_INFORMATION_ACTION } from "../phaseEditorAdapter";
+
+const { useEditorCharactersMock, useReadingSectionsMock } = vi.hoisted(() => ({
+  useEditorCharactersMock: vi.fn(),
+  useReadingSectionsMock: vi.fn(),
+}));
+
+vi.mock("../../../api", () => ({
+  useEditorCharacters: () => useEditorCharactersMock(),
+}));
+
+vi.mock("../../../readingApi", () => ({
+  useReadingSections: () => useReadingSectionsMock(),
+}));
+
+vi.stubGlobal("crypto", { randomUUID: () => "delivery-new" });
+
+const characters = [
+  { id: "char-1", name: "탐정 A" },
+  { id: "char-2", name: "용의자 B" },
+];
+
+const sections = [
+  { id: "rs-1", name: "비밀 편지", lines: [{ Text: "편지" }] },
+  { id: "rs-2", name: "저택 소문", lines: [{ Text: "소문" }, { Text: "증언" }] },
+];
+
+beforeEach(() => {
+  useEditorCharactersMock.mockReturnValue({ data: characters, isLoading: false });
+  useReadingSectionsMock.mockReturnValue({ data: sections, isLoading: false });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("InformationDeliveryPanel", () => {
+  it("모든 페이즈에서 캐릭터별 정보 전달 설정을 추가할 수 있다", () => {
+    const onChange = vi.fn();
+    render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "캐릭터별 추가" }));
+
+    expect(screen.getByText("받을 캐릭터를 선택하세요 · 0개 정보")).toBeDefined();
+    expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
+  });
+
+  it("캐릭터와 전달 정보를 검색하고 여러 정보를 선택/삭제할 수 있다", () => {
+    const onChange = vi.fn();
+    const phaseData: FlowNodeData = {
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character" },
+                reading_section_ids: ["rs-1"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    render(<InformationDeliveryPanel themeId="theme-1" phaseData={phaseData} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText("이름으로 찾기"), {
+      target: { value: "용의자" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /용의자 B/ }));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-2" },
+                reading_section_ids: ["rs-1"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("정보 이름으로 찾기"), {
+      target: { value: "저택" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /저택 소문/ }));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-2" },
+                reading_section_ids: ["rs-1", "rs-2"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "전달 설정 1 삭제" }));
+    expect(onChange).toHaveBeenLastCalledWith({ onEnter: [] });
+  });
+
+  it("스토리 진행 페이즈에서는 모든 플레이어 공통 전달을 추가할 수 있다", () => {
+    const onChange = vi.fn();
+    render(
+      <InformationDeliveryPanel
+        themeId="theme-1"
+
+        phaseData={{ phase_type: "story_progression" }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "전체 전달" }));
+
+    expect(screen.getByText("모든 플레이어 · 0개 정보")).toBeDefined();
+    expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNode.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNode.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 
 // ---------------------------------------------------------------------------
@@ -63,6 +63,11 @@ describe("PhaseNode", () => {
   it("data.phase_type이 있으면 한국어 타입명을 표시한다", () => {
     render(<PhaseNode {...makeProps({ phase_type: "investigation" })} />);
     expect(screen.getByText("수사")).toBeDefined();
+  });
+
+  it("스토리 진행 phase type을 제작자용 라벨로 표시한다", () => {
+    render(<PhaseNode {...makeProps({ phase_type: "story_progression" })} />);
+    expect(screen.getByText("스토리 진행")).toBeDefined();
   });
 
   it("data.duration이 있으면 분 단위로 표시한다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FlowNodeData } from "../../../flowTypes";
+import {
+  DELIVER_INFORMATION_ACTION,
+  flowNodeToInformationDeliveries,
+  informationDeliveriesToFlowNodePatch,
+} from "../phaseEditorAdapter";
+
+vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
+
+describe("phaseEditorAdapter", () => {
+  it("API flow node의 정보 전달 action을 제작자용 ViewModel로 변환한다", () => {
+    const data: FlowNodeData = {
+      onEnter: [
+        { id: "a1", type: "broadcast", params: { message: "시작" } },
+        {
+          id: "info-1",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-1" },
+                reading_section_ids: ["rs-1", "rs-2", "rs-1"],
+              },
+              {
+                id: "d2",
+                target: { type: "all_players" },
+                reading_section_ids: ["rs-common"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(flowNodeToInformationDeliveries(data)).toEqual([
+      {
+        id: "d1",
+        recipientType: "character",
+        characterId: "char-1",
+        readingSectionIds: ["rs-1", "rs-2"],
+      },
+      {
+        id: "d2",
+        recipientType: "all_players",
+        readingSectionIds: ["rs-common"],
+      },
+    ]);
+  });
+
+  it("정보 전달 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다", () => {
+    const data: FlowNodeData = {
+      onEnter: [
+        { id: "legacy", type: "deliver_information", params: { deliveries: [] } },
+        { id: "bgm", type: "play_bgm", params: { mediaId: "bgm-1" } },
+      ],
+    };
+
+    const patch = informationDeliveriesToFlowNodePatch(data, [
+      {
+        id: "draft",
+        recipientType: "character",
+        readingSectionIds: [],
+      },
+      {
+        id: "d1",
+        recipientType: "character",
+        characterId: "char-1",
+        readingSectionIds: ["rs-1", "rs-2", "rs-1"],
+      },
+    ]);
+
+    expect(patch.onEnter).toEqual([
+      { id: "bgm", type: "play_bgm", params: { mediaId: "bgm-1" } },
+      {
+        id: "legacy",
+        type: DELIVER_INFORMATION_ACTION,
+        params: {
+          deliveries: [
+            {
+              id: "d1",
+              target: { type: "character", character_id: "char-1" },
+              reading_section_ids: ["rs-1", "rs-2"],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("마지막 전달 설정을 삭제하면 정보 전달 action만 제거하고 다른 action은 유지한다", () => {
+    const data: FlowNodeData = {
+      onEnter: [
+        { id: "info", type: DELIVER_INFORMATION_ACTION, params: { deliveries: [] } },
+        { id: "chat", type: "enable_chat" },
+      ],
+    };
+
+    expect(informationDeliveriesToFlowNodePatch(data, [])).toEqual({
+      onEnter: [{ id: "chat", type: "enable_chat" }],
+    });
+  });
+
+  it("미완성 전달 설정은 저장 payload에서 제외한다", () => {
+    const data: FlowNodeData = { onEnter: [{ id: "chat", type: "enable_chat" }] };
+
+    expect(
+      informationDeliveriesToFlowNodePatch(data, [
+        { id: "empty", recipientType: "character", readingSectionIds: [] },
+        { id: "no-character", recipientType: "character", readingSectionIds: ["rs-1"] },
+        { id: "no-section", recipientType: "all_players", readingSectionIds: [] },
+      ]),
+    ).toEqual({ onEnter: [{ id: "chat", type: "enable_chat" }] });
+  });
+
+});

--- a/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
@@ -114,4 +114,47 @@ describe("phaseEditorAdapter", () => {
     ).toEqual({ onEnter: [{ id: "chat", type: "enable_chat" }] });
   });
 
+
+  it("스토리 진행 페이즈가 아니면 all_players 전달 설정을 저장하지 않는다", () => {
+    expect(
+      informationDeliveriesToFlowNodePatch(
+        { phase_type: "investigation" },
+        [
+          {
+            id: "all",
+            recipientType: "all_players",
+            readingSectionIds: ["rs-common"],
+          },
+        ],
+      ),
+    ).toEqual({ onEnter: [] });
+
+    expect(
+      informationDeliveriesToFlowNodePatch(
+        { phase_type: "story_progression" },
+        [
+          {
+            id: "all",
+            recipientType: "all_players",
+            readingSectionIds: ["rs-common"],
+          },
+        ],
+      ).onEnter,
+    ).toEqual([
+      {
+        id: "generated-id",
+        type: DELIVER_INFORMATION_ACTION,
+        params: {
+          deliveries: [
+            {
+              id: "all",
+              target: { type: "all_players" },
+              reading_section_ids: ["rs-common"],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
 });

--- a/apps/web/src/features/editor/components/design/phaseEditorAdapter.ts
+++ b/apps/web/src/features/editor/components/design/phaseEditorAdapter.ts
@@ -1,0 +1,164 @@
+import type { FlowNodeData, PhaseAction } from "../../flowTypes";
+
+export const DELIVER_INFORMATION_ACTION = "DELIVER_INFORMATION";
+const LEGACY_DELIVER_INFORMATION_ACTION = "deliver_information";
+
+export type InformationRecipientType = "character" | "all_players";
+
+export interface InformationDeliveryViewModel {
+  id: string;
+  recipientType: InformationRecipientType;
+  characterId?: string;
+  readingSectionIds: string[];
+}
+
+interface StoredInformationDelivery {
+  id?: string;
+  target?: {
+    type?: unknown;
+    character_id?: unknown;
+  };
+  recipient_type?: unknown;
+  character_id?: unknown;
+  reading_section_ids?: unknown;
+  readingSectionIds?: unknown;
+}
+
+interface DeliverInformationParams {
+  deliveries?: unknown;
+}
+
+export function isDeliverInformationAction(action: PhaseAction): boolean {
+  return (
+    action.type === DELIVER_INFORMATION_ACTION ||
+    action.type === LEGACY_DELIVER_INFORMATION_ACTION
+  );
+}
+
+export function flowNodeToInformationDeliveries(
+  data: FlowNodeData,
+): InformationDeliveryViewModel[] {
+  const action = findDeliverInformationAction(data.onEnter ?? []);
+  const deliveries = readDeliveries(action?.params);
+  return deliveries.map(normalizeDelivery);
+}
+
+export function informationDeliveriesToFlowNodePatch(
+  data: FlowNodeData,
+  deliveries: InformationDeliveryViewModel[],
+): Pick<FlowNodeData, "onEnter"> {
+  const nextActions = withoutDeliverInformationActions(data.onEnter ?? []);
+  const normalized = deliveries.map(normalizeViewModel).filter(isCompleteDelivery);
+
+  if (normalized.length === 0) {
+    return { onEnter: nextActions };
+  }
+
+  return {
+    onEnter: [
+      ...nextActions,
+      {
+        id: findDeliverInformationAction(data.onEnter ?? [])?.id ?? makeId(),
+        type: DELIVER_INFORMATION_ACTION,
+        params: {
+          deliveries: normalized.map(toStoredDelivery),
+        },
+      },
+    ],
+  };
+}
+
+export function makeEmptyInformationDelivery(
+  recipientType: InformationRecipientType = "character",
+): InformationDeliveryViewModel {
+  return {
+    id: makeId(),
+    recipientType,
+    readingSectionIds: [],
+  };
+}
+
+function findDeliverInformationAction(actions: PhaseAction[]): PhaseAction | undefined {
+  return actions.find(isDeliverInformationAction);
+}
+
+function withoutDeliverInformationActions(actions: PhaseAction[]): PhaseAction[] {
+  return actions.filter((action) => !isDeliverInformationAction(action));
+}
+
+function readDeliveries(params: PhaseAction["params"]): StoredInformationDelivery[] {
+  if (!params || typeof params !== "object") return [];
+  const maybeDeliveries = (params as DeliverInformationParams).deliveries;
+  return Array.isArray(maybeDeliveries)
+    ? (maybeDeliveries as StoredInformationDelivery[])
+    : [];
+}
+
+function normalizeDelivery(
+  delivery: StoredInformationDelivery,
+): InformationDeliveryViewModel {
+  const targetType =
+    delivery.target?.type === "all_players" || delivery.recipient_type === "all_players"
+      ? "all_players"
+      : "character";
+  const rawSectionIds = Array.isArray(delivery.reading_section_ids)
+    ? delivery.reading_section_ids
+    : Array.isArray(delivery.readingSectionIds)
+      ? delivery.readingSectionIds
+      : [];
+
+  return normalizeViewModel({
+    id: typeof delivery.id === "string" && delivery.id ? delivery.id : makeId(),
+    recipientType: targetType,
+    characterId:
+      typeof delivery.target?.character_id === "string"
+        ? delivery.target.character_id
+        : typeof delivery.character_id === "string"
+          ? delivery.character_id
+          : undefined,
+    readingSectionIds: rawSectionIds.filter(
+      (id): id is string => typeof id === "string" && id.length > 0,
+    ),
+  });
+}
+
+function normalizeViewModel(
+  delivery: InformationDeliveryViewModel,
+): InformationDeliveryViewModel {
+  const uniqueSectionIds = Array.from(new Set(delivery.readingSectionIds)).filter(Boolean);
+  if (delivery.recipientType === "all_players") {
+    return {
+      id: delivery.id || makeId(),
+      recipientType: "all_players",
+      readingSectionIds: uniqueSectionIds,
+    };
+  }
+  return {
+    id: delivery.id || makeId(),
+    recipientType: "character",
+    characterId: delivery.characterId,
+    readingSectionIds: uniqueSectionIds,
+  };
+}
+
+function isCompleteDelivery(delivery: InformationDeliveryViewModel): boolean {
+  if (delivery.readingSectionIds.length === 0) return false;
+  return delivery.recipientType === "all_players" || Boolean(delivery.characterId);
+}
+
+function toStoredDelivery(delivery: InformationDeliveryViewModel) {
+  return {
+    id: delivery.id,
+    target:
+      delivery.recipientType === "all_players"
+        ? { type: "all_players" }
+        : { type: "character", character_id: delivery.characterId },
+    reading_section_ids: delivery.readingSectionIds,
+  };
+}
+
+function makeId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `delivery-${Math.random().toString(36).slice(2)}`;
+}

--- a/apps/web/src/features/editor/components/design/phaseEditorAdapter.ts
+++ b/apps/web/src/features/editor/components/design/phaseEditorAdapter.ts
@@ -48,7 +48,11 @@ export function informationDeliveriesToFlowNodePatch(
   deliveries: InformationDeliveryViewModel[],
 ): Pick<FlowNodeData, "onEnter"> {
   const nextActions = withoutDeliverInformationActions(data.onEnter ?? []);
-  const normalized = deliveries.map(normalizeViewModel).filter(isCompleteDelivery);
+  const allowAllPlayers = data.phase_type === "story_progression";
+  const normalized = deliveries
+    .map(normalizeViewModel)
+    .filter((delivery) => allowAllPlayers || delivery.recipientType !== "all_players")
+    .filter(isCompleteInformationDelivery);
 
   if (normalized.length === 0) {
     return { onEnter: nextActions };
@@ -141,7 +145,7 @@ function normalizeViewModel(
   };
 }
 
-function isCompleteDelivery(delivery: InformationDeliveryViewModel): boolean {
+export function isCompleteInformationDelivery(delivery: InformationDeliveryViewModel): boolean {
   if (delivery.readingSectionIds.length === 0) return false;
   return delivery.recipientType === "all_players" || Boolean(delivery.characterId);
 }

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -2,7 +2,7 @@
 phase_id: "phase-24-editor-redesign"
 phase_title: "Phase 24 — 에디터 ECS 재설계 (단서 단일 진실 위치 + 동적 모듈 + 결말 분기 매트릭스)"
 created: 2026-05-01
-status: "issue-based Phase 24 continuation — PR-5A active"
+status: "issue-based Phase 24 continuation — PR-5B active"
 spec: "docs/superpowers/specs/2026-05-01-phase-24-editor-redesign/design.md"
 prs_estimated: "issue-based: PR-5A~PR-9 active after PR-4"
 parent_phase: "phase-21-editor-ux"
@@ -35,8 +35,8 @@ parent_phase: "phase-21-editor-ux"
 
 | Issue | PR | 범위 | 상태 |
 | --- | --- | --- | --- |
-| [#230](https://github.com/sabyunrepo/muder_platform/issues/230) | PR-5A | Adapter/Engine 공통 계약 및 Issue 기반 전환 | active |
-| [#231](https://github.com/sabyunrepo/muder_platform/issues/231) | PR-5B | 페이즈 정보 전달 Frontend Adapter | next |
+| [#230](https://github.com/sabyunrepo/muder_platform/issues/230) | PR-5A | Adapter/Engine 공통 계약 및 Issue 기반 전환 | done |
+| [#231](https://github.com/sabyunrepo/muder_platform/issues/231) | PR-5B | 페이즈 정보 전달 Frontend Adapter | active |
 | [#232](https://github.com/sabyunrepo/muder_platform/issues/232) | PR-5C | 정보 전달 Backend Engine 및 런타임 공개 상태 | queued |
 | [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | brainstorming gate |
 | [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | brainstorming gate |


### PR DESCRIPTION
## 요약

- 페이즈 설정 패널에 `정보 전달` 전용 섹션을 추가했습니다.
- 제작자가 받을 캐릭터를 검색/선택하고, 전달할 스토리 정보를 여러 개 선택할 수 있게 했습니다.
- `story_progression` 페이즈에서는 모든 플레이어에게 공통 정보를 전달하는 편의 입력을 제공합니다.
- 저장 payload는 `DELIVER_INFORMATION` 액션으로 정규화하고, 미완성 전달 설정은 저장하지 않도록 adapter에서 필터링했습니다.

## 설계 기준

- 프론트는 제작자용 ViewModel과 저장 payload 변환을 담당하는 Adapter 역할만 수행합니다.
- 실제 게임 중 캐릭터별 공개 상태, 재접속 유지, 중복 전달 방지는 후속 PR-5C 백엔드 Engine에서 처리합니다.
- 제작자 화면에는 내부 ID, JSON shape, engine key를 노출하지 않습니다.

## 검증

- `cd apps/web && pnpm exec vitest run src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx src/features/editor/components/design/__tests__/PhaseNode.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx`
- `cd apps/web && pnpm typecheck`
- `cd apps/web && pnpm exec playwright test e2e/phase24-editor-information-delivery.spec.ts --project=chromium`
- `cd apps/web && pnpm lint`
- `git diff --check`

## PR 운영 메모

- 의도적으로 `ready-for-ci` 라벨은 붙이지 않았습니다.
- CodeRabbit 리뷰를 먼저 확인하고, 타당한 리뷰만 반영한 뒤 재리뷰까지 완료되면 `ready-for-ci` 라벨로 CI를 시작합니다.

Closes #231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 페이즈용 정보 전달 편집 패널 추가(캐릭터별·전체 플레이어 대상, 검색·선택·섹션 토글, 추가/삭제, 실시간 저장)
  * 편집기 UI에 "스토리 진행" 페이즈 타입 표시 추가
  * 액션 편집기에 특정 액션 유형을 숨기는 옵션 추가

* **테스트**
  * InformationDeliveryPanel 유닛/통합 테스트 추가 및 E2E 시나리오 보강(편집 흐름, PATCH 전송 검증, 접근성 검사 포함)

* **문서/플랜**
  * Phase 24 체크리스트 상태 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->