### PR TITLE
#263 미디어 리소스 Adapter 정리

### DIFF
--- a/apps/web/src/features/editor/components/media/MediaPicker.tsx
+++ b/apps/web/src/features/editor/components/media/MediaPicker.tsx
@@ -1,25 +1,17 @@
-import { useEffect, useState } from "react";
-import {
-  FileAudio,
-  FileText,
-  Film,
-  Mic,
-  Music,
-  Search,
-  Sparkles,
-  X,
-  Youtube,
-} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
+import { ResourcePicker } from "./ResourcePicker";
+import {
+  filterMediaResourceViewModels,
+  getMediaResourceTypeLabel,
+  toMediaResourceViewModels,
+  type MediaResourceUseCase,
+} from "@/features/editor/entities/mediaResource/mediaResourceAdapter";
 import {
   useMediaList,
   type MediaResponse,
   type MediaType,
 } from "@/features/editor/mediaApi";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 export interface MediaPickerProps {
   open: boolean;
@@ -28,51 +20,13 @@ export interface MediaPickerProps {
   themeId: string;
   /** When set, only media of this type are queried/listed. */
   filterType?: MediaType;
+  /** Restrict selection for a creator workflow without exposing storage details. */
+  useCase?: MediaResourceUseCase;
   /** Highlight currently selected media id. */
   selectedId?: string | null;
   /** Optional dialog title (defaults to "미디어 선택"). */
   title?: string;
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatDuration(seconds: number): string {
-  const total = Math.max(0, Math.floor(seconds));
-  const mm = Math.floor(total / 60);
-  const ss = total % 60;
-  return `${mm}:${ss.toString().padStart(2, "0")}`;
-}
-
-function MediaTypeIcon({ type }: { type: MediaType }) {
-  switch (type) {
-    case "BGM":
-      return <Music className="h-5 w-5 text-amber-400" />;
-    case "SFX":
-      return <Sparkles className="h-5 w-5 text-cyan-400" />;
-    case "VOICE":
-      return <Mic className="h-5 w-5 text-emerald-400" />;
-    case "VIDEO":
-      return <Film className="h-5 w-5 text-rose-400" />;
-    case "DOCUMENT":
-      return <FileText className="h-5 w-5 text-violet-400" />;
-    default:
-      return <FileAudio className="h-5 w-5 text-slate-400" />;
-  }
-}
-
-const TYPE_LABEL: Record<MediaType, string> = {
-  BGM: "배경음악",
-  SFX: "효과음",
-  VOICE: "음성",
-  VIDEO: "비디오",
-  DOCUMENT: "문서",
-};
-
-// ---------------------------------------------------------------------------
-// MediaPicker
-// ---------------------------------------------------------------------------
 
 export function MediaPicker({
   open,
@@ -80,6 +34,7 @@ export function MediaPicker({
   onSelect,
   themeId,
   filterType,
+  useCase,
   selectedId,
   title,
 }: MediaPickerProps) {
@@ -90,113 +45,41 @@ export function MediaPicker({
     if (!open) setSearchQuery("");
   }, [open]);
 
+  const resourceViewModels = useMemo(
+    () => toMediaResourceViewModels(media, { useCase }),
+    [media, useCase],
+  );
+  const filteredResources = useMemo(
+    () => filterMediaResourceViewModels(resourceViewModels, searchQuery),
+    [resourceViewModels, searchQuery],
+  );
+
   if (!open) return null;
 
-  const query = searchQuery.trim().toLowerCase();
-  const filtered = query
-    ? media.filter((m) => m.name.toLowerCase().includes(query))
-    : media;
+  const handleSelect = (resourceId: string) => {
+    const selected = media.find((item) => item.id === resourceId);
+    if (!selected) return;
+    onSelect(selected);
+    onClose();
+  };
+
+  const filterHint = filterType
+    ? `${getMediaResourceTypeLabel(filterType)} 유형만 표시됩니다`
+    : null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-label={title || "미디어 선택"}
-    >
-      <div className="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg bg-slate-800 p-6">
-        {/* Header */}
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-slate-100">
-            {title || "미디어 선택"}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="닫기"
-            className="rounded p-1 text-slate-400 transition-colors hover:bg-slate-700 hover:text-slate-200"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* Search */}
-        <div className="relative mb-3">
-          <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
-          <input
-            type="text"
-            className="w-full rounded border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-100 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
-            placeholder="이름으로 검색"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            aria-label="미디어 이름 검색"
-          />
-        </div>
-
-        {/* List */}
-        <div className="flex-1 overflow-y-auto">
-          {isLoading ? (
-            <div
-              className="py-8 text-center text-sm text-slate-400"
-              role="status"
-            >
-              불러오는 중...
-            </div>
-          ) : filtered.length === 0 ? (
-            <div className="py-8 text-center text-sm text-slate-400">
-              {query ? "검색 결과가 없습니다" : "미디어가 없습니다"}
-            </div>
-          ) : (
-            <ul className="space-y-1">
-              {filtered.map((m) => {
-                const isSelected = selectedId === m.id;
-                return (
-                  <li key={m.id}>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        onSelect(m);
-                        onClose();
-                      }}
-                      aria-pressed={isSelected}
-                      className={`flex w-full items-center gap-3 rounded border p-3 text-left transition-colors ${
-                        isSelected
-                          ? "border-amber-500/40 bg-amber-500/20"
-                          : "border-transparent bg-slate-900 hover:bg-slate-700"
-                      }`}
-                    >
-                      <MediaTypeIcon type={m.type} />
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium text-slate-200">
-                          {m.name}
-                        </p>
-                        {m.duration ? (
-                          <p className="text-xs text-slate-400">
-                            {formatDuration(m.duration)}
-                          </p>
-                        ) : null}
-                      </div>
-                      {m.source_type === "YOUTUBE" && (
-                        <Youtube
-                          className="h-4 w-4 text-rose-500"
-                          aria-label="YouTube"
-                        />
-                      )}
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-
-        {/* Footer hint */}
-        {filterType && (
-          <p className="mt-3 text-xs text-slate-500">
-            {TYPE_LABEL[filterType]} 유형만 표시됩니다
-          </p>
-        )}
-      </div>
-    </div>
+    <ResourcePicker
+      title={title || "미디어 선택"}
+      resources={filteredResources}
+      searchQuery={searchQuery}
+      onSearchQueryChange={setSearchQuery}
+      onClose={onClose}
+      onSelect={handleSelect}
+      selectedId={selectedId}
+      isLoading={isLoading}
+      emptyLabel="미디어가 없습니다"
+      searchEmptyLabel="검색 결과가 없습니다"
+      filterHint={filterHint}
+    />
   );
 }

--- a/apps/web/src/features/editor/components/media/ResourcePicker.tsx
+++ b/apps/web/src/features/editor/components/media/ResourcePicker.tsx
@@ -1,0 +1,166 @@
+import {
+  FileAudio,
+  FileText,
+  Film,
+  Mic,
+  Music,
+  Search,
+  Sparkles,
+  X,
+  Youtube,
+} from "lucide-react";
+
+import type {
+  MediaResourceViewModel,
+} from "@/features/editor/entities/mediaResource/mediaResourceAdapter";
+import type { MediaType } from "@/features/editor/mediaApi";
+
+export interface ResourcePickerProps {
+  title: string;
+  resources: MediaResourceViewModel[];
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+  onClose: () => void;
+  onSelect: (resourceId: string) => void;
+  selectedId?: string | null;
+  isLoading?: boolean;
+  emptyLabel?: string;
+  searchEmptyLabel?: string;
+  filterHint?: string | null;
+}
+
+function MediaTypeIcon({ type }: { type: MediaType }) {
+  switch (type) {
+    case "BGM":
+      return <Music className="h-5 w-5 text-amber-400" />;
+    case "SFX":
+      return <Sparkles className="h-5 w-5 text-cyan-400" />;
+    case "VOICE":
+      return <Mic className="h-5 w-5 text-emerald-400" />;
+    case "VIDEO":
+      return <Film className="h-5 w-5 text-rose-400" />;
+    case "DOCUMENT":
+      return <FileText className="h-5 w-5 text-violet-400" />;
+    default:
+      return <FileAudio className="h-5 w-5 text-slate-400" />;
+  }
+}
+
+export function ResourcePicker({
+  title,
+  resources,
+  searchQuery,
+  onSearchQueryChange,
+  onClose,
+  onSelect,
+  selectedId,
+  isLoading = false,
+  emptyLabel = "리소스가 없습니다",
+  searchEmptyLabel = "검색 결과가 없습니다",
+  filterHint,
+}: ResourcePickerProps) {
+  const hasQuery = searchQuery.trim().length > 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <div className="flex max-h-[84vh] w-full max-w-2xl flex-col rounded-xl border border-slate-700 bg-slate-900 p-4 shadow-2xl shadow-black/40 sm:p-6">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
+            <p className="mt-1 text-xs text-slate-400">
+              제작에 필요한 리소스만 검색하고 선택하세요.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="닫기"
+            className="rounded p-1 text-slate-400 transition-colors hover:bg-slate-800 hover:text-slate-200"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="relative mb-3">
+          <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
+          <input
+            type="text"
+            className="w-full rounded-lg border border-slate-700 bg-slate-950 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+            placeholder="이름, 태그, 종류로 검색"
+            value={searchQuery}
+            onChange={(event) => onSearchQueryChange(event.target.value)}
+            aria-label="미디어 이름 검색"
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto pr-1">
+          {isLoading ? (
+            <div
+              className="py-8 text-center text-sm text-slate-400"
+              role="status"
+            >
+              불러오는 중...
+            </div>
+          ) : resources.length === 0 ? (
+            <div className="py-8 text-center text-sm text-slate-400">
+              {hasQuery ? searchEmptyLabel : emptyLabel}
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {resources.map((resource) => {
+                const isSelected = selectedId === resource.id;
+                return (
+                  <li key={resource.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (resource.isSelectable) onSelect(resource.id);
+                      }}
+                      disabled={!resource.isSelectable}
+                      aria-pressed={isSelected}
+                      className={`flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                        isSelected
+                          ? "border-amber-500/50 bg-amber-500/15"
+                          : "border-slate-800 bg-slate-950 hover:border-slate-700 hover:bg-slate-800"
+                      }`}
+                    >
+                      <MediaTypeIcon type={resource.type} />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="truncate text-sm font-medium text-slate-100">
+                            {resource.name}
+                          </p>
+                          <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300">
+                            {resource.typeLabel}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs text-slate-400">
+                          {resource.unselectableReason ?? resource.metaLabel}
+                        </p>
+                      </div>
+                      {resource.isExternal ? (
+                        <Youtube
+                          className="h-4 w-4 shrink-0 text-rose-500"
+                          aria-label="YouTube"
+                        />
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        {filterHint ? (
+          <p className="mt-3 text-xs text-slate-500">{filterHint}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
@@ -193,7 +193,7 @@ describe("MediaPicker", () => {
     expect(screen.getByText("검색 결과가 없습니다")).toBeDefined();
   });
 
-  it("YOUTUBE source_type 항목에 YouTube 아이콘을 표시한다", () => {
+  it("YOUTUBE source_type 항목에 YouTube 아이콘을 표시하되 raw URL은 노출하지 않는다", () => {
     render(
       <MediaPicker
         open={true}
@@ -203,6 +203,8 @@ describe("MediaPicker", () => {
       />,
     );
     expect(screen.getByLabelText("YouTube")).toBeDefined();
+    expect(screen.queryByText("https://www.youtube.com/watch?v=xyz")).toBeNull();
+    expect(screen.queryByText("https://example.com/bgm.mp3")).toBeNull();
   });
 
   it("selectedId와 일치하는 항목을 강조한다", () => {
@@ -224,6 +226,27 @@ describe("MediaPicker", () => {
       .getByText("오프닝 BGM")
       .closest("button") as HTMLElement;
     expect(otherBtn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("useCase가 맞지 않는 항목은 선택하지 못하게 한다", () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <MediaPicker
+        open={true}
+        onClose={onClose}
+        onSelect={onSelect}
+        themeId="theme-1"
+        useCase="role_sheet_document"
+      />,
+    );
+
+    const bgmItem = screen.getByText("오프닝 BGM").closest("button") as HTMLElement;
+    fireEvent.click(bgmItem);
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getAllByText(/문서 리소스만 선택/).length).toBeGreaterThan(0);
   });
 
   it("로딩 상태를 표시한다", () => {

--- a/apps/web/src/features/editor/components/media/__tests__/ResourcePicker.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/ResourcePicker.test.tsx
@@ -1,0 +1,158 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ResourcePicker } from "../ResourcePicker";
+import type { MediaResourceViewModel } from "@/features/editor/entities/mediaResource/mediaResourceAdapter";
+
+const resources: MediaResourceViewModel[] = [
+  {
+    id: "resource-1",
+    name: "오프닝 BGM",
+    type: "BGM",
+    typeLabel: "배경음악",
+    sourceLabel: "업로드 파일",
+    durationLabel: "2:05",
+    fileSizeLabel: "1.5MB",
+    metaLabel: "배경음악 · 업로드 파일 · 2:05 · 1.5MB",
+    tags: ["오프닝"],
+    isExternal: false,
+    canPreview: true,
+    isSelectable: true,
+    unselectableReason: null,
+  },
+  {
+    id: "resource-2",
+    name: "엔딩 영상",
+    type: "VIDEO",
+    typeLabel: "영상",
+    sourceLabel: "YouTube",
+    durationLabel: null,
+    fileSizeLabel: null,
+    metaLabel: "영상 · YouTube",
+    tags: [],
+    isExternal: true,
+    canPreview: false,
+    isSelectable: false,
+    unselectableReason: "페이즈 배경음악에는 배경음악만 선택할 수 있어요.",
+  },
+];
+
+afterEach(() => cleanup());
+
+describe("ResourcePicker", () => {
+  it("제작자용 리소스 목록과 검색 입력을 렌더링한다", () => {
+    render(
+      <ResourcePicker
+        title="리소스 선택"
+        resources={resources}
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "리소스 선택" })).toBeDefined();
+    expect(screen.getByText("오프닝 BGM")).toBeDefined();
+    expect(screen.getByText("배경음악 · 업로드 파일 · 2:05 · 1.5MB")).toBeDefined();
+    expect(screen.getByLabelText("미디어 이름 검색")).toBeDefined();
+  });
+
+  it("검색어 변경과 닫기 액션을 부모에 전달한다", () => {
+    const onSearchQueryChange = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ResourcePicker
+        title="리소스 선택"
+        resources={resources}
+        searchQuery=""
+        onSearchQueryChange={onSearchQueryChange}
+        onClose={onClose}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("미디어 이름 검색"), {
+      target: { value: "오프닝" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "닫기" }));
+
+    expect(onSearchQueryChange).toHaveBeenCalledWith("오프닝");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("선택 가능한 리소스만 선택 이벤트를 발생시킨다", () => {
+    const onSelect = vi.fn();
+    render(
+      <ResourcePicker
+        title="리소스 선택"
+        resources={resources}
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onClose={vi.fn()}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("오프닝 BGM").closest("button")!);
+    fireEvent.click(screen.getByText("엔딩 영상").closest("button")!);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("resource-1");
+    expect(screen.getByText(/배경음악만 선택/)).toBeDefined();
+  });
+
+  it("외부 리소스에는 YouTube 표시를 보여준다", () => {
+    render(
+      <ResourcePicker
+        title="리소스 선택"
+        resources={resources}
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("YouTube")).toBeDefined();
+  });
+
+  it("빈 상태와 로딩 상태를 사용자 문장으로 표시한다", () => {
+    const { rerender } = render(
+      <ResourcePicker
+        title="리소스 선택"
+        resources={[]}
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("리소스가 없습니다")).toBeDefined();
+
+    rerender(
+      <ResourcePicker
+        title="리소스 선택"
+        resources={[]}
+        searchQuery="abc"
+        onSearchQueryChange={vi.fn()}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("검색 결과가 없습니다")).toBeDefined();
+
+    rerender(
+      <ResourcePicker
+        title="리소스 선택"
+        resources={[]}
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        isLoading={true}
+      />,
+    );
+    expect(screen.getByRole("status").textContent).toContain("불러오는 중...");
+  });
+});

--- a/apps/web/src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts
@@ -94,6 +94,7 @@ describe("mediaResourceAdapter", () => {
     expect(formatMediaFileSize(512)).toBe("512B");
     expect(formatMediaFileSize(20_480)).toBe("20KB");
     expect(formatMediaFileSize(1_572_864)).toBe("1.5MB");
+    expect(formatMediaFileSize(1_048_064)).toBe("1MB");
     expect(formatMediaFileSize(undefined)).toBeNull();
   });
 });

--- a/apps/web/src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import type { MediaResponse } from "@/features/editor/mediaApi";
+import {
+  filterMediaResourceViewModels,
+  formatMediaDuration,
+  formatMediaFileSize,
+  getAllowedMediaTypesForUseCase,
+  isMediaSelectableForUseCase,
+  toMediaResourceViewModel,
+} from "../mediaResourceAdapter";
+
+const baseMedia: MediaResponse = {
+  id: "media-1",
+  theme_id: "theme-1",
+  name: "  오프닝 테마  ",
+  type: "BGM",
+  source_type: "FILE",
+  url: "https://storage.example.com/private/object-key.mp3",
+  duration: 125,
+  file_size: 1_572_864,
+  mime_type: "audio/mpeg",
+  tags: ["오프닝", "긴장"],
+  sort_order: 1,
+  created_at: "2026-05-04T00:00:00Z",
+};
+
+describe("mediaResourceAdapter", () => {
+  it("MediaResponse를 제작자용 ViewModel로 변환하고 raw URL을 노출하지 않는다", () => {
+    const vm = toMediaResourceViewModel(baseMedia, { useCase: "phase_bgm" });
+
+    expect(vm).toMatchObject({
+      id: "media-1",
+      name: "오프닝 테마",
+      typeLabel: "배경음악",
+      sourceLabel: "업로드 파일",
+      durationLabel: "2:05",
+      fileSizeLabel: "1.5MB",
+      isExternal: false,
+      canPreview: true,
+      isSelectable: true,
+      unselectableReason: null,
+    });
+    expect(JSON.stringify(vm)).not.toContain("storage.example.com");
+    expect(JSON.stringify(vm)).not.toContain("object-key");
+  });
+
+  it("사용 위치에 맞지 않는 리소스는 선택 불가 사유를 제공한다", () => {
+    const vm = toMediaResourceViewModel(
+      { ...baseMedia, type: "VIDEO", name: "엔딩 영상" },
+      { useCase: "phase_bgm" },
+    );
+
+    expect(vm.isSelectable).toBe(false);
+    expect(vm.unselectableReason).toContain("배경음악만 선택");
+  });
+
+  it("유스케이스별 허용 타입을 복사본으로 반환한다", () => {
+    const allowed = getAllowedMediaTypesForUseCase("phase_sound_effect");
+    allowed.push("BGM");
+
+    expect(getAllowedMediaTypesForUseCase("phase_sound_effect")).toEqual([
+      "SFX",
+      "VOICE",
+    ]);
+  });
+
+  it("location_image는 현재 미디어 타입으로 직접 선택하지 않도록 막는다", () => {
+    expect(isMediaSelectableForUseCase(baseMedia, "location_image")).toBe(false);
+    const vm = toMediaResourceViewModel(baseMedia, { useCase: "location_image" });
+    expect(vm.unselectableReason).toContain("이미지 업로드 흐름");
+  });
+
+  it("검색어로 이름, 라벨, 태그를 필터링한다", () => {
+    const resources = [
+      toMediaResourceViewModel(baseMedia),
+      toMediaResourceViewModel({
+        ...baseMedia,
+        id: "media-2",
+        name: "문 닫는 소리",
+        type: "SFX",
+        tags: ["문", "효과"],
+      }),
+    ];
+
+    expect(filterMediaResourceViewModels(resources, "효과")).toHaveLength(1);
+    expect(filterMediaResourceViewModels(resources, "배경음악")).toHaveLength(1);
+    expect(filterMediaResourceViewModels(resources, "")).toHaveLength(2);
+  });
+
+  it("시간과 파일 크기를 읽기 쉬운 값으로 포맷한다", () => {
+    expect(formatMediaDuration(0)).toBeNull();
+    expect(formatMediaDuration(65.9)).toBe("1:05");
+    expect(formatMediaFileSize(512)).toBe("512B");
+    expect(formatMediaFileSize(20_480)).toBe("20KB");
+    expect(formatMediaFileSize(1_572_864)).toBe("1.5MB");
+    expect(formatMediaFileSize(undefined)).toBeNull();
+  });
+});

--- a/apps/web/src/features/editor/entities/mediaResource/mediaResourceAdapter.ts
+++ b/apps/web/src/features/editor/entities/mediaResource/mediaResourceAdapter.ts
@@ -1,0 +1,172 @@
+import type {
+  MediaResponse,
+  MediaSourceType,
+  MediaType,
+} from "@/features/editor/mediaApi";
+
+export type MediaResourceUseCase =
+  | "phase_bgm"
+  | "phase_sound_effect"
+  | "role_sheet_document"
+  | "story_voice"
+  | "location_image"
+  | "video_action";
+
+export interface MediaResourceViewModel {
+  id: string;
+  name: string;
+  type: MediaType;
+  typeLabel: string;
+  sourceLabel: string;
+  durationLabel: string | null;
+  fileSizeLabel: string | null;
+  metaLabel: string;
+  tags: string[];
+  isExternal: boolean;
+  canPreview: boolean;
+  isSelectable: boolean;
+  unselectableReason: string | null;
+}
+
+const TYPE_LABEL: Record<MediaType, string> = {
+  BGM: "배경음악",
+  SFX: "효과음",
+  VOICE: "음성/내레이션",
+  VIDEO: "영상",
+  DOCUMENT: "문서",
+};
+
+const SOURCE_LABEL: Record<MediaSourceType, string> = {
+  FILE: "업로드 파일",
+  YOUTUBE: "YouTube",
+};
+
+const USE_CASE_ALLOWED_TYPES: Record<MediaResourceUseCase, MediaType[]> = {
+  phase_bgm: ["BGM"],
+  phase_sound_effect: ["SFX", "VOICE"],
+  role_sheet_document: ["DOCUMENT"],
+  story_voice: ["VOICE", "SFX"],
+  location_image: [],
+  video_action: ["VIDEO"],
+};
+
+const USE_CASE_EMPTY_REASON: Record<MediaResourceUseCase, string> = {
+  phase_bgm: "페이즈 배경음악에는 배경음악만 선택할 수 있어요.",
+  phase_sound_effect: "페이즈 효과에는 효과음 또는 음성/내레이션만 선택할 수 있어요.",
+  role_sheet_document: "롤지 문서에는 PDF 같은 문서 리소스만 선택할 수 있어요.",
+  story_voice: "스토리 음성에는 음성/내레이션 또는 효과음만 선택할 수 있어요.",
+  location_image:
+    "장소 이미지는 현재 이미지 업로드 흐름에서 선택해요. 공통 이미지 리소스는 후속 작업에서 연결합니다.",
+  video_action: "영상 액션에는 영상 리소스만 선택할 수 있어요.",
+};
+
+export function getMediaResourceTypeLabel(type: MediaType): string {
+  return TYPE_LABEL[type];
+}
+
+export function getMediaResourceSourceLabel(sourceType: MediaSourceType): string {
+  return SOURCE_LABEL[sourceType];
+}
+
+export function getAllowedMediaTypesForUseCase(
+  useCase: MediaResourceUseCase,
+): MediaType[] {
+  return [...USE_CASE_ALLOWED_TYPES[useCase]];
+}
+
+export function formatMediaDuration(seconds?: number): string | null {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) return null;
+  const total = Math.floor(seconds);
+  const minutes = Math.floor(total / 60);
+  const rest = total % 60;
+  return `${minutes}:${rest.toString().padStart(2, "0")}`;
+}
+
+export function formatMediaFileSize(bytes?: number): string | null {
+  if (bytes == null || !Number.isFinite(bytes) || bytes <= 0) return null;
+  if (bytes < 1024) return `${Math.round(bytes)}B`;
+  const kib = bytes / 1024;
+  if (kib < 1024) return `${formatCompactNumber(kib)}KB`;
+  return `${formatCompactNumber(kib / 1024)}MB`;
+}
+
+function formatCompactNumber(value: number): string {
+  const rounded = value >= 10 ? Math.round(value) : Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+}
+
+export function isMediaSelectableForUseCase(
+  media: Pick<MediaResponse, "type">,
+  useCase?: MediaResourceUseCase,
+): boolean {
+  if (!useCase) return true;
+  return USE_CASE_ALLOWED_TYPES[useCase].includes(media.type);
+}
+
+export function getMediaResourceUnselectableReason(
+  media: Pick<MediaResponse, "type">,
+  useCase?: MediaResourceUseCase,
+): string | null {
+  if (!useCase || isMediaSelectableForUseCase(media, useCase)) return null;
+  return USE_CASE_EMPTY_REASON[useCase];
+}
+
+export function toMediaResourceViewModel(
+  media: MediaResponse,
+  options: { useCase?: MediaResourceUseCase } = {},
+): MediaResourceViewModel {
+  const durationLabel = formatMediaDuration(media.duration);
+  const fileSizeLabel = formatMediaFileSize(media.file_size);
+  const sourceLabel = getMediaResourceSourceLabel(media.source_type);
+  const typeLabel = getMediaResourceTypeLabel(media.type);
+  const metaParts = [typeLabel, sourceLabel, durationLabel, fileSizeLabel].filter(
+    Boolean,
+  );
+  const isSelectable = isMediaSelectableForUseCase(media, options.useCase);
+
+  return {
+    id: media.id,
+    name: media.name.trim() || "이름 없는 리소스",
+    type: media.type,
+    typeLabel,
+    sourceLabel,
+    durationLabel,
+    fileSizeLabel,
+    metaLabel: metaParts.join(" · "),
+    tags: [...media.tags],
+    isExternal: media.source_type === "YOUTUBE",
+    canPreview: media.type !== "DOCUMENT" && media.source_type === "FILE",
+    isSelectable,
+    unselectableReason: isSelectable
+      ? null
+      : getMediaResourceUnselectableReason(media, options.useCase),
+  };
+}
+
+export function toMediaResourceViewModels(
+  media: MediaResponse[],
+  options: { useCase?: MediaResourceUseCase } = {},
+): MediaResourceViewModel[] {
+  return media.map((item) => toMediaResourceViewModel(item, options));
+}
+
+export function filterMediaResourceViewModels(
+  resources: MediaResourceViewModel[],
+  query: string,
+): MediaResourceViewModel[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return resources;
+
+  return resources.filter((resource) => {
+    const searchable = [
+      resource.name,
+      resource.typeLabel,
+      resource.sourceLabel,
+      resource.metaLabel,
+      ...resource.tags,
+    ]
+      .join(" ")
+      .toLowerCase();
+    return searchable.includes(normalizedQuery);
+  });
+}

--- a/apps/web/src/features/editor/entities/mediaResource/mediaResourceAdapter.ts
+++ b/apps/web/src/features/editor/entities/mediaResource/mediaResourceAdapter.ts
@@ -86,7 +86,8 @@ export function formatMediaFileSize(bytes?: number): string | null {
   if (bytes == null || !Number.isFinite(bytes) || bytes <= 0) return null;
   if (bytes < 1024) return `${Math.round(bytes)}B`;
   const kib = bytes / 1024;
-  if (kib < 1024) return `${formatCompactNumber(kib)}KB`;
+  const kbLabel = formatCompactNumber(kib);
+  if (Number(kbLabel) < 1024) return `${kbLabel}KB`;
   return `${formatCompactNumber(kib / 1024)}MB`;
 }
 

--- a/docs/plans/2026-05-04-issue-263-media-resource-adapter/checklist.md
+++ b/docs/plans/2026-05-04-issue-263-media-resource-adapter/checklist.md
@@ -1,0 +1,42 @@
+# Issue #263 — Media/Effect Resource Adapter 정리
+
+## 목표
+
+BGM, 효과음, 음성/내레이션, 문서(PDF), 영상 리소스를 제작자가 한 가지 방식으로 검색·선택할 수 있게 정리한다. R2 object key, presign URL, raw storage path 같은 백엔드 저장 세부는 UI에 노출하지 않는다.
+
+## Uzu 참고점
+
+- `docs/uzu-studio-docs/basic-features/effect/bgm.md`: BGM은 단계/큐를 조건으로 반복 재생·정지 조건을 관리한다.
+- `docs/uzu-studio-docs/basic-features/effect/se.md`: 효과음/내레이션은 조건 충족 시 1회 재생하며, 큐나 특정 캐릭터 대상 재생이 가능하다.
+- `docs/uzu-studio-docs/basic-features/effect/movie.md`: 영상은 단계/큐/액션에서 재생될 수 있고 스킵 가능 여부 같은 런타임 설정이 붙는다.
+- `docs/uzu-studio-docs/basic-features/texttab.md`: 텍스트/이미지 리소스는 그룹과 전달 조건으로 플레이어에게 배포된다.
+- `docs/uzu-studio-docs/basic-features/effect/background.md`: 배경 이미지는 기본/조건부 리소스와 우선순위가 중요하다.
+
+## MMP 적용 방식
+
+- Uzu의 “리소스 + 조건/사용 위치” 모델을 그대로 복제하지 않고, MMP는 먼저 공통 Resource Adapter/Picker로 제작자 선택 경험을 통일한다.
+- 프론트 어댑터는 `MediaResponse` API DTO를 제작자용 ViewModel로 변환한다.
+- Phase Action, Role Sheet, Story/Reading, Location image 등은 같은 Picker 계약을 재사용하되, 실제 런타임 조건 실행은 후속 백엔드 engine PR에서 소유한다.
+- 이미지 리소스는 현재 `MediaType`에 `IMAGE`가 없으므로 이번 PR에서 새 백엔드 타입을 만들지 않고, 기존 이미지 업로드 흐름과의 연결 지점을 명시한다.
+
+## 제외/후순위
+
+- 전체 미디어 viewer 재작성
+- 영상/효과음 런타임 engine 완성
+- `IMAGE` MediaType 추가 및 R2 이미지 통합 마이그레이션
+- Phase cue/character-specific playback rule 실행
+
+## 작업 체크리스트
+
+- [x] `mediaResourceAdapter` 추가: 타입 라벨, 출처 라벨, duration/file size, 사용 위치별 선택 가능 여부, 검색 필터
+- [x] `ResourcePicker` 순수 컴포넌트 추가: 검색, 선택, 빈 상태, 선택 불가 사유, raw URL/object key 비노출
+- [x] 기존 `MediaPicker`를 `ResourcePicker` 기반으로 정리해 외부 API 유지
+- [x] 어댑터 단위 테스트 추가
+- [x] Resource picker/MediaPicker 컴포넌트 테스트 보강
+- [ ] focused 검증 실행
+
+## 완료 조건
+
+- 제작자 UI에서 backend storage path/object key/public URL을 직접 보여주지 않는다.
+- 새 미디어 선택 UI는 기능별 중복 구현 대신 공통 Resource Picker 계약을 사용한다.
+- 순수 어댑터 테스트와 컴포넌트 테스트로 Codecov patch coverage 70% 이상을 방어한다.


### PR DESCRIPTION
## 요약

- #263 범위로 `MediaResponse`를 제작자용 `MediaResourceViewModel`로 변환하는 프론트 어댑터를 추가했습니다.
- 기존 `MediaPicker`를 공통 `ResourcePicker` 기반으로 정리해 Phase Action, 롤지, 스토리, 영상 액션 같은 후속 화면에서 같은 선택 패턴을 재사용할 수 있게 했습니다.
- 제작자 UI에 R2 object key, presign URL, raw storage path, public URL 문자열이 직접 노출되지 않도록 테스트를 추가했습니다.

## Uzu 참고 / MMP 적용

- Uzu의 BGM/SE/무비/텍스트 탭 문서는 “리소스 + 재생/전달 조건”을 분리해 관리합니다.
- MMP는 이번 PR에서 런타임 실행까지 확장하지 않고, 먼저 제작자가 리소스를 안전하게 선택하는 공통 Adapter/Picker 경계를 마련했습니다.
- 장소 이미지는 현재 `MediaType`에 `IMAGE`가 없어 기존 이미지 업로드 흐름을 유지하고, 공통 이미지 리소스화는 후속 PR로 남겼습니다.

## 검증

- `pnpm --dir apps/web exec vitest run src/features/editor/components/media/__tests__ src/features/editor/entities/mediaResource/__tests__`
- `pnpm --dir apps/web exec eslint src/features/editor/entities/mediaResource/mediaResourceAdapter.ts src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts src/features/editor/components/media/ResourcePicker.tsx src/features/editor/components/media/__tests__/ResourcePicker.test.tsx src/features/editor/components/media/MediaPicker.tsx src/features/editor/components/media/__tests__/MediaPicker.test.tsx`
- `pnpm --dir apps/web exec tsc --noEmit`

## E2E 대체 사유

이번 PR은 새 라우트나 저장 플로우를 추가하지 않고, 기존 `MediaPicker` 내부를 어댑터/순수 컴포넌트로 분리한 변경입니다. 그래서 Playwright E2E 대신 사용자 행동 기반 컴포넌트 테스트로 검색, 선택, 선택 불가, 빈 상태, raw URL 비노출을 검증했습니다. 후속으로 Phase BGM/롤지 PDF 선택 화면에 실제 연결할 때 대표 E2E를 추가합니다.

## CI 운영

- PR 생성 시 `ready-for-ci` 라벨을 붙이지 않습니다.
- CodeRabbit 리뷰를 확인하고 타당한 코멘트를 반영한 뒤, unresolved thread 0 상태에서만 `ready-for-ci`를 붙이겠습니다.

Closes #263


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 통합된 리소스 픽커(UI) 도입: 검색·필터링, 로딩/빈 상태, 선택 힌트가 개선되었습니다
  * 선택 제약을 위한 useCase 지원 및 필터 힌트 표시

* **버그 픽스**
  * YouTube 관련 원문 URL 노출 제거 및 외부 리소스 표시 개선
  * 용도에 맞지 않는 항목은 선택되지 않도록 동작 강화

* **테스트**
  * 픽커·어댑터 관련 단위·통합 테스트 추가 및 보강

* **문서**
  * 미디어 리소스 어댑터 작업 계획 및 체크리스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->