### PR TITLE
feat(editor): 단서 Adapter/Engine 경계 정리

### DIFF
--- a/apps/server/internal/domain/editor/service_clue.go
+++ b/apps/server/internal/domain/editor/service_clue.go
@@ -42,6 +42,10 @@ func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, 
 	if err := validateClueRoundOrder(req.RevealRound, req.HideRound); err != nil {
 		return nil, err
 	}
+	usePolicy, err := BuildClueUsePolicy(req.IsUsable, req.UseEffect, req.UseTarget, req.UseConsumed)
+	if err != nil {
+		return nil, err
+	}
 	count, err := s.q.CountCluesByTheme(ctx, themeID)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to count clues")
@@ -59,10 +63,10 @@ func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, 
 		IsCommon:    req.IsCommon,
 		Level:       req.Level,
 		SortOrder:   req.SortOrder,
-		IsUsable:    req.IsUsable,
-		UseEffect:   ptrToText(req.UseEffect),
-		UseTarget:   ptrToText(req.UseTarget),
-		UseConsumed: req.UseConsumed,
+		IsUsable:    usePolicy.IsUsable,
+		UseEffect:   ptrToText(usePolicy.UseEffect),
+		UseTarget:   ptrToText(usePolicy.UseTarget),
+		UseConsumed: usePolicy.UseConsumed,
 		RevealRound: int32PtrToPgtype(req.RevealRound),
 		HideRound:   int32PtrToPgtype(req.HideRound),
 	})
@@ -76,6 +80,10 @@ func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, 
 
 func (s *service) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, req UpdateClueRequest) (*ClueResponse, error) {
 	if err := validateClueRoundOrder(req.RevealRound, req.HideRound); err != nil {
+		return nil, err
+	}
+	usePolicy, err := BuildClueUsePolicy(req.IsUsable, req.UseEffect, req.UseTarget, req.UseConsumed)
+	if err != nil {
 		return nil, err
 	}
 	c, err := s.q.GetClueWithOwner(ctx, db.GetClueWithOwnerParams{ID: clueID, CreatorID: creatorID})
@@ -95,10 +103,10 @@ func (s *service) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, r
 		IsCommon:    req.IsCommon,
 		Level:       req.Level,
 		SortOrder:   req.SortOrder,
-		IsUsable:    req.IsUsable,
-		UseEffect:   ptrToText(req.UseEffect),
-		UseTarget:   ptrToText(req.UseTarget),
-		UseConsumed: req.UseConsumed,
+		IsUsable:    usePolicy.IsUsable,
+		UseEffect:   ptrToText(usePolicy.UseEffect),
+		UseTarget:   ptrToText(usePolicy.UseTarget),
+		UseConsumed: usePolicy.UseConsumed,
 		RevealRound: int32PtrToPgtype(req.RevealRound),
 		HideRound:   int32PtrToPgtype(req.HideRound),
 	})

--- a/apps/server/internal/domain/editor/service_clue_policy.go
+++ b/apps/server/internal/domain/editor/service_clue_policy.go
@@ -1,0 +1,77 @@
+package editor
+
+import (
+	"fmt"
+
+	"github.com/mmp-platform/server/internal/apperror"
+)
+
+const (
+	ClueUseEffectPeek   = "peek"
+	ClueUseEffectSteal  = "steal"
+	ClueUseEffectReveal = "reveal"
+	ClueUseEffectBlock  = "block"
+	ClueUseEffectSwap   = "swap"
+
+	ClueUseTargetPlayer = "player"
+	ClueUseTargetClue   = "clue"
+	ClueUseTargetSelf   = "self"
+)
+
+// ClueUsePolicy is the backend interpretation of editor clue use settings.
+// React labels and form state are not runtime truth; this policy keeps effect,
+// target, and consumption rules testable without rendering the editor UI.
+type ClueUsePolicy struct {
+	IsUsable    bool
+	UseEffect   *string
+	UseTarget   *string
+	UseConsumed bool
+}
+
+func BuildClueUsePolicy(isUsable bool, effect, target *string, consumed bool) (ClueUsePolicy, error) {
+	if !isUsable {
+		return ClueUsePolicy{IsUsable: false}, nil
+	}
+
+	normalizedEffect := valueOrDefault(effect, ClueUseEffectPeek)
+	defaultTarget, err := defaultClueUseTarget(normalizedEffect)
+	if err != nil {
+		return ClueUsePolicy{}, err
+	}
+
+	normalizedTarget := valueOrDefault(target, defaultTarget)
+	if normalizedTarget != defaultTarget {
+		return ClueUsePolicy{}, apperror.BadRequest(fmt.Sprintf("use_target %q is not valid for use_effect %q", normalizedTarget, normalizedEffect))
+	}
+
+	return ClueUsePolicy{
+		IsUsable:    true,
+		UseEffect:   stringPtr(normalizedEffect),
+		UseTarget:   stringPtr(normalizedTarget),
+		UseConsumed: consumed,
+	}, nil
+}
+
+func defaultClueUseTarget(effect string) (string, error) {
+	switch effect {
+	case ClueUseEffectPeek, ClueUseEffectSteal, ClueUseEffectBlock:
+		return ClueUseTargetPlayer, nil
+	case ClueUseEffectReveal:
+		return ClueUseTargetSelf, nil
+	case ClueUseEffectSwap:
+		return ClueUseTargetClue, nil
+	default:
+		return "", apperror.BadRequest(fmt.Sprintf("invalid use_effect: %s", effect))
+	}
+}
+
+func valueOrDefault(value *string, fallback string) string {
+	if value == nil || *value == "" {
+		return fallback
+	}
+	return *value
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/apps/server/internal/domain/editor/service_clue_policy_test.go
+++ b/apps/server/internal/domain/editor/service_clue_policy_test.go
@@ -1,0 +1,120 @@
+package editor
+
+import (
+	"context"
+	"testing"
+)
+
+func TestClueUsePolicy(t *testing.T) {
+	strPtr := func(value string) *string { return &value }
+	tests := []struct {
+		name         string
+		isUsable     bool
+		effect       *string
+		target       *string
+		consumed     bool
+		wantUsable   bool
+		wantEffect   *string
+		wantTarget   *string
+		wantConsumed bool
+		wantErr      bool
+	}{
+		{name: "disabled clue clears use settings", isUsable: false, effect: strPtr(ClueUseEffectPeek), target: strPtr(ClueUseTargetPlayer), consumed: true, wantUsable: false},
+		{name: "usable defaults to peek player", isUsable: true, wantUsable: true, wantEffect: strPtr(ClueUseEffectPeek), wantTarget: strPtr(ClueUseTargetPlayer)},
+		{name: "reveal defaults to self", isUsable: true, effect: strPtr(ClueUseEffectReveal), wantUsable: true, wantEffect: strPtr(ClueUseEffectReveal), wantTarget: strPtr(ClueUseTargetSelf)},
+		{name: "swap defaults to clue", isUsable: true, effect: strPtr(ClueUseEffectSwap), wantUsable: true, wantEffect: strPtr(ClueUseEffectSwap), wantTarget: strPtr(ClueUseTargetClue)},
+		{name: "consume remains option", isUsable: true, consumed: true, wantUsable: true, wantEffect: strPtr(ClueUseEffectPeek), wantTarget: strPtr(ClueUseTargetPlayer), wantConsumed: true},
+		{name: "unknown effect is rejected", isUsable: true, effect: strPtr("grant_clue"), wantErr: true},
+		{name: "mismatched target is rejected", isUsable: true, effect: strPtr(ClueUseEffectReveal), target: strPtr(ClueUseTargetPlayer), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildClueUsePolicy(tc.isUsable, tc.effect, tc.target, tc.consumed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildClueUsePolicy: %v", err)
+			}
+			if got.IsUsable != tc.wantUsable {
+				t.Fatalf("IsUsable = %v, want %v", got.IsUsable, tc.wantUsable)
+			}
+			if stringPtrValue(got.UseEffect) != stringPtrValue(tc.wantEffect) {
+				t.Fatalf("UseEffect = %q, want %q", stringPtrValue(got.UseEffect), stringPtrValue(tc.wantEffect))
+			}
+			if stringPtrValue(got.UseTarget) != stringPtrValue(tc.wantTarget) {
+				t.Fatalf("UseTarget = %q, want %q", stringPtrValue(got.UseTarget), stringPtrValue(tc.wantTarget))
+			}
+			if got.UseConsumed != tc.wantConsumed {
+				t.Fatalf("UseConsumed = %v, want %v", got.UseConsumed, tc.wantConsumed)
+			}
+		})
+	}
+}
+
+func TestService_CreateClueUsePolicyDefaults(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	reveal := ClueUseEffectReveal
+	resp, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{
+		Name:      "공개되는 정보",
+		Level:     1,
+		SortOrder: 0,
+		IsUsable:  true,
+		UseEffect: &reveal,
+	})
+	if err != nil {
+		t.Fatalf("CreateClue: %v", err)
+	}
+	if stringPtrValue(resp.UseEffect) != ClueUseEffectReveal {
+		t.Fatalf("UseEffect = %q, want %q", stringPtrValue(resp.UseEffect), ClueUseEffectReveal)
+	}
+	if stringPtrValue(resp.UseTarget) != ClueUseTargetSelf {
+		t.Fatalf("UseTarget = %q, want %q", stringPtrValue(resp.UseTarget), ClueUseTargetSelf)
+	}
+}
+
+func TestService_CreateClueUsePolicyClearsDisabledSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	effect := ClueUseEffectPeek
+	target := ClueUseTargetPlayer
+	resp, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{
+		Name:        "비활성 단서",
+		Level:       1,
+		SortOrder:   0,
+		IsUsable:    false,
+		UseEffect:   &effect,
+		UseTarget:   &target,
+		UseConsumed: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateClue: %v", err)
+	}
+	if resp.UseEffect != nil || resp.UseTarget != nil || resp.UseConsumed {
+		t.Fatalf("disabled clue use policy not cleared: effect=%v target=%v consumed=%v", resp.UseEffect, resp.UseTarget, resp.UseConsumed)
+	}
+}
+
+func stringPtrValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -92,6 +92,8 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await expect(page.getByLabel("단서 목록")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByLabel("단서 상세 영역")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText("첫 단서").first()).toBeVisible();
+    await expect(page.getByText("정보 공개하기")).toBeVisible();
+    await expect(page.getByText("사용하면 내 단서함에서 사라짐")).toBeVisible();
     await expect(page.getByText("이 단서가 쓰이는 곳")).toBeVisible();
   });
 

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -372,8 +372,10 @@ function cluePayload(state: MockState) {
     level: 1,
     sort_order: 0,
     is_common: false,
-    is_usable: false,
-    use_consumed: false,
+    is_usable: true,
+    use_effect: "reveal",
+    use_target: "self",
+    use_consumed: true,
     image_url: state.clueImageURL,
     created_at: new Date().toISOString(),
   };

--- a/apps/web/src/features/editor/components/ClueForm.tsx
+++ b/apps/web/src/features/editor/components/ClueForm.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/shared/components/ui/Input';
 import { type ClueResponse } from '@/features/editor/api';
 import { useClueFormSubmit } from '@/features/editor/hooks/useClueFormSubmit';
 import { ClueFormImageSection } from './ClueFormImageSection';
+import { buildClueUsePayload, getClueUseEffectOption } from '@/features/editor/entities/clue/clueEntityAdapter';
 import { ClueFormAdvancedFields } from './ClueFormAdvancedFields';
 
 // ---------------------------------------------------------------------------
@@ -135,6 +136,12 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
     setPendingPreview(null);
   }
 
+  function handleUseEffectChange(effect: string) {
+    setUseEffect(effect);
+    const option = getClueUseEffectOption(effect);
+    if (option) setUseTarget(option.target);
+  }
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     const validationErrors = validate();
@@ -142,7 +149,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
     if (Object.keys(validationErrors).length > 0) return;
 
     submit(
-      {
+      buildClueUsePayload({
         name: name.trim(),
         description: description || undefined,
         image_url: imageUrl || undefined,
@@ -155,7 +162,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
         use_consumed: isUsable ? useConsumed : undefined,
         reveal_round: revealRound,
         hide_round: hideRound,
-      },
+      }),
       pendingImage,
     );
   }
@@ -229,7 +236,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
           isUsable={isUsable}
           onIsUsableChange={setIsUsable}
           useEffect_={useEffect_}
-          onUseEffectChange={setUseEffect}
+          onUseEffectChange={handleUseEffectChange}
           useTarget={useTarget}
           onUseTargetChange={setUseTarget}
           useConsumed={useConsumed}

--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -258,6 +258,28 @@ describe('ClueForm', () => {
     expect(screen.getByText('사용하면 내 단서함에서 사라짐')).toBeDefined();
   });
 
+
+  it('사용 효과를 정보 공개로 바꾸면 backend policy에 맞게 대상 없음으로 저장한다', () => {
+    const onClose = vi.fn();
+    render(<ClueForm themeId="theme-1" isOpen onClose={onClose} />);
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '정보 단서' },
+    });
+    fireEvent.click(screen.getByText('고급 설정'));
+    fireEvent.click(screen.getByLabelText('사용 가능한 단서'));
+    fireEvent.change(screen.getByLabelText('사용하면 일어나는 일'), {
+      target: { value: 'reveal' },
+    });
+
+    fireEvent.submit(document.getElementById('clue-form')!);
+
+    expect(createMutate).toHaveBeenCalledTimes(1);
+    const [body] = createMutate.mock.calls[0];
+    expect(body.use_effect).toBe('reveal');
+    expect(body.use_target).toBe('self');
+  });
+
   it('고급 설정의 공개/사라짐 라운드 입력이 payload에 포함된다', () => {
     const onClose = vi.fn();
     render(<ClueForm themeId="theme-1" isOpen onClose={onClose} />);

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -4,7 +4,7 @@ import type { ClueResponse, EditorCharacterResponse, LocationResponse } from '@/
 import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import { buildClueUsageMap, getClueBacklinks, type EntityReference } from '@/features/editor/utils/entityReferences';
-import { formatRoundRange } from '@/features/editor/utils/roundFormat';
+import { buildClueBadges, toClueEditorViewModel } from '@/features/editor/entities/clue/clueEntityAdapter';
 
 interface ClueEntityWorkspaceProps {
   clues: ClueResponse[];
@@ -41,21 +41,12 @@ export function ClueEntityWorkspace({
       getItemId={(clue) => clue.id}
       getItemTitle={(clue) => clue.name}
       getItemDescription={(clue) => clue.description || '설명 없음'}
-      getItemBadges={(clue) => clueBadges(clue, usageMap[clue.id]?.references.length ?? 0)}
+      getItemBadges={(clue) => buildClueBadges(clue, usageMap[clue.id]?.references.length ?? 0)}
       renderDetail={(clue) => <ClueDetailCard clue={clue} onEdit={onEdit} onDelete={onDelete} />}
       renderInspector={(clue) => <ClueUsageCard references={getClueBacklinks(usageMap, clue.id)} />}
     />
   );
 }
-
-function clueBadges(clue: ClueResponse, referenceCount: number) {
-  return [
-    clue.is_common ? '모두에게 공개' : null,
-    clue.is_usable ? '사용 가능' : null,
-    referenceCount > 0 ? `연결 ${referenceCount}` : '미배치',
-  ].filter((badge): badge is string => !!badge);
-}
-
 function ClueDetailCard({
   clue,
   onEdit,
@@ -65,6 +56,8 @@ function ClueDetailCard({
   onEdit: (clue: ClueResponse) => void;
   onDelete: (clue: ClueResponse) => void;
 }) {
+  const view = toClueEditorViewModel(clue);
+
   return (
     <article className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -72,7 +65,7 @@ function ClueDetailCard({
           <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">단서 상세</p>
           <h3 className="mt-1 text-xl font-bold text-slate-100">{clue.name}</h3>
           <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-400">
-            {clue.description || '플레이어에게 보일 단서 설명을 입력하세요.'}
+            {view.description}
           </p>
         </div>
         <div className="flex shrink-0 gap-2">
@@ -95,10 +88,10 @@ function ClueDetailCard({
       </div>
 
       <div className="mt-5 grid gap-3 md:grid-cols-2">
-        <InfoBlock title="공개 범위" value={clue.is_common ? '모든 플레이어가 공유' : '지정된 캐릭터나 장소에서만 획득'} />
-        <InfoBlock title="등장 라운드" value={formatRoundRange(clue.reveal_round, clue.hide_round) || '처음부터 끝까지'} />
-        <InfoBlock title="사용 효과" value={clue.is_usable ? formatEffectLabel(clue.use_effect) : '사용 효과 없음'} />
-        <InfoBlock title="사용 후 처리" value={formatConsumeLabel(clue)} />
+        <InfoBlock title="공개 범위" value={view.publicScopeLabel} />
+        <InfoBlock title="등장 라운드" value={view.roundLabel} />
+        <InfoBlock title="사용 효과" value={view.useEffectLabel} />
+        <InfoBlock title="사용 후 처리" value={view.consumeLabel} />
       </div>
     </article>
   );
@@ -133,20 +126,6 @@ function InfoBlock({ title, value }: { title: string; value: string }) {
       <p className="mt-1 text-sm text-slate-200">{value}</p>
     </div>
   );
-}
-
-function formatEffectLabel(effect?: string | null) {
-  if (effect === 'peek') return '다른 플레이어 단서 보기';
-  if (effect === 'steal') return '다른 플레이어에게서 단서 가져오기';
-  if (effect === 'reveal') return '정보 공개하기';
-  if (effect === 'block') return '상대의 사용 막기';
-  if (effect === 'swap') return '단서 교환하기';
-  return '사용 효과 없음';
-}
-
-function formatConsumeLabel(clue: ClueResponse) {
-  if (!clue.is_usable) return '해당 없음';
-  return clue.use_consumed ? '사용하면 내 단서함에서 사라짐' : '사용 후에도 단서함에 남음';
 }
 
 function formatReference(ref: EntityReference) {

--- a/apps/web/src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { ClueResponse } from '@/features/editor/api/types';
+import {
+  buildClueBadges,
+  buildClueUsePayload,
+  formatClueConsumeLabel,
+  getClueUseEffectOption,
+  toClueEditorViewModel,
+} from '../clueEntityAdapter';
+
+function clue(overrides: Partial<ClueResponse> = {}): ClueResponse {
+  return {
+    id: 'clue-1',
+    theme_id: 'theme-1',
+    location_id: null,
+    name: '피 묻은 열쇠',
+    description: '잠긴 상자를 열 수 있다.',
+    image_url: null,
+    is_common: false,
+    level: 1,
+    sort_order: 0,
+    created_at: '2026-05-03T00:00:00Z',
+    is_usable: true,
+    use_effect: 'peek',
+    use_target: 'player',
+    use_consumed: true,
+    reveal_round: null,
+    hide_round: null,
+    ...overrides,
+  };
+}
+
+describe('clueEntityAdapter', () => {
+  it('단서 API 응답을 제작자용 ViewModel으로 변환한다', () => {
+    const vm = toClueEditorViewModel(clue({ use_effect: 'steal', reveal_round: 2, hide_round: 4 }), 3);
+
+    expect(vm).toMatchObject({
+      id: 'clue-1',
+      name: '피 묻은 열쇠',
+      description: '잠긴 상자를 열 수 있다.',
+      publicScopeLabel: '지정된 캐릭터나 장소에서만 획득',
+      roundLabel: 'R2~4',
+      useEffectLabel: '다른 플레이어에게서 단서 가져오기',
+      consumeLabel: '사용하면 내 단서함에서 사라짐',
+      badges: ['사용 가능', '연결 3'],
+    });
+  });
+
+  it('사용 효과가 없는 단서는 내부 key 없이 사용자 문구로 표시한다', () => {
+    const vm = toClueEditorViewModel(clue({ is_usable: false, use_effect: null, use_consumed: false }));
+
+    expect(vm.useEffectLabel).toBe('사용 효과 없음');
+    expect(vm.useEffectDescription).toBe('플레이어가 이 단서를 눌러 실행하는 효과가 없습니다.');
+    expect(vm.consumeLabel).toBe('해당 없음');
+  });
+
+  it('consume은 독립 효과가 아니라 사용 후 처리 옵션으로 표시한다', () => {
+    expect(formatClueConsumeLabel({ is_usable: true, use_consumed: true })).toBe('사용하면 내 단서함에서 사라짐');
+    expect(formatClueConsumeLabel({ is_usable: true, use_consumed: false })).toBe('사용 후에도 단서함에 남음');
+  });
+
+  it('효과별 권장 대상 선택 방식을 제공한다', () => {
+    expect(getClueUseEffectOption('peek')).toMatchObject({ target: 'player', requiresTargetSelection: true });
+    expect(getClueUseEffectOption('reveal')).toMatchObject({ target: 'self', requiresTargetSelection: false });
+    expect(getClueUseEffectOption('unknown')).toBeNull();
+  });
+
+  it('사용 불가 단서 저장 payload에서는 효과 필드를 비운다', () => {
+    expect(buildClueUsePayload({ name: '단서', is_usable: false, use_effect: 'peek', use_target: 'player', use_consumed: true })).toMatchObject({
+      is_usable: false,
+      use_effect: undefined,
+      use_target: undefined,
+      use_consumed: false,
+    });
+  });
+
+  it('사용 가능 payload에서는 효과에 맞는 대상 선택 방식을 적용한다', () => {
+    expect(buildClueUsePayload({ name: '단서', is_usable: true, use_effect: 'reveal', use_target: 'player', use_consumed: false })).toMatchObject({
+      is_usable: true,
+      use_effect: 'reveal',
+      use_target: 'self',
+      use_consumed: false,
+    });
+  });
+
+  it('목록 배지는 공개/사용/연결 상태만 제작자 언어로 표시한다', () => {
+    expect(buildClueBadges(clue({ is_common: true }), 0)).toEqual(['모두에게 공개', '사용 가능', '미배치']);
+  });
+});

--- a/apps/web/src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts
@@ -83,6 +83,15 @@ describe('clueEntityAdapter', () => {
     });
   });
 
+  it('지원하지 않는 legacy 효과는 조용히 다른 효과로 바꾸지 않고 backend 검증에 맡긴다', () => {
+    expect(buildClueUsePayload({ name: '단서', is_usable: true, use_effect: 'grant_clue', use_target: 'clue', use_consumed: true })).toMatchObject({
+      is_usable: true,
+      use_effect: 'grant_clue',
+      use_target: 'clue',
+      use_consumed: true,
+    });
+  });
+
   it('목록 배지는 공개/사용/연결 상태만 제작자 언어로 표시한다', () => {
     expect(buildClueBadges(clue({ is_common: true }), 0)).toEqual(['모두에게 공개', '사용 가능', '미배치']);
   });

--- a/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
@@ -115,7 +115,16 @@ export function buildClueUsePayload<T extends CreateClueRequest | UpdateClueRequ
     return payload;
   }
 
+  const hasEffect = Boolean(payload.use_effect && payload.use_effect.trim());
   const option = getClueUseEffectOption(payload.use_effect);
+
+  if (hasEffect && !option) {
+    return {
+      ...payload,
+      use_consumed: Boolean(payload.use_consumed),
+    };
+  }
+
   return {
     ...payload,
     use_effect: option?.value ?? 'peek',

--- a/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
@@ -1,0 +1,125 @@
+import type { ClueResponse, CreateClueRequest, UpdateClueRequest } from '@/features/editor/api/types';
+import { formatRoundRange } from '@/features/editor/utils/roundFormat';
+
+export type ClueUseEffect = 'peek' | 'steal' | 'reveal' | 'block' | 'swap';
+export type ClueUseTarget = 'player' | 'clue' | 'self';
+
+export interface ClueUseEffectOption {
+  value: ClueUseEffect;
+  target: ClueUseTarget;
+  label: string;
+  description: string;
+  requiresTargetSelection: boolean;
+}
+
+export interface ClueEditorViewModel {
+  id: string;
+  name: string;
+  description: string;
+  imageUrl: string | null;
+  publicScopeLabel: string;
+  roundLabel: string;
+  useEffectLabel: string;
+  useEffectDescription: string;
+  consumeLabel: string;
+  badges: string[];
+}
+
+export const clueUseEffectOptions: ClueUseEffectOption[] = [
+  {
+    value: 'peek',
+    target: 'player',
+    label: '다른 플레이어 단서 보기',
+    description: '사용자가 선택한 플레이어의 보유 단서 목록을 확인합니다.',
+    requiresTargetSelection: true,
+  },
+  {
+    value: 'steal',
+    target: 'player',
+    label: '다른 플레이어에게서 단서 가져오기',
+    description: '대상 플레이어의 단서 하나를 가져오는 효과입니다. 실제 양도 기능은 후속 엔진에서 분리합니다.',
+    requiresTargetSelection: true,
+  },
+  {
+    value: 'reveal',
+    target: 'self',
+    label: '정보 공개하기',
+    description: '사용한 플레이어에게 추가 정보를 공개합니다.',
+    requiresTargetSelection: false,
+  },
+  {
+    value: 'block',
+    target: 'player',
+    label: '상대의 사용 막기',
+    description: '대상 플레이어의 다음 단서 사용을 막는 효과입니다.',
+    requiresTargetSelection: true,
+  },
+  {
+    value: 'swap',
+    target: 'clue',
+    label: '단서 교환하기',
+    description: '선택한 단서와 교환하는 효과입니다.',
+    requiresTargetSelection: true,
+  },
+];
+
+const effectMap = new Map<string, ClueUseEffectOption>(
+  clueUseEffectOptions.map((option) => [option.value, option]),
+);
+
+export function getClueUseEffectOption(effect?: string | null): ClueUseEffectOption | null {
+  if (!effect) return null;
+  return effectMap.get(effect) ?? null;
+}
+
+export function toClueEditorViewModel(clue: ClueResponse, referenceCount = 0): ClueEditorViewModel {
+  const effect = clue.is_usable ? getClueUseEffectOption(clue.use_effect) : null;
+  return {
+    id: clue.id,
+    name: clue.name,
+    description: clue.description?.trim() || '플레이어에게 보일 단서 설명을 입력하세요.',
+    imageUrl: clue.image_url ?? null,
+    publicScopeLabel: clue.is_common ? '모든 플레이어가 공유' : '지정된 캐릭터나 장소에서만 획득',
+    roundLabel: formatRoundRange(clue.reveal_round, clue.hide_round) || '처음부터 끝까지',
+    useEffectLabel: effect?.label ?? '사용 효과 없음',
+    useEffectDescription: effect?.description ?? '플레이어가 이 단서를 눌러 실행하는 효과가 없습니다.',
+    consumeLabel: formatClueConsumeLabel(clue),
+    badges: buildClueBadges(clue, referenceCount),
+  };
+}
+
+export function buildClueBadges(clue: ClueResponse, referenceCount: number): string[] {
+  return [
+    clue.is_common ? '모두에게 공개' : null,
+    clue.is_usable ? '사용 가능' : null,
+    referenceCount > 0 ? `연결 ${referenceCount}` : '미배치',
+  ].filter((badge): badge is string => Boolean(badge));
+}
+
+export function formatClueConsumeLabel(clue: Pick<ClueResponse, 'is_usable' | 'use_consumed'>): string {
+  if (!clue.is_usable) return '해당 없음';
+  return clue.use_consumed ? '사용하면 내 단서함에서 사라짐' : '사용 후에도 단서함에 남음';
+}
+
+export function buildClueUsePayload<T extends CreateClueRequest | UpdateClueRequest>(payload: T): T {
+  if (payload.is_usable === false) {
+    return {
+      ...payload,
+      use_effect: undefined,
+      use_target: undefined,
+      use_consumed: false,
+    };
+  }
+
+  if (payload.is_usable !== true) {
+    return payload;
+  }
+
+  const option = getClueUseEffectOption(payload.use_effect);
+  return {
+    ...payload,
+    use_effect: option?.value ?? 'peek',
+    use_target: option?.target ?? 'player',
+    use_consumed: Boolean(payload.use_consumed),
+  };
+}

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -2,7 +2,7 @@
 phase_id: "phase-24-editor-redesign"
 phase_title: "Phase 24 — 에디터 ECS 재설계 (단서 단일 진실 위치 + 동적 모듈 + 결말 분기 매트릭스)"
 created: 2026-05-01
-status: "issue-based Phase 24 continuation — PR-6 active"
+status: "issue-based Phase 24 continuation — PR-7 active"
 spec: "docs/superpowers/specs/2026-05-01-phase-24-editor-redesign/design.md"
 prs_estimated: "issue-based: PR-5A~PR-9 active after PR-4"
 parent_phase: "phase-21-editor-ux"
@@ -38,8 +38,8 @@ parent_phase: "phase-21-editor-ux"
 | [#230](https://github.com/sabyunrepo/muder_platform/issues/230) | PR-5A | Adapter/Engine 공통 계약 및 Issue 기반 전환 | done |
 | [#231](https://github.com/sabyunrepo/muder_platform/issues/231) | PR-5B | 페이즈 정보 전달 Frontend Adapter | done |
 | [#232](https://github.com/sabyunrepo/muder_platform/issues/232) | PR-5C | 정보 전달 Backend Engine 및 런타임 공개 상태 | done |
-| [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | active |
-| [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | brainstorming gate |
+| [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | done |
+| [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | active |
 | [#235](https://github.com/sabyunrepo/muder_platform/issues/235) | PR-8 | 장소 Adapter/Engine 이관 | brainstorming gate |
 | [#236](https://github.com/sabyunrepo/muder_platform/issues/236) | PR-9 | 결말/통합 Adapter-Engine 검증 및 E2E | brainstorming gate |
 

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-7-clue-adapter-engine-plan.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-7-clue-adapter-engine-plan.md
@@ -1,0 +1,89 @@
+# Phase 24 PR-7 — 단서 Adapter/Engine 이관 계획
+
+## 상태
+
+- GitHub Issue: [#234](https://github.com/sabyunrepo/muder_platform/issues/234)
+- Branch: `feat/issue-234-clue-adapter-engine`
+- 목표: 기존 단서 entity UI와 사용 효과 필드를 유지하면서, 프론트는 제작자용 Clue Adapter, 백엔드는 단서 사용/양도/소모 정책 Engine 경계로 정리한다.
+
+## Uzu 참고점
+
+Uzu 단서 문서에서 확인한 제작자 모델은 다음과 같다.
+
+- 단서 기본 정보는 플레이 중 단서 목록/상세에 표시된다.
+- 비공개 단서는 소유자 외 사용자에게 “비공개 시 제목 + 태그”만 보여줄 수 있다.
+- 배포 조건은 “어떤 조건으로, 어떤 방식으로, 누구에게” 단서를 줄지 정한다.
+- 소유권이 있는 단서는 전체 공개, 공유, 양도가 가능하다.
+- 회수 조건을 두면 이미 배포된 단서를 다시 장에서 제거할 수 있다.
+- 덱은 토큰을 소비해 단서를 얻는 별도 조사 시스템이다.
+- 조건 그룹은 AND/OR 조합을 지원하지만 제작자 UI가 복잡해지기 쉽다.
+
+## MMP 적용 방식
+
+PR-7에서는 Uzu 구조를 그대로 복제하지 않고 MMP의 실시간 멀티플레이/백엔드 Engine 구조에 맞춰 다음만 적용한다.
+
+1. 기존 단서 기본 정보, 라운드 공개 범위, 장소/시작단서/조합 backlink는 유지한다.
+2. 현재 API 필드인 `is_usable`, `use_effect`, `use_target`, `use_consumed`를 제작자용 ViewModel로 변환한다.
+3. 단서 사용 효과 1차 구현 범위는 현재 저장 스키마와 API 검증값을 기준으로 고정한다.
+   - `peek`: 다른 플레이어 단서 보기
+   - `steal`: 다른 플레이어에게서 단서 가져오기
+   - `reveal`: 사용한 플레이어에게 정보 공개
+   - `block`: 대상 플레이어의 다음 단서 사용 막기
+   - `swap`: 선택 단서와 교환
+   - `consume`: 독립 효과가 아니라 위 효과의 “사용 후 소모” 옵션으로 둔다.
+4. Uzu식 공유/양도/보상/잠금 해제 모델은 이번 PR에서 이름만 바꾸어 저장하지 않는다. 현재 API와 런타임에 없는 `transfer`, `reveal_info`, `grant_clue`, `unlock_password`, `combine`은 후속 engine PR에서 명시 계약을 추가한다.
+5. 백엔드는 frontend에서 온 문자열을 신뢰하지 않고 policy에서 허용 효과/대상/소모 조합을 검증한다.
+
+## 제외 / 후순위
+
+이번 PR에서 구현하지 않는다.
+
+- 덱/토큰 조사 런타임: Uzu 문서상 별도 큰 시스템이므로 PR-8 이후 또는 Phase 25 후보로 둔다.
+- 복잡한 조건 그룹 UI 전체 구현: 조건 엔진과 phase/ending 연동이 필요하므로 후속으로 둔다.
+- 회수 조건 전체 구현: 단서 지급/소유권 ledger가 먼저 안정화된 뒤 다룬다.
+- 비공개 단서 존재 표시 API 확장: 이번 PR에서는 adapter/plan 경계만 두고, player-aware inventory state 작업 때 구현한다.
+
+## 구현 범위
+
+### Frontend Adapter
+
+- `ClueEntityAdapter` 추가
+  - API `ClueResponse` → 제작자용 `ClueEditorViewModel`
+  - 공개 범위, 등장 라운드, 사용 효과, 사용 후 처리, backlink 배지를 제작자 언어로 변환
+  - 저장 가능한 `CreateClueRequest`/`UpdateClueRequest` payload helper 추가
+- `ClueEntityWorkspace`에서 효과/배지/상세 문구 계산을 adapter로 이동한다.
+- 기존 컴포넌트는 internal ID/raw JSON/config key를 노출하지 않는다.
+
+### Backend Engine / Policy
+
+- `ClueUsePolicy` 추가
+  - `use_effect`, `use_target`, `use_consumed` 조합 정규화
+  - 현재 API 효과(`peek/steal/reveal/block/swap`)와 대상(`player/clue/self`) 호환성 검증
+  - unsupported effect/target 또는 mismatched target을 명확한 400 오류로 차단
+- `CreateClue`/`UpdateClue`는 policy 결과를 사용해 저장한다.
+- 현재 `clue_interaction` 모듈의 실제 구현과 충돌하지 않도록, runtime 미구현 효과는 저장 검증/계획 문서에만 범위를 고정하고 실행은 별도 engine PR로 분리한다.
+
+## 테스트 계획
+
+- Frontend unit
+  - 단서 API 응답이 제작자용 ViewModel으로 변환된다.
+  - `consume`이 독립 효과가 아니라 “사용 후 사라짐” 옵션으로 표시된다.
+  - `steal/reveal/swap` 등 현재 API 효과가 제작자 언어로 안전하게 표시된다.
+  - 배지/라운드/공개 범위 문구가 internal key 없이 표시된다.
+- Existing frontend component test
+  - `ClueEntityWorkspace` 상세/삭제/backlink 회귀 검증 유지.
+- Backend unit
+  - 사용 효과/대상/소모 조합 정규화
+  - 잘못된 효과/대상 조합 400 차단
+  - 기존 `peek/steal/reveal/block/swap` 저장 호환성 검증
+- Focused commands
+  - `pnpm --dir apps/web test -- src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts src/features/editor/components/clues/ClueEntityWorkspace.test.tsx`
+  - `pnpm --dir apps/web typecheck`
+  - `go test ./internal/domain/editor -run 'TestClueUsePolicy|TestService_(CreateClue|UpdateClue|DeleteClue)|TestRemoveClueReferences'`
+
+## 완료 조건
+
+- 단서 UI가 기존 기능을 잃지 않는다.
+- 단서 사용 효과 문구/저장 payload 생성이 React 컴포넌트에서 분리된다.
+- 단서 사용 정책이 React 없이 Go test로 검증된다.
+- 덱/토큰/복잡 조건/회수 조건은 후속으로 안전하게 이어질 수 있는 경계가 문서화된다.


### PR DESCRIPTION
## 요약

- Phase 24 PR-7 단서 Adapter/Engine 이관 계획을 문서화했습니다.
- 프론트 단서 상세/저장 payload 계산을 `ClueEntityAdapter`로 분리했습니다.
- 백엔드 `ClueUsePolicy`를 추가해 `use_effect`, `use_target`, `use_consumed` 조합을 서버에서 검증합니다.
- 단서 폼 저장 시 효과별 대상값을 adapter 기준으로 정규화해 backend policy와 충돌하지 않게 했습니다.
- 골든패스 E2E fixture에 사용 가능한 단서 표시 검증을 추가했습니다.

## 범위

- 현재 API가 지원하는 효과만 구현: `peek`, `steal`, `reveal`, `block`, `swap`
- `grant_clue`, `unlock_password`, `combine`, deck/token 조사는 후속 engine PR에서 다룹니다.
- `ready-for-ci` 라벨은 붙이지 않았습니다. CodeRabbit 리뷰 확인/해소 후 라벨을 붙일 예정입니다.

## 검증

- `pnpm --dir apps/web test -- src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/components/__tests__/ClueForm.test.tsx`
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web test:e2e -- editor-golden-path.spec.ts -g "[2A]"` — 실행 결과 editor-golden-path 10개 테스트 통과
- `go test ./internal/domain/editor -run 'TestClueUsePolicy|TestService_(CreateClue|UpdateClue|DeleteClue)|TestRemoveClueReferences'`
- `git diff --check`

Closes #234


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 단서 사용 정책을 자동으로 결정하고 저장하도록 검증 로직 통합
  * 편집 폼에서 사용 효과 변경 시 대상 필드 자동 동기화

* **개선사항**
  * 단서 사용 가능/불가에 따른 관련 필드 자동 초기화로 입력 일관성 향상
  * UI 뷰모델 및 뱃지·레이블 표시 일관성 개선

* **테스트**
  * 사용 정책 및 편집 플로우에 대한 단위·통합 테스트 추가

* **문서**
  * 편집자 리디자인 계획 및 관련 체크리스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->