### PR TITLE
feat(editor): #292 Entity Editor 제작 경로 연결

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -145,6 +145,8 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await expect(page.getByRole("tab", { name: "등장인물", selected: true })).toBeVisible({
       timeout: 10_000,
     });
+    await expect(page.getByRole("button", { name: "제작" })).toBeVisible();
+    await expect(page.getByLabel("캐릭터 목록")).toBeVisible();
     await expect(page.getByText("탐정 A").first()).toBeVisible();
 
     await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
@@ -163,6 +165,8 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await expect(page.getByRole("tab", { name: "게임설계", selected: true })).toBeVisible({
       timeout: 10_000,
     });
+    await expect(page.getByLabel("장소 목록")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel("거실 조사 시 발견 단서")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText("저택 1층").first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/endings`);
@@ -376,14 +380,11 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     const got = await locReq;
     expect(got).not.toBeNull();
 
-    const mapButton = page.getByRole("button", { name: /^저택 1층$/ }).first();
-    if (await mapButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      await mapButton.click();
-      await expect(page.getByText("거실").first()).toBeVisible({ timeout: 3_000 });
-      await expect(page.getByText("R2~4").first()).toBeVisible({ timeout: 3_000 });
-      await expect(page.getByText(/조사 시 발견 단서/).first()).toBeVisible({ timeout: 3_000 });
-      await expect(page.getByText(/접근 제한/).first()).toBeVisible({ timeout: 3_000 });
-    }
+    await expect(page.getByLabel("장소 목록")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("거실").first()).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText("R2~4").first()).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByLabel("거실 조사 시 발견 단서")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText(/접근 제한/).first()).toBeVisible({ timeout: 3_000 });
 
     // UI: 단서 chip/체크박스가 있으면 토글 + 즉시 반영
     const chip = page.getByRole("checkbox").first();

--- a/apps/web/e2e/phase24-editor-character-role.spec.ts
+++ b/apps/web/e2e/phase24-editor-character-role.spec.ts
@@ -22,10 +22,9 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
     await page.goto(`${BASE}/editor/${THEME_ID}`);
 
     await page.getByRole("tab", { name: "등장인물" }).click();
-    await expect(page.getByRole("button", { name: "배정" })).toBeVisible();
-    await page.getByRole("button", { name: "배정" }).click();
+    await expect(page.getByRole("button", { name: "제작" })).toBeVisible();
 
-    await page.getByRole("button", { name: /탐정 A/ }).click();
+    await page.getByRole("button", { name: "탐정 A 선택" }).click();
 
     const updateRequestPromise = page.waitForRequest(
       (request) =>
@@ -60,9 +59,8 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
     await page.goto(`${BASE}/editor/${THEME_ID}`);
 
     await page.getByRole("tab", { name: "등장인물" }).click();
-    await expect(page.getByRole("button", { name: "배정" })).toBeVisible();
-    await page.getByRole("button", { name: "배정" }).click();
-    await page.getByRole("button", { name: /탐정 A/ }).click();
+    await expect(page.getByRole("button", { name: "제작" })).toBeVisible();
+    await page.getByRole("button", { name: "탐정 A 선택" }).click();
 
     await page.getByRole("button", { name: /이미지/ }).click();
     await page.getByRole("textbox", { name: "이미지 페이지 URL" }).fill("https://cdn.example/role-1.svg");

--- a/apps/web/src/features/editor/components/CharactersTab.tsx
+++ b/apps/web/src/features/editor/components/CharactersTab.tsx
@@ -1,14 +1,19 @@
 import { useState } from 'react';
 import { List, UserCheck } from 'lucide-react';
+import { toast } from 'sonner';
+import { Modal } from '@/shared/components/ui/Modal';
+import { Button } from '@/shared/components/ui/Button';
+import { useDeleteCharacter, type EditorCharacterResponse } from '@/features/editor/api';
 import { CharacterListTab } from './CharacterListTab';
 import { CharacterAssignPanel } from './design/CharacterAssignPanel';
+import { CharacterForm } from './CharacterForm';
 import type { EditorThemeResponse } from '@/features/editor/api';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type SubTab = 'list' | 'assignment';
+type SubTab = 'workspace' | 'list';
 
 interface CharactersTabProps {
   themeId: string;
@@ -16,8 +21,8 @@ interface CharactersTabProps {
 }
 
 const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
-  { key: 'list', label: '목록', icon: List },
-  { key: 'assignment', label: '배정', icon: UserCheck },
+  { key: 'workspace', label: '제작', icon: UserCheck },
+  { key: 'list', label: '빠른 목록', icon: List },
 ];
 
 // ---------------------------------------------------------------------------
@@ -25,7 +30,40 @@ const SUB_TABS: { key: SubTab; label: string; icon: React.ElementType }[] = [
 // ---------------------------------------------------------------------------
 
 export function CharactersTab({ themeId, theme }: CharactersTabProps) {
-  const [activeSubTab, setActiveSubTab] = useState<SubTab>('list');
+  const [activeSubTab, setActiveSubTab] = useState<SubTab>('workspace');
+  const deleteCharacter = useDeleteCharacter(themeId);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingCharacter, setEditingCharacter] = useState<EditorCharacterResponse | undefined>(undefined);
+  const [deletingCharacter, setDeletingCharacter] = useState<EditorCharacterResponse | undefined>(undefined);
+
+  function handleCreate() {
+    setEditingCharacter(undefined);
+    setIsFormOpen(true);
+  }
+
+  function handleEdit(character: EditorCharacterResponse) {
+    setEditingCharacter(character);
+    setIsFormOpen(true);
+  }
+
+  function handleFormClose() {
+    setIsFormOpen(false);
+    setEditingCharacter(undefined);
+  }
+
+  function handleDeleteConfirm() {
+    if (!deletingCharacter) return;
+    deleteCharacter.mutate(deletingCharacter.id, {
+      onSuccess: () => {
+        toast.success('캐릭터가 삭제되었습니다');
+        setDeletingCharacter(undefined);
+      },
+      onError: (err) => {
+        toast.error(err.message || '캐릭터 삭제에 실패했습니다');
+        setDeletingCharacter(undefined);
+      },
+    });
+  }
 
   return (
     <div className="flex h-full flex-col">
@@ -50,11 +88,54 @@ export function CharactersTab({ themeId, theme }: CharactersTabProps) {
 
       {/* ── SubTab Content ── */}
       <div className="min-h-0 flex-1 overflow-auto">
-        {activeSubTab === 'list' && <CharacterListTab themeId={themeId} />}
-        {activeSubTab === 'assignment' && (
-          <CharacterAssignPanel themeId={themeId} theme={theme} />
+        {activeSubTab === 'workspace' && (
+          <CharacterAssignPanel
+            themeId={themeId}
+            theme={theme}
+            onCreate={handleCreate}
+            onEdit={handleEdit}
+            onDelete={setDeletingCharacter}
+          />
         )}
+        {activeSubTab === 'list' && <CharacterListTab themeId={themeId} />}
       </div>
+
+      <CharacterForm
+        themeId={themeId}
+        character={editingCharacter}
+        isOpen={isFormOpen}
+        onClose={handleFormClose}
+      />
+
+      <Modal
+        isOpen={!!deletingCharacter}
+        onClose={() => setDeletingCharacter(undefined)}
+        title="캐릭터 삭제"
+        size="sm"
+        footer={
+          <>
+            <Button
+              variant="ghost"
+              onClick={() => setDeletingCharacter(undefined)}
+              disabled={deleteCharacter.isPending}
+            >
+              취소
+            </Button>
+            <Button
+              variant="danger"
+              isLoading={deleteCharacter.isPending}
+              onClick={handleDeleteConfirm}
+            >
+              삭제
+            </Button>
+          </>
+        }
+      >
+        <p className="text-sm text-slate-300">
+          <span className="font-semibold text-slate-100">{deletingCharacter?.name}</span> 캐릭터를
+          삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+        </p>
+      </Modal>
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/__tests__/CharactersTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CharactersTab.test.tsx
@@ -5,9 +5,10 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { useEditorCharactersMock, useDeleteCharacterMock } = vi.hoisted(() => ({
+const { useEditorCharactersMock, useDeleteCharacterMock, deleteMutateMock } = vi.hoisted(() => ({
   useEditorCharactersMock: vi.fn(),
   useDeleteCharacterMock: vi.fn(),
+  deleteMutateMock: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -26,12 +27,25 @@ vi.mock('@/features/editor/api', () => ({
 }));
 
 vi.mock('../CharacterForm', () => ({
-  CharacterForm: () => null,
+  CharacterForm: ({
+    isOpen,
+    character,
+  }: {
+    isOpen: boolean;
+    character?: { name: string };
+  }) => (isOpen ? <div role="dialog">{character ? `${character.name} 수정 폼` : '캐릭터 생성 폼'}</div> : null),
 }));
 
 vi.mock('@/shared/components/ui/Modal', () => ({
-  Modal: ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) =>
-    isOpen ? <div>{children}</div> : null,
+  Modal: ({
+    children,
+    footer,
+    isOpen,
+  }: {
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+    isOpen: boolean;
+  }) => (isOpen ? <div role="dialog">{children}{footer}</div> : null),
 }));
 
 vi.mock('@/shared/components/ui/Spinner', () => ({
@@ -45,7 +59,26 @@ vi.mock('@/shared/components/ui/Button', () => ({
 }));
 
 vi.mock('../design/CharacterAssignPanel', () => ({
-  CharacterAssignPanel: () => <div>CharacterAssignPanel 콘텐츠</div>,
+  CharacterAssignPanel: ({
+    onCreate,
+    onEdit,
+    onDelete,
+  }: {
+    onCreate?: () => void;
+    onEdit?: (character: { id: string; name: string }) => void;
+    onDelete?: (character: { id: string; name: string }) => void;
+  }) => (
+    <div>
+      CharacterAssignPanel 콘텐츠
+      <button type="button" onClick={onCreate}>캐릭터 추가</button>
+      <button type="button" onClick={() => onEdit?.({ id: 'char-1', name: '탐정 A' })}>
+        탐정 A 수정
+      </button>
+      <button type="button" onClick={() => onDelete?.({ id: 'char-1', name: '탐정 A' })}>
+        탐정 A 삭제
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('../design/MissionEditor', () => ({
@@ -94,35 +127,61 @@ afterEach(() => {
 describe('CharactersTab', () => {
   beforeEach(() => {
     useEditorCharactersMock.mockReturnValue({ data: [], isLoading: false });
-    useDeleteCharacterMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    useDeleteCharacterMock.mockReturnValue({ mutate: deleteMutateMock, isPending: false });
   });
 
-  it('서브탭 목록, 배정 2개를 렌더링한다', () => {
+  it('서브탭 제작, 빠른 목록 2개를 렌더링한다', () => {
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
 
-    expect(screen.getByText('목록')).toBeDefined();
-    expect(screen.getByText('배정')).toBeDefined();
+    expect(screen.getByText('제작')).toBeDefined();
+    expect(screen.getByText('빠른 목록')).toBeDefined();
   });
 
-  it('기본 선택 탭은 목록이다', () => {
+  it('기본 선택 탭은 새 제작 workspace다', () => {
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
 
-    const listTab = screen.getByText('목록').closest('button');
-    expect(listTab?.className).toContain('border-amber-500');
-  });
-
-  it('배정 탭 클릭 시 CharacterAssignPanel이 표시된다', () => {
-    render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
-
-    fireEvent.click(screen.getByText('배정'));
+    const workspaceTab = screen.getByText('제작').closest('button');
+    expect(workspaceTab?.className).toContain('border-amber-500');
     expect(screen.getByText('CharacterAssignPanel 콘텐츠')).toBeDefined();
   });
 
-  it('목록 탭 클릭 시 캐릭터 목록 콘텐츠가 표시된다', () => {
+  it('빠른 목록 탭 클릭 시 캐릭터 목록 콘텐츠가 표시된다', () => {
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
 
-    fireEvent.click(screen.getByText('배정'));
-    fireEvent.click(screen.getByText('목록'));
+    fireEvent.click(screen.getByText('빠른 목록'));
     expect(screen.getByText('등장인물 없음')).toBeDefined();
+  });
+
+  it('빠른 목록에서 제작 탭으로 돌아가면 Entity workspace가 표시된다', () => {
+    render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+
+    fireEvent.click(screen.getByText('빠른 목록'));
+    fireEvent.click(screen.getByText('제작'));
+    expect(screen.getByText('CharacterAssignPanel 콘텐츠')).toBeDefined();
+  });
+
+  it('제작 workspace에서 캐릭터 생성 폼을 연다', () => {
+    render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+
+    fireEvent.click(screen.getByText('캐릭터 추가'));
+
+    expect(screen.getByText('캐릭터 생성 폼')).toBeDefined();
+  });
+
+  it('제작 workspace에서 캐릭터 수정 폼을 연다', () => {
+    render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+
+    fireEvent.click(screen.getByText('탐정 A 수정'));
+
+    expect(screen.getByText('탐정 A 수정 폼')).toBeDefined();
+  });
+
+  it('제작 workspace에서 캐릭터 삭제를 확정하면 delete mutation을 호출한다', () => {
+    render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+
+    fireEvent.click(screen.getByText('탐정 A 삭제'));
+    fireEvent.click(screen.getByText('삭제'));
+
+    expect(deleteMutateMock).toHaveBeenCalledWith('char-1', expect.any(Object));
   });
 });

--- a/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
@@ -91,10 +91,10 @@ describe('CluesTab', () => {
     expect(screen.getByTestId('spinner')).toBeDefined();
   });
 
-  it('단서가 없으면 빈 상태를 표시한다', () => {
+  it('단서가 없으면 Entity workspace 빈 상태를 표시한다', () => {
     useEditorCluesMock.mockReturnValue({ data: [], isLoading: false });
     render(<CluesTab themeId="theme-1" />);
-    expect(screen.getByText('단서 없음')).toBeDefined();
+    expect(screen.getByText('아직 단서가 없습니다')).toBeDefined();
   });
 
   it('단서 목록과 선택된 단서 상세를 함께 렌더링한다', () => {

--- a/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
@@ -95,6 +95,25 @@ describe('CluesTab', () => {
     useEditorCluesMock.mockReturnValue({ data: [], isLoading: false });
     render(<CluesTab themeId="theme-1" />);
     expect(screen.getByText('아직 단서가 없습니다')).toBeDefined();
+    expect(screen.getByRole('button', { name: '단서 추가' })).toBeDefined();
+  });
+
+  it('단서 조회 실패 시 빈 상태 대신 오류와 재시도 액션을 표시한다', () => {
+    const refetch = vi.fn();
+    useEditorCluesMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('network failed'),
+      refetch,
+    });
+
+    render(<CluesTab themeId="theme-1" />);
+
+    expect(screen.getByText('단서를 불러오지 못했습니다')).toBeDefined();
+    expect(screen.queryByText('network failed')).toBeNull();
+    screen.getByText('다시 시도').click();
+    expect(refetch).toHaveBeenCalledOnce();
   });
 
   it('단서 목록과 선택된 단서 상세를 함께 렌더링한다', () => {

--- a/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
@@ -450,6 +450,7 @@ describe("CharactersTab", () => {
     });
 
     const { container } = render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+    fireEvent.click(screen.getByRole("button", { name: "빠른 목록" }));
     const spinner = container.querySelector('[role="status"]');
     expect(spinner).not.toBeNull();
   });
@@ -461,6 +462,7 @@ describe("CharactersTab", () => {
     });
 
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+    fireEvent.click(screen.getByRole("button", { name: "빠른 목록" }));
     expect(screen.getByText("등장인물 없음")).toBeDefined();
   });
 
@@ -471,6 +473,7 @@ describe("CharactersTab", () => {
     });
 
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+    fireEvent.click(screen.getByRole("button", { name: "빠른 목록" }));
     expect(screen.getByText("탐정")).toBeDefined();
     expect(screen.getByText("범인 캐릭터")).toBeDefined();
   });
@@ -482,6 +485,7 @@ describe("CharactersTab", () => {
     });
 
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+    fireEvent.click(screen.getByRole("button", { name: "빠른 목록" }));
     expect(screen.getByText("범인")).toBeDefined();
   });
 
@@ -492,6 +496,7 @@ describe("CharactersTab", () => {
     });
 
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
+    fireEvent.click(screen.getByRole("button", { name: "빠른 목록" }));
     expect(screen.getByText("캐릭터 추가")).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { Plus } from 'lucide-react';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import { Modal } from '@/shared/components/ui/Modal';
 import { Button } from '@/shared/components/ui/Button';
@@ -75,7 +74,6 @@ export function ClueListView({ themeId }: ClueListViewProps) {
     return <div className="flex items-center justify-center py-12"><Spinner size="lg" /></div>;
   }
 
-  const isEmpty = !clues || clues.length === 0;
   const deletingReferences = deletingClue && clues
     ? buildClueUsageMap({
       configJson: theme?.config_json,
@@ -87,28 +85,17 @@ export function ClueListView({ themeId }: ClueListViewProps) {
 
   return (
     <div className="px-4 py-6">
-      {isEmpty ? (
-        <div className="py-16 text-center">
-          <div className="text-4xl font-mono font-bold text-slate-800 mb-2">0</div>
-          <div className="text-xs font-mono uppercase tracking-widest text-slate-700 mb-4">단서 없음</div>
-          <div className="text-xs text-slate-600 mb-6">단서를 추가하여 게임에 활용하세요</div>
-          <Button onClick={handleCreate}><Plus className="h-4 w-4 mr-1.5" />단서 추가</Button>
-        </div>
-      ) : (
-        <>
-          <ClueEntityWorkspace
-            clues={clues}
-            configJson={theme?.config_json}
-            locations={locations}
-            characters={characters}
-            onCreate={handleCreate}
-            onEdit={handleEdit}
-            onDelete={setDeletingClue}
-            onConfigChange={handleConfigChange}
-            isConfigSaving={updateConfig.isPending}
-          />
-        </>
-      )}
+      <ClueEntityWorkspace
+        clues={clues ?? []}
+        configJson={theme?.config_json}
+        locations={locations}
+        characters={characters}
+        onCreate={handleCreate}
+        onEdit={handleEdit}
+        onDelete={setDeletingClue}
+        onConfigChange={handleConfigChange}
+        isConfigSaving={updateConfig.isPending}
+      />
 
       <ClueForm themeId={themeId} clue={editingClue} isOpen={isFormOpen} onClose={handleFormClose} />
 

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -30,7 +30,7 @@ interface ClueListViewProps {
 // ---------------------------------------------------------------------------
 
 export function ClueListView({ themeId }: ClueListViewProps) {
-  const { data: clues, isLoading } = useEditorClues(themeId);
+  const { data: clues, isLoading, isError, refetch } = useEditorClues(themeId);
   const { data: theme } = useEditorTheme(themeId);
   const { data: locations = [] } = useEditorLocations(themeId);
   const { data: characters = [] } = useEditorCharacters(themeId);
@@ -74,6 +74,26 @@ export function ClueListView({ themeId }: ClueListViewProps) {
     return <div className="flex items-center justify-center py-12"><Spinner size="lg" /></div>;
   }
 
+  if (isError) {
+    return (
+      <div className="px-4 py-6">
+        <div className="rounded-xl border border-red-500/30 bg-red-950/20 p-5">
+          <p className="text-sm font-semibold text-red-100">단서를 불러오지 못했습니다</p>
+          <p className="mt-2 text-sm leading-6 text-red-200/80">
+            네트워크나 권한 문제일 수 있습니다. 잠시 후 다시 시도해 주세요.
+          </p>
+          <Button onClick={() => void refetch()}>
+            다시 시도
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!clues) {
+    return <div className="flex items-center justify-center py-12"><Spinner size="lg" /></div>;
+  }
+
   const deletingReferences = deletingClue && clues
     ? buildClueUsageMap({
       configJson: theme?.config_json,
@@ -86,7 +106,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
   return (
     <div className="px-4 py-6">
       <ClueEntityWorkspace
-        clues={clues ?? []}
+        clues={clues}
         configJson={theme?.config_json}
         locations={locations}
         characters={characters}

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
-import type { EditorThemeResponse, MysteryRole } from "@/features/editor/api";
+import { Edit3, Trash2 } from "lucide-react";
+import type { EditorCharacterResponse, EditorThemeResponse, MysteryRole } from "@/features/editor/api";
 import { useEditorCharacters, useEditorClues, useUpdateCharacter } from "@/features/editor/api";
 import { useCharacterConfigDebounce } from "@/features/editor/hooks/useCharacterConfigDebounce";
 import { CharacterDetailPanel } from "./CharacterDetailPanel";
@@ -22,9 +23,18 @@ import {
 interface CharacterAssignPanelProps {
   themeId: string;
   theme: EditorThemeResponse;
+  onCreate?: () => void;
+  onEdit?: (character: EditorCharacterResponse) => void;
+  onDelete?: (character: EditorCharacterResponse) => void;
 }
 
-export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelProps) {
+export function CharacterAssignPanel({
+  themeId,
+  theme,
+  onCreate,
+  onEdit,
+  onDelete,
+}: CharacterAssignPanelProps) {
   const { data: characters, isLoading: charsLoading } = useEditorCharacters(themeId);
   const { data: clues } = useEditorClues(themeId);
   const updateCharacter = useUpdateCharacter(themeId);
@@ -124,8 +134,9 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
         items={[]}
         selectedId={undefined}
         onSelect={() => undefined}
+        onCreate={onCreate}
         emptyMessage="캐릭터를 먼저 추가하세요"
-        emptyDescription="기본 탭에서 캐릭터를 만든 뒤 역할지와 시작 단서를 배정할 수 있습니다."
+        emptyDescription="캐릭터를 만든 뒤 역할지, 시작 단서, 히든 미션을 한 곳에서 관리합니다."
         getItemId={(char) => char.id}
         getItemTitle={(char) => char.name}
         renderDetail={() => null}
@@ -147,10 +158,35 @@ export function CharacterAssignPanel({ themeId, theme }: CharacterAssignPanelPro
         items={characters}
         selectedId={activeCharId ?? undefined}
         onSelect={handleSelectChar}
+        onCreate={onCreate}
         getItemId={(char) => char.id}
         getItemTitle={(char) => char.name}
         getItemDescription={(char) => char.description ?? ''}
         getItemBadges={(char) => [getCharacterRoleBadge(char)]}
+        renderItemActions={(char) => (
+          <div className="flex gap-1">
+            {onEdit && (
+              <button
+                type="button"
+                onClick={() => onEdit(char)}
+                aria-label={`${char.name} 수정`}
+                className="rounded-md p-2 text-slate-600 transition hover:bg-slate-800 hover:text-amber-300"
+              >
+                <Edit3 className="h-3.5 w-3.5" />
+              </button>
+            )}
+            {onDelete && (
+              <button
+                type="button"
+                onClick={() => onDelete(char)}
+                aria-label={`${char.name} 삭제`}
+                className="rounded-md p-2 text-slate-600 transition hover:bg-red-950/40 hover:text-red-300"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        )}
         renderDetail={(char) => (
           <CharacterDetailPanel
             themeId={themeId}

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -40,8 +40,9 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   const [addingMap, setAddingMap] = useState(false);
   const [addingLocation, setAddingLocation] = useState(false);
 
-  const selectedMap = maps?.find((m) => m.id === selectedMapId) ?? null;
-  const mapLocations = locations?.filter((l) => l.map_id === selectedMapId) ?? [];
+  const effectiveSelectedMapId = selectedMapId ?? maps?.[0]?.id ?? null;
+  const selectedMap = maps?.find((m) => m.id === effectiveSelectedMapId) ?? null;
+  const mapLocations = locations?.filter((l) => l.map_id === effectiveSelectedMapId) ?? [];
   const selectedLocation =
     mapLocations.find((l) => l.id === selectedLocationId) ?? mapLocations[0] ?? null;
 
@@ -74,9 +75,9 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   }
 
   function handleAddLocation(name: string) {
-    if (!selectedMapId) return;
+    if (!effectiveSelectedMapId) return;
     createLocation.mutate(
-      { mapId: selectedMapId, body: { name } },
+      { mapId: effectiveSelectedMapId, body: { name } },
       {
         onSuccess: (newLocation) => {
           toast.success('장소가 추가되었습니다');
@@ -142,40 +143,37 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           </div>
         ) : (
           maps.map((map) => {
-            const isSelected = selectedMapId === map.id;
+            const isSelected = effectiveSelectedMapId === map.id;
             return (
               <div
                 key={map.id}
-                role="button"
-                tabIndex={0}
-                onClick={() => {
-                  setSelectedMapId(isSelected ? null : map.id);
-                  setSelectedLocationId(null);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    setSelectedMapId(isSelected ? null : map.id);
-                    setSelectedLocationId(null);
-                  }
-                }}
-                className={`group flex w-full cursor-pointer items-center gap-2 border-l-2 px-3 py-1.5 text-left transition-colors ${
+                className={`group flex w-full items-center gap-1 border-l-2 px-2 py-1.5 transition-colors ${
                   isSelected
                     ? 'border-amber-500 bg-slate-900 text-slate-200'
                     : 'border-transparent text-slate-500 hover:bg-slate-900/50 hover:text-slate-300'
                 }`}
               >
-                <Map className="h-3.5 w-3.5 shrink-0" />
-                <span className="flex-1 truncate text-xs font-medium">{map.name}</span>
+                <button
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => {
+                    setSelectedMapId(map.id);
+                    setSelectedLocationId(null);
+                  }}
+                  className="flex min-h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+                >
+                  <Map className="h-3.5 w-3.5 shrink-0" />
+                  <span className="flex-1 truncate text-xs font-medium">{map.name}</span>
+                </button>
                 <button
                   type="button"
                   onClick={(e) => {
-                    e.stopPropagation();
                     if (window.confirm(`${map.name} 맵을 삭제할까요? 하위 장소 편집 흐름도 함께 영향을 받습니다.`)) {
                       handleDeleteMap(map.id);
                     }
                   }}
                   aria-label={`${map.name} 삭제`}
-                  className="p-0.5 text-slate-700 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all shrink-0"
+                  className="shrink-0 rounded-md p-2 text-slate-600 transition hover:bg-red-950/40 hover:text-red-300 md:text-slate-700 md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100"
                 >
                   <Trash2 className="h-3 w-3" />
                 </button>

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -166,7 +166,7 @@ describe('LocationsSubTab', () => {
 
     it('맵 이름들을 렌더링한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      expect(screen.getByText('저택 1층')).toBeDefined();
+      expect(screen.getAllByText('저택 1층').length).toBeGreaterThan(0);
       expect(screen.getByText('저택 2층')).toBeDefined();
     });
 
@@ -230,14 +230,14 @@ describe('LocationsSubTab', () => {
   describe('장소 목록 렌더링', () => {
     beforeEach(setupDefaultMocks);
 
-    it('맵 미선택 시 empty state를 표시한다', () => {
+    it('직접 진입 시 첫 맵의 공통 엔티티 Shell을 바로 표시한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      expect(screen.getByText('좌측에서 맵을 선택하세요')).toBeDefined();
+      expect(screen.getByRole('region', { name: '장소 목록' })).toBeDefined();
+      expect(screen.getAllByText('거실').length).toBeGreaterThan(0);
     });
 
     it('맵 선택 시 공통 엔티티 Shell로 해당 맵의 장소만 표시한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       expect(screen.getByRole('region', { name: '장소 목록' })).toBeDefined();
       // LocationDetailPanel row + clue-assignment picker option 두 곳에서 렌더됨
       expect(screen.getAllByText('거실').length).toBeGreaterThan(0);
@@ -246,10 +246,20 @@ describe('LocationsSubTab', () => {
       expect(screen.queryByText('침실')).toBeNull();
     });
 
+    it('다른 맵을 선택하면 해당 맵의 장소 workspace로 전환한다', () => {
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '저택 2층' }));
+
+      expect(screen.getByRole('region', { name: '장소 목록' })).toBeDefined();
+      expect(screen.getAllByText('침실').length).toBeGreaterThan(0);
+      expect(screen.queryByText('거실')).toBeNull();
+      expect(screen.queryByText('주방')).toBeNull();
+    });
+
     it('선택한 맵에 장소가 없을 때 빈 상태를 표시한다', () => {
       useEditorLocationsMock.mockReturnValue({ data: [], isLoading: false });
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       expect(screen.getByText('장소 없음')).toBeDefined();
     });
   });
@@ -259,20 +269,17 @@ describe('LocationsSubTab', () => {
 
     it('맵 선택 후 장소 추가 버튼이 나타난다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       expect(screen.getByText('장소 추가')).toBeDefined();
     });
 
     it('장소 추가 버튼 클릭 시 인라인 입력이 나타난다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       fireEvent.click(screen.getByText('장소 추가'));
       expect(screen.getByPlaceholderText('장소 이름')).toBeDefined();
     });
 
     it('Enter 키로 장소를 추가하면 mutate가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       fireEvent.click(screen.getByText('장소 추가'));
       const input = screen.getByPlaceholderText('장소 이름');
       fireEvent.change(input, { target: { value: '서재' } });
@@ -289,13 +296,11 @@ describe('LocationsSubTab', () => {
 
     it('맵 선택 시 장소 선택 picker 가 표시된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       expect(screen.getByText('전체 단서 목록')).toBeDefined();
     });
 
     it('location picker 를 통해 선택한 location 에 대해 LocationClueAssignPanel 이 렌더된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       fireEvent.click(screen.getByRole('button', { name: '주방 선택' }));
       expect(screen.getByLabelText('주방 조사 시 발견 단서')).toBeDefined();
       expect(screen.getByLabelText('단검 추가')).toBeDefined();
@@ -303,7 +308,6 @@ describe('LocationsSubTab', () => {
 
     it('chip 토글 시 useUpdateConfigJson.mutate 가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       fireEvent.click(screen.getByLabelText('단검 추가'));
       expect(updateConfigMutateMock).toHaveBeenCalledOnce();
       const [config] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
@@ -317,7 +321,8 @@ describe('LocationsSubTab', () => {
       });
     });
 
-    it('맵 미선택 상태에서는 단서 배정 picker 가 표시되지 않는다', () => {
+    it('맵이 없으면 단서 배정 picker 가 표시되지 않는다', () => {
+      useEditorMapsMock.mockReturnValue({ data: [], isLoading: false });
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       expect(screen.queryByText('전체 단서 목록')).toBeNull();
     });
@@ -328,14 +333,12 @@ describe('LocationsSubTab', () => {
 
     it('등장/퇴장 라운드 입력이 각 장소 행마다 존재한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       expect(screen.getByLabelText('거실 등장 라운드')).toBeDefined();
       expect(screen.getByLabelText('거실 퇴장 라운드')).toBeDefined();
     });
 
     it('라운드 값 입력 후 blur 하면 useUpdateLocation.mutate 가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
       fireEvent.change(fromInput, { target: { value: '2' } });
       fireEvent.blur(fromInput);
@@ -350,7 +353,6 @@ describe('LocationsSubTab', () => {
 
     it('등장 > 퇴장 조합은 에러 토스트 후 저장되지 않는다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
       const untilInput = screen.getByLabelText('거실 퇴장 라운드') as HTMLInputElement;
       fireEvent.change(untilInput, { target: { value: '2' } });
@@ -368,7 +370,6 @@ describe('LocationsSubTab', () => {
         isLoading: false,
       });
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      fireEvent.click(screen.getByText('저택 1층'));
       const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
       fireEvent.change(fromInput, { target: { value: '' } });
       fireEvent.blur(fromInput);


### PR DESCRIPTION
## 요약

- /editor/:id/characters 기본 진입을 캐릭터 Entity workspace 제작 흐름으로 전환했습니다.
- /editor/:id/clues 빈 상태도 ClueEntityWorkspace/EntityEditorShell 경로로 통일했습니다.
- /editor/:id/locations 직접 진입 시 첫 맵의 장소 Entity workspace가 바로 열리도록 연결했습니다.
- 직접 URL/장소/캐릭터 역할 E2E와 focused Vitest를 새 route migration 기준으로 갱신했습니다.

## 범위

- Closes #292
- Refs #293
- Refs #294

#278/#279/#280의 세부 runtime 저장 계약은 이번 PR에 섞지 않았습니다. backend read-heavy audit에서 확인한 결말 runtime 계약과 flow API 소유권 검증은 각각 #293, #294로 분리했습니다.

## 검증

- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/__tests__/CharactersTab.test.tsx src/features/editor/components/__tests__/CluesTab.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium --grep "직접 URL|장소 탭" --reporter=list
- pnpm --filter @mmp/web exec playwright test e2e/phase24-editor-character-role.spec.ts --project=chromium --reporter=list
- git diff --check

참고: focused coverage 명령은 대상 테스트 38개는 통과했지만, 일부 파일만 실행하면 앱 전체 global coverage threshold가 낮게 계산되어 실패하므로 merge 판단은 PR Codecov patch report로 확인합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 캐릭터 탭에 "제작"/"빠른 목록" 서브탭 도입(기본: 제작) 및 CharacterAssignPanel에 생성/수정/삭제 액션 노출
  * 단서 목록 오류 패널과 "다시 시도" 버튼 추가

* **개선**
  * 캐릭터 생성/수정/삭제 흐름·삭제 확인 모달 및 토스트 처리 개선
  * 맵·위치 선택 로직과 UI를 버튼 기반으로 변경해 기본 선택 보장 및 로딩 스피너 처리 추가

* **테스트**
  * E2E·단위 테스트 보강: 에디터 경로별 UI(제작 버튼·목록·장소/단서 레이블), 탐정 A 선택 흐름 및 오류 경로 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->