### PR TITLE
feat(error): MMP 에러 계약 v1 기반 추가

### DIFF
--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -906,31 +906,31 @@ components:
     BadRequest:
       description: Invalid request
       content:
-        application/json:
+        application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetail"
     Unauthorized:
       description: Authentication required
       content:
-        application/json:
+        application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetail"
     Forbidden:
       description: Insufficient permissions
       content:
-        application/json:
+        application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetail"
     NotFound:
       description: Resource not found
       content:
-        application/json:
+        application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetail"
     Conflict:
       description: Conflict with current state
       content:
-        application/json:
+        application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetail"
 
@@ -960,6 +960,43 @@ components:
         instance:
           type: string
           description: URI reference identifying the specific occurrence
+        params:
+          type: object
+          additionalProperties: true
+          description: Structured parameters for localized messages
+        errors:
+          type: array
+          description: Field-level validation errors
+          items:
+            type: object
+            required: [field, message, code]
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+              code:
+                type: string
+        extensions:
+          type: object
+          additionalProperties: true
+          description: MMP-specific extension metadata
+        trace_id:
+          type: string
+          description: OpenTelemetry trace identifier when tracing is active
+        request_id:
+          type: string
+          description: Request identifier mirrored from X-Request-ID
+        severity:
+          type: string
+          enum: [critical, high, medium, low]
+          description: Operational impact level for UI routing
+        retryable:
+          type: boolean
+          description: Whether retry is generally safe for this error type
+        user_action:
+          type: string
+          description: Machine-readable recovery action hint for clients
 
     # ── Generic ────────────────────────────────────────────
     MessageResponse:

--- a/apps/server/internal/apperror/apperror.go
+++ b/apps/server/internal/apperror/apperror.go
@@ -143,11 +143,11 @@ func (e *AppError) WithErrors(errs []FieldError) *AppError {
 	return &copied
 }
 
-// WithExtensions returns a copy of the error with RFC 9457 extension members
-// attached. Extensions surface as top-level fields in the Problem Details
-// response body (not nested under "params"), enabling caller-specific metadata
-// such as {"current_version": 42} on optimistic-lock conflicts. The map is
-// deep-copied to prevent shared mutation across goroutines.
+// WithExtensions returns a copy of the error with MMP extension metadata
+// attached. Extensions surface under the "extensions" field in the Problem
+// Details response body, enabling caller-specific metadata such as
+// {"current_version": 42} on optimistic-lock conflicts. The map is deep-copied
+// to prevent shared mutation across goroutines.
 func (e *AppError) WithExtensions(ext map[string]any) *AppError {
 	copied := *e
 	if len(ext) > 0 {

--- a/apps/server/internal/apperror/handler.go
+++ b/apps/server/internal/apperror/handler.go
@@ -23,6 +23,10 @@ type problemResponse struct {
 	Errors     []FieldError   `json:"errors,omitempty"`
 	Extensions map[string]any `json:"extensions,omitempty"`
 	TraceID    string         `json:"trace_id,omitempty"`
+	RequestID  string         `json:"request_id,omitempty"`
+	Severity   Severity       `json:"severity,omitempty"`
+	Retryable  bool           `json:"retryable"`
+	UserAction string         `json:"user_action,omitempty"`
 	Debug      *debugInfo     `json:"debug,omitempty"`
 }
 
@@ -83,6 +87,7 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 		typeURI = "about:blank"
 	}
 
+	defn := definitionForResponse(appErr)
 	resp := problemResponse{
 		Type:       typeURI,
 		Title:      appErr.Title,
@@ -93,6 +98,10 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 		Params:     appErr.Params,
 		Errors:     appErr.Errors,
 		Extensions: appErr.Extensions,
+		RequestID:  requestIDFrom(w, r),
+		Severity:   defn.Severity,
+		Retryable:  defn.Retryable,
+		UserAction: defn.UserAction,
 	}
 
 	// Include trace_id in error response if OTel is active.
@@ -120,4 +129,11 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
 		logger.Error().Err(encErr).Msg("failed to encode error response")
 	}
+}
+
+func requestIDFrom(w http.ResponseWriter, r *http.Request) string {
+	if id := w.Header().Get("X-Request-ID"); id != "" {
+		return id
+	}
+	return r.Header.Get("X-Request-ID")
 }

--- a/apps/server/internal/apperror/handler_test.go
+++ b/apps/server/internal/apperror/handler_test.go
@@ -155,8 +155,8 @@ func TestWriteError_WithRequestIDAndRegistryMetadata(t *testing.T) {
 	appErr := New(ErrEditorConfigVersionMismatch, http.StatusConflict, "stale editor config")
 
 	rec := httptest.NewRecorder()
-	rec.Header().Set("X-Request-ID", "req-123")
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/editor/config", nil)
+	req.Header.Set("X-Request-ID", "req-123")
 
 	WriteError(rec, req, appErr)
 
@@ -179,6 +179,29 @@ func TestWriteError_WithRequestIDAndRegistryMetadata(t *testing.T) {
 	}
 	if body["user_action"] != "reload_or_merge" {
 		t.Errorf("user_action = %v, want reload_or_merge", body["user_action"])
+	}
+}
+
+func TestWriteError_UsesResponseRequestIDFromMiddleware(t *testing.T) {
+	appErr := BadRequest("invalid input")
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "middleware-generated")
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("X-Request-ID", "client-provided")
+
+	WriteError(rec, req, appErr)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["request_id"] != "middleware-generated" {
+		t.Errorf("request_id = %v, want middleware-generated", body["request_id"])
 	}
 }
 

--- a/apps/server/internal/apperror/handler_test.go
+++ b/apps/server/internal/apperror/handler_test.go
@@ -151,6 +151,68 @@ func TestWriteError_WithParams(t *testing.T) {
 	}
 }
 
+func TestWriteError_WithRequestIDAndRegistryMetadata(t *testing.T) {
+	appErr := New(ErrEditorConfigVersionMismatch, http.StatusConflict, "stale editor config")
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "req-123")
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/editor/config", nil)
+
+	WriteError(rec, req, appErr)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["request_id"] != "req-123" {
+		t.Errorf("request_id = %v, want req-123", body["request_id"])
+	}
+	if body["severity"] != string(SeverityHigh) {
+		t.Errorf("severity = %v, want %s", body["severity"], SeverityHigh)
+	}
+	if body["retryable"] != false {
+		t.Errorf("retryable = %v, want false", body["retryable"])
+	}
+	if body["user_action"] != "reload_or_merge" {
+		t.Errorf("user_action = %v, want reload_or_merge", body["user_action"])
+	}
+}
+
+func TestWriteError_UnknownCodeUsesStatusFallback(t *testing.T) {
+	appErr := New("CUSTOM_UPSTREAM_TIMEOUT", http.StatusBadGateway, "upstream failed")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("X-Request-ID", "client-req")
+
+	WriteError(rec, req, appErr)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["request_id"] != "client-req" {
+		t.Errorf("request_id = %v, want client-req", body["request_id"])
+	}
+	if body["severity"] != string(SeverityHigh) {
+		t.Errorf("severity = %v, want %s", body["severity"], SeverityHigh)
+	}
+	if body["retryable"] != true {
+		t.Errorf("retryable = %v, want true", body["retryable"])
+	}
+	if body["user_action"] != "retry_later" {
+		t.Errorf("user_action = %v, want retry_later", body["user_action"])
+	}
+}
+
 func TestWriteError_WithFieldErrors(t *testing.T) {
 	errs := []FieldError{
 		{Field: "name", Message: "required", Code: "REQUIRED"},

--- a/apps/server/internal/apperror/registry.go
+++ b/apps/server/internal/apperror/registry.go
@@ -1,0 +1,174 @@
+package apperror
+
+import "net/http"
+
+// Severity is the operational impact level for an application error.
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityHigh     Severity = "high"
+	SeverityMedium   Severity = "medium"
+	SeverityLow      Severity = "low"
+)
+
+// ErrorDefinition describes how a code should be exposed and recovered from.
+// It is intentionally metadata-only: the concrete AppError still owns status
+// and detail for each occurrence.
+type ErrorDefinition struct {
+	Code       string
+	Domain     string
+	Layer      string
+	Severity   Severity
+	HTTPStatus int
+	Retryable  bool
+	UserAction string
+	DefaultKR  string
+}
+
+var errorDefinitions = map[string]ErrorDefinition{
+	ErrInternal:           def(ErrInternal, "common", "infrastructure", http.StatusInternalServerError, SeverityHigh, true, "retry_later", "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+	ErrNotFound:           def(ErrNotFound, "common", "interface", http.StatusNotFound, SeverityMedium, false, "go_back", "요청한 리소스를 찾을 수 없습니다."),
+	ErrBadRequest:         def(ErrBadRequest, "common", "interface", http.StatusBadRequest, SeverityMedium, false, "fix_input", "요청 내용을 확인해주세요."),
+	ErrUnauthorized:       def(ErrUnauthorized, "auth", "interface", http.StatusUnauthorized, SeverityHigh, false, "login", "로그인이 필요합니다."),
+	ErrForbidden:          def(ErrForbidden, "auth", "interface", http.StatusForbidden, SeverityHigh, false, "request_access", "접근 권한이 없습니다."),
+	ErrConflict:           def(ErrConflict, "common", "domain", http.StatusConflict, SeverityMedium, false, "refresh", "현재 상태와 충돌했습니다. 새로고침 후 다시 시도해주세요."),
+	ErrValidation:         def(ErrValidation, "common", "interface", http.StatusUnprocessableEntity, SeverityMedium, false, "fix_input", "입력값을 확인해주세요."),
+	ErrTimeout:            def(ErrTimeout, "common", "infrastructure", http.StatusRequestTimeout, SeverityMedium, true, "retry", "요청 시간이 초과되었습니다. 다시 시도해주세요."),
+	ErrServiceUnavailable: def(ErrServiceUnavailable, "common", "infrastructure", http.StatusServiceUnavailable, SeverityHigh, true, "retry_later", "서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요."),
+	ErrMethodNotAllowed:   def(ErrMethodNotAllowed, "common", "interface", http.StatusMethodNotAllowed, SeverityLow, false, "none", "지원하지 않는 요청 방식입니다."),
+
+	ErrAuthTokenExpired: def(ErrAuthTokenExpired, "auth", "interface", http.StatusUnauthorized, SeverityHigh, false, "login", "세션이 만료되었습니다. 다시 로그인해주세요."),
+	ErrAuthTokenInvalid: def(ErrAuthTokenInvalid, "auth", "interface", http.StatusUnauthorized, SeverityHigh, false, "login", "인증 정보가 유효하지 않습니다."),
+	ErrAuthTokenMissing: def(ErrAuthTokenMissing, "auth", "interface", http.StatusUnauthorized, SeverityHigh, false, "login", "로그인이 필요합니다."),
+
+	ErrGameNotFound:    def(ErrGameNotFound, "game", "domain", http.StatusNotFound, SeverityMedium, false, "go_back", "게임을 찾을 수 없습니다."),
+	ErrGameFull:        def(ErrGameFull, "game", "domain", http.StatusConflict, SeverityMedium, false, "choose_other", "게임 정원이 가득 찼습니다."),
+	ErrGameNotStarted:  def(ErrGameNotStarted, "game", "domain", http.StatusConflict, SeverityLow, true, "wait", "아직 게임이 시작되지 않았습니다."),
+	ErrGameAlreadyOver: def(ErrGameAlreadyOver, "game", "domain", http.StatusConflict, SeverityMedium, false, "go_back", "이미 종료된 게임입니다."),
+
+	ErrSessionNotFound:  def(ErrSessionNotFound, "session", "domain", http.StatusNotFound, SeverityMedium, false, "go_back", "세션을 찾을 수 없습니다."),
+	ErrSessionExpired:   def(ErrSessionExpired, "session", "domain", http.StatusGone, SeverityMedium, false, "restart", "세션이 만료되었습니다."),
+	ErrSessionStopped:   def(ErrSessionStopped, "session", "domain", http.StatusConflict, SeverityHigh, false, "restart", "세션이 중단되었습니다."),
+	ErrSessionInboxFull: def(ErrSessionInboxFull, "session", "application", http.StatusTooManyRequests, SeverityMedium, true, "retry_later", "요청이 많아 잠시 후 다시 시도해주세요."),
+	ErrInvalidPayload:   def(ErrInvalidPayload, "session", "interface", http.StatusBadRequest, SeverityMedium, false, "fix_input", "요청 데이터가 올바르지 않습니다."),
+
+	ErrPlayerNotFound:  def(ErrPlayerNotFound, "player", "domain", http.StatusNotFound, SeverityMedium, false, "go_back", "플레이어를 찾을 수 없습니다."),
+	ErrPlayerNotInGame: def(ErrPlayerNotInGame, "player", "domain", http.StatusForbidden, SeverityHigh, false, "join_game", "해당 게임에 참여하지 않은 플레이어입니다."),
+	ErrPlayerAlreadyIn: def(ErrPlayerAlreadyIn, "player", "domain", http.StatusConflict, SeverityLow, false, "none", "이미 게임에 참여 중입니다."),
+
+	ErrRoomNotFound:   def(ErrRoomNotFound, "room", "domain", http.StatusNotFound, SeverityMedium, false, "go_back", "방을 찾을 수 없습니다."),
+	ErrRoomFull:       def(ErrRoomFull, "room", "domain", http.StatusConflict, SeverityMedium, false, "choose_other", "방이 가득 찼습니다."),
+	ErrRoomNotWaiting: def(ErrRoomNotWaiting, "room", "domain", http.StatusConflict, SeverityMedium, false, "choose_other", "현재 참가할 수 없는 방입니다."),
+
+	ErrFriendRequestSelf:      def(ErrFriendRequestSelf, "social", "domain", http.StatusBadRequest, SeverityLow, false, "fix_input", "자기 자신에게 친구 요청을 보낼 수 없습니다."),
+	ErrFriendRequestDuplicate: def(ErrFriendRequestDuplicate, "social", "domain", http.StatusConflict, SeverityLow, false, "none", "이미 보낸 친구 요청입니다."),
+	ErrFriendRequestBlocked:   def(ErrFriendRequestBlocked, "social", "domain", http.StatusForbidden, SeverityMedium, false, "none", "친구 요청을 보낼 수 없습니다."),
+	ErrFriendshipNotFound:     def(ErrFriendshipNotFound, "social", "domain", http.StatusNotFound, SeverityLow, false, "refresh", "친구 관계를 찾을 수 없습니다."),
+	ErrChatRoomNotFound:       def(ErrChatRoomNotFound, "social", "domain", http.StatusNotFound, SeverityMedium, false, "go_back", "채팅방을 찾을 수 없습니다."),
+	ErrChatNotMember:          def(ErrChatNotMember, "social", "domain", http.StatusForbidden, SeverityHigh, false, "go_back", "채팅방 참여자가 아닙니다."),
+	ErrChatInvalidMsgType:     def(ErrChatInvalidMsgType, "social", "interface", http.StatusBadRequest, SeverityLow, false, "none", "지원하지 않는 채팅 메시지입니다."),
+	ErrChatBlocked:            def(ErrChatBlocked, "social", "domain", http.StatusForbidden, SeverityMedium, false, "none", "차단된 사용자와는 채팅할 수 없습니다."),
+
+	ErrPaymentDuplicate:           def(ErrPaymentDuplicate, "payment", "domain", http.StatusConflict, SeverityMedium, false, "refresh", "이미 처리된 결제입니다."),
+	ErrPaymentIdempotencyMismatch: def(ErrPaymentIdempotencyMismatch, "payment", "domain", http.StatusConflict, SeverityHigh, false, "contact_support", "결제 요청 정보가 이전 요청과 다릅니다. 고객센터에 문의해주세요."),
+	ErrPaymentNotFound:            def(ErrPaymentNotFound, "payment", "domain", http.StatusNotFound, SeverityMedium, false, "go_back", "결제 정보를 찾을 수 없습니다."),
+	ErrPaymentInvalidStatus:       def(ErrPaymentInvalidStatus, "payment", "domain", http.StatusConflict, SeverityMedium, false, "refresh", "현재 결제 상태에서 처리할 수 없습니다."),
+	ErrPaymentProviderError:       def(ErrPaymentProviderError, "payment", "infrastructure", http.StatusBadGateway, SeverityHigh, true, "retry_later", "결제사 연결이 불안정합니다. 잠시 후 다시 시도해주세요."),
+	ErrPaymentWebhookInvalid:      def(ErrPaymentWebhookInvalid, "payment", "interface", http.StatusBadRequest, SeverityHigh, false, "none", "결제 알림 검증에 실패했습니다."),
+
+	ErrCoinInsufficient:    def(ErrCoinInsufficient, "coin", "domain", http.StatusConflict, SeverityMedium, false, "charge", "보유 코인이 부족합니다."),
+	ErrCoinBalanceMismatch: def(ErrCoinBalanceMismatch, "coin", "domain", http.StatusConflict, SeverityHigh, true, "retry", "코인 잔액이 변경되었습니다. 다시 시도해주세요."),
+
+	ErrPurchaseAlreadyOwned: def(ErrPurchaseAlreadyOwned, "purchase", "domain", http.StatusConflict, SeverityLow, false, "none", "이미 보유한 테마입니다."),
+	ErrPurchaseSelfTheme:    def(ErrPurchaseSelfTheme, "purchase", "domain", http.StatusBadRequest, SeverityLow, false, "none", "자신이 만든 테마는 구매할 수 없습니다."),
+	ErrPurchaseNotFound:     def(ErrPurchaseNotFound, "purchase", "domain", http.StatusNotFound, SeverityMedium, false, "go_back", "구매 정보를 찾을 수 없습니다."),
+
+	ErrRefundExpired:       def(ErrRefundExpired, "refund", "domain", http.StatusConflict, SeverityMedium, false, "none", "환불 가능 기간이 지났습니다."),
+	ErrRefundAlreadyPlayed: def(ErrRefundAlreadyPlayed, "refund", "domain", http.StatusConflict, SeverityMedium, false, "none", "이미 플레이한 테마는 환불할 수 없습니다."),
+	ErrRefundAlreadyDone:   def(ErrRefundAlreadyDone, "refund", "domain", http.StatusConflict, SeverityLow, false, "none", "이미 환불 처리된 구매입니다."),
+	ErrRefundFreeTheme:     def(ErrRefundFreeTheme, "refund", "domain", http.StatusBadRequest, SeverityLow, false, "none", "무료 테마는 환불할 수 없습니다."),
+	ErrRefundLimitExceeded: def(ErrRefundLimitExceeded, "refund", "domain", http.StatusTooManyRequests, SeverityMedium, false, "contact_support", "환불 요청 한도를 초과했습니다."),
+
+	ErrSettlementInvalidStatus: def(ErrSettlementInvalidStatus, "settlement", "domain", http.StatusConflict, SeverityMedium, false, "refresh", "현재 정산 상태에서 처리할 수 없습니다."),
+	ErrThemePriceNotSet:        def(ErrThemePriceNotSet, "theme", "domain", http.StatusConflict, SeverityMedium, false, "set_price", "테마 가격이 설정되지 않았습니다."),
+	ErrThemePriceOutOfRange:    def(ErrThemePriceOutOfRange, "theme", "domain", http.StatusBadRequest, SeverityMedium, false, "fix_input", "테마 가격 범위를 확인해주세요."),
+
+	ErrMediaInvalidType:     def(ErrMediaInvalidType, "media", "interface", http.StatusBadRequest, SeverityMedium, false, "choose_file", "지원하지 않는 미디어 형식입니다."),
+	ErrMediaInvalidURL:      def(ErrMediaInvalidURL, "media", "interface", http.StatusBadRequest, SeverityMedium, false, "fix_input", "미디어 URL이 올바르지 않습니다."),
+	ErrMediaTooLarge:        def(ErrMediaTooLarge, "media", "interface", http.StatusRequestEntityTooLarge, SeverityMedium, false, "choose_smaller_file", "파일 크기가 너무 큽니다."),
+	ErrMediaLimitExceeded:   def(ErrMediaLimitExceeded, "media", "domain", http.StatusConflict, SeverityMedium, false, "delete_unused", "미디어 개수 제한을 초과했습니다."),
+	ErrMediaStorageFull:     def(ErrMediaStorageFull, "media", "infrastructure", http.StatusInsufficientStorage, SeverityHigh, false, "contact_support", "저장 공간이 부족합니다. 관리자에게 문의해주세요."),
+	ErrMediaUploadExpired:   def(ErrMediaUploadExpired, "media", "domain", http.StatusGone, SeverityLow, true, "retry", "업로드 시간이 만료되었습니다. 다시 시도해주세요."),
+	ErrMediaOEmbedFailed:    def(ErrMediaOEmbedFailed, "media", "infrastructure", http.StatusBadGateway, SeverityMedium, true, "retry", "외부 미디어 정보를 가져오지 못했습니다."),
+	ErrMediaReferenceInUse:  def(ErrMediaReferenceInUse, "media", "domain", http.StatusConflict, SeverityMedium, false, "review_references", "이 미디어는 다른 곳에서 사용 중이라 삭제할 수 없습니다."),
+	ErrMediaNotInTheme:      def(ErrMediaNotInTheme, "media", "domain", http.StatusForbidden, SeverityHigh, false, "go_back", "이 테마에 속하지 않은 미디어입니다."),
+	ErrImageInvalidType:     def(ErrImageInvalidType, "image", "interface", http.StatusBadRequest, SeverityMedium, false, "choose_file", "지원하지 않는 이미지 형식입니다."),
+	ErrImageInvalidTarget:   def(ErrImageInvalidTarget, "image", "interface", http.StatusBadRequest, SeverityMedium, false, "fix_input", "이미지 업로드 대상이 올바르지 않습니다."),
+	ErrImageTooLarge:        def(ErrImageTooLarge, "image", "interface", http.StatusRequestEntityTooLarge, SeverityMedium, false, "choose_smaller_file", "이미지 크기가 너무 큽니다."),
+	ErrWSUnknownMessageType: def(ErrWSUnknownMessageType, "websocket", "interface", http.StatusBadRequest, SeverityLow, false, "none", "지원하지 않는 실시간 메시지입니다."),
+
+	ErrReadingSectionNotFound:  def(ErrReadingSectionNotFound, "reading", "domain", http.StatusNotFound, SeverityMedium, false, "refresh", "리딩 섹션을 찾을 수 없습니다."),
+	ErrReadingAdvanceForbidden: def(ErrReadingAdvanceForbidden, "reading", "domain", http.StatusForbidden, SeverityMedium, false, "wait", "리딩을 진행할 권한이 없습니다."),
+	ErrReadingInvalidAdvanceBy: def(ErrReadingInvalidAdvanceBy, "reading", "interface", http.StatusUnprocessableEntity, SeverityMedium, false, "fix_input", "리딩 진행 방식이 올바르지 않습니다."),
+	ErrReadingLineOutOfRange:   def(ErrReadingLineOutOfRange, "reading", "domain", http.StatusNotFound, SeverityMedium, false, "refresh", "리딩 줄이 범위를 벗어났습니다."),
+	ErrReadingVoiceRequired:    def(ErrReadingVoiceRequired, "reading", "domain", http.StatusConflict, SeverityMedium, false, "add_media", "음성 자동 진행에는 음성 파일이 필요합니다."),
+
+	ErrEditorConfigVersionMismatch: def(ErrEditorConfigVersionMismatch, "editor", "domain", http.StatusConflict, SeverityHigh, false, "reload_or_merge", "다른 변경사항과 충돌했습니다. 최신 내용으로 새로고침 후 다시 저장해주세요."),
+}
+
+func def(code, domain, layer string, status int, severity Severity, retryable bool, userAction, defaultKR string) ErrorDefinition {
+	return ErrorDefinition{
+		Code:       code,
+		Domain:     domain,
+		Layer:      layer,
+		Severity:   severity,
+		HTTPStatus: status,
+		Retryable:  retryable,
+		UserAction: userAction,
+		DefaultKR:  defaultKR,
+	}
+}
+
+// LookupDefinition returns registry metadata for a known error code.
+func LookupDefinition(code string) (ErrorDefinition, bool) {
+	defn, ok := errorDefinitions[code]
+	return defn, ok
+}
+
+func definitionForResponse(appErr *AppError) ErrorDefinition {
+	if defn, ok := LookupDefinition(appErr.Code); ok {
+		defn.HTTPStatus = appErr.Status
+		return defn
+	}
+
+	return def(appErr.Code, "unknown", "unknown", appErr.Status, severityForStatus(appErr.Status), appErr.Status >= 500 || appErr.Status == http.StatusRequestTimeout, defaultActionForStatus(appErr.Status), "")
+}
+
+func severityForStatus(status int) Severity {
+	switch {
+	case status >= 500:
+		return SeverityHigh
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return SeverityHigh
+	case status >= 400:
+		return SeverityMedium
+	default:
+		return SeverityLow
+	}
+}
+
+func defaultActionForStatus(status int) string {
+	switch {
+	case status == http.StatusUnauthorized:
+		return "login"
+	case status == http.StatusForbidden:
+		return "request_access"
+	case status == http.StatusRequestTimeout || status >= 500:
+		return "retry_later"
+	case status >= 400:
+		return "fix_input"
+	default:
+		return "none"
+	}
+}

--- a/apps/server/internal/apperror/registry_test.go
+++ b/apps/server/internal/apperror/registry_test.go
@@ -37,3 +37,48 @@ func TestDefinitionForResponse_PreservesOccurrenceStatus(t *testing.T) {
 		t.Errorf("Code = %q, want %q", defn.Code, ErrBadRequest)
 	}
 }
+
+func TestSeverityForStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   Severity
+	}{
+		{name: "server", status: http.StatusBadGateway, want: SeverityHigh},
+		{name: "unauthorized", status: http.StatusUnauthorized, want: SeverityHigh},
+		{name: "forbidden", status: http.StatusForbidden, want: SeverityHigh},
+		{name: "client", status: http.StatusBadRequest, want: SeverityMedium},
+		{name: "success fallback", status: http.StatusOK, want: SeverityLow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := severityForStatus(tt.status); got != tt.want {
+				t.Errorf("severityForStatus(%d) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultActionForStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{name: "login", status: http.StatusUnauthorized, want: "login"},
+		{name: "access", status: http.StatusForbidden, want: "request_access"},
+		{name: "timeout", status: http.StatusRequestTimeout, want: "retry_later"},
+		{name: "server", status: http.StatusInternalServerError, want: "retry_later"},
+		{name: "client", status: http.StatusBadRequest, want: "fix_input"},
+		{name: "success fallback", status: http.StatusOK, want: "none"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultActionForStatus(tt.status); got != tt.want {
+				t.Errorf("defaultActionForStatus(%d) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/server/internal/apperror/registry_test.go
+++ b/apps/server/internal/apperror/registry_test.go
@@ -1,0 +1,39 @@
+package apperror
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestLookupDefinition_KnownCode(t *testing.T) {
+	defn, ok := LookupDefinition(ErrMediaReferenceInUse)
+	if !ok {
+		t.Fatal("expected media reference definition")
+	}
+
+	if defn.Domain != "media" {
+		t.Errorf("Domain = %q, want media", defn.Domain)
+	}
+	if defn.HTTPStatus != http.StatusConflict {
+		t.Errorf("HTTPStatus = %d, want %d", defn.HTTPStatus, http.StatusConflict)
+	}
+	if defn.UserAction != "review_references" {
+		t.Errorf("UserAction = %q, want review_references", defn.UserAction)
+	}
+	if defn.DefaultKR == "" {
+		t.Error("DefaultKR should be set for creator-facing message fallback")
+	}
+}
+
+func TestDefinitionForResponse_PreservesOccurrenceStatus(t *testing.T) {
+	appErr := New(ErrBadRequest, http.StatusUnprocessableEntity, "domain validation failed")
+
+	defn := definitionForResponse(appErr)
+
+	if defn.HTTPStatus != http.StatusUnprocessableEntity {
+		t.Errorf("HTTPStatus = %d, want occurrence status %d", defn.HTTPStatus, http.StatusUnprocessableEntity)
+	}
+	if defn.Code != ErrBadRequest {
+		t.Errorf("Code = %q, want %q", defn.Code, ErrBadRequest)
+	}
+}

--- a/apps/web/src/lib/api-error.ts
+++ b/apps/web/src/lib/api-error.ts
@@ -26,6 +26,10 @@ export class ApiHttpError extends Error {
   get traceId(): string | undefined {
     return this.apiError.trace_id;
   }
+
+  get requestId(): string | undefined {
+    return this.apiError.request_id;
+  }
 }
 
 /** Type guard for ApiError shape. */

--- a/apps/web/src/lib/show-error-toast.test.ts
+++ b/apps/web/src/lib/show-error-toast.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiError } from '@mmp/shared';
+import { toast } from 'sonner';
 
-import { getErrorReference } from '@/lib/show-error-toast';
+import { captureApiError } from '@/lib/sentry';
+import { getErrorReference, showErrorToast } from '@/lib/show-error-toast';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/sentry', () => ({
+  captureApiError: vi.fn(),
+}));
 
 function apiError(overrides: Partial<ApiError>): ApiError {
   return {
@@ -13,6 +25,10 @@ function apiError(overrides: Partial<ApiError>): ApiError {
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('getErrorReference', () => {
   it('request_id를 trace_id보다 우선 표시한다', () => {
@@ -40,5 +56,38 @@ describe('getErrorReference', () => {
 
   it('표시 가능한 추적 ID가 없으면 undefined를 반환한다', () => {
     expect(getErrorReference(apiError({}))).toBeUndefined();
+  });
+});
+
+describe('showErrorToast', () => {
+  it('4xx 에러는 5초 토스트와 request_id 참조를 표시한다', () => {
+    showErrorToast(apiError({ request_id: 'request-123456789' }));
+
+    expect(toast.error).toHaveBeenCalledWith('잘못된 요청입니다.', {
+      description: 'Ref: request-',
+      duration: 5000,
+    });
+    expect(captureApiError).not.toHaveBeenCalled();
+  });
+
+  it('5xx 에러는 Sentry에 캡처하고 수동 닫기 토스트로 표시한다', () => {
+    showErrorToast(
+      apiError({
+        status: 500,
+        title: 'Internal Server Error',
+        code: 'INTERNAL_ERROR',
+        detail: 'server failed',
+        trace_id: 'trace-987654321',
+      })
+    );
+
+    expect(captureApiError).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+      {
+        description: 'Ref: trace-98',
+        duration: Infinity,
+      }
+    );
   });
 });

--- a/apps/web/src/lib/show-error-toast.test.ts
+++ b/apps/web/src/lib/show-error-toast.test.ts
@@ -32,6 +32,12 @@ describe('getErrorReference', () => {
     expect(ref).toBe('trace-98');
   });
 
+  it('request_id가 비어 있으면 trace_id로 대체한다', () => {
+    const ref = getErrorReference(apiError({ request_id: '   ', trace_id: 'trace-987654321' }));
+
+    expect(ref).toBe('trace-98');
+  });
+
   it('표시 가능한 추적 ID가 없으면 undefined를 반환한다', () => {
     expect(getErrorReference(apiError({}))).toBeUndefined();
   });

--- a/apps/web/src/lib/show-error-toast.test.ts
+++ b/apps/web/src/lib/show-error-toast.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { ApiError } from '@mmp/shared';
+
+import { getErrorReference } from '@/lib/show-error-toast';
+
+function apiError(overrides: Partial<ApiError>): ApiError {
+  return {
+    type: 'about:blank',
+    title: 'Bad Request',
+    status: 400,
+    detail: 'bad request',
+    code: 'BAD_REQUEST',
+    ...overrides,
+  };
+}
+
+describe('getErrorReference', () => {
+  it('request_id를 trace_id보다 우선 표시한다', () => {
+    const ref = getErrorReference(
+      apiError({
+        request_id: 'request-123456789',
+        trace_id: 'trace-987654321',
+      })
+    );
+
+    expect(ref).toBe('request-');
+  });
+
+  it('request_id가 없으면 trace_id를 표시한다', () => {
+    const ref = getErrorReference(apiError({ trace_id: 'trace-987654321' }));
+
+    expect(ref).toBe('trace-98');
+  });
+
+  it('표시 가능한 추적 ID가 없으면 undefined를 반환한다', () => {
+    expect(getErrorReference(apiError({}))).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/show-error-toast.ts
+++ b/apps/web/src/lib/show-error-toast.ts
@@ -37,6 +37,8 @@ export function showErrorToast(error: ApiError): void {
 }
 
 export function getErrorReference(error: ApiError): string | undefined {
-  const id = error.request_id ?? error.trace_id;
+  const requestId = error.request_id?.trim();
+  const traceId = error.trace_id?.trim();
+  const id = requestId || traceId;
   return id ? id.slice(0, 8) : undefined;
 }

--- a/apps/web/src/lib/show-error-toast.ts
+++ b/apps/web/src/lib/show-error-toast.ts
@@ -1,7 +1,7 @@
-import { toast } from "sonner";
-import type { ApiError } from "@mmp/shared";
-import { getUserMessage } from "@/lib/error-messages";
-import { captureApiError } from "@/lib/sentry";
+import { toast } from 'sonner';
+import type { ApiError } from '@mmp/shared';
+import { getUserMessage } from '@/lib/error-messages';
+import { captureApiError } from '@/lib/sentry';
 
 /**
  * API 에러를 sonner 토스트로 표시한다.
@@ -11,18 +11,14 @@ import { captureApiError } from "@/lib/sentry";
  */
 export function showErrorToast(error: ApiError): void {
   // 401은 토스트 대신 리다이렉트 (로그인 페이지에서는 루프 방지)
-  if (
-    error.status === 401 &&
-    !window.location.pathname.startsWith("/login")
-  ) {
-    window.location.href = "/login";
+  if (error.status === 401 && !window.location.pathname.startsWith('/login')) {
+    window.location.href = '/login';
     return;
   }
 
   const message = getUserMessage(error);
-  const description = error.trace_id
-    ? `Ref: ${error.trace_id.slice(0, 8)}`
-    : undefined;
+  const ref = getErrorReference(error);
+  const description = ref ? `Ref: ${ref}` : undefined;
 
   if (error.status >= 500) {
     captureApiError(new Error(error.detail), error);
@@ -38,4 +34,9 @@ export function showErrorToast(error: ApiError): void {
       duration: 5000,
     });
   }
+}
+
+export function getErrorReference(error: ApiError): string | undefined {
+  const id = error.request_id ?? error.trace_id;
+  return id ? id.slice(0, 8) : undefined;
 }

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -37,7 +37,7 @@ Phase 24의 목표는 제작자용 에디터를 **프론트 Adapter / 백엔드 
 | [#259](https://github.com/sabyunrepo/muder_platform/issues/259) | 미션·덱 조사·미디어 효과 후속 엔티티 정리 | done |
 | [#261](https://github.com/sabyunrepo/muder_platform/issues/261) | Mission Adapter/Engine 경계 정리 | done — PR #272 merged |
 | [#260](https://github.com/sabyunrepo/muder_platform/issues/260) | 미전환 에디터 엔티티 Adapter Epic | ready to close |
-| [#246](https://github.com/sabyunrepo/muder_platform/issues/246) | Phase 24 wrap-up 및 후속 범위 정리 | active in this PR |
+| [#246](https://github.com/sabyunrepo/muder_platform/issues/246) | Phase 24 wrap-up 및 후속 범위 정리 | done |
 
 ## Phase 25 후보 큐
 
@@ -50,7 +50,7 @@ Phase 24의 목표는 제작자용 에디터를 **프론트 Adapter / 백엔드 
 3. [#249](https://github.com/sabyunrepo/muder_platform/issues/249) — 결말/투표 결과 breakdown 및 종료 화면 연결
    - 게임 종료 시 공통 결말, 캐릭터별 결과, 투표/미션 점수 요약을 연결한다.
 4. [#271](https://github.com/sabyunrepo/muder_platform/issues/271) — RFC 9457 + Google AIP-193 에러 계약
-   - 기능 개발을 막지 않는 별도 기반 작업으로 둔다. API/런타임 에러 응답 표준화가 필요할 때 착수한다.
+   - PR-1 감사 문서화부터 착수했다. API/런타임 에러 응답 표준화는 PR-2 이후 코드 변경으로 나눈다.
 
 ## 유지할 원칙
 
@@ -69,7 +69,7 @@ Phase 24의 목표는 제작자용 에디터를 **프론트 Adapter / 백엔드 
 | dev preview/mock route 혼동 | #250에서 정리 | 새 mock은 실제 구현 컴포넌트와 분리하지 않는다 |
 | 단서/장소 runtime 효과 미완성 | Phase 25 후보 | #247, #248에서 백엔드 Engine 우선 설계 |
 | 결말/투표 breakdown 미완성 | Phase 25 후보 | #249에서 종료 화면과 함께 처리 |
-| 에러 계약 표준화 | 별도 후보 | #271에서 RFC 9457/Google AIP-193 기반으로 진행 |
+| 에러 계약 표준화 | 진행 중 | #271 PR-1에서 현재 HTTP/FE/WS 에러 계약 감사를 먼저 문서화하고, PR-2 이후 backend registry/front recovery로 분리한다 |
 
 ## 검증 게이트
 

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/checklist.md
@@ -50,7 +50,7 @@ Phase 24의 목표는 제작자용 에디터를 **프론트 Adapter / 백엔드 
 3. [#249](https://github.com/sabyunrepo/muder_platform/issues/249) — 결말/투표 결과 breakdown 및 종료 화면 연결
    - 게임 종료 시 공통 결말, 캐릭터별 결과, 투표/미션 점수 요약을 연결한다.
 4. [#271](https://github.com/sabyunrepo/muder_platform/issues/271) — RFC 9457 + Google AIP-193 에러 계약
-   - PR-1 감사 문서화부터 착수했다. API/런타임 에러 응답 표준화는 PR-2 이후 코드 변경으로 나눈다.
+   - PR-1에서 감사 문서화와 v1 핵심 계약 일부(`apperror` registry, ProblemDetail metadata, frontend ApiError)를 함께 반영한다. PR-2 이후에는 남은 표준화와 도메인별 적용을 분리한다.
 
 ## 유지할 원칙
 

--- a/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-271-error-contract-audit.md
+++ b/docs/plans/2026-05-01-phase-24-editor-redesign/refs/issue-271-error-contract-audit.md
@@ -1,0 +1,214 @@
+# Issue #271 — MMP Error Contract v1 감사
+
+## 목표
+
+Phase 24 이후 에디터/런타임 API가 늘어나는 상황에서 프론트와 백엔드가 같은 에러 계약을 보도록 정리한다. 이번 문서는 바로 구현을 바꾸기 전, 현재 코드와 표준 사이의 차이를 확인하고 PR-2 이후 구현 범위를 자르는 감사 결과다.
+
+## 외부 기준
+
+- RFC 9457 Problem Details for HTTP APIs
+  - `application/problem+json` 응답과 `type`, `title`, `status`, `detail`, `instance` 표준 필드를 기준으로 한다.
+  - API별 추가 정보는 확장 멤버로 제공할 수 있어야 한다.
+  - `detail`은 내부 스택/DB 오류가 아니라 클라이언트가 문제를 해결하는 데 도움이 되는 설명이어야 한다.
+- Google AIP-193 Errors
+  - 기계가 읽는 식별자와 사람용 메시지를 분리한다.
+  - 동적 정보는 메시지 문자열 파싱이 아니라 구조화된 metadata/detail로 전달한다.
+  - 오류 메시지는 짧고 실행 가능한 안내여야 하며, 권한/존재 여부 같은 민감 정보 노출 정책을 분명히 한다.
+
+## 현재 코드 감사
+
+### 백엔드 HTTP 에러
+
+대상 파일:
+
+- `apps/server/internal/apperror/apperror.go`
+- `apps/server/internal/apperror/handler.go`
+- `apps/server/internal/apperror/codes.go`
+- `apps/server/internal/httputil/handler.go`
+- `apps/server/internal/middleware/requestid.go`
+- `apps/server/api/openapi.yaml`
+
+확인 결과:
+
+- `AppError`는 이미 RFC 9457 계열 필드(`type`, `title`, `status`, `detail`, `instance`)와 MMP 확장 필드(`code`, `params`, `errors`, `extensions`)를 가진다.
+- `WriteError`는 `Content-Type: application/problem+json`을 내려주고, production 5xx `detail`을 raw 내부 메시지로 노출하지 않도록 마스킹한다.
+- `Internal` 원인은 `json:"-"`로 숨기고 Sentry/logging에만 보낸다.
+- `trace_id`는 OpenTelemetry span이 유효할 때만 응답 body에 포함된다.
+- `RequestID` 미들웨어는 `X-Request-ID`를 생성/반환하지만 `WriteError` body에는 `request_id` 또는 `correlation_id`로 포함되지 않는다.
+- `codes.go`는 const 목록만 있고 domain/severity/retryable/user_action/default message 같은 registry metadata는 없다.
+- OpenAPI `ProblemDetail` schema는 기본 필드와 `code`만 문서화되어 있고 `params`, `errors`, `extensions`, `trace_id`, 향후 `severity`, `retryable`, `user_action`, `request_id`가 빠져 있다.
+- OpenAPI 공통 오류 response content type이 `application/json`으로 되어 있어 실제 `application/problem+json`과 어긋난다.
+
+### 프론트 HTTP 에러
+
+대상 파일:
+
+- `packages/shared/src/api/types.ts`
+- `apps/web/src/services/api.ts`
+- `apps/web/src/lib/api-error.ts`
+- `apps/web/src/lib/error-messages.ts`
+- `apps/web/src/lib/show-error-toast.ts`
+- `apps/web/src/components/error/*`
+
+확인 결과:
+
+- shared `ApiError`는 RFC 9457 계열 타입과 `code`, `params`, `errors`, `trace_id`, `debug`를 가진다.
+- API client는 실패 응답 body가 `ApiError` shape이면 `ApiHttpError`로 던진다.
+- 네트워크 실패는 프론트 자체 `NETWORK_ERROR`로 감싼다.
+- `showErrorToast`는 401 redirect, 4xx 5초 toast, 5xx 무한 toast + Sentry 캡처를 한다.
+- `error-messages.ts`는 코드별 한국어 메시지를 직접 관리하지만 백엔드 `codes.go`와 동기화 검증이 없다.
+- `ApiError` 타입에는 `extensions`가 없어 백엔드 `WithExtensions` 응답을 타입 차원에서 잃는다.
+- `severity`, `retryable`, `user_action`, `request_id` 기반 복구 전략은 아직 없다.
+- 일부 feature code는 `status === 409`, `code === MEDIA_REFERENCE_IN_USE` 같은 개별 분기를 직접 가진다. 이것 자체는 문제는 아니지만 중앙 recovery map 없이 늘어나면 사용자 메시지와 복구 UX가 분산된다.
+
+### WebSocket 에러
+
+대상 파일:
+
+- `apps/server/internal/ws/message.go`
+- `apps/server/internal/ws/reading_handler.go`
+- `apps/server/internal/ws/envelope_registry.go`
+
+확인 결과:
+
+- WS error envelope는 `{ type: "error", payload: { code: number, message: string } }` 형태다.
+- reading handler는 `apperror.AppError`를 WS numeric code와 string code가 섞인 message로 변환한다.
+- HTTP ProblemDetail과 WS error envelope는 같은 wire shape를 쓰지 않는다. 이는 괜찮지만, WS payload 안에도 `app_code`, `user_message`, `retryable`, `request_id` 같은 최소 계약을 둘지 결정이 필요하다.
+
+## 갭과 영향
+
+### 1. Backend `extensions` 주석과 실제 wire shape 불일치
+
+`WithExtensions` 주석은 RFC 9457 extension members가 top-level에 노출된다고 설명하지만, 실제 `problemResponse`는 `extensions`라는 nested object로 내려준다.
+
+영향:
+
+- 프론트/문서가 top-level 확장 멤버를 기대하면 런타임에서 값을 못 읽는다.
+- 반대로 지금 wire shape를 이미 쓰고 있다면 top-level로 바꾸는 것은 breaking change가 될 수 있다.
+
+권장:
+
+- MMP v1에서는 `extensions` nested object를 유지하고 문서/주석을 실제 wire shape에 맞춘다.
+- RFC 9457 extension member로 top-level을 꼭 써야 하는 경우는 v2 migration으로 분리한다.
+
+### 2. Correlation ID 이름과 위치 불일치
+
+현재 서버는 `X-Request-ID` header를 제공하고, OTel span이 있으면 body에 `trace_id`를 넣는다. 프론트는 `trace_id`만 표시한다.
+
+영향:
+
+- OTel span이 없는 일반 요청 실패에서는 사용자가 전달할 짧은 오류 ID가 없다.
+- 운영자는 `X-Request-ID`, `trace_id`, Sentry event를 연결해 찾아야 해서 디버깅 흐름이 흔들린다.
+
+권장:
+
+- HTTP body에는 `request_id`를 추가한다.
+- `trace_id`는 관측성용으로 유지한다.
+- 프론트 오류 UI는 `request_id ?? trace_id`의 앞 8자를 표시한다.
+
+### 3. Error code registry 부재
+
+현재 error code는 const 문자열 목록이고, 프론트 메시지는 별도 TS map이다.
+
+영향:
+
+- 백엔드에 새 코드가 추가되어도 프론트 메시지가 빠지는 것을 자동으로 잡기 어렵다.
+- 사용자에게 표시할 메시지, 복구 버튼, 재시도 가능 여부가 기능별로 흩어진다.
+
+권장:
+
+- PR-2에서 백엔드 `ErrorDefinition` registry를 추가한다.
+- PR-3에서 프론트 `recoveryMap`을 추가하되, 초기에는 registry code subset을 수동 mirror하고 테스트로 누락을 잡는다.
+- generated shared source는 지금은 과하다. OpenAPI/코드 생성 정리 시점에 별도 검토한다.
+
+### 4. OpenAPI와 실제 응답 불일치
+
+OpenAPI 공통 오류 response는 `application/json`이며 `ProblemDetail` schema도 실제 확장 필드를 모두 담지 않는다.
+
+영향:
+
+- API 문서와 클라이언트 타입 생성 결과가 실제 응답과 달라질 수 있다.
+- CodeRabbit/자동검증보다 운영 중 프론트에서 먼저 깨질 가능성이 있다.
+
+권장:
+
+- PR-2에서 OpenAPI 오류 content type을 `application/problem+json`으로 정리한다.
+- `ProblemDetail`에 MMP extension field를 문서화한다.
+
+### 5. WS 에러는 HTTP ProblemDetail과 동일화하지 말고 매핑 계약만 둔다
+
+WS는 실시간 게임 메시지라 HTTP shape를 그대로 넣으면 payload가 무거워지고 기존 클라이언트와 충돌한다.
+
+영향:
+
+- 단기적으로는 기존 numeric code 호환성을 유지해야 한다.
+- 다만 message 문자열에 app code를 섞는 방식은 장기적으로 안전하지 않다.
+
+권장:
+
+- PR-4 이후 WS payload를 확장 가능한 형태로 바꾼다.
+- 예: `{ code: 4004, app_code: "READING_SECTION_NOT_FOUND", message: "...", request_id: "...", retryable: false }`.
+
+## PR 분해
+
+### PR-1: 감사 문서화
+
+현재 PR 범위. 코드 변경 없이 감사 문서와 이슈 진행 기록만 남긴다.
+
+완료 조건:
+
+- 현재 HTTP/FE/WS 에러 shape와 표준 대비 갭이 문서화된다.
+- PR-2 이후 구현 범위가 명확해진다.
+
+### PR-2: Backend Error Registry + ProblemDetail 정합성
+
+범위:
+
+- `ErrorDefinition` registry 추가
+- `AppError`/`WriteError`가 registry metadata를 참조하도록 확장
+- `request_id`, `severity`, `retryable`, `user_action` 응답 필드 추가
+- `extensions` 주석/문서 정합성 수정
+- OpenAPI `application/problem+json` 및 schema 갱신
+- handler unit test 추가
+
+완료 조건:
+
+- production 5xx masking 유지
+- 기존 `code/status/detail` 클라이언트 호환성 유지
+- request id가 header와 body에 모두 존재
+
+### PR-3: Frontend Recovery Strategy
+
+범위:
+
+- shared `ApiError` 타입에 `extensions`, `request_id`, `severity`, `retryable`, `user_action` 추가
+- `showErrorToast`를 severity/user_action 기반으로 확장
+- auth/editor/media 주요 code recovery map 추가
+- 사용자에게 내부 detail 대신 해결 행동을 보여준다
+- Vitest 추가
+
+완료 조건:
+
+- code별 한국어 메시지 누락을 테스트로 잡는다.
+- 5xx는 request/trace short id를 표시한다.
+- editor/media 충돌 UX가 중앙 정책과 충돌하지 않는다.
+
+### PR-4: Editor/Media/Session 우선 적용 + WS 경계
+
+범위:
+
+- editor config conflict, media reference-in-use, upload error UX 우선 적용
+- session/phase runtime error 우선 적용
+- WS error payload 확장 방향 확정 및 호환 테스트
+
+완료 조건:
+
+- 제작자는 “무엇이 문제이고 어떻게 해결할지”를 볼 수 있다.
+- 내부 구현 detail, DB/stack/raw JSON은 production UI에 노출되지 않는다.
+
+## 즉시 구현하지 않는 것
+
+- `{Domain}-{Severity}-{Layer}-{Sequence}` 코드 체계 이식
+- top-level RFC extension member로 wire shape 변경
+- Sentry/OTel 전면 재설계
+- Python/Temporal/ErrorPrism 계층 도입

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -15,6 +15,11 @@ export interface ApiError {
   code?: string;
   errors?: FieldError[];
   params?: Record<string, unknown>;
+  extensions?: Record<string, unknown>;
+  request_id?: string;
+  severity?: 'critical' | 'high' | 'medium' | 'low';
+  retryable?: boolean;
+  user_action?: string;
   trace_id?: string;
   debug?: {
     internal?: string;


### PR DESCRIPTION
## 요약

- #271 에러 계약 작업을 시작하고 RFC 9457/Google AIP-193 기준 감사 문서를 추가했습니다.
- 백엔드 `apperror`에 Error Registry를 추가해 code별 `severity`, `retryable`, `user_action` 메타데이터를 내려주도록 했습니다.
- `ProblemDetail` 응답과 OpenAPI 문서에 `request_id`, `severity`, `retryable`, `user_action`, `extensions` 등을 반영했습니다.
- 프론트 `ApiError` 타입과 오류 토스트 reference 표시를 `request_id` 우선으로 확장했습니다.

## 검증

- `cd apps/server && go test ./internal/apperror`
- `cd apps/server && go test ./internal/apperror ./internal/httputil`
- `pnpm --filter @mmp/web exec vitest run src/lib/show-error-toast.test.ts`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec eslint src/lib/show-error-toast.ts src/lib/show-error-toast.test.ts src/lib/api-error.ts`
- `git diff --check`

## 이슈

- Ref #271

## CI 운영

- PR 생성 시 `ready-for-ci` 라벨은 붙이지 않습니다.
- CodeRabbit 리뷰를 먼저 확인하고 타당한 내용 반영 후 재검토까지 완료한 뒤 라벨을 붙입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 에러 응답이 RFC 9457 기반의 application/problem+json 형식으로 전환되고, params·errors·extensions·trace_id·request_id·severity·retryable·user_action 등의 진단·복구 필드가 추가되었습니다.
  * 클라이언트 API 에러 타입에 request_id/trace_id/severity/retryable/user_action 필드가 노출되어 토스트와 오류 참조에서 request_id 우선 사용이 가능합니다.

* **Documentation**
  * 에러 계약 감사 문서와 체크리스트가 추가·갱신되었습니다.

* **Tests**
  * 서버·클라이언트의 새 동작(요청 ID 우선순위, 레지스트리 메타데이터 등)을 검증하는 테스트들이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->