### PR TITLE
chore: 병렬 이슈 설계 워크플로 추가

### DIFF
--- a/.codex/agents/mmp-backend-engine-reviewer.toml
+++ b/.codex/agents/mmp-backend-engine-reviewer.toml
@@ -1,4 +1,5 @@
 name = "mmp-backend-engine-reviewer"
+sandbox_mode = "read-only"
 description = "Review MMP backend entity, API, persistence, and runtime engine changes for Phase 24 editor/runtime consistency."
 developer_instructions = """
 You are the MMP backend engine reviewer.

--- a/.codex/agents/mmp-frontend-editor-reviewer.toml
+++ b/.codex/agents/mmp-frontend-editor-reviewer.toml
@@ -1,4 +1,5 @@
 name = "mmp-frontend-editor-reviewer"
+sandbox_mode = "read-only"
 description = "Review MMP editor frontend changes for creator usability, responsive UI, adapter boundaries, reusable components, accessibility, and E2E coverage readiness."
 developer_instructions = """
 You are the MMP frontend editor reviewer.

--- a/.codex/agents/mmp-issue-architect.toml
+++ b/.codex/agents/mmp-issue-architect.toml
@@ -1,0 +1,41 @@
+name = "mmp-issue-architect"
+description = "Draft or rewrite MMP GitHub issues into execution-ready plans with parallel work design, file ownership, PR grouping, and validation criteria."
+sandbox_mode = "read-only"
+developer_instructions = """
+You are the MMP issue architect.
+
+Mission:
+- Turn MMP feature, bug, refactor, or workflow requests into GitHub issue bodies that can be executed across sessions.
+- Design issues so Codex can safely use parallel subagents when the user explicitly asks for parallel/subagent work.
+- Keep issues creator- and maintainer-friendly: clear scope, explicit exclusions, validation, and completion criteria.
+
+Use this issue structure unless the parent agent asks for a narrower patch:
+1. 목표
+2. 배경
+3. 작업 범위
+4. 병렬 작업 설계
+   - 병렬 가능 작업
+   - 파일/모듈 소유권
+   - 병렬 금지/주의 영역
+   - 취합 방식
+5. 제외
+6. 완료 조건
+7. 검증 계획
+8. PR 묶음 제안
+9. 브레인스토밍 필요 여부
+10. 순서/의존성
+
+Rules:
+- Prefer read-heavy parallel audit first, then main-agent integration.
+- Name the concrete MMP agents when applicable: `mmp-parallel-coordinator`, `mmp-frontend-editor-reviewer`, `mmp-backend-engine-reviewer`, `mmp-test-coverage-reviewer`.
+- Do not assign two agents to edit the same file or contract boundary at the same time.
+- Put API DTO, frontend adapter/ViewModel mapping, migration decisions, labels, PR creation, and merge decisions under main-agent ownership.
+- Separate MVP scope from future scope. Do not add enterprise bloat.
+- Mention Uzu docs only for editor domain improvement; do not copy another system blindly.
+- Write Korean issue text. Keep code identifiers and paths in original form.
+
+Output modes:
+- If the parent asks for a GitHub issue body, return the issue body directly in Markdown using the structure above.
+- If the parent asks for review or comparison instead of a final issue body, output in Korean under 700 words with exactly these sections: 발견 / 수행 / 판단 / 미해결.
+"""
+nickname_candidates = ["Naru", "Oren", "Pia"]

--- a/.codex/agents/mmp-parallel-coordinator.toml
+++ b/.codex/agents/mmp-parallel-coordinator.toml
@@ -1,0 +1,41 @@
+name = "mmp-parallel-coordinator"
+description = "Plan MMP parallel subagent execution by splitting read/write tasks, assigning ownership, identifying conflicts, and defining integration checkpoints."
+sandbox_mode = "read-only"
+developer_instructions = """
+You are the MMP parallel work coordinator.
+
+Mission:
+- Before implementation, inspect an issue, plan, or diff and decide how to use parallel subagents safely.
+- Split work into independent read-heavy audit, review, test, and documentation tasks first.
+- For write-heavy work, assign disjoint file/module ownership and mark shared contracts for the main Codex agent.
+
+Plan format:
+1. 병렬화 판단
+   - 가능 여부
+   - 예상 효과
+   - 주요 충돌 위험
+2. 권장 에이전트 배치
+   - Coordinator: `mmp-parallel-coordinator` when the task needs orchestration before spawning others.
+   - Frontend: `mmp-frontend-editor-reviewer` for editor UI, adapter, responsive UX, creator-facing exposure, and E2E readiness.
+   - Backend: `mmp-backend-engine-reviewer` for Go API, persistence, runtime engine, migration, and deletion consistency.
+   - Test/Coverage: `mmp-test-coverage-reviewer` for E2E, Vitest, Go tests, Codecov, and CI readiness.
+   - Docs/Spec: main Codex or a read-only explorer when no dedicated docs agent exists.
+3. 파일/모듈 소유권
+4. 실행 순서
+5. 중단 조건
+6. 메인 에이전트 통합 체크리스트
+
+Rules:
+- Codex subagents are used only when the user explicitly asks for subagents, delegation, or parallel agent work.
+- Read-heavy work is the default parallel candidate: exploration, tests, triage, log analysis, and summarization.
+- Be cautious with parallel code edits. If two agents must touch the same adapter, API DTO, migration, or route file, make the main agent integrate sequentially.
+- Do not perform code edits, PR creation, label changes, merge, deploy, secret access, or destructive commands.
+- Keep recommendations practical for current MMP Phase 25 issues.
+
+Output in Korean, under 600 words, with exactly these sections:
+- 발견
+- 수행
+- 판단
+- 미해결
+"""
+nickname_candidates = ["Rin", "Sora", "Tao"]

--- a/.codex/agents/mmp-test-coverage-reviewer.toml
+++ b/.codex/agents/mmp-test-coverage-reviewer.toml
@@ -1,4 +1,5 @@
 name = "mmp-test-coverage-reviewer"
+sandbox_mode = "read-only"
 description = "Review MMP test strategy, E2E coverage, Codecov patch coverage, and CI readiness before PR labeling or merge."
 developer_instructions = """
 You are the MMP test and coverage reviewer.

--- a/.codex/skills/mmp-issue-planning/SKILL.md
+++ b/.codex/skills/mmp-issue-planning/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: mmp-issue-planning
+description: Use when creating, rewriting, prioritizing, or executing MMP GitHub issues, especially when issue bodies need parallel work design, subagent assignment, file ownership, PR grouping, or brainstorming gates.
+---
+
+# MMP Issue Planning
+
+## 근거
+
+이 워크플로는 현재 Codex 공식 문서의 원칙을 MMP 방식으로 좁혀 적용한다.
+
+- Subagents: https://developers.openai.com/codex/subagents
+- Subagent concepts: https://developers.openai.com/codex/concepts/subagents
+- Skills: https://developers.openai.com/codex/skills
+- AGENTS.md: https://developers.openai.com/codex/guides/agents-md
+- Worktrees: https://developers.openai.com/codex/app/worktrees
+
+핵심 원칙:
+- subagent는 사용자가 병렬/위임/subagent 작업을 명시한 경우에만 사용한다.
+- 병렬화는 탐색, 테스트, triage, 로그 분석, 요약 같은 read-heavy 작업부터 적용한다.
+- write-heavy 병렬 작업은 같은 파일/계약을 동시에 수정하면 충돌이 커지므로 파일 소유권을 먼저 나눈다.
+- skill은 반복 워크플로를 담고, AGENTS.md는 항상 알아야 하는 durable project rule만 담는다.
+
+## When
+
+- GitHub Issue를 새로 만들거나 기존 Issue를 재작성할 때.
+- 다음 세션에서 바로 실행할 수 있게 작업 범위, 병렬 작업, 검증 조건을 정리해야 할 때.
+- 사용자가 병렬작업, subagent, PR 묶음, 이슈 재설계, 브레인스토밍 필요 여부를 물을 때.
+
+## Do
+
+1. Issue 편집이나 repo 파일 변경은 feature/chore branch에서 진행한다.
+2. 각 Issue에는 가능한 한 아래 섹션을 포함한다.
+   - `## 목표`
+   - `## 배경`
+   - `## 작업 범위`
+   - `## 병렬 작업 설계`
+   - `## 제외`
+   - `## 완료 조건`
+   - `## 검증 계획`
+   - `## PR 묶음 제안`
+   - `## 브레인스토밍 필요 여부`
+   - `## 순서/의존성`
+3. `## 병렬 작업 설계`에는 아래 하위 섹션을 둔다.
+   - `### 병렬 가능 작업`: 실제 사용할 agent lane을 적는다.
+   - `### 파일/모듈 소유권`: 각 lane이 읽거나 수정할 수 있는 디렉터리/파일을 적는다.
+   - `### 병렬 금지/주의 영역`: shared contract, migration, PR label/merge, 같은 파일 수정 위험을 적는다.
+   - `### 취합 방식`: 각 subagent는 `발견 / 수행 / 판단 / 미해결`로 보고하고, 메인 Codex가 중복 제거와 최종 통합을 맡는다고 적는다.
+4. 가능한 경우 실제 MMP agent 이름을 명시한다.
+   - `mmp-parallel-coordinator`
+   - `mmp-frontend-editor-reviewer`
+   - `mmp-backend-engine-reviewer`
+   - `mmp-test-coverage-reviewer`
+5. API DTO, frontend adapter/ViewModel mapping, migration 결정, PR 생성, label, merge는 메인 Codex 소유로 둔다.
+6. MVP와 후순위를 분리한다. 범위가 커지면 후속 Issue를 만든다.
+7. 에디터 이슈는 Uzu docs를 참고할 수 있지만, MMP runtime/gameplay 규칙이 최종 기준이다.
+
+## Done
+
+- Issue 본문만 읽어도 병렬 audit, 순차 통합, 검증 범위가 보인다.
+- 병렬 가능한 lane과 충돌 금지 영역이 둘 다 적혀 있다.
+- 완료 조건에 테스트 또는 테스트 대체 근거가 있다.
+- PR 묶음과 브레인스토밍 필요 여부가 명확하다.
+
+## Avoid
+
+- 모든 Issue를 억지로 병렬화하지 않는다. 의존성이 강하면 sequential로 표시한다.
+- 여러 agent에게 같은 파일/모듈 write ownership을 주지 않는다.
+- 제작자 UI 요구사항에 내부 ID, raw JSON, engine key, debug state 노출을 넣지 않는다.
+- 이슈 작성만으로 구현 검증이 끝났다고 주장하지 않는다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,12 +52,17 @@ Do:
 2. PR 본문에 `Closes #번호` 또는 `Refs #번호`를 명시한다.
 3. 작업 중 scope가 바뀌면 Issue checklist 또는 plan 문서를 먼저 갱신한다.
 4. 완료 보고에는 닫힌 Issue, 남은 Issue, 다음 권장 Issue를 포함한다.
+5. 새 Issue를 만들거나 기존 Issue를 재설계할 때는 가능한 경우 `mmp-issue-planning` skill을 사용한다.
+6. 병렬 처리가 가능한 Issue에는 `## 병렬 작업 설계`를 포함해 병렬 가능 작업, 파일/모듈 소유권, 병렬 금지/주의 영역, 취합 방식을 명시한다.
+7. Issue 작성/재작성 자체가 복잡하면 `.codex/agents/mmp-issue-architect.toml` 역할을 사용해 초안을 만들고, 메인 Codex가 scope와 우선순위를 최종 검토한다.
 
 Done when:
 - PR/commit/보고에서 어떤 Issue를 해결했는지 추적 가능하다.
+- 다음 세션이 Issue 본문만 보고도 병렬 audit, 순차 통합, 검증 범위를 알 수 있다.
 
 Avoid:
 - 계획 없는 대형 PR로 여러 Issue를 한 번에 섞지 않는다. 단, 사용자가 명시적으로 묶기를 승인한 경우는 예외다.
+- 병렬작업 설계 없이 여러 sub-agent나 worker에게 같은 파일/계약을 동시에 맡기지 않는다.
 
 ## 작업 루틴
 
@@ -117,13 +122,17 @@ Do:
 3. 코드 수정 sub-agent에는 소유 파일/모듈을 명확히 지정하고, 다른 작업자가 있을 수 있으니 기존 변경을 되돌리지 말라고 지시한다.
 4. 리뷰 sub-agent 결과는 사용자에게 raw output으로 붙이지 말고 `발견 / 수행 / 판단 / 미해결` 4섹션으로 압축한다.
 5. MMP 전용 리뷰에는 가능한 경우 `.codex/agents/mmp-frontend-editor-reviewer.toml`, `.codex/agents/mmp-backend-engine-reviewer.toml`, `.codex/agents/mmp-test-coverage-reviewer.toml` 역할을 사용한다.
+6. 병렬 실행 계획이 필요한 경우 `.codex/agents/mmp-parallel-coordinator.toml` 역할을 먼저 사용해 read-heavy audit, write ownership, 중단 조건, 메인 통합 체크리스트를 만든다.
+7. 기본 병렬화 순서는 `parallel-coordinator → 필요한 reviewer/worker 병렬 실행 → 메인 Codex 취합 → 충돌 없는 구현 → focused 검증`이다.
 
 Done when:
 - 위임한 범위, sub-agent 결과 요약, 메인 Codex의 최종 판단이 분리되어 보고된다.
+- 병렬화로 줄인 작업과 병렬화하지 않은 이유가 함께 보고된다.
 
 Avoid:
 - secret 조회, destructive command, PR 생성, label 부착, merge, 배포 트리거를 sub-agent에 맡기지 않는다.
 - 다음 로컬 작업이 바로 막히는 critical path를 불필요하게 위임하지 않는다.
+- API DTO, frontend adapter/ViewModel mapping, migration, PR/CI 라벨 전환처럼 공유 계약을 바꾸는 작업은 최종 통합 전까지 여러 agent가 동시에 수정하지 않는다.
 
 ## Git 및 PR 규율
 


### PR DESCRIPTION
## 요약
- MMP 이슈를 병렬작업 친화적으로 작성/재작성하는 `mmp-issue-planning` skill을 추가했습니다.
- 이슈 작성 전용 `mmp-issue-architect`, 병렬 실행 설계용 `mmp-parallel-coordinator` subagent를 추가했습니다.
- 기존 frontend/backend/test reviewer를 read-only로 고정하고, AGENTS.md에 병렬 이슈 설계/실행 규칙을 보강했습니다.

## 검증
- TOML agent schema 파싱 확인
- skill frontmatter 확인
- `git diff --check HEAD~1..HEAD`
- `scripts/mmp-self-improvement-scan.sh --validate`
- GitHub Issue #277~#285 본문에 병렬 작업 설계와 실제 agent 이름 반영 확인

## 운영 메모
- 변경 범위는 `AGENTS.md`, `.codex/**` 중심입니다.
- 앱 런타임/테스트/빌드 트리거 경로를 변경하지 않아 CodeRabbit 확인 후 운영성 PR 경로로 처리합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 기존 에이전트의 보안 설정을 강화하여 읽기 전용 모드로 제한

* **Documentation**
  * 이슈 기획 워크플로우에 대한 새로운 스킬 가이드 추가
  * 새로운 에이전트 역할 및 병렬 작업 조정 메커니즘 구성
  * 작업 진행 프로세스 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->