### PR TITLE
단서 런타임 효과 편집 UI 연결

### DIFF
--- a/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
@@ -11,12 +11,14 @@ const {
   useEditorThemeMock,
   useEditorLocationsMock,
   useEditorCharactersMock,
+  useUpdateConfigJsonMock,
 } = vi.hoisted(() => ({
   useEditorCluesMock: vi.fn(),
   useDeleteClueMock: vi.fn(),
   useEditorThemeMock: vi.fn(),
   useEditorLocationsMock: vi.fn(),
   useEditorCharactersMock: vi.fn(),
+  useUpdateConfigJsonMock: vi.fn(),
 }));
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
@@ -45,6 +47,7 @@ vi.mock('@/features/editor/api', () => ({
   useEditorTheme: () => useEditorThemeMock(),
   useEditorLocations: () => useEditorLocationsMock(),
   useEditorCharacters: () => useEditorCharactersMock(),
+  useUpdateConfigJson: () => useUpdateConfigJsonMock(),
   editorKeys: { clues: (id: string) => ['clues', id] },
 }));
 vi.mock('../ClueForm', () => ({
@@ -76,6 +79,7 @@ describe('CluesTab', () => {
     useEditorThemeMock.mockReturnValue({ data: { config_json: {} } });
     useEditorLocationsMock.mockReturnValue({ data: [] });
     useEditorCharactersMock.mockReturnValue({ data: [] });
+    useUpdateConfigJsonMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
   });
 
   it('로딩 중이면 스피너를 렌더링한다', () => {

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
@@ -78,7 +78,7 @@ describe('ClueEntityWorkspace', () => {
 
     expect(screen.getByText('단서 상세')).toBeDefined();
     expect(screen.getByText('다른 플레이어에게서 단서 가져오기')).toBeDefined();
-    expect(screen.getByText('사용하면 내 단서함에서 사라짐')).toBeDefined();
+    expect(screen.getAllByText('사용하면 내 단서함에서 사라짐').length).toBeGreaterThan(0);
     expect(screen.getByText('서재의 발견 단서')).toBeDefined();
     expect(screen.getByText('탐정의 시작 단서')).toBeDefined();
   });

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -5,6 +5,7 @@ import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import { buildClueUsageMap, getClueBacklinks, type EntityReference } from '@/features/editor/utils/entityReferences';
 import { buildClueBadges, toClueEditorViewModel } from '@/features/editor/entities/clue/clueEntityAdapter';
+import { ClueRuntimeEffectCard } from './ClueRuntimeEffectCard';
 
 interface ClueEntityWorkspaceProps {
   clues: ClueResponse[];
@@ -14,6 +15,8 @@ interface ClueEntityWorkspaceProps {
   onCreate: () => void;
   onEdit: (clue: ClueResponse) => void;
   onDelete: (clue: ClueResponse) => void;
+  onConfigChange?: (configJson: EditorConfig) => void;
+  isConfigSaving?: boolean;
 }
 
 export function ClueEntityWorkspace({
@@ -24,6 +27,8 @@ export function ClueEntityWorkspace({
   onCreate,
   onEdit,
   onDelete,
+  onConfigChange,
+  isConfigSaving,
 }: ClueEntityWorkspaceProps) {
   const [selectedId, setSelectedId] = useState(clues[0]?.id ?? '');
   const usageMap = useMemo(
@@ -42,7 +47,18 @@ export function ClueEntityWorkspace({
       getItemTitle={(clue) => clue.name}
       getItemDescription={(clue) => clue.description || '설명 없음'}
       getItemBadges={(clue) => buildClueBadges(clue, usageMap[clue.id]?.references.length ?? 0)}
-      renderDetail={(clue) => <ClueDetailCard clue={clue} onEdit={onEdit} onDelete={onDelete} />}
+      renderDetail={(clue) => (
+        <div className="space-y-4">
+          <ClueDetailCard clue={clue} onEdit={onEdit} onDelete={onDelete} />
+          <ClueRuntimeEffectCard
+            clue={clue}
+            clues={clues}
+            configJson={configJson}
+            onConfigChange={onConfigChange}
+            isSaving={isConfigSaving}
+          />
+        </div>
+      )}
       renderInspector={(clue) => <ClueUsageCard references={getClueBacklinks(usageMap, clue.id)} />}
     />
   );

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -10,8 +10,10 @@ import {
   useEditorLocations,
   useEditorClues,
   useDeleteClue,
+  useUpdateConfigJson,
   type ClueResponse,
 } from '@/features/editor/api';
+import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { buildClueUsageMap, type EntityReference } from '@/features/editor/utils/entityReferences';
 import { ClueForm } from '../ClueForm';
 import { ClueEntityWorkspace } from './ClueEntityWorkspace';
@@ -34,6 +36,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
   const { data: locations = [] } = useEditorLocations(themeId);
   const { data: characters = [] } = useEditorCharacters(themeId);
   const deleteClue = useDeleteClue(themeId);
+  const updateConfig = useUpdateConfigJson(themeId);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingClue, setEditingClue] = useState<ClueResponse | undefined>(undefined);
   const [deletingClue, setDeletingClue] = useState<ClueResponse | undefined>(undefined);
@@ -58,6 +61,13 @@ export function ClueListView({ themeId }: ClueListViewProps) {
     deleteClue.mutate(deletingClue.id, {
       onSuccess: () => { toast.success('단서가 삭제되었습니다'); setDeletingClue(undefined); },
       onError: (err) => { toast.error(err.message || '단서 삭제에 실패했습니다'); setDeletingClue(undefined); },
+    });
+  }
+
+  function handleConfigChange(nextConfig: EditorConfig) {
+    updateConfig.mutate(nextConfig, {
+      onSuccess: () => toast.success('단서 사용 효과가 저장되었습니다'),
+      onError: () => toast.error('단서 사용 효과 저장에 실패했습니다'),
     });
   }
 
@@ -94,6 +104,8 @@ export function ClueListView({ themeId }: ClueListViewProps) {
             onCreate={handleCreate}
             onEdit={handleEdit}
             onDelete={setDeletingClue}
+            onConfigChange={handleConfigChange}
+            isConfigSaving={updateConfig.isPending}
           />
         </>
       )}

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ClueResponse } from '@/features/editor/api';
+import { readClueItemEffect, type EditorConfig } from '@/features/editor/utils/configShape';
+import { ClueRuntimeEffectCard } from './ClueRuntimeEffectCard';
+
+function clue(overrides: Partial<ClueResponse>): ClueResponse {
+  return {
+    id: 'clue-1',
+    theme_id: 'theme-1',
+    location_id: null,
+    name: '피 묻은 열쇠',
+    description: '잠긴 상자를 열 수 있다.',
+    image_url: null,
+    is_common: false,
+    level: 1,
+    sort_order: 0,
+    created_at: '2026-05-03T00:00:00Z',
+    is_usable: true,
+    use_effect: 'reveal',
+    use_target: 'self',
+    use_consumed: false,
+    ...overrides,
+  };
+}
+
+const clues = [
+  clue({ id: 'clue-1', name: '피 묻은 열쇠' }),
+  clue({ id: 'clue-2', name: '금고 비밀번호' }),
+  clue({ id: 'clue-3', name: '찢어진 사진' }),
+];
+
+afterEach(cleanup);
+
+describe('ClueRuntimeEffectCard', () => {
+  it('기존 정보 공개 효과를 제작자 언어로 편집하고 저장한다', () => {
+    const onConfigChange = vi.fn();
+    const configJson: EditorConfig = {
+      modules: {
+        clue_interaction: {
+          enabled: true,
+          config: {
+            itemEffects: {
+              'clue-1': {
+                effect: 'reveal',
+                target: 'self',
+                revealText: '숫자 0427이 보입니다.',
+                consume: false,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <ClueRuntimeEffectCard
+        clue={clues[0]}
+        clues={clues}
+        configJson={configJson}
+        onConfigChange={onConfigChange}
+      />,
+    );
+
+    expect(screen.getByText('게임 중 사용 효과')).toBeDefined();
+    expect(screen.queryByText('itemEffects')).toBeNull();
+    expect(screen.queryByText('grant_clue')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('공개할 정보'), {
+      target: { value: '열쇠 뒤에 새 숫자 1234가 보입니다.' },
+    });
+    fireEvent.click(screen.getByLabelText(/사용하면 내 단서함에서 사라짐/));
+    fireEvent.click(screen.getByRole('button', { name: '효과 저장' }));
+
+    expect(onConfigChange).toHaveBeenCalledTimes(1);
+    const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
+    expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
+      effect: 'reveal',
+      target: 'self',
+      revealText: '열쇠 뒤에 새 숫자 1234가 보입니다.',
+      consume: true,
+    });
+  });
+
+  it('검색으로 지급할 단서를 다중 선택하고 저장한다', () => {
+    const onConfigChange = vi.fn();
+
+    render(
+      <ClueRuntimeEffectCard
+        clue={clues[0]}
+        clues={clues}
+        configJson={{}}
+        onConfigChange={onConfigChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '새 단서 지급' }));
+    fireEvent.change(screen.getByLabelText('지급할 단서 검색'), {
+      target: { value: '금고' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '금고 비밀번호' }));
+
+    expect(screen.getByText('선택된 지급 단서')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: '효과 저장' }));
+
+    expect(onConfigChange).toHaveBeenCalledTimes(1);
+    const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
+    expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
+      effect: 'grant_clue',
+      target: 'self',
+      grantClueIds: ['clue-2'],
+    });
+  });
+
+  it('효과 없음으로 저장하면 기존 런타임 효과를 제거한다', () => {
+    const onConfigChange = vi.fn();
+
+    render(
+      <ClueRuntimeEffectCard
+        clue={clues[0]}
+        clues={clues}
+        configJson={{
+          modules: {
+            clue_interaction: {
+              enabled: true,
+              config: {
+                itemEffects: {
+                  'clue-1': { effect: 'grant_clue', grantClueIds: ['clue-2'] },
+                },
+              },
+            },
+          },
+        }}
+        onConfigChange={onConfigChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '효과 없음' }));
+    fireEvent.click(screen.getByRole('button', { name: '효과 저장' }));
+
+    const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
+    expect(readClueItemEffect(saved, 'clue-1')).toBeNull();
+  });
+});

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Eye, Gift, Save, Search, X } from 'lucide-react';
+import type { ClueResponse } from '@/features/editor/api';
+import {
+  readClueItemEffect,
+  writeClueItemEffect,
+  type ClueItemEffectConfig,
+  type EditorConfig,
+} from '@/features/editor/utils/configShape';
+
+type EffectMode = 'none' | 'reveal' | 'grant';
+
+interface ClueRuntimeEffectCardProps {
+  clue: ClueResponse;
+  clues: ClueResponse[];
+  configJson: EditorConfig | null | undefined;
+  onConfigChange?: (nextConfig: EditorConfig) => void;
+  isSaving?: boolean;
+}
+
+interface DraftState {
+  mode: EffectMode;
+  revealText: string;
+  grantClueIds: string[];
+  consume: boolean;
+}
+
+function draftFromConfig(config: ClueItemEffectConfig | null): DraftState {
+  if (config?.effect === 'reveal') {
+    return {
+      mode: 'reveal',
+      revealText: config.revealText ?? '',
+      grantClueIds: [],
+      consume: config.consume === true,
+    };
+  }
+  if (config?.effect === 'grant_clue') {
+    return {
+      mode: 'grant',
+      revealText: '',
+      grantClueIds: config.grantClueIds ?? [],
+      consume: config.consume === true,
+    };
+  }
+  return { mode: 'none', revealText: '', grantClueIds: [], consume: false };
+}
+
+function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
+  if (draft.mode === 'reveal') {
+    return {
+      effect: 'reveal',
+      target: 'self',
+      revealText: draft.revealText.trim(),
+      consume: draft.consume,
+    };
+  }
+  if (draft.mode === 'grant') {
+    return {
+      effect: 'grant_clue',
+      target: 'self',
+      grantClueIds: draft.grantClueIds,
+      consume: draft.consume,
+    };
+  }
+  return null;
+}
+
+function isDraftValid(draft: DraftState) {
+  if (draft.mode === 'reveal') return draft.revealText.trim().length > 0;
+  if (draft.mode === 'grant') return draft.grantClueIds.length > 0;
+  return true;
+}
+
+export function ClueRuntimeEffectCard({
+  clue,
+  clues,
+  configJson,
+  onConfigChange,
+  isSaving = false,
+}: ClueRuntimeEffectCardProps) {
+  const savedEffect = useMemo(
+    () => readClueItemEffect(configJson, clue.id),
+    [configJson, clue.id],
+  );
+  const [draft, setDraft] = useState<DraftState>(() => draftFromConfig(savedEffect));
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    setDraft(draftFromConfig(savedEffect));
+    setQuery('');
+  }, [savedEffect]);
+
+  const candidates = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return clues
+      .filter((item) => item.id !== clue.id)
+      .filter((item) => (q ? item.name.toLowerCase().includes(q) : true))
+      .slice(0, 8);
+  }, [clue.id, clues, query]);
+
+  const selectedClues = useMemo(
+    () => clues.filter((item) => draft.grantClueIds.includes(item.id)),
+    [clues, draft.grantClueIds],
+  );
+
+  const canSave = !!onConfigChange && !isSaving && isDraftValid(draft);
+
+  function updateDraft(patch: Partial<DraftState>) {
+    setDraft((current) => ({ ...current, ...patch }));
+  }
+
+  function toggleGrantClue(clueId: string) {
+    setDraft((current) => {
+      const hasClue = current.grantClueIds.includes(clueId);
+      return {
+        ...current,
+        grantClueIds: hasClue
+          ? current.grantClueIds.filter((id) => id !== clueId)
+          : [...current.grantClueIds, clueId],
+      };
+    });
+  }
+
+  function handleSave() {
+    if (!canSave) return;
+    const nextConfig = writeClueItemEffect(configJson, clue.id, toEffectConfig(draft));
+    onConfigChange?.(nextConfig);
+  }
+
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
+            게임 중 사용 효과
+          </p>
+          <h4 className="mt-1 text-lg font-bold text-slate-100">이 단서를 사용하면</h4>
+          <p className="mt-1 text-sm leading-6 text-slate-400">
+            플레이어가 이 단서를 눌렀을 때 공개할 정보나 지급할 단서를 설정합니다.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!canSave}
+          className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-amber-500/30 px-3 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
+        >
+          <Save className="h-4 w-4" />
+          {isSaving ? '저장 중' : '효과 저장'}
+        </button>
+      </div>
+
+      <fieldset className="mt-4 grid gap-2 sm:grid-cols-3">
+        <EffectChoice mode="none" current={draft.mode} label="효과 없음" onSelect={() => updateDraft({ mode: 'none' })} />
+        <EffectChoice mode="reveal" current={draft.mode} label="정보 공개" icon={<Eye className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'reveal' })} />
+        <EffectChoice mode="grant" current={draft.mode} label="새 단서 지급" icon={<Gift className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'grant' })} />
+      </fieldset>
+
+      {draft.mode === 'reveal' && (
+        <div className="mt-4 space-y-2">
+          <label htmlFor="clue-runtime-reveal" className="text-sm font-semibold text-slate-200">
+            공개할 정보
+          </label>
+          <textarea
+            id="clue-runtime-reveal"
+            value={draft.revealText}
+            onChange={(e) => updateDraft({ revealText: e.target.value })}
+            rows={4}
+            placeholder="예: 낡은 열쇠 안쪽에 작은 숫자 0427이 새겨져 있다."
+            className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          />
+        </div>
+      )}
+
+      {draft.mode === 'grant' && (
+        <GrantCluePicker
+          candidates={candidates}
+          selectedClues={selectedClues}
+          query={query}
+          selectedIds={draft.grantClueIds}
+          onQueryChange={setQuery}
+          onToggle={toggleGrantClue}
+        />
+      )}
+
+      {draft.mode !== 'none' && (
+        <label className="mt-4 flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-sm text-slate-300">
+          <input
+            type="checkbox"
+            checked={draft.consume}
+            onChange={(e) => updateDraft({ consume: e.target.checked })}
+            className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+          />
+          <span>
+            <span className="font-semibold text-slate-200">사용하면 내 단서함에서 사라짐</span>
+            <span className="mt-1 block text-xs leading-5 text-slate-500">
+              일회용 열쇠처럼 효과를 발동한 뒤 보유 단서에서 제거할 때 켭니다.
+            </span>
+          </span>
+        </label>
+      )}
+    </section>
+  );
+}
+
+function EffectChoice({
+  mode,
+  current,
+  label,
+  icon,
+  onSelect,
+}: {
+  mode: EffectMode;
+  current: EffectMode;
+  label: string;
+  icon?: ReactNode;
+  onSelect: () => void;
+}) {
+  const selected = current === mode;
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold ${
+        selected
+          ? 'border-amber-500/70 bg-amber-500/10 text-amber-200'
+          : 'border-slate-800 bg-slate-900/70 text-slate-300 hover:border-slate-700'
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function GrantCluePicker({
+  candidates,
+  selectedClues,
+  query,
+  selectedIds,
+  onQueryChange,
+  onToggle,
+}: {
+  candidates: ClueResponse[];
+  selectedClues: ClueResponse[];
+  query: string;
+  selectedIds: string[];
+  onQueryChange: (value: string) => void;
+  onToggle: (clueId: string) => void;
+}) {
+  return (
+    <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(220px,0.8fr)]">
+      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+        <label htmlFor="clue-grant-search" className="text-sm font-semibold text-slate-200">
+          지급할 단서 검색
+        </label>
+        <div className="mt-2 flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2">
+          <Search className="h-4 w-4 text-slate-500" />
+          <input
+            id="clue-grant-search"
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder="단서 이름으로 검색"
+            className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-600 focus:outline-none"
+          />
+        </div>
+        <div className="mt-3 space-y-2">
+          {candidates.map((candidate) => {
+            const selected = selectedIds.includes(candidate.id);
+            return (
+              <button
+                key={candidate.id}
+                type="button"
+                onClick={() => onToggle(candidate.id)}
+                aria-pressed={selected}
+                className={`w-full rounded-lg border px-3 py-2 text-left text-sm ${
+                  selected
+                    ? 'border-amber-500/60 bg-amber-500/10 text-amber-100'
+                    : 'border-slate-800 bg-slate-950/70 text-slate-300 hover:border-slate-700'
+                }`}
+              >
+                {candidate.name}
+              </button>
+            );
+          })}
+          {candidates.length === 0 && (
+            <p className="rounded-lg border border-dashed border-slate-800 px-3 py-6 text-center text-xs text-slate-500">
+              검색 결과가 없습니다.
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+        <p className="text-sm font-semibold text-slate-200">선택된 지급 단서</p>
+        {selectedClues.length === 0 ? (
+          <p className="mt-3 rounded-lg border border-dashed border-slate-800 px-3 py-6 text-center text-xs text-slate-500">
+            아직 지급할 단서를 고르지 않았습니다.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {selectedClues.map((selected) => (
+              <li key={selected.id} className="flex items-center justify-between gap-2 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm text-slate-200">
+                <span>{selected.name}</span>
+                <button
+                  type="button"
+                  onClick={() => onToggle(selected.id)}
+                  aria-label={`${selected.name} 지급 목록에서 제거`}
+                  className="rounded-md p-1 text-slate-500 hover:bg-slate-800 hover:text-slate-200"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -190,6 +190,7 @@ describe('configShape', () => {
             cooldownSec: 5,
             itemEffects: {
               'future-clue': { effect: 'future_effect', custom: true },
+              'clue-1': { effect: 'reveal', legacyNote: 'preserve me', grantClueIds: ['old'] },
             },
           },
         },
@@ -208,6 +209,7 @@ describe('configShape', () => {
       target: 'self',
       grantClueIds: ['clue-2', 'clue-3'],
       consume: true,
+      legacyNote: 'preserve me',
     });
     expect(readModuleConfig(withEffect, 'clue_interaction')).toMatchObject({
       cooldownSec: 5,
@@ -222,5 +224,16 @@ describe('configShape', () => {
       cooldownSec: 5,
       itemEffects: {},
     });
+  });
+
+  it('does not create clue interaction config when deleting a missing runtime effect', () => {
+    const base = { modules: { timer: { enabled: true, config: { seconds: 30 } } } };
+
+    const next = writeClueItemEffect(base, 'missing-clue', null);
+
+    expect(next).toBe(base);
+    expect(readClueItemEffect(next, 'missing-clue')).toBeNull();
+    expect(readModuleConfig(next, 'clue_interaction')).toEqual({});
+    expect(readModuleConfig(next, 'timer')).toEqual({ seconds: 30 });
   });
 });

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -220,9 +220,11 @@ describe('configShape', () => {
 
     const removed = writeClueItemEffect(withEffect, 'clue-1', null);
     expect(readClueItemEffect(removed, 'clue-1')).toBeNull();
-    expect(readModuleConfig(removed, 'clue_interaction')).toMatchObject({
+    expect(readModuleConfig(removed, 'clue_interaction')).toEqual({
       cooldownSec: 5,
-      itemEffects: {},
+      itemEffects: {
+        'future-clue': { effect: 'future_effect', custom: true },
+      },
     });
   });
 

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
   normalizeConfigForSave,
+  readClueItemEffect,
+  readClueItemEffects,
   readCharacterStartingClueMap,
   readCluePlacement,
   readEnabledModuleIds,
   readLocationClueIds,
   readModuleConfig,
   writeCharacterStartingClueMap,
+  writeClueItemEffect,
   writeCluePlacement,
   writeLocationClueIds,
   writeModuleConfig,
@@ -145,5 +148,79 @@ describe('configShape', () => {
     };
 
     expect(readCharacterStartingClueMap(config)).toEqual({});
+  });
+
+  it('reads valid clue runtime effects from the clue interaction module only', () => {
+    const config = {
+      modules: {
+        clue_interaction: {
+          enabled: true,
+          config: {
+            itemEffects: {
+              'clue-1': {
+                effect: 'reveal',
+                target: 'self',
+                revealText: '숫자 0427이 보입니다.',
+                consume: true,
+              },
+              'clue-2': { effect: 'unknown', revealText: '무시' },
+            },
+          },
+        },
+      },
+    };
+
+    expect(readClueItemEffects(config)).toEqual({
+      'clue-1': {
+        effect: 'reveal',
+        target: 'self',
+        revealText: '숫자 0427이 보입니다.',
+        consume: true,
+      },
+    });
+    expect(readClueItemEffect(config, 'clue-2')).toBeNull();
+  });
+
+  it('writes and removes clue runtime effects while preserving module settings', () => {
+    const base = {
+      modules: {
+        clue_interaction: {
+          enabled: true,
+          config: {
+            cooldownSec: 5,
+            itemEffects: {
+              'future-clue': { effect: 'future_effect', custom: true },
+            },
+          },
+        },
+      },
+    };
+
+    const withEffect = writeClueItemEffect(base, 'clue-1', {
+      effect: 'grant_clue',
+      target: 'self',
+      grantClueIds: ['clue-2', 'clue-3'],
+      consume: true,
+    });
+
+    expect(readClueItemEffect(withEffect, 'clue-1')).toEqual({
+      effect: 'grant_clue',
+      target: 'self',
+      grantClueIds: ['clue-2', 'clue-3'],
+      consume: true,
+    });
+    expect(readModuleConfig(withEffect, 'clue_interaction')).toMatchObject({
+      cooldownSec: 5,
+      itemEffects: {
+        'future-clue': { effect: 'future_effect', custom: true },
+      },
+    });
+
+    const removed = writeClueItemEffect(withEffect, 'clue-1', null);
+    expect(readClueItemEffect(removed, 'clue-1')).toBeNull();
+    expect(readModuleConfig(removed, 'clue_interaction')).toMatchObject({
+      cooldownSec: 5,
+      itemEffects: {},
+    });
   });
 });

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -152,7 +152,18 @@ describe('configShape', () => {
 
   it('reads valid clue runtime effects from the clue interaction module only', () => {
     const config = {
+      itemEffects: {
+        'root-decoy': { effect: 'reveal', revealText: '잘못된 위치' },
+      },
       modules: {
+        timer: {
+          enabled: true,
+          config: {
+            itemEffects: {
+              'timer-decoy': { effect: 'reveal', revealText: '다른 모듈' },
+            },
+          },
+        },
         clue_interaction: {
           enabled: true,
           config: {
@@ -170,7 +181,8 @@ describe('configShape', () => {
       },
     };
 
-    expect(readClueItemEffects(config)).toEqual({
+    const effects = readClueItemEffects(config);
+    expect(effects).toEqual({
       'clue-1': {
         effect: 'reveal',
         target: 'self',
@@ -178,6 +190,10 @@ describe('configShape', () => {
         consume: true,
       },
     });
+    expect(effects).not.toHaveProperty('root-decoy');
+    expect(effects).not.toHaveProperty('timer-decoy');
+    expect(readClueItemEffect(config, 'root-decoy')).toBeNull();
+    expect(readClueItemEffect(config, 'timer-decoy')).toBeNull();
     expect(readClueItemEffect(config, 'clue-2')).toBeNull();
   });
 

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -74,6 +74,17 @@ function readRawClueItemEffects(
   return isRecord(rawEffects) ? { ...rawEffects } : {};
 }
 
+function stripKnownClueEffectFields(value: unknown): EditorConfig {
+  if (!isRecord(value)) return {};
+  const next = { ...value };
+  delete next.effect;
+  delete next.target;
+  delete next.consume;
+  delete next.revealText;
+  delete next.grantClueIds;
+  return next;
+}
+
 function readLegacyModuleConfigs(configJson: EditorConfig | null | undefined) {
   const raw = configJson?.module_configs;
   return isRecord(raw) ? (raw as Record<string, EditorConfig>) : {};
@@ -235,8 +246,14 @@ export function writeClueItemEffect(
   const itemEffects = readRawClueItemEffects(configJson);
 
   if (effectConfig) {
-    itemEffects[clueId] = effectConfig;
+    itemEffects[clueId] = {
+      ...stripKnownClueEffectFields(itemEffects[clueId]),
+      ...effectConfig,
+    };
   } else {
+    if (!hasOwnKey(current, CLUE_ITEM_EFFECTS_KEY) || !hasOwnKey(itemEffects, clueId)) {
+      return configJson ?? {};
+    }
     delete itemEffects[clueId];
   }
 

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -16,7 +16,19 @@ export interface LocationConfig extends Record<string, unknown> {
   clueIds?: string[];
 }
 
+export type ClueItemEffectKind = 'peek' | 'reveal' | 'grant_clue';
+
+export interface ClueItemEffectConfig extends EditorConfig {
+  effect: ClueItemEffectKind;
+  target?: 'player' | 'self';
+  consume?: boolean;
+  revealText?: string;
+  grantClueIds?: string[];
+}
+
 const LEGACY_KEYS = ['module_configs', 'clue_placement', 'character_clues'] as const;
+const CLUE_INTERACTION_MODULE_ID = 'clue_interaction';
+const CLUE_ITEM_EFFECTS_KEY = 'itemEffects';
 
 function isRecord(value: unknown): value is EditorConfig {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -31,6 +43,35 @@ function hasOwnKey<T extends string>(
 
 function stringList(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+function readClueItemEffectConfig(value: unknown): ClueItemEffectConfig | null {
+  if (!isRecord(value)) return null;
+
+  const effect = value.effect;
+  if (effect !== 'peek' && effect !== 'reveal' && effect !== 'grant_clue') return null;
+
+  const target = value.target === 'player' || value.target === 'self' ? value.target : undefined;
+  const consume = typeof value.consume === 'boolean' ? value.consume : undefined;
+  const revealText = typeof value.revealText === 'string' ? value.revealText : undefined;
+  const grantClueIds = stringList(value.grantClueIds);
+
+  return {
+    ...value,
+    effect,
+    ...(target ? { target } : {}),
+    ...(consume !== undefined ? { consume } : {}),
+    ...(revealText !== undefined ? { revealText } : {}),
+    ...(grantClueIds.length > 0 ? { grantClueIds } : {}),
+  };
+}
+
+function readRawClueItemEffects(
+  configJson: EditorConfig | null | undefined,
+): Record<string, unknown> {
+  const moduleConfig = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
+  const rawEffects = moduleConfig[CLUE_ITEM_EFFECTS_KEY];
+  return isRecord(rawEffects) ? { ...rawEffects } : {};
 }
 
 function readLegacyModuleConfigs(configJson: EditorConfig | null | undefined) {
@@ -162,6 +203,47 @@ export function writeModuleConfigPath(
 ): EditorConfig {
   const current = readModuleConfig(configJson, moduleId);
   return writeModuleConfig(configJson, moduleId, writePath(current, path, value));
+}
+
+export function readClueItemEffects(
+  configJson: EditorConfig | null | undefined,
+): Record<string, ClueItemEffectConfig> {
+  const moduleConfig = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
+  const rawEffects = moduleConfig[CLUE_ITEM_EFFECTS_KEY];
+  if (!isRecord(rawEffects)) return {};
+
+  return Object.fromEntries(
+    Object.entries(rawEffects)
+      .map(([clueId, rawConfig]) => [clueId, readClueItemEffectConfig(rawConfig)] as const)
+      .filter((entry): entry is [string, ClueItemEffectConfig] => !!entry[1]),
+  );
+}
+
+export function readClueItemEffect(
+  configJson: EditorConfig | null | undefined,
+  clueId: string,
+): ClueItemEffectConfig | null {
+  return readClueItemEffects(configJson)[clueId] ?? null;
+}
+
+export function writeClueItemEffect(
+  configJson: EditorConfig | null | undefined,
+  clueId: string,
+  effectConfig: ClueItemEffectConfig | null,
+): EditorConfig {
+  const current = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
+  const itemEffects = readRawClueItemEffects(configJson);
+
+  if (effectConfig) {
+    itemEffects[clueId] = effectConfig;
+  } else {
+    delete itemEffects[clueId];
+  }
+
+  return writeModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID, {
+    ...current,
+    [CLUE_ITEM_EFFECTS_KEY]: itemEffects,
+  });
 }
 
 export function readLocationsConfig(

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-247-clue-effect-engine.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-247-clue-effect-engine.md
@@ -72,6 +72,29 @@ Uzu를 그대로 복제하지 않고, MMP는 실시간 멀티플레이와 player
 - 복합 조건 UI 전체: Phase/condition 엔진과 결합해야 하므로 후속 이슈로 둔다.
 - 프론트 제작자 UI 전면 개편: 이번 PR은 Engine 계약과 테스트가 우선이며, UI는 Adapter가 이 계약을 바라보도록 후속 연결한다.
 
+## 후속 UI 연결 PR
+
+Branch: `feat/issue-247-clue-effect-ui`
+
+백엔드 Engine 계약을 제작자가 안전하게 편집할 수 있도록 프론트 Adapter/UI를 연결한다.
+
+### 범위
+
+- `clue_interaction.itemEffects`를 직접 JSON으로 보여주지 않고, 단서 상세의 “게임 중 사용 효과” 카드에서 편집한다.
+- MVP 효과는 Engine 구현이 완료된 `정보 공개`와 `새 단서 지급`만 제작자 UI에 노출한다.
+- “새 단서 지급”은 단서가 많아도 고를 수 있도록 검색 + 다중 선택 UI를 제공한다.
+- “사용하면 내 단서함에서 사라짐”은 효과별 공통 옵션으로 둔다.
+- 저장은 기존 theme `config_json` 저장 API를 사용하되, 화면 컴포넌트는 `writeClueItemEffect` Adapter helper를 통해서만 계약을 변경한다.
+
+### E2E 대체 사유
+
+- 이번 slice는 신규 라우트나 플레이어 런타임 흐름이 아니라, 기존 단서 상세 내부의 설정 카드와 config adapter 변경이다.
+- Playwright E2E는 editor auth/seed 환경 의존도가 높아 이 PR에서는 component integration test로 대체한다.
+- 대체 검증:
+  - `configShape` unit test로 config read/write/삭제를 검증한다.
+  - `ClueRuntimeEffectCard` component test로 정보 공개 저장, 단서 지급 검색/다중 선택, raw key 미노출을 검증한다.
+  - typecheck로 실제 API 타입 연결을 검증한다.
+
 ## 테스트 계획
 
 - Go unit/integration


### PR DESCRIPTION
## 요약
- 단서 상세에 제작자용 “게임 중 사용 효과” 카드를 추가했습니다.
- `clue_interaction.itemEffects`를 직접 노출하지 않고, 정보 공개/새 단서 지급/소모 여부를 UI에서 편집하도록 Adapter helper를 연결했습니다.
- 지급 단서는 검색 + 다중 선택으로 고를 수 있게 했고, 기존/미래 raw config를 저장 중 불필요하게 지우지 않도록 보존했습니다.

## 검증
- `pnpm --dir apps/web test -- src/features/editor/utils/__tests__/configShape.test.ts src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx`
- `pnpm --dir apps/web exec tsc --noEmit`
- `pnpm --dir apps/web lint` (기존 warning만 존재, 신규 warning 없음)
- `git diff --check`

## E2E 미작성 사유 / 대체 테스트
- 이번 변경은 신규 라우트나 플레이어 런타임 플로우가 아니라 기존 단서 상세 내부의 config Adapter 편집 카드입니다.
- Playwright E2E는 editor auth/seed 환경 의존도가 커서 이번 PR에서는 component integration test로 대체했습니다.
- 대체 테스트로 config read/write/삭제, 정보 공개 저장, 지급 단서 검색/다중 선택, raw key 미노출을 검증했습니다.

## 관련 이슈
- Related #247

## CI 운영
- CodeRabbit 리뷰 확인 전까지 `ready-for-ci` 라벨을 붙이지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 단서 상세에 “게임 중 사용 효과” 편집 카드 추가 — 모드(정보 공개·새 단서 지급·없음), 공개 문구 편집, 대상 단서 선택, 소실 옵션 포함하고 상세 패널에서 함께 표시
  * 편집한 효과를 저장하는 흐름 연결 및 저장중 상태 표시와 성공/오류 피드백 제공

* **Tests**
  * 런타임 효과 UI와 구성 읽기/쓰기 동작을 검증하는 테스트 추가
  * 기존 워크스페이스 테스트를 중복 텍스트 허용으로 안정화

* **Documentation**
  * UI 연동 범위·저장 방식·검증 계획 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->