### PR TITLE
feat(editor): 미션 Adapter/Engine 경계 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/MissionEditor.tsx
+++ b/apps/web/src/features/editor/components/design/MissionEditor.tsx
@@ -116,7 +116,7 @@ function MissionCard({
         placeholder="미션 설명"
         className="mb-2 w-full rounded bg-slate-800 px-2 py-1 text-xs text-slate-300 placeholder-slate-600"
       />
-      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+      <div className="mb-2 grid gap-2 text-xs text-slate-500 sm:grid-cols-2">
         <label className="flex items-center gap-2">
           <span>포인트:</span>
           <input
@@ -126,9 +126,24 @@ function MissionCard({
             className="w-16 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
           />
         </label>
-        <span className="rounded-full bg-slate-800 px-2 py-0.5 text-slate-400">
-          {viewModel.resultVisibilityLabel}
-        </span>
+        <label className="flex items-center gap-2">
+          <span>판정:</span>
+          <select
+            value={viewModel.verification}
+            onChange={(e) => onChange(mission.id, 'verification', e.target.value)}
+            className="min-w-0 flex-1 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
+            aria-label="미션 판정 방식"
+          >
+            <option value="auto">자동 판정</option>
+            <option value="self_report">플레이어 신고</option>
+            <option value="gm_verify">진행자 확인</option>
+          </select>
+        </label>
+      </div>
+      <div className="mb-2 flex flex-wrap gap-2 text-[11px] text-slate-400">
+        <span className="rounded-full bg-slate-800 px-2 py-0.5">{viewModel.resultVisibilityLabel}</span>
+        <span className="rounded-full bg-slate-800 px-2 py-0.5">{viewModel.verificationLabel}</span>
+        <span className="rounded-full bg-slate-800 px-2 py-0.5">{viewModel.engineOwnerLabel}</span>
       </div>
       <MissionTypeFields
         mission={mission}

--- a/apps/web/src/features/editor/components/design/MissionEditor.tsx
+++ b/apps/web/src/features/editor/components/design/MissionEditor.tsx
@@ -2,6 +2,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { MissionTypeFields } from './MissionTypeFields';
 import {
   MISSION_TYPES,
+  getMissionVerificationOptions,
   toMissionViewModel,
   type Mission,
   type MissionEditorCharacter,
@@ -82,6 +83,7 @@ function MissionCard({
   onDelete: (missionId: string) => void;
 }) {
   const viewModel = toMissionViewModel(mission);
+  const verificationOptions = getMissionVerificationOptions(viewModel.runtimeType);
   const descriptionId = `mission-description-${mission.id}`;
   return (
     <div className="rounded border border-slate-800 bg-slate-900 p-3">
@@ -134,9 +136,11 @@ function MissionCard({
             className="min-w-0 flex-1 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
             aria-label="미션 판정 방식"
           >
-            <option value="auto">자동 판정</option>
-            <option value="self_report">플레이어 신고</option>
-            <option value="gm_verify">진행자 확인</option>
+            {verificationOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
           </select>
         </label>
       </div>

--- a/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
@@ -113,6 +113,25 @@ describe('MissionEditor', () => {
     expect(onDelete).toHaveBeenCalled();
   });
 
+  it('결과 공개 시점과 백엔드 판정 경계를 제작자용 문구로 표시한다', () => {
+    const onChange = vi.fn();
+    render(
+      <MissionEditor
+        missions={[baseMission({ type: 'secret' })]}
+        onAdd={noop}
+        onChange={onChange}
+        onDelete={noop}
+      />,
+    );
+
+    expect(screen.getByText('결과 화면에서만 공개')).toBeDefined();
+    expect(screen.getAllByText('플레이어 신고').length).toBeGreaterThan(0);
+    expect(screen.getByText('게임 판정은 백엔드가 담당')).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText('미션 판정 방식'), { target: { value: 'gm_verify' } });
+    expect(onChange).toHaveBeenCalledWith('mission-1', 'verification', 'gm_verify');
+  });
+
   it('MISSION_TYPES에 kill/possess/secret/protect가 포함된다', () => {
     render(
       <MissionEditor

--- a/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
@@ -132,6 +132,24 @@ describe('MissionEditor', () => {
     expect(onChange).toHaveBeenCalledWith('mission-1', 'verification', 'gm_verify');
   });
 
+  it('수동 판정 미션에서는 자동 판정을 선택지에서 숨긴다', () => {
+    render(
+      <MissionEditor
+        missions={[baseMission({ type: 'secret', verification: 'auto' })]}
+        onAdd={noop}
+        onChange={noop}
+        onDelete={noop}
+      />,
+    );
+
+    const select = screen.getByLabelText('미션 판정 방식') as HTMLSelectElement;
+    expect(select.value).toBe('self_report');
+    expect(Array.from(select.options).map((option) => option.value)).toEqual([
+      'self_report',
+      'gm_verify',
+    ]);
+  });
+
   it('MISSION_TYPES에 kill/possess/secret/protect가 포함된다', () => {
     render(
       <MissionEditor

--- a/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createMissionDraft,
   readCharacterMissionMap,
+  toMissionEngineContractDraft,
   toMissionRuntimeDraft,
   toMissionViewModel,
   writeCharacterMissionMap,
@@ -48,6 +49,8 @@ describe("missionAdapter", () => {
       description: "단서를 가진다",
       points: 7,
       verification: "auto",
+      resultVisibility: "result_only",
+      engineOwner: "backend_engine",
       targetClueId: "clue-1",
     });
   });
@@ -60,6 +63,8 @@ describe("missionAdapter", () => {
     expect(runtime).toEqual(expect.objectContaining({
       type: "hold_clue",
       verification: "auto",
+      resultVisibility: "result_only",
+      engineOwner: "backend_engine",
     }));
     vi.restoreAllMocks();
   });
@@ -70,11 +75,40 @@ describe("missionAdapter", () => {
       title: "미션 내용을 입력해 주세요",
       typeLabel: "살해",
       pointsLabel: "점수 없음",
-      resultVisibilityLabel: "결과 화면에서 공개",
+      resultVisibilityLabel: "결과 화면에서만 공개",
       runtimeType: "vote_target",
+      verification: "auto",
+      verificationLabel: "자동 판정",
+      engineOwnerLabel: "게임 판정은 백엔드가 담당",
       warnings: [
         "플레이어가 이해할 미션 내용을 입력해 주세요.",
         "투표형 미션은 대상 캐릭터를 선택해야 자동 판정할 수 있습니다.",
+      ],
+    });
+  });
+
+  it("캐릭터별 미션을 백엔드 엔진 후보 계약으로 요약한다", () => {
+    expect(toMissionEngineContractDraft({
+      "char-1": [
+        { id: "m1", type: "possess", description: "편지를 가진다", points: 5, targetClueId: "clue-1" },
+        { id: "m2", type: "secret", description: "비밀을 지킨다", points: 0 },
+      ],
+      "char-empty": [],
+    })).toEqual({
+      moduleId: "hidden_mission",
+      resultVisibility: "result_only",
+      engineOwner: "backend_engine",
+      assignments: [
+        {
+          characterId: "char-1",
+          totalPoints: 5,
+          autoVerifiableCount: 1,
+          manualReviewCount: 1,
+          missions: [
+            expect.objectContaining({ id: "m1", type: "hold_clue", verification: "auto" }),
+            expect.objectContaining({ id: "m2", type: "custom", verification: "self_report" }),
+          ],
+        },
       ],
     });
   });

--- a/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createMissionDraft,
+  getMissionVerificationOptions,
   readCharacterMissionMap,
   toMissionEngineContractDraft,
   toMissionRuntimeDraft,
@@ -67,6 +68,47 @@ describe("missionAdapter", () => {
       engineOwner: "backend_engine",
     }));
     vi.restoreAllMocks();
+  });
+
+  it("custom 런타임은 저장값이 auto여도 수동 판정으로 정규화한다", () => {
+    const runtime = toMissionRuntimeDraft({
+      id: "m-custom",
+      type: "secret",
+      description: "비밀을 지킨다",
+      points: 3,
+      verification: "auto",
+    });
+
+    expect(runtime).toEqual(expect.objectContaining({
+      type: "custom",
+      verification: "self_report",
+    }));
+    expect(toMissionEngineContractDraft({
+      "char-1": [
+        {
+          id: "m-custom",
+          type: "secret",
+          description: "비밀을 지킨다",
+          points: 3,
+          verification: "auto",
+        },
+      ],
+    }).assignments[0]).toEqual(expect.objectContaining({
+      autoVerifiableCount: 0,
+      manualReviewCount: 1,
+    }));
+  });
+
+  it("판정 방식 선택지는 runtime 타입에 맞게 제한한다", () => {
+    expect(getMissionVerificationOptions("custom").map((option) => option.value)).toEqual([
+      "self_report",
+      "gm_verify",
+    ]);
+    expect(getMissionVerificationOptions("hold_clue").map((option) => option.value)).toEqual([
+      "auto",
+      "self_report",
+      "gm_verify",
+    ]);
   });
 
   it("제작자가 이해할 요약과 자동 판정 경고를 만든다", () => {

--- a/apps/web/src/features/editor/entities/mission/missionAdapter.ts
+++ b/apps/web/src/features/editor/entities/mission/missionAdapter.ts
@@ -92,6 +92,9 @@ const VERIFICATION_LABELS: Record<MissionVerification, string> = {
   gm_verify: "진행자 확인",
 };
 
+const MANUAL_VERIFICATIONS: MissionVerification[] = ["self_report", "gm_verify"];
+const AUTO_VERIFICATIONS: MissionVerification[] = ["auto", ...MANUAL_VERIFICATIONS];
+
 function isRecord(value: unknown): value is EditorConfig {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -157,6 +160,13 @@ export function getMissionTypeLabel(type: string): string {
   return MISSION_TYPE_LABELS[type] ?? "직접 설정";
 }
 
+export function getMissionVerificationOptions(
+  runtimeType: MissionRuntimeType,
+): Array<{ value: MissionVerification; label: string }> {
+  const values = runtimeType === "custom" ? MANUAL_VERIFICATIONS : AUTO_VERIFICATIONS;
+  return values.map((value) => ({ value, label: VERIFICATION_LABELS[value] }));
+}
+
 export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
   const runtimeType = toRuntimeType(mission);
   return {
@@ -164,9 +174,7 @@ export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
     type: runtimeType,
     description: mission.description.trim(),
     points: Math.max(0, Math.trunc(mission.points || 0)),
-    verification: isMissionVerification(mission.verification)
-      ? mission.verification
-      : defaultVerification(runtimeType),
+    verification: normalizeVerificationForRuntime(runtimeType, mission.verification),
     resultVisibility: "result_only",
     engineOwner: "backend_engine",
     ...(mission.targetCharacterId ? { targetCharacterId: mission.targetCharacterId } : {}),
@@ -225,6 +233,21 @@ function toRuntimeType(mission: Mission): MissionRuntimeType {
 
 function defaultVerification(runtimeType: MissionRuntimeType): MissionVerification {
   return runtimeType === "custom" ? "self_report" : "auto";
+}
+
+function normalizeVerificationForRuntime(
+  runtimeType: MissionRuntimeType,
+  verification: unknown,
+): MissionVerification {
+  const normalized = isMissionVerification(verification)
+    ? verification
+    : defaultVerification(runtimeType);
+
+  if (runtimeType === "custom" && normalized === "auto") {
+    return "self_report";
+  }
+
+  return normalized;
 }
 
 function buildMissionWarnings(mission: Mission, runtimeDraft: MissionRuntimeDraft): string[] {

--- a/apps/web/src/features/editor/entities/mission/missionAdapter.ts
+++ b/apps/web/src/features/editor/entities/mission/missionAdapter.ts
@@ -6,6 +6,8 @@ export const LEGACY_CHARACTER_MISSIONS_KEY = "character_missions";
 export type MissionCreatorType = "kill" | "possess" | "secret" | "protect";
 export type MissionRuntimeType = "hold_clue" | "vote_target" | "transfer_clue" | "survive" | "custom";
 export type MissionVerification = "auto" | "self_report" | "gm_verify";
+export type MissionResultVisibility = "result_only";
+export type MissionRuntimeOwner = "backend_engine";
 
 export interface Mission {
   id: string;
@@ -39,6 +41,9 @@ export interface MissionViewModel {
   pointsLabel: string;
   resultVisibilityLabel: string;
   runtimeType: MissionRuntimeType;
+  verification: MissionVerification;
+  verificationLabel: string;
+  engineOwnerLabel: string;
   warnings: string[];
 }
 
@@ -48,9 +53,26 @@ export interface MissionRuntimeDraft {
   description: string;
   points: number;
   verification: MissionVerification;
+  resultVisibility: MissionResultVisibility;
+  engineOwner: MissionRuntimeOwner;
   targetCharacterId?: string;
   targetClueId?: string;
   condition?: string;
+}
+
+export interface MissionEngineAssignmentDraft {
+  characterId: string;
+  missions: MissionRuntimeDraft[];
+  totalPoints: number;
+  autoVerifiableCount: number;
+  manualReviewCount: number;
+}
+
+export interface MissionEngineContractDraft {
+  moduleId: typeof HIDDEN_MISSION_MODULE_ID;
+  resultVisibility: MissionResultVisibility;
+  engineOwner: MissionRuntimeOwner;
+  assignments: MissionEngineAssignmentDraft[];
 }
 
 export const MISSION_TYPES: Array<{ value: MissionCreatorType; label: string }> = [
@@ -64,8 +86,18 @@ const MISSION_TYPE_LABELS: Record<string, string> = Object.fromEntries(
   MISSION_TYPES.map((type) => [type.value, type.label]),
 );
 
+const VERIFICATION_LABELS: Record<MissionVerification, string> = {
+  auto: "자동 판정",
+  self_report: "플레이어 신고",
+  gm_verify: "진행자 확인",
+};
+
 function isRecord(value: unknown): value is EditorConfig {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isMissionVerification(value: unknown): value is MissionVerification {
+  return value === "auto" || value === "self_report" || value === "gm_verify";
 }
 
 function normalizeMission(value: unknown, index: number): Mission | null {
@@ -86,9 +118,7 @@ function normalizeMission(value: unknown, index: number): Mission | null {
     ...(typeof value.secretContent === "string" ? { secretContent: value.secretContent } : {}),
     ...(typeof value.penalty === "number" ? { penalty: value.penalty } : {}),
     ...(typeof value.difficulty === "number" ? { difficulty: value.difficulty } : {}),
-    ...(value.verification === "auto" || value.verification === "self_report" || value.verification === "gm_verify"
-      ? { verification: value.verification }
-      : {}),
+    ...(isMissionVerification(value.verification) ? { verification: value.verification } : {}),
   };
 }
 
@@ -134,10 +164,38 @@ export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
     type: runtimeType,
     description: mission.description.trim(),
     points: Math.max(0, Math.trunc(mission.points || 0)),
-    verification: mission.verification ?? defaultVerification(runtimeType),
+    verification: isMissionVerification(mission.verification)
+      ? mission.verification
+      : defaultVerification(runtimeType),
+    resultVisibility: "result_only",
+    engineOwner: "backend_engine",
     ...(mission.targetCharacterId ? { targetCharacterId: mission.targetCharacterId } : {}),
     ...(mission.targetClueId ? { targetClueId: mission.targetClueId } : {}),
     ...(mission.condition ? { condition: mission.condition } : {}),
+  };
+}
+
+export function toMissionEngineContractDraft(
+  missionsByCharacter: Record<string, Mission[]>,
+): MissionEngineContractDraft {
+  const assignments = Object.entries(missionsByCharacter)
+    .map(([characterId, missions]) => {
+      const runtimeMissions = missions.map(toMissionRuntimeDraft);
+      return {
+        characterId,
+        missions: runtimeMissions,
+        totalPoints: runtimeMissions.reduce((sum, mission) => sum + mission.points, 0),
+        autoVerifiableCount: runtimeMissions.filter((mission) => mission.verification === "auto").length,
+        manualReviewCount: runtimeMissions.filter((mission) => mission.verification !== "auto").length,
+      };
+    })
+    .filter((assignment) => assignment.missions.length > 0);
+
+  return {
+    moduleId: HIDDEN_MISSION_MODULE_ID,
+    resultVisibility: "result_only",
+    engineOwner: "backend_engine",
+    assignments,
   };
 }
 
@@ -149,8 +207,11 @@ export function toMissionViewModel(mission: Mission): MissionViewModel {
     title: mission.description.trim() || "미션 내용을 입력해 주세요",
     typeLabel: getMissionTypeLabel(mission.type),
     pointsLabel: runtimeDraft.points > 0 ? `${runtimeDraft.points}점` : "점수 없음",
-    resultVisibilityLabel: "결과 화면에서 공개",
+    resultVisibilityLabel: "결과 화면에서만 공개",
     runtimeType: runtimeDraft.type,
+    verification: runtimeDraft.verification,
+    verificationLabel: VERIFICATION_LABELS[runtimeDraft.verification],
+    engineOwnerLabel: "게임 판정은 백엔드가 담당",
     warnings,
   };
 }

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-261-mission-adapter-engine.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-261-mission-adapter-engine.md
@@ -1,0 +1,40 @@
+# Issue #261 — Mission Adapter/Engine 경계 정리
+
+## 원인
+
+Uzu의 미션 기능은 캐릭터별 목표를 만들고, 조건을 만족하면 자동으로 판정하며, 점수는 종료 후 감상/결과 화면에서 보여주는 구조다. MMP에도 `hidden_mission` 모듈과 캐릭터별 `character_missions` 설정이 있지만, 제작자 UI와 런타임 엔진의 책임 경계가 흐려지면 플레이 중 스포일러 노출이나 프론트 단독 판정 문제가 생길 수 있다.
+
+## Uzu 참고점
+
+- 캐릭터별 미션을 추가한다.
+- 미션에는 내용, 달성 조건, 점수가 있다.
+- 미션 내용은 플레이 중 자동 배포되지 않는다.
+- 달성 여부와 점수는 결과/감상 공유 화면에서 확인한다.
+
+## MMP 적용 방식
+
+- 제작자 UI는 미션 내용, 점수, 판정 방식, 대상 캐릭터/단서만 보여준다.
+- 내부 module key, raw JSON, player UUID 매핑은 기본 UI에 노출하지 않는다.
+- 프론트 Adapter는 제작자용 `MissionViewModel`과 백엔드 후보 계약 `MissionEngineContractDraft`를 만든다.
+- 백엔드 `hidden_mission` 모듈은 실제 달성 판정, 점수 계산, player-aware 결과 공개를 담당한다.
+- 캐릭터 ID → 실제 플레이어 UUID 매핑은 런타임 세션 배정 이후 백엔드가 소유한다.
+
+## 이번 PR 범위
+
+- `missionAdapter`에 결과 공개 시점과 백엔드 판정 owner를 명시한다.
+- 캐릭터별 미션을 엔진 후보 계약으로 요약하는 `toMissionEngineContractDraft`를 추가한다.
+- `MissionEditor`에서 제작자가 판정 방식을 선택할 수 있게 하고, “결과 화면에서만 공개 / 게임 판정은 백엔드 담당”을 제작자용 문구로 보여준다.
+- Adapter/component test를 보강한다.
+
+## 제외 범위
+
+- 미션 런타임 대규모 재작성.
+- 종료 화면 전체 리디자인.
+- 캐릭터 ID → 플레이어 UUID 세션 매핑 구현.
+- 미션 달성 조건 DSL 전체 재설계.
+
+## 완료 조건
+
+- 제작자 UI와 runtime engine 경계가 타입과 문서에 남는다.
+- 미션 결과는 결과 화면 공개 전 플레이어 전체에게 노출되지 않는다는 경계가 유지된다.
+- 후속 Mission Engine 구현자가 어떤 payload를 받아야 하는지 알 수 있다.


### PR DESCRIPTION
## 목표

#261 Mission Adapter/Engine 경계를 정리합니다.

## 변경 내용

- Mission Adapter에 백엔드 엔진 후보 계약 `MissionEngineContractDraft` 추가
- 미션 결과 공개 정책을 `result_only`로 명시
- 미션 판정 owner를 `backend_engine`으로 명시
- `MissionEditor`에서 판정 방식 선택 UI 추가
- 제작자에게 내부 키 대신 다음 문구를 표시
  - 결과 화면에서만 공개
  - 자동 판정 / 플레이어 신고 / 진행자 확인
  - 게임 판정은 백엔드가 담당
- Uzu 참고점과 MMP 적용/제외 범위를 문서화

## 검증

- `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/mission/__tests__/missionAdapter.test.ts src/features/editor/components/design/__tests__/MissionEditor.test.tsx`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `git diff --check`

## E2E 관련

이번 변경은 기존 미션 컴포넌트 내부의 Adapter/ViewModel/표시 문구 보강이며 신규 라우트나 저장 플로우 변경은 없습니다. 따라서 Playwright E2E 대신 Mission Adapter unit test와 MissionEditor component test로 대체했습니다.

Closes #261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 미션에 판정 방식 선택(판정 드롭다운) 추가 및 판정 상태 반영
  * 미션 카드에 판정 라벨과 엔진 소유자 라벨 표시 확대

* **UI 개선**
  * 포인트/판정 입력 영역을 반응형 2열 그리드로 변경
  * 상태 표시(결과 공개/판정/엔진 소유자)용 표시 요소 스타일 개선

* **Tests**
  * 미션 판정 관련 동작 및 뷰모델 표현에 대한 테스트 보강

* **Documentation**
  * 에디터와 런타임 엔진 책임 경계 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->