### PR TITLE
feat(editor): #278 단서 효과 제작 UI 저장 계약 연결

### DIFF
--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -58,6 +59,100 @@ func validateConfigShape(raw json.RawMessage) error {
 			}
 			if _, hasDeadKey := loc["clueIds"]; hasDeadKey {
 				return fmt.Errorf("config_json: locations[%d].clueIds dead key rejected (D-20) — use locationClueConfig.clueIds", i)
+			}
+		}
+	}
+	if err := validateClueInteractionConfigShape(cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateClueInteractionConfigShape(cfg map[string]any) error {
+	modules, ok := cfg["modules"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	rawModule, exists := modules["clue_interaction"]
+	if !exists {
+		return nil
+	}
+	module, ok := rawModule.(map[string]any)
+	if !ok {
+		return fmt.Errorf("config_json: modules.clue_interaction must be an object")
+	}
+	moduleConfigRaw, exists := module["config"]
+	if !exists || moduleConfigRaw == nil {
+		return nil
+	}
+	moduleConfig, ok := moduleConfigRaw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("config_json: modules.clue_interaction.config must be an object")
+	}
+	rawEffects, exists := moduleConfig["itemEffects"]
+	if !exists || rawEffects == nil {
+		return nil
+	}
+	itemEffects, ok := rawEffects.(map[string]any)
+	if !ok {
+		return fmt.Errorf("config_json: modules.clue_interaction.config.itemEffects must be an object")
+	}
+	for clueID, rawEffect := range itemEffects {
+		if _, err := uuid.Parse(clueID); err != nil {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects invalid clue id %q", clueID)
+		}
+		effect, ok := rawEffect.(map[string]any)
+		if !ok {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s] must be an object", clueID)
+		}
+		if err := validateClueItemEffectShape(clueID, effect); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateClueItemEffectShape(clueID string, effect map[string]any) error {
+	for key := range effect {
+		if key != "effect" && key != "target" && key != "consume" && key != "revealText" && key != "grantClueIds" {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].%s is not supported", clueID, key)
+		}
+	}
+	kind, ok := effect["effect"].(string)
+	if !ok || kind == "" {
+		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].effect is required", clueID)
+	}
+	if kind != "peek" && kind != "reveal" && kind != "grant_clue" {
+		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].effect %q is not supported", clueID, kind)
+	}
+	if target, exists := effect["target"]; exists && target != nil {
+		if target != "self" && target != "player" {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].target must be self or player", clueID)
+		}
+	}
+	if consume, exists := effect["consume"]; exists && consume != nil {
+		if _, ok := consume.(bool); !ok {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].consume must be boolean", clueID)
+		}
+	}
+	if kind == "reveal" {
+		text, ok := effect["revealText"].(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].revealText is required for reveal", clueID)
+		}
+	}
+	if kind == "grant_clue" {
+		ids, ok := effect["grantClueIds"].([]any)
+		if !ok || len(ids) == 0 {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].grantClueIds is required for grant_clue", clueID)
+		}
+		for _, id := range ids {
+			grantClueID, ok := id.(string)
+			if !ok {
+				return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].grantClueIds must contain strings", clueID)
+			}
+			if _, err := uuid.Parse(grantClueID); err != nil {
+				return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].grantClueIds has invalid clue id %q", clueID, grantClueID)
 			}
 		}
 	}

--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -131,12 +131,18 @@ func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 	if kind != "peek" && kind != "reveal" && kind != "grant_clue" {
 		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].effect %q is not supported", clueID, kind)
 	}
-	if target, exists := effect["target"]; exists && target != nil {
+	if target, exists := effect["target"]; exists {
+		if target == nil {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].target cannot be null", clueID)
+		}
 		if target != "self" && target != "player" {
 			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].target must be self or player", clueID)
 		}
 	}
-	if consume, exists := effect["consume"]; exists && consume != nil {
+	if consume, exists := effect["consume"]; exists {
+		if consume == nil {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].consume cannot be null", clueID)
+		}
 		if _, ok := consume.(bool); !ok {
 			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].consume must be boolean", clueID)
 		}

--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -82,8 +82,11 @@ func validateClueInteractionConfigShape(cfg map[string]any) error {
 		return fmt.Errorf("config_json: modules.clue_interaction must be an object")
 	}
 	moduleConfigRaw, exists := module["config"]
-	if !exists || moduleConfigRaw == nil {
+	if !exists {
 		return nil
+	}
+	if moduleConfigRaw == nil {
+		return fmt.Errorf("config_json: modules.clue_interaction.config cannot be null")
 	}
 	moduleConfig, ok := moduleConfigRaw.(map[string]any)
 	if !ok {

--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -90,8 +90,11 @@ func validateClueInteractionConfigShape(cfg map[string]any) error {
 		return fmt.Errorf("config_json: modules.clue_interaction.config must be an object")
 	}
 	rawEffects, exists := moduleConfig["itemEffects"]
-	if !exists || rawEffects == nil {
+	if !exists {
 		return nil
+	}
+	if rawEffects == nil {
+		return fmt.Errorf("config_json: modules.clue_interaction.config.itemEffects cannot be null")
 	}
 	itemEffects, ok := rawEffects.(map[string]any)
 	if !ok {

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -331,6 +332,115 @@ func TestUpdateConfigJson_RejectsLocationsDeadKey(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), "D-20") {
 				t.Errorf("expected error to contain %q, got: %v", "D-20", err)
+			}
+		})
+	}
+}
+
+func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	clueID := uuid.NewString()
+	rewardClueID := uuid.NewString()
+
+	valid := json.RawMessage(fmt.Sprintf(`{
+		"modules": {
+			"clue_interaction": {
+				"enabled": true,
+				"config": {
+					"itemEffects": {
+						"%s": {
+							"effect": "grant_clue",
+							"target": "self",
+							"consume": true,
+							"grantClueIds": ["%s"]
+						}
+					}
+				}
+			}
+		}
+	}`, clueID, rewardClueID))
+	if _, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, valid); err != nil {
+		t.Fatalf("valid clue_interaction itemEffects must save: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		input json.RawMessage
+		want  string
+	}{
+		{
+			name: "invalid item effect clue id",
+			input: json.RawMessage(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"clue-1": {"effect": "reveal", "revealText": "비밀"}}}
+					}
+				}
+			}`),
+			want: "invalid clue id",
+		},
+		{
+			name: "reveal requires text",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "reveal"}}}
+					}
+				}
+			}`, clueID)),
+			want: "revealText is required",
+		},
+		{
+			name: "grant requires ids",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "grant_clue", "grantClueIds": []}}}
+					}
+				}
+			}`, clueID)),
+			want: "grantClueIds is required",
+		},
+		{
+			name: "unsupported effect",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "steal"}}}
+					}
+				}
+			}`, clueID)),
+			want: "is not supported",
+		},
+		{
+			name: "unknown effect field",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "peek", "debugOnly": true}}}
+					}
+				}
+			}`, clueID)),
+			want: "debugOnly is not supported",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, tc.input)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected error to contain %q, got: %v", tc.want, err)
 			}
 		})
 	}

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -384,6 +384,18 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			want: "invalid clue id",
 		},
 		{
+			name: "null item effects",
+			input: json.RawMessage(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": null}
+					}
+				}
+			}`),
+			want: "itemEffects cannot be null",
+		},
+		{
 			name: "reveal requires text",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -420,6 +420,30 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			want: "revealText is required",
 		},
 		{
+			name: "target cannot be null",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "reveal", "target": null, "revealText": "비밀"}}}
+					}
+				}
+			}`, clueID)),
+			want: "target cannot be null",
+		},
+		{
+			name: "consume cannot be null",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "reveal", "consume": null, "revealText": "비밀"}}}
+					}
+				}
+			}`, clueID)),
+			want: "consume cannot be null",
+		},
+		{
 			name: "grant requires ids",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -487,6 +487,13 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error for %s, got nil", tc.name)
 			}
+			var appErr *apperror.AppError
+			if !errors.As(err, &appErr) {
+				t.Fatalf("expected *apperror.AppError for %s, got %T: %v", tc.name, err, err)
+			}
+			if appErr.Status != http.StatusBadRequest {
+				t.Fatalf("expected status 400 for %s, got %d", tc.name, appErr.Status)
+			}
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Errorf("expected error to contain %q, got: %v", tc.want, err)
 			}

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -366,11 +366,50 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 		t.Fatalf("valid clue_interaction itemEffects must save: %v", err)
 	}
 
+	validCases := []struct {
+		name  string
+		input json.RawMessage
+	}{
+		{
+			name:  "no clue interaction module",
+			input: json.RawMessage(`{"modules":{"voting":{"enabled":false}}}`),
+		},
+		{
+			name:  "clue interaction without config",
+			input: json.RawMessage(`{"modules":{"clue_interaction":{"enabled":true}}}`),
+		},
+		{
+			name:  "clue interaction empty config",
+			input: json.RawMessage(`{"modules":{"clue_interaction":{"enabled":true,"config":{}}}}`),
+		},
+		{
+			name:  "clue interaction empty item effects",
+			input: json.RawMessage(`{"modules":{"clue_interaction":{"enabled":true,"config":{"itemEffects":{}}}}}`),
+		},
+	}
+	for _, tc := range validCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, tc.input); err != nil {
+				t.Fatalf("expected valid config for %s, got: %v", tc.name, err)
+			}
+		})
+	}
+
 	cases := []struct {
 		name  string
 		input json.RawMessage
 		want  string
 	}{
+		{
+			name: "clue interaction module must be object",
+			input: json.RawMessage(`{
+				"modules": {
+					"clue_interaction": true
+				}
+			}`),
+			want: "modules.clue_interaction must be an object",
+		},
 		{
 			name: "null clue interaction config",
 			input: json.RawMessage(`{
@@ -382,6 +421,30 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 				}
 			}`),
 			want: "config cannot be null",
+		},
+		{
+			name: "clue interaction config must be object",
+			input: json.RawMessage(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": []
+					}
+				}
+			}`),
+			want: "config must be an object",
+		},
+		{
+			name: "item effects must be object",
+			input: json.RawMessage(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": []}
+					}
+				}
+			}`),
+			want: "itemEffects must be an object",
 		},
 		{
 			name: "invalid item effect clue id",
@@ -408,6 +471,30 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			want: "itemEffects cannot be null",
 		},
 		{
+			name: "item effect must be object",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": null}}
+					}
+				}
+			}`, clueID)),
+			want: "must be an object",
+		},
+		{
+			name: "effect is required",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"target": "self"}}}
+					}
+				}
+			}`, clueID)),
+			want: "effect is required",
+		},
+		{
 			name: "reveal requires text",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {
@@ -432,6 +519,18 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			want: "target cannot be null",
 		},
 		{
+			name: "target must be supported",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "peek", "target": "room"}}}
+					}
+				}
+			}`, clueID)),
+			want: "target must be self or player",
+		},
+		{
 			name: "consume cannot be null",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {
@@ -444,6 +543,18 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			want: "consume cannot be null",
 		},
 		{
+			name: "consume must be boolean",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "peek", "consume": "yes"}}}
+					}
+				}
+			}`, clueID)),
+			want: "consume must be boolean",
+		},
+		{
 			name: "grant requires ids",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {
@@ -454,6 +565,30 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 				}
 			}`, clueID)),
 			want: "grantClueIds is required",
+		},
+		{
+			name: "grant ids must contain strings",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "grant_clue", "grantClueIds": [123]}}}
+					}
+				}
+			}`, clueID)),
+			want: "grantClueIds must contain strings",
+		},
+		{
+			name: "grant ids must be valid uuids",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "grant_clue", "grantClueIds": ["clue-2"]}}}
+					}
+				}
+			}`, clueID)),
+			want: "has invalid clue id",
 		},
 		{
 			name: "unsupported effect",

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -372,6 +372,18 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 		want  string
 	}{
 		{
+			name: "null clue interaction config",
+			input: json.RawMessage(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": null
+					}
+				}
+			}`),
+			want: "config cannot be null",
+		},
+		{
 			name: "invalid item effect clue id",
 			input: json.RawMessage(`{
 				"modules": {

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -24,6 +24,8 @@ import { test, expect, type Page, type Request } from "@playwright/test";
 import {
   BASE,
   THEME_ID,
+  CLUE_ID,
+  REWARD_CLUE_ID,
   freshState,
   mockCommonApis,
   loginAsE2EUser,
@@ -95,6 +97,36 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await expect(page.getByText("정보 공개하기")).toBeVisible();
     await expect(page.getByText("사용하면 내 단서함에서 사라짐")).toBeVisible();
     await expect(page.getByText("이 단서가 쓰이는 곳")).toBeVisible();
+  });
+
+  test("[2C] 단서 효과 제작 UI는 grant_clue 계약으로 config 를 저장한다", async ({ page }) => {
+    state.conflictCountdown = 0;
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
+    await expect(page.getByLabel("단서 상세 영역")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("게임 중 사용 효과")).toBeVisible();
+    await expect(page.getByText("itemEffects")).toHaveCount(0);
+    await expect(page.getByText("grant_clue")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "새 단서 지급" }).click();
+    await page.getByLabel("지급할 단서 검색").fill("금고");
+    await page.getByRole("button", { name: "금고 비밀번호", exact: true }).click();
+    await page.getByLabel(/사용하면 내 단서함에서 사라짐/).check();
+    await page.getByRole("button", { name: "효과 저장" }).click();
+
+    await expect.poll(() => state.configPutCalls).toBeGreaterThanOrEqual(1);
+    const modules = state.configJson.modules as Record<string, { config?: Record<string, unknown> }>;
+    const clueInteraction = modules.clue_interaction?.config as
+      | { itemEffects?: Record<string, Record<string, unknown>> }
+      | undefined;
+
+    expect(clueInteraction?.itemEffects?.[CLUE_ID]).toMatchObject({
+      effect: "grant_clue",
+      target: "self",
+      consume: true,
+      grantClueIds: [REWARD_CLUE_ID],
+    });
+    expect(JSON.stringify(state.lastConfigRequestBody)).not.toContain("module_configs");
   });
 
   test("[2B] 직접 URL은 올바른 제작 탭과 서브탭을 연다", async ({ page }) => {

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -14,6 +14,7 @@ import type { Page } from "@playwright/test";
 export const BASE = "http://localhost:3000";
 export const THEME_ID = "00000000-0000-0000-0000-000000000184";
 export const CLUE_ID = "cccccccc-0000-0000-0000-000000000001";
+export const REWARD_CLUE_ID = "cccccccc-0000-0000-0000-000000000002";
 export const MAP_ID = "bbbbbbbb-0000-0000-0000-000000000001";
 export const LOCATION_ID = "dddddddd-0000-0000-0000-000000000001";
 export const FLOW_NODE_ID = "eeeeeeee-0000-0000-0000-000000000001";
@@ -39,6 +40,7 @@ export interface MockState {
   characterMysteryRole: "suspect" | "culprit" | "accomplice" | "detective";
   roleSheet: Record<string, unknown>;
   configPutCalls: number;
+  lastConfigRequestBody: Record<string, unknown> | null;
   imageUploadUrlCalls: number;
   templatesCalls: number;
   clueRelationsCalls: number;
@@ -66,6 +68,7 @@ export function freshState(): MockState {
       markdown: { body: "" },
     },
     configPutCalls: 0,
+    lastConfigRequestBody: null,
     imageUploadUrlCalls: 0,
     templatesCalls: 0,
     clueRelationsCalls: 0,
@@ -150,7 +153,7 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
     return r.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify([cluePayload(state)]),
+      body: JSON.stringify([cluePayload(state), rewardCluePayload()]),
     });
   });
 
@@ -387,6 +390,7 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
     if (r.request().method() !== "PUT") return r.continue();
     state.configPutCalls += 1;
     const body = JSON.parse(r.request().postData() ?? "{}");
+    state.lastConfigRequestBody = body;
     if (state.conflictCountdown > 0 && body.version === state.configVersion) {
       state.conflictCountdown -= 1;
       return r.fulfill({
@@ -403,7 +407,8 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
       });
     }
     state.configVersion = (body.version ?? state.configVersion) + 1;
-    state.configJson = { ...state.configJson, ...(body.config_json ?? {}) };
+    const { version: _version, ...nextConfig } = body as Record<string, unknown>;
+    state.configJson = nextConfig;
     return r.fulfill({
       status: 200,
       contentType: "application/json",
@@ -469,6 +474,24 @@ function cluePayload(state: MockState) {
     use_target: "self",
     use_consumed: true,
     image_url: state.clueImageURL,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function rewardCluePayload() {
+  return {
+    id: REWARD_CLUE_ID,
+    theme_id: THEME_ID,
+    name: "금고 비밀번호",
+    description: "금고를 열 수 있는 숫자 단서입니다.",
+    level: 1,
+    sort_order: 1,
+    is_common: false,
+    is_usable: false,
+    use_effect: null,
+    use_target: null,
+    use_consumed: false,
+    image_url: null,
     created_at: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## 요약\n- 단서 효과 제작 UI의 grant_clue 저장 흐름을 Playwright E2E로 고정합니다.\n- editor config 저장 시 clue_interaction.itemEffects가 Engine schema와 맞지 않으면 BadRequest로 거절합니다.\n- E2E fixture가 실제 raw config PUT payload를 저장하도록 보정했습니다.\n\nCloses #278\n\n## 검증\n- pnpm --filter @mmp/web exec tsc --noEmit\n- pnpm --filter @mmp/web exec vitest run src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx src/features/editor/utils/__tests__/configShape.test.ts src/features/editor/components/__tests__/CluesTab.test.tsx\n- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium --reporter=list\n- cd apps/server && go test ./internal/domain/editor ./internal/module/core\n\n## CI 운영\n- 생성 시 ready-for-ci 라벨은 붙이지 않습니다.\n- CodeRabbit 확인 후 unresolved thread 0 상태에서 ready-for-ci로 전환합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 단서 상호작용의 itemEffects 구성 검증을 강화했습니다. 단서 ID 형식(유효한 UUID), 지원 효과(peek/reveal/grant_clue), 대상(self/player), 소비 여부(boolean) 및 효과별 필수 필드(revealText, grantClueIds 등)를 엄격히 검사합니다.

* **테스트**
  * itemEffects 검증을 확인하는 단위/통합 테스트를 추가했습니다.
  * 단서 지급 흐름을 검증하는 E2E 테스트를 추가했습니다.
  * 테스트 헬퍼에 리워드 단서 ID와 마지막 구성 요청 본문 캡처를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->