### PR TITLE
feat(runtime): 장소 조사 단서 발견 계약 추가

### DIFF
--- a/apps/server/internal/module/crime_scene/location.go
+++ b/apps/server/internal/module/crime_scene/location.go
@@ -25,22 +25,36 @@ type LocationDef struct {
 	AccessRules []string `json:"accessRules"`
 }
 
+// LocationClueDiscovery defines a runtime-owned clue discovery candidate for a
+// location. The editor adapter may expose this as "이 장소를 조사하면 발견할 단서"
+// but the backend engine owns idempotency and player-aware state.
+type LocationClueDiscovery struct {
+	ID              string   `json:"id,omitempty"`
+	LocationID      string   `json:"locationId"`
+	ClueID          string   `json:"clueId"`
+	RequiredClueIDs []string `json:"requiredClueIds,omitempty"`
+	OncePerPlayer   bool     `json:"oncePerPlayer"`
+}
+
 // LocationConfig defines settings for the location module.
 type LocationConfig struct {
-	Locations    []LocationDef `json:"locations"`
-	StartingLoc  string        `json:"startingLocation"`
-	MoveCooldown int           `json:"moveCooldownSec"` // 0 = no cooldown
+	Locations    []LocationDef           `json:"locations"`
+	StartingLoc  string                  `json:"startingLocation"`
+	MoveCooldown int                     `json:"moveCooldownSec"` // 0 = no cooldown
+	Discoveries  []LocationClueDiscovery `json:"discoveries,omitempty"`
 }
 
 // LocationModule tracks player positions and movement within the crime scene.
 type LocationModule struct {
-	mu          sync.RWMutex
-	deps        engine.ModuleDeps
-	config      LocationConfig
-	locationSet map[string]LocationDef
-	positions   map[uuid.UUID]string
-	history     map[uuid.UUID][]string
-	lastMove    map[uuid.UUID]time.Time
+	mu                    sync.RWMutex
+	deps                  engine.ModuleDeps
+	config                LocationConfig
+	locationSet           map[string]LocationDef
+	discoveriesByLocation map[string][]LocationClueDiscovery
+	positions             map[uuid.UUID]string
+	history               map[uuid.UUID][]string
+	discoveredClues       map[uuid.UUID][]string
+	lastMove              map[uuid.UUID]time.Time
 }
 
 // NewLocationModule creates a new LocationModule instance.
@@ -61,6 +75,8 @@ func (m *LocationModule) Init(_ context.Context, deps engine.ModuleDeps, config 
 	m.history = make(map[uuid.UUID][]string)
 	m.lastMove = make(map[uuid.UUID]time.Time)
 	m.locationSet = make(map[string]LocationDef)
+	m.discoveriesByLocation = make(map[string][]LocationClueDiscovery)
+	m.discoveredClues = make(map[uuid.UUID][]string)
 
 	if len(config) > 0 {
 		if err := json.Unmarshal(config, &m.config); err != nil {
@@ -80,7 +96,34 @@ func (m *LocationModule) Init(_ context.Context, deps engine.ModuleDeps, config 
 			return fmt.Errorf("location: startingLocation %q not found", m.config.StartingLoc)
 		}
 	}
+	if err := m.initDiscoveriesLocked(); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+func (m *LocationModule) initDiscoveriesLocked() error {
+	for _, discovery := range m.config.Discoveries {
+		if discovery.LocationID == "" {
+			return fmt.Errorf("location: discovery missing locationId")
+		}
+		if _, ok := m.locationSet[discovery.LocationID]; !ok {
+			return fmt.Errorf("location: discovery location %q not found", discovery.LocationID)
+		}
+		if discovery.ClueID == "" {
+			return fmt.Errorf("location: discovery at %q missing clueId", discovery.LocationID)
+		}
+		// Default to one discovery per player. Re-discoverable clues require a
+		// future explicit repeat policy rather than relying on the bool zero value.
+		if !discovery.OncePerPlayer {
+			discovery.OncePerPlayer = true
+		}
+		m.discoveriesByLocation[discovery.LocationID] = append(
+			m.discoveriesByLocation[discovery.LocationID],
+			discovery,
+		)
+	}
 	return nil
 }
 
@@ -143,28 +186,88 @@ func (m *LocationModule) handleExamine(_ context.Context, playerID uuid.UUID, pa
 		return fmt.Errorf("location: invalid examine payload: %w", err)
 	}
 
-	m.mu.RLock()
-	_, ok := m.locationSet[p.LocationID]
-	m.mu.RUnlock()
-
-	if !ok {
+	m.mu.Lock()
+	if _, ok := m.locationSet[p.LocationID]; !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("location: invalid examine: location %q not found", p.LocationID)
 	}
+	discovered := m.discoverCluesLocked(playerID, p.LocationID)
+	m.mu.Unlock()
 
 	m.deps.EventBus.Publish(engine.Event{
 		Type: "location.examined",
 		Payload: map[string]any{
-			"playerID":   playerID,
-			"locationID": p.LocationID,
+			"playerID":          playerID,
+			"locationID":        p.LocationID,
+			"discoveredClueIDs": discovered,
 		},
 	})
+	for _, clueID := range discovered {
+		m.deps.EventBus.Publish(engine.Event{
+			Type: "location.clue_discovered",
+			Payload: map[string]any{
+				"playerID":   playerID,
+				"locationID": p.LocationID,
+				"clueID":     clueID,
+			},
+		})
+		m.deps.EventBus.Publish(engine.Event{
+			Type: "clue.acquired",
+			Payload: map[string]any{
+				"playerId":   playerID.String(),
+				"clueId":     clueID,
+				"locationId": p.LocationID,
+				"source":     "location_discovery",
+			},
+		})
+	}
 	return nil
+}
+
+func (m *LocationModule) discoverCluesLocked(playerID uuid.UUID, locationID string) []string {
+	candidates := m.discoveriesByLocation[locationID]
+	if len(candidates) == 0 {
+		return nil
+	}
+	discovered := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if !m.discoveryRequirementsMetLocked(playerID, candidate.RequiredClueIDs) {
+			continue
+		}
+		if candidate.OncePerPlayer && playerHasDiscoveredClue(m.discoveredClues[playerID], candidate.ClueID) {
+			continue
+		}
+		if !playerHasDiscoveredClue(m.discoveredClues[playerID], candidate.ClueID) {
+			m.discoveredClues[playerID] = append(m.discoveredClues[playerID], candidate.ClueID)
+		}
+		discovered = append(discovered, candidate.ClueID)
+	}
+	return discovered
+}
+
+func (m *LocationModule) discoveryRequirementsMetLocked(playerID uuid.UUID, requiredClueIDs []string) bool {
+	for _, clueID := range requiredClueIDs {
+		if !playerHasDiscoveredClue(m.discoveredClues[playerID], clueID) {
+			return false
+		}
+	}
+	return true
+}
+
+func playerHasDiscoveredClue(clues []string, clueID string) bool {
+	for _, ownedID := range clues {
+		if ownedID == clueID {
+			return true
+		}
+	}
+	return false
 }
 
 // locationState is the serialisable snapshot of location positions and history.
 type locationState struct {
-	Positions map[string]string   `json:"positions"`
-	History   map[string][]string `json:"history"`
+	Positions       map[string]string   `json:"positions"`
+	History         map[string][]string `json:"history"`
+	DiscoveredClues map[string][]string `json:"discoveredClues"`
 }
 
 func (m *LocationModule) snapshot() locationState {
@@ -178,7 +281,13 @@ func (m *LocationModule) snapshot() locationState {
 		copy(cp, locs)
 		history[pid.String()] = cp
 	}
-	return locationState{Positions: positions, History: history}
+	discoveredClues := make(map[string][]string, len(m.discoveredClues))
+	for pid, clueIDs := range m.discoveredClues {
+		cp := make([]string, len(clueIDs))
+		copy(cp, clueIDs)
+		discoveredClues[pid.String()] = cp
+	}
+	return locationState{Positions: positions, History: history, DiscoveredClues: discoveredClues}
 }
 
 // BuildState returns the module's current state for client sync.
@@ -196,8 +305,10 @@ func (m *LocationModule) Cleanup(_ context.Context) error {
 
 	m.positions = nil
 	m.history = nil
+	m.discoveredClues = nil
 	m.lastMove = nil
 	m.locationSet = nil
+	m.discoveriesByLocation = nil
 	return nil
 }
 
@@ -285,6 +396,16 @@ func (m *LocationModule) RestoreState(_ context.Context, _ uuid.UUID, state engi
 		copy(cp, locs)
 		m.history[pid] = cp
 	}
+	m.discoveredClues = make(map[uuid.UUID][]string, len(s.DiscoveredClues))
+	for pidStr, clueIDs := range s.DiscoveredClues {
+		pid, err := uuid.Parse(pidStr)
+		if err != nil {
+			return fmt.Errorf("location: restore state: invalid discovered playerID %q: %w", pidStr, err)
+		}
+		cp := make([]string, len(clueIDs))
+		copy(cp, clueIDs)
+		m.discoveredClues[pid] = cp
+	}
 	return nil
 }
 
@@ -329,7 +450,17 @@ func (m *LocationModule) BuildStateFor(playerID uuid.UUID) (json.RawMessage, err
 		copy(cp, locs)
 		history[playerID.String()] = cp
 	}
-	return json.Marshal(locationState{Positions: positions, History: history})
+	discoveredClues := make(map[string][]string, 1)
+	if clueIDs, ok := m.discoveredClues[playerID]; ok {
+		cp := make([]string, len(clueIDs))
+		copy(cp, clueIDs)
+		discoveredClues[playerID.String()] = cp
+	}
+	return json.Marshal(locationState{
+		Positions:       positions,
+		History:         history,
+		DiscoveredClues: discoveredClues,
+	})
 }
 
 // Compile-time interface assertions.

--- a/apps/server/internal/module/crime_scene/location.go
+++ b/apps/server/internal/module/crime_scene/location.go
@@ -186,13 +186,10 @@ func (m *LocationModule) handleExamine(_ context.Context, playerID uuid.UUID, pa
 		return fmt.Errorf("location: invalid examine payload: %w", err)
 	}
 
-	m.mu.Lock()
-	if _, ok := m.locationSet[p.LocationID]; !ok {
-		m.mu.Unlock()
-		return fmt.Errorf("location: invalid examine: location %q not found", p.LocationID)
+	discovered, err := m.discoverCluesForExamine(playerID, p.LocationID)
+	if err != nil {
+		return err
 	}
-	discovered := m.discoverCluesLocked(playerID, p.LocationID)
-	m.mu.Unlock()
 
 	m.deps.EventBus.Publish(engine.Event{
 		Type: "location.examined",
@@ -222,6 +219,16 @@ func (m *LocationModule) handleExamine(_ context.Context, playerID uuid.UUID, pa
 		})
 	}
 	return nil
+}
+
+func (m *LocationModule) discoverCluesForExamine(playerID uuid.UUID, locationID string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.locationSet[locationID]; !ok {
+		return nil, fmt.Errorf("location: invalid examine: location %q not found", locationID)
+	}
+	return m.discoverCluesLocked(playerID, locationID), nil
 }
 
 func (m *LocationModule) discoverCluesLocked(playerID uuid.UUID, locationID string) []string {

--- a/apps/server/internal/module/crime_scene/location_discovery_test.go
+++ b/apps/server/internal/module/crime_scene/location_discovery_test.go
@@ -1,0 +1,193 @@
+package crime_scene
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func locationDiscoveryCfg(clueID string) json.RawMessage {
+	data, _ := json.Marshal(LocationConfig{
+		Locations: []LocationDef{
+			{ID: "hall", Name: "Hall", Description: "Entry hall"},
+			{ID: "library", Name: "Library", Description: "Book room"},
+		},
+		StartingLoc: "hall",
+		Discoveries: []LocationClueDiscovery{
+			{LocationID: "library", ClueID: clueID, OncePerPlayer: true},
+		},
+	})
+	return data
+}
+
+func TestLocationModule_Init_InvalidDiscovery(t *testing.T) {
+	m := NewLocationModule()
+	err := m.Init(context.Background(), newTestDeps(), json.RawMessage(`{
+		"locations":[{"id":"hall","name":"Hall"}],
+		"discoveries":[{"locationId":"nowhere","clueId":"clue-1"}]
+	}`))
+	if err == nil {
+		t.Fatal("expected error for discovery pointing to unknown location")
+	}
+}
+
+func TestLocationModule_Init_DiscoveryDefaultsOncePerPlayer(t *testing.T) {
+	m := NewLocationModule()
+	if err := m.Init(context.Background(), newTestDeps(), json.RawMessage(`{
+		"locations":[{"id":"hall","name":"Hall"}],
+		"discoveries":[{"locationId":"hall","clueId":"clue-1"}]
+	}`)); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if !m.discoveriesByLocation["hall"][0].OncePerPlayer {
+		t.Fatal("expected discovery to default to oncePerPlayer")
+	}
+}
+
+func TestLocationModule_HandleMessage_ExamineDiscoversLocationClue(t *testing.T) {
+	deps := newTestDeps()
+	m := NewLocationModule()
+	playerID := uuid.New()
+	clueID := uuid.New().String()
+	if err := m.Init(context.Background(), deps, locationDiscoveryCfg(clueID)); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	var examined, discovered, acquired bool
+	deps.EventBus.Subscribe("location.examined", func(e engine.Event) {
+		payload := e.Payload.(map[string]any)
+		ids := payload["discoveredClueIDs"].([]string)
+		examined = len(ids) == 1 && ids[0] == clueID
+	})
+	deps.EventBus.Subscribe("location.clue_discovered", func(e engine.Event) {
+		payload := e.Payload.(map[string]any)
+		discovered = payload["clueID"] == clueID
+	})
+	deps.EventBus.Subscribe("clue.acquired", func(e engine.Event) {
+		payload := e.Payload.(map[string]any)
+		acquired = payload["clueId"] == clueID && payload["source"] == "location_discovery"
+	})
+
+	err := m.HandleMessage(context.Background(), playerID,
+		"examine", json.RawMessage(`{"location_id":"library"}`))
+	if err != nil {
+		t.Fatalf("examine: %v", err)
+	}
+	if !examined || !discovered || !acquired {
+		t.Fatalf(
+			"expected examined/discovered/acquired events, got examined=%v discovered=%v acquired=%v",
+			examined,
+			discovered,
+			acquired,
+		)
+	}
+
+	data, err := m.BuildStateFor(playerID)
+	if err != nil {
+		t.Fatalf("BuildStateFor: %v", err)
+	}
+	var state locationState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := state.DiscoveredClues[playerID.String()]; len(got) != 1 || got[0] != clueID {
+		t.Fatalf("expected discovered clue %q, got %v", clueID, got)
+	}
+}
+
+func TestLocationModule_HandleMessage_ExamineDiscoveryIsIdempotent(t *testing.T) {
+	deps := newTestDeps()
+	m := NewLocationModule()
+	playerID := uuid.New()
+	clueID := uuid.New().String()
+	if err := m.Init(context.Background(), deps, locationDiscoveryCfg(clueID)); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	acquiredEvents := 0
+	deps.EventBus.Subscribe("clue.acquired", func(e engine.Event) { acquiredEvents++ })
+	for i := 0; i < 2; i++ {
+		if err := m.HandleMessage(context.Background(), playerID,
+			"examine", json.RawMessage(`{"location_id":"library"}`)); err != nil {
+			t.Fatalf("examine %d: %v", i+1, err)
+		}
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if got := m.discoveredClues[playerID]; len(got) != 1 || got[0] != clueID {
+		t.Fatalf("expected one discovered clue, got %v", got)
+	}
+	if acquiredEvents != 1 {
+		t.Fatalf("expected one clue.acquired event, got %d", acquiredEvents)
+	}
+}
+
+func TestLocationModule_HandleMessage_ExamineDiscoveryRequiresClue(t *testing.T) {
+	m := NewLocationModule()
+	playerID := uuid.New()
+	keyID := uuid.New().String()
+	rewardID := uuid.New().String()
+	config, _ := json.Marshal(LocationConfig{
+		Locations: []LocationDef{{ID: "hall", Name: "Hall"}, {ID: "safe", Name: "Safe"}},
+		Discoveries: []LocationClueDiscovery{
+			{LocationID: "hall", ClueID: keyID, OncePerPlayer: true},
+			{LocationID: "safe", ClueID: rewardID, RequiredClueIDs: []string{keyID}, OncePerPlayer: true},
+		},
+	})
+	if err := m.Init(context.Background(), newTestDeps(), config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := m.HandleMessage(context.Background(), playerID,
+		"examine", json.RawMessage(`{"location_id":"safe"}`)); err != nil {
+		t.Fatalf("safe examine before key: %v", err)
+	}
+	m.mu.RLock()
+	if len(m.discoveredClues[playerID]) != 0 {
+		t.Fatalf("reward should not be discovered before key, got %v", m.discoveredClues[playerID])
+	}
+	m.mu.RUnlock()
+
+	if err := m.HandleMessage(context.Background(), playerID,
+		"examine", json.RawMessage(`{"location_id":"hall"}`)); err != nil {
+		t.Fatalf("hall examine: %v", err)
+	}
+	if err := m.HandleMessage(context.Background(), playerID,
+		"examine", json.RawMessage(`{"location_id":"safe"}`)); err != nil {
+		t.Fatalf("safe examine after key: %v", err)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !playerHasDiscoveredClue(m.discoveredClues[playerID], rewardID) {
+		t.Fatalf("reward should be discovered after key, got %v", m.discoveredClues[playerID])
+	}
+}
+
+func TestLocationModule_BuildStateFor_DiscoveredCluesCallerOnly(t *testing.T) {
+	m := NewLocationModule()
+	if err := m.Init(context.Background(), newTestDeps(), locationCfg()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	alice := uuid.New()
+	bob := uuid.New()
+	m.mu.Lock()
+	m.discoveredClues[alice] = []string{"alice-clue"}
+	m.discoveredClues[bob] = []string{"bob-secret"}
+	m.mu.Unlock()
+
+	aliceData, err := m.BuildStateFor(alice)
+	if err != nil {
+		t.Fatalf("BuildStateFor: %v", err)
+	}
+	if !bytes.Contains(aliceData, []byte("alice-clue")) {
+		t.Fatalf("alice should see her discovered clue: %s", aliceData)
+	}
+	if bytes.Contains(aliceData, []byte("bob-secret")) || bytes.Contains(aliceData, []byte(bob.String())) {
+		t.Fatalf("alice leaked bob discovery: %s", aliceData)
+	}
+}

--- a/apps/server/internal/module/crime_scene/location_test.go
+++ b/apps/server/internal/module/crime_scene/location_test.go
@@ -187,6 +187,9 @@ func TestLocationModule_SaveRestoreState(t *testing.T) {
 		"move", json.RawMessage(`{"location_id":"library"}`)); err != nil {
 		t.Fatalf("move: %v", err)
 	}
+	m.mu.Lock()
+	m.discoveredClues[playerID] = []string{"clue-library"}
+	m.mu.Unlock()
 
 	gs, err := m.SaveState(context.Background())
 	if err != nil {
@@ -207,6 +210,9 @@ func TestLocationModule_SaveRestoreState(t *testing.T) {
 	m2.mu.RLock()
 	if m2.positions[playerID] != "library" {
 		t.Fatalf("expected library after restore, got %q", m2.positions[playerID])
+	}
+	if got := m2.discoveredClues[playerID]; len(got) != 1 || got[0] != "clue-library" {
+		t.Fatalf("expected restored discovered clue, got %v", got)
 	}
 	m2.mu.RUnlock()
 }

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-248-location-discovery-runtime.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-248-location-discovery-runtime.md
@@ -1,0 +1,66 @@
+# Issue #248 — 장소 조사 Runtime 및 장소 단서 발견 흐름
+
+## 목표
+
+장소를 조사했을 때 발견 가능한 단서를 백엔드 Runtime Engine이 결정하도록 최소 계약을 만든다.
+프론트는 이후 Adapter/UI에서 “이 장소를 조사하면 발견할 단서”로 보여준다.
+실제 지급, 공개, 중복 방지는 백엔드가 담당한다.
+
+## Uzu 참고점
+
+- Uzu는 단서를 “플레이 중 소유권이 있는 자산”으로 다룬다.
+  배포 조건에서는 언제/누구에게/어떤 방식으로 줄지 나눈다.
+- 조사 단계 예시는 투표 선택지와 단서 배포 조건을 조합해 조사 지점별 단서를 지급한다.
+- 단서 회수, 전체 공개, 공유, 양도는 별도 조건으로 확장된다.
+
+## MMP 적용 방식
+
+Uzu의 조건 시스템을 그대로 복제하지 않는다.
+MMP는 실시간 멀티플레이 runtime state를 우선한다.
+
+- `location.discoveries[]` 계약으로 장소별 발견 후보 단서를 정의한다.
+- `examine` 메시지를 받으면 Location Engine이 조건을 확인하고 발견 단서를 기록한다.
+- 발견 단서는 player-aware state의 `discoveredClues`에 본인 것만 노출한다.
+- 발견 시 `location.clue_discovered`와 `clue.acquired` 이벤트를 발행한다.
+  후속 단서함/로그 연결은 이 이벤트를 재사용한다.
+- 기본은 플레이어당 1회 발견이다. 반복 조사/토큰 소비/덱 차감은 후속 확장으로 둔다.
+
+## 이번 PR 범위
+
+- `LocationConfig.Discoveries` 추가
+- `LocationClueDiscovery` 계약 추가
+  - `locationId`
+  - `clueId`
+  - `requiredClueIds`
+  - `oncePerPlayer`
+- `LocationModule.handleExamine`에서 발견 후보 처리
+- player-aware `BuildStateFor`에 caller의 `discoveredClues`만 포함
+- Save/Restore에 발견 상태 포함
+- focused Go tests 추가
+
+## 제외 / 후순위
+
+- 장소 이미지 업로드/표시 UI 변경
+- 프론트 장소 상세의 발견 후보 편집 카드
+- 토큰/덱 소비형 조사
+- 전체 공개/회수/양도 조건
+- DB editor 삭제 cascade 변경
+
+## 정합성 확인
+
+- 장소 이미지와 기본 설명은 제작자/플레이어 표시 정보이며, 이번 runtime state에는 넣지 않는다.
+- 발견 계약은 `locationId`와 `clueId`만 참조한다.
+- runtime init은 존재하지 않는 `locationId`를 거부한다.
+- clue catalog 검증과 삭제 cascade는 프론트 UI가 이 계약을 저장하는 후속 PR에서 editor service 경계로 연결한다.
+
+## 검증
+
+- `go test ./internal/module/crime_scene -run 'LocationModule'`
+- `go test ./internal/module/core -run 'ClueInteraction|ClueItem'`
+
+## 완료 조건
+
+- 장소 조사 시 configured clue가 idempotent하게 발견된다.
+- required clue 조건이 동작한다.
+- 다른 플레이어에게 발견 단서 상태가 새지 않는다.
+- 기존 clue interaction item effect 테스트가 깨지지 않는다.


### PR DESCRIPTION
## 목표

장소를 조사했을 때 발견 가능한 단서를 백엔드 Runtime Engine이 결정하도록 최소 계약을 추가합니다.

## 변경 사항

- `LocationConfig.discoveries[]`와 `LocationClueDiscovery` 계약 추가
- `examine` 처리 시 장소별 발견 후보 단서를 player별로 기록
- 발견 시 `location.clue_discovered`와 `clue.acquired` 이벤트 발행
- `BuildStateFor`에서 본인의 `discoveredClues`만 노출하도록 player-aware redaction 적용
- Save/Restore에 발견 단서 상태 포함
- Uzu 참고점과 MMP 적용 범위 문서화

## 검증

- `go test ./internal/module/crime_scene -run 'LocationModule'`
- `go test ./internal/module/core -run 'ClueInteraction|ClueItem'`
- `git diff --check`

## E2E 대체 사유

이번 PR은 신규 화면/라우트가 아니라 백엔드 runtime module 계약과 player-aware state 변경입니다. 사용자 브라우저 흐름은 후속 프론트 장소 발견 후보 편집 UI에서 Playwright E2E로 연결하고, 이번 slice는 Go runtime tests로 대체합니다.

## Uzu 참고 / MMP 차이

Uzu는 단서 배포 조건으로 조사 흐름을 구성합니다. MMP는 이를 그대로 복제하지 않고, 실시간 멀티플레이에서 중복 발견 방지와 플레이어별 공개 상태를 백엔드 Engine이 소유하도록 축소 적용했습니다.

Closes #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 위치 조사 시 런타임에서 단서 발견 후보를 결정하고, 발견된 단서를 플레이어별로 추적·동기화하는 기능 추가
  * 발견 시 관련 이벤트(단서 발견·획득)가 발행되고, 기본적으로 플레이어당 1회만 발견 허용

* **테스트**
  * 초기화, 탐색(idempotency), 전제 조건, 상태 빌드·영속성 등 포괄적 단위 테스트 추가

* **문서**
  * 위치 발견 런타임 명세 및 실행 흐름 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->