### PR TITLE
ci(runner-image): dual-push to GHCR and KT Container Registry

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -39,6 +39,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # KT Cloud Container Registry — primary pull target for arc-runner-set
+      # (intra-region pull, KT 인바운드 트래픽 미과금). GHCR 는 fallback / 외부 협업용.
+      # 자격증명 회전 시 KT_REGISTRY_USERNAME / KT_REGISTRY_PASSWORD secret 도 갱신 필수.
+      - name: Login to KT Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: registry.cloud.kt.com
+          username: ${{ secrets.KT_REGISTRY_USERNAME }}
+          password: ${{ secrets.KT_REGISTRY_PASSWORD }}
       - name: Build image
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
@@ -48,6 +58,8 @@ jobs:
           tags: |
             ghcr.io/sabyunrepo/mmp-runner:latest
             ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }}
+            registry.cloud.kt.com/dldxu5p5/mmp-runner:latest
+            registry.cloud.kt.com/dldxu5p5/mmp-runner:${{ github.sha }}
           cache-from: type=gha,scope=runner-image
           cache-to: type=gha,mode=max,scope=runner-image
           load: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

[#268](../pull/268) 후속 — runner image 빌드 시 KT Container Registry에도 자동 푸시.

- GHCR 단일 푸시 → **GHCR + KT registry dual-push**
- 안 하면 다음 runner image 빌드 시 KT registry 이미지가 stale되어 PR #268 의 인바운드 절감 효과가 조용히 사라짐

## Changes

`.github/workflows/build-runner-image.yml`:
- KT registry login step 추가 (`docker/login-action`)
- `build-push-action` tags 에 KT registry 2개 태그 추가 (latest + sha)
- buildx가 단일 빌드에서 양쪽 레지스트리에 병렬 푸시

## Required GitHub Secrets (이미 등록 완료)

- `KT_REGISTRY_USERNAME`
- `KT_REGISTRY_PASSWORD`

자격증명 회전 시 이 secret들도 같이 재설정 필요.

## Admin-merge 정당화

- Single CI workflow 변경, 코드/인프라 영향 0
- PR #268 후속으로 빠른 머지 필요 (안 머지되면 다음 runner build 시 회귀)
- 사용자 explicit admin-merge 요청
- 정책 master: `memory/feedback_4agent_review_before_admin_merge.md`

## Test plan
- [x] yaml 문법 검증 (gh action linter는 머지 후 자동 실행)
- [ ] 머지 후 runner image 변경 PR 또는 manual `workflow_dispatch` 로 dual-push 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 추가 컨테이너 레지스트리에 대한 배포 지원 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->