### PR TITLE
fix(editor): #288 에디터 직접 URL 제작 흐름 연결

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -97,6 +97,55 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await expect(page.getByText("이 단서가 쓰이는 곳")).toBeVisible();
   });
 
+  test("[2B] 직접 URL은 올바른 제작 탭과 서브탭을 연다", async ({ page }) => {
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+    await expect(page.getByRole("tab", { name: "기본정보", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/story`);
+    await expect(page.getByRole("tab", { name: "스토리", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByPlaceholder("마크다운으로 스토리를 작성하세요...")).toBeVisible();
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
+    await expect(page.getByRole("tab", { name: "등장인물", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("탐정 A").first()).toBeVisible();
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
+    await expect(page.getByRole("tab", { name: "단서", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByLabel("단서 목록")).toBeVisible();
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/relations`);
+    await expect(page.getByRole("tab", { name: "단서", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText(/노드를 드래그하여 연결/).first()).toBeVisible({ timeout: 10_000 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/locations`);
+    await expect(page.getByRole("tab", { name: "게임설계", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("저택 1층").first()).toBeVisible({ timeout: 10_000 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/endings`);
+    await expect(page.getByRole("tab", { name: "게임설계", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("ending-entity-panel")).toBeVisible({ timeout: 10_000 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/media`);
+    await expect(page.getByRole("tab", { name: "미디어", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByLabel("미디어 목록")).toBeVisible({ timeout: 10_000 });
+  });
+
   test("[2] 단서 이미지 업로드 경로는 /v1/editor/themes/{id}/images/upload-url (network-only)", async ({ page }) => {
     test.info().annotations.push({
       type: "soft-skip",

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -48,7 +48,7 @@ export interface MockState {
 export function freshState(): MockState {
   return {
     configVersion: 1,
-    configJson: { characters: [], locations: [], modules: { voice_chat: true }, module_configs: {} },
+    configJson: { characters: [], locations: [], modules: {}, module_configs: {} },
     clueImageURL: null,
     startingClueIds: [],
     locationClueIds: [CLUE_ID],
@@ -206,7 +206,7 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
     });
   });
 
-  await page.route(`**/v1/editor/themes/${THEME_ID}/media**`, (r) => {
+  await page.route(new RegExp(`/v1/editor/themes/${THEME_ID}/media(?:\\?.*)?$`), (r) => {
     if (r.request().method() !== "GET") return r.continue();
     return r.fulfill({
       status: 200,

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -48,7 +48,7 @@ export interface MockState {
 export function freshState(): MockState {
   return {
     configVersion: 1,
-    configJson: { characters: [], locations: [], modules: {}, module_configs: {} },
+    configJson: { characters: [], locations: [], modules: { voice_chat: true }, module_configs: {} },
     clueImageURL: null,
     startingClueIds: [],
     locationClueIds: [CLUE_ID],
@@ -206,12 +206,73 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
     });
   });
 
+  await page.route(`**/v1/editor/themes/${THEME_ID}/media**`, (r) => {
+    if (r.request().method() !== "GET") return r.continue();
+    return r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "media-1",
+          theme_id: THEME_ID,
+          name: "긴장감 배경음",
+          type: "BGM",
+          source_type: "FILE",
+          url: "https://mock-storage.example/themes/media/bgm.mp3",
+          duration: 92,
+          file_size: 123456,
+          mime_type: "audio/mpeg",
+          tags: ["조사"],
+          sort_order: 0,
+          created_at: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
+  await page.route(`**/v1/editor/themes/${THEME_ID}/reading-sections`, (r) => {
+    if (r.request().method() !== "GET") return r.continue();
+    return r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "reading-1",
+          themeId: THEME_ID,
+          name: "오프닝 리딩",
+          bgmMediaId: null,
+          lines: [{ Index: 0, Speaker: "GM", Text: "사건의 밤이 시작됩니다.", AdvanceBy: "gm" }],
+          sortOrder: 0,
+          version: 1,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
   await page.route(`**/v1/editor/themes/${THEME_ID}/characters`, (r) => {
     if (r.request().method() !== "GET") return r.continue();
     return r.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify([characterPayload(state)]),
+    });
+  });
+
+  await page.route(`**/v1/editor/themes/${THEME_ID}/flow`, (r) => {
+    if (r.request().method() === "PUT") {
+      return r.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(flowPayload()),
+      });
+    }
+    if (r.request().method() !== "GET") return r.continue();
+    return r.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(flowPayload()),
     });
   });
 
@@ -409,6 +470,50 @@ function cluePayload(state: MockState) {
     use_consumed: true,
     image_url: state.clueImageURL,
     created_at: new Date().toISOString(),
+  };
+}
+
+function flowPayload() {
+  const now = new Date().toISOString();
+  return {
+    nodes: [
+      {
+        id: "phase-1",
+        theme_id: THEME_ID,
+        type: "phase",
+        data: { label: "조사 단계", phase_type: "investigation", duration: 20 },
+        position_x: 120,
+        position_y: 120,
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: "ending-1",
+        theme_id: THEME_ID,
+        type: "ending",
+        data: {
+          label: "진실",
+          description: "범인이 밝혀지는 결말",
+          endingContent: "모든 단서가 하나의 진실을 가리킵니다.",
+        },
+        position_x: 420,
+        position_y: 180,
+        created_at: now,
+        updated_at: now,
+      },
+    ],
+    edges: [
+      {
+        id: "edge-1",
+        theme_id: THEME_ID,
+        source_id: "phase-1",
+        target_id: "ending-1",
+        condition: null,
+        label: null,
+        sort_order: 0,
+        created_at: now,
+      },
+    ],
   };
 }
 

--- a/apps/web/src/features/editor/components/DesignTab.tsx
+++ b/apps/web/src/features/editor/components/DesignTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
 import { Puzzle, GitBranch, MapPin, Drama } from 'lucide-react';
 import type { EditorThemeResponse } from '@/features/editor/api';
 import {
@@ -29,6 +30,7 @@ const SUB_TABS: { key: DesignSubTab; label: string; icon: React.ElementType }[] 
 
 // ---------------------------------------------------------------------------
 export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
+  const navigate = useNavigate();
   const [activeSubTab, setActiveSubTab] = useState<DesignSubTab>(() =>
     readDesignSubTabFromRouteSegment(routeSegment),
   );
@@ -36,6 +38,11 @@ export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
   useEffect(() => {
     setActiveSubTab(readDesignSubTabFromRouteSegment(routeSegment));
   }, [routeSegment]);
+
+  const handleSubTabClick = (key: DesignSubTab) => {
+    setActiveSubTab(key);
+    navigate(`/editor/${themeId}/${key}`);
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -45,7 +52,7 @@ export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
           <button
             key={key}
             type="button"
-            onClick={() => setActiveSubTab(key)}
+            onClick={() => handleSubTabClick(key)}
             className={`flex items-center gap-1.5 border-b-2 px-4 py-2.5 text-xs font-medium transition-colors ${
               activeSubTab === key
                 ? 'border-amber-500 text-amber-400'

--- a/apps/web/src/features/editor/components/DesignTab.tsx
+++ b/apps/web/src/features/editor/components/DesignTab.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Puzzle, GitBranch, MapPin, Drama } from 'lucide-react';
 import type { EditorThemeResponse } from '@/features/editor/api';
+import {
+  readDesignSubTabFromRouteSegment,
+  type DesignSubTab,
+} from '@/features/editor/routeSegments';
 import { ModulesSubTab } from './design/ModulesSubTab';
 import { FlowSubTab } from './design/FlowSubTab';
 import { LocationsSubTab } from './design/LocationsSubTab';
@@ -10,15 +14,13 @@ import { EndingEntitySubTab } from './design/EndingEntitySubTab';
 // Types
 // ---------------------------------------------------------------------------
 
-type SubTab = 'modules' | 'flow' | 'locations' | 'endings';
-
 interface DesignTabProps {
   themeId: string;
   theme: EditorThemeResponse;
   routeSegment?: string;
 }
 
-const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
+const SUB_TABS: { key: DesignSubTab; label: string; icon: React.ElementType }[] = [
   { key: 'modules', label: '모듈', icon: Puzzle },
   { key: 'flow', label: '흐름', icon: GitBranch },
   { key: 'endings', label: '결말', icon: Drama },
@@ -26,21 +28,13 @@ const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// DesignTab
-// ---------------------------------------------------------------------------
-
-function readInitialSubTab(routeSegment?: string): SubTab {
-  if (routeSegment === 'flow') return 'flow';
-  if (routeSegment === 'locations') return 'locations';
-  if (routeSegment === 'endings') return 'endings';
-  return 'modules';
-}
-
 export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
-  const [activeSubTab, setActiveSubTab] = useState<SubTab>(() => readInitialSubTab(routeSegment));
+  const [activeSubTab, setActiveSubTab] = useState<DesignSubTab>(() =>
+    readDesignSubTabFromRouteSegment(routeSegment),
+  );
 
   useEffect(() => {
-    setActiveSubTab(readInitialSubTab(routeSegment));
+    setActiveSubTab(readDesignSubTabFromRouteSegment(routeSegment));
   }, [routeSegment]);
 
   return (

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -8,9 +8,11 @@ import { SaveIndicator } from "./SaveIndicator";
 import { EditorTabNav } from "./EditorTabNav";
 import { TabContent } from "./TabContent";
 import { ValidationPanel } from "./ValidationPanel";
+import { STATUS_LABEL } from "@/features/editor/constants";
 import type { DesignWarning } from "@/features/editor/validation";
 import type { SaveStatus } from "@/features/editor/hooks/useAutoSave";
 import { readEnabledModuleIds } from "@/features/editor/utils/configShape";
+import { readEditorTabFromRouteSegment } from "@/features/editor/routeSegments";
 
 // ---------------------------------------------------------------------------
 // EditorLayout
@@ -49,6 +51,10 @@ export function EditorLayout({
   const activeModules = useMemo(
     () => readEnabledModuleIds(theme.config_json),
     [theme.config_json],
+  );
+  const routeTab = useMemo(
+    () => (routeSegment ? readEditorTabFromRouteSegment(routeSegment) : undefined),
+    [routeSegment],
   );
 
   const handleValidate = () => {
@@ -93,7 +99,7 @@ export function EditorLayout({
             {theme.title}
           </span>
           <span className="shrink-0 rounded-sm bg-slate-800 px-1.5 py-0.5 text-[10px] font-mono text-slate-500">
-            {theme.status}
+            {STATUS_LABEL[theme.status] ?? theme.status}
           </span>
         </div>
 
@@ -123,7 +129,7 @@ export function EditorLayout({
       </header>
 
       {/* ── Tab nav ── */}
-      <EditorTabNav activeModules={activeModules} />
+      <EditorTabNav activeModules={activeModules} forcedVisibleTab={routeTab} />
 
       {/* ── Validation panel ── */}
       {!dismissed && (validationResult ?? externalWarnings) && (

--- a/apps/web/src/features/editor/components/EditorTabNav.tsx
+++ b/apps/web/src/features/editor/components/EditorTabNav.tsx
@@ -1,5 +1,5 @@
 import { useRef, useCallback, useMemo, useEffect } from "react";
-import { EDITOR_TABS } from "@/features/editor/constants";
+import { EDITOR_TABS, type EditorTab } from "@/features/editor/constants";
 import { useEditorUI } from "@/features/editor/stores/editorUIStore";
 
 // ---------------------------------------------------------------------------
@@ -10,22 +10,29 @@ const EMPTY_MODULES: string[] = [];
 
 interface EditorTabNavProps {
   activeModules?: string[];
+  forcedVisibleTab?: EditorTab;
 }
 
 // ---------------------------------------------------------------------------
 // EditorTabNav — scrollable tab navigation bar with dynamic filtering
 // ---------------------------------------------------------------------------
 
-export function EditorTabNav({ activeModules = EMPTY_MODULES }: EditorTabNavProps) {
+export function EditorTabNav({
+  activeModules = EMPTY_MODULES,
+  forcedVisibleTab,
+}: EditorTabNavProps) {
   const { activeTab, setActiveTab } = useEditorUI();
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const visibleTabs = useMemo(
     () =>
       EDITOR_TABS.filter(
-        (tab) => tab.always || activeModules.includes(tab.requiredModule ?? ""),
+        (tab) =>
+          tab.always ||
+          tab.key === forcedVisibleTab ||
+          activeModules.includes(tab.requiredModule ?? ""),
       ),
-    [activeModules],
+    [activeModules, forcedVisibleTab],
   );
 
   // If active tab is now hidden, fallback to overview

--- a/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
@@ -56,6 +56,9 @@ vi.mock('../ClueForm', () => ({
 vi.mock('../ImageUpload', () => ({
   ImageUpload: () => null,
 }));
+vi.mock('../clues/ClueEdgeGraph', () => ({
+  ClueEdgeGraph: () => <div>단서 관계 그래프</div>,
+}));
 // ---------------------------------------------------------------------------
 // Import after mocks
 // ---------------------------------------------------------------------------
@@ -118,5 +121,13 @@ describe('CluesTab', () => {
     useEditorCluesMock.mockReturnValue({ data: mockClues, isLoading: false });
     render(<CluesTab themeId="theme-1" />);
     expect(screen.getByText('2개의 단서')).toBeDefined();
+  });
+
+  it('relations routeSegment로 직접 진입하면 관계 서브탭을 연다', () => {
+    useEditorCluesMock.mockReturnValue({ data: mockClues, isLoading: false });
+
+    render(<CluesTab themeId="theme-1" routeSegment="relations" />);
+
+    expect(screen.getByText('단서 관계 그래프')).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -49,6 +49,14 @@ describe("EditorTabNav dynamic tabs", () => {
     expect(screen.queryByText("미디어")).toBeNull();
   });
 
+  it("직접 URL로 열린 탭은 모듈이 비활성이어도 숨기지 않는다", () => {
+    mockActiveTab.current = "media";
+    render(<EditorTabNav activeModules={[]} forcedVisibleTab="media" />);
+
+    expect(screen.getByText("미디어")).toBeDefined();
+    expect(mockSetActiveTab).not.toHaveBeenCalledWith("overview");
+  });
+
   it("현재 탭이 숨겨지면 overview로 전환된다", () => {
     mockActiveTab.current = "media";
     render(<EditorTabNav activeModules={[]} />);

--- a/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
@@ -5,8 +5,9 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { mutateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(() => ({
+const { mutateMock, navigateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
+  navigateMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
   useModuleSchemasMock: vi.fn(),
 }));
@@ -17,6 +18,10 @@ const { mutateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: () => navigateMock,
 }));
 
 vi.mock('@/features/editor/api', () => ({
@@ -155,6 +160,7 @@ describe('DesignTab', () => {
 
     fireEvent.click(screen.getByText('흐름'));
     expect(screen.getByText('FlowSubTab 콘텐츠')).toBeDefined();
+    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/flow');
   });
 
   it('장소 탭 클릭 시 장소 콘텐츠로 전환된다', () => {
@@ -162,6 +168,7 @@ describe('DesignTab', () => {
 
     fireEvent.click(screen.getByText('장소'));
     expect(screen.getByText('LocationsSubTab 콘텐츠')).toBeDefined();
+    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/locations');
   });
 
   it('결말 탭 클릭 시 결말 entity 콘텐츠로 전환된다', () => {
@@ -169,6 +176,7 @@ describe('DesignTab', () => {
 
     fireEvent.click(screen.getByText('결말'));
     expect(screen.getByText('EndingEntitySubTab 콘텐츠')).toBeDefined();
+    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/endings');
   });
 
   it.each([

--- a/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
@@ -171,6 +171,16 @@ describe('DesignTab', () => {
     expect(screen.getByText('EndingEntitySubTab 콘텐츠')).toBeDefined();
   });
 
+  it.each([
+    ['locations', 'LocationsSubTab 콘텐츠'],
+    ['endings', 'EndingEntitySubTab 콘텐츠'],
+    ['flow', 'FlowSubTab 콘텐츠'],
+  ] as const)('routeSegment=%s이면 해당 제작 서브탭을 바로 연다', (routeSegment, expectedText) => {
+    render(<DesignTab themeId="theme-1" theme={mockTheme} routeSegment={routeSegment} />);
+
+    expect(screen.getByText(expectedText)).toBeDefined();
+  });
+
   it('모듈 탭이 기본 선택되어 모듈 사이드바가 표시된다', () => {
     render(<DesignTab themeId="theme-1" theme={mockTheme} />);
 

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -1,0 +1,36 @@
+import type { EditorTab } from "./constants";
+
+export type DesignSubTab = "modules" | "flow" | "locations" | "endings";
+
+const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
+  overview: "overview",
+  story: "story",
+  characters: "characters",
+  clues: "clues",
+  relations: "clues",
+  modules: "design",
+  flow: "design",
+  locations: "design",
+  endings: "design",
+  media: "media",
+  advanced: "advanced",
+  templates: "template",
+  template: "template",
+};
+
+const DESIGN_ROUTE_SUBTAB_MAP: Record<string, DesignSubTab> = {
+  modules: "modules",
+  flow: "flow",
+  locations: "locations",
+  endings: "endings",
+};
+
+export function readEditorTabFromRouteSegment(routeSegment?: string): EditorTab {
+  if (!routeSegment) return "overview";
+  return EDITOR_ROUTE_TAB_MAP[routeSegment] ?? "overview";
+}
+
+export function readDesignSubTabFromRouteSegment(routeSegment?: string): DesignSubTab {
+  if (!routeSegment) return "modules";
+  return DESIGN_ROUTE_SUBTAB_MAP[routeSegment] ?? "modules";
+}

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -2,27 +2,15 @@ import { useEffect } from "react";
 import { useParams } from "react-router";
 import { EditorDashboard } from "@/features/editor/components";
 import { ThemeEditor } from "@/features/editor/components";
-import type { EditorTab } from "@/features/editor/constants";
+import { readEditorTabFromRouteSegment } from "@/features/editor/routeSegments";
 import { useEditorUI } from "@/features/editor/stores/editorUIStore";
-
-const TAB_SEGMENT_MAP: Record<string, EditorTab> = {
-  characters: "characters",
-  clues: "clues",
-  relations: "clues",
-  modules: "design",
-  flow: "design",
-  locations: "design",
-  templates: "template",
-  template: "template",
-};
 
 export default function EditorPage() {
   const { id, tab } = useParams<{ id: string; tab?: string }>();
   const setActiveTab = useEditorUI((state) => state.setActiveTab);
 
   useEffect(() => {
-    const nextTab = tab ? TAB_SEGMENT_MAP[tab] : undefined;
-    setActiveTab(nextTab ?? "overview");
+    setActiveTab(readEditorTabFromRouteSegment(tab));
   }, [setActiveTab, tab]);
 
   if (id) {

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -50,6 +50,23 @@ describe('EditorPage', () => {
     expect(setActiveTabMock).toHaveBeenCalledWith('characters');
   });
 
+  it.each([
+    ['story', 'story'],
+    ['characters', 'characters'],
+    ['clues', 'clues'],
+    ['relations', 'clues'],
+    ['locations', 'design'],
+    ['endings', 'design'],
+    ['media', 'media'],
+  ] as const)('%s 라우트 segment를 %s 탭으로 매핑한다', (segment, expectedTab) => {
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: segment });
+
+    render(<EditorPage />);
+
+    expect(screen.getByText(new RegExp(`테마 에디터 theme-1 ${segment}`))).toBeDefined();
+    expect(setActiveTabMock).toHaveBeenCalledWith(expectedTab);
+  });
+
   it('modules 라우트 segment를 design 탭으로 매핑한다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'modules' });
 


### PR DESCRIPTION
## 요약
- `EditorPage` route segment mapping을 `routeSegments.ts`로 분리해 `/editor/:id/story`, `/characters`, `/clues`, `/relations`, `/locations`, `/endings`, `/media` 직접 URL이 실제 제작 탭/서브탭을 열도록 정리했습니다.
- `/editor/:id/endings`는 `design` 탭의 결말 Entity 화면으로, `/editor/:id/relations`는 단서 관계 서브탭으로 연결됩니다.
- 직접 URL로 열린 모듈 탭은 탭 내비게이션에서 숨겨져 `overview`로 되돌아가지 않게 했고, 에디터 상단 상태 코드는 제작자용 라벨로 표시합니다.

## 범위
- 이번 PR은 route/page migration 기준 고정만 다룹니다.
- #278/#279/#280의 기능별 저장 계약, backend DTO, runtime engine 변경은 포함하지 않았습니다.
- Deck investigation은 backend access/draw 판단까지 연결되는 별도 후속 이슈로 분리하는 판단입니다. #279 장소 저장 계약에 섞지 않습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/components/__tests__/EditorTabNav.test.tsx src/features/editor/components/__tests__/CluesTab.test.tsx src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/__tests__/ThemeEditor.test.tsx` — 5 files / 36 tests pass
- `pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium --reporter=list` — 11 tests pass

Closes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * URL 경로로 에디터의 디자인 하위 탭(흐름/장소/결말 등) 직접 활성화 지원

* **개선사항**
  * 라우팅을 기반으로 에디터 탭 자동 활성화 및 특정 탭 강제 표시 개선
  * 상단 상태 텍스트 표시 로직 개선

* **테스트**
  * 에디터 주요 흐름에 대한 E2E 및 단위 테스트 추가/확장 (직접 URL 네비게이션 검증 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->