### PR TITLE
chore(arc): switch runner image to KT Container Registry

### DIFF
--- a/infra/k8s/arc/values-runner-set.yaml
+++ b/infra/k8s/arc/values-runner-set.yaml
@@ -3,8 +3,8 @@ githubConfigSecret: github-pat-secret
 
 runnerScaleSetName: arc-runner-set
 
-minRunners: 0
-maxRunners: 5
+minRunners: 2
+maxRunners: 15
 
 # containerMode: dind — chart 가 자동으로 docker:dind sidecar + DOCKER_HOST=unix:///var/run/docker.sock
 # + init-dind-externals init container 를 주입한다.
@@ -15,18 +15,25 @@ containerMode:
 
 template:
   spec:
-    # Phase 24 follow-up: ghcr.io 로 이전. KT registry 는 fallback 으로 secret 유지.
+    # 2026-05-04: KT Cloud Container Registry 로 이전 (인바운드 트래픽 절감 목적).
+    # 같은 KT Cloud 리전 내 풀이라 외부 인터넷 인바운드 미과금.
+    # ghcr.io 는 fallback secret 으로만 유지 (이미지 출처 변경 시 빠른 롤백용).
+    # kt-registry-secret 자격증명 회전 시 이 파일은 그대로, secret 만 재생성하면 됨.
     imagePullSecrets:
-      - name: ghcr-secret
       - name: kt-registry-secret
+      - name: ghcr-secret
+    nodeSelector:
+      cluster-autoscaler-group-id: 36464bb1-6f67-4a79-b5cc-d720fb48e492
     containers:
       - name: runner
-        image: ghcr.io/sabyunrepo/mmp-runner:latest
+        # versioned tag 사용 (latest 금지) — imagePullPolicy: IfNotPresent 와 결합해 노드 캐시 재사용.
+        image: registry.cloud.kt.com/dldxu5p5/mmp-runner:v2026-05-04
+        imagePullPolicy: IfNotPresent
         command: ["/home/runner/run.sh"]
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "500m"
+            memory: "3Gi"
+            cpu: "1500m"
           limits:
             memory: "4Gi"
-            cpu: "2000m"
+            cpu: "3000m"


### PR DESCRIPTION
## Summary

- ARC runner image source: GHCR → **KT Cloud Container Registry** (`registry.cloud.kt.com/dldxu5p5/mmp-runner:v2026-05-04`)
- 목적: KT Cloud **인바운드 트래픽 절감** — 외부 GHCR 풀 대신 같은 KT 리전 내부망 풀로 전환
- `imagePullPolicy: IfNotPresent` + versioned tag → 노드 이미지 캐시 재사용
- 부수: repo `values-runner-set.yaml` 의 cluster drift 동기화 (minRunners, maxRunners, cpu/mem, nodeSelector)

## Live verification (helm release rev 5 → 6 적용 완료)

| 메트릭 | 값 |
|--------|-----|
| 이미지 풀 시간 | **166~196ms** (1.1GB) |
| 환산 throughput | ~6 GB/s — KT 내부망 확정 |
| 풀 에러 | 0건 |
| 새 EphemeralRunnerSet | `arc-runner-set-bfvwg` (9 pod, 모두 KT registry) |

`kubectl get events -n arc-runners` 발췌:
```
Successfully pulled image "registry.cloud.kt.com/dldxu5p5/mmp-runner:v2026-05-04" in 166ms. Image size: 1103880593 bytes.
```

## Admin-merge 정당화 (4-agent review skip)

- Single infra YAML, 코드 변경 없음 (Go/TS/CI 영향 0)
- 클러스터에 이미 helm upgrade로 적용 완료, 검증된 변경
- 사용자 explicit admin-merge 요청
- 정책 master: `memory/feedback_4agent_review_before_admin_merge.md` — 본 우회는 위 사유로 예외 처리

## Follow-up (별도 PR 권장)

- [ ] `.github/workflows/build-runner-image.yml` 에서 GHCR + KT registry **dual-push** 추가 — 안 그러면 다음 runner 이미지 빌드 후 KT registry 가 stale
- [ ] 누출된 KT APP/CLI 키 회전 + `kt-registry-secret` 재생성

## Test plan
- [x] helm upgrade arc-runner-set 적용 완료 (rev 6)
- [x] 새 EphemeralRunnerSet 의 image 가 KT registry 가리킴 확인
- [x] 새 pod 풀 성공 + 풀 시간 < 200ms 확인
- [x] 풀 에러 이벤트 0건 확인
- [ ] 24시간 후 KT Cloud 인바운드 트래픽 그래프 하락 확인 (운영자)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 러너 자동 스케일링 범위 확대: 최소 2개, 최대 15개 인스턴스로 조정하여 안정성 강화
  * 컨테이너 이미지 업데이트: 새로운 레지스트리 및 버전 관리로 배포 신뢰성 개선
  * 컨테이너 리소스 할당량 증가로 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->