### PR TITLE
feat(editor): 결말 판정 엔진과 에디터 검수 UI 연결

### DIFF
--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -188,16 +188,15 @@ func ensureImplicitPhaseActionModules(cfg *GameConfig) error {
 	if cfg == nil {
 		return nil
 	}
-	implicitModules := []struct {
-		action     PhaseAction
-		moduleName string
-	}{
-		{action: ActionDeliverInformation, moduleName: "information_delivery"},
-		{action: ActionEvaluateEnding, moduleName: "ending_branch"},
+	implicitActions := []PhaseAction{
+		ActionDeliverInformation,
+		ActionEvaluateEnding,
 	}
-	for _, implicit := range implicitModules {
-		action := implicit.action
-		moduleName := implicit.moduleName
+	for _, action := range implicitActions {
+		moduleName, ok := ActionRequiresModule[action]
+		if !ok || moduleName == "" {
+			continue
+		}
 		usesAction, err := phasesUseAction(cfg.Phases, action)
 		if err != nil {
 			return err

--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -188,14 +188,24 @@ func ensureImplicitPhaseActionModules(cfg *GameConfig) error {
 	if cfg == nil {
 		return nil
 	}
-	usesAction, err := phasesUseAction(cfg.Phases, ActionDeliverInformation)
-	if err != nil {
-		return err
+	implicitModules := []struct {
+		action     PhaseAction
+		moduleName string
+	}{
+		{action: ActionDeliverInformation, moduleName: "information_delivery"},
+		{action: ActionEvaluateEnding, moduleName: "ending_branch"},
 	}
-	if !usesAction || hasModuleConfig(cfg.Modules, "information_delivery") {
-		return nil
+	for _, implicit := range implicitModules {
+		action := implicit.action
+		moduleName := implicit.moduleName
+		usesAction, err := phasesUseAction(cfg.Phases, action)
+		if err != nil {
+			return err
+		}
+		if usesAction && !hasModuleConfig(cfg.Modules, moduleName) {
+			cfg.Modules = append(cfg.Modules, ModuleConfig{Name: moduleName})
+		}
 	}
-	cfg.Modules = append(cfg.Modules, ModuleConfig{Name: "information_delivery"})
 	return nil
 }
 

--- a/apps/server/internal/engine/factory_test.go
+++ b/apps/server/internal/engine/factory_test.go
@@ -189,6 +189,28 @@ func TestParseGameConfig_AddsInformationDeliveryModuleForPhaseAction(t *testing.
 	}
 }
 
+func TestParseGameConfig_AddsEndingBranchModuleForEvaluateEndingAction(t *testing.T) {
+	data := []byte(`{"phases":[{"id":"final","name":"Final","onEnter":[{"type":"EVALUATE_ENDING"}]}],"modules":[]}`)
+	cfg, err := ParseGameConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Modules) != 1 || cfg.Modules[0].Name != "ending_branch" {
+		t.Fatalf("implicit modules = %#v", cfg.Modules)
+	}
+}
+
+func TestParseGameConfig_DoesNotDuplicateImplicitEndingBranchModule(t *testing.T) {
+	data := []byte(`{"phases":[{"id":"final","name":"Final","onEnter":[{"type":"EVALUATE_ENDING"}]}],"modules":[{"name":"ending_branch","config":{"defaultEnding":"미해결"}}]}`)
+	cfg, err := ParseGameConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Modules) != 1 || cfg.Modules[0].Name != "ending_branch" {
+		t.Fatalf("modules = %#v", cfg.Modules)
+	}
+}
+
 func TestParseGameConfig_InvalidPhaseActionConfigFailsEarly(t *testing.T) {
 	data := []byte(`{"phases":[{"id":"p1","name":"Phase 1","onEnter":"not-actions"}],"modules":[]}`)
 	_, err := ParseGameConfig(data)

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -20,6 +20,7 @@ const (
 	ActionAllowExchange       PhaseAction = "ALLOW_EXCHANGE"
 	ActionBroadcastMessage    PhaseAction = "BROADCAST_MESSAGE"
 	ActionDeliverInformation  PhaseAction = "DELIVER_INFORMATION"
+	ActionEvaluateEnding      PhaseAction = "EVALUATE_ENDING"
 	ActionPlaySound           PhaseAction = "PLAY_SOUND"
 	ActionPlayMedia           PhaseAction = "PLAY_MEDIA"
 	ActionSetBGM              PhaseAction = "SET_BGM"
@@ -64,6 +65,7 @@ var ActionRequiresModule = map[PhaseAction]string{
 	ActionOpenGroupChat:       "group_chat",
 	ActionCloseGroupChat:      "group_chat",
 	ActionDeliverInformation:  "information_delivery",
+	ActionEvaluateEnding:      "ending_branch",
 }
 
 // --- Module Interfaces ---

--- a/apps/server/internal/module/decision/ending_branch/config.go
+++ b/apps/server/internal/module/decision/ending_branch/config.go
@@ -12,8 +12,8 @@ type Question struct {
 	ScoreMap    map[string]int `json:"scoreMap,omitempty"`
 }
 
-// MatrixRow is one priority-ordered branching rule. JSONLogic evaluator (PR-5)
-// converts conditions to a JSONLogic AST.
+// MatrixRow is one priority-ordered branching rule. Runtime evaluation passes
+// Conditions to the shared JSONLogic evaluator.
 type MatrixRow struct {
 	Priority   int            `json:"priority"`
 	Conditions map[string]any `json:"conditions"`

--- a/apps/server/internal/module/decision/ending_branch/config.go
+++ b/apps/server/internal/module/decision/ending_branch/config.go
@@ -7,7 +7,7 @@ type Question struct {
 	Text        string         `json:"text"`
 	Type        string         `json:"type"` // "single" | "multi"
 	Choices     []string       `json:"choices"`
-	Respondents any            `json:"respondents,omitempty"` // []string | "all" | "some" — runtime validate
+	Respondents any            `json:"respondents,omitempty"` // []string | "all" — validated at config apply
 	Impact      string         `json:"impact"`                // "branch" | "score"
 	ScoreMap    map[string]int `json:"scoreMap,omitempty"`
 }

--- a/apps/server/internal/module/decision/ending_branch/config_validation.go
+++ b/apps/server/internal/module/decision/ending_branch/config_validation.go
@@ -26,6 +26,9 @@ func validateConfig(cfg Config) error {
 		if len(question.Choices) == 0 {
 			return fmt.Errorf("question %q requires at least one choice", question.ID)
 		}
+		if err := validateRespondents(question.ID, question.Respondents); err != nil {
+			return err
+		}
 		if question.Impact == "score" {
 			for _, choice := range question.Choices {
 				if _, ok := question.ScoreMap[choice]; !ok {
@@ -55,4 +58,37 @@ func validateConfig(cfg Config) error {
 		}
 	}
 	return nil
+}
+
+func validateRespondents(questionID string, respondents any) error {
+	switch value := respondents.(type) {
+	case nil:
+		return nil
+	case string:
+		switch value {
+		case "", "all":
+			return nil
+		case "some":
+			return fmt.Errorf("question %q respondents value %q is not supported; use explicit player or target codes", questionID, value)
+		default:
+			return fmt.Errorf("question %q has invalid respondents value %q", questionID, value)
+		}
+	case []any:
+		for _, item := range value {
+			candidate, ok := item.(string)
+			if !ok || candidate == "" {
+				return fmt.Errorf("question %q respondents must contain non-empty strings", questionID)
+			}
+		}
+		return nil
+	case []string:
+		for _, candidate := range value {
+			if candidate == "" {
+				return fmt.Errorf("question %q respondents must contain non-empty strings", questionID)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("question %q has unsupported respondents type %T", questionID, respondents)
+	}
 }

--- a/apps/server/internal/module/decision/ending_branch/config_validation.go
+++ b/apps/server/internal/module/decision/ending_branch/config_validation.go
@@ -1,0 +1,58 @@
+package ending_branch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func validateConfig(cfg Config) error {
+	seenQuestions := make(map[string]struct{}, len(cfg.Questions))
+	for _, question := range cfg.Questions {
+		if question.ID == "" {
+			return fmt.Errorf("question id is required")
+		}
+		if _, dup := seenQuestions[question.ID]; dup {
+			return fmt.Errorf("duplicate question id %q", question.ID)
+		}
+		seenQuestions[question.ID] = struct{}{}
+		if question.Type != "single" && question.Type != "multi" {
+			return fmt.Errorf("question %q has invalid type %q", question.ID, question.Type)
+		}
+		if question.Impact != "branch" && question.Impact != "score" {
+			return fmt.Errorf("question %q has invalid impact %q", question.ID, question.Impact)
+		}
+		if len(question.Choices) == 0 {
+			return fmt.Errorf("question %q requires at least one choice", question.ID)
+		}
+		if question.Impact == "score" {
+			for _, choice := range question.Choices {
+				if _, ok := question.ScoreMap[choice]; !ok {
+					return fmt.Errorf("question %q scoreMap missing choice %q", question.ID, choice)
+				}
+			}
+		}
+	}
+	for _, row := range cfg.Matrix {
+		if row.Priority < 1 {
+			return fmt.Errorf("matrix row priority must be >= 1")
+		}
+		if row.Ending == "" {
+			return fmt.Errorf("matrix row ending is required")
+		}
+		if row.Conditions == nil {
+			return fmt.Errorf("matrix row conditions are required")
+		}
+		if len(row.Conditions) > 0 {
+			logic, err := json.Marshal(row.Conditions)
+			if err != nil {
+				return fmt.Errorf("matrix row %d conditions cannot be encoded", row.Priority)
+			}
+			if !engine.IsValid(logic) {
+				return fmt.Errorf("matrix row %d conditions must be valid JSONLogic", row.Priority)
+			}
+		}
+	}
+	return nil
+}

--- a/apps/server/internal/module/decision/ending_branch/config_validation.go
+++ b/apps/server/internal/module/decision/ending_branch/config_validation.go
@@ -74,6 +74,9 @@ func validateRespondents(questionID string, respondents any) error {
 			return fmt.Errorf("question %q has invalid respondents value %q", questionID, value)
 		}
 	case []any:
+		if len(value) == 0 {
+			return fmt.Errorf("question %q respondents must contain at least one code", questionID)
+		}
 		for _, item := range value {
 			candidate, ok := item.(string)
 			if !ok || candidate == "" {
@@ -82,6 +85,9 @@ func validateRespondents(questionID string, respondents any) error {
 		}
 		return nil
 	case []string:
+		if len(value) == 0 {
+			return fmt.Errorf("question %q respondents must contain at least one code", questionID)
+		}
 		for _, candidate := range value {
 			if candidate == "" {
 				return fmt.Errorf("question %q respondents must contain non-empty strings", questionID)

--- a/apps/server/internal/module/decision/ending_branch/module.go
+++ b/apps/server/internal/module/decision/ending_branch/module.go
@@ -1,7 +1,7 @@
 // Package ending_branch implements the ending_branch module — a configurable
 // question-driven branching system that routes sessions to distinct endings
 // based on player responses and a priority-ordered condition matrix (D-23).
-// The JSONLogic matrix evaluator is deferred to PR-5.
+// Runtime evaluation is connected to phase actions in Phase 24 PR-9.
 package ending_branch
 
 import (
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/google/uuid"
@@ -17,18 +18,16 @@ import (
 )
 
 // Module implements the ending_branch session module.
-// It is a skeleton for Phase 24 PR-1: Name + Schema + Init + ApplyConfig are
-// fully implemented; HandleMessage and matrix evaluation are deferred to PR-5.
 //
-// Skeleton declares PublicStateModule (engine.PublicStateMarker embed) because
-// the only state currently exposed is config-derived metadata (question count,
-// default ending) — identical for every player. PR-5 will (a) drop the marker,
-// (b) add BuildStateFor with real per-player answer redaction. The F-sec-2
-// playeraware-lint canon enforces that switch atomically.
+// It stores player answers, evaluates the priority-ordered ending matrix, and
+// exposes player-aware state so one player's answer choices are not leaked to
+// others during reconnect or live sync.
 type Module struct {
-	engine.PublicStateMarker
-	mu  sync.RWMutex
-	cfg Config
+	mu      sync.RWMutex
+	cfg     Config
+	deps    engine.ModuleDeps
+	answers map[string]map[uuid.UUID][]string
+	result  *evaluationResult
 }
 
 // NewModule creates a new Module instance.
@@ -42,10 +41,11 @@ func (m *Module) Name() string { return "ending_branch" }
 // Init initialises the module. The config JSON passed via Init is applied
 // immediately; callers may also call ApplyConfig separately before the first
 // player message.
-func (m *Module) Init(_ context.Context, _ engine.ModuleDeps, config json.RawMessage) error {
+func (m *Module) Init(_ context.Context, deps engine.ModuleDeps, config json.RawMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deps = deps
 	if len(config) > 0 {
-		m.mu.Lock()
-		defer m.mu.Unlock()
 		return m.applyConfigLocked(config)
 	}
 	return nil
@@ -69,6 +69,8 @@ func (m *Module) ApplyConfig(_ context.Context, raw json.RawMessage) error {
 func (m *Module) applyConfigLocked(raw json.RawMessage) error {
 	if len(raw) == 0 {
 		m.cfg = Config{}
+		m.answers = nil
+		m.result = nil
 		return nil
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
@@ -77,8 +79,12 @@ func (m *Module) applyConfigLocked(raw json.RawMessage) error {
 	if err := dec.Decode(&cfg); err != nil {
 		return fmt.Errorf("ending_branch: invalid config: %w", err)
 	}
-	if dec.More() {
-		return fmt.Errorf("ending_branch: invalid config: unexpected trailing data")
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("ending_branch: invalid config: unexpected trailing data")
+		}
+		return fmt.Errorf("ending_branch: invalid config: %w", err)
 	}
 	// D-26: apply default 0.5 when threshold is absent; validate range.
 	if cfg.MultiVoteThreshold == nil {
@@ -87,26 +93,69 @@ func (m *Module) applyConfigLocked(raw json.RawMessage) error {
 	} else if *cfg.MultiVoteThreshold < 0 || *cfg.MultiVoteThreshold > 1 {
 		return fmt.Errorf("ending_branch: invalid config: multiVoteThreshold must be in [0, 1], got %v", *cfg.MultiVoteThreshold)
 	}
+	if err := validateConfig(cfg); err != nil {
+		return fmt.Errorf("ending_branch: invalid config: %w", err)
+	}
 	m.cfg = cfg
+	m.answers = nil
+	m.result = nil
 	return nil
 }
 
-// BuildState returns the public module state for client sync.
-// For this skeleton, only config metadata is exposed (no runtime answers yet).
+// BuildState returns the all-player persistence/admin state. Runtime client sync
+// must use BuildStateFor via engine.BuildModuleStateFor.
 func (m *Module) BuildState() (json.RawMessage, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-
-	return json.Marshal(map[string]any{
-		"questionCount": len(m.cfg.Questions),
-		"defaultEnding": m.cfg.DefaultEnding,
-	})
+	return m.stateLocked(nil)
 }
 
-// HandleMessage processes a player action routed to this module.
-// Full answer-submission logic is deferred to PR-5.
-func (m *Module) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
-	return fmt.Errorf("ending_branch: message handling not yet implemented (PR-5)")
+// BuildStateFor returns the ending state visible to one player.
+func (m *Module) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.stateLocked(&playerID)
+}
+
+// HandleMessage processes player answer submissions.
+func (m *Module) HandleMessage(ctx context.Context, playerID uuid.UUID, msgType string, payload json.RawMessage) error {
+	switch msgType {
+	case "submit_answer", "ending_branch:submit_answer":
+		return m.submitAnswer(ctx, playerID, payload)
+	default:
+		return fmt.Errorf("ending_branch: unsupported message type %q", msgType)
+	}
+}
+
+// ReactTo handles phase actions that trigger ending evaluation.
+func (m *Module) ReactTo(_ context.Context, action engine.PhaseActionPayload) error {
+	if action.Action != engine.ActionEvaluateEnding {
+		return nil
+	}
+	m.mu.Lock()
+	result, err := m.evaluateLocked()
+	if err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	m.result = result
+	m.mu.Unlock()
+
+	if m.deps.EventBus != nil {
+		m.deps.EventBus.Publish(engine.Event{
+			Type: "ending.evaluated",
+			Payload: map[string]any{
+				"selectedEnding":  result.SelectedEnding,
+				"matchedPriority": result.MatchedPriority,
+			},
+		})
+	}
+	return nil
+}
+
+// SupportedActions lists the phase actions this module handles.
+func (m *Module) SupportedActions() []engine.PhaseAction {
+	return []engine.PhaseAction{engine.ActionEvaluateEnding}
 }
 
 // Cleanup releases resources when the session ends.
@@ -114,6 +163,8 @@ func (m *Module) Cleanup(_ context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.cfg = Config{}
+	m.answers = nil
+	m.result = nil
 	return nil
 }
 
@@ -122,8 +173,6 @@ func (m *Module) Cleanup(_ context.Context) error {
 // `questions[]` 배열은 분기(impact: "branch")와 점수(impact: "score") 두 종류 통합.
 // `scoreMap`은 impact:"score" 케이스에 보기→점수 매핑 (D-24 embed).
 // `multiVoteThreshold`는 D-26 per-choice threshold (default 0.5).
-//
-// TODO(refactor): consider sync.Once cache pattern uniformly across all module Schema() impls (sibling: voting/accusation/hidden_mission).
 func (m *Module) Schema() json.RawMessage {
 	schema := map[string]any{
 		"type": "object",
@@ -137,10 +186,10 @@ func (m *Module) Schema() json.RawMessage {
 						"text":    map[string]any{"type": "string"},
 						"type":    map[string]any{"type": "string", "enum": []string{"single", "multi"}},
 						"choices": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-						// TODO(PR-5): oneOf [array<string>, enum["all","some"]]
-						"respondents": map[string]any{}, // []string | "all" | "some" — runtime validate
-						"impact":      map[string]any{"type": "string", "enum": []string{"branch", "score"}},
-						// TODO(PR-5): JSON Schema if/then to enforce scoreMap required when impact=="score" and forbidden when impact=="branch" (D-24 §9 example)
+						"respondents": map[string]any{
+							"description": "all or array of player IDs / character target codes",
+						},
+						"impact": map[string]any{"type": "string", "enum": []string{"branch", "score"}},
 						"scoreMap": map[string]any{
 							"type":                 "object",
 							"additionalProperties": map[string]any{"type": "integer"},
@@ -196,5 +245,6 @@ func mustMarshal(v any) json.RawMessage {
 var (
 	_ engine.Module            = (*Module)(nil)
 	_ engine.ConfigSchema      = (*Module)(nil)
-	_ engine.PublicStateModule = (*Module)(nil)
+	_ engine.PlayerAwareModule = (*Module)(nil)
+	_ engine.PhaseReactor      = (*Module)(nil)
 )

--- a/apps/server/internal/module/decision/ending_branch/module.go
+++ b/apps/server/internal/module/decision/ending_branch/module.go
@@ -138,6 +138,10 @@ func (m *Module) ReactTo(_ context.Context, action engine.PhaseActionPayload) er
 		m.mu.Unlock()
 		return err
 	}
+	if evaluationResultsEqual(m.result, result) {
+		m.mu.Unlock()
+		return nil
+	}
 	m.result = result
 	m.mu.Unlock()
 
@@ -151,6 +155,31 @@ func (m *Module) ReactTo(_ context.Context, action engine.PhaseActionPayload) er
 		})
 	}
 	return nil
+}
+
+func evaluationResultsEqual(a, b *evaluationResult) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.SelectedEnding != b.SelectedEnding || !matchedPriorityEqual(a.MatchedPriority, b.MatchedPriority) {
+		return false
+	}
+	if len(a.Scores) != len(b.Scores) {
+		return false
+	}
+	for key, aScore := range a.Scores {
+		if b.Scores[key] != aScore {
+			return false
+		}
+	}
+	return true
+}
+
+func matchedPriorityEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // SupportedActions lists the phase actions this module handles.

--- a/apps/server/internal/module/decision/ending_branch/module_test.go
+++ b/apps/server/internal/module/decision/ending_branch/module_test.go
@@ -187,6 +187,34 @@ func TestModule_ReactTo_EvaluatesPriorityMatrixAndPublishesEvent(t *testing.T) {
 	assert.Equal(t, "진실", payload["selectedEnding"])
 }
 
+func TestModule_ReactTo_EvaluateEndingIsIdempotent(t *testing.T) {
+	bus := engine.NewEventBus(nil)
+	var events []engine.Event
+	bus.Subscribe("ending.evaluated", func(event engine.Event) { events = append(events, event) })
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [
+			{"id": "q1", "text": "진범은?", "type": "single", "choices": ["A","B"], "impact": "branch"}
+		],
+		"matrix": [
+			{"priority": 1, "conditions": {"==": [{"var":"answers.q1.winning"}, "A"]}, "ending": "진실"}
+		],
+		"defaultEnding": "미해결"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{EventBus: bus}, cfg))
+	player := uuid.New()
+	require.NoError(t, m.HandleMessage(context.Background(), player, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"A"}`)))
+
+	action := engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}
+	require.NoError(t, m.ReactTo(context.Background(), action))
+	require.NoError(t, m.ReactTo(context.Background(), action))
+
+	require.Len(t, events, 1, "re-entering the same ending evaluation must not publish duplicate events")
+	payload := events[0].Payload.(map[string]any)
+	assert.Equal(t, "진실", payload["selectedEnding"])
+	assert.Equal(t, 1, *m.result.MatchedPriority)
+}
+
 func TestModule_HandleMessage_RejectsInvalidChoice(t *testing.T) {
 	m := NewModule()
 	cfg := json.RawMessage(`{
@@ -351,6 +379,26 @@ func TestModule_ApplyConfig_RejectsInvalidSemanticConfig(t *testing.T) {
 	err := m.ApplyConfig(context.Background(), json.RawMessage(`{"questions":[{"id":"q1","text":"?","type":"unknown","choices":["A"],"impact":"branch"}]}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid type")
+}
+
+func TestModule_ApplyConfig_RejectsUnsupportedRespondentsSome(t *testing.T) {
+	m := NewModule()
+	err := m.ApplyConfig(context.Background(), json.RawMessage(`{
+		"questions":[{"id":"q1","text":"?","type":"single","choices":["A"],"impact":"branch","respondents":"some"}],
+		"matrix":[]
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `respondents value "some" is not supported`)
+}
+
+func TestModule_ApplyConfig_RejectsInvalidRespondentList(t *testing.T) {
+	m := NewModule()
+	err := m.ApplyConfig(context.Background(), json.RawMessage(`{
+		"questions":[{"id":"q1","text":"?","type":"single","choices":["A"],"impact":"branch","respondents":[""]}],
+		"matrix":[]
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "respondents must contain non-empty strings")
 }
 
 func TestModule_ApplyConfig_RejectsInvalidMatrixCondition(t *testing.T) {

--- a/apps/server/internal/module/decision/ending_branch/module_test.go
+++ b/apps/server/internal/module/decision/ending_branch/module_test.go
@@ -401,6 +401,16 @@ func TestModule_ApplyConfig_RejectsInvalidRespondentList(t *testing.T) {
 	assert.Contains(t, err.Error(), "respondents must contain non-empty strings")
 }
 
+func TestModule_ApplyConfig_RejectsEmptyRespondentList(t *testing.T) {
+	m := NewModule()
+	err := m.ApplyConfig(context.Background(), json.RawMessage(`{
+		"questions":[{"id":"q1","text":"?","type":"single","choices":["A"],"impact":"branch","respondents":[]}],
+		"matrix":[]
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "respondents must contain at least one code")
+}
+
 func TestModule_ApplyConfig_RejectsInvalidMatrixCondition(t *testing.T) {
 	m := NewModule()
 	err := m.ApplyConfig(context.Background(), json.RawMessage(`{

--- a/apps/server/internal/module/decision/ending_branch/module_test.go
+++ b/apps/server/internal/module/decision/ending_branch/module_test.go
@@ -105,7 +105,7 @@ func TestModule_BuildState_WithConfig(t *testing.T) {
 	cfg := json.RawMessage(`{
 		"questions": [
 			{"id": "q1", "text": "선택?", "type": "single", "choices": ["A","B"], "impact": "branch"},
-			{"id": "q2", "text": "점수?", "type": "single", "choices": ["X","Y"], "impact": "score"}
+			{"id": "q2", "text": "점수?", "type": "single", "choices": ["X","Y"], "impact": "score", "scoreMap": {"X": 1, "Y": 0}}
 		],
 		"matrix": [],
 		"defaultEnding": "좋은결말"
@@ -121,13 +121,84 @@ func TestModule_BuildState_WithConfig(t *testing.T) {
 	assert.Equal(t, "좋은결말", state["defaultEnding"])
 }
 
-// TestModule_HandleMessage_NotImplemented verifies the stub returns the expected
-// "not yet implemented (PR-5)" error and does not panic.
-func TestModule_HandleMessage_NotImplemented(t *testing.T) {
+func TestModule_HandleMessage_SubmitAnswerAndPlayerAwareState(t *testing.T) {
 	m := NewModule()
-	err := m.HandleMessage(context.Background(), uuid.New(), "submit_answer", json.RawMessage(`{}`))
+	cfg := json.RawMessage(`{
+		"questions": [
+			{"id": "q1", "text": "진범은?", "type": "single", "choices": ["A","B"], "impact": "branch"}
+		],
+		"matrix": [],
+		"defaultEnding": "미해결"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{}, cfg))
+
+	playerA := uuid.New()
+	playerB := uuid.New()
+	require.NoError(t, m.HandleMessage(context.Background(), playerA, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"A"}`)))
+	require.NoError(t, m.HandleMessage(context.Background(), playerB, "ending_branch:submit_answer", json.RawMessage(`{"question_id":"q1","choice":"B"}`)))
+
+	rawA, err := m.BuildStateFor(playerA)
+	require.NoError(t, err)
+	var stateA map[string]any
+	require.NoError(t, json.Unmarshal(rawA, &stateA))
+	answersA := stateA["myAnswers"].(map[string]any)
+	assert.Equal(t, []any{"A"}, answersA["q1"])
+
+	rawB, err := m.BuildStateFor(playerB)
+	require.NoError(t, err)
+	var stateB map[string]any
+	require.NoError(t, json.Unmarshal(rawB, &stateB))
+	answersB := stateB["myAnswers"].(map[string]any)
+	assert.Equal(t, []any{"B"}, answersB["q1"])
+	assert.NotEqual(t, answersA["q1"], answersB["q1"], "players must not receive sibling answers")
+}
+
+func TestModule_ReactTo_EvaluatesPriorityMatrixAndPublishesEvent(t *testing.T) {
+	bus := engine.NewEventBus(nil)
+	var events []engine.Event
+	bus.Subscribe("ending.evaluated", func(event engine.Event) { events = append(events, event) })
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [
+			{"id": "q1", "text": "진범은?", "type": "single", "choices": ["A","B"], "impact": "branch"},
+			{"id": "q2", "text": "공헌도", "type": "single", "choices": ["높음","낮음"], "impact": "score", "scoreMap": {"높음": 3, "낮음": 1}}
+		],
+		"matrix": [
+			{"priority": 2, "conditions": {"==": [{"var":"answers.q1.winning"}, "B"]}, "ending": "오판"},
+			{"priority": 1, "conditions": {"==": [{"var":"answers.q1.winning"}, "A"]}, "ending": "진실"}
+		],
+		"defaultEnding": "미해결"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{EventBus: bus}, cfg))
+	player := uuid.New()
+	require.NoError(t, m.HandleMessage(context.Background(), player, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"A"}`)))
+	require.NoError(t, m.HandleMessage(context.Background(), player, "submit_answer", json.RawMessage(`{"question_id":"q2","choice":"높음"}`)))
+
+	require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+	raw, err := m.BuildStateFor(player)
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal(raw, &state))
+	assert.Equal(t, true, state["evaluated"])
+	assert.Equal(t, "진실", state["selectedEnding"])
+	require.Len(t, events, 1)
+	payload := events[0].Payload.(map[string]any)
+	assert.Equal(t, "진실", payload["selectedEnding"])
+}
+
+func TestModule_HandleMessage_RejectsInvalidChoice(t *testing.T) {
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [
+			{"id": "q1", "text": "선택", "type": "single", "choices": ["A"], "impact": "branch"}
+		],
+		"matrix": []
+	}`)
+	require.NoError(t, m.ApplyConfig(context.Background(), cfg))
+	err := m.HandleMessage(context.Background(), uuid.New(), "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"B"}`))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "PR-5", "stub must reference PR-5 deferral")
+	assert.Contains(t, err.Error(), "invalid choice")
 }
 
 // TestModule_Cleanup_ReturnsNil verifies Cleanup resets state and returns nil.
@@ -266,4 +337,28 @@ func TestModule_ApplyConfig_RejectsTrailingData(t *testing.T) {
 	err := m.ApplyConfig(context.Background(), json.RawMessage(`{"questions":[]}{"trailing":"data"}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "trailing data")
+}
+
+func TestModule_ApplyConfig_RejectsTrailingJSON(t *testing.T) {
+	m := NewModule()
+	err := m.ApplyConfig(context.Background(), json.RawMessage(`{"questions":[]} {"matrix":[]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected trailing data")
+}
+
+func TestModule_ApplyConfig_RejectsInvalidSemanticConfig(t *testing.T) {
+	m := NewModule()
+	err := m.ApplyConfig(context.Background(), json.RawMessage(`{"questions":[{"id":"q1","text":"?","type":"unknown","choices":["A"],"impact":"branch"}]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid type")
+}
+
+func TestModule_ApplyConfig_RejectsInvalidMatrixCondition(t *testing.T) {
+	m := NewModule()
+	err := m.ApplyConfig(context.Background(), json.RawMessage(`{
+		"questions":[{"id":"q1","text":"?","type":"single","choices":["A"],"impact":"branch"}],
+		"matrix":[{"priority":1,"conditions":{"bad op":[1]},"ending":"end"}]
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "valid JSONLogic")
 }

--- a/apps/server/internal/module/decision/ending_branch/runtime.go
+++ b/apps/server/internal/module/decision/ending_branch/runtime.go
@@ -162,6 +162,9 @@ func respondentAllowed(ctx context.Context, deps engine.ModuleDeps, question Que
 	case nil:
 		return true
 	case string:
+		if respondents == "some" && deps.Logger != nil {
+			deps.Logger.Printf("ending_branch: unsupported respondents value %q", respondents)
+		}
 		return respondents == "" || respondents == "all"
 	case []any:
 		return respondentListAllows(ctx, deps, respondents, playerID)

--- a/apps/server/internal/module/decision/ending_branch/runtime.go
+++ b/apps/server/internal/module/decision/ending_branch/runtime.go
@@ -1,0 +1,249 @@
+package ending_branch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+type submittedAnswer struct {
+	QuestionID string   `json:"question_id"`
+	Choice     string   `json:"choice,omitempty"`
+	Choices    []string `json:"choices,omitempty"`
+}
+
+type evaluationResult struct {
+	SelectedEnding  string         `json:"selectedEnding"`
+	MatchedPriority *int           `json:"matchedPriority,omitempty"`
+	Scores          map[string]int `json:"scores,omitempty"`
+}
+
+func (m *Module) submitAnswer(ctx context.Context, playerID uuid.UUID, payload json.RawMessage) error {
+	var input submittedAnswer
+	if err := json.Unmarshal(payload, &input); err != nil {
+		return fmt.Errorf("ending_branch: invalid answer payload: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	question, ok := findQuestion(m.cfg.Questions, input.QuestionID)
+	if !ok {
+		return fmt.Errorf("ending_branch: unknown question %q", input.QuestionID)
+	}
+	if !respondentAllowed(ctx, m.deps, question, playerID) {
+		return fmt.Errorf("ending_branch: player is not allowed to answer question %q", input.QuestionID)
+	}
+	choices, err := normalizeAnswerChoices(question, input)
+	if err != nil {
+		return err
+	}
+	if m.answers == nil {
+		m.answers = make(map[string]map[uuid.UUID][]string)
+	}
+	if m.answers[question.ID] == nil {
+		m.answers[question.ID] = make(map[uuid.UUID][]string)
+	}
+	m.answers[question.ID][playerID] = choices
+	m.result = nil
+	return nil
+}
+
+func (m *Module) evaluateLocked() (*evaluationResult, error) {
+	ctx := m.evaluationContextLocked()
+	ctxJSON, err := json.Marshal(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ending_branch: marshal evaluation context: %w", err)
+	}
+	evaluator := engine.NewRuleEvaluator()
+	evaluator.SetContextRaw(ctxJSON)
+
+	rows := append([]MatrixRow(nil), m.cfg.Matrix...)
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].Priority < rows[j].Priority })
+	for _, row := range rows {
+		logic, err := json.Marshal(row.Conditions)
+		if err != nil {
+			return nil, fmt.Errorf("ending_branch: marshal matrix row %d: %w", row.Priority, err)
+		}
+		res, err := evaluator.Evaluate(logic)
+		if err != nil {
+			return nil, fmt.Errorf("ending_branch: evaluate matrix row %d: %w", row.Priority, err)
+		}
+		if res.Bool {
+			priority := row.Priority
+			return &evaluationResult{SelectedEnding: row.Ending, MatchedPriority: &priority, Scores: scoreTotals(ctx)}, nil
+		}
+	}
+	return &evaluationResult{SelectedEnding: m.cfg.DefaultEnding, Scores: scoreTotals(ctx)}, nil
+}
+
+func (m *Module) evaluationContextLocked() map[string]any {
+	answers := make(map[string]any, len(m.cfg.Questions))
+	scores := make(map[string]int)
+	for _, question := range m.cfg.Questions {
+		byPlayer := m.answers[question.ID]
+		counts := make(map[string]int, len(question.Choices))
+		for playerID, choices := range byPlayer {
+			for _, choice := range choices {
+				counts[choice]++
+				if question.Impact == "score" {
+					scores[playerID.String()] += question.ScoreMap[choice]
+				}
+			}
+		}
+		answers[question.ID] = map[string]any{
+			"counts":   counts,
+			"winning":  winningChoice(counts),
+			"choices":  thresholdChoices(counts, len(byPlayer), m.thresholdLocked()),
+			"answered": len(byPlayer),
+		}
+	}
+	return map[string]any{"answers": answers, "scores": scores}
+}
+
+func scoreTotals(ctx map[string]any) map[string]int {
+	scores, ok := ctx["scores"].(map[string]int)
+	if !ok || len(scores) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(scores))
+	for k, v := range scores {
+		out[k] = v
+	}
+	return out
+}
+
+func findQuestion(questions []Question, questionID string) (Question, bool) {
+	for _, question := range questions {
+		if question.ID == questionID {
+			return question, true
+		}
+	}
+	return Question{}, false
+}
+
+func normalizeAnswerChoices(question Question, input submittedAnswer) ([]string, error) {
+	choices := input.Choices
+	if input.Choice != "" {
+		choices = append([]string{input.Choice}, choices...)
+	}
+	if question.Type == "single" && len(choices) != 1 {
+		return nil, fmt.Errorf("ending_branch: question %q expects exactly one choice", question.ID)
+	}
+	if len(choices) == 0 {
+		return nil, fmt.Errorf("ending_branch: question %q requires at least one choice", question.ID)
+	}
+	allowed := make(map[string]struct{}, len(question.Choices))
+	for _, choice := range question.Choices {
+		allowed[choice] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(choices))
+	out := make([]string, 0, len(choices))
+	for _, choice := range choices {
+		if _, ok := allowed[choice]; !ok {
+			return nil, fmt.Errorf("ending_branch: invalid choice %q for question %q", choice, question.ID)
+		}
+		if _, dup := seen[choice]; dup {
+			continue
+		}
+		seen[choice] = struct{}{}
+		out = append(out, choice)
+	}
+	return out, nil
+}
+
+func respondentAllowed(ctx context.Context, deps engine.ModuleDeps, question Question, playerID uuid.UUID) bool {
+	switch respondents := question.Respondents.(type) {
+	case nil:
+		return true
+	case string:
+		return respondents == "" || respondents == "all"
+	case []any:
+		return respondentListAllows(ctx, deps, respondents, playerID)
+	case []string:
+		items := make([]any, len(respondents))
+		for i, item := range respondents {
+			items[i] = item
+		}
+		return respondentListAllows(ctx, deps, items, playerID)
+	default:
+		return false
+	}
+}
+
+func respondentListAllows(ctx context.Context, deps engine.ModuleDeps, respondents []any, playerID uuid.UUID) bool {
+	for _, item := range respondents {
+		candidate, ok := item.(string)
+		if !ok || candidate == "" {
+			continue
+		}
+		if candidate == playerID.String() {
+			return true
+		}
+		if deps.PlayerInfoProvider != nil {
+			if resolved, ok := deps.PlayerInfoProvider.ResolvePlayerID(ctx, candidate); ok && resolved == playerID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func winningChoice(counts map[string]int) string {
+	bestChoice := ""
+	bestCount := 0
+	for choice, count := range counts {
+		if count > bestCount || (count == bestCount && count > 0 && (bestChoice == "" || choice < bestChoice)) {
+			bestChoice = choice
+			bestCount = count
+		}
+	}
+	return bestChoice
+}
+
+func thresholdChoices(counts map[string]int, respondentCount int, threshold float64) []string {
+	if respondentCount == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(counts))
+	for choice, count := range counts {
+		if float64(count)/float64(respondentCount) >= threshold {
+			out = append(out, choice)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (m *Module) thresholdLocked() float64 {
+	if m.cfg.MultiVoteThreshold == nil {
+		return 0.5
+	}
+	return *m.cfg.MultiVoteThreshold
+}
+
+func (m *Module) stateLocked(playerID *uuid.UUID) (json.RawMessage, error) {
+	state := map[string]any{
+		"questionCount": len(m.cfg.Questions),
+		"defaultEnding": m.cfg.DefaultEnding,
+		"evaluated":     m.result != nil,
+	}
+	if m.result != nil {
+		state["selectedEnding"] = m.result.SelectedEnding
+	}
+	if playerID != nil {
+		myAnswers := make(map[string][]string)
+		for questionID, byPlayer := range m.answers {
+			if choices, ok := byPlayer[*playerID]; ok {
+				myAnswers[questionID] = append([]string(nil), choices...)
+			}
+		}
+		state["myAnswers"] = myAnswers
+	}
+	return json.Marshal(state)
+}

--- a/apps/web/e2e/editor-phase-ending.spec.ts
+++ b/apps/web/e2e/editor-phase-ending.spec.ts
@@ -40,7 +40,18 @@ test.describe("Phase 24 페이즈/결말 entity smoke", () => {
                 updated_at: "2026-05-03T00:00:00Z",
               },
             ],
-            edges: [],
+            edges: [
+              {
+                id: "edge-ending-1",
+                theme_id: THEME_ID,
+                source_id: "phase-final",
+                target_id: FLOW_NODE_ID,
+                condition: null,
+                label: "기본",
+                sort_order: 0,
+                created_at: "2026-05-03T00:00:00Z",
+              },
+            ],
           }),
         });
       }
@@ -58,6 +69,8 @@ test.describe("Phase 24 페이즈/결말 entity smoke", () => {
     await page.getByRole("button", { name: /결말/ }).click();
 
     await expect(page.getByRole("heading", { name: "결말 목록" })).toBeVisible();
+    await expect(page.getByLabel("결말 판정 준비")).toBeVisible();
+    await expect(page.getByLabel("결말 판정 준비").getByText("본문 작성", { exact: true })).toBeVisible();
     await expect(page.getByText("진실").first()).toBeVisible();
     await expect(page.getByLabel("결말 이름")).toHaveValue("진실");
     await expect(page.getByLabel("결말 본문")).toHaveValue("범인은 밝혀졌다.");

--- a/apps/web/src/features/editor/components/design/EndingDecisionSummaryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingDecisionSummaryPanel.tsx
@@ -1,0 +1,52 @@
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import type { EndingDecisionSummary } from "../../entities/ending/endingEntityAdapter";
+
+interface EndingDecisionSummaryPanelProps {
+  summary: EndingDecisionSummary;
+}
+
+export function EndingDecisionSummaryPanel({ summary }: EndingDecisionSummaryPanelProps) {
+  return (
+    <section
+      className="grid gap-3 rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300 md:grid-cols-3"
+      aria-label="결말 판정 준비"
+    >
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">결말 수</p>
+        <p className="mt-1 text-lg font-semibold text-slate-100">{summary.totalCount}개</p>
+      </div>
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">본문 작성</p>
+        <p className="mt-1 text-lg font-semibold text-slate-100">
+          {summary.readyCount}/{summary.totalCount}
+        </p>
+      </div>
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">기본 결말 후보</p>
+        <p className="mt-1 text-lg font-semibold text-slate-100">
+          {summary.defaultEndingName ?? "아직 없음"}
+        </p>
+      </div>
+      {summary.warnings.length > 0 ? (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-amber-100 md:col-span-3">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div>
+              <p className="font-medium">확인할 점</p>
+              <ul className="mt-1 list-disc space-y-1 pl-4 text-xs leading-5 text-amber-100/90">
+                {summary.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-emerald-100 md:col-span-3">
+          <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+          결말 본문과 도달 경로가 준비되어 있습니다.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/EndingEmptyState.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEmptyState.tsx
@@ -1,0 +1,13 @@
+export function EndingEmptyState() {
+  return (
+    <div className="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-700 bg-slate-900/50 p-8 text-center">
+      <div className="max-w-md space-y-3">
+        <h3 className="text-lg font-semibold text-slate-100">아직 결말이 없습니다</h3>
+        <p className="text-sm leading-6 text-slate-400">
+          Flow에서 결말 노드를 추가하면 이곳에서 결말 내용을 작성할 수 있어요. 바로 시작하려면 위의 “결말 추가”
+          버튼을 눌러도 됩니다.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -60,7 +60,7 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
         </h3>
         <p className="text-sm leading-6 text-slate-400">
           게임이 끝났을 때 모두에게 공개할 결말 이름과 본문을 작성합니다.
-          점수 배율은 사용하지 않고 모든 결말은 같은 기준으로 계산됩니다.
+          투표·질문·조건 결과는 서버가 판정하므로, 여기에는 플레이어에게 보여줄 내용만 적으면 됩니다.
         </p>
       </div>
 

--- a/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
@@ -1,0 +1,28 @@
+import { Plus } from "lucide-react";
+
+interface EndingEntityHeaderProps {
+  onAddEnding: () => void;
+}
+
+export function EndingEntityHeader({ onAddEnding }: EndingEntityHeaderProps) {
+  return (
+    <header className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 lg:flex-row lg:items-center lg:justify-between">
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">결말 entity</p>
+        <h2 className="text-xl font-semibold text-slate-100">결말 목록</h2>
+        <p className="max-w-3xl text-sm leading-6 text-slate-400">
+          Flow의 엔딩 노드를 결말 목록으로 모아 보여줍니다. 게임 종료 시 서버가 투표·질문·조건 결과를 판정하고,
+          이곳에서는 플레이어에게 공개될 결말 이름과 본문을 정리합니다.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onAddEnding}
+        className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-amber-500/50 bg-amber-500/10 px-4 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-400/60"
+      >
+        <Plus className="h-4 w-4" />
+        결말 추가
+      </button>
+    </header>
+  );
+}

--- a/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
@@ -8,7 +8,7 @@ export function EndingEntityHeader({ onAddEnding }: EndingEntityHeaderProps) {
   return (
     <header className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 lg:flex-row lg:items-center lg:justify-between">
       <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">결말 entity</p>
+        <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">결말 편집</p>
         <h2 className="text-xl font-semibold text-slate-100">결말 목록</h2>
         <p className="max-w-3xl text-sm leading-6 text-slate-400">
           Flow의 엔딩 노드를 결말 목록으로 모아 보여줍니다. 게임 종료 시 서버가 투표·질문·조건 결과를 판정하고,

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -1,28 +1,21 @@
 import { useMemo, useState } from "react";
-import { Plus, Search } from "lucide-react";
-import type { Node } from "@xyflow/react";
+import { Search } from "lucide-react";
 import { useFlowData } from "../../hooks/useFlowData";
 import type { FlowNodeData } from "../../flowTypes";
 import { EndingEntityDetail } from "./EndingEntityDetail";
+import { EndingDecisionSummaryPanel } from "./EndingDecisionSummaryPanel";
+import { EndingEmptyState } from "./EndingEmptyState";
+import { EndingEntityHeader } from "./EndingEntityHeader";
+import { buildEndingDecisionSummary, toEndingEditorViewModel } from "../../entities/ending/endingEntityAdapter";
 
 interface EndingEntitySubTabProps {
   themeId: string;
 }
 
-function getEndingLabel(node: Node) {
-  const data = node.data as FlowNodeData;
-  return data.label || "이름 없는 결말";
-}
-
-function getEndingDescription(node: Node) {
-  const data = node.data as FlowNodeData;
-  return data.description || "결말 설명을 작성해 주세요.";
-}
-
 export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const { nodes, isLoading, isError, error, refetch, addNode, updateNodeData } = useFlowData(themeId);
+  const { nodes, edges = [], isLoading, isError, error, refetch, addNode, updateNodeData } = useFlowData(themeId);
 
   const endingNodes = useMemo(
     () => nodes.filter((node) => node.type === "ending"),
@@ -42,6 +35,11 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
 
   const selectedNode =
     filteredNodes.find((node) => node.id === selectedId) ?? filteredNodes[0] ?? null;
+
+  const decisionSummary = useMemo(
+    () => buildEndingDecisionSummary(nodes, edges),
+    [nodes, edges],
+  );
 
   const handleAddEnding = () => {
     addNode("ending", { x: 360 + endingNodes.length * 40, y: 220 });
@@ -82,37 +80,12 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
 
   return (
     <div data-testid="ending-entity-panel" className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6">
-      <header className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
-            결말 entity
-          </p>
-          <h2 className="text-xl font-semibold text-slate-100">결말 목록</h2>
-          <p className="max-w-3xl text-sm leading-6 text-slate-400">
-            Flow의 엔딩 노드를 결말 목록으로 모아 보여줍니다. 분기 매트릭스는 다음 PR에서 연결하고,
-            여기서는 플레이어에게 공개될 결말 이름과 본문을 먼저 정리합니다.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={handleAddEnding}
-          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-amber-500/50 bg-amber-500/10 px-4 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-400/60"
-        >
-          <Plus className="h-4 w-4" />
-          결말 추가
-        </button>
-      </header>
+      <EndingEntityHeader onAddEnding={handleAddEnding} />
+
+      <EndingDecisionSummaryPanel summary={decisionSummary} />
 
       {endingNodes.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-700 bg-slate-900/50 p-8 text-center">
-          <div className="max-w-md space-y-3">
-            <h3 className="text-lg font-semibold text-slate-100">아직 결말이 없습니다</h3>
-            <p className="text-sm leading-6 text-slate-400">
-              Flow에서 결말 노드를 추가하면 이곳에서 결말 내용을 작성할 수 있어요.
-              바로 시작하려면 위의 “결말 추가” 버튼을 눌러도 됩니다.
-            </p>
-          </div>
-        </div>
+        <EndingEmptyState />
       ) : (
         <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(260px,360px)_minmax(0,1fr)]">
           <aside className="flex min-h-0 flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
@@ -135,7 +108,8 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
                 </p>
               ) : (
                 filteredNodes.map((node) => {
-                  const data = node.data as FlowNodeData;
+                  const incomingCount = edges.filter((edge) => edge.target === node.id).length;
+                  const viewModel = toEndingEditorViewModel(node, incomingCount);
                   const selected = selectedNode?.id === node.id;
                   return (
                     <button
@@ -150,12 +124,19 @@ export function EndingEntitySubTab({ themeId }: EndingEntitySubTabProps) {
                       }`}
                     >
                       <div className="flex items-center gap-2">
-                        <span aria-hidden="true">{data.icon || "🎭"}</span>
-                        <span className="font-medium text-slate-100">{getEndingLabel(node)}</span>
+                        <span aria-hidden="true">{viewModel.icon}</span>
+                        <span className="font-medium text-slate-100">{viewModel.name}</span>
                       </div>
                       <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-400">
-                        {getEndingDescription(node)}
+                        {viewModel.description}
                       </p>
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {viewModel.badges.map((badge) => (
+                          <span key={badge} className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300">
+                            {badge}
+                          </span>
+                        ))}
+                      </div>
                     </button>
                   );
                 })

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -48,6 +48,7 @@ beforeEach(() => {
       makeNode("phase-1", { label: "1막" }, "phase"),
       makeNode("ending-2", { label: "오판", description: "잘못된 선택" }),
     ],
+    edges: [{ id: "edge-1", source: "phase-1", target: "ending-1" }],
     isLoading: false,
     isError: false,
     error: null,
@@ -69,12 +70,15 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getByText("결말 목록")).toBeDefined();
     expect(screen.getAllByText("진실").length).toBeGreaterThan(0);
     expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("결말 판정 준비")).toBeDefined();
+    expect(screen.getByText("본문 작성")).toBeDefined();
     expect(screen.queryByText("1막")).toBeNull();
   });
 
   it("결말이 없으면 제작자가 이해할 수 있는 빈 상태를 보여준다", () => {
     useFlowDataMock.mockReturnValue({
       nodes: [],
+      edges: [],
       isLoading: false,
       isError: false,
       error: null,
@@ -93,6 +97,7 @@ describe("EndingEntitySubTab", () => {
   it("결말 목록을 불러오지 못하면 에러 안내와 재시도 버튼을 보여준다", () => {
     useFlowDataMock.mockReturnValue({
       nodes: [],
+      edges: [],
       isLoading: false,
       isError: true,
       error: new Error("권한이 없습니다"),
@@ -128,7 +133,7 @@ describe("EndingEntitySubTab", () => {
 
     expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /오판/ }).getAttribute("aria-pressed")).toBe("true");
-    expect(screen.queryByText("진실")).toBeNull();
+    expect(screen.queryByRole("button", { name: /진실/ })).toBeNull();
   });
 
   it("상세 입력을 변경하면 선택한 결말 노드 데이터만 갱신한다", () => {

--- a/apps/web/src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+import { buildEndingDecisionSummary, toEndingEditorViewModel } from "../endingEntityAdapter";
+
+function node(id: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: "ending", position: { x: 0, y: 0 }, data };
+}
+
+function edge(id: string, target: string): Edge {
+  return { id, source: "phase-1", target };
+}
+
+describe("endingEntityAdapter", () => {
+  it("제작자에게 필요한 결말 표시 정보만 만든다", () => {
+    const vm = toEndingEditorViewModel(node("end-1", {
+      label: "진실",
+      icon: "⚖️",
+      description: "정답 결말",
+      endingContent: "범인이 밝혀졌다.",
+    }), 2);
+
+    expect(vm).toMatchObject({
+      id: "end-1",
+      name: "진실",
+      icon: "⚖️",
+      description: "정답 결말",
+      contentPreview: "범인이 밝혀졌다.",
+      isReady: true,
+    });
+    expect(vm.badges).toContain("도달 경로 2개");
+  });
+
+  it("결말 준비 상태와 제작자용 경고를 요약한다", () => {
+    const nodes: Node[] = [
+      node("end-1", { label: "진실", endingContent: "범인이 밝혀졌다." }),
+      node("end-2", { label: "오판" }),
+      { id: "phase-1", type: "phase", position: { x: 0, y: 0 }, data: { label: "투표" } },
+    ];
+
+    const summary = buildEndingDecisionSummary(nodes, [edge("e1", "end-1")]);
+
+    expect(summary.totalCount).toBe(2);
+    expect(summary.readyCount).toBe(1);
+    expect(summary.connectedCount).toBe(1);
+    expect(summary.defaultEndingName).toBe("진실");
+    expect(summary.warnings).toContain("1개 결말은 이름 또는 본문이 비어 있습니다.");
+  });
+
+  it("결말이 없으면 다음 행동을 알려준다", () => {
+    const summary = buildEndingDecisionSummary([], []);
+
+    expect(summary.totalCount).toBe(0);
+    expect(summary.warnings).toEqual(["최종 장면에서 보여줄 결말을 1개 이상 추가해 주세요."]);
+  });
+});

--- a/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
@@ -1,0 +1,87 @@
+import type { Edge, Node } from "@xyflow/react";
+import type { FlowNodeData } from "../../flowTypes";
+
+export interface EndingEditorViewModel {
+  id: string;
+  name: string;
+  icon: string;
+  description: string;
+  contentPreview: string;
+  isReady: boolean;
+  badges: string[];
+}
+
+export interface EndingDecisionSummary {
+  totalCount: number;
+  readyCount: number;
+  connectedCount: number;
+  defaultEndingName: string | null;
+  warnings: string[];
+}
+
+export function toEndingEditorViewModel(node: Node, incomingCount = 0): EndingEditorViewModel {
+  const data = node.data as FlowNodeData;
+  const name = data.label?.trim() || "이름 없는 결말";
+  const content = data.endingContent?.trim() ?? "";
+  return {
+    id: node.id,
+    name,
+    icon: data.icon?.trim() || "🎭",
+    description: data.description?.trim() || "플레이어에게 보일 결말 설명을 작성해 주세요.",
+    contentPreview: content || "결말 본문을 아직 작성하지 않았습니다.",
+    isReady: Boolean(data.label?.trim() && content),
+    badges: buildEndingBadges(Boolean(data.label?.trim()), Boolean(content), incomingCount),
+  };
+}
+
+export function buildEndingDecisionSummary(nodes: Node[], edges: Edge[]): EndingDecisionSummary {
+  const endingNodes = nodes.filter((node) => node.type === "ending");
+  const endingIds = new Set(endingNodes.map((node) => node.id));
+  const incomingByEnding = new Map<string, number>();
+  for (const edge of edges) {
+    if (endingIds.has(edge.target)) {
+      incomingByEnding.set(edge.target, (incomingByEnding.get(edge.target) ?? 0) + 1);
+    }
+  }
+
+  const viewModels = endingNodes.map((node) =>
+    toEndingEditorViewModel(node, incomingByEnding.get(node.id) ?? 0),
+  );
+  const readyCount = viewModels.filter((ending) => ending.isReady).length;
+  const connectedCount = endingNodes.filter((node) => (incomingByEnding.get(node.id) ?? 0) > 0).length;
+  const warnings = buildEndingWarnings(viewModels, endingNodes.length, connectedCount);
+
+  return {
+    totalCount: endingNodes.length,
+    readyCount,
+    connectedCount,
+    defaultEndingName: viewModels[0]?.name ?? null,
+    warnings,
+  };
+}
+
+function buildEndingBadges(hasName: boolean, hasContent: boolean, incomingCount: number): string[] {
+  return [
+    hasName ? "이름 있음" : "이름 필요",
+    hasContent ? "본문 작성됨" : "본문 필요",
+    incomingCount > 0 ? `도달 경로 ${incomingCount}개` : "아직 연결 없음",
+  ];
+}
+
+function buildEndingWarnings(
+  endings: EndingEditorViewModel[],
+  totalCount: number,
+  connectedCount: number,
+): string[] {
+  if (totalCount === 0) return ["최종 장면에서 보여줄 결말을 1개 이상 추가해 주세요."];
+
+  const warnings: string[] = [];
+  const missingContent = endings.filter((ending) => !ending.isReady).length;
+  if (missingContent > 0) {
+    warnings.push(`${missingContent}개 결말은 이름 또는 본문이 비어 있습니다.`);
+  }
+  if (connectedCount === 0) {
+    warnings.push("페이즈 흐름에서 결말로 이어지는 경로가 아직 없습니다.");
+  }
+  return warnings;
+}

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -2,7 +2,7 @@
 phase_id: "phase-24-editor-redesign"
 phase_title: "Phase 24 — 에디터 ECS 재설계 (단서 단일 진실 위치 + 동적 모듈 + 결말 분기 매트릭스)"
 created: 2026-05-01
-status: "issue-based Phase 24 continuation — PR-8 active"
+status: "issue-based Phase 24 continuation — PR-9 active"
 spec: "docs/superpowers/specs/2026-05-01-phase-24-editor-redesign/design.md"
 prs_estimated: "issue-based: PR-5A~PR-9 active after PR-4"
 parent_phase: "phase-21-editor-ux"
@@ -40,8 +40,8 @@ parent_phase: "phase-21-editor-ux"
 | [#232](https://github.com/sabyunrepo/muder_platform/issues/232) | PR-5C | 정보 전달 Backend Engine 및 런타임 공개 상태 | done |
 | [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | done |
 | [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | done |
-| [#235](https://github.com/sabyunrepo/muder_platform/issues/235) | PR-8 | 장소 Adapter/Engine 이관 | active |
-| [#236](https://github.com/sabyunrepo/muder_platform/issues/236) | PR-9 | 결말/통합 Adapter-Engine 검증 및 E2E | brainstorming gate |
+| [#235](https://github.com/sabyunrepo/muder_platform/issues/235) | PR-8 | 장소 Adapter/Engine 이관 | done |
+| [#236](https://github.com/sabyunrepo/muder_platform/issues/236) | PR-9 | 결말/통합 Adapter-Engine 검증 및 E2E | active — `refs/pr-9-ending-integration-plan.md` |
 
 ## Legacy Wave/PR 분해 (6 PR — historical baseline)
 

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-9-ending-integration-plan.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/pr-9-ending-integration-plan.md
@@ -1,0 +1,54 @@
+# PR-9 — 결말/통합 Adapter-Engine 검증 계획
+
+## 목표
+
+Issue #236 범위의 1차 통합을 닫는다. 제작자가 만든 결말 노드와 런타임 `ending_branch` 판정이 같은 흐름에서 동작하도록 연결하고, 플레이어별 상태에서 다른 사람의 답변이 보이지 않게 검증한다.
+
+## Uzu 참고점
+
+- `phase/flow.md`: 단계 흐름은 기본 전이와 조건 전이를 함께 둔다. 조건 전이는 위에서부터 우선순위를 가진다.
+- `phase/discussion.md`: 단계 안에 텍스트, 이미지, 액션, 투표 같은 실행 항목을 추가한다.
+- `textTab.md`: 공통/개별 텍스트를 한곳에서 관리하고 특정 단계·캐릭터·조건에 따라 배포한다.
+- `phase/select.md`: 투표는 단계 안의 투표 박스이며, 투표 가능 대상·열람 대상·표시 조건을 분리한다.
+
+## MMP 적용 방식
+
+- Uzu를 그대로 복제하지 않고, MMP는 `Frontend Adapter`와 `Backend Engine`으로 나눈다.
+- 프론트 결말 화면은 제작자가 알아야 할 “결말 수, 본문 작성 상태, 도달 경로”만 보여준다. 내부 module key, raw JSON, DB ID 같은 정보는 숨긴다.
+- 백엔드는 `EVALUATE_ENDING` phase action을 통해 `ending_branch` 엔진을 실행한다.
+- `ending_branch`는 질문 답변을 저장하고, JSONLogic 조건 매트릭스를 우선순위대로 평가해 결말을 선택한다.
+- 플레이어 재접속 상태는 `BuildStateFor`를 통해 자기 답변만 포함한다.
+
+## 이번 PR 포함
+
+1. Backend
+   - `ActionEvaluateEnding = "EVALUATE_ENDING"` 추가
+   - phase action 사용 시 `ending_branch` implicit module 자동 추가
+   - `ending_branch` answer submit 처리
+   - 우선순위 매트릭스 평가 및 `ending.evaluated` 이벤트 발행
+   - player-aware state redaction
+2. Frontend
+   - 결말 entity adapter 추가
+   - 결말 목록에 제작자용 준비 상태 요약 추가
+   - 결말 상세 문구에서 엔진 내부 정보를 숨기고 플레이어 공개 본문 작성에 집중
+3. Tests
+   - Go unit/integration: answer submit, matrix evaluation, implicit module
+   - Vitest: ending adapter, 결말 entity UI
+   - Playwright E2E: 결말 화면 smoke + 접근성
+
+## 이번 PR 제외 / 후속
+
+- 결말 질문/매트릭스 전체 편집 UI
+- 캐릭터별 결말 본문
+- 투표 결과와 결말 질문의 최종 우선순위 정책 UI
+- GM override
+- 기존 캐릭터·단서·장소 entity 전체 재마이그레이션
+
+## 완료 조건
+
+- [x] `ending_branch`가 `PublicStateMarker`가 아닌 `PlayerAwareModule`로 동작한다.
+- [x] `submit_answer` 후 `BuildStateFor(playerA)`에 playerB 답변이 보이지 않는다.
+- [x] `EVALUATE_ENDING` phase action이 `ending_branch`를 실행한다.
+- [x] 결말 entity UI가 제작자에게 필요한 준비 상태만 보여준다.
+- [x] Focused Go/Vitest/E2E 검증이 통과한다.
+- [ ] PR 생성 전 코드 리뷰를 수행한다.


### PR DESCRIPTION
## 목표

Phase 24 PR-9 / Issue #236 범위로, 결말 엔티티 UI와 런타임 `ending_branch` 판정 엔진의 1차 통합을 연결합니다.

## 변경 내용

### 백엔드
- `EVALUATE_ENDING` phase action 추가
- phase action 사용 시 `ending_branch` 모듈을 자동으로 활성화
- `ending_branch` 답변 제출 처리 추가
- JSONLogic 조건 매트릭스 기반 결말 평가 추가
- 플레이어별 `BuildStateFor`로 자기 답변만 보이도록 redaction 적용
- 질문/점수/매트릭스 config validation 보강

### 프론트엔드
- 결말 entity adapter 추가
- 결말 목록에 “결말 판정 준비” 요약 패널 추가
- 결말 헤더/요약/빈 상태 컴포넌트 분리
- 제작자에게 불필요한 엔진 내부 정보 대신 결말 수, 본문 작성 상태, 도달 경로만 표시

### 문서
- PR-9 구현 계획 문서 추가
- Phase 24 checklist를 PR-9 active 기준으로 갱신

## 검증

- `cd apps/server && go test ./internal/module/decision/ending_branch ./internal/engine -count=1`
- `pnpm --dir apps/web exec vitest run src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx`
- `pnpm --dir apps/web exec tsc --noEmit`
- `pnpm --dir apps/web exec playwright test e2e/editor-phase-ending.spec.ts --project=chromium`
- `git diff --check`

## CI 운영

- 이 PR에는 생성 시점에 `ready-for-ci` 라벨을 붙이지 않습니다.
- CodeRabbit 리뷰를 확인하고 타당한 지적을 반영한 뒤, 재리뷰까지 정리되면 `ready-for-ci`를 붙여 CI를 실행합니다.

Closes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게임에서 페이즈 기반 결말 평가가 자동으로 실행되고 플레이어별 답변 제출·저장 및 판정 결과(선택된 결말) 노출이 지원됩니다.
  * 에디터에 결말 요약 패널·헤더·빈 상태 컴포넌트 추가로 제작자용 준비 상태(본문 작성 등) 가시화.

* **테스트**
  * 결말 판정, 제출/상태 관리, UI 연동을 위한 단위·통합·E2E 테스트 강화.

* **문서**
  * 결말 통합 계획 및 검증 범위 문서화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->