### PR TITLE
feat(editor): 장소 Adapter/Engine 경계 정리

### DIFF
--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -114,7 +114,7 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
 		return nil, err
 	}
-	accessPolicy, err := BuildLocationAccessPolicy(req.RestrictedCharacters, req.FromRound, req.UntilRound)
+	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, themeID, req.RestrictedCharacters, req.FromRound, req.UntilRound)
 	if err != nil {
 		return nil, err
 	}
@@ -154,10 +154,6 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 }
 
 func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID, req UpdateLocationRequest) (*LocationResponse, error) {
-	accessPolicy, err := BuildLocationAccessPolicy(req.RestrictedCharacters, req.FromRound, req.UntilRound)
-	if err != nil {
-		return nil, err
-	}
 	l, err := s.q.GetLocationWithOwner(ctx, db.GetLocationWithOwnerParams{ID: locID, CreatorID: creatorID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -165,6 +161,10 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		}
 		s.logger.Error().Err(err).Msg("failed to get location")
 		return nil, apperror.Internal("failed to get location")
+	}
+	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, l.ThemeID, req.RestrictedCharacters, req.FromRound, req.UntilRound)
+	if err != nil {
+		return nil, err
 	}
 	imageURL := l.ImageUrl
 	if req.ImageURL != nil {
@@ -185,6 +185,36 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 	}
 	resp := toLocationResponse(updated)
 	return &resp, nil
+}
+
+func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID uuid.UUID, restrictedCharacters *string, fromRound, untilRound *int32) (LocationAccessPolicy, error) {
+	accessPolicy, err := BuildLocationAccessPolicy(restrictedCharacters, fromRound, untilRound)
+	if err != nil {
+		return LocationAccessPolicy{}, err
+	}
+	if len(accessPolicy.RestrictedCharacterIDs) == 0 {
+		return accessPolicy, nil
+	}
+
+	chars, err := s.q.GetThemeCharacters(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to validate location restricted characters")
+		return LocationAccessPolicy{}, apperror.Internal("failed to validate location access policy")
+	}
+	allowed := make(map[string]struct{}, len(chars))
+	for _, char := range chars {
+		allowed[char.ID.String()] = struct{}{}
+	}
+	for _, rawID := range accessPolicy.RestrictedCharacterIDs {
+		parsedID, err := uuid.Parse(rawID)
+		if err != nil {
+			return LocationAccessPolicy{}, apperror.BadRequest("restricted character must be a valid theme character")
+		}
+		if _, ok := allowed[parsedID.String()]; !ok {
+			return LocationAccessPolicy{}, apperror.BadRequest("restricted character must belong to this theme")
+		}
+	}
+	return accessPolicy, nil
 }
 
 // validateLocationRoundOrder enforces from_round <= until_round when both set.

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -114,11 +114,12 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
 		return nil, err
 	}
-	if err := validateLocationRoundOrder(req.FromRound, req.UntilRound); err != nil {
+	accessPolicy, err := BuildLocationAccessPolicy(req.RestrictedCharacters, req.FromRound, req.UntilRound)
+	if err != nil {
 		return nil, err
 	}
 	// verify map belongs to the theme via ownership check
-	_, err := s.q.GetMapWithOwner(ctx, db.GetMapWithOwnerParams{ID: mapID, CreatorID: creatorID})
+	_, err = s.q.GetMapWithOwner(ctx, db.GetMapWithOwnerParams{ID: mapID, CreatorID: creatorID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, apperror.NotFound("map not found")
@@ -138,10 +139,10 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 		ThemeID:              themeID,
 		MapID:                mapID,
 		Name:                 req.Name,
-		RestrictedCharacters: ptrToText(req.RestrictedCharacters),
+		RestrictedCharacters: ptrToText(accessPolicy.RestrictedCharacters),
 		SortOrder:            req.SortOrder,
-		FromRound:            int32PtrToPgtype(req.FromRound),
-		UntilRound:           int32PtrToPgtype(req.UntilRound),
+		FromRound:            int32PtrToPgtype(accessPolicy.FromRound),
+		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
 		ImageUrl:             ptrToText(req.ImageURL),
 	})
 	if err != nil {
@@ -153,7 +154,8 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 }
 
 func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID, req UpdateLocationRequest) (*LocationResponse, error) {
-	if err := validateLocationRoundOrder(req.FromRound, req.UntilRound); err != nil {
+	accessPolicy, err := BuildLocationAccessPolicy(req.RestrictedCharacters, req.FromRound, req.UntilRound)
+	if err != nil {
 		return nil, err
 	}
 	l, err := s.q.GetLocationWithOwner(ctx, db.GetLocationWithOwnerParams{ID: locID, CreatorID: creatorID})
@@ -171,10 +173,10 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 	updated, err := s.q.UpdateLocation(ctx, db.UpdateLocationParams{
 		ID:                   l.ID,
 		Name:                 req.Name,
-		RestrictedCharacters: ptrToText(req.RestrictedCharacters),
+		RestrictedCharacters: ptrToText(accessPolicy.RestrictedCharacters),
 		SortOrder:            req.SortOrder,
-		FromRound:            int32PtrToPgtype(req.FromRound),
-		UntilRound:           int32PtrToPgtype(req.UntilRound),
+		FromRound:            int32PtrToPgtype(accessPolicy.FromRound),
+		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
 		ImageUrl:             imageURL,
 	})
 	if err != nil {

--- a/apps/server/internal/domain/editor/service_location_policy.go
+++ b/apps/server/internal/domain/editor/service_location_policy.go
@@ -48,6 +48,9 @@ func (p LocationAccessPolicy) CanCharacterAccess(characterID string, round int32
 	if !p.IsVisibleInRound(round) {
 		return false
 	}
+	if len(p.RestrictedCharacterIDs) > 0 && strings.TrimSpace(characterID) == "" {
+		return false
+	}
 	for _, restrictedID := range p.RestrictedCharacterIDs {
 		if restrictedID == characterID {
 			return false

--- a/apps/server/internal/domain/editor/service_location_policy.go
+++ b/apps/server/internal/domain/editor/service_location_policy.go
@@ -48,11 +48,12 @@ func (p LocationAccessPolicy) CanCharacterAccess(characterID string, round int32
 	if !p.IsVisibleInRound(round) {
 		return false
 	}
-	if len(p.RestrictedCharacterIDs) > 0 && strings.TrimSpace(characterID) == "" {
+	normalizedCharacterID := strings.TrimSpace(characterID)
+	if len(p.RestrictedCharacterIDs) > 0 && normalizedCharacterID == "" {
 		return false
 	}
 	for _, restrictedID := range p.RestrictedCharacterIDs {
-		if restrictedID == characterID {
+		if restrictedID == normalizedCharacterID {
 			return false
 		}
 	}

--- a/apps/server/internal/domain/editor/service_location_policy.go
+++ b/apps/server/internal/domain/editor/service_location_policy.go
@@ -1,0 +1,77 @@
+package editor
+
+import "strings"
+
+// LocationAccessPolicy is the backend interpretation of creator-facing place access settings.
+// The editor may show friendly labels, but runtime visibility/access decisions are made here.
+type LocationAccessPolicy struct {
+	RestrictedCharacterIDs []string
+	RestrictedCharacters   *string
+	FromRound              *int32
+	UntilRound             *int32
+}
+
+func BuildLocationAccessPolicy(restrictedCharacters *string, fromRound, untilRound *int32) (LocationAccessPolicy, error) {
+	if err := validateLocationRoundOrder(fromRound, untilRound); err != nil {
+		return LocationAccessPolicy{}, err
+	}
+
+	ids := parseLocationRestrictedCharacterIDs(restrictedCharacters)
+	var normalized *string
+	if len(ids) > 0 {
+		normalized = stringPtr(strings.Join(ids, ","))
+	}
+
+	return LocationAccessPolicy{
+		RestrictedCharacterIDs: ids,
+		RestrictedCharacters:   normalized,
+		FromRound:              fromRound,
+		UntilRound:             untilRound,
+	}, nil
+}
+
+func (p LocationAccessPolicy) IsPublic() bool {
+	return len(p.RestrictedCharacterIDs) == 0
+}
+
+func (p LocationAccessPolicy) IsVisibleInRound(round int32) bool {
+	if p.FromRound != nil && round < *p.FromRound {
+		return false
+	}
+	if p.UntilRound != nil && round > *p.UntilRound {
+		return false
+	}
+	return true
+}
+
+func (p LocationAccessPolicy) CanCharacterAccess(characterID string, round int32) bool {
+	if !p.IsVisibleInRound(round) {
+		return false
+	}
+	for _, restrictedID := range p.RestrictedCharacterIDs {
+		if restrictedID == characterID {
+			return false
+		}
+	}
+	return true
+}
+
+func parseLocationRestrictedCharacterIDs(value *string) []string {
+	if value == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	ids := make([]string, 0)
+	for _, raw := range strings.Split(*value, ",") {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -55,6 +55,7 @@ func TestBuildLocationAccessPolicy(t *testing.T) {
 		}{
 			{name: "before visible round", characterID: "char-1", round: 1, want: false},
 			{name: "allowed character in range", characterID: "char-1", round: 2, want: true},
+			{name: "missing character context on restricted location", characterID: " ", round: 2, want: false},
 			{name: "restricted character in range", characterID: "char-2", round: 3, want: false},
 			{name: "after visible round", characterID: "char-1", round: 5, want: false},
 		}

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -1,0 +1,91 @@
+package editor
+
+import "testing"
+
+func int32Value(value int32) *int32 { return &value }
+
+func TestBuildLocationAccessPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("restricted character CSV를 trim/dedupe하고 저장용 문자열을 정규화한다", func(t *testing.T) {
+		t.Parallel()
+		policy, err := BuildLocationAccessPolicy(stringPtr(" char-1, char-2, char-1,  "), int32Value(2), int32Value(4))
+		if err != nil {
+			t.Fatalf("BuildLocationAccessPolicy returned error: %v", err)
+		}
+
+		if got, want := policy.RestrictedCharacterIDs, []string{"char-1", "char-2"}; !stringSlicesEqual(got, want) {
+			t.Fatalf("RestrictedCharacterIDs = %v, want %v", got, want)
+		}
+		if policy.RestrictedCharacters == nil || *policy.RestrictedCharacters != "char-1,char-2" {
+			t.Fatalf("RestrictedCharacters = %v, want char-1,char-2", policy.RestrictedCharacters)
+		}
+		if policy.IsPublic() {
+			t.Fatal("restricted policy should not be public")
+		}
+	})
+
+	t.Run("빈 제한값은 공개 장소로 해석한다", func(t *testing.T) {
+		t.Parallel()
+		policy, err := BuildLocationAccessPolicy(stringPtr(" , "), nil, nil)
+		if err != nil {
+			t.Fatalf("BuildLocationAccessPolicy returned error: %v", err)
+		}
+
+		if !policy.IsPublic() {
+			t.Fatal("empty restricted characters should be public")
+		}
+		if policy.RestrictedCharacters != nil {
+			t.Fatalf("RestrictedCharacters = %v, want nil", *policy.RestrictedCharacters)
+		}
+	})
+
+	t.Run("라운드 범위와 캐릭터 제한으로 접근 가능 여부를 판단한다", func(t *testing.T) {
+		t.Parallel()
+		policy, err := BuildLocationAccessPolicy(stringPtr("char-2"), int32Value(2), int32Value(4))
+		if err != nil {
+			t.Fatalf("BuildLocationAccessPolicy returned error: %v", err)
+		}
+
+		cases := []struct {
+			name        string
+			characterID string
+			round       int32
+			want        bool
+		}{
+			{name: "before visible round", characterID: "char-1", round: 1, want: false},
+			{name: "allowed character in range", characterID: "char-1", round: 2, want: true},
+			{name: "restricted character in range", characterID: "char-2", round: 3, want: false},
+			{name: "after visible round", characterID: "char-1", round: 5, want: false},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				if got := policy.CanCharacterAccess(tc.characterID, tc.round); got != tc.want {
+					t.Fatalf("CanCharacterAccess(%q, %d) = %v, want %v", tc.characterID, tc.round, got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("from_round이 until_round보다 크면 거부한다", func(t *testing.T) {
+		t.Parallel()
+		if _, err := BuildLocationAccessPolicy(nil, int32Value(5), int32Value(3)); err == nil {
+			t.Fatal("expected invalid round order error")
+		}
+	})
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -1,6 +1,12 @@
 package editor
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mmp-platform/server/internal/apperror"
+)
 
 func int32Value(value int32) *int32 { return &value }
 
@@ -89,4 +95,61 @@ func stringSlicesEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestService_LocationRestrictedCharactersMustBelongToTheme(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
+	if err != nil {
+		t.Fatalf("CreateMap: %v", err)
+	}
+	allowedChar, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{Name: "탐정"})
+	if err != nil {
+		t.Fatalf("CreateCharacter allowed: %v", err)
+	}
+	otherChar, err := f.svc.CreateCharacter(ctx, creatorID, otherThemeID, CreateCharacterRequest{Name: "다른 테마 캐릭터"})
+	if err != nil {
+		t.Fatalf("CreateCharacter other: %v", err)
+	}
+
+	allowedCSV := allowedChar.ID.String() + "," + allowedChar.ID.String()
+	created, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{
+		Name:                 "서재",
+		RestrictedCharacters: &allowedCSV,
+	})
+	if err != nil {
+		t.Fatalf("CreateLocation with theme character: %v", err)
+	}
+	if created.RestrictedCharacters == nil || *created.RestrictedCharacters != allowedChar.ID.String() {
+		t.Fatalf("RestrictedCharacters = %v, want normalized allowed id", created.RestrictedCharacters)
+	}
+
+	invalidCSV := otherChar.ID.String()
+	if _, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{
+		Name:                 "금지 장소",
+		RestrictedCharacters: &invalidCSV,
+	}); !isBadRequest(err) {
+		t.Fatalf("CreateLocation with other theme character error = %T %v, want bad request", err, err)
+	}
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, created.ID, UpdateLocationRequest{
+		Name:                 created.Name,
+		RestrictedCharacters: &invalidCSV,
+		SortOrder:            created.SortOrder,
+		FromRound:            created.FromRound,
+		UntilRound:           created.UntilRound,
+	}); !isBadRequest(err) {
+		t.Fatalf("UpdateLocation with other theme character error = %T %v, want bad request", err, err)
+	}
+}
+
+func isBadRequest(err error) bool {
+	var appErr *apperror.AppError
+	return errors.As(err, &appErr) && appErr.Code == apperror.ErrBadRequest
 }

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -63,6 +63,7 @@ func TestBuildLocationAccessPolicy(t *testing.T) {
 			{name: "allowed character in range", characterID: "char-1", round: 2, want: true},
 			{name: "missing character context on restricted location", characterID: " ", round: 2, want: false},
 			{name: "restricted character in range", characterID: "char-2", round: 3, want: false},
+			{name: "restricted character with whitespace in range", characterID: " char-2 ", round: 3, want: false},
 			{name: "after visible round", characterID: "char-1", round: 5, want: false},
 		}
 

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -295,13 +295,13 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     const got = await locReq;
     expect(got).not.toBeNull();
 
-    const mapButton = page.getByText("저택 1층").first();
+    const mapButton = page.getByRole("button", { name: /^저택 1층$/ }).first();
     if (await mapButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
       await mapButton.click();
       await expect(page.getByText("거실").first()).toBeVisible({ timeout: 3_000 });
-      await expect(page.getByText(/R2~4|조사 시 발견 단서|접근 제한/).first()).toBeVisible({
-        timeout: 3_000,
-      });
+      await expect(page.getByText("R2~4").first()).toBeVisible({ timeout: 3_000 });
+      await expect(page.getByText(/조사 시 발견 단서/).first()).toBeVisible({ timeout: 3_000 });
+      await expect(page.getByText(/접근 제한/).first()).toBeVisible({ timeout: 3_000 });
     }
 
     // UI: 단서 chip/체크박스가 있으면 토글 + 즉시 반영

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -295,6 +295,15 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     const got = await locReq;
     expect(got).not.toBeNull();
 
+    const mapButton = page.getByText("저택 1층").first();
+    if (await mapButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await mapButton.click();
+      await expect(page.getByText("거실").first()).toBeVisible({ timeout: 3_000 });
+      await expect(page.getByText(/R2~4|조사 시 발견 단서|접근 제한/).first()).toBeVisible({
+        timeout: 3_000,
+      });
+    }
+
     // UI: 단서 chip/체크박스가 있으면 토글 + 즉시 반영
     const chip = page.getByRole("checkbox").first();
     if (await chip.isVisible({ timeout: 2_000 }).catch(() => false)) {

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -14,6 +14,7 @@ import type { Page } from "@playwright/test";
 export const BASE = "http://localhost:3000";
 export const THEME_ID = "00000000-0000-0000-0000-000000000184";
 export const CLUE_ID = "cccccccc-0000-0000-0000-000000000001";
+export const MAP_ID = "bbbbbbbb-0000-0000-0000-000000000001";
 export const LOCATION_ID = "dddddddd-0000-0000-0000-000000000001";
 export const FLOW_NODE_ID = "eeeeeeee-0000-0000-0000-000000000001";
 
@@ -164,13 +165,43 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
     });
   });
 
+  await page.route(`**/v1/editor/themes/${THEME_ID}/maps`, (r) => {
+    if (r.request().method() !== "GET") return r.continue();
+    return r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: MAP_ID,
+          theme_id: THEME_ID,
+          name: "저택 1층",
+          image_url: null,
+          sort_order: 0,
+          created_at: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
   await page.route(`**/v1/editor/themes/${THEME_ID}/locations`, (r) => {
     if (r.request().method() !== "GET") return r.continue();
     return r.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify([
-        { id: LOCATION_ID, theme_id: THEME_ID, name: "거실", sort_order: 0, clueIds: state.locationClueIds },
+        {
+          id: LOCATION_ID,
+          theme_id: THEME_ID,
+          map_id: MAP_ID,
+          name: "거실",
+          restricted_characters: "char-1",
+          image_url: "https://mock-storage.example/themes/location.png",
+          from_round: 2,
+          until_round: 4,
+          sort_order: 0,
+          created_at: new Date().toISOString(),
+          clueIds: state.locationClueIds,
+        },
       ]),
     });
   });

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -51,7 +51,7 @@ export function freshState(): MockState {
     configJson: { characters: [], locations: [], modules: {}, module_configs: {} },
     clueImageURL: null,
     startingClueIds: [],
-    locationClueIds: [],
+    locationClueIds: [CLUE_ID],
     moduleToggles: {},
     conflictCountdown: 1,
     flowPatchCalls: 0,

--- a/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
@@ -2,6 +2,12 @@ import { LockKeyhole } from 'lucide-react';
 import { toast } from 'sonner';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import type { LocationResponse } from '@/features/editor/api';
+import { getCharacterRoleOption } from '@/features/editor/entities/character/characterEditorAdapter';
+import {
+  formatLocationAccessLabel,
+  parseLocationRestrictedCharacterIds,
+  stringifyLocationRestrictedCharacterIds,
+} from '@/features/editor/entities/location/locationEntityAdapter';
 import { useEditorCharacters, useUpdateLocation } from '@/features/editor/api';
 
 interface LocationAccessPolicyPanelProps {
@@ -9,24 +15,13 @@ interface LocationAccessPolicyPanelProps {
   location: LocationResponse;
 }
 
-function parseRestrictedCharacters(value: string | null) {
-  if (!value) return new Set<string>();
-  return new Set(
-    value
-      .split(',')
-      .map((id) => id.trim())
-      .filter(Boolean)
-  );
-}
-
-function stringifyRestrictedCharacters(ids: Set<string>) {
-  return ids.size > 0 ? Array.from(ids).join(',') : null;
-}
-
 export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessPolicyPanelProps) {
   const { data: characters, isLoading, isError, error, refetch } = useEditorCharacters(themeId);
   const updateLocation = useUpdateLocation(themeId);
-  const restrictedSet = parseRestrictedCharacters(location.restricted_characters);
+  const restrictedSet = new Set(
+    parseLocationRestrictedCharacterIds(location.restricted_characters)
+  );
+  const accessLabel = formatLocationAccessLabel(location.restricted_characters, characters ?? []);
 
   function toggleCharacter(characterId: string, restricted: boolean) {
     const next = new Set(restrictedSet);
@@ -38,7 +33,7 @@ export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessP
         locationId: location.id,
         body: {
           name: location.name,
-          restricted_characters: stringifyRestrictedCharacters(next),
+          restricted_characters: stringifyLocationRestrictedCharacterIds(next),
           image_url: location.image_url,
           sort_order: location.sort_order,
           from_round: location.from_round ?? null,
@@ -56,7 +51,7 @@ export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessP
         <div>
           <p className="text-xs font-semibold text-slate-200">접근 제한</p>
           <p className="mt-1 text-xs leading-5 text-slate-500">
-            체크한 캐릭터는 이 장소에 들어오지 못합니다.
+            체크한 캐릭터는 이 장소에 들어오지 못합니다. 현재: {accessLabel}
           </p>
         </div>
       </div>
@@ -95,7 +90,9 @@ export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessP
               />
               <span className="min-w-0">
                 <span className="block truncate font-medium text-slate-200">{character.name}</span>
-                <span className="block text-xs text-slate-500">{character.mystery_role}</span>
+                <span className="block text-xs text-slate-500">
+                  {getCharacterRoleOption(character.mystery_role).label}
+                </span>
               </span>
             </label>
           ))}

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -119,7 +119,7 @@ export function LocationClueAssignPanel({
     >
       <header className="mb-3 flex flex-wrap items-center gap-2">
         <MapPin className="h-3.5 w-3.5 text-amber-500/70" />
-        <h4 className="text-sm font-semibold text-slate-200">{location.name} 단서 추가</h4>
+        <h4 className="text-sm font-semibold text-slate-200">{location.name} 조사 시 발견 단서</h4>
         <span className="text-xs text-slate-600">
           ({assignedIds.length}/{clues.length})
         </span>
@@ -175,7 +175,7 @@ export function LocationClueAssignPanel({
             </div>
             {selectedClues.length === 0 ? (
               <p className="rounded-md border border-dashed border-slate-800 px-2.5 py-5 text-center text-xs text-slate-600">
-                아직 배정된 단서가 없습니다. 좌측 목록에서 단서를 클릭하세요.
+                아직 배정된 단서가 없습니다. 좌측 목록에서 조사 시 발견할 단서를 클릭하세요.
               </p>
             ) : (
               <div className="space-y-2">

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -97,7 +97,7 @@ export function LocationClueAssignPanel({
   if (!allClues && isError) {
     return (
       <section
-        aria-label={`${location.name} 단서 배정`}
+        aria-label={`${location.name} 조사 시 발견 단서`}
         className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-center text-xs text-red-100"
       >
         <p>{error instanceof Error ? error.message : '단서 목록을 불러오지 못했습니다.'}</p>
@@ -114,7 +114,7 @@ export function LocationClueAssignPanel({
 
   return (
     <section
-      aria-label={`${location.name} 단서 배정`}
+      aria-label={`${location.name} 조사 시 발견 단서`}
       className="rounded-lg border border-slate-800 bg-slate-950/70 p-3"
     >
       <header className="mb-3 flex flex-wrap items-center gap-2">

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -5,6 +5,7 @@ import type { EditorThemeResponse, MapResponse, LocationResponse } from '@/featu
 import { useUpdateLocation } from '@/features/editor/api';
 import { ImageUpload } from '@/features/editor/components/ImageUpload';
 import { readLocationClueIds } from '@/features/editor/editorTypes';
+import { toLocationEditorViewModel } from '@/features/editor/entities/location/locationEntityAdapter';
 import { AddNameInput } from './AddNameInput';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import { LocationAccessPolicyPanel } from './LocationAccessPolicyPanel';
@@ -81,13 +82,24 @@ export function LocationDetailPanel({
       }
       getItemId={(location) => location.id}
       getItemTitle={(location) => location.name}
-      getItemDescription={(location) => formatLocationRounds(location)}
-      getItemBadges={() => [selectedMap.name]}
+      getItemDescription={(location) =>
+        toLocationEditorViewModel(location, {
+          clueCount: readLocationClueIds(theme.config_json, location.id).length,
+          mapName: selectedMap.name,
+        }).roundLabel
+      }
+      getItemBadges={(location) =>
+        toLocationEditorViewModel(location, {
+          clueCount: readLocationClueIds(theme.config_json, location.id).length,
+          mapName: selectedMap.name,
+        }).badges
+      }
       renderItemActions={(location) => (
         <button
           type="button"
           onClick={() => {
-            if (window.confirm(`${location.name} 장소를 삭제할까요?`)) onDeleteLocation(location.id);
+            if (window.confirm(`${location.name} 장소를 삭제할까요?`))
+              onDeleteLocation(location.id);
           }}
           aria-label={`${location.name} 삭제`}
           className="rounded-md p-2 text-slate-700 opacity-100 transition hover:bg-red-950/40 hover:text-red-300 md:opacity-0 md:group-hover:opacity-100"
@@ -106,12 +118,6 @@ export function LocationDetailPanel({
     />
   );
 }
-function formatLocationRounds(location: LocationResponse) {
-  const from = location.from_round ? `${location.from_round}라운드부터` : '처음부터';
-  const until = location.until_round ? `${location.until_round}라운드까지` : '끝까지';
-  return `${from} · ${until}`;
-}
-
 function SelectedLocationDetail({
   themeId,
   theme,
@@ -130,6 +136,10 @@ function SelectedLocationDetail({
     () => readLocationClueIds(theme.config_json, location.id).length,
     [theme.config_json, location.id]
   );
+  const viewModel = toLocationEditorViewModel(location, {
+    clueCount: assignedCount,
+    mapName: map.name,
+  });
 
   useEffect(() => {
     setFromRoundInput(roundToInput(location.from_round));
@@ -184,11 +194,12 @@ function SelectedLocationDetail({
             <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-amber-300/80">
               장소 상세
             </p>
-            <h3 className="mt-1 text-xl font-semibold text-slate-100">{location.name}</h3>
+            <h3 className="mt-1 text-xl font-semibold text-slate-100">{viewModel.name}</h3>
             <p className="mt-1 text-xs text-slate-500">트리 경로: {getPathLabel(map, location)}</p>
+            <p className="mt-1 text-xs text-slate-400">{viewModel.roundLabel}</p>
           </div>
           <div className="rounded-lg border border-slate-800 bg-slate-900/80 px-3 py-2 text-xs text-slate-400">
-            단서 연결 <span className="font-semibold text-amber-300">{assignedCount}개</span>
+            {viewModel.clueCountLabel.replace('조사 시 발견 단서 ', '단서 ')}
           </div>
         </div>
         <div className="grid gap-4 lg:grid-cols-[minmax(12rem,0.42fr)_minmax(0,1fr)]">
@@ -201,7 +212,7 @@ function SelectedLocationDetail({
               themeId={themeId}
               target="location"
               targetId={location.id}
-              currentImageUrl={location.image_url}
+              currentImageUrl={viewModel.imageUrl}
               aspectRatio="16 / 10"
               onUploaded={(url) => saveLocation({ image_url: url || null })}
             />
@@ -254,7 +265,7 @@ function RoundFields({
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
       <p className="mb-2 text-xs font-semibold text-slate-300">라운드 노출</p>
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid gap-2 sm:grid-cols-2">
         <label className="text-xs text-slate-500">
           등장 라운드
           <input

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -199,7 +199,7 @@ function SelectedLocationDetail({
             <p className="mt-1 text-xs text-slate-400">{viewModel.roundLabel}</p>
           </div>
           <div className="rounded-lg border border-slate-800 bg-slate-900/80 px-3 py-2 text-xs text-slate-400">
-            {viewModel.clueCountLabel.replace('조사 시 발견 단서 ', '단서 ')}
+            {viewModel.clueShortLabel}
           </div>
         </div>
         <div className="grid gap-4 lg:grid-cols-[minmax(12rem,0.42fr)_minmax(0,1fr)]">

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -37,11 +37,7 @@ vi.mock('@/features/editor/api', () => ({
 // ---------------------------------------------------------------------------
 
 import { LocationClueAssignPanel } from '../LocationClueAssignPanel';
-import type {
-  EditorThemeResponse,
-  ClueResponse,
-  LocationResponse,
-} from '@/features/editor/api';
+import type { EditorThemeResponse, ClueResponse, LocationResponse } from '@/features/editor/api';
 
 // ---------------------------------------------------------------------------
 // Mock data
@@ -142,11 +138,7 @@ function renderQC(ui: ReactElement): { qc: QueryClient } {
 describe('LocationClueAssignPanel', () => {
   it('모든 clue가 chip으로 렌더링된다', () => {
     renderQC(
-      <LocationClueAssignPanel
-        themeId="theme-1"
-        theme={baseTheme}
-        location={mockLocation}
-      />,
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
     expect(screen.getByText('단검')).toBeDefined();
     expect(screen.getByText('편지')).toBeDefined();
@@ -157,9 +149,7 @@ describe('LocationClueAssignPanel', () => {
       ...baseTheme,
       config_json: { locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }] },
     };
-    renderQC(
-      <LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />,
-    );
+    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
     expect(screen.getByText('(1/2)')).toBeDefined();
   });
 
@@ -168,9 +158,7 @@ describe('LocationClueAssignPanel', () => {
       ...baseTheme,
       config_json: { locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }] },
     };
-    renderQC(
-      <LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />,
-    );
+    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
     expect((screen.getByLabelText('단검 추가') as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByLabelText('편지 추가') as HTMLButtonElement).disabled).toBe(false);
     expect(screen.getByLabelText('단검 제거')).toBeDefined();
@@ -178,16 +166,15 @@ describe('LocationClueAssignPanel', () => {
 
   it('배정되지 않은 clue 클릭 시 clueIds에 추가되어 mutate가 호출된다', () => {
     renderQC(
-      <LocationClueAssignPanel
-        themeId="theme-1"
-        theme={baseTheme}
-        location={mockLocation}
-      />,
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
     fireEvent.click(screen.getByLabelText('단검 추가'));
     expect(mutateMock).toHaveBeenCalledOnce();
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
-    const locs = config.locations as Array<{ id: string; locationClueConfig: { clueIds: string[] } }>;
+    const locs = config.locations as Array<{
+      id: string;
+      locationClueConfig: { clueIds: string[] };
+    }>;
     expect(locs).toHaveLength(1);
     expect(locs[0]).toEqual({ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } });
   });
@@ -195,15 +182,18 @@ describe('LocationClueAssignPanel', () => {
   it('이미 배정된 clue 클릭 시 clueIds에서 제거된다', () => {
     const theme: EditorThemeResponse = {
       ...baseTheme,
-      config_json: { locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1', 'clue-2'] } }] },
+      config_json: {
+        locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1', 'clue-2'] } }],
+      },
     };
-    renderQC(
-      <LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />,
-    );
+    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
     fireEvent.click(screen.getByLabelText('단검 제거'));
     expect(mutateMock).toHaveBeenCalledOnce();
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
-    const locs = config.locations as Array<{ id: string; locationClueConfig: { clueIds: string[] } }>;
+    const locs = config.locations as Array<{
+      id: string;
+      locationClueConfig: { clueIds: string[] };
+    }>;
     expect(locs[0].locationClueConfig.clueIds).toEqual(['clue-2']);
   });
 
@@ -217,7 +207,7 @@ describe('LocationClueAssignPanel', () => {
         theme={baseTheme}
         location={mockLocation}
         onChange={onChange}
-      />,
+      />
     );
     fireEvent.click(screen.getByLabelText('단검 추가'));
     expect(onChange).toHaveBeenCalledWith(['clue-1']);
@@ -226,11 +216,7 @@ describe('LocationClueAssignPanel', () => {
   it('clue가 없으면 안내 메시지가 표시된다', () => {
     useEditorCluesMock.mockReturnValue({ data: [], isLoading: false });
     renderQC(
-      <LocationClueAssignPanel
-        themeId="theme-1"
-        theme={baseTheme}
-        location={mockLocation}
-      />,
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
     expect(screen.getByText('단서가 없습니다')).toBeDefined();
   });
@@ -243,7 +229,7 @@ describe('LocationClueAssignPanel', () => {
         theme={baseTheme}
         location={mockLocation}
         allClues={mockClues}
-      />,
+      />
     );
     expect(screen.getByText('단검')).toBeDefined();
   });
@@ -251,11 +237,7 @@ describe('LocationClueAssignPanel', () => {
   it('isPending 중에는 chip 이 disabled 된다', () => {
     useUpdateConfigJsonMock.mockReturnValue({ mutate: mutateMock, isPending: true });
     renderQC(
-      <LocationClueAssignPanel
-        themeId="theme-1"
-        theme={baseTheme}
-        location={mockLocation}
-      />,
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
     const chip = screen.getByLabelText('단검 추가') as HTMLButtonElement;
     expect(chip.disabled).toBe(true);
@@ -271,20 +253,18 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
 
   it('commit 시 theme 캐시의 config_json 이 낙관 반영된다', () => {
     const { qc } = renderQC(
-      <LocationClueAssignPanel
-        themeId="theme-1"
-        theme={baseTheme}
-        location={mockLocation}
-      />,
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
     qc.setQueryData(cacheKey, baseTheme);
 
     fireEvent.click(screen.getByLabelText('단검 추가'));
 
     const cached = qc.getQueryData<EditorThemeResponse>(cacheKey);
-    const locs = (cached?.config_json as {
-      locations?: Array<{ id: string; locationClueConfig: { clueIds: string[] } }>;
-    })?.locations;
+    const locs = (
+      cached?.config_json as {
+        locations?: Array<{ id: string; locationClueConfig: { clueIds: string[] } }>;
+      }
+    )?.locations;
     expect(locs?.[0]).toEqual({
       id: 'loc-1',
       locationClueConfig: { clueIds: ['clue-1'] },
@@ -296,11 +276,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     mutateMock.mockImplementation((_cfg, opts) => opts?.onError?.(new Error('fail')));
 
     const { qc } = renderQC(
-      <LocationClueAssignPanel
-        themeId="theme-1"
-        theme={baseTheme}
-        location={mockLocation}
-      />,
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
     qc.setQueryData(cacheKey, baseTheme);
 
@@ -332,7 +308,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
         theme={baseTheme}
         location={mockLocation}
         onChange={onChange}
-      />,
+      />
     );
     // 초기 캐시: 배정 없음
     qc.setQueryData(cacheKey, baseTheme);
@@ -360,11 +336,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
   it('theme 캐시가 없으면 mutate 만 호출되고 rollback 대상도 없다', () => {
     mutateMock.mockImplementation((_cfg, opts) => opts?.onError?.(new Error('fail')));
     const { qc } = renderQC(
-      <LocationClueAssignPanel
-        themeId="theme-1"
-        theme={baseTheme}
-        location={mockLocation}
-      />,
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
     // no setQueryData
 

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -297,7 +297,7 @@ describe('LocationsSubTab', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       fireEvent.click(screen.getByText('저택 1층'));
       fireEvent.click(screen.getByRole('button', { name: '주방 선택' }));
-      expect(screen.getByLabelText('주방 단서 배정')).toBeDefined();
+      expect(screen.getByLabelText('주방 조사 시 발견 단서')).toBeDefined();
       expect(screen.getByLabelText('단검 추가')).toBeDefined();
     });
 

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import type { EditorCharacterResponse, LocationResponse } from '@/features/editor/api/types';
+import {
+  buildLocationBadges,
+  formatLocationAccessLabel,
+  parseLocationRestrictedCharacterIds,
+  stringifyLocationRestrictedCharacterIds,
+  toLocationEditorViewModel,
+} from '../locationEntityAdapter';
+
+const characters: EditorCharacterResponse[] = [
+  {
+    id: 'char-1',
+    theme_id: 'theme-1',
+    name: '탐정 한나',
+    description: null,
+    image_url: null,
+    is_culprit: false,
+    mystery_role: 'detective',
+    sort_order: 0,
+  },
+  {
+    id: 'char-2',
+    theme_id: 'theme-1',
+    name: '정원사 민수',
+    description: null,
+    image_url: null,
+    is_culprit: false,
+    mystery_role: 'suspect',
+    sort_order: 1,
+  },
+];
+
+function location(overrides: Partial<LocationResponse> = {}): LocationResponse {
+  return {
+    id: 'loc-1',
+    theme_id: 'theme-1',
+    map_id: 'map-1',
+    name: '서재',
+    restricted_characters: null,
+    image_url: null,
+    sort_order: 0,
+    created_at: '2026-05-03T00:00:00Z',
+    from_round: null,
+    until_round: null,
+    ...overrides,
+  };
+}
+
+describe('locationEntityAdapter', () => {
+  it('장소 API 응답을 제작자용 ViewModel으로 변환한다', () => {
+    const vm = toLocationEditorViewModel(
+      location({
+        restricted_characters: 'char-1',
+        image_url: 'https://cdn.example/study.webp',
+        from_round: 2,
+        until_round: 4,
+      }),
+      { characters, clueCount: 3, mapName: '저택 1층' }
+    );
+
+    expect(vm).toMatchObject({
+      id: 'loc-1',
+      name: '서재',
+      imageUrl: 'https://cdn.example/study.webp',
+      roundLabel: 'R2~4',
+      accessLabel: '탐정 한나 접근 제한',
+      clueCountLabel: '조사 시 발견 단서 3개',
+      badges: ['저택 1층', 'R2~4', '접근 제한 있음', '단서 3', '이미지 있음'],
+    });
+  });
+
+  it('restricted character CSV를 trim/dedupe한다', () => {
+    expect(parseLocationRestrictedCharacterIds(' char-1, char-2, char-1, ')).toEqual([
+      'char-1',
+      'char-2',
+    ]);
+    expect(stringifyLocationRestrictedCharacterIds([' char-1 ', '', 'char-2'])).toBe(
+      'char-1,char-2'
+    );
+  });
+
+  it('제작자에게 내부 ID 대신 접근 요약 문구를 제공한다', () => {
+    expect(formatLocationAccessLabel(null, characters)).toBe('모든 캐릭터 접근 가능');
+    expect(formatLocationAccessLabel('char-unknown', characters)).toBe('1명 접근 제한');
+    expect(formatLocationAccessLabel('char-1,char-2,char-3', characters)).toBe(
+      '탐정 한나, 정원사 민수 외 1명 접근 제한'
+    );
+  });
+
+  it('목록 배지는 맵/라운드/접근/단서/이미지 상태만 표시한다', () => {
+    expect(buildLocationBadges(location(), 0, '저택 1층')).toEqual([
+      '저택 1층',
+      '처음부터 끝까지',
+      '전체 접근',
+      '단서 없음',
+    ]);
+  });
+});

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -66,6 +66,7 @@ describe('locationEntityAdapter', () => {
       roundLabel: 'R2~4',
       accessLabel: '탐정 한나 접근 제한',
       clueCountLabel: '조사 시 발견 단서 3개',
+      clueShortLabel: '단서 3개',
       badges: ['저택 1층', 'R2~4', '접근 제한 있음', '단서 3', '이미지 있음'],
     });
   });
@@ -75,7 +76,7 @@ describe('locationEntityAdapter', () => {
       'char-1',
       'char-2',
     ]);
-    expect(stringifyLocationRestrictedCharacterIds([' char-1 ', '', 'char-2'])).toBe(
+    expect(stringifyLocationRestrictedCharacterIds([' char-1 ', '', 'char-2', 'char-1'])).toBe(
       'char-1,char-2'
     );
   });

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -1,0 +1,93 @@
+import type { EditorCharacterResponse, LocationResponse } from '@/features/editor/api/types';
+import { formatRoundRange } from '@/features/editor/utils/roundFormat';
+
+export interface LocationEditorViewModel {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+  roundLabel: string;
+  accessLabel: string;
+  clueCountLabel: string;
+  badges: string[];
+}
+
+export function toLocationEditorViewModel(
+  location: LocationResponse,
+  options: { characters?: EditorCharacterResponse[]; clueCount?: number; mapName?: string } = {}
+): LocationEditorViewModel {
+  const clueCount = options.clueCount ?? 0;
+  return {
+    id: location.id,
+    name: location.name,
+    imageUrl: location.image_url ?? null,
+    roundLabel: formatLocationRoundLabel(location),
+    accessLabel: formatLocationAccessLabel(
+      location.restricted_characters,
+      options.characters ?? []
+    ),
+    clueCountLabel: `조사 시 발견 단서 ${clueCount}개`,
+    badges: buildLocationBadges(location, clueCount, options.mapName),
+  };
+}
+
+export function parseLocationRestrictedCharacterIds(value: string | null | undefined): string[] {
+  if (!value) return [];
+  const seen = new Set<string>();
+  return value
+    .split(',')
+    .map((id) => id.trim())
+    .filter((id) => {
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+}
+
+export function stringifyLocationRestrictedCharacterIds(ids: Iterable<string>): string | null {
+  const normalized = Array.from(ids)
+    .map((id) => id.trim())
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized.join(',') : null;
+}
+
+export function formatLocationAccessLabel(
+  restrictedCharacters: string | null | undefined,
+  characters: EditorCharacterResponse[]
+): string {
+  const restrictedIds = parseLocationRestrictedCharacterIds(restrictedCharacters);
+  if (restrictedIds.length === 0) return '모든 캐릭터 접근 가능';
+
+  const nameById = new Map(characters.map((character) => [character.id, character.name]));
+  const names = restrictedIds
+    .map((id) => nameById.get(id))
+    .filter((name): name is string => Boolean(name));
+  if (names.length === 0) return `${restrictedIds.length}명 접근 제한`;
+  if (names.length === restrictedIds.length && names.length <= 2)
+    return `${names.join(', ')} 접근 제한`;
+
+  const visibleNames = names.slice(0, 2);
+  const hiddenCount = restrictedIds.length - visibleNames.length;
+  return `${visibleNames.join(', ')} 외 ${hiddenCount}명 접근 제한`;
+}
+
+export function formatLocationRoundLabel(
+  location: Pick<LocationResponse, 'from_round' | 'until_round'>
+): string {
+  return formatRoundRange(location.from_round, location.until_round) || '처음부터 끝까지';
+}
+
+export function buildLocationBadges(
+  location: LocationResponse,
+  clueCount: number,
+  mapName?: string
+): string[] {
+  return [
+    mapName || null,
+    formatLocationRoundLabel(location),
+    parseLocationRestrictedCharacterIds(location.restricted_characters).length > 0
+      ? '접근 제한 있음'
+      : '전체 접근',
+    clueCount > 0 ? `단서 ${clueCount}` : '단서 없음',
+    location.image_url ? '이미지 있음' : null,
+  ].filter((badge): badge is string => Boolean(badge));
+}

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -8,6 +8,7 @@ export interface LocationEditorViewModel {
   roundLabel: string;
   accessLabel: string;
   clueCountLabel: string;
+  clueShortLabel: string;
   badges: string[];
 }
 
@@ -26,6 +27,7 @@ export function toLocationEditorViewModel(
       options.characters ?? []
     ),
     clueCountLabel: `조사 시 발견 단서 ${clueCount}개`,
+    clueShortLabel: `단서 ${clueCount}개`,
     badges: buildLocationBadges(location, clueCount, options.mapName),
   };
 }
@@ -44,9 +46,7 @@ export function parseLocationRestrictedCharacterIds(value: string | null | undef
 }
 
 export function stringifyLocationRestrictedCharacterIds(ids: Iterable<string>): string | null {
-  const normalized = Array.from(ids)
-    .map((id) => id.trim())
-    .filter(Boolean);
+  const normalized = parseLocationRestrictedCharacterIds(Array.from(ids).join(','));
   return normalized.length > 0 ? normalized.join(',') : null;
 }
 

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -2,7 +2,7 @@
 phase_id: "phase-24-editor-redesign"
 phase_title: "Phase 24 — 에디터 ECS 재설계 (단서 단일 진실 위치 + 동적 모듈 + 결말 분기 매트릭스)"
 created: 2026-05-01
-status: "issue-based Phase 24 continuation — PR-7 active"
+status: "issue-based Phase 24 continuation — PR-8 active"
 spec: "docs/superpowers/specs/2026-05-01-phase-24-editor-redesign/design.md"
 prs_estimated: "issue-based: PR-5A~PR-9 active after PR-4"
 parent_phase: "phase-21-editor-ux"
@@ -39,8 +39,8 @@ parent_phase: "phase-21-editor-ux"
 | [#231](https://github.com/sabyunrepo/muder_platform/issues/231) | PR-5B | 페이즈 정보 전달 Frontend Adapter | done |
 | [#232](https://github.com/sabyunrepo/muder_platform/issues/232) | PR-5C | 정보 전달 Backend Engine 및 런타임 공개 상태 | done |
 | [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | done |
-| [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | active |
-| [#235](https://github.com/sabyunrepo/muder_platform/issues/235) | PR-8 | 장소 Adapter/Engine 이관 | brainstorming gate |
+| [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | done |
+| [#235](https://github.com/sabyunrepo/muder_platform/issues/235) | PR-8 | 장소 Adapter/Engine 이관 | active |
 | [#236](https://github.com/sabyunrepo/muder_platform/issues/236) | PR-9 | 결말/통합 Adapter-Engine 검증 및 E2E | brainstorming gate |
 
 ## Legacy Wave/PR 분해 (6 PR — historical baseline)

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-8-location-adapter-engine-plan.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-8-location-adapter-engine-plan.md
@@ -1,0 +1,70 @@
+# PR-8 — 장소 Adapter/Engine 이관 계획
+
+## 상태
+
+- Issue: #235 `[Phase 24][PR-8] 장소 Adapter/Engine 브레인스토밍 및 이관`
+- Branch: `feat/issue-235-location-adapter-engine`
+- 목표: 기존 장소 UI/저장 흐름을 유지하면서, 제작자 화면은 Frontend Adapter가 읽기 쉬운 ViewModel로 정리하고 런타임 판단은 Backend Engine 정책으로 분리한다.
+
+## Uzu 참고점
+
+- `basic-features/room.md`: 방/장소는 플레이어가 머무는 공간이며, 최소 1개 기본 공간은 항상 사용 가능해야 한다. 특정 방은 phase나 조건에 따라 사용 가능 여부를 바꿀 수 있다.
+- `basic-features/decks.md`: 조사는 token/deck 기반으로 단서를 지급할 수 있으며, 실행 조건과 지급 단서의 공개 방식을 분리한다.
+- `overview/available.md`: 조건은 AND/OR 조합으로 중첩될 수 있고, 방 조건/단서 배포/회수/비밀번호 단서 같은 기능을 제공한다.
+
+## MMP 적용 방식
+
+- 장소는 현재 `Map -> Location` 구조를 유지한다. 제작자는 내부 ID나 config key를 보지 않고 “어느 맵의 장소인지”, “언제 보이는지”, “누가 못 들어가는지”, “조사 시 발견 가능한 단서”만 관리한다.
+- 접근 제한은 현재 저장 필드인 `restricted_characters`, `from_round`, `until_round`를 Backend Engine 정책으로 해석한다.
+- 장소 단서는 이번 PR에서 “조사 시 발견 후보”로 표시하되, token/deck 소비와 조건부 조사 런타임은 후속 entity/engine PR에서 확장한다.
+- 장소 이미지는 기존 R2 업로드/presign 흐름을 그대로 사용한다.
+- 삭제 정합성은 기존 backend transaction cleanup을 유지하고, 장소 참조 제거 정책의 테스트 범위를 보강한다.
+
+## 제외 / 후순위
+
+- 무한 장소 트리 런타임, token/deck 조사 비용, 비밀번호 조사, 조건식 조합 UI는 이번 PR에서 구현하지 않는다.
+- 단, 후속 확장이 막히지 않도록 adapter/engine 함수 경계를 작게 만든다.
+- 제작자 화면에는 raw JSON, DB 필드명, internal ID, config key를 표시하지 않는다.
+
+## 구현 범위
+
+### Frontend Adapter
+
+- `LocationEntityAdapter` 추가
+  - API DTO -> 제작자 ViewModel 변환
+  - 라운드 표시 문구, 접근 제한 요약, 단서 개수, 이미지 여부, 목록 배지 생성
+  - CSV restricted character 문자열을 캐릭터 이름 요약으로 변환
+- 장소 상세/목록에서 Adapter 파생 문구 사용
+- 단서 배정 문구를 “조사 시 발견 단서”로 정리
+- 모바일 우선 세로 흐름 유지
+
+### Backend Engine Policy
+
+- `LocationAccessPolicy` 추가
+  - restricted character CSV 정규화
+  - 라운드 표시 가능 여부 판단
+  - 캐릭터 접근 가능 여부 판단
+  - create/update 시 동일 정책으로 validation/normalization
+- 기존 삭제 정합성 transaction 유지
+
+## 테스트 계획
+
+- Go unit test
+  - restricted character CSV trim/dedupe/empty 처리
+  - round window 검증과 접근 가능 여부
+  - invalid round order 거부
+- Vitest
+  - Location adapter ViewModel 변환
+  - 접근 제한 패널이 adapter 기준으로 사용자 문구/저장 payload 유지
+  - 장소 상세/목록에서 내부 정보 없이 필요한 요약 표시
+- Playwright E2E
+  - 장소 탭 로드 시 위치/접근/조사 단서 UI가 보이는지 network-only fixture로 확인
+
+## 완료 조건
+
+- [ ] PR-8 계획과 checklist 상태가 최신이다.
+- [ ] Frontend Adapter와 테스트가 있다.
+- [ ] Backend Engine Policy와 테스트가 있다.
+- [ ] 장소 E2E가 fixture 기반으로 보강되었다.
+- [ ] focused `go test`, `vitest`, 가능하면 해당 E2E가 통과한다.
+- [ ] PR 생성 전 코드 리뷰를 수행한다.


### PR DESCRIPTION
## 목표

Phase 24 PR-8로 장소 엔티티를 Frontend Adapter / Backend Engine 경계에 맞게 정리합니다.

## 변경 내용

- 장소 제작자 화면용 `LocationEntityAdapter` 추가
  - 라운드 표시, 접근 제한 요약, 조사 시 발견 단서 개수, 목록 배지를 사용자 문구로 변환
  - internal ID / raw config key 노출 없이 필요한 정보만 표시
- 장소 접근 제한 backend policy 추가
  - `restricted_characters` CSV trim/dedupe 정규화
  - 라운드 범위와 캐릭터 접근 가능 여부를 backend에서 판단 가능하게 분리
  - create/update 저장 경로에서 동일 policy 사용
- 장소 단서 배정 문구를 “조사 시 발견 단서” 흐름으로 정리
- E2E fixture에 map/location 응답과 장소 접근/라운드 표시 검증 보강
- Phase 24 checklist와 PR-8 계획 문서 갱신

## Uzu 참고 및 MMP 적용

- Uzu의 room/deck 문서를 참고해 장소 접근과 조사 단서 후보 개념만 반영했습니다.
- token/deck 조사 비용, 조건식 조합, 비밀번호 조사 런타임은 이번 PR 범위에서 제외하고 후속 PR로 남겼습니다.
- 기존 Map/Location 저장 구조와 R2 이미지 업로드 경로는 유지했습니다.

## 검증

- `cd apps/web && pnpm vitest run src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx`
  - 4 files / 44 tests passed
- `cd apps/server && go test ./internal/domain/editor -run 'TestBuildLocationAccessPolicy|Test.*Location' -count=1`
  - passed
- `cd apps/web && pnpm typecheck`
  - passed
- `cd apps/web && pnpm lint`
  - passed, 기존 warning만 존재
- `cd apps/web && pnpm exec playwright test e2e/editor-golden-path.spec.ts -g "\[8\]" --project=chromium`
  - 1 passed
- `git diff --check`
  - passed

## PR 운영 메모

- `ready-for-ci` 라벨은 아직 붙이지 않습니다.
- CodeRabbit 리뷰를 먼저 확인하고, 타당한 리뷰 반영 및 재리뷰 확인 후 라벨을 붙여 CI를 실행합니다.

Closes #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 장소 접근 정책 엔진 추가: 라운드 범위와 제한된 캐릭터 목록 정규화·검증 및 접근 판단 제공(생성/수정 시 동일 검증, 제한된 캐릭터는 동일 테마 소속만 허용).
  * 장소 어댑터 추가: UI용 뷰모델 생성(라운드·접근 레이블, 배지, 이미지·단서 카운트) 및 제한 캐릭터 CSV 파싱/직렬화 유틸 제공.

* **UI**
  * 접근 레이블 반영, 일부 문구 변경(예: “조사 시 발견 단서”) 및 상세 패널 레이아웃/데이터 소스 조정.
  * E2E 목업/픽스처 확장으로 지도·장소 표현 강화.

* **Tests**
  * 접근 정책 단위·통합 테스트, 뷰모델 Vitest 및 E2E 시나리오 추가/확장.

* **Documentation**
  * 장소 어댑터/엔진 이관 계획 문서 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->