### PR TITLE
Phase 25 후보 덱/토큰 조사 Adapter와 Runtime 계약 정리

### DIFF
--- a/apps/server/internal/module/exploration/deck_investigation/contract.go
+++ b/apps/server/internal/module/exploration/deck_investigation/contract.go
@@ -1,0 +1,181 @@
+package deck_investigation
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+)
+
+const (
+	DeliveryPrivateOwnership = "private_ownership"
+	DeliveryPublicReveal     = "public_reveal"
+	DeliveryViewOnly         = "view_only"
+
+	DrawSequential = "sequential"
+	DrawRandom     = "random"
+)
+
+var (
+	ErrDeckNotFound      = errors.New("deck_investigation: deck not found")
+	ErrDeckNotAllowed    = errors.New("deck_investigation: deck is not available")
+	ErrInsufficientToken = errors.New("deck_investigation: insufficient token balance")
+)
+
+type Config struct {
+	Tokens []TokenConfig `json:"tokens"`
+	Decks  []DeckConfig  `json:"decks"`
+}
+
+type TokenConfig struct {
+	ID            string `json:"id"`
+	DefaultAmount int    `json:"defaultAmount"`
+}
+
+type DeckConfig struct {
+	ID                  string       `json:"id"`
+	TokenID             string       `json:"tokenId"`
+	TokenCost           int          `json:"tokenCost"`
+	DrawOrder           string       `json:"drawOrder"`
+	PhaseIDs            []string     `json:"phaseIds"`
+	LocationIDs         []string     `json:"locationIds"`
+	BlockedCharacterIDs []string     `json:"blockedCharacterIds"`
+	RequiredClueIDs     []string     `json:"requiredClueIds"`
+	Cards               []CardConfig `json:"cards"`
+	EmptyMessage        string       `json:"emptyMessage"`
+}
+
+type CardConfig struct {
+	ClueID   string `json:"clueId"`
+	Delivery string `json:"delivery"`
+}
+
+type PlayerState struct {
+	PlayerID      uuid.UUID
+	CharacterID   string
+	PhaseID       string
+	LocationID    string
+	TokenBalances map[string]int
+	HeldClueIDs   map[string]bool
+}
+
+type AccessDecision struct {
+	DeckID     string `json:"deckId"`
+	Allowed    bool   `json:"allowed"`
+	TokenID    string `json:"tokenId"`
+	TokenCost  int    `json:"tokenCost"`
+	ReasonCode string `json:"reasonCode"`
+}
+
+type DrawResult struct {
+	DeckID   string `json:"deckId"`
+	ClueID   string `json:"clueId"`
+	Delivery string `json:"delivery"`
+}
+
+func ValidateConfig(config Config) error {
+	tokenIDs := make(map[string]struct{}, len(config.Tokens))
+	for _, token := range config.Tokens {
+		if token.ID == "" {
+			return fmt.Errorf("deck_investigation: token id is required")
+		}
+		if _, exists := tokenIDs[token.ID]; exists {
+			return fmt.Errorf("deck_investigation: duplicate token id %q", token.ID)
+		}
+		if token.DefaultAmount < 0 {
+			return fmt.Errorf("deck_investigation: token %q defaultAmount must be non-negative", token.ID)
+		}
+		tokenIDs[token.ID] = struct{}{}
+	}
+
+	deckIDs := make(map[string]struct{}, len(config.Decks))
+	for _, deck := range config.Decks {
+		if deck.ID == "" {
+			return fmt.Errorf("deck_investigation: deck id is required")
+		}
+		if _, exists := deckIDs[deck.ID]; exists {
+			return fmt.Errorf("deck_investigation: duplicate deck id %q", deck.ID)
+		}
+		if _, ok := tokenIDs[deck.TokenID]; !ok {
+			return fmt.Errorf("deck_investigation: deck %q references missing token %q", deck.ID, deck.TokenID)
+		}
+		if deck.TokenCost < 0 {
+			return fmt.Errorf("deck_investigation: deck %q tokenCost must be non-negative", deck.ID)
+		}
+		if deck.DrawOrder != "" && deck.DrawOrder != DrawSequential && deck.DrawOrder != DrawRandom {
+			return fmt.Errorf("deck_investigation: deck %q has unsupported drawOrder %q", deck.ID, deck.DrawOrder)
+		}
+		for _, card := range deck.Cards {
+			if err := validateCard(deck.ID, card); err != nil {
+				return err
+			}
+		}
+		deckIDs[deck.ID] = struct{}{}
+	}
+	return nil
+}
+
+func EvaluateAccess(config Config, deckID string, player PlayerState) (AccessDecision, error) {
+	deck, ok := findDeck(config.Decks, deckID)
+	if !ok {
+		return AccessDecision{DeckID: deckID, Allowed: false, ReasonCode: "missing_deck"}, ErrDeckNotFound
+	}
+
+	decision := AccessDecision{DeckID: deck.ID, TokenID: deck.TokenID, TokenCost: deck.TokenCost, Allowed: false}
+	if len(deck.PhaseIDs) > 0 && !slices.Contains(deck.PhaseIDs, player.PhaseID) {
+		decision.ReasonCode = "wrong_phase"
+		return decision, ErrDeckNotAllowed
+	}
+	if len(deck.LocationIDs) > 0 && !slices.Contains(deck.LocationIDs, player.LocationID) {
+		decision.ReasonCode = "wrong_location"
+		return decision, ErrDeckNotAllowed
+	}
+	if slices.Contains(deck.BlockedCharacterIDs, player.CharacterID) {
+		decision.ReasonCode = "blocked_character"
+		return decision, ErrDeckNotAllowed
+	}
+	for _, clueID := range deck.RequiredClueIDs {
+		if !player.HeldClueIDs[clueID] {
+			decision.ReasonCode = "missing_required_clue"
+			return decision, ErrDeckNotAllowed
+		}
+	}
+	if player.TokenBalances[deck.TokenID] < deck.TokenCost {
+		decision.ReasonCode = "insufficient_token"
+		return decision, ErrInsufficientToken
+	}
+
+	decision.Allowed = true
+	decision.ReasonCode = "allowed"
+	return decision, nil
+}
+
+func BuildDrawResult(deck DeckConfig, drawnCardIndex int) (DrawResult, bool) {
+	if drawnCardIndex < 0 || drawnCardIndex >= len(deck.Cards) {
+		return DrawResult{}, false
+	}
+	card := deck.Cards[drawnCardIndex]
+	return DrawResult{DeckID: deck.ID, ClueID: card.ClueID, Delivery: card.Delivery}, true
+}
+
+func findDeck(decks []DeckConfig, deckID string) (DeckConfig, bool) {
+	for _, deck := range decks {
+		if deck.ID == deckID {
+			return deck, true
+		}
+	}
+	return DeckConfig{}, false
+}
+
+func validateCard(deckID string, card CardConfig) error {
+	if card.ClueID == "" {
+		return fmt.Errorf("deck_investigation: deck %q card clueId is required", deckID)
+	}
+	switch card.Delivery {
+	case DeliveryPrivateOwnership, DeliveryPublicReveal, DeliveryViewOnly:
+		return nil
+	default:
+		return fmt.Errorf("deck_investigation: deck %q has unsupported delivery %q", deckID, card.Delivery)
+	}
+}

--- a/apps/server/internal/module/exploration/deck_investigation/contract_test.go
+++ b/apps/server/internal/module/exploration/deck_investigation/contract_test.go
@@ -1,0 +1,129 @@
+package deck_investigation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func validConfig() Config {
+	return Config{
+		Tokens: []TokenConfig{{ID: "coin", DefaultAmount: 2}},
+		Decks: []DeckConfig{{
+			ID:                  "library",
+			TokenID:             "coin",
+			TokenCost:           1,
+			DrawOrder:           DrawSequential,
+			PhaseIDs:            []string{"phase-1"},
+			LocationIDs:         []string{"loc-1"},
+			BlockedCharacterIDs: []string{"char-blocked"},
+			RequiredClueIDs:     []string{"key"},
+			Cards:               []CardConfig{{ClueID: "clue-1", Delivery: DeliveryPrivateOwnership}},
+		}},
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	t.Run("accepts valid token deck contract", func(t *testing.T) {
+		if err := ValidateConfig(validConfig()); err != nil {
+			t.Fatalf("ValidateConfig() error = %v", err)
+		}
+	})
+
+	t.Run("rejects duplicate token ids", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.Tokens = append(cfg.Tokens, TokenConfig{ID: "coin"})
+		if err := ValidateConfig(cfg); err == nil {
+			t.Fatal("expected duplicate token error")
+		}
+	})
+
+	t.Run("rejects deck with missing token", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.Decks[0].TokenID = "missing"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Fatal("expected missing token error")
+		}
+	})
+
+	t.Run("rejects unsupported card delivery", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.Decks[0].Cards[0].Delivery = "raw-json"
+		if err := ValidateConfig(cfg); err == nil {
+			t.Fatal("expected delivery error")
+		}
+	})
+}
+
+func TestEvaluateAccess(t *testing.T) {
+	player := PlayerState{
+		PlayerID:      uuid.New(),
+		CharacterID:   "char-1",
+		PhaseID:       "phase-1",
+		LocationID:    "loc-1",
+		TokenBalances: map[string]int{"coin": 1},
+		HeldClueIDs:   map[string]bool{"key": true},
+	}
+
+	t.Run("allows deck when phase location clue and token requirements pass", func(t *testing.T) {
+		decision, err := EvaluateAccess(validConfig(), "library", player)
+		if err != nil {
+			t.Fatalf("EvaluateAccess() error = %v", err)
+		}
+		if !decision.Allowed || decision.ReasonCode != "allowed" || decision.TokenCost != 1 {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("blocks wrong phase before token consumption", func(t *testing.T) {
+		blocked := player
+		blocked.PhaseID = "phase-2"
+		decision, err := EvaluateAccess(validConfig(), "library", blocked)
+		if !errors.Is(err, ErrDeckNotAllowed) || decision.ReasonCode != "wrong_phase" {
+			t.Fatalf("expected wrong_phase, got decision=%+v err=%v", decision, err)
+		}
+	})
+
+	t.Run("blocks configured character", func(t *testing.T) {
+		blocked := player
+		blocked.CharacterID = "char-blocked"
+		decision, err := EvaluateAccess(validConfig(), "library", blocked)
+		if !errors.Is(err, ErrDeckNotAllowed) || decision.ReasonCode != "blocked_character" {
+			t.Fatalf("expected blocked_character, got decision=%+v err=%v", decision, err)
+		}
+	})
+
+	t.Run("blocks missing prerequisite clue", func(t *testing.T) {
+		blocked := player
+		blocked.HeldClueIDs = map[string]bool{}
+		decision, err := EvaluateAccess(validConfig(), "library", blocked)
+		if !errors.Is(err, ErrDeckNotAllowed) || decision.ReasonCode != "missing_required_clue" {
+			t.Fatalf("expected missing_required_clue, got decision=%+v err=%v", decision, err)
+		}
+	})
+
+	t.Run("blocks insufficient token balance", func(t *testing.T) {
+		blocked := player
+		blocked.TokenBalances = map[string]int{"coin": 0}
+		decision, err := EvaluateAccess(validConfig(), "library", blocked)
+		if !errors.Is(err, ErrInsufficientToken) || decision.ReasonCode != "insufficient_token" {
+			t.Fatalf("expected insufficient_token, got decision=%+v err=%v", decision, err)
+		}
+	})
+}
+
+func TestBuildDrawResult(t *testing.T) {
+	deck := validConfig().Decks[0]
+	result, ok := BuildDrawResult(deck, 0)
+	if !ok {
+		t.Fatal("expected draw result")
+	}
+	if result != (DrawResult{DeckID: "library", ClueID: "clue-1", Delivery: DeliveryPrivateOwnership}) {
+		t.Fatalf("unexpected draw result: %+v", result)
+	}
+
+	if _, ok := BuildDrawResult(deck, 10); ok {
+		t.Fatal("out-of-range draw should be rejected")
+	}
+}

--- a/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import type { ClueResponse, LocationResponse } from '@/features/editor/api/types';
+import {
+  createDeckInvestigationDraft,
+  createInvestigationDeckDraft,
+  readDeckInvestigationConfig,
+  toDeckInvestigationRuntimeDraft,
+  toDeckInvestigationViewModel,
+  writeDeckInvestigationConfig,
+} from '../deckInvestigationAdapter';
+
+const clue = (id: string, name = id): ClueResponse => ({
+  id,
+  theme_id: 'theme-1',
+  location_id: null,
+  name,
+  description: null,
+  image_url: null,
+  is_common: false,
+  level: 1,
+  sort_order: 0,
+  created_at: '2026-05-04T00:00:00Z',
+  is_usable: false,
+  use_effect: null,
+  use_target: null,
+  use_consumed: false,
+});
+
+const location = (id: string, name: string): LocationResponse => ({
+  id,
+  theme_id: 'theme-1',
+  map_id: 'map-1',
+  name,
+  restricted_characters: null,
+  image_url: null,
+  sort_order: 0,
+  created_at: '2026-05-04T00:00:00Z',
+});
+
+describe('deckInvestigationAdapter', () => {
+  it('설정이 없으면 제작자가 바로 이해할 기본 토큰을 제공한다', () => {
+    expect(createDeckInvestigationDraft()).toMatchObject({
+      tokens: [{ id: 'investigation-token', name: '조사 토큰', defaultAmount: 0 }],
+      decks: [],
+    });
+    expect(readDeckInvestigationConfig(null)).toMatchObject({
+      tokens: [{ id: 'investigation-token', name: '조사 토큰' }],
+      decks: [],
+    });
+  });
+
+  it('modules.deck_investigation.config에서 token/deck draft를 읽는다', () => {
+    const config = readDeckInvestigationConfig({
+      modules: {
+        deck_investigation: {
+          enabled: true,
+          config: {
+            tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 2.8 }],
+            decks: [{
+              id: 'deck-1',
+              title: '서재 조사',
+              tokenId: 'coin',
+              tokenCost: 1,
+              drawOrder: 'random',
+              access: { locationIds: ['loc-1'], blockedCharacterIds: ['char-2'] },
+              cards: [
+                { clueId: 'clue-1', delivery: 'public_reveal' },
+                { clueId: 'clue-2', delivery: 'unknown' },
+              ],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(config.tokens[0]).toMatchObject({ id: 'coin', name: '동전', defaultAmount: 2 });
+    expect(config.decks[0]).toMatchObject({
+      id: 'deck-1',
+      title: '서재 조사',
+      tokenId: 'coin',
+      drawOrder: 'random',
+      access: expect.objectContaining({ locationIds: ['loc-1'], blockedCharacterIds: ['char-2'] }),
+      cards: [
+        { clueId: 'clue-1', delivery: 'public_reveal' },
+        { clueId: 'clue-2', delivery: 'private_ownership' },
+      ],
+    });
+  });
+
+
+
+  it('legacy 배열 값은 공백과 중복을 정리해 저장 경계 밖으로 새지 않게 한다', () => {
+    const config = readDeckInvestigationConfig({
+      modules: {
+        deck_investigation: {
+          config: {
+            tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙' }],
+            decks: [{
+              title: '공백 정리',
+              tokenId: 'coin',
+              access: { locationIds: [' loc-1 ', 'loc-1', '', 'loc-2'] },
+              cards: [],
+            }],
+          },
+        },
+      },
+    });
+
+    expect(config.decks[0].access.locationIds).toEqual(['loc-1', 'loc-2']);
+  });
+
+  it('저장할 때 기존 config와 module의 다른 필드를 보존한다', () => {
+    const next = writeDeckInvestigationConfig(
+      {
+        title: '보존',
+        modules: {
+          deck_investigation: { enabled: true, config: { keep: true, tokens: [] } },
+          starting_clue: { enabled: true, config: { startingClues: { char: ['clue'] } } },
+        },
+      },
+      {
+        tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 3 }],
+        decks: [createInvestigationDeckDraft(0, 'coin')],
+      },
+    );
+
+    expect(next.title).toBe('보존');
+    expect(next.modules).toMatchObject({
+      deck_investigation: {
+        enabled: true,
+        config: {
+          keep: true,
+          tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 3 }],
+          decks: [expect.objectContaining({ tokenId: 'coin' })],
+        },
+      },
+      starting_clue: { enabled: true, config: { startingClues: { char: ['clue'] } } },
+    });
+  });
+
+  it('ViewModel은 내부 key 대신 제작자용 요약과 경고를 만든다', () => {
+    const draft = {
+      tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 2 }],
+      decks: [{
+        ...createInvestigationDeckDraft(0, 'coin'),
+        title: '응접실 조사',
+        drawOrder: 'random' as const,
+        access: { phaseIds: [], locationIds: ['loc-1', 'loc-2', 'loc-3'], blockedCharacterIds: [], requiredClueIds: [] },
+        cards: [
+          { clueId: 'clue-1', delivery: 'private_ownership' as const },
+          { clueId: 'clue-2', delivery: 'public_reveal' as const },
+          { clueId: 'missing', delivery: 'view_only' as const },
+        ],
+      }],
+    };
+
+    const vm = toDeckInvestigationViewModel(draft, {
+      clues: [clue('clue-1'), clue('clue-2')],
+      locations: [location('loc-1', '응접실'), location('loc-2', '서재')],
+    });
+
+    expect(vm.deckCountLabel).toBe('조사 덱 1개');
+    expect(vm.tokenCountLabel).toBe('토큰 1종');
+    expect(vm.decks[0]).toMatchObject({
+      title: '응접실 조사',
+      tokenLabel: '🪙 동전 1개 소비',
+      placementLabel: '응접실, 서재 외 1곳',
+      cardCountLabel: '단서 3개',
+      drawOrderLabel: '무작위로 지급',
+      deliverySummary: '개별 지급 1 · 전체 공개 1 · 보기만 1',
+      warningLabels: ['없는 단서 1개가 연결되어 있습니다.'],
+    });
+  });
+
+  it('runtime draft에는 UI label 대신 엔진 판단에 필요한 값만 남긴다', () => {
+    const runtime = toDeckInvestigationRuntimeDraft({
+      tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 2 }],
+      decks: [{
+        ...createInvestigationDeckDraft(0, 'coin'),
+        access: { phaseIds: ['phase-1'], locationIds: ['loc-1'], blockedCharacterIds: ['char-2'], requiredClueIds: ['clue-key'] },
+        cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+      }],
+    });
+
+    expect(runtime).toEqual({
+      tokens: [{ id: 'coin', defaultAmount: 2 }],
+      decks: [{
+        id: 'deck-1',
+        tokenId: 'coin',
+        tokenCost: 1,
+        drawOrder: 'sequential',
+        phaseIds: ['phase-1'],
+        locationIds: ['loc-1'],
+        blockedCharacterIds: ['char-2'],
+        requiredClueIds: ['clue-key'],
+        cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+        emptyMessage: '더 이상 얻을 단서가 없습니다.',
+      }],
+    });
+  });
+});

--- a/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
@@ -99,6 +99,7 @@ describe('deckInvestigationAdapter', () => {
               id: ' deck-1 ',
               title: ' 공백 정리 ',
               tokenId: ' coin ',
+              emptyMessage: ' 비어 있음 ',
               access: { locationIds: [' loc-1 ', 'loc-1', '', 'loc-2'] },
               cards: [{ clueId: ' clue-1 ', delivery: 'view_only' }],
             }],
@@ -108,7 +109,12 @@ describe('deckInvestigationAdapter', () => {
     });
 
     expect(config.tokens[0]).toMatchObject({ id: 'coin', name: '동전', iconLabel: '🪙' });
-    expect(config.decks[0]).toMatchObject({ id: 'deck-1', title: '공백 정리', tokenId: 'coin' });
+    expect(config.decks[0]).toMatchObject({
+      id: 'deck-1',
+      title: '공백 정리',
+      tokenId: 'coin',
+      emptyMessage: '비어 있음',
+    });
     expect(config.decks[0].access.locationIds).toEqual(['loc-1', 'loc-2']);
     expect(config.decks[0].cards[0]).toMatchObject({ clueId: 'clue-1', delivery: 'view_only' });
   });
@@ -190,6 +196,26 @@ describe('deckInvestigationAdapter', () => {
     });
 
     expect(vm.decks[0].placementLabel).toBe('응접실 외 1곳');
+  });
+
+
+
+  it('runtime draft는 원본 editor draft의 배열과 카드 객체를 공유하지 않는다', () => {
+    const draft = {
+      tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 2 }],
+      decks: [{
+        ...createInvestigationDeckDraft(0, 'coin'),
+        access: { phaseIds: ['phase-1'], locationIds: ['loc-1'], blockedCharacterIds: ['char-2'], requiredClueIds: ['clue-key'] },
+        cards: [{ clueId: 'clue-1', delivery: 'private_ownership' as const }],
+      }],
+    };
+
+    const runtime = toDeckInvestigationRuntimeDraft(draft);
+    runtime.decks[0].phaseIds.push('phase-mutated');
+    runtime.decks[0].cards[0].clueId = 'clue-mutated';
+
+    expect(draft.decks[0].access.phaseIds).toEqual(['phase-1']);
+    expect(draft.decks[0].cards[0]).toEqual({ clueId: 'clue-1', delivery: 'private_ownership' });
   });
 
   it('runtime draft에는 UI label 대신 엔진 판단에 필요한 값만 남긴다', () => {

--- a/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
@@ -89,24 +89,28 @@ describe('deckInvestigationAdapter', () => {
 
 
 
-  it('legacy 배열 값은 공백과 중복을 정리해 저장 경계 밖으로 새지 않게 한다', () => {
+  it('legacy 배열 값과 ID 문자열은 공백과 중복을 정리해 저장 경계 밖으로 새지 않게 한다', () => {
     const config = readDeckInvestigationConfig({
       modules: {
         deck_investigation: {
           config: {
-            tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙' }],
+            tokens: [{ id: ' coin ', name: ' 동전 ', iconLabel: ' 🪙 ' }],
             decks: [{
-              title: '공백 정리',
-              tokenId: 'coin',
+              id: ' deck-1 ',
+              title: ' 공백 정리 ',
+              tokenId: ' coin ',
               access: { locationIds: [' loc-1 ', 'loc-1', '', 'loc-2'] },
-              cards: [],
+              cards: [{ clueId: ' clue-1 ', delivery: 'view_only' }],
             }],
           },
         },
       },
     });
 
+    expect(config.tokens[0]).toMatchObject({ id: 'coin', name: '동전', iconLabel: '🪙' });
+    expect(config.decks[0]).toMatchObject({ id: 'deck-1', title: '공백 정리', tokenId: 'coin' });
     expect(config.decks[0].access.locationIds).toEqual(['loc-1', 'loc-2']);
+    expect(config.decks[0].cards[0]).toMatchObject({ clueId: 'clue-1', delivery: 'view_only' });
   });
 
   it('저장할 때 기존 config와 module의 다른 필드를 보존한다', () => {
@@ -170,6 +174,22 @@ describe('deckInvestigationAdapter', () => {
       deliverySummary: '개별 지급 1 · 전체 공개 1 · 보기만 1',
       warningLabels: ['없는 단서 1개가 연결되어 있습니다.'],
     });
+  });
+
+
+
+  it('위치 일부만 이름을 찾을 수 있어도 숨은 위치 수를 정확히 표시한다', () => {
+    const vm = toDeckInvestigationViewModel({
+      tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 2 }],
+      decks: [{
+        ...createInvestigationDeckDraft(0, 'coin'),
+        access: { phaseIds: [], locationIds: ['loc-1', 'missing'], blockedCharacterIds: [], requiredClueIds: [] },
+      }],
+    }, {
+      locations: [location('loc-1', '응접실')],
+    });
+
+    expect(vm.decks[0].placementLabel).toBe('응접실 외 1곳');
   });
 
   it('runtime draft에는 UI label 대신 엔진 판단에 필요한 값만 남긴다', () => {

--- a/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
@@ -114,18 +114,25 @@ function readDrawOrder(value: unknown): DeckDrawOrder {
 
 function normalizeToken(value: unknown, index: number): InvestigationTokenDraft | null {
   if (!isRecord(value)) return null;
-  const id = typeof value.id === 'string' && value.id.trim() ? value.id : `token-${index + 1}`;
-  const name = typeof value.name === 'string' && value.name.trim() ? value.name : '조사 토큰';
-  const iconLabel = typeof value.iconLabel === 'string' && value.iconLabel.trim() ? value.iconLabel : '🔎';
+  const rawId = typeof value.id === 'string' ? value.id.trim() : '';
+  const rawName = typeof value.name === 'string' ? value.name.trim() : '';
+  const rawIconLabel = typeof value.iconLabel === 'string' ? value.iconLabel.trim() : '';
   const defaultAmount = typeof value.defaultAmount === 'number' && Number.isFinite(value.defaultAmount)
     ? Math.max(0, Math.floor(value.defaultAmount))
     : 0;
-  return { id, name, iconLabel, defaultAmount };
+  return {
+    id: rawId || `token-${index + 1}`,
+    name: rawName || '조사 토큰',
+    iconLabel: rawIconLabel || '🔎',
+    defaultAmount,
+  };
 }
 
 function normalizeCard(value: unknown): InvestigationDeckCardDraft | null {
-  if (!isRecord(value) || typeof value.clueId !== 'string' || !value.clueId.trim()) return null;
-  return { clueId: value.clueId, delivery: readDelivery(value.delivery) };
+  if (!isRecord(value) || typeof value.clueId !== 'string') return null;
+  const clueId = value.clueId.trim();
+  if (!clueId) return null;
+  return { clueId, delivery: readDelivery(value.delivery) };
 }
 
 function normalizeAccess(value: unknown): InvestigationDeckAccessDraft {
@@ -140,10 +147,13 @@ function normalizeAccess(value: unknown): InvestigationDeckAccessDraft {
 
 function normalizeDeck(value: unknown, index: number, fallbackTokenId: string): InvestigationDeckDraft | null {
   if (!isRecord(value)) return null;
-  const id = typeof value.id === 'string' && value.id.trim() ? value.id : `deck-${index + 1}`;
-  const title = typeof value.title === 'string' && value.title.trim() ? value.title : '새 조사 덱';
-  const description = typeof value.description === 'string' ? value.description : '';
-  const tokenId = typeof value.tokenId === 'string' && value.tokenId.trim() ? value.tokenId : fallbackTokenId;
+  const rawId = typeof value.id === 'string' ? value.id.trim() : '';
+  const rawTitle = typeof value.title === 'string' ? value.title.trim() : '';
+  const description = typeof value.description === 'string' ? value.description.trim() : '';
+  const rawTokenId = typeof value.tokenId === 'string' ? value.tokenId.trim() : '';
+  const id = rawId || `deck-${index + 1}`;
+  const title = rawTitle || '새 조사 덱';
+  const tokenId = rawTokenId || fallbackTokenId;
   const tokenCost = typeof value.tokenCost === 'number' && Number.isFinite(value.tokenCost)
     ? Math.max(0, Math.floor(value.tokenCost))
     : 1;
@@ -289,9 +299,11 @@ function formatPlacementLabel(
 ): string {
   if (locationIds.length === 0) return '모든 배치 위치에서 실행 가능';
   const names = locationIds.map((id) => locationById.get(id)?.name).filter((name): name is string => !!name);
-  if (names.length === 0) return `${locationIds.length}개 위치에 배치`;
-  if (names.length <= 2 && names.length === locationIds.length) return names.join(', ');
-  return `${names.slice(0, 2).join(', ')} 외 ${locationIds.length - 2}곳`;
+  const shownCount = names.length;
+  if (shownCount === 0) return `${locationIds.length}개 위치에 배치`;
+  if (shownCount <= 2 && shownCount === locationIds.length) return names.join(', ');
+  const displayedCount = Math.min(2, shownCount);
+  return `${names.slice(0, displayedCount).join(', ')} 외 ${locationIds.length - displayedCount}곳`;
 }
 
 function formatDeliverySummary(cards: InvestigationDeckCardDraft[]): string {

--- a/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
@@ -1,0 +1,308 @@
+import type { ClueResponse, LocationResponse } from '@/features/editor/api/types';
+import {
+  readModuleConfig,
+  writeModuleConfig,
+  type EditorConfig,
+} from '@/features/editor/utils/configShape';
+
+export const DECK_INVESTIGATION_MODULE_ID = 'deck_investigation';
+
+export type DeckDrawOrder = 'sequential' | 'random';
+export type DeckCardDelivery = 'private_ownership' | 'public_reveal' | 'view_only';
+
+export interface InvestigationTokenDraft {
+  id: string;
+  name: string;
+  iconLabel: string;
+  defaultAmount: number;
+}
+
+export interface InvestigationDeckCardDraft {
+  clueId: string;
+  delivery: DeckCardDelivery;
+}
+
+export interface InvestigationDeckAccessDraft {
+  phaseIds: string[];
+  locationIds: string[];
+  blockedCharacterIds: string[];
+  requiredClueIds: string[];
+}
+
+export interface InvestigationDeckDraft {
+  id: string;
+  title: string;
+  description: string;
+  tokenId: string;
+  tokenCost: number;
+  drawOrder: DeckDrawOrder;
+  emptyMessage: string;
+  access: InvestigationDeckAccessDraft;
+  cards: InvestigationDeckCardDraft[];
+}
+
+export interface DeckInvestigationConfigDraft {
+  tokens: InvestigationTokenDraft[];
+  decks: InvestigationDeckDraft[];
+}
+
+export interface DeckInvestigationViewModel {
+  deckCountLabel: string;
+  tokenCountLabel: string;
+  warnings: string[];
+  decks: InvestigationDeckViewModel[];
+}
+
+export interface InvestigationDeckViewModel {
+  id: string;
+  title: string;
+  tokenLabel: string;
+  placementLabel: string;
+  cardCountLabel: string;
+  drawOrderLabel: string;
+  deliverySummary: string;
+  warningLabels: string[];
+}
+
+export interface DeckInvestigationRuntimeDraft {
+  tokens: Array<{ id: string; defaultAmount: number }>;
+  decks: Array<{
+    id: string;
+    tokenId: string;
+    tokenCost: number;
+    drawOrder: DeckDrawOrder;
+    phaseIds: string[];
+    locationIds: string[];
+    blockedCharacterIds: string[];
+    requiredClueIds: string[];
+    cards: InvestigationDeckCardDraft[];
+    emptyMessage: string;
+  }>;
+}
+
+const DEFAULT_TOKEN: InvestigationTokenDraft = {
+  id: 'investigation-token',
+  name: '조사 토큰',
+  iconLabel: '🔎',
+  defaultAmount: 0,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function readDelivery(value: unknown): DeckCardDelivery {
+  if (value === 'public_reveal' || value === 'view_only') return value;
+  return 'private_ownership';
+}
+
+function readDrawOrder(value: unknown): DeckDrawOrder {
+  return value === 'random' ? 'random' : 'sequential';
+}
+
+function normalizeToken(value: unknown, index: number): InvestigationTokenDraft | null {
+  if (!isRecord(value)) return null;
+  const id = typeof value.id === 'string' && value.id.trim() ? value.id : `token-${index + 1}`;
+  const name = typeof value.name === 'string' && value.name.trim() ? value.name : '조사 토큰';
+  const iconLabel = typeof value.iconLabel === 'string' && value.iconLabel.trim() ? value.iconLabel : '🔎';
+  const defaultAmount = typeof value.defaultAmount === 'number' && Number.isFinite(value.defaultAmount)
+    ? Math.max(0, Math.floor(value.defaultAmount))
+    : 0;
+  return { id, name, iconLabel, defaultAmount };
+}
+
+function normalizeCard(value: unknown): InvestigationDeckCardDraft | null {
+  if (!isRecord(value) || typeof value.clueId !== 'string' || !value.clueId.trim()) return null;
+  return { clueId: value.clueId, delivery: readDelivery(value.delivery) };
+}
+
+function normalizeAccess(value: unknown): InvestigationDeckAccessDraft {
+  const record = isRecord(value) ? value : {};
+  return {
+    phaseIds: stringList(record.phaseIds),
+    locationIds: stringList(record.locationIds),
+    blockedCharacterIds: stringList(record.blockedCharacterIds),
+    requiredClueIds: stringList(record.requiredClueIds),
+  };
+}
+
+function normalizeDeck(value: unknown, index: number, fallbackTokenId: string): InvestigationDeckDraft | null {
+  if (!isRecord(value)) return null;
+  const id = typeof value.id === 'string' && value.id.trim() ? value.id : `deck-${index + 1}`;
+  const title = typeof value.title === 'string' && value.title.trim() ? value.title : '새 조사 덱';
+  const description = typeof value.description === 'string' ? value.description : '';
+  const tokenId = typeof value.tokenId === 'string' && value.tokenId.trim() ? value.tokenId : fallbackTokenId;
+  const tokenCost = typeof value.tokenCost === 'number' && Number.isFinite(value.tokenCost)
+    ? Math.max(0, Math.floor(value.tokenCost))
+    : 1;
+  const emptyMessage = typeof value.emptyMessage === 'string' && value.emptyMessage.trim()
+    ? value.emptyMessage
+    : '더 이상 얻을 단서가 없습니다.';
+  const cards = Array.isArray(value.cards)
+    ? value.cards.map(normalizeCard).filter((card): card is InvestigationDeckCardDraft => !!card)
+    : [];
+  return {
+    id,
+    title,
+    description,
+    tokenId,
+    tokenCost,
+    drawOrder: readDrawOrder(value.drawOrder),
+    emptyMessage,
+    access: normalizeAccess(value.access),
+    cards,
+  };
+}
+
+export function createDeckInvestigationDraft(): DeckInvestigationConfigDraft {
+  return {
+    tokens: [{ ...DEFAULT_TOKEN }],
+    decks: [],
+  };
+}
+
+export function createInvestigationDeckDraft(index = 0, tokenId = DEFAULT_TOKEN.id): InvestigationDeckDraft {
+  return {
+    id: `deck-${index + 1}`,
+    title: '새 조사 덱',
+    description: '',
+    tokenId,
+    tokenCost: 1,
+    drawOrder: 'sequential',
+    emptyMessage: '더 이상 얻을 단서가 없습니다.',
+    access: { phaseIds: [], locationIds: [], blockedCharacterIds: [], requiredClueIds: [] },
+    cards: [],
+  };
+}
+
+export function readDeckInvestigationConfig(
+  configJson: EditorConfig | null | undefined,
+): DeckInvestigationConfigDraft {
+  const moduleConfig = readModuleConfig(configJson, DECK_INVESTIGATION_MODULE_ID);
+  const tokens = Array.isArray(moduleConfig.tokens)
+    ? moduleConfig.tokens.map(normalizeToken).filter((token): token is InvestigationTokenDraft => !!token)
+    : [];
+  const effectiveTokens = tokens.length > 0 ? tokens : [{ ...DEFAULT_TOKEN }];
+  const fallbackTokenId = effectiveTokens[0]?.id ?? DEFAULT_TOKEN.id;
+  const decks = Array.isArray(moduleConfig.decks)
+    ? moduleConfig.decks.map((deck, index) => normalizeDeck(deck, index, fallbackTokenId)).filter((deck): deck is InvestigationDeckDraft => !!deck)
+    : [];
+  return { tokens: effectiveTokens, decks };
+}
+
+export function writeDeckInvestigationConfig(
+  configJson: EditorConfig | null | undefined,
+  draft: DeckInvestigationConfigDraft,
+): EditorConfig {
+  const current = readModuleConfig(configJson, DECK_INVESTIGATION_MODULE_ID);
+  return writeModuleConfig(configJson, DECK_INVESTIGATION_MODULE_ID, {
+    ...current,
+    tokens: draft.tokens,
+    decks: draft.decks,
+  });
+}
+
+export function toDeckInvestigationRuntimeDraft(
+  draft: DeckInvestigationConfigDraft,
+): DeckInvestigationRuntimeDraft {
+  return {
+    tokens: draft.tokens.map((token) => ({ id: token.id, defaultAmount: token.defaultAmount })),
+    decks: draft.decks.map((deck) => ({
+      id: deck.id,
+      tokenId: deck.tokenId,
+      tokenCost: deck.tokenCost,
+      drawOrder: deck.drawOrder,
+      phaseIds: deck.access.phaseIds,
+      locationIds: deck.access.locationIds,
+      blockedCharacterIds: deck.access.blockedCharacterIds,
+      requiredClueIds: deck.access.requiredClueIds,
+      cards: deck.cards,
+      emptyMessage: deck.emptyMessage,
+    })),
+  };
+}
+
+export function toDeckInvestigationViewModel(
+  draft: DeckInvestigationConfigDraft,
+  options: { clues?: ClueResponse[]; locations?: LocationResponse[] } = {},
+): DeckInvestigationViewModel {
+  const tokenById = new Map(draft.tokens.map((token) => [token.id, token]));
+  const clueIds = new Set((options.clues ?? []).map((clue) => clue.id));
+  const locationById = new Map((options.locations ?? []).map((location) => [location.id, location]));
+  const warnings: string[] = [];
+  const decks = draft.decks.map((deck) => {
+    const deckWarnings = buildDeckWarnings(deck, tokenById, clueIds);
+    warnings.push(...deckWarnings.map((warning) => `${deck.title}: ${warning}`));
+    return {
+      id: deck.id,
+      title: deck.title,
+      tokenLabel: formatTokenLabel(deck, tokenById.get(deck.tokenId)),
+      placementLabel: formatPlacementLabel(deck.access.locationIds, locationById),
+      cardCountLabel: `단서 ${deck.cards.length}개`,
+      drawOrderLabel: deck.drawOrder === 'random' ? '무작위로 지급' : '위에서부터 지급',
+      deliverySummary: formatDeliverySummary(deck.cards),
+      warningLabels: deckWarnings,
+    };
+  });
+  return {
+    deckCountLabel: `조사 덱 ${draft.decks.length}개`,
+    tokenCountLabel: `토큰 ${draft.tokens.length}종`,
+    warnings,
+    decks,
+  };
+}
+
+function buildDeckWarnings(
+  deck: InvestigationDeckDraft,
+  tokenById: Map<string, InvestigationTokenDraft>,
+  clueIds: Set<string>,
+): string[] {
+  const warnings: string[] = [];
+  if (!tokenById.has(deck.tokenId)) warnings.push('소비 토큰을 선택해야 합니다.');
+  if (deck.cards.length === 0) warnings.push('덱에 지급할 단서를 추가해야 합니다.');
+  const missingClueCount = deck.cards.filter((card) => !clueIds.has(card.clueId)).length;
+  if (clueIds.size > 0 && missingClueCount > 0) warnings.push(`없는 단서 ${missingClueCount}개가 연결되어 있습니다.`);
+  if (deck.tokenCost < 0) warnings.push('소비 토큰 수는 0 이상이어야 합니다.');
+  return warnings;
+}
+
+function formatTokenLabel(deck: InvestigationDeckDraft, token?: InvestigationTokenDraft): string {
+  const tokenName = token ? `${token.iconLabel} ${token.name}` : '토큰 미선택';
+  return `${tokenName} ${deck.tokenCost}개 소비`;
+}
+
+function formatPlacementLabel(
+  locationIds: string[],
+  locationById: Map<string, LocationResponse>,
+): string {
+  if (locationIds.length === 0) return '모든 배치 위치에서 실행 가능';
+  const names = locationIds.map((id) => locationById.get(id)?.name).filter((name): name is string => !!name);
+  if (names.length === 0) return `${locationIds.length}개 위치에 배치`;
+  if (names.length <= 2 && names.length === locationIds.length) return names.join(', ');
+  return `${names.slice(0, 2).join(', ')} 외 ${locationIds.length - 2}곳`;
+}
+
+function formatDeliverySummary(cards: InvestigationDeckCardDraft[]): string {
+  if (cards.length === 0) return '지급 단서 없음';
+  const counts = cards.reduce<Record<DeckCardDelivery, number>>(
+    (acc, card) => ({ ...acc, [card.delivery]: acc[card.delivery] + 1 }),
+    { private_ownership: 0, public_reveal: 0, view_only: 0 },
+  );
+  return [
+    counts.private_ownership > 0 ? `개별 지급 ${counts.private_ownership}` : null,
+    counts.public_reveal > 0 ? `전체 공개 ${counts.public_reveal}` : null,
+    counts.view_only > 0 ? `보기만 ${counts.view_only}` : null,
+  ].filter(Boolean).join(' · ');
+}

--- a/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
@@ -157,9 +157,8 @@ function normalizeDeck(value: unknown, index: number, fallbackTokenId: string): 
   const tokenCost = typeof value.tokenCost === 'number' && Number.isFinite(value.tokenCost)
     ? Math.max(0, Math.floor(value.tokenCost))
     : 1;
-  const emptyMessage = typeof value.emptyMessage === 'string' && value.emptyMessage.trim()
-    ? value.emptyMessage
-    : '더 이상 얻을 단서가 없습니다.';
+  const rawEmptyMessage = typeof value.emptyMessage === 'string' ? value.emptyMessage.trim() : '';
+  const emptyMessage = rawEmptyMessage || '더 이상 얻을 단서가 없습니다.';
   const cards = Array.isArray(value.cards)
     ? value.cards.map(normalizeCard).filter((card): card is InvestigationDeckCardDraft => !!card)
     : [];
@@ -234,11 +233,11 @@ export function toDeckInvestigationRuntimeDraft(
       tokenId: deck.tokenId,
       tokenCost: deck.tokenCost,
       drawOrder: deck.drawOrder,
-      phaseIds: deck.access.phaseIds,
-      locationIds: deck.access.locationIds,
-      blockedCharacterIds: deck.access.blockedCharacterIds,
-      requiredClueIds: deck.access.requiredClueIds,
-      cards: deck.cards,
+      phaseIds: [...deck.access.phaseIds],
+      locationIds: [...deck.access.locationIds],
+      blockedCharacterIds: [...deck.access.blockedCharacterIds],
+      requiredClueIds: [...deck.access.requiredClueIds],
+      cards: deck.cards.map((card) => ({ ...card })),
       emptyMessage: deck.emptyMessage,
     })),
   };

--- a/docs/plans/2026-05-04-issue-262-deck-token-investigation/checklist.md
+++ b/docs/plans/2026-05-04-issue-262-deck-token-investigation/checklist.md
@@ -1,0 +1,27 @@
+# Issue #262 — Deck/Token Investigation Adapter/Runtime 경계 정리
+
+## Uzu 참고점
+- `basic-features/decks.md`: 덱은 토큰을 소비해 단서를 획득한다. 소비 토큰은 덱 단위로 고정되고, 단서별 지급 방식은 덱 카드 설정에서 정한다.
+- `basic-features/decks.md`: 덱은 페이즈 내용에 배치하며, 덱 조사 페이즈에서는 토큰 표시도 같이 두는 것을 권장한다.
+- `advanced/investigation.md`: 장소 조사는 투표/선택과 단서 배포를 조합해 만들 수 있고, 중복 선택 금지 같은 플레이어별 제한이 중요하다.
+
+## MMP 적용 방식
+- 제작자 UI/Adapter는 “어떤 덱을 어느 페이즈/장소에서 실행하고, 어떤 토큰을 몇 개 소비하며, 어떤 단서를 어떤 방식으로 받는가”만 다룬다.
+- Frontend Adapter는 `modules.deck_investigation.config`를 읽고 쓴다. 내부 storage key/raw JSON은 UI에 직접 노출하지 않는다.
+- Backend Engine 계약은 덱 실행 가능 여부, 토큰 잔액, 페이즈/장소/캐릭터 제한, 지급 카드 공개 정책을 판단한다.
+
+## #247/#248과의 책임 경계
+- #247 단서 효과 Engine: 이미 소유한 단서를 “사용”했을 때의 효과 실행 담당.
+- #248 장소 조사 Runtime: 장소 진입/조사 이력/반복 조사 제한 담당.
+- #262 Deck/Token Investigation: 토큰 소비와 덱 카드 지급 담당. 장소/페이즈 조건은 입력으로 받되, 장소 이동 자체나 단서 사용 효과는 실행하지 않는다.
+
+## 완료 조건
+- [ ] Frontend Deck/Token Adapter와 단위 테스트
+- [ ] Backend runtime contract와 Go 테스트
+- [ ] 기존 config를 보존하는 read/write helper
+- [ ] Codecov patch coverage 70% 이상
+- [ ] PR 본문에 E2E 작성/대체 사유 명시
+
+## 후순위
+- 실제 장소 조사 화면 저장 E2E는 UI가 붙는 PR에서 추가한다.
+- Deck draw 결과를 단서 인벤토리/공개 상태에 반영하는 전체 runtime integration은 #247/#248 경계 확정 후 연결한다.


### PR DESCRIPTION
## 요약
- 덱/토큰 조사 설정을 제작자용 ViewModel과 runtime draft로 나누는 frontend adapter를 추가했습니다.
- backend `deck_investigation` runtime 계약 초안을 추가해 페이즈/장소/캐릭터/필수 단서/토큰 잔액 접근 판단을 테스트 가능하게 했습니다.
- Uzu 덱/조사 문서 참고점과 #247/#248 책임 경계를 체크리스트에 정리했습니다.

## 검증
- `pnpm --dir apps/web exec eslint src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts`
- `pnpm --dir apps/web exec vitest run src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts`
- `pnpm --dir apps/web typecheck`
- `cd apps/server && go test ./internal/module/exploration/deck_investigation`
- `git diff --check main...HEAD`

## E2E 대체 사유
이번 PR은 새 라우트나 저장 UI를 추가하지 않고 Adapter/Runtime 계약 경계를 정리합니다. 플레이어/제작자 화면이 붙는 후속 PR에서 장소 조사 UI/저장 E2E를 추가하고, 이번 범위는 frontend adapter unit test와 Go runtime contract test로 대체했습니다.

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카드 덱 조사 시스템 추가: 토큰 소비로 카드 추출, 추출 결과의 전달 방식(개인/공개/보기 전용) 및 순차/무작위 추출 지원
  * 에디터 통합 개선: 구성 생성·읽기·쓰기, UI용 뷰모델 및 런타임 페이로드 변환, 입력 정규화(공백제거·중복제거·기본값 적용)
* **테스트**
  * 구성 검증, 접근 평가(이유 코드 포함), 추출 결과 및 에디터 변환 동작을 검증하는 테스트 추가
* **문서**
  * 구현 범위와 책임 분담을 정리한 체크리스트 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->