### PR TITLE
feat(editor): 캐릭터 Adapter/Engine 경계 정리

### DIFF
--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -23,31 +22,12 @@ const (
 	MysteryRoleDetective  = "detective"
 )
 
-func normalizeMysteryRole(role string, isCulprit bool) (string, error) {
-	if role == "" {
-		if isCulprit {
-			return MysteryRoleCulprit, nil
-		}
-		return MysteryRoleSuspect, nil
-	}
-
-	switch role {
-	case MysteryRoleSuspect, MysteryRoleCulprit, MysteryRoleAccomplice, MysteryRoleDetective:
-		if isCulprit && role != MysteryRoleCulprit {
-			return "", apperror.BadRequest("mystery_role conflicts with is_culprit")
-		}
-		return role, nil
-	default:
-		return "", apperror.BadRequest(fmt.Sprintf("invalid mystery_role: %s", role))
-	}
-}
-
 func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.UUID, req CreateCharacterRequest) (*CharacterResponse, error) {
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
 		return nil, err
 	}
 
-	mysteryRole, err := normalizeMysteryRole(req.MysteryRole, req.IsCulprit)
+	rolePolicy, err := BuildCharacterRolePolicy(req.MysteryRole, req.IsCulprit)
 	if err != nil {
 		return nil, err
 	}
@@ -57,8 +37,8 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		Name:        req.Name,
 		Description: ptrToText(req.Description),
 		ImageUrl:    ptrToText(req.ImageURL),
-		IsCulprit:   mysteryRole == MysteryRoleCulprit,
-		MysteryRole: mysteryRole,
+		IsCulprit:   rolePolicy.IsCulprit,
+		MysteryRole: rolePolicy.MysteryRole,
 		SortOrder:   req.SortOrder,
 	})
 	if err != nil {
@@ -81,7 +61,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		return nil, err
 	}
 
-	mysteryRole, err := normalizeMysteryRole(req.MysteryRole, req.IsCulprit)
+	rolePolicy, err := BuildCharacterRolePolicy(req.MysteryRole, req.IsCulprit)
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +71,8 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		Name:        req.Name,
 		Description: ptrToText(req.Description),
 		ImageUrl:    ptrToText(req.ImageURL),
-		IsCulprit:   mysteryRole == MysteryRoleCulprit,
-		MysteryRole: mysteryRole,
+		IsCulprit:   rolePolicy.IsCulprit,
+		MysteryRole: rolePolicy.MysteryRole,
 		SortOrder:   req.SortOrder,
 	})
 	if err != nil {

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -48,6 +48,54 @@ func TestNormalizeMysteryRole(t *testing.T) {
 	}
 }
 
+func TestCharacterRolePolicy(t *testing.T) {
+	tests := []struct {
+		name                string
+		role                string
+		legacyIsCulprit     bool
+		wantRole            string
+		wantCulprit         bool
+		wantSpoiler         bool
+		wantVotingCandidate bool
+		wantErr             bool
+	}{
+		{name: "empty role defaults to suspect", wantRole: MysteryRoleSuspect, wantVotingCandidate: true},
+		{name: "legacy culprit flag maps to culprit", legacyIsCulprit: true, wantRole: MysteryRoleCulprit, wantCulprit: true, wantSpoiler: true, wantVotingCandidate: true},
+		{name: "explicit culprit is spoiler and candidate", role: MysteryRoleCulprit, wantRole: MysteryRoleCulprit, wantCulprit: true, wantSpoiler: true, wantVotingCandidate: true},
+		{name: "accomplice is spoiler but not culprit", role: MysteryRoleAccomplice, wantRole: MysteryRoleAccomplice, wantSpoiler: true, wantVotingCandidate: true},
+		{name: "detective is spoiler and excluded by default voting policy", role: MysteryRoleDetective, wantRole: MysteryRoleDetective, wantSpoiler: true, wantVotingCandidate: false},
+		{name: "legacy culprit cannot conflict with detective", role: MysteryRoleDetective, legacyIsCulprit: true, wantErr: true},
+		{name: "unknown role is rejected", role: "gm", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildCharacterRolePolicy(tc.role, tc.legacyIsCulprit)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildCharacterRolePolicy: %v", err)
+			}
+			if got.MysteryRole != tc.wantRole {
+				t.Fatalf("MysteryRole = %q, want %q", got.MysteryRole, tc.wantRole)
+			}
+			if got.IsCulprit != tc.wantCulprit {
+				t.Fatalf("IsCulprit = %v, want %v", got.IsCulprit, tc.wantCulprit)
+			}
+			if got.IsSpoiler != tc.wantSpoiler {
+				t.Fatalf("IsSpoiler = %v, want %v", got.IsSpoiler, tc.wantSpoiler)
+			}
+			if got.DefaultVotingCandidate != tc.wantVotingCandidate {
+				t.Fatalf("DefaultVotingCandidate = %v, want %v", got.DefaultVotingCandidate, tc.wantVotingCandidate)
+			}
+		})
+	}
+}
+
 func TestService_CreateCharacter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/apps/server/internal/domain/editor/service_character_policy.go
+++ b/apps/server/internal/domain/editor/service_character_policy.go
@@ -1,0 +1,58 @@
+package editor
+
+import (
+	"fmt"
+
+	"github.com/mmp-platform/server/internal/apperror"
+)
+
+// CharacterRolePolicy is the backend runtime interpretation of an editor
+// character role. UI labels and layout must not be used as runtime truth; this
+// policy keeps spoiler, culprit, and voting defaults testable without React.
+type CharacterRolePolicy struct {
+	MysteryRole            string
+	IsCulprit              bool
+	IsSpoiler              bool
+	DefaultVotingCandidate bool
+}
+
+func BuildCharacterRolePolicy(role string, legacyIsCulprit bool) (CharacterRolePolicy, error) {
+	normalized, err := normalizeCharacterMysteryRole(role, legacyIsCulprit)
+	if err != nil {
+		return CharacterRolePolicy{}, err
+	}
+
+	return CharacterRolePolicy{
+		MysteryRole:            normalized,
+		IsCulprit:              normalized == MysteryRoleCulprit,
+		IsSpoiler:              normalized == MysteryRoleCulprit || normalized == MysteryRoleAccomplice || normalized == MysteryRoleDetective,
+		DefaultVotingCandidate: normalized != MysteryRoleDetective,
+	}, nil
+}
+
+func normalizeCharacterMysteryRole(role string, legacyIsCulprit bool) (string, error) {
+	if role == "" {
+		if legacyIsCulprit {
+			return MysteryRoleCulprit, nil
+		}
+		return MysteryRoleSuspect, nil
+	}
+
+	switch role {
+	case MysteryRoleSuspect, MysteryRoleCulprit, MysteryRoleAccomplice, MysteryRoleDetective:
+		if legacyIsCulprit && role != MysteryRoleCulprit {
+			return "", apperror.BadRequest("mystery_role conflicts with is_culprit")
+		}
+		return role, nil
+	default:
+		return "", apperror.BadRequest(fmt.Sprintf("invalid mystery_role: %s", role))
+	}
+}
+
+func normalizeMysteryRole(role string, isCulprit bool) (string, error) {
+	policy, err := BuildCharacterRolePolicy(role, isCulprit)
+	if err != nil {
+		return "", err
+	}
+	return policy.MysteryRole, nil
+}

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -9,6 +9,10 @@ import {
   readCharacterStartingClueMap,
   writeCharacterStartingClueMap,
 } from "@/features/editor/utils/configShape";
+import {
+  buildCharacterRoleUpdatePayload,
+  getCharacterRoleBadge,
+} from "@/features/editor/entities/character/characterEditorAdapter";
 
 interface CharacterAssignPanelProps {
   themeId: string;
@@ -106,14 +110,7 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
 
       updateCharacter.mutate({
         characterId: selected.id,
-        body: {
-          name: selected.name,
-          description: selected.description ?? undefined,
-          image_url: selected.image_url ?? undefined,
-          is_culprit: role === "culprit",
-          mystery_role: role,
-          sort_order: selected.sort_order,
-        },
+        body: buildCharacterRoleUpdatePayload(selected, role),
       });
     },
     [characters, updateCharacter],
@@ -160,7 +157,7 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
         getItemId={(char) => char.id}
         getItemTitle={(char) => char.name}
         getItemDescription={(char) => char.description ?? ''}
-        getItemBadges={(char) => [formatMysteryRoleBadge(char.mystery_role, char.is_culprit)]}
+        getItemBadges={(char) => [getCharacterRoleBadge(char)]}
         renderDetail={(char) => (
           <CharacterDetailPanel
             themeId={themeId}
@@ -179,12 +176,4 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
       />
     </div>
   );
-}
-
-
-function formatMysteryRoleBadge(role: MysteryRole | undefined, isCulprit: boolean | undefined) {
-  if (role === "culprit" || (!role && isCulprit)) return "범인";
-  if (role === "accomplice") return "공범";
-  if (role === "detective") return "탐정";
-  return "용의자";
 }

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -4,6 +4,11 @@ import type { Mission } from './MissionEditor';
 import { MissionEditor } from './MissionEditor';
 import { StartingClueAssigner } from './StartingClueAssigner';
 import { CharacterRoleSheetSection } from './CharacterRoleSheetSection';
+import {
+  characterRoleOptions,
+  getCharacterRoleOption,
+  normalizeCharacterEditorRole,
+} from '@/features/editor/entities/character/characterEditorAdapter';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,17 +45,6 @@ interface CharacterDetailPanelProps {
   onMysteryRoleChange?: (role: MysteryRole) => void;
 }
 
-const mysteryRoleOptions: Array<{ value: MysteryRole; label: string; description: string }> = [
-  { value: 'suspect', label: '용의자', description: '일반 투표 후보' },
-  { value: 'culprit', label: '범인', description: '정답 캐릭터' },
-  { value: 'accomplice', label: '공범', description: '범인을 돕는 캐릭터' },
-  { value: 'detective', label: '탐정', description: '투표 후보 포함 여부를 별도 설정' },
-];
-
-function getMysteryRoleLabel(role: MysteryRole) {
-  return mysteryRoleOptions.find((option) => option.value === role)?.label ?? '용의자';
-}
-
 // ---------------------------------------------------------------------------
 // CharacterDetailPanel
 // ---------------------------------------------------------------------------
@@ -76,8 +70,7 @@ export function CharacterDetailPanel({
     );
   }
 
-  const selectedRole: MysteryRole = selectedChar.mystery_role
-    ?? (selectedChar.is_culprit ? 'culprit' : 'suspect');
+  const selectedRole: MysteryRole = normalizeCharacterEditorRole(selectedChar);
 
   return (
     <div className="max-w-5xl space-y-4">
@@ -92,7 +85,7 @@ export function CharacterDetailPanel({
           {
             id: 'base',
             title: '기본 정보',
-            subtitle: `${getMysteryRoleLabel(selectedRole)} · 공개 소개`,
+            subtitle: `${getCharacterRoleOption(selectedRole).label} · 공개 소개`,
             defaultOpen: true,
             forceOpen: true,
             children: (
@@ -108,7 +101,7 @@ export function CharacterDetailPanel({
                   <div>
                     <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">역할</p>
                     <div className="mt-2 grid gap-2 sm:grid-cols-2">
-                      {mysteryRoleOptions.map((option) => {
+                      {characterRoleOptions.map((option) => {
                         const active = selectedRole === option.value;
                         return (
                           <button

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { EditorCharacterResponse } from '@/features/editor/api/types';
+import {
+  buildCharacterRoleUpdatePayload,
+  getCharacterRoleBadge,
+  normalizeCharacterEditorRole,
+  toCharacterEditorViewModel,
+} from '../characterEditorAdapter';
+
+function character(overrides: Partial<EditorCharacterResponse> = {}): EditorCharacterResponse {
+  return {
+    id: 'char-1',
+    theme_id: 'theme-1',
+    name: '홍길동',
+    description: '공개 소개',
+    image_url: null,
+    is_culprit: false,
+    mystery_role: 'suspect',
+    sort_order: 3,
+    ...overrides,
+  };
+}
+
+describe('characterEditorAdapter', () => {
+  it('API 캐릭터를 제작자용 ViewModel로 변환한다', () => {
+    const vm = toCharacterEditorViewModel(character({ mystery_role: 'detective', image_url: 'https://cdn.example/detective.webp' }));
+
+    expect(vm).toMatchObject({
+      id: 'char-1',
+      name: '홍길동',
+      description: '공개 소개',
+      imageUrl: 'https://cdn.example/detective.webp',
+      role: 'detective',
+      roleLabel: '탐정',
+      roleBadge: '탐정',
+      isSpoilerRole: true,
+      isDefaultVotingCandidate: false,
+      hasPublicIntro: true,
+    });
+  });
+
+  it('legacy is_culprit 플래그만 있어도 범인 역할로 보존한다', () => {
+    expect(normalizeCharacterEditorRole(character({ mystery_role: undefined as unknown as EditorCharacterResponse['mystery_role'], is_culprit: true }))).toBe('culprit');
+    expect(getCharacterRoleBadge(character({ mystery_role: undefined as unknown as EditorCharacterResponse['mystery_role'], is_culprit: true }))).toBe('범인');
+  });
+
+  it('역할 변경 저장 payload에서 mystery_role과 is_culprit를 일관되게 만든다', () => {
+    const payload = buildCharacterRoleUpdatePayload(character({ image_url: 'https://cdn.example/a.webp' }), 'accomplice');
+
+    expect(payload).toEqual({
+      name: '홍길동',
+      description: '공개 소개',
+      image_url: 'https://cdn.example/a.webp',
+      is_culprit: false,
+      mystery_role: 'accomplice',
+      sort_order: 3,
+    });
+  });
+
+  it('범인으로 변경할 때만 legacy is_culprit를 true로 보낸다', () => {
+    expect(buildCharacterRoleUpdatePayload(character(), 'culprit').is_culprit).toBe(true);
+    expect(buildCharacterRoleUpdatePayload(character(), 'detective').is_culprit).toBe(false);
+  });
+});

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -1,0 +1,114 @@
+import type {
+  EditorCharacterResponse,
+  MysteryRole,
+  UpdateCharacterRequest,
+} from '@/features/editor/api/types';
+
+export interface CharacterRoleOption {
+  value: MysteryRole;
+  label: string;
+  description: string;
+  spoiler: boolean;
+  defaultVotingCandidate: boolean;
+}
+
+export interface CharacterEditorViewModel {
+  id: string;
+  name: string;
+  description: string;
+  imageUrl: string | null;
+  sortOrder: number;
+  role: MysteryRole;
+  roleLabel: string;
+  roleDescription: string;
+  roleBadge: string;
+  isSpoilerRole: boolean;
+  isDefaultVotingCandidate: boolean;
+  hasPublicIntro: boolean;
+}
+
+export const characterRoleOptions: CharacterRoleOption[] = [
+  {
+    value: 'suspect',
+    label: '용의자',
+    description: '일반 투표 후보입니다.',
+    spoiler: false,
+    defaultVotingCandidate: true,
+  },
+  {
+    value: 'culprit',
+    label: '범인',
+    description: '정답 캐릭터입니다. 플레이어 화면에는 숨겨집니다.',
+    spoiler: true,
+    defaultVotingCandidate: true,
+  },
+  {
+    value: 'accomplice',
+    label: '공범',
+    description: '범인을 돕는 캐릭터입니다. 결말 판정에서 별도로 사용할 수 있습니다.',
+    spoiler: true,
+    defaultVotingCandidate: true,
+  },
+  {
+    value: 'detective',
+    label: '탐정',
+    description: '추리 진행자 역할입니다. 투표 후보 포함 여부는 투표 설정에서 정합니다.',
+    spoiler: true,
+    defaultVotingCandidate: false,
+  },
+];
+
+const roleOptionMap = new Map<MysteryRole, CharacterRoleOption>(
+  characterRoleOptions.map((option) => [option.value, option]),
+);
+
+export function getCharacterRoleOption(role: MysteryRole): CharacterRoleOption {
+  return roleOptionMap.get(role) ?? roleOptionMap.get('suspect')!;
+}
+
+export function normalizeCharacterEditorRole(character: { mystery_role?: MysteryRole | null; is_culprit?: boolean | null }): MysteryRole {
+  if (character.mystery_role) return character.mystery_role;
+  return character.is_culprit ? 'culprit' : 'suspect';
+}
+
+export function toCharacterEditorViewModel(character: EditorCharacterResponse): CharacterEditorViewModel {
+  const role = normalizeCharacterEditorRole(character);
+  const option = getCharacterRoleOption(role);
+
+  return {
+    id: character.id,
+    name: character.name,
+    description: character.description?.trim() ?? '',
+    imageUrl: character.image_url,
+    sortOrder: character.sort_order,
+    role,
+    roleLabel: option.label,
+    roleDescription: option.description,
+    roleBadge: option.label,
+    isSpoilerRole: option.spoiler,
+    isDefaultVotingCandidate: option.defaultVotingCandidate,
+    hasPublicIntro: Boolean(character.description?.trim() || character.image_url),
+  };
+}
+
+export function toCharacterEditorViewModels(characters: EditorCharacterResponse[]): CharacterEditorViewModel[] {
+  return characters.map(toCharacterEditorViewModel);
+}
+
+export function buildCharacterRoleUpdatePayload(
+  character: EditorCharacterResponse,
+  role: MysteryRole,
+): UpdateCharacterRequest {
+  return {
+    name: character.name,
+    description: character.description ?? undefined,
+    image_url: character.image_url ?? undefined,
+    is_culprit: role === 'culprit',
+    mystery_role: role,
+    sort_order: character.sort_order,
+  };
+}
+
+export function getCharacterRoleBadge(character: { mystery_role?: MysteryRole | null; is_culprit?: boolean | null }): string {
+  return getCharacterRoleOption(normalizeCharacterEditorRole(character)).label;
+}

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -2,7 +2,7 @@
 phase_id: "phase-24-editor-redesign"
 phase_title: "Phase 24 — 에디터 ECS 재설계 (단서 단일 진실 위치 + 동적 모듈 + 결말 분기 매트릭스)"
 created: 2026-05-01
-status: "issue-based Phase 24 continuation — PR-5C active"
+status: "issue-based Phase 24 continuation — PR-6 active"
 spec: "docs/superpowers/specs/2026-05-01-phase-24-editor-redesign/design.md"
 prs_estimated: "issue-based: PR-5A~PR-9 active after PR-4"
 parent_phase: "phase-21-editor-ux"
@@ -37,8 +37,8 @@ parent_phase: "phase-21-editor-ux"
 | --- | --- | --- | --- |
 | [#230](https://github.com/sabyunrepo/muder_platform/issues/230) | PR-5A | Adapter/Engine 공통 계약 및 Issue 기반 전환 | done |
 | [#231](https://github.com/sabyunrepo/muder_platform/issues/231) | PR-5B | 페이즈 정보 전달 Frontend Adapter | done |
-| [#232](https://github.com/sabyunrepo/muder_platform/issues/232) | PR-5C | 정보 전달 Backend Engine 및 런타임 공개 상태 | active |
-| [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | brainstorming gate |
+| [#232](https://github.com/sabyunrepo/muder_platform/issues/232) | PR-5C | 정보 전달 Backend Engine 및 런타임 공개 상태 | done |
+| [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | active |
 | [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | brainstorming gate |
 | [#235](https://github.com/sabyunrepo/muder_platform/issues/235) | PR-8 | 장소 Adapter/Engine 이관 | brainstorming gate |
 | [#236](https://github.com/sabyunrepo/muder_platform/issues/236) | PR-9 | 결말/통합 Adapter-Engine 검증 및 E2E | brainstorming gate |

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-6-character-adapter-engine-plan.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-6-character-adapter-engine-plan.md
@@ -1,0 +1,79 @@
+# Phase 24 PR-6 — 캐릭터 Adapter/Engine 이관 계획
+
+## 상태
+
+- GitHub Issue: [#233](https://github.com/sabyunrepo/muder_platform/issues/233)
+- Branch: `feat/issue-233-character-adapter-engine`
+- 목표: 이미 구현된 캐릭터 역할/롤지/시작 단서 흐름을 유지하면서, 프론트는 제작자용 Adapter, 백엔드는 런타임 역할 정책 Engine 경계로 정리한다.
+
+## Uzu 참고점
+
+Uzu 캐릭터 문서에서 확인한 제작자 모델은 다음과 같다.
+
+- PC/NPC를 구분하고, NPC는 플레이 중 등장인물 소개에 표시할지 선택한다.
+- 캐릭터별 미션은 플레이 중 자동 배포가 아니라 감상/결과 공유 화면에서 판정된다.
+- 아이콘/닉네임은 조건에 따라 바뀔 수 있다.
+- 회차 플레이 캐릭터는 플레이 이력/예약/공개 운영 정책과 연결된다.
+
+## MMP 적용 방식
+
+PR-6에서는 Uzu 구조를 그대로 복제하지 않고 MMP의 현재 런타임 구조에 맞춰 다음만 적용한다.
+
+1. 기존 캐릭터 역할 모델을 안정화한다.
+   - `suspect`, `culprit`, `accomplice`, `detective`
+   - legacy `is_culprit`와 새 `mystery_role`의 충돌을 backend policy에서 차단한다.
+2. 프론트 캐릭터 화면은 API DTO를 직접 편집하지 않고 제작자용 ViewModel로 변환한다.
+3. 백엔드는 캐릭터 역할이 투표/스포일러/런타임 권한에 어떤 의미를 갖는지 policy 함수로 분리한다.
+4. 제작자 UI에는 internal ID, raw JSON, DB/config key를 노출하지 않는다.
+
+## 제외 / 후순위
+
+이번 PR에서 구현하지 않는다.
+
+- NPC 전체 런타임: Phase 24에서는 설계 메모만 남기고 Phase 25 후보로 둔다.
+- 캐릭터 미션 점수와 결말 통합: PR-9 결말/통합 검증에서 다룬다.
+- 조건부 이름/아이콘 변경: phase/ending 조건 엔진과 연결해야 하므로 후속으로 둔다.
+- 회차 플레이 캐릭터: 플레이 이력/예약/운영 정책이 필요하므로 Phase 25 후보로 둔다.
+
+## 구현 범위
+
+### Frontend Adapter
+
+- `CharacterEditorAdapter` 추가
+  - API `EditorCharacterResponse` → 제작자용 `CharacterEditorViewModel`
+  - 역할 라벨/설명/배지/스포일러 여부를 한 곳에서 관리
+  - 역할 변경 저장 payload 생성
+- `CharacterAssignPanel`과 `CharacterDetailPanel`에서 adapter를 사용한다.
+- adapter round-trip/role payload Vitest를 추가한다.
+
+### Backend Engine / Policy
+
+- `CharacterRolePolicy` 추가
+  - 역할 정규화
+  - legacy culprit flag 충돌 검증
+  - 스포일러 역할 여부
+  - 기본 투표 후보 포함 여부
+- `CreateCharacter`/`UpdateCharacter`는 policy 결과를 사용해 `is_culprit`를 결정한다.
+- policy unit test를 추가한다.
+
+## 테스트 계획
+
+- Frontend unit
+  - API 캐릭터가 제작자용 ViewModel으로 변환된다.
+  - legacy culprit flag가 `culprit` 배지로 보존된다.
+  - 역할 변경 payload가 `mystery_role`과 `is_culprit`를 일관되게 만든다.
+- Existing frontend component test
+  - 캐릭터 역할 변경 UI 회귀 검증 유지.
+- Backend unit
+  - role 정규화, 충돌 차단, 스포일러 판정, 투표 후보 기본 정책 검증.
+- Focused commands
+  - `pnpm --dir apps/web test -- src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx`
+  - `pnpm --dir apps/web typecheck`
+  - `go test ./internal/domain/editor -run 'TestCharacterRolePolicy|TestNormalizeMysteryRole|TestService_(CreateCharacter|UpdateCharacter|DeleteCharacter)'`
+
+## 완료 조건
+
+- 캐릭터 UI가 기존 기능을 잃지 않는다.
+- 캐릭터 역할/스포일러 정책이 React 없이 Go test로 검증된다.
+- Adapter가 API DTO와 제작자 ViewModel 사이의 책임을 갖는다.
+- PR 전 CodeRabbit/Codecov/CI 순서를 지킬 수 있게 변경 범위와 테스트 근거가 남는다.


### PR DESCRIPTION
## 목표

Phase 24 PR-6 범위로 기존 캐릭터 편집 기능을 유지하면서, 프론트는 제작자용 Adapter, 백엔드는 런타임 역할 Policy/Engine 경계로 정리합니다.

Closes #233

## 변경 사항

- `CharacterEditorAdapter` 추가
  - API 캐릭터 응답을 제작자용 ViewModel로 변환
  - 역할 라벨/설명/배지/스포일러 여부/기본 투표 후보 정책을 한 곳에서 관리
  - 역할 변경 저장 payload 생성 책임을 컴포넌트에서 분리
- 캐릭터 편집 UI 연결
  - `CharacterAssignPanel`의 역할 저장 payload 생성 로직을 adapter로 이동
  - `CharacterDetailPanel`의 역할 옵션/라벨 계산을 adapter로 이동
- 백엔드 `CharacterRolePolicy` 추가
  - `mystery_role` 정규화
  - legacy `is_culprit` 충돌 차단
  - 스포일러 역할 여부와 기본 투표 후보 정책을 React 없이 검증 가능하게 분리
- Phase 24 계획 갱신
  - PR-5C 완료 반영
  - PR-6 active 전환
  - PR-6 상세 계획 문서 추가

## Uzu 참고 및 MMP 적용

- Uzu 문서에서 PC/NPC, 캐릭터 미션, 조건부 아이콘/닉네임, 회차 플레이 캐릭터 개념을 확인했습니다.
- 이번 PR에서는 기능 확장을 크게 넣지 않고, 기존 MMP 역할/롤지/시작 단서 흐름을 Adapter/Engine 구조로 안정화합니다.
- NPC 런타임, 캐릭터 미션 점수/결말 통합, 조건부 이름/아이콘, 회차 플레이 캐릭터는 후속 범위로 분리했습니다.

## 검증

- `pnpm --dir apps/web test -- src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx`
  - 27 passed
- `go test ./internal/domain/editor -run 'TestCharacterRolePolicy|TestNormalizeMysteryRole|TestService_(CreateCharacter|UpdateCharacter|DeleteCharacter)'`
  - passed
- `pnpm --dir apps/web typecheck`
  - passed
- `git diff --check`
  - passed
- `pnpm --dir apps/web lint -- ...`
  - 신규 error 없음. 기존 warning만 확인됨.

## E2E 메모

이번 PR은 새 라우트/새 화면/새 버튼 흐름 추가가 아니라 기존 캐릭터 화면의 Adapter/Policy 경계 정리입니다. 기존 `CharacterAssignPanel` 사용자 행동 테스트와 adapter/backend policy unit test로 대체 검증했습니다.

## PR 운영 메모

- `ready-for-ci` 라벨은 붙이지 않았습니다.
- CodeRabbit 리뷰 확인 및 타당한 코멘트 반영 후 재리뷰를 확인한 다음 `ready-for-ci`를 붙입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐릭터 역할 관리 시스템이 개선되었습니다.

* **리팩토링**
  * 캐릭터 역할 처리 로직이 재구성되어 더 일관된 동작을 제공합니다.
  * 편집 인터페이스의 캐릭터 역할 표시 방식이 최적화되었습니다.

* **테스트**
  * 캐릭터 역할 처리에 대한 테스트 커버리지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->