### PR TITLE
Phase 25 후보 미션 Adapter와 Engine 계약 정리

### DIFF
--- a/apps/server/internal/module/decision/hidden_mission/config.go
+++ b/apps/server/internal/module/decision/hidden_mission/config.go
@@ -12,13 +12,16 @@ type HiddenMissionConfig struct {
 
 // Mission represents a single hidden mission assigned to a player.
 type Mission struct {
-	ID           string `json:"id"`
-	Type         string `json:"type"` // "hold_clue"|"vote_target"|"transfer_clue"|"survive"|"custom"
-	Description  string `json:"description"`
-	Points       int    `json:"points"`
-	Verification string `json:"verification"` // "auto"|"self_report"|"gm_verify"
-	TargetClueID string `json:"targetClueId,omitempty"`
-	Completed    bool   `json:"completed"`
+	ID                string `json:"id"`
+	Type              string `json:"type"` // "hold_clue"|"vote_target"|"transfer_clue"|"survive"|"custom"
+	Description       string `json:"description"`
+	Points            int    `json:"points"`
+	Verification      string `json:"verification"` // "auto"|"self_report"|"gm_verify"
+	TargetClueID      string `json:"targetClueId,omitempty"`
+	TargetCharacterID string `json:"targetCharacterId,omitempty"`
+	TargetEndingID    string `json:"targetEndingId,omitempty"`
+	Condition         string `json:"condition,omitempty"`
+	Completed         bool   `json:"completed"`
 }
 
 // Schema returns the JSON Schema describing the module's init config.

--- a/apps/server/internal/module/decision/hidden_mission/contract.go
+++ b/apps/server/internal/module/decision/hidden_mission/contract.go
@@ -1,0 +1,82 @@
+package hidden_mission
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/google/uuid"
+)
+
+// ErrMissionResultNotVisible is returned when a caller asks for unredacted
+// mission results before the ending/result boundary or without host/system
+// authorization.
+var ErrMissionResultNotVisible = errors.New("hidden_mission: result breakdown is not visible")
+
+// MissionResultAccess is the explicit guard for result-screen mission data.
+// ResultVisible should be true only after the configured result boundary, and
+// CanViewAll should be true only for host/system result aggregation paths.
+type MissionResultAccess struct {
+	ResultVisible bool
+	CanViewAll    bool
+}
+
+// MissionResultItem is the ending/result-screen contract for one mission.
+// It intentionally contains creator-facing text and scoring outcome only; raw
+// rule internals stay inside the engine.
+type MissionResultItem struct {
+	MissionID   string `json:"missionId"`
+	Description string `json:"description"`
+	Completed   bool   `json:"completed"`
+	Points      int    `json:"points"`
+}
+
+// MissionResultBreakdown is consumed by ending/vote result screens when they
+// need per-player mission scoring without exposing other hidden state earlier.
+type MissionResultBreakdown struct {
+	PlayerID   uuid.UUID           `json:"playerId"`
+	TotalScore int                 `json:"totalScore"`
+	Missions   []MissionResultItem `json:"missions"`
+}
+
+// MissionAuditEvent is the module-level audit contract emitted when runtime
+// verification changes a mission outcome.
+type MissionAuditEvent struct {
+	PlayerID  uuid.UUID `json:"playerId"`
+	MissionID string    `json:"missionId"`
+	Completed bool      `json:"completed"`
+	Points    int       `json:"points"`
+	Reason    string    `json:"reason"`
+}
+
+// BuildResultBreakdown returns result-screen safe mission outcomes. It is not
+// used for in-game player sync; BuildStateFor remains the player-aware path.
+func (m *HiddenMissionModule) BuildResultBreakdown(access MissionResultAccess) ([]MissionResultBreakdown, error) {
+	if !access.ResultVisible || !access.CanViewAll {
+		return nil, ErrMissionResultNotVisible
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	breakdowns := make([]MissionResultBreakdown, 0, len(m.playerMissions))
+	for playerID, missions := range m.playerMissions {
+		items := make([]MissionResultItem, 0, len(missions))
+		for _, mission := range missions {
+			items = append(items, MissionResultItem{
+				MissionID:   mission.ID,
+				Description: mission.Description,
+				Completed:   mission.Completed,
+				Points:      mission.Points,
+			})
+		}
+		breakdowns = append(breakdowns, MissionResultBreakdown{
+			PlayerID:   playerID,
+			TotalScore: m.scores[playerID],
+			Missions:   items,
+		})
+	}
+	sort.Slice(breakdowns, func(i, j int) bool {
+		return breakdowns[i].PlayerID.String() < breakdowns[j].PlayerID.String()
+	})
+	return breakdowns, nil
+}

--- a/apps/server/internal/module/decision/hidden_mission/contract_test.go
+++ b/apps/server/internal/module/decision/hidden_mission/contract_test.go
@@ -1,0 +1,100 @@
+package hidden_mission
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func TestHiddenMissionModule_AutoVerify_VoteCast_TargetCharacterID(t *testing.T) {
+	pid := uuid.New()
+	deps := newTestDeps()
+	var completed []MissionAuditEvent
+	deps.EventBus.Subscribe("mission.completed", func(event engine.Event) {
+		if payload, ok := event.Payload.(MissionAuditEvent); ok {
+			completed = append(completed, payload)
+		}
+	})
+	cfg := map[string]any{
+		"playerMissions": map[string]any{
+			pid.String(): []map[string]any{
+				{"id": "m1", "type": "vote_target", "description": "Vote for char_A", "points": 5, "verification": "auto", "targetCharacterId": "char_A"},
+			},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal cfg: %v", err)
+	}
+
+	m := NewHiddenMissionModule()
+	if err := m.Init(context.Background(), deps, data); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	deps.EventBus.Publish(engine.Event{
+		Type: "vote.cast",
+		Payload: map[string]any{
+			"playerId":   pid.String(),
+			"targetCode": "char_A",
+		},
+	})
+
+	if len(completed) != 1 {
+		t.Fatalf("expected 1 audit event, got %d", len(completed))
+	}
+	if completed[0].MissionID != "m1" || completed[0].Reason != "vote.cast" {
+		t.Fatalf("unexpected audit event: %#v", completed[0])
+	}
+}
+
+func TestHiddenMissionModule_BuildResultBreakdown(t *testing.T) {
+	pid := uuid.New()
+	deps := newTestDeps()
+	cfg := map[string]any{
+		"playerMissions": map[string]any{
+			pid.String(): []map[string]any{
+				{"id": "m1", "type": "hold_clue", "description": "Hold clue_1", "points": 10, "verification": "auto", "targetClueId": "clue_1"},
+				{"id": "m2", "type": "custom", "description": "Tell secret", "points": 0, "verification": "self_report"},
+			},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal cfg: %v", err)
+	}
+
+	m := NewHiddenMissionModule()
+	if err := m.Init(context.Background(), deps, data); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	deps.EventBus.Publish(engine.Event{
+		Type: "clue.acquired",
+		Payload: map[string]any{
+			"playerId": pid.String(),
+			"clueId":   "clue_1",
+		},
+	})
+
+	if _, err := m.BuildResultBreakdown(MissionResultAccess{}); !errors.Is(err, ErrMissionResultNotVisible) {
+		t.Fatalf("expected ErrMissionResultNotVisible, got %v", err)
+	}
+
+	breakdowns, err := m.BuildResultBreakdown(MissionResultAccess{ResultVisible: true, CanViewAll: true})
+	if err != nil {
+		t.Fatalf("BuildResultBreakdown: %v", err)
+	}
+	if len(breakdowns) != 1 {
+		t.Fatalf("expected 1 breakdown, got %d", len(breakdowns))
+	}
+	if breakdowns[0].PlayerID != pid || breakdowns[0].TotalScore != 10 {
+		t.Fatalf("unexpected breakdown summary: %#v", breakdowns[0])
+	}
+	if len(breakdowns[0].Missions) != 2 || !breakdowns[0].Missions[0].Completed {
+		t.Fatalf("unexpected mission items: %#v", breakdowns[0].Missions)
+	}
+}

--- a/apps/server/internal/module/decision/hidden_mission/events.go
+++ b/apps/server/internal/module/decision/hidden_mission/events.go
@@ -26,8 +26,13 @@ func (m *HiddenMissionModule) onClueAcquired(event engine.Event) {
 	m.mu.RUnlock()
 
 	for _, mission := range missionsCopy {
-		if mission.Type == "hold_clue" && mission.TargetClueID == clueID && !mission.Completed {
-			m.completeMission(pid, mission.ID)
+		if mission.Type == "hold_clue" &&
+			mission.Verification == "auto" &&
+			clueID != "" &&
+			mission.TargetClueID != "" &&
+			mission.TargetClueID == clueID &&
+			!mission.Completed {
+			m.completeMission(pid, mission.ID, "clue.acquired")
 		}
 	}
 }
@@ -51,8 +56,17 @@ func (m *HiddenMissionModule) onVoteCast(event engine.Event) {
 	m.mu.RUnlock()
 
 	for _, mission := range missionsCopy {
-		if mission.Type == "vote_target" && mission.TargetClueID == targetCode && !mission.Completed {
-			m.completeMission(pid, mission.ID)
+		targetID := mission.TargetCharacterID
+		if targetID == "" {
+			targetID = mission.TargetClueID
+		}
+		if mission.Type == "vote_target" &&
+			mission.Verification == "auto" &&
+			targetID != "" &&
+			targetCode != "" &&
+			targetID == targetCode &&
+			!mission.Completed {
+			m.completeMission(pid, mission.ID, "vote.cast")
 		}
 	}
 }
@@ -75,8 +89,8 @@ func (m *HiddenMissionModule) onClueTransferred(event engine.Event) {
 	m.mu.RUnlock()
 
 	for _, mission := range missionsCopy {
-		if mission.Type == "transfer_clue" && !mission.Completed {
-			m.completeMission(pid, mission.ID)
+		if mission.Type == "transfer_clue" && mission.Verification == "auto" && !mission.Completed {
+			m.completeMission(pid, mission.ID, "clue.transferred")
 		}
 	}
 }

--- a/apps/server/internal/module/decision/hidden_mission/handlers.go
+++ b/apps/server/internal/module/decision/hidden_mission/handlers.go
@@ -81,7 +81,7 @@ func (m *HiddenMissionModule) handleVerify(payload json.RawMessage) error {
 	}
 
 	if p.Completed {
-		m.completeMission(p.PlayerID, p.MissionID)
+		m.completeMission(p.PlayerID, p.MissionID, "gm.verify")
 	}
 
 	m.deps.EventBus.Publish(engine.Event{
@@ -114,13 +114,14 @@ func (m *HiddenMissionModule) handleCheck(playerID uuid.UUID) error {
 }
 
 // completeMission marks a mission complete and updates the score.
-func (m *HiddenMissionModule) completeMission(playerID uuid.UUID, missionID string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+func (m *HiddenMissionModule) completeMission(playerID uuid.UUID, missionID string, reason string) {
+	var audit *MissionAuditEvent
 
+	m.mu.Lock()
 	// Check if already completed.
 	for _, mid := range m.completedMissions[playerID] {
 		if mid == missionID {
+			m.mu.Unlock()
 			return
 		}
 	}
@@ -133,7 +134,22 @@ func (m *HiddenMissionModule) completeMission(playerID uuid.UUID, missionID stri
 			if m.config.AffectsScore {
 				m.scores[playerID] += mission.Points
 			}
-			return
+			audit = &MissionAuditEvent{
+				PlayerID:  playerID,
+				MissionID: missionID,
+				Completed: true,
+				Points:    mission.Points,
+				Reason:    reason,
+			}
+			break
 		}
+	}
+	m.mu.Unlock()
+
+	if audit != nil && m.deps.EventBus != nil {
+		m.deps.EventBus.Publish(engine.Event{
+			Type:    "mission.completed",
+			Payload: *audit,
+		})
 	}
 }

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, useMemo } from "react";
 import type { EditorThemeResponse, MysteryRole } from "@/features/editor/api";
 import { useEditorCharacters, useEditorClues, useUpdateCharacter } from "@/features/editor/api";
 import { useCharacterConfigDebounce } from "@/features/editor/hooks/useCharacterConfigDebounce";
-import type { Mission } from "./MissionEditor";
 import { CharacterDetailPanel } from "./CharacterDetailPanel";
 import { EntityEditorShell } from "@/features/editor/entities/shell/EntityEditorShell";
 import {
@@ -13,6 +12,12 @@ import {
   buildCharacterRoleUpdatePayload,
   getCharacterRoleBadge,
 } from "@/features/editor/entities/character/characterEditorAdapter";
+import {
+  createMissionDraft,
+  readCharacterMissionMap,
+  writeCharacterMissionMap,
+  type Mission,
+} from "@/features/editor/entities/mission/missionAdapter";
 
 interface CharacterAssignPanelProps {
   themeId: string;
@@ -34,10 +39,7 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
   );
 
   const characterMissions = useMemo((): Record<string, Mission[]> => {
-    const cm = (theme.config_json ?? {}).character_missions;
-    return cm && typeof cm === "object" && !Array.isArray(cm)
-      ? (cm as Record<string, Mission[]>)
-      : {};
+    return readCharacterMissionMap(theme.config_json);
   }, [theme.config_json]);
 
   const { saveConfig, flush } = useCharacterConfigDebounce(themeId, theme.config_json);
@@ -64,26 +66,19 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
 
   const handleAddMissionForChar = useCallback((characterId: string) => {
     const current = characterMissions[characterId] ?? [];
-    const mission: Mission = {
-      id: crypto.randomUUID(),
-      type: "kill",
-      description: "",
-      points: 10,
-    };
-    saveConfig({
-      character_missions: { ...characterMissions, [characterId]: [...current, mission] },
-    });
+    saveConfig(writeCharacterMissionMap(undefined, {
+      ...characterMissions,
+      [characterId]: [...current, createMissionDraft()],
+    }));
   }, [characterMissions, saveConfig]);
 
   const handleDeleteMissionForChar = useCallback(
     (characterId: string, missionId: string) => {
       const current = characterMissions[characterId] ?? [];
-      saveConfig({
-        character_missions: {
-          ...characterMissions,
-          [characterId]: current.filter((m) => m.id !== missionId),
-        },
-      });
+      saveConfig(writeCharacterMissionMap(undefined, {
+        ...characterMissions,
+        [characterId]: current.filter((m) => m.id !== missionId),
+      }));
     },
     [characterMissions, saveConfig],
   );
@@ -91,14 +86,12 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
   const handleMissionChangeForChar = useCallback(
     (characterId: string, missionId: string, field: keyof Mission, value: string | number) => {
       const current = characterMissions[characterId] ?? [];
-      saveConfig({
-        character_missions: {
-          ...characterMissions,
-          [characterId]: current.map((m) =>
-            m.id === missionId ? { ...m, [field]: value } : m,
-          ),
-        },
-      });
+      saveConfig(writeCharacterMissionMap(undefined, {
+        ...characterMissions,
+        [characterId]: current.map((m) =>
+          m.id === missionId ? { ...m, [field]: value } : m,
+        ),
+      }));
     },
     [characterMissions, saveConfig],
   );

--- a/apps/web/src/features/editor/components/design/MissionEditor.tsx
+++ b/apps/web/src/features/editor/components/design/MissionEditor.tsx
@@ -1,33 +1,18 @@
 import { Plus, Trash2 } from 'lucide-react';
 import { MissionTypeFields } from './MissionTypeFields';
+import {
+  MISSION_TYPES,
+  toMissionViewModel,
+  type Mission,
+  type MissionEditorCharacter,
+  type MissionEditorClue,
+} from '../../entities/mission/missionAdapter';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export interface Mission {
-  id: string;
-  type: string;
-  description: string;
-  points: number;
-  targetCharacterId?: string;
-  targetClueId?: string;
-  condition?: string;
-  quantity?: number;
-  secretContent?: string;
-  penalty?: number;
-  difficulty?: number;
-}
-
-export interface MissionEditorCharacter {
-  id: string;
-  name: string;
-}
-
-export interface MissionEditorClue {
-  id: string;
-  name: string;
-}
+export type { Mission, MissionEditorCharacter, MissionEditorClue };
 
 interface MissionEditorProps {
   missions: Mission[];
@@ -37,13 +22,6 @@ interface MissionEditorProps {
   onChange: (missionId: string, field: keyof Mission, value: string | number) => void;
   onDelete: (missionId: string) => void;
 }
-
-export const MISSION_TYPES = [
-  { value: 'kill', label: '살해' },
-  { value: 'possess', label: '보유' },
-  { value: 'secret', label: '비밀' },
-  { value: 'protect', label: '보호' },
-];
 
 // ---------------------------------------------------------------------------
 // MissionEditor
@@ -73,58 +51,95 @@ export function MissionEditor({
       {missions.length > 0 ? (
         <div className="space-y-3">
           {missions.map((mission) => (
-            <div
+            <MissionCard
               key={mission.id}
-              className="rounded border border-slate-800 bg-slate-900 p-3"
-            >
-              <div className="mb-2 flex items-center justify-between">
-                <select
-                  value={mission.type}
-                  onChange={(e) => onChange(mission.id, 'type', e.target.value)}
-                  className="rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
-                >
-                  {MISSION_TYPES.map((t) => (
-                    <option key={t.value} value={t.value}>
-                      {t.label}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  onClick={() => onDelete(mission.id)}
-                  aria-label="미션 삭제"
-                  className="text-slate-600 hover:text-red-400"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              </div>
-              <input
-                type="text"
-                value={mission.description}
-                onChange={(e) => onChange(mission.id, 'description', e.target.value)}
-                placeholder="미션 설명"
-                className="mb-2 w-full rounded bg-slate-800 px-2 py-1 text-xs text-slate-300 placeholder-slate-600"
-              />
-              <div className="mb-2 flex items-center gap-2">
-                <span className="text-xs text-slate-500">포인트:</span>
-                <input
-                  type="number"
-                  value={mission.points}
-                  onChange={(e) => onChange(mission.id, 'points', Number(e.target.value))}
-                  className="w-16 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
-                />
-              </div>
-              <MissionTypeFields
-                mission={mission}
-                characters={characters}
-                clues={clues}
-                onChange={onChange}
-              />
-            </div>
+              mission={mission}
+              characters={characters}
+              clues={clues}
+              onChange={onChange}
+              onDelete={onDelete}
+            />
           ))}
         </div>
       ) : (
         <p className="text-xs text-slate-600">미션이 없습니다</p>
+      )}
+    </div>
+  );
+}
+
+function MissionCard({
+  mission,
+  characters,
+  clues,
+  onChange,
+  onDelete,
+}: {
+  mission: Mission;
+  characters: MissionEditorCharacter[];
+  clues: MissionEditorClue[];
+  onChange: (missionId: string, field: keyof Mission, value: string | number) => void;
+  onDelete: (missionId: string) => void;
+}) {
+  const viewModel = toMissionViewModel(mission);
+  const descriptionId = `mission-description-${mission.id}`;
+  return (
+    <div className="rounded border border-slate-800 bg-slate-900 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <select
+          value={mission.type}
+          onChange={(e) => onChange(mission.id, 'type', e.target.value)}
+          className="rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
+          aria-label="미션 유형"
+        >
+          {MISSION_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => onDelete(mission.id)}
+          aria-label="미션 삭제"
+          className="text-slate-600 hover:text-red-400"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <label className="sr-only" htmlFor={descriptionId}>미션 설명</label>
+      <input
+        id={descriptionId}
+        type="text"
+        value={mission.description}
+        onChange={(e) => onChange(mission.id, 'description', e.target.value)}
+        placeholder="미션 설명"
+        className="mb-2 w-full rounded bg-slate-800 px-2 py-1 text-xs text-slate-300 placeholder-slate-600"
+      />
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <label className="flex items-center gap-2">
+          <span>포인트:</span>
+          <input
+            type="number"
+            value={mission.points}
+            onChange={(e) => onChange(mission.id, 'points', Number(e.target.value))}
+            className="w-16 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
+          />
+        </label>
+        <span className="rounded-full bg-slate-800 px-2 py-0.5 text-slate-400">
+          {viewModel.resultVisibilityLabel}
+        </span>
+      </div>
+      <MissionTypeFields
+        mission={mission}
+        characters={characters}
+        clues={clues}
+        onChange={onChange}
+      />
+      {viewModel.warnings.length > 0 && (
+        <ul className="mt-2 list-disc space-y-1 pl-4 text-[11px] leading-4 text-amber-200">
+          {viewModel.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+        </ul>
       )}
     </div>
   );

--- a/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMissionDraft,
+  readCharacterMissionMap,
+  toMissionRuntimeDraft,
+  toMissionViewModel,
+  writeCharacterMissionMap,
+} from "../missionAdapter";
+
+describe("missionAdapter", () => {
+  it("legacy character_missions를 제작자용 미션 맵으로 정규화한다", () => {
+    const missions = readCharacterMissionMap({
+      character_missions: {
+        "char-1": [
+          { id: "m1", type: "possess", description: "비밀 편지를 가진다", points: 10, targetClueId: "clue-1" },
+          { broken: true },
+        ],
+      },
+    });
+
+    expect(missions["char-1"]).toEqual([
+      expect.objectContaining({ id: "m1", type: "possess", description: "비밀 편지를 가진다", points: 10 }),
+      expect.objectContaining({ id: "mission-2", type: "secret", points: 0 }),
+    ]);
+  });
+
+  it("새 미션은 결과 화면 공개와 수동 판정을 기본값으로 만든다", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("mission-new");
+    expect(createMissionDraft()).toEqual({
+      id: "mission-new",
+      type: "secret",
+      description: "",
+      points: 0,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("제작자 타입을 runtime engine 후보 계약으로 변환한다", () => {
+    expect(toMissionRuntimeDraft({
+      id: "m1",
+      type: "possess",
+      description: "단서를 가진다",
+      points: 7,
+      targetClueId: "clue-1",
+    })).toEqual({
+      id: "m1",
+      type: "hold_clue",
+      description: "단서를 가진다",
+      points: 7,
+      verification: "auto",
+      targetClueId: "clue-1",
+    });
+  });
+
+  it("새 미션을 자동 판정 타입으로 바꾸면 runtime verification은 auto가 된다", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("mission-new");
+    const draft = createMissionDraft();
+    const runtime = toMissionRuntimeDraft({ ...draft, type: "possess", targetClueId: "clue-1" });
+
+    expect(runtime).toEqual(expect.objectContaining({
+      type: "hold_clue",
+      verification: "auto",
+    }));
+    vi.restoreAllMocks();
+  });
+
+  it("제작자가 이해할 요약과 자동 판정 경고를 만든다", () => {
+    expect(toMissionViewModel({ id: "m2", type: "kill", description: "", points: -1 })).toEqual({
+      id: "m2",
+      title: "미션 내용을 입력해 주세요",
+      typeLabel: "살해",
+      pointsLabel: "점수 없음",
+      resultVisibilityLabel: "결과 화면에서 공개",
+      runtimeType: "vote_target",
+      warnings: [
+        "플레이어가 이해할 미션 내용을 입력해 주세요.",
+        "투표형 미션은 대상 캐릭터를 선택해야 자동 판정할 수 있습니다.",
+      ],
+    });
+  });
+
+  it("저장 payload는 legacy character_missions 경계에만 쓴다", () => {
+    expect(writeCharacterMissionMap(
+      { title: "기존 설정" },
+      { "char-1": [{ id: "m1", type: "secret", description: "비밀", points: 0 }] },
+    )).toEqual({
+      title: "기존 설정",
+      character_missions: { "char-1": [{ id: "m1", type: "secret", description: "비밀", points: 0 }] },
+    });
+  });
+});

--- a/apps/web/src/features/editor/entities/mission/missionAdapter.ts
+++ b/apps/web/src/features/editor/entities/mission/missionAdapter.ts
@@ -1,0 +1,182 @@
+import type { EditorConfig } from "../../utils/configShape";
+
+export const HIDDEN_MISSION_MODULE_ID = "hidden_mission";
+export const LEGACY_CHARACTER_MISSIONS_KEY = "character_missions";
+
+export type MissionCreatorType = "kill" | "possess" | "secret" | "protect";
+export type MissionRuntimeType = "hold_clue" | "vote_target" | "transfer_clue" | "survive" | "custom";
+export type MissionVerification = "auto" | "self_report" | "gm_verify";
+
+export interface Mission {
+  id: string;
+  type: MissionCreatorType | string;
+  description: string;
+  points: number;
+  targetCharacterId?: string;
+  targetClueId?: string;
+  condition?: string;
+  quantity?: number;
+  secretContent?: string;
+  penalty?: number;
+  difficulty?: number;
+  verification?: MissionVerification;
+}
+
+export interface MissionEditorCharacter {
+  id: string;
+  name: string;
+}
+
+export interface MissionEditorClue {
+  id: string;
+  name: string;
+}
+
+export interface MissionViewModel {
+  id: string;
+  title: string;
+  typeLabel: string;
+  pointsLabel: string;
+  resultVisibilityLabel: string;
+  runtimeType: MissionRuntimeType;
+  warnings: string[];
+}
+
+export interface MissionRuntimeDraft {
+  id: string;
+  type: MissionRuntimeType;
+  description: string;
+  points: number;
+  verification: MissionVerification;
+  targetCharacterId?: string;
+  targetClueId?: string;
+  condition?: string;
+}
+
+export const MISSION_TYPES: Array<{ value: MissionCreatorType; label: string }> = [
+  { value: "kill", label: "살해" },
+  { value: "possess", label: "보유" },
+  { value: "secret", label: "비밀" },
+  { value: "protect", label: "보호" },
+];
+
+const MISSION_TYPE_LABELS: Record<string, string> = Object.fromEntries(
+  MISSION_TYPES.map((type) => [type.value, type.label]),
+);
+
+function isRecord(value: unknown): value is EditorConfig {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeMission(value: unknown, index: number): Mission | null {
+  if (!isRecord(value)) return null;
+  const id = typeof value.id === "string" && value.id.trim() ? value.id : `mission-${index + 1}`;
+  const type = typeof value.type === "string" && value.type.trim() ? value.type : "secret";
+  const description = typeof value.description === "string" ? value.description : "";
+  const points = typeof value.points === "number" && Number.isFinite(value.points) ? value.points : 0;
+  return {
+    id,
+    type,
+    description,
+    points,
+    ...(typeof value.targetCharacterId === "string" ? { targetCharacterId: value.targetCharacterId } : {}),
+    ...(typeof value.targetClueId === "string" ? { targetClueId: value.targetClueId } : {}),
+    ...(typeof value.condition === "string" ? { condition: value.condition } : {}),
+    ...(typeof value.quantity === "number" ? { quantity: value.quantity } : {}),
+    ...(typeof value.secretContent === "string" ? { secretContent: value.secretContent } : {}),
+    ...(typeof value.penalty === "number" ? { penalty: value.penalty } : {}),
+    ...(typeof value.difficulty === "number" ? { difficulty: value.difficulty } : {}),
+    ...(value.verification === "auto" || value.verification === "self_report" || value.verification === "gm_verify"
+      ? { verification: value.verification }
+      : {}),
+  };
+}
+
+export function createMissionDraft(): Mission {
+  return {
+    id: crypto.randomUUID(),
+    type: "secret",
+    description: "",
+    points: 0,
+  };
+}
+
+export function readCharacterMissionMap(
+  configJson: EditorConfig | null | undefined,
+): Record<string, Mission[]> {
+  const source = configJson?.[LEGACY_CHARACTER_MISSIONS_KEY];
+  if (!isRecord(source)) return {};
+  return Object.fromEntries(
+    Object.entries(source).map(([characterId, missions]) => [
+      characterId,
+      Array.isArray(missions)
+        ? missions.map(normalizeMission).filter((mission): mission is Mission => !!mission)
+        : [],
+    ]),
+  );
+}
+
+export function writeCharacterMissionMap(
+  configJson: EditorConfig | null | undefined,
+  missionsByCharacter: Record<string, Mission[]>,
+): EditorConfig {
+  return { ...(configJson ?? {}), [LEGACY_CHARACTER_MISSIONS_KEY]: missionsByCharacter };
+}
+
+export function getMissionTypeLabel(type: string): string {
+  return MISSION_TYPE_LABELS[type] ?? "직접 설정";
+}
+
+export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
+  const runtimeType = toRuntimeType(mission);
+  return {
+    id: mission.id,
+    type: runtimeType,
+    description: mission.description.trim(),
+    points: Math.max(0, Math.trunc(mission.points || 0)),
+    verification: mission.verification ?? defaultVerification(runtimeType),
+    ...(mission.targetCharacterId ? { targetCharacterId: mission.targetCharacterId } : {}),
+    ...(mission.targetClueId ? { targetClueId: mission.targetClueId } : {}),
+    ...(mission.condition ? { condition: mission.condition } : {}),
+  };
+}
+
+export function toMissionViewModel(mission: Mission): MissionViewModel {
+  const runtimeDraft = toMissionRuntimeDraft(mission);
+  const warnings = buildMissionWarnings(mission, runtimeDraft);
+  return {
+    id: mission.id,
+    title: mission.description.trim() || "미션 내용을 입력해 주세요",
+    typeLabel: getMissionTypeLabel(mission.type),
+    pointsLabel: runtimeDraft.points > 0 ? `${runtimeDraft.points}점` : "점수 없음",
+    resultVisibilityLabel: "결과 화면에서 공개",
+    runtimeType: runtimeDraft.type,
+    warnings,
+  };
+}
+
+function toRuntimeType(mission: Mission): MissionRuntimeType {
+  if (mission.type === "possess") return "hold_clue";
+  if (mission.type === "kill") return "vote_target";
+  if (mission.type === "protect") return mission.targetClueId ? "hold_clue" : "custom";
+  return "custom";
+}
+
+function defaultVerification(runtimeType: MissionRuntimeType): MissionVerification {
+  return runtimeType === "custom" ? "self_report" : "auto";
+}
+
+function buildMissionWarnings(mission: Mission, runtimeDraft: MissionRuntimeDraft): string[] {
+  const warnings: string[] = [];
+  if (!mission.description.trim()) warnings.push("플레이어가 이해할 미션 내용을 입력해 주세요.");
+  if (runtimeDraft.type === "hold_clue" && !runtimeDraft.targetClueId) {
+    warnings.push("보유 미션은 대상 단서를 선택해야 자동 판정할 수 있습니다.");
+  }
+  if (runtimeDraft.type === "vote_target" && !runtimeDraft.targetCharacterId) {
+    warnings.push("투표형 미션은 대상 캐릭터를 선택해야 자동 판정할 수 있습니다.");
+  }
+  if (runtimeDraft.type === "custom") {
+    warnings.push("이 미션은 자동 판정 대신 플레이어 신고 또는 진행자 확인으로 처리됩니다.");
+  }
+  return warnings;
+}

--- a/docs/plans/2026-05-04-issue-261-mission-adapter-engine/checklist.md
+++ b/docs/plans/2026-05-04-issue-261-mission-adapter-engine/checklist.md
@@ -1,0 +1,26 @@
+# Issue #261 — Mission Adapter/Engine 경계 정리
+
+## Uzu 참고점
+
+- Uzu mission은 캐릭터별 목표를 만들고, 달성 조건/점수를 결과 공유 화면에서 판정한다.
+- 미션은 플레이 중 자동 배포되지 않으며, 플레이어에게 알려야 하는 내용은 별도 텍스트에 써야 한다.
+
+## MMP 적용 방식
+
+- 제작자 UI는 캐릭터 내부의 “히든 미션” 섹션으로 유지한다.
+- 프론트는 `missionAdapter`가 제작자용 ViewModel, 경고, legacy `character_missions` 저장 경계를 담당한다.
+- 백엔드는 `hidden_mission` engine이 player-aware state, 자동 판정, 점수, 결과 breakdown, audit event의 runtime truth를 담당한다.
+
+## 완료 조건
+
+- [x] Mission Frontend Adapter 추가
+- [x] Mission Adapter unit test 추가
+- [x] CharacterAssignPanel이 직접 config shape를 만지지 않고 adapter를 사용
+- [x] hidden_mission runtime result breakdown 계약 추가
+- [x] mission.completed audit event 계약 추가
+- [x] Go unit test로 TargetCharacterID 자동 판정과 breakdown 검증
+
+## 후순위
+
+- `character_missions` legacy 저장을 `modules.hidden_mission.config.playerMissions`로 완전 마이그레이션하려면 캐릭터 ID와 실제 player ID 매핑 정책이 먼저 필요하다.
+- 종료 화면 breakdown 전체 UI 연결은 #249에서 처리한다.


### PR DESCRIPTION
## 목표\n- #261 미션 엔티티의 제작자 UI Adapter와 backend runtime engine 계약을 분리합니다.\n- Uzu mission 문서의 ‘캐릭터별 목표, 점수, 결과 공유 화면 판정’ 패턴을 참고하되, MMP는 실시간 멀티플레이/PlayerAware backend engine 기준으로 재해석했습니다.\n\n## 변경 내용\n- Mission Frontend Adapter 추가\n  - legacy character_missions 정규화\n  - 제작자용 ViewModel/경고/점수/결과 공개 요약\n  - 제작자 타입을 runtime 후보 계약으로 변환\n- CharacterAssignPanel이 mission config shape를 직접 만지지 않고 Adapter를 사용하도록 정리\n- MissionEditor가 Adapter ViewModel 기반으로 결과 공개/검수 경고를 표시\n- hidden_mission backend 계약 추가\n  - MissionResultBreakdown\n  - MissionAuditEvent\n  - mission.completed event\n  - targetCharacterId 기반 vote_target 자동 판정\n- #261 작업 체크리스트 문서 추가\n\n## 검증\n- pnpm --dir apps/web exec eslint src/features/editor/entities/mission/missionAdapter.ts src/features/editor/entities/mission/__tests__/missionAdapter.test.ts src/features/editor/components/design/MissionEditor.tsx src/features/editor/components/design/CharacterAssignPanel.tsx\n- pnpm --dir apps/web exec vitest run src/features/editor/entities/mission/__tests__/missionAdapter.test.ts src/features/editor/components/design/__tests__/MissionEditor.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx\n- pnpm --dir apps/web typecheck\n- cd apps/server && go test ./internal/module/decision/hidden_mission\n\n## E2E 대체 사유\n- 새 라우트나 저장 플로우를 추가하지 않고 기존 캐릭터 미션 섹션의 Adapter/Engine 계약을 정리한 변경입니다.\n- 사용자 동작은 기존 CharacterAssignPanel/MissionEditor Testing Library 테스트로, runtime 계약은 Go unit test로 검증했습니다.\n\nCloses #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 미션에 캐릭터/엔딩 타겟 및 조건 필드가 선택적으로 추가됨
  * 결과 화면에서 플레이어별 미션 항목과 총점을 조건부로 조회할 수 있는 공개 제어 추가
  * 에디터에 미션 어댑터 도입: 생성·읽기·쓰기 및 뷰모델 변환 제공
* **Bug Fixes**
  * 자동 검증 흐름과 완료 이벤트 발행 동작 안정화
* **Tests**
  * 자동검증 및 결과 요약 빌드 관련 단위/통합 테스트 추가
* **Documentation**
  * 미션 어댑터 및 역할 분담 체크리스트 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->