### PR TITLE
단서 효과 Engine MVP 계약 추가

### DIFF
--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -17,21 +17,24 @@ func init() {
 
 // ClueInteractionConfig defines the settings for the clue interaction module.
 type ClueInteractionConfig struct {
-	DrawLimit            int    `json:"drawLimit"`
-	InitialClueLevel     int    `json:"initialClueLevel"`
-	CumulativeLevel      bool   `json:"cumulativeLevel"`
-	DuplicatePolicy      string `json:"duplicatePolicy"`
-	CommonClueVisibility string `json:"commonClueVisibility"`
-	AutoRevealClues      bool   `json:"autoRevealClues"`
+	DrawLimit            int                             `json:"drawLimit"`
+	InitialClueLevel     int                             `json:"initialClueLevel"`
+	CumulativeLevel      bool                            `json:"cumulativeLevel"`
+	DuplicatePolicy      string                          `json:"duplicatePolicy"`
+	CommonClueVisibility string                          `json:"commonClueVisibility"`
+	AutoRevealClues      bool                            `json:"autoRevealClues"`
+	ItemEffects          map[string]ClueItemEffectConfig `json:"itemEffects,omitempty"`
 }
 
 // ItemUseState tracks an in-progress item use action.
 type ItemUseState struct {
-	UserID    uuid.UUID `json:"userId"`
-	ClueID    uuid.UUID `json:"clueId"`
-	Effect    string    `json:"effect"`
-	Target    string    `json:"target"`
-	StartedAt time.Time `json:"startedAt"`
+	UserID     uuid.UUID `json:"userId"`
+	ClueID     uuid.UUID `json:"clueId"`
+	Effect     string    `json:"effect"`
+	Target     string    `json:"target"`
+	Consume    bool      `json:"consume"`
+	Configured bool      `json:"configured"`
+	StartedAt  time.Time `json:"startedAt"`
 }
 
 // ClueInteractionModule handles clue drawing and transfer mechanics.
@@ -44,6 +47,7 @@ type ClueInteractionModule struct {
 	acquiredClues    map[uuid.UUID][]string
 	activeItemUse    *ItemUseState
 	usedItems        map[uuid.UUID][]uuid.UUID // playerID -> used clue IDs
+	revealedInfo     map[uuid.UUID]map[string]string
 	itemTimeout      *time.Timer
 }
 
@@ -62,6 +66,7 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 	m.playerDrawCounts = make(map[uuid.UUID]int)
 	m.acquiredClues = make(map[uuid.UUID][]string)
 	m.usedItems = make(map[uuid.UUID][]uuid.UUID)
+	m.revealedInfo = make(map[uuid.UUID]map[string]string)
 
 	// Apply defaults first.
 	m.config = ClueInteractionConfig{
@@ -71,6 +76,7 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 		DuplicatePolicy:      "exclusive",
 		CommonClueVisibility: "all",
 		AutoRevealClues:      false,
+		ItemEffects:          map[string]ClueItemEffectConfig{},
 	}
 
 	// Unmarshal directly into m.config — only provided JSON fields overwrite defaults.
@@ -78,6 +84,12 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 		if err := json.Unmarshal(config, &m.config); err != nil {
 			return fmt.Errorf("clue_interaction: invalid config: %w", err)
 		}
+	}
+	if m.config.ItemEffects == nil {
+		m.config.ItemEffects = map[string]ClueItemEffectConfig{}
+	}
+	if err := validateClueItemEffectConfig(m.config.ItemEffects); err != nil {
+		return err
 	}
 
 	m.currentClueLevel = m.config.InitialClueLevel
@@ -192,161 +204,6 @@ func (m *ClueInteractionModule) handleTransferClue(_ context.Context, playerID u
 	return nil
 }
 
-type itemUsePayload struct {
-	ClueID string `json:"clueId"`
-	Effect string `json:"effect"`
-	Target string `json:"target"`
-}
-
-type itemUseTargetPayload struct {
-	TargetPlayerID string `json:"targetPlayerId"`
-}
-
-func (m *ClueInteractionModule) handleItemUse(_ context.Context, playerID uuid.UUID, payload json.RawMessage) error {
-	var p itemUsePayload
-	if err := json.Unmarshal(payload, &p); err != nil {
-		return fmt.Errorf("clue_interaction: invalid clue:use payload: %w", err)
-	}
-	clueID, err := uuid.Parse(p.ClueID)
-	if err != nil {
-		return fmt.Errorf("clue_interaction: invalid clueId: %w", err)
-	}
-
-	m.mu.Lock()
-	if m.activeItemUse != nil {
-		m.mu.Unlock()
-		return fmt.Errorf("clue_interaction: item use already in progress")
-	}
-
-	m.activeItemUse = &ItemUseState{
-		UserID:    playerID,
-		ClueID:    clueID,
-		Effect:    p.Effect,
-		Target:    p.Target,
-		StartedAt: time.Now(),
-	}
-
-	timer := time.AfterFunc(30*time.Second, func() {
-		m.mu.Lock()
-		if m.activeItemUse != nil && m.activeItemUse.ClueID == clueID {
-			m.activeItemUse = nil
-		}
-		m.mu.Unlock()
-		m.deps.EventBus.Publish(engine.Event{
-			Type: "clue.item_timeout",
-			Payload: map[string]any{
-				"playerId": playerID.String(),
-				"clueId":   clueID.String(),
-			},
-		})
-	})
-	m.itemTimeout = timer
-	m.mu.Unlock()
-
-	m.deps.EventBus.Publish(engine.Event{
-		Type: "clue.item_declared",
-		Payload: map[string]any{
-			"playerId": playerID.String(),
-			"clueId":   clueID.String(),
-		},
-	})
-	return nil
-}
-
-func (m *ClueInteractionModule) handleItemUseTarget(ctx context.Context, playerID uuid.UUID, payload json.RawMessage) error {
-	var p itemUseTargetPayload
-	if err := json.Unmarshal(payload, &p); err != nil {
-		return fmt.Errorf("clue_interaction: invalid clue:use_target payload: %w", err)
-	}
-
-	m.mu.Lock()
-	if m.activeItemUse == nil {
-		m.mu.Unlock()
-		return fmt.Errorf("clue_interaction: no active item use")
-	}
-	if m.activeItemUse.UserID != playerID {
-		m.mu.Unlock()
-		return fmt.Errorf("clue_interaction: not the active item user")
-	}
-	state := *m.activeItemUse
-	m.mu.Unlock()
-
-	var resolveErr error
-	switch state.Effect {
-	case "peek":
-		resolveErr = m.handlePeekEffect(ctx, playerID, state.ClueID, p.TargetPlayerID)
-	case "":
-		// Effect not set in declaration — treat as unimplemented.
-		resolveErr = fmt.Errorf("clue_interaction: effect not specified")
-	default:
-		resolveErr = fmt.Errorf("clue_interaction: effect %q not implemented", state.Effect)
-	}
-
-	if resolveErr != nil {
-		return resolveErr
-	}
-
-	m.mu.Lock()
-	if m.itemTimeout != nil {
-		m.itemTimeout.Stop()
-		m.itemTimeout = nil
-	}
-	if m.activeItemUse != nil && m.activeItemUse.ClueID == state.ClueID {
-		m.usedItems[playerID] = append(m.usedItems[playerID], state.ClueID)
-		m.activeItemUse = nil
-	}
-	m.mu.Unlock()
-
-	m.deps.EventBus.Publish(engine.Event{
-		Type: "clue.item_resolved",
-		Payload: map[string]any{
-			"playerId": playerID.String(),
-			"clueId":   state.ClueID.String(),
-			"effect":   state.Effect,
-		},
-	})
-	return nil
-}
-
-func (m *ClueInteractionModule) handlePeekEffect(_ context.Context, _ uuid.UUID, _ uuid.UUID, targetPlayerIDStr string) error {
-	targetPlayerID, err := uuid.Parse(targetPlayerIDStr)
-	if err != nil {
-		return fmt.Errorf("clue_interaction: invalid targetPlayerId: %w", err)
-	}
-
-	m.mu.RLock()
-	clues := make([]string, len(m.acquiredClues[targetPlayerID]))
-	copy(clues, m.acquiredClues[targetPlayerID])
-	m.mu.RUnlock()
-
-	m.deps.EventBus.Publish(engine.Event{
-		Type: "clue.peek_result",
-		Payload: map[string]any{
-			"targetPlayerId": targetPlayerID.String(),
-			"clues":          clues,
-		},
-	})
-	return nil
-}
-
-func (m *ClueInteractionModule) handleItemUseCancel(_ context.Context, playerID uuid.UUID) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if m.activeItemUse == nil {
-		return fmt.Errorf("clue_interaction: no active item use")
-	}
-	if m.activeItemUse.UserID != playerID {
-		return fmt.Errorf("clue_interaction: not the active item user")
-	}
-	if m.itemTimeout != nil {
-		m.itemTimeout.Stop()
-		m.itemTimeout = nil
-	}
-	m.activeItemUse = nil
-	return nil
-}
-
 // --- PhaseReactor ---
 
 func (m *ClueInteractionModule) ReactTo(_ context.Context, action engine.PhaseActionPayload) error {
@@ -398,6 +255,22 @@ func (m *ClueInteractionModule) Schema() json.RawMessage {
 			"duplicatePolicy":      map[string]any{"type": "string", "enum": []string{"exclusive", "shared", "copy"}, "default": "exclusive", "description": "How duplicate clue draws are handled"},
 			"commonClueVisibility": map[string]any{"type": "string", "enum": []string{"all", "finder_only", "same_location"}, "default": "all", "description": "Who can see common clues"},
 			"autoRevealClues":      map[string]any{"type": "boolean", "default": false, "description": "Automatically reveal clues when drawn"},
+			"itemEffects": map[string]any{
+				"type": "object",
+				"additionalProperties": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"effect":       map[string]any{"type": "string", "enum": []string{"peek", "reveal", "grant_clue"}},
+						"target":       map[string]any{"type": "string", "enum": []string{"player", "self"}},
+						"consume":      map[string]any{"type": "boolean", "default": false},
+						"revealText":   map[string]any{"type": "string"},
+						"grantClueIds": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					},
+					"required":             []string{"effect"},
+					"additionalProperties": false,
+				},
+				"description": "Runtime clue use effects keyed by clue ID",
+			},
 		},
 		"additionalProperties": false,
 	}
@@ -406,12 +279,13 @@ func (m *ClueInteractionModule) Schema() json.RawMessage {
 }
 
 type clueInteractionState struct {
-	PlayerDrawCounts map[uuid.UUID]int         `json:"playerDrawCounts"`
-	CurrentClueLevel int                       `json:"currentClueLevel"`
-	AcquiredClues    map[uuid.UUID][]string    `json:"acquiredClues"`
-	Config           ClueInteractionConfig     `json:"config"`
-	UsedItems        map[uuid.UUID][]uuid.UUID `json:"usedItems"`
-	ActiveItemUse    *ItemUseState             `json:"activeItemUse,omitempty"`
+	PlayerDrawCounts map[uuid.UUID]int               `json:"playerDrawCounts"`
+	CurrentClueLevel int                             `json:"currentClueLevel"`
+	AcquiredClues    map[uuid.UUID][]string          `json:"acquiredClues"`
+	Config           ClueInteractionConfig           `json:"config"`
+	UsedItems        map[uuid.UUID][]uuid.UUID       `json:"usedItems"`
+	RevealedInfo     map[uuid.UUID]map[string]string `json:"revealedInfo"`
+	ActiveItemUse    *ItemUseState                   `json:"activeItemUse,omitempty"`
 }
 
 func (m *ClueInteractionModule) BuildState() (json.RawMessage, error) {
@@ -424,6 +298,7 @@ func (m *ClueInteractionModule) BuildState() (json.RawMessage, error) {
 		AcquiredClues:    m.acquiredClues,
 		Config:           m.config,
 		UsedItems:        m.usedItems,
+		RevealedInfo:     m.revealedInfo,
 		ActiveItemUse:    m.activeItemUse,
 	})
 }
@@ -435,6 +310,7 @@ func (m *ClueInteractionModule) Cleanup(_ context.Context) error {
 	m.playerDrawCounts = nil
 	m.acquiredClues = nil
 	m.usedItems = nil
+	m.revealedInfo = nil
 	m.activeItemUse = nil
 	if m.itemTimeout != nil {
 		m.itemTimeout.Stop()
@@ -471,7 +347,9 @@ func (m *ClueInteractionModule) Apply(_ context.Context, event engine.GameEvent,
 // Per-player maps (PlayerDrawCounts / AcquiredClues / UsedItems) are filtered
 // to the caller's own entry. ActiveItemUse is revealed only when the caller
 // is the item user — watching another player's in-flight item use leaks
-// strategy. CurrentClueLevel and Config are session-wide and remain public.
+// strategy. CurrentClueLevel and non-secret Config are session-wide and remain
+// public; configured clue effects are removed because they may contain hidden
+// reveal text and future rewards.
 func (m *ClueInteractionModule) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -485,10 +363,17 @@ func (m *ClueInteractionModule) BuildStateFor(playerID uuid.UUID) (json.RawMessa
 		PlayerDrawCounts: engine.FilterByPlayer(m.playerDrawCounts, playerID),
 		CurrentClueLevel: m.currentClueLevel,
 		AcquiredClues:    engine.FilterByPlayer(m.acquiredClues, playerID),
-		Config:           m.config,
+		Config:           m.configForPlayerState(),
 		UsedItems:        engine.FilterByPlayer(m.usedItems, playerID),
+		RevealedInfo:     engine.FilterByPlayer(m.revealedInfo, playerID),
 		ActiveItemUse:    activeItemUse,
 	})
+}
+
+func (m *ClueInteractionModule) configForPlayerState() ClueInteractionConfig {
+	config := m.config
+	config.ItemEffects = nil
+	return config
 }
 
 // Compile-time interface checks.

--- a/apps/server/internal/module/core/clue_item_effects.go
+++ b/apps/server/internal/module/core/clue_item_effects.go
@@ -1,0 +1,359 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+const (
+	clueEffectPeek      = "peek"
+	clueEffectReveal    = "reveal"
+	clueEffectGrantClue = "grant_clue"
+)
+
+// ClueItemEffectConfig is the runtime-owned contract for configured clue use.
+// Editor labels are mapped to this contract by adapters; the engine executes
+// only this typed shape and never trusts client-side labels as runtime truth.
+type ClueItemEffectConfig struct {
+	Effect       string   `json:"effect"`
+	Target       string   `json:"target,omitempty"`
+	Consume      bool     `json:"consume"`
+	RevealText   string   `json:"revealText,omitempty"`
+	GrantClueIDs []string `json:"grantClueIds,omitempty"`
+}
+
+type itemUsePayload struct {
+	ClueID string `json:"clueId"`
+	Effect string `json:"effect"`
+	Target string `json:"target"`
+}
+
+type itemUseTargetPayload struct {
+	TargetPlayerID string `json:"targetPlayerId"`
+}
+
+func (m *ClueInteractionModule) handleItemUse(ctx context.Context, playerID uuid.UUID, payload json.RawMessage) error {
+	var p itemUsePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("clue_interaction: invalid clue:use payload: %w", err)
+	}
+	clueID, err := uuid.Parse(p.ClueID)
+	if err != nil {
+		return fmt.Errorf("clue_interaction: invalid clueId: %w", err)
+	}
+
+	effectCfg, configured := m.config.ItemEffects[p.ClueID]
+	state := ItemUseState{
+		UserID:     playerID,
+		ClueID:     clueID,
+		Effect:     p.Effect,
+		Target:     p.Target,
+		Consume:    false,
+		Configured: configured,
+		StartedAt:  time.Now(),
+	}
+	if configured {
+		if m.playerUsedItem(playerID, clueID) {
+			return nil
+		}
+		if err := m.validateConfiguredItemUse(playerID, p.ClueID, effectCfg); err != nil {
+			return err
+		}
+		state.Effect = effectCfg.Effect
+		state.Target = effectCfg.Target
+		state.Consume = effectCfg.Consume
+	}
+
+	if state.Configured && (state.Target == "self" || state.Effect == clueEffectReveal || state.Effect == clueEffectGrantClue) {
+		m.publishItemDeclared(playerID, clueID)
+		return m.resolveItemUse(ctx, state, "")
+	}
+
+	m.mu.Lock()
+	if m.activeItemUse != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("clue_interaction: item use already in progress")
+	}
+	m.activeItemUse = &state
+	m.startItemUseTimer(playerID, clueID)
+	m.mu.Unlock()
+
+	m.publishItemDeclared(playerID, clueID)
+	return nil
+}
+
+func (m *ClueInteractionModule) handleItemUseTarget(ctx context.Context, playerID uuid.UUID, payload json.RawMessage) error {
+	var p itemUseTargetPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("clue_interaction: invalid clue:use_target payload: %w", err)
+	}
+
+	m.mu.RLock()
+	if m.activeItemUse == nil {
+		m.mu.RUnlock()
+		return fmt.Errorf("clue_interaction: no active item use")
+	}
+	if m.activeItemUse.UserID != playerID {
+		m.mu.RUnlock()
+		return fmt.Errorf("clue_interaction: not the active item user")
+	}
+	state := *m.activeItemUse
+	m.mu.RUnlock()
+
+	return m.resolveItemUse(ctx, state, p.TargetPlayerID)
+}
+
+func (m *ClueInteractionModule) resolveItemUse(ctx context.Context, state ItemUseState, targetPlayerID string) error {
+	var resolveErr error
+	switch state.Effect {
+	case clueEffectPeek:
+		resolveErr = m.handlePeekEffect(ctx, state.UserID, state.ClueID, targetPlayerID)
+	case clueEffectReveal:
+		if state.Configured {
+			resolveErr = m.handleRevealEffect(state.UserID, state.ClueID)
+		} else {
+			resolveErr = fmt.Errorf("clue_interaction: effect %q not implemented", state.Effect)
+		}
+	case clueEffectGrantClue:
+		if state.Configured {
+			resolveErr = m.handleGrantClueEffect(state.UserID, state.ClueID)
+		} else {
+			resolveErr = fmt.Errorf("clue_interaction: effect %q not implemented", state.Effect)
+		}
+	case "":
+		resolveErr = fmt.Errorf("clue_interaction: effect not specified")
+	default:
+		resolveErr = fmt.Errorf("clue_interaction: effect %q not implemented", state.Effect)
+	}
+	if resolveErr != nil {
+		return resolveErr
+	}
+
+	m.finishItemUse(state)
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.item_resolved",
+		Payload: map[string]any{
+			"playerId": state.UserID.String(),
+			"clueId":   state.ClueID.String(),
+			"effect":   state.Effect,
+			"consumed": state.Consume,
+		},
+	})
+	return nil
+}
+
+func (m *ClueInteractionModule) validateConfiguredItemUse(playerID uuid.UUID, clueID string, cfg ClueItemEffectConfig) error {
+	if err := validateSingleClueItemEffectConfig(clueID, cfg); err != nil {
+		return err
+	}
+	if !m.playerHasClue(playerID, clueID) {
+		return fmt.Errorf("clue_interaction: player does not own clue %q", clueID)
+	}
+	return nil
+}
+
+func validateClueItemEffectConfig(effects map[string]ClueItemEffectConfig) error {
+	for clueID, cfg := range effects {
+		if _, err := uuid.Parse(clueID); err != nil {
+			return fmt.Errorf("clue_interaction: invalid itemEffects clue id %q: %w", clueID, err)
+		}
+		if err := validateSingleClueItemEffectConfig(clueID, cfg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSingleClueItemEffectConfig(clueID string, cfg ClueItemEffectConfig) error {
+	if cfg.Effect == "" {
+		return fmt.Errorf("clue_interaction: item effect missing for clue %q", clueID)
+	}
+	if cfg.Effect != clueEffectReveal && cfg.Effect != clueEffectGrantClue && cfg.Effect != clueEffectPeek {
+		return fmt.Errorf("clue_interaction: effect %q not implemented", cfg.Effect)
+	}
+	if cfg.Effect == clueEffectGrantClue && len(cfg.GrantClueIDs) == 0 {
+		return fmt.Errorf("clue_interaction: grant_clue requires grantClueIds")
+	}
+	if cfg.Effect == clueEffectReveal && cfg.RevealText == "" {
+		return fmt.Errorf("clue_interaction: reveal requires revealText")
+	}
+	return nil
+}
+
+func (m *ClueInteractionModule) handlePeekEffect(_ context.Context, _ uuid.UUID, _ uuid.UUID, targetPlayerIDStr string) error {
+	targetPlayerID, err := uuid.Parse(targetPlayerIDStr)
+	if err != nil {
+		return fmt.Errorf("clue_interaction: invalid targetPlayerId: %w", err)
+	}
+
+	m.mu.RLock()
+	clues := make([]string, len(m.acquiredClues[targetPlayerID]))
+	copy(clues, m.acquiredClues[targetPlayerID])
+	m.mu.RUnlock()
+
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.peek_result",
+		Payload: map[string]any{
+			"targetPlayerId": targetPlayerID.String(),
+			"clues":          clues,
+		},
+	})
+	return nil
+}
+
+func (m *ClueInteractionModule) handleRevealEffect(playerID uuid.UUID, clueID uuid.UUID) error {
+	cfg := m.config.ItemEffects[clueID.String()]
+	m.mu.Lock()
+	if m.revealedInfo[playerID] == nil {
+		m.revealedInfo[playerID] = make(map[string]string)
+	}
+	m.revealedInfo[playerID][clueID.String()] = cfg.RevealText
+	m.mu.Unlock()
+
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.reveal_result",
+		Payload: map[string]any{
+			"playerId":   playerID.String(),
+			"clueId":     clueID.String(),
+			"revealText": cfg.RevealText,
+		},
+	})
+	return nil
+}
+
+func (m *ClueInteractionModule) handleGrantClueEffect(playerID uuid.UUID, clueID uuid.UUID) error {
+	cfg := m.config.ItemEffects[clueID.String()]
+	m.mu.Lock()
+	granted := make([]string, 0, len(cfg.GrantClueIDs))
+	for _, grantID := range cfg.GrantClueIDs {
+		if grantID == "" || m.playerHasClueLocked(playerID, grantID) {
+			continue
+		}
+		m.acquiredClues[playerID] = append(m.acquiredClues[playerID], grantID)
+		granted = append(granted, grantID)
+	}
+	m.mu.Unlock()
+
+	for _, grantID := range granted {
+		m.deps.EventBus.Publish(engine.Event{
+			Type: "clue.acquired",
+			Payload: map[string]any{
+				"playerId": playerID.String(),
+				"clueId":   grantID,
+				"source":   "clue_effect",
+				"usedClue": clueID.String(),
+			},
+		})
+	}
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.grant_result",
+		Payload: map[string]any{
+			"playerId":     playerID.String(),
+			"clueId":       clueID.String(),
+			"grantClueIds": granted,
+		},
+	})
+	return nil
+}
+
+func (m *ClueInteractionModule) handleItemUseCancel(_ context.Context, playerID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.activeItemUse == nil {
+		return fmt.Errorf("clue_interaction: no active item use")
+	}
+	if m.activeItemUse.UserID != playerID {
+		return fmt.Errorf("clue_interaction: not the active item user")
+	}
+	if m.itemTimeout != nil {
+		m.itemTimeout.Stop()
+		m.itemTimeout = nil
+	}
+	m.activeItemUse = nil
+	return nil
+}
+
+func (m *ClueInteractionModule) startItemUseTimer(playerID uuid.UUID, clueID uuid.UUID) {
+	m.itemTimeout = time.AfterFunc(30*time.Second, func() {
+		m.mu.Lock()
+		if m.activeItemUse != nil && m.activeItemUse.ClueID == clueID {
+			m.activeItemUse = nil
+		}
+		m.mu.Unlock()
+		m.deps.EventBus.Publish(engine.Event{
+			Type: "clue.item_timeout",
+			Payload: map[string]any{
+				"playerId": playerID.String(),
+				"clueId":   clueID.String(),
+			},
+		})
+	})
+}
+
+func (m *ClueInteractionModule) publishItemDeclared(playerID uuid.UUID, clueID uuid.UUID) {
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.item_declared",
+		Payload: map[string]any{
+			"playerId": playerID.String(),
+			"clueId":   clueID.String(),
+		},
+	})
+}
+
+func (m *ClueInteractionModule) finishItemUse(state ItemUseState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.activeItemUse != nil && m.activeItemUse.ClueID == state.ClueID {
+		if m.itemTimeout != nil {
+			m.itemTimeout.Stop()
+			m.itemTimeout = nil
+		}
+		m.activeItemUse = nil
+	}
+	m.usedItems[state.UserID] = append(m.usedItems[state.UserID], state.ClueID)
+	if state.Consume {
+		m.removePlayerClueLocked(state.UserID, state.ClueID.String())
+	}
+}
+
+func (m *ClueInteractionModule) playerHasClue(playerID uuid.UUID, clueID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.playerHasClueLocked(playerID, clueID)
+}
+
+func (m *ClueInteractionModule) playerUsedItem(playerID uuid.UUID, clueID uuid.UUID) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, usedID := range m.usedItems[playerID] {
+		if usedID == clueID {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *ClueInteractionModule) playerHasClueLocked(playerID uuid.UUID, clueID string) bool {
+	for _, ownedID := range m.acquiredClues[playerID] {
+		if ownedID == clueID {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *ClueInteractionModule) removePlayerClueLocked(playerID uuid.UUID, clueID string) {
+	clues := m.acquiredClues[playerID]
+	for i, ownedID := range clues {
+		if ownedID == clueID {
+			m.acquiredClues[playerID] = append(clues[:i], clues[i+1:]...)
+			return
+		}
+	}
+}

--- a/apps/server/internal/module/core/clue_item_effects_test.go
+++ b/apps/server/internal/module/core/clue_item_effects_test.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func TestClueInteractionModule_ConfiguredRevealConsumesAndRedacts(t *testing.T) {
+	deps := newTestDeps()
+	m := NewClueInteractionModule()
+	playerID := uuid.New()
+	otherID := uuid.New()
+	clueID := uuid.New()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		clueID.String(): {Effect: clueEffectReveal, Target: "self", Consume: true, RevealText: "금고 비밀번호는 0421입니다."},
+	}})
+	if err := m.Init(context.Background(), deps, cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	m.mu.Lock()
+	m.acquiredClues[playerID] = []string{clueID.String()}
+	m.mu.Unlock()
+
+	var declared, resolved, revealed bool
+	deps.EventBus.Subscribe("clue.item_declared", func(e engine.Event) { declared = true })
+	deps.EventBus.Subscribe("clue.item_resolved", func(e engine.Event) {
+		payload := e.Payload.(map[string]any)
+		resolved = payload["consumed"] == true
+	})
+	deps.EventBus.Subscribe("clue.reveal_result", func(e engine.Event) { revealed = true })
+
+	payload, _ := json.Marshal(itemUsePayload{ClueID: clueID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", payload); err != nil {
+		t.Fatalf("clue:use reveal: %v", err)
+	}
+	if !declared || !resolved || !revealed {
+		t.Fatalf("expected declared/resolved/revealed events, got declared=%v resolved=%v revealed=%v", declared, resolved, revealed)
+	}
+	m.mu.RLock()
+	if m.playerHasClueLocked(playerID, clueID.String()) {
+		t.Fatal("consumed reveal clue should be removed from player inventory")
+	}
+	if got := m.revealedInfo[playerID][clueID.String()]; got != "금고 비밀번호는 0421입니다." {
+		t.Fatalf("revealed text = %q", got)
+	}
+	m.mu.RUnlock()
+
+	ownData, err := m.BuildStateFor(playerID)
+	if err != nil {
+		t.Fatalf("BuildStateFor owner: %v", err)
+	}
+	if !bytes.Contains(ownData, []byte("0421")) {
+		t.Fatalf("owner should see revealed info: %s", ownData)
+	}
+	otherData, err := m.BuildStateFor(otherID)
+	if err != nil {
+		t.Fatalf("BuildStateFor other: %v", err)
+	}
+	if bytes.Contains(otherData, []byte("0421")) || bytes.Contains(otherData, []byte(playerID.String())) {
+		t.Fatalf("other player leaked revealed info: %s", otherData)
+	}
+}
+
+func TestClueInteractionModule_ConfiguredGrantClueIsIdempotent(t *testing.T) {
+	deps := newTestDeps()
+	m := NewClueInteractionModule()
+	playerID := uuid.New()
+	keyID := uuid.New()
+	rewardID := uuid.New().String()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		keyID.String(): {Effect: clueEffectGrantClue, Target: "self", Consume: false, GrantClueIDs: []string{rewardID}},
+	}})
+	if err := m.Init(context.Background(), deps, cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	m.mu.Lock()
+	m.acquiredClues[playerID] = []string{keyID.String()}
+	m.mu.Unlock()
+
+	acquiredEvents := 0
+	deps.EventBus.Subscribe("clue.acquired", func(e engine.Event) { acquiredEvents++ })
+	payload, _ := json.Marshal(itemUsePayload{ClueID: keyID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", payload); err != nil {
+		t.Fatalf("first grant use: %v", err)
+	}
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", payload); err != nil {
+		t.Fatalf("second grant use should be idempotent: %v", err)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.playerHasClueLocked(playerID, keyID.String()) {
+		t.Fatal("non-consumed grant clue should remain in inventory")
+	}
+	if !m.playerHasClueLocked(playerID, rewardID) {
+		t.Fatal("reward clue should be granted")
+	}
+	if len(m.usedItems[playerID]) != 1 {
+		t.Fatalf("configured item use should be recorded once, got %d", len(m.usedItems[playerID]))
+	}
+	if acquiredEvents != 1 {
+		t.Fatalf("expected one clue.acquired event, got %d", acquiredEvents)
+	}
+}
+
+func TestClueInteractionModule_ConfiguredEffectRequiresOwnership(t *testing.T) {
+	m := NewClueInteractionModule()
+	clueID := uuid.New()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		clueID.String(): {Effect: clueEffectReveal, Target: "self", RevealText: "비밀"},
+	}})
+	if err := m.Init(context.Background(), newTestDeps(), cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	payload, _ := json.Marshal(itemUsePayload{ClueID: clueID.String()})
+	if err := m.HandleMessage(context.Background(), uuid.New(), "clue:use", payload); err == nil {
+		t.Fatal("expected ownership error for configured clue effect")
+	}
+}
+
+func TestClueInteractionModule_ConfiguredEffectInvalidConfig(t *testing.T) {
+	m := NewClueInteractionModule()
+	clueID := uuid.New()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		clueID.String(): {Effect: clueEffectGrantClue, Target: "self"},
+	}})
+	if err := m.Init(context.Background(), newTestDeps(), cfg); err == nil {
+		t.Fatal("expected invalid config error when grant_clue has no rewards")
+	}
+}
+
+func TestClueInteractionModule_LegacyRevealPayloadIsNotRuntimeTruth(t *testing.T) {
+	m := NewClueInteractionModule()
+	if err := m.Init(context.Background(), newTestDeps(), nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	playerID := uuid.New()
+	clueID := uuid.New()
+	usePayload, _ := json.Marshal(itemUsePayload{ClueID: clueID.String(), Effect: clueEffectReveal, Target: "self"})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", usePayload); err != nil {
+		t.Fatalf("legacy reveal declaration should keep old declare-then-fail behavior: %v", err)
+	}
+	targetPayload, _ := json.Marshal(itemUseTargetPayload{TargetPlayerID: playerID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use_target", targetPayload); err == nil {
+		t.Fatal("expected legacy reveal payload to be rejected without configured engine effect")
+	}
+}
+
+func TestClueInteractionModule_ImmediateConfiguredUseDoesNotClearActiveTargetFlow(t *testing.T) {
+	m := NewClueInteractionModule()
+	selfPlayer := uuid.New()
+	activePlayer := uuid.New()
+	configuredClueID := uuid.New()
+	activeClueID := uuid.New()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		configuredClueID.String(): {Effect: clueEffectReveal, Target: "self", RevealText: "개인 정보"},
+	}})
+	if err := m.Init(context.Background(), newTestDeps(), cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	m.mu.Lock()
+	m.activeItemUse = &ItemUseState{UserID: activePlayer, ClueID: activeClueID, Effect: clueEffectPeek, Target: "player"}
+	m.acquiredClues[selfPlayer] = []string{configuredClueID.String()}
+	m.mu.Unlock()
+
+	payload, _ := json.Marshal(itemUsePayload{ClueID: configuredClueID.String()})
+	if err := m.HandleMessage(context.Background(), selfPlayer, "clue:use", payload); err != nil {
+		t.Fatalf("configured self use should resolve: %v", err)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.activeItemUse == nil || m.activeItemUse.ClueID != activeClueID {
+		t.Fatalf("unrelated active target flow was cleared: %+v", m.activeItemUse)
+	}
+}

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-247-clue-effect-engine.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-247-clue-effect-engine.md
@@ -1,0 +1,92 @@
+# Issue #247 — 단서 효과 Engine 계약 및 런타임 실행
+
+## 상태
+
+- GitHub Issue: [#247](https://github.com/sabyunrepo/muder_platform/issues/247)
+- Branch: `feat/issue-247-clue-effect-engine`
+- 목표: 제작자 UI의 단서 사용 설정이 프론트 표시값에 머물지 않고, 백엔드 런타임 Engine에서 실제로 실행되도록 최소 계약을 만든다.
+
+## Uzu 참고점
+
+Uzu 단서 문서는 단서를 단순 텍스트가 아니라 “소유권이 있는 플레이 중 자산”으로 다룬다.
+
+- 단서 기본 정보는 플레이 중 단서 목록/상세에 표시된다.
+- 비공개 단서는 소유자 외 사용자에게 제목/태그만 보이고 상세는 숨길 수 있다.
+- 배포 조건은 “어떤 조건으로, 어떤 방식으로, 누구에게 줄지”를 나눈다.
+- 소유권이 있는 단서는 전체 공개, 공유, 양도가 가능하다.
+- 회수 조건으로 이미 배포된 단서를 다시 장에서 제거할 수 있다.
+- 조건 그룹은 AND/OR를 지원하지만 깊어질수록 제작자 UI가 복잡해진다.
+
+## MMP 적용 방식
+
+Uzu를 그대로 복제하지 않고, MMP는 실시간 멀티플레이와 player-aware state를 우선한다.
+
+1. 프론트 Adapter는 제작자에게 쉬운 문구와 선택 UI를 제공한다.
+2. 백엔드 Engine은 단서 사용 효과의 실제 실행과 권한 검증을 담당한다.
+3. 플레이어별 공개 정보는 `BuildStateFor`에서 분리한다.
+4. 같은 단서를 재사용하거나 재접속 상태가 반복되어도 중복 지급/중복 공개가 생기지 않도록 idempotency를 둔다.
+5. 내부 raw JSON, module key, 숨겨진 reveal text는 플레이어 state에 노출하지 않는다.
+
+## 이번 PR의 구현 범위
+
+### Engine 계약
+
+`clue_interaction` 모듈 config에 `itemEffects`를 추가한다.
+
+```json
+{
+  "itemEffects": {
+    "<clueId>": {
+      "effect": "reveal",
+      "target": "self",
+      "consume": true,
+      "revealText": "사용자에게만 공개할 정보"
+    }
+  }
+}
+```
+
+지원 효과는 MVP 기준으로 제한한다.
+
+| effect | 의미 | 이번 PR 동작 |
+| --- | --- | --- |
+| `peek` | 다른 플레이어 단서 보기 | 기존 대상 선택 흐름 유지 |
+| `reveal` | 사용한 플레이어에게 정보 공개 | `revealedInfo`에 저장하고 본인에게만 state 공개 |
+| `grant_clue` | 사용 성공 시 새 단서 지급 | 보유 단서에 추가하고 `clue.acquired` 이벤트 발행 |
+
+### 보안/정합성
+
+- configured effect는 단서 소유자만 사용할 수 있다.
+- `grant_clue`는 지급 대상이 없으면 config init 단계에서 실패한다.
+- `reveal`은 공개할 텍스트가 없으면 config init 단계에서 실패한다.
+- `consume=true`이면 사용 단서를 보유 목록에서 제거한다.
+- 이미 사용한 configured effect는 다시 적용하지 않는다.
+- 플레이어 state에는 본인의 `revealedInfo`만 포함하고, 전체 `itemEffects` config는 제거한다.
+
+## 제외 / 후순위
+
+이번 PR에서 구현하지 않는다.
+
+- `steal`, `block`, `swap`의 실제 플레이어 간 상호작용: ownership ledger, 대상 승인, 악용 방지 규칙이 필요하다.
+- Uzu식 회수 조건 전체: 배포/회수 ledger가 안정화된 뒤 별도 PR에서 다룬다.
+- 복합 조건 UI 전체: Phase/condition 엔진과 결합해야 하므로 후속 이슈로 둔다.
+- 프론트 제작자 UI 전면 개편: 이번 PR은 Engine 계약과 테스트가 우선이며, UI는 Adapter가 이 계약을 바라보도록 후속 연결한다.
+
+## 테스트 계획
+
+- Go unit/integration
+  - configured `reveal` 실행 시 본인에게만 공개되고 `consume=true`이면 보유 단서에서 제거된다.
+  - configured `grant_clue` 실행 시 새 단서가 지급되고 재사용해도 중복 지급되지 않는다.
+  - configured effect는 소유하지 않은 플레이어가 사용할 수 없다.
+  - 잘못된 effect config는 Init 단계에서 실패한다.
+  - 기존 `peek` 대상 선택 흐름은 유지된다.
+- E2E 대체 사유
+  - 이번 slice는 React 화면/라우트를 바꾸지 않고 백엔드 runtime module 계약을 추가한다.
+  - 사용자 관점 흐름은 WS 세션 런타임 연결 후 Playwright로 확장한다.
+
+## 완료 조건
+
+- `clue_interaction` runtime module이 `reveal`/`grant_clue`를 실제 state/event로 실행한다.
+- player-aware redaction으로 다른 플레이어에게 공개 텍스트와 effect config가 새지 않는다.
+- 기존 `peek` 흐름과 phase action이 깨지지 않는다.
+- focused Go test가 통과한다.


### PR DESCRIPTION
## 목표

Issue #247의 첫 번째 구현 slice로, 단서 사용 효과를 프론트 표시값이 아니라 백엔드 `clue_interaction` Engine이 실행하는 계약으로 분리했습니다.

## 변경 내용

- `clue_interaction` config에 `itemEffects` 계약 추가
  - `reveal`: 사용한 플레이어에게만 정보 공개
  - `grant_clue`: 사용 성공 시 새 단서 지급
  - `peek`: 기존 대상 선택 흐름 유지
- configured effect 보안/정합성 강화
  - 소유하지 않은 단서 사용 차단
  - 잘못된 config는 module `Init` 단계에서 실패
  - `consume=true`이면 사용 단서를 보유 목록에서 제거
  - 이미 실행한 configured effect는 중복 적용하지 않음
  - `BuildStateFor`에서 다른 플레이어에게 reveal text / itemEffects config가 새지 않도록 redaction
- 기존 `clue:use`/`clue:use_target` item use 로직을 별도 파일로 분리해 `clue_interaction.go` 크기 축소
- Uzu 참고점과 MMP 적용/후순위 범위를 문서화

## 검증

- `go test ./...` (apps/server) 통과
- `go test ./internal/module/core -cover` → 90.4%
- `git diff --check` 통과

## E2E 대체 사유

이번 PR은 React 화면/라우트가 아니라 백엔드 runtime module 계약 변경입니다. 사용자 화면 E2E는 WS 세션 런타임 UI 연결 PR에서 추가하고, 이번 PR에서는 Go runtime test로 player-aware redaction, idempotency, ownership, consume/reward/reveal 이벤트를 검증했습니다.

## 후속 작업

- `steal`, `block`, `swap` 실제 상호작용은 ownership ledger와 대상 승인 규칙이 필요하므로 후속 PR로 분리합니다.
- `unlock`/회수 조건은 단서 배포 ledger와 condition engine 연결 후 별도 구현합니다.

Refs #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 힌트 아이템에 효과 설정 기능 추가 (공개, 단서 부여 등)
  * 플레이어별 공개된 정보 추적 및 필터링

* **문서**
  * 힌트 효과 엔진 사양 문서 추가

* **테스트**
  * 효과 설정 및 실행 관련 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->