### PR TITLE
docs: Phase 24 wrap-up 추적 상태 정리

### DIFF
--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -2,9 +2,9 @@
 phase_id: "phase-24-editor-redesign"
 phase_title: "Phase 24 — 에디터 ECS 재설계 (단서 단일 진실 위치 + 동적 모듈 + 결말 분기 매트릭스)"
 created: 2026-05-01
-status: "issue-based Phase 24 continuation — PR-9 active"
+status: "PR-5A~PR-9 merged — wrap-up tracking active"
 spec: "docs/superpowers/specs/2026-05-01-phase-24-editor-redesign/design.md"
-prs_estimated: "issue-based: PR-5A~PR-9 active after PR-4"
+prs_estimated: "issue-based: PR-5A~PR-9 merged; wrap-up active"
 parent_phase: "phase-21-editor-ux"
 ---
 
@@ -31,7 +31,7 @@ parent_phase: "phase-21-editor-ux"
 
 ## Wave/PR 분해 (Issue 기반 continuation)
 
-> 2026-05-03 업데이트: PR-1~PR-4는 기반/엔티티 작업으로 진행되었고, 후속 작업은 GitHub Issue 기준 PR-5A~PR-9로 추적한다. Adapter/Engine 공통 계약과 이슈 링크는 `refs/pr-5-adapter-engine-issue-plan.md`를 기준으로 한다.
+> 2026-05-03 업데이트: PR-1~PR-4는 기반/엔티티 작업으로 진행되었고, GitHub Issue 기준 PR-5A~PR-9까지 머지 완료했다. Adapter/Engine 공통 계약과 이슈 링크는 `refs/pr-5-adapter-engine-issue-plan.md`를 기준으로 하며, wrap-up 및 후속 범위 정리는 [#246](https://github.com/sabyunrepo/muder_platform/issues/246)에서 추적한다.
 
 | Issue | PR | 범위 | 상태 |
 | --- | --- | --- | --- |
@@ -41,7 +41,8 @@ parent_phase: "phase-21-editor-ux"
 | [#233](https://github.com/sabyunrepo/muder_platform/issues/233) | PR-6 | 캐릭터 Adapter/Engine 이관 | done |
 | [#234](https://github.com/sabyunrepo/muder_platform/issues/234) | PR-7 | 단서 Adapter/Engine 이관 | done |
 | [#235](https://github.com/sabyunrepo/muder_platform/issues/235) | PR-8 | 장소 Adapter/Engine 이관 | done |
-| [#236](https://github.com/sabyunrepo/muder_platform/issues/236) | PR-9 | 결말/통합 Adapter-Engine 검증 및 E2E | active — `refs/pr-9-ending-integration-plan.md` |
+| [#236](https://github.com/sabyunrepo/muder_platform/issues/236) | PR-9 | 결말/통합 Adapter-Engine 검증 및 E2E | done — PR #245 merged |
+| [#246](https://github.com/sabyunrepo/muder_platform/issues/246) | Wrap-up | 마이그레이션 sweep 및 후속 런타임 확장 정리 | active |
 
 ## Legacy Wave/PR 분해 (6 PR — historical baseline)
 

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/phase-24-wrap-up-tracking.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/phase-24-wrap-up-tracking.md
@@ -1,0 +1,41 @@
+# Phase 24 Wrap-up Tracking — PR-5A~PR-9 이후
+
+## 목적
+
+PR-5A~PR-9에서 에디터 Adapter와 백엔드 Engine 경계를 1차로 닫았다. 이제 다음 기능을 바로 추가하기 전에, 현재 main 기준 상태와 후속 작업 범위를 분리한다.
+
+## 현재 완료
+
+- PR-5A: Adapter/Engine 공통 계약 및 Issue 기반 전환
+- PR-5B: 페이즈 정보 전달 Frontend Adapter
+- PR-5C: 정보 전달 Backend Engine 및 런타임 공개 상태
+- PR-6: 캐릭터 Adapter/Engine 이관
+- PR-7: 단서 Adapter/Engine 이관
+- PR-8: 장소 Adapter/Engine 이관
+- PR-9: 결말/통합 Adapter-Engine 검증 및 E2E — PR #245 merged
+
+## 다음 추적 이슈
+
+- GitHub Issue: #246 `[Phase 24][Wrap-up] 마이그레이션 sweep 및 후속 런타임 확장 정리`
+
+## 후속 분리 기준
+
+1. **마이그레이션/운영 cleanup**
+   - lazy normalizer와 legacy shape가 실제로 더 필요한지 확인한다.
+   - sweep/telemetry/preview route 정리는 기능 PR과 섞지 않는다.
+   - 추적 이슈: #250 `[Phase 24][Cleanup] legacy shape/dev preview/lazy normalizer sweep`
+
+2. **런타임 기능 확장**
+   - 단서 효과 engine, 장소 조사 runtime, 결말/투표 breakdown은 각각 별도 이슈/PR로 분리한다.
+   - 프론트는 Adapter, 백엔드는 Engine 소유 원칙을 유지한다.
+   - 추적 이슈: #247 단서 효과 Engine, #248 장소 조사 Runtime, #249 결말/투표 breakdown
+
+3. **제작자 UI 원칙**
+   - 내부 ID, raw JSON, module key, legacy shape는 기본 화면에 노출하지 않는다.
+   - Uzu 문서는 참고하되 MMP의 멀티플레이 runtime과 데이터 정합성에 맞게 변형한다.
+
+## 완료 조건
+
+- checklist 상태가 main과 일치한다.
+- 다음 기능자가 어떤 이슈부터 시작할지 알 수 있다.
+- Phase 24에서 의도적으로 미룬 항목이 추적 가능한 이슈로 분리되어 있다.


### PR DESCRIPTION
## 목표
Phase 24 PR-5A~PR-9 머지 후 checklist와 후속 작업 추적 상태를 main 기준으로 맞춥니다.

## 변경
- PR-9 상태를 active에서 done으로 갱신
- wrap-up 추적 이슈 #246 연결
- 후속 작업 이슈 #247~#250 기준을 문서화

## 검증
- `git diff --check`

## CI
- CodeRabbit 리뷰 확인 전 `ready-for-ci` 라벨을 붙이지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * Phase 24 에디터 재설계 프로젝트의 진행 상황을 반영하여 추적 체크리스트를 업데이트했습니다.
  * 후속 작업 추적을 위한 문서가 신규 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->