### PR TITLE
feat(editor): #279 장소 조사 단서 제작 UI 연결

### DIFF
--- a/apps/server/internal/domain/editor/service_clue_cleanup.go
+++ b/apps/server/internal/domain/editor/service_clue_cleanup.go
@@ -49,6 +49,12 @@ func removeClueIDFromConfigValue(value any, clueID string) (any, bool) {
 		}
 		return items, changed
 	case map[string]any:
+		if currentClueID, ok := v["clueId"].(string); ok && currentClueID == clueID {
+			if _, hasLocation := v["locationId"].(string); hasLocation {
+				return deletedConfigNode, true
+			}
+		}
+
 		changed := false
 		out := make(map[string]any, len(v))
 		for key, child := range v {

--- a/apps/server/internal/domain/editor/service_clue_cleanup_test.go
+++ b/apps/server/internal/domain/editor/service_clue_cleanup_test.go
@@ -14,7 +14,11 @@ func TestRemoveClueReferencesFromConfigJSON(t *testing.T) {
 		"locations": [{"id":"loc-1","name":"서재","locationClueConfig":{"clueIds":["11111111-1111-1111-1111-111111111111","22222222-2222-2222-2222-222222222222"]}}],
 		"modules": {
 			"starting_clue": {"enabled": true, "config": {"startingClues": {"char-1": ["11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333"]}}},
-			"clue_action": {"enabled": true, "config": {"targetClueId": "11111111-1111-1111-1111-111111111111", "rewards": ["11111111-1111-1111-1111-111111111111", "44444444-4444-4444-4444-444444444444"]}}
+			"clue_action": {"enabled": true, "config": {"targetClueId": "11111111-1111-1111-1111-111111111111", "rewards": ["11111111-1111-1111-1111-111111111111", "44444444-4444-4444-4444-444444444444"]}},
+			"location": {"enabled": true, "config": {"discoveries": [
+				{"locationId":"loc-1","clueId":"11111111-1111-1111-1111-111111111111","requiredClueIds":["22222222-2222-2222-2222-222222222222"]},
+				{"locationId":"loc-1","clueId":"55555555-5555-5555-5555-555555555555","requiredClueIds":["11111111-1111-1111-1111-111111111111","22222222-2222-2222-2222-222222222222"]}
+			]}}
 		}
 	}`)
 
@@ -27,6 +31,26 @@ func TestRemoveClueReferencesFromConfigJSON(t *testing.T) {
 	}
 	if strings.Contains(string(cleaned), clueID.String()) {
 		t.Fatalf("deleted clue id still present in cleaned config: %s", string(cleaned))
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(cleaned, &decoded); err != nil {
+		t.Fatalf("unmarshal cleaned config: %v", err)
+	}
+	modules := decoded["modules"].(map[string]any)
+	locationModule := modules["location"].(map[string]any)
+	locationConfig := locationModule["config"].(map[string]any)
+	discoveries := locationConfig["discoveries"].([]any)
+	if len(discoveries) != 1 {
+		t.Fatalf("expected only discovery with deleted clueId to be removed, got %#v", discoveries)
+	}
+	keptDiscovery := discoveries[0].(map[string]any)
+	if keptDiscovery["clueId"] != "55555555-5555-5555-5555-555555555555" {
+		t.Fatalf("unexpected kept discovery: %#v", keptDiscovery)
+	}
+	required := keptDiscovery["requiredClueIds"].([]any)
+	if len(required) != 1 || required[0] != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("deleted required clue id should be removed from kept discovery: %#v", required)
 	}
 }
 
@@ -63,5 +87,41 @@ func TestRemoveClueReferencesFromConfigJSON_PreservesNullValues(t *testing.T) {
 	nested := decoded["nested"].(map[string]any)
 	if _, ok := nested["keepNull"]; !ok || nested["keepNull"] != nil {
 		t.Fatalf("nested null should be preserved: %#v", nested)
+	}
+}
+
+func TestRemoveClueReferencesFromConfigJSON_IgnoresMalformedDiscoveryWithoutPanic(t *testing.T) {
+	clueID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	raw := json.RawMessage(`{
+		"modules": {
+			"location": {
+				"enabled": true,
+				"config": {
+					"discoveries": [
+						{"locationId":"loc-1","clueId":["11111111-1111-1111-1111-111111111111"]},
+						{"locationId":"loc-1","clueId":"22222222-2222-2222-2222-222222222222"}
+					]
+				}
+			}
+		}
+	}`)
+
+	cleaned, changed, err := removeClueReferencesFromConfigJSON(raw, clueID)
+	if err != nil {
+		t.Fatalf("removeClueReferencesFromConfigJSON: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected nested clue id string to be removed without deleting malformed discovery")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(cleaned, &decoded); err != nil {
+		t.Fatalf("unmarshal cleaned config: %v", err)
+	}
+	modules := decoded["modules"].(map[string]any)
+	locationModule := modules["location"].(map[string]any)
+	locationConfig := locationModule["config"].(map[string]any)
+	discoveries := locationConfig["discoveries"].([]any)
+	if len(discoveries) != 2 {
+		t.Fatalf("malformed discovery should be preserved, got %#v", discoveries)
 	}
 }

--- a/apps/server/internal/domain/editor/service_entity_cleanup.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup.go
@@ -58,6 +58,11 @@ func removeEntityIDFromConfigValue(value any, entityID string) (any, bool) {
 		if id, ok := v["id"].(string); ok && id == entityID {
 			return deletedConfigNode, true
 		}
+		if locationID, ok := v["locationId"].(string); ok && locationID == entityID {
+			if _, hasClue := v["clueId"].(string); hasClue {
+				return deletedConfigNode, true
+			}
+		}
 
 		changed := false
 		out := make(map[string]any, len(v))

--- a/apps/server/internal/domain/editor/service_entity_cleanup_test.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup_test.go
@@ -70,6 +70,21 @@ func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
 			{"id": "%s", "name": "삭제 장소", "locationClueConfig": {"clueIds": ["clue-1"]}},
 			{"id": "%s", "name": "남길 장소", "locationClueConfig": {"clueIds": ["clue-2"]}}
 		],
+		"modules": {
+			"location": {
+				"enabled": true,
+				"config": {
+					"locations": [
+						{"id": "%s", "name": "삭제 장소"},
+						{"id": "%s", "name": "남길 장소"}
+					],
+					"discoveries": [
+						{"locationId": "%s", "clueId": "clue-1"},
+						{"locationId": "%s", "clueId": "clue-2"}
+					]
+				}
+			}
+		},
 		"locationMeta": {
 			"%s": {"entryMessage": "삭제"},
 			"child": {"parentLocationId": "%s", "entryMessage": "자식"},
@@ -80,7 +95,7 @@ func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
 			"kept-clue": "%s"
 		},
 		"nullable": null
-	}`, locationID, keptLocationID, locationID, locationID, keptLocationID, locationID, keptLocationID))
+	}`, locationID, keptLocationID, locationID, keptLocationID, locationID, keptLocationID, locationID, locationID, keptLocationID, locationID, keptLocationID))
 
 	cleaned, changed, err := removeLocationReferencesFromConfigJSON(raw, locationID)
 	if err != nil {
@@ -105,8 +120,55 @@ func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected root config to be map[string]any, got %T", decoded)
 	}
+	modules := root["modules"].(map[string]any)
+	locationModule := modules["location"].(map[string]any)
+	locationConfig := locationModule["config"].(map[string]any)
+	discoveries := locationConfig["discoveries"].([]any)
+	if len(discoveries) != 1 {
+		t.Fatalf("expected only discovery with deleted locationId to be removed, got %#v", discoveries)
+	}
+	keptDiscovery := discoveries[0].(map[string]any)
+	if keptDiscovery["locationId"] != keptLocationID.String() {
+		t.Fatalf("unexpected kept discovery: %#v", keptDiscovery)
+	}
 	if _, exists := root["nullable"]; !exists || root["nullable"] != nil {
 		t.Fatalf("json null must be preserved, got %#v", root["nullable"])
+	}
+}
+
+func TestRemoveLocationReferencesFromConfigJSON_IgnoresMalformedDiscoveryWithoutPanic(t *testing.T) {
+	locationID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	raw := json.RawMessage(`{
+		"modules": {
+			"location": {
+				"enabled": true,
+				"config": {
+					"discoveries": [
+						{"locationId":["33333333-3333-3333-3333-333333333333"],"clueId":"clue-1"},
+						{"locationId":"44444444-4444-4444-4444-444444444444","clueId":"clue-2"}
+					]
+				}
+			}
+		}
+	}`)
+
+	cleaned, changed, err := removeLocationReferencesFromConfigJSON(raw, locationID)
+	if err != nil {
+		t.Fatalf("removeLocationReferencesFromConfigJSON: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected nested location id string to be removed without deleting malformed discovery")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(cleaned, &decoded); err != nil {
+		t.Fatalf("unmarshal cleaned config: %v", err)
+	}
+	modules := decoded["modules"].(map[string]any)
+	locationModule := modules["location"].(map[string]any)
+	locationConfig := locationModule["config"].(map[string]any)
+	discoveries := locationConfig["discoveries"].([]any)
+	if len(discoveries) != 2 {
+		t.Fatalf("malformed discovery should be preserved, got %#v", discoveries)
 	}
 }
 

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -5,7 +5,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import type { EditorThemeResponse, LocationResponse, ClueResponse } from '@/features/editor/api';
 import { editorKeys, useEditorClues, useUpdateConfigJson } from '@/features/editor/api';
-import { readLocationClueIds, writeLocationClueIds } from '@/features/editor/editorTypes';
+import {
+  readLocationDiscoveries,
+  writeLocationDiscoveries,
+  type LocationDiscoveryConfig,
+} from '@/features/editor/editorTypes';
 
 interface LocationClueAssignPanelProps {
   themeId: string;
@@ -32,17 +36,22 @@ export function LocationClueAssignPanel({
   allClues,
   onChange,
 }: LocationClueAssignPanelProps) {
-  const { data: fetchedClues, isLoading, isError, error, refetch } = useEditorClues(themeId);
+  const { data: fetchedClues, isLoading, isError, refetch } = useEditorClues(themeId);
   const clues = useMemo(() => allClues ?? fetchedClues ?? [], [allClues, fetchedClues]);
   const updateConfig = useUpdateConfigJson(themeId);
   const queryClient = useQueryClient();
   const [query, setQuery] = useState('');
 
-  const assignedIds = useMemo(
-    () => readLocationClueIds(theme.config_json, location.id),
+  const discoveries = useMemo(
+    () => readLocationDiscoveries(theme.config_json, location.id),
     [theme.config_json, location.id]
   );
+  const assignedIds = useMemo(
+    () => discoveries.map((discovery) => discovery.clueId),
+    [discoveries]
+  );
   const assignedSet = useMemo(() => new Set(assignedIds), [assignedIds]);
+  const clueById = useMemo(() => new Map(clues.map((clue) => [clue.id, clue])), [clues]);
   const selectedClues = clues.filter((clue) => assignedSet.has(clue.id));
   const visibleClues = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -56,8 +65,9 @@ export function LocationClueAssignPanel({
     );
   }, [clues, query]);
 
-  function commit(next: string[]) {
-    const nextConfig = writeLocationClueIds(theme.config_json, location.id, next);
+  function commit(next: LocationDiscoveryConfig[]) {
+    const nextConfig = writeLocationDiscoveries(theme.config_json, location.id, next);
+    const nextIds = next.map((discovery) => discovery.clueId);
     const cacheKey = editorKeys.theme(themeId);
     const previous = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
     if (previous)
@@ -67,23 +77,42 @@ export function LocationClueAssignPanel({
       });
     updateConfig.mutate(nextConfig, {
       onSuccess: () => {
-        toast.success('단서 배정이 저장되었습니다');
-        onChange?.(next);
+        toast.success('장소 조사 단서가 저장되었습니다');
+        onChange?.(nextIds);
       },
       onError: () => {
         if (previous) queryClient.setQueryData(cacheKey, previous);
-        toast.error('단서 배정 저장에 실패했습니다');
+        toast.error('장소 조사 단서 저장에 실패했습니다');
       },
     });
   }
 
   function addClue(clueId: string) {
     if (assignedSet.has(clueId)) return;
-    commit([...assignedIds, clueId]);
+    commit([
+      ...discoveries,
+      { locationId: location.id, clueId, requiredClueIds: [], oncePerPlayer: true },
+    ]);
   }
 
   function removeClue(clueId: string) {
-    commit(assignedIds.filter((id) => id !== clueId));
+    commit(discoveries.filter((discovery) => discovery.clueId !== clueId));
+  }
+
+  function toggleRequiredClue(clueId: string, requiredClueId: string) {
+    commit(
+      discoveries.map((discovery) => {
+        if (discovery.clueId !== clueId) return discovery;
+        const requiredSet = new Set(discovery.requiredClueIds);
+        if (requiredSet.has(requiredClueId)) requiredSet.delete(requiredClueId);
+        else requiredSet.add(requiredClueId);
+        return {
+          ...discovery,
+          requiredClueIds: Array.from(requiredSet).filter((id) => id !== clueId),
+          oncePerPlayer: true,
+        };
+      })
+    );
   }
 
   if (!allClues && isLoading) {
@@ -100,7 +129,7 @@ export function LocationClueAssignPanel({
         aria-label={`${location.name} 조사 시 발견 단서`}
         className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-center text-xs text-red-100"
       >
-        <p>{error instanceof Error ? error.message : '단서 목록을 불러오지 못했습니다.'}</p>
+        <p>단서 목록을 불러오지 못했습니다.</p>
         <button
           type="button"
           onClick={() => refetch?.()}
@@ -169,9 +198,9 @@ export function LocationClueAssignPanel({
           <section className="rounded-lg border border-amber-500/20 bg-amber-950/10 p-2.5">
             <div className="mb-2 flex items-center justify-between gap-2">
               <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
-                이 장소의 단서
+                조사 보상
               </p>
-              <span className="text-[10px] text-slate-600">클릭 제거</span>
+              <span className="text-[10px] text-slate-600">플레이어당 1회</span>
             </div>
             {selectedClues.length === 0 ? (
               <p className="rounded-md border border-dashed border-slate-800 px-2.5 py-5 text-center text-xs text-slate-600">
@@ -183,8 +212,12 @@ export function LocationClueAssignPanel({
                   <SelectedClue
                     key={clue.id}
                     clue={clue}
+                    discovery={discoveries.find((item) => item.clueId === clue.id)}
+                    availableClues={clues.filter((candidate) => candidate.id !== clue.id)}
+                    clueById={clueById}
                     disabled={updateConfig.isPending}
                     onRemove={removeClue}
+                    onToggleRequired={toggleRequiredClue}
                   />
                 ))}
               </div>
@@ -231,31 +264,85 @@ function ClueOption({
 
 function SelectedClue({
   clue,
+  discovery,
+  availableClues,
+  clueById,
   disabled,
   onRemove,
+  onToggleRequired,
 }: {
   clue: ClueResponse;
+  discovery?: LocationDiscoveryConfig;
+  availableClues: ClueResponse[];
+  clueById: Map<string, ClueResponse>;
   disabled: boolean;
   onRemove: (id: string) => void;
+  onToggleRequired: (clueId: string, requiredClueId: string) => void;
 }) {
+  const requiredIds = discovery?.requiredClueIds ?? [];
+  const requiredSet = new Set(requiredIds);
+  const selectedRequiredNames = requiredIds
+    .map((id) => clueById.get(id)?.name)
+    .filter(Boolean)
+    .join(', ');
+
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-slate-950/80 px-2.5 py-1.5">
-      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-amber-500/10 text-[9px] font-semibold text-amber-300">
-        {roundLabel(clue)}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-xs font-medium text-slate-200">{clue.name}</span>
-        <span className="block truncate text-[10px] text-slate-600">{clueMeta(clue)}</span>
-      </span>
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => onRemove(clue.id)}
-        aria-label={`${clue.name} 제거`}
-        className="rounded-full p-1 text-slate-600 hover:bg-red-950/40 hover:text-red-300 disabled:opacity-50"
-      >
-        <X className="h-3 w-3" />
-      </button>
+    <div className="rounded-lg border border-amber-500/20 bg-slate-950/80 px-2.5 py-2">
+      <div className="flex items-center gap-2">
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-amber-500/10 text-[9px] font-semibold text-amber-300">
+          {roundLabel(clue)}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-xs font-medium text-slate-200">{clue.name}</span>
+          <span className="block truncate text-[10px] text-slate-600">{clueMeta(clue)}</span>
+        </span>
+        <span className="shrink-0 rounded-full border border-slate-800 px-2 py-0.5 text-[10px] text-slate-500">
+          1회 발견
+        </span>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onRemove(clue.id)}
+          aria-label={`${clue.name} 제거`}
+          className="rounded-full p-1 text-slate-600 hover:bg-red-950/40 hover:text-red-300 disabled:opacity-50"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+      <div className="mt-2 rounded-md border border-slate-800 bg-slate-950/80 p-2">
+        <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+          필요 단서
+        </p>
+        {availableClues.length === 0 ? (
+          <p className="text-[10px] text-slate-600">조건으로 사용할 다른 단서가 없습니다.</p>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {availableClues.map((candidate) => {
+              const selected = requiredSet.has(candidate.id);
+              return (
+                <button
+                  key={candidate.id}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onToggleRequired(clue.id, candidate.id)}
+                  aria-pressed={selected}
+                  aria-label={`${clue.name} 발견 조건 ${candidate.name} ${selected ? '해제' : '필요'}`}
+                  className={`rounded-full border px-2 py-1 text-[10px] transition disabled:opacity-50 ${
+                    selected
+                      ? 'border-amber-400/50 bg-amber-500/10 text-amber-200'
+                      : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-300'
+                  }`}
+                >
+                  {candidate.name}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        <p className="mt-1.5 text-[10px] text-slate-600">
+          {selectedRequiredNames ? `${selectedRequiredNames} 보유 시 발견` : '조건 없음'}
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -175,8 +175,23 @@ describe('LocationClueAssignPanel', () => {
       id: string;
       locationClueConfig: { clueIds: string[] };
     }>;
+    const modules = config.modules as {
+      location: {
+        config: {
+          discoveries: Array<{
+            locationId: string;
+            clueId: string;
+            requiredClueIds: string[];
+            oncePerPlayer: boolean;
+          }>;
+        };
+      };
+    };
     expect(locs).toHaveLength(1);
     expect(locs[0]).toEqual({ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } });
+    expect(modules.location.config.discoveries).toEqual([
+      { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: [], oncePerPlayer: true },
+    ]);
   });
 
   it('이미 배정된 clue 클릭 시 clueIds에서 제거된다', () => {
@@ -194,7 +209,131 @@ describe('LocationClueAssignPanel', () => {
       id: string;
       locationClueConfig: { clueIds: string[] };
     }>;
+    const modules = config.modules as {
+      location: {
+        config: {
+          discoveries: Array<{
+            locationId: string;
+            clueId: string;
+            requiredClueIds: string[];
+            oncePerPlayer: boolean;
+          }>;
+        };
+      };
+    };
     expect(locs[0].locationClueConfig.clueIds).toEqual(['clue-2']);
+    expect(modules.location.config.discoveries).toEqual([
+      { locationId: 'loc-1', clueId: 'clue-2', requiredClueIds: [], oncePerPlayer: true },
+    ]);
+  });
+
+  it('필요 단서를 선택하면 requiredClueIds 런타임 조건으로 저장된다', () => {
+    const theme: EditorThemeResponse = {
+      ...baseTheme,
+      config_json: {
+        locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+        modules: {
+          location: {
+            enabled: true,
+            config: {
+              discoveries: [
+                {
+                  locationId: 'loc-1',
+                  clueId: 'clue-1',
+                  requiredClueIds: [],
+                  oncePerPlayer: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
+
+    expect(screen.getByText('1회 발견')).toBeDefined();
+    fireEvent.click(screen.getByLabelText('단검 발견 조건 편지 필요'));
+
+    expect(mutateMock).toHaveBeenCalledOnce();
+    const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
+    const modules = config.modules as {
+      location: {
+        config: {
+          discoveries: Array<{
+            locationId: string;
+            clueId: string;
+            requiredClueIds: string[];
+            oncePerPlayer: boolean;
+          }>;
+        };
+      };
+    };
+    expect(modules.location.config.discoveries).toEqual([
+      { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: ['clue-2'], oncePerPlayer: true },
+    ]);
+  });
+
+  it('이미 선택된 필요 단서를 다시 클릭하면 requiredClueIds에서 해제된다', () => {
+    const theme: EditorThemeResponse = {
+      ...baseTheme,
+      config_json: {
+        locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+        modules: {
+          location: {
+            enabled: true,
+            config: {
+              discoveries: [
+                {
+                  locationId: 'loc-1',
+                  clueId: 'clue-1',
+                  requiredClueIds: ['clue-2'],
+                  oncePerPlayer: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
+
+    expect(screen.getByText('편지 보유 시 발견')).toBeDefined();
+    fireEvent.click(screen.getByLabelText('단검 발견 조건 편지 해제'));
+
+    expect(mutateMock).toHaveBeenCalledOnce();
+    const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
+    const modules = config.modules as {
+      location: {
+        config: {
+          discoveries: Array<{
+            locationId: string;
+            clueId: string;
+            requiredClueIds: string[];
+            oncePerPlayer: boolean;
+          }>;
+        };
+      };
+    };
+    expect(modules.location.config.discoveries).toEqual([
+      { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: [], oncePerPlayer: true },
+    ]);
+  });
+
+  it('단서 로드 실패 시 내부 에러 문자열을 노출하지 않는다', () => {
+    useEditorCluesMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('database connection refused'),
+      refetch: vi.fn(),
+    });
+
+    renderQC(
+      <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
+    );
+
+    expect(screen.getByText('단서 목록을 불러오지 못했습니다.')).toBeDefined();
+    expect(screen.queryByText('database connection refused')).toBeNull();
   });
 
   it('onChange prop은 mutate 성공 시 호출된다', () => {
@@ -284,7 +423,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
 
     const cached = qc.getQueryData<EditorThemeResponse>(cacheKey);
     expect(cached?.config_json).toEqual({}); // rolled back to baseTheme.config_json
-    expect(toastError).toHaveBeenCalledWith('단서 배정 저장에 실패했습니다');
+    expect(toastError).toHaveBeenCalledWith('장소 조사 단서 저장에 실패했습니다');
   });
 
   it('연속 토글에서 첫 mutation 실패 시 첫 토글 직전 상태로 rollback 된다 (M5 closure)', () => {
@@ -330,7 +469,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     // 핵심 검증: 첫 토글 직전 상태로 롤백 (빈 config_json).
     // 단일 rollbackRef 구현이었다면 두 번째 토글 직전 스냅샷(clue-1 포함)으로 잘못 복원됨.
     expect(cached?.config_json).toEqual({});
-    expect(toastError).toHaveBeenCalledWith('단서 배정 저장에 실패했습니다');
+    expect(toastError).toHaveBeenCalledWith('장소 조사 단서 저장에 실패했습니다');
   });
 
   it('theme 캐시가 없으면 mutate 만 호출되고 rollback 대상도 없다', () => {

--- a/apps/web/src/features/editor/editorTypes.ts
+++ b/apps/web/src/features/editor/editorTypes.ts
@@ -4,6 +4,7 @@
 
 export type {
   EditorConfig,
+  LocationDiscoveryConfig,
   LocationConfig as EditorLocationConfig,
 } from '@/features/editor/utils/configShape';
 
@@ -11,6 +12,8 @@ export type EditorLocationsConfig = import('@/features/editor/utils/configShape'
 
 export {
   readLocationsConfig,
+  readLocationDiscoveries,
   readLocationClueIds,
+  writeLocationDiscoveries,
   writeLocationClueIds,
 } from '@/features/editor/utils/configShape';

--- a/apps/web/src/features/editor/utils/__tests__/configClueCleanup.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configClueCleanup.test.ts
@@ -3,42 +3,62 @@ import { removeClueReferencesFromConfig } from '../configShape';
 
 describe('removeClueReferencesFromConfig', () => {
   it('removes a deleted clue from location and starting clue settings without removing entities', () => {
-    const next = removeClueReferencesFromConfig({
-      locations: [
-        { id: 'loc-1', name: '서재', locationClueConfig: { clueIds: ['clue-1', 'clue-2'] } },
-      ],
-      modules: {
-        starting_clue: {
-          enabled: true,
-          config: { startingClues: { 'char-1': ['clue-1', 'clue-3'] } },
+    const next = removeClueReferencesFromConfig(
+      {
+        locations: [
+          { id: 'loc-1', name: '서재', locationClueConfig: { clueIds: ['clue-1', 'clue-2'] } },
+        ],
+        modules: {
+          location: {
+            enabled: true,
+            config: {
+              discoveries: [
+                { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: ['clue-2'] },
+                { locationId: 'loc-1', clueId: 'clue-4', requiredClueIds: ['clue-1', 'clue-2'] },
+              ],
+            },
+          },
+          starting_clue: {
+            enabled: true,
+            config: { startingClues: { 'char-1': ['clue-1', 'clue-3'] } },
+          },
         },
       },
-    }, 'clue-1');
+      'clue-1'
+    );
 
     expect(next.locations).toEqual([
       { id: 'loc-1', name: '서재', locationClueConfig: { clueIds: ['clue-2'] } },
     ]);
     expect(next.modules).toMatchObject({
+      location: {
+        config: {
+          discoveries: [{ locationId: 'loc-1', clueId: 'clue-4', requiredClueIds: ['clue-2'] }],
+        },
+      },
       starting_clue: { config: { startingClues: { 'char-1': ['clue-3'] } } },
     });
   });
 
   it('removes deleted clue ids from nested action and combination settings', () => {
-    const next = removeClueReferencesFromConfig({
-      modules: {
-        clue_action: {
-          enabled: true,
-          config: {
-            rewards: ['clue-1', 'clue-2'],
-            fixedTargetClueId: 'clue-1',
+    const next = removeClueReferencesFromConfig(
+      {
+        modules: {
+          clue_action: {
+            enabled: true,
+            config: {
+              rewards: ['clue-1', 'clue-2'],
+              fixedTargetClueId: 'clue-1',
+            },
+          },
+          combination: {
+            enabled: true,
+            config: { recipes: [{ required: ['clue-1', 'clue-3'], output: 'clue-1' }] },
           },
         },
-        combination: {
-          enabled: true,
-          config: { recipes: [{ required: ['clue-1', 'clue-3'], output: 'clue-1' }] },
-        },
       },
-    }, 'clue-1');
+      'clue-1'
+    );
 
     expect(next.modules).toEqual({
       clue_action: { enabled: true, config: { rewards: ['clue-2'] } },

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -4,12 +4,14 @@ import {
   readClueItemEffect,
   readClueItemEffects,
   readCharacterStartingClueMap,
+  readLocationDiscoveries,
   readCluePlacement,
   readEnabledModuleIds,
   readLocationClueIds,
   readModuleConfig,
   writeCharacterStartingClueMap,
   writeClueItemEffect,
+  writeLocationDiscoveries,
   writeCluePlacement,
   writeLocationClueIds,
   writeModuleConfig,
@@ -57,7 +59,7 @@ describe('configShape', () => {
       },
       'voting',
       'candidatePolicy.includeDetective',
-      true,
+      true
     );
 
     expect(readModuleConfig(next, 'voting')).toEqual({
@@ -90,15 +92,13 @@ describe('configShape', () => {
 
     const next = normalizeConfigForSave(config);
     expect(next).not.toHaveProperty('clue_placement');
-    expect(next.locations).toEqual([
-      { id: 'loc-1', locationClueConfig: { clueIds: [] } },
-    ]);
+    expect(next.locations).toEqual([{ id: 'loc-1', locationClueConfig: { clueIds: [] } }]);
   });
 
   it('writes clue placement through locations[].locationClueConfig', () => {
     const next = writeCluePlacement(
       { clue_placement: { old: 'legacy' }, locations: [{ id: 'loc-1' }] },
-      { 'clue-1': 'loc-1', 'clue-2': 'loc-1' },
+      { 'clue-1': 'loc-1', 'clue-2': 'loc-1' }
     );
 
     expect(readCluePlacement(next)).toEqual({ 'clue-1': 'loc-1', 'clue-2': 'loc-1' });
@@ -106,19 +106,144 @@ describe('configShape', () => {
     expect(next.locations).toEqual([
       { id: 'loc-1', locationClueConfig: { clueIds: ['clue-1', 'clue-2'] } },
     ]);
+    expect(readModuleConfig(next, 'location')).toMatchObject({
+      locations: [{ id: 'loc-1', name: 'loc-1' }],
+      discoveries: [
+        { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: [], oncePerPlayer: true },
+        { locationId: 'loc-1', clueId: 'clue-2', requiredClueIds: [], oncePerPlayer: true },
+      ],
+    });
   });
 
   it('writes one location assignment without locations[].clueIds', () => {
-    const next = writeLocationClueIds(
-      { locations: [{ id: 'loc-1', clueIds: ['old'] }] },
+    const next = writeLocationClueIds({ locations: [{ id: 'loc-1', clueIds: ['old'] }] }, 'loc-1', [
+      'clue-1',
+    ]);
+
+    expect(readLocationClueIds(next, 'loc-1')).toEqual(['clue-1']);
+    expect(next.locations).toEqual([{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }]);
+  });
+
+  it('writes location discoveries into the runtime location module while keeping clueIds bridge', () => {
+    const next = writeLocationDiscoveries(
+      {
+        locations: [
+          { id: 'loc-1', name: '서재' },
+          { id: 'loc-2', name: '복도' },
+        ],
+        modules: {
+          location: {
+            enabled: true,
+            config: {
+              startingLocation: 'loc-1',
+              locations: [{ id: 'loc-1', name: 'Old', accessRules: ['gm'] }],
+              discoveries: [{ locationId: 'loc-2', clueId: 'clue-9', oncePerPlayer: true }],
+            },
+          },
+        },
+      },
       'loc-1',
-      ['clue-1'],
+      [
+        {
+          locationId: 'loc-1',
+          clueId: 'clue-1',
+          requiredClueIds: ['clue-2', 'clue-1', 'clue-2'],
+          oncePerPlayer: false,
+        },
+      ]
     );
 
     expect(readLocationClueIds(next, 'loc-1')).toEqual(['clue-1']);
-    expect(next.locations).toEqual([
-      { id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } },
+    expect(readLocationDiscoveries(next, 'loc-1')).toEqual([
+      {
+        locationId: 'loc-1',
+        clueId: 'clue-1',
+        requiredClueIds: ['clue-2'],
+        oncePerPlayer: true,
+      },
     ]);
+    expect(next.locations).toEqual([
+      { id: 'loc-1', name: '서재', locationClueConfig: { clueIds: ['clue-1'] } },
+      { id: 'loc-2', name: '복도' },
+    ]);
+    expect(readModuleConfig(next, 'location')).toMatchObject({
+      startingLocation: 'loc-1',
+      locations: [
+        { id: 'loc-1', name: '서재', accessRules: ['gm'] },
+        { id: 'loc-2', name: '복도' },
+      ],
+      discoveries: [
+        { locationId: 'loc-2', clueId: 'clue-9', oncePerPlayer: true },
+        { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: ['clue-2'], oncePerPlayer: true },
+      ],
+    });
+  });
+
+  it('promotes legacy-only discoveries from other locations when writing one location', () => {
+    const next = writeLocationDiscoveries(
+      {
+        locations: [
+          { id: 'loc-1', name: '서재', locationClueConfig: { clueIds: ['clue-1'] } },
+          { id: 'loc-2', name: '복도', locationClueConfig: { clueIds: ['clue-2'] } },
+        ],
+        modules: {
+          location: {
+            enabled: true,
+            config: { discoveries: [] },
+          },
+        },
+      },
+      'loc-1',
+      [{ locationId: 'loc-1', clueId: 'clue-3', requiredClueIds: [], oncePerPlayer: true }]
+    );
+
+    expect(readLocationClueIds(next, 'loc-2')).toEqual(['clue-2']);
+    expect(readModuleConfig(next, 'location')).toMatchObject({
+      discoveries: [
+        { locationId: 'loc-2', clueId: 'clue-2', requiredClueIds: [], oncePerPlayer: true },
+        { locationId: 'loc-1', clueId: 'clue-3', requiredClueIds: [], oncePerPlayer: true },
+      ],
+    });
+  });
+
+  it('preserves malformed and unknown raw discoveries when writing one location', () => {
+    const malformedDiscovery = { locationId: 'loc-2', clueId: ['bad-shape'] };
+    const unknownLocationDiscovery = {
+      locationId: 'archived-location',
+      clueId: 'archived-clue',
+      requiredClueIds: ['legacy-required'],
+    };
+    const next = writeLocationDiscoveries(
+      {
+        locations: [
+          { id: 'loc-1', name: '서재', locationClueConfig: { clueIds: ['clue-1'] } },
+          { id: 'loc-2', name: '복도', locationClueConfig: { clueIds: ['clue-2'] } },
+        ],
+        modules: {
+          location: {
+            enabled: true,
+            config: {
+              discoveries: [
+                { locationId: 'loc-1', clueId: 'old-clue', oncePerPlayer: true },
+                malformedDiscovery,
+                unknownLocationDiscovery,
+              ],
+            },
+          },
+        },
+      },
+      'loc-1',
+      [{ locationId: 'loc-1', clueId: 'clue-3', requiredClueIds: [], oncePerPlayer: true }]
+    );
+
+    expect(readModuleConfig(next, 'location')).toMatchObject({
+      discoveries: [
+        malformedDiscovery,
+        unknownLocationDiscovery,
+        { locationId: 'loc-2', clueId: 'clue-2', requiredClueIds: [], oncePerPlayer: true },
+        { locationId: 'loc-1', clueId: 'clue-3', requiredClueIds: [], oncePerPlayer: true },
+      ],
+    });
   });
 
   it('reads legacy character clues and writes starting_clue module config', () => {

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -16,6 +16,14 @@ export interface LocationConfig extends Record<string, unknown> {
   clueIds?: string[];
 }
 
+export interface LocationDiscoveryConfig extends EditorConfig {
+  id?: string;
+  locationId: string;
+  clueId: string;
+  requiredClueIds: string[];
+  oncePerPlayer: boolean;
+}
+
 export type ClueItemEffectKind = 'peek' | 'reveal' | 'grant_clue';
 
 export interface ClueItemEffectConfig extends EditorConfig {
@@ -29,6 +37,8 @@ export interface ClueItemEffectConfig extends EditorConfig {
 const LEGACY_KEYS = ['module_configs', 'clue_placement', 'character_clues'] as const;
 const CLUE_INTERACTION_MODULE_ID = 'clue_interaction';
 const CLUE_ITEM_EFFECTS_KEY = 'itemEffects';
+const LOCATION_MODULE_ID = 'location';
+const LOCATION_DISCOVERIES_KEY = 'discoveries';
 
 function isRecord(value: unknown): value is EditorConfig {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -36,13 +46,17 @@ function isRecord(value: unknown): value is EditorConfig {
 
 function hasOwnKey<T extends string>(
   value: EditorConfig | null | undefined,
-  key: T,
+  key: T
 ): value is EditorConfig & Record<T, unknown> {
   return !!value && Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function stringList(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
 }
 
 function readClueItemEffectConfig(value: unknown): ClueItemEffectConfig | null {
@@ -67,7 +81,7 @@ function readClueItemEffectConfig(value: unknown): ClueItemEffectConfig | null {
 }
 
 function readRawClueItemEffects(
-  configJson: EditorConfig | null | undefined,
+  configJson: EditorConfig | null | undefined
 ): Record<string, unknown> {
   const moduleConfig = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
   const rawEffects = moduleConfig[CLUE_ITEM_EFFECTS_KEY];
@@ -91,7 +105,7 @@ function readLegacyModuleConfigs(configJson: EditorConfig | null | undefined) {
 }
 
 export function readModulesMap(
-  configJson: EditorConfig | null | undefined,
+  configJson: EditorConfig | null | undefined
 ): Record<string, ModuleEntry> {
   const rawModules = configJson?.modules;
   const legacyConfigs = readLegacyModuleConfigs(configJson);
@@ -123,9 +137,7 @@ export function readModulesMap(
   return entries;
 }
 
-export function readEnabledModuleIds(
-  configJson: EditorConfig | null | undefined,
-): string[] {
+export function readEnabledModuleIds(configJson: EditorConfig | null | undefined): string[] {
   return Object.entries(readModulesMap(configJson))
     .filter(([, entry]) => entry.enabled !== false)
     .map(([id]) => id);
@@ -133,7 +145,7 @@ export function readEnabledModuleIds(
 
 export function readModuleConfig(
   configJson: EditorConfig | null | undefined,
-  moduleId: string,
+  moduleId: string
 ): EditorConfig {
   const cfg = readModulesMap(configJson)[moduleId]?.config;
   return isRecord(cfg) ? cfg : {};
@@ -160,9 +172,7 @@ function stripLegacyConfigKeys(configJson: EditorConfig): EditorConfig {
   return next;
 }
 
-export function normalizeConfigForSave(
-  configJson: EditorConfig | null | undefined,
-): EditorConfig {
+export function normalizeConfigForSave(configJson: EditorConfig | null | undefined): EditorConfig {
   const base = configJson ?? {};
   return stripLegacyConfigKeys({ ...base, modules: readModulesMap(base) });
 }
@@ -170,7 +180,7 @@ export function normalizeConfigForSave(
 export function writeModuleEnabled(
   configJson: EditorConfig | null | undefined,
   moduleId: string,
-  enabled: boolean,
+  enabled: boolean
 ): EditorConfig {
   const next = normalizeConfigForSave(configJson);
   const modules = readModulesMap(next);
@@ -181,7 +191,7 @@ export function writeModuleEnabled(
 export function writeModuleConfig(
   configJson: EditorConfig | null | undefined,
   moduleId: string,
-  moduleConfig: EditorConfig,
+  moduleConfig: EditorConfig
 ): EditorConfig {
   const next = normalizeConfigForSave(configJson);
   const modules = readModulesMap(next);
@@ -210,14 +220,14 @@ export function writeModuleConfigPath(
   configJson: EditorConfig | null | undefined,
   moduleId: string,
   path: string,
-  value: unknown,
+  value: unknown
 ): EditorConfig {
   const current = readModuleConfig(configJson, moduleId);
   return writeModuleConfig(configJson, moduleId, writePath(current, path, value));
 }
 
 export function readClueItemEffects(
-  configJson: EditorConfig | null | undefined,
+  configJson: EditorConfig | null | undefined
 ): Record<string, ClueItemEffectConfig> {
   const moduleConfig = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
   const rawEffects = moduleConfig[CLUE_ITEM_EFFECTS_KEY];
@@ -226,13 +236,13 @@ export function readClueItemEffects(
   return Object.fromEntries(
     Object.entries(rawEffects)
       .map(([clueId, rawConfig]) => [clueId, readClueItemEffectConfig(rawConfig)] as const)
-      .filter((entry): entry is [string, ClueItemEffectConfig] => !!entry[1]),
+      .filter((entry): entry is [string, ClueItemEffectConfig] => !!entry[1])
   );
 }
 
 export function readClueItemEffect(
   configJson: EditorConfig | null | undefined,
-  clueId: string,
+  clueId: string
 ): ClueItemEffectConfig | null {
   return readClueItemEffects(configJson)[clueId] ?? null;
 }
@@ -240,7 +250,7 @@ export function readClueItemEffect(
 export function writeClueItemEffect(
   configJson: EditorConfig | null | undefined,
   clueId: string,
-  effectConfig: ClueItemEffectConfig | null,
+  effectConfig: ClueItemEffectConfig | null
 ): EditorConfig {
   const current = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
   const itemEffects = readRawClueItemEffects(configJson);
@@ -263,19 +273,94 @@ export function writeClueItemEffect(
   });
 }
 
-export function readLocationsConfig(
-  configJson: EditorConfig | null | undefined,
-): LocationConfig[] {
+export function readLocationsConfig(configJson: EditorConfig | null | undefined): LocationConfig[] {
   const raw = configJson?.locations;
   if (!Array.isArray(raw)) return [];
   return raw.filter(
-    (item): item is LocationConfig => isRecord(item) && typeof item.id === 'string',
+    (item): item is LocationConfig => isRecord(item) && typeof item.id === 'string'
   );
 }
 
-export function readLocationClueIds(
+function readRawLocationDiscoveries(
+  configJson: EditorConfig | null | undefined
+): LocationDiscoveryConfig[] {
+  const moduleConfig = readModuleConfig(configJson, LOCATION_MODULE_ID);
+  const rawDiscoveries = moduleConfig[LOCATION_DISCOVERIES_KEY];
+  if (!Array.isArray(rawDiscoveries)) return [];
+
+  return rawDiscoveries
+    .map((raw): LocationDiscoveryConfig | null => {
+      if (!isRecord(raw)) return null;
+      const locationId = typeof raw.locationId === 'string' ? raw.locationId : '';
+      const clueId = typeof raw.clueId === 'string' ? raw.clueId : '';
+      if (!locationId || !clueId) return null;
+
+      return {
+        ...raw,
+        ...(typeof raw.id === 'string' ? { id: raw.id } : {}),
+        locationId,
+        clueId,
+        requiredClueIds: uniqueStrings(
+          stringList(raw.requiredClueIds).filter((id) => id !== clueId)
+        ),
+        oncePerPlayer: typeof raw.oncePerPlayer === 'boolean' ? raw.oncePerPlayer : true,
+      };
+    })
+    .filter((entry): entry is LocationDiscoveryConfig => !!entry);
+}
+
+function rawLocationDiscoveries(value: unknown): unknown[] {
+  return Array.isArray(value) ? [...value] : [];
+}
+
+function validRawLocationDiscovery(value: unknown): LocationDiscoveryConfig | null {
+  if (!isRecord(value)) return null;
+  const locationId = typeof value.locationId === 'string' ? value.locationId : '';
+  const clueId = typeof value.clueId === 'string' ? value.clueId : '';
+  if (!locationId || !clueId) return null;
+  return {
+    ...value,
+    ...(typeof value.id === 'string' ? { id: value.id } : {}),
+    locationId,
+    clueId,
+    requiredClueIds: uniqueStrings(stringList(value.requiredClueIds).filter((id) => id !== clueId)),
+    oncePerPlayer: typeof value.oncePerPlayer === 'boolean' ? value.oncePerPlayer : true,
+  };
+}
+
+export function readLocationDiscoveries(
   configJson: EditorConfig | null | undefined,
-  locationId: string,
+  locationId: string
+): LocationDiscoveryConfig[] {
+  const discoveries = readRawLocationDiscoveries(configJson).filter(
+    (discovery) => discovery.locationId === locationId
+  );
+  const seenClueIds = new Set(discoveries.map((discovery) => discovery.clueId));
+  const legacyDiscoveries = readLegacyLocationClueIds(configJson, locationId)
+    .filter((clueId) => !seenClueIds.has(clueId))
+    .map((clueId) => ({
+      locationId,
+      clueId,
+      requiredClueIds: [],
+      oncePerPlayer: true,
+    }));
+
+  const locationModuleConfig = readModuleConfig(configJson, LOCATION_MODULE_ID);
+  if (hasOwnKey(locationModuleConfig, LOCATION_DISCOVERIES_KEY)) {
+    return [...discoveries, ...legacyDiscoveries];
+  }
+
+  return readLegacyLocationClueIds(configJson, locationId).map((clueId) => ({
+    locationId,
+    clueId,
+    requiredClueIds: [],
+    oncePerPlayer: true,
+  }));
+}
+
+function readLegacyLocationClueIds(
+  configJson: EditorConfig | null | undefined,
+  locationId: string
 ): string[] {
   const entry = readLocationsConfig(configJson).find((loc) => loc.id === locationId);
   const canonical = entry?.locationClueConfig?.clueIds;
@@ -283,10 +368,17 @@ export function readLocationClueIds(
   return stringList(entry?.clueIds);
 }
 
+export function readLocationClueIds(
+  configJson: EditorConfig | null | undefined,
+  locationId: string
+): string[] {
+  return readLocationDiscoveries(configJson, locationId).map((discovery) => discovery.clueId);
+}
+
 export function writeLocationClueIds(
   configJson: EditorConfig | null | undefined,
   locationId: string,
-  clueIds: string[],
+  clueIds: string[]
 ): EditorConfig {
   const next = normalizeConfigForSave(configJson);
   const locations = readLocationsConfig(next);
@@ -296,14 +388,102 @@ export function writeLocationClueIds(
     ...loc,
     locationClueConfig: { ...(loc.locationClueConfig ?? {}), clueIds: cleanIds },
   });
-  const nextLocations = idx >= 0
-    ? locations.map((loc, i) => (i === idx ? upsert(loc) : loc))
-    : [...locations, { id: locationId, locationClueConfig: { clueIds: cleanIds } }];
+  const nextLocations =
+    idx >= 0
+      ? locations.map((loc, i) => (i === idx ? upsert(loc) : loc))
+      : [...locations, { id: locationId, locationClueConfig: { clueIds: cleanIds } }];
   return { ...next, locations: nextLocations };
 }
 
-export function readCluePlacement(
+function runtimeLocationDefs(existing: unknown, locations: LocationConfig[]): EditorConfig[] {
+  const existingById = new Map<string, EditorConfig>();
+  if (Array.isArray(existing)) {
+    for (const item of existing) {
+      if (isRecord(item) && typeof item.id === 'string') existingById.set(item.id, item);
+    }
+  }
+
+  return locations.map((loc) => {
+    const existingLoc = existingById.get(loc.id) ?? {};
+    return {
+      ...existingLoc,
+      id: loc.id,
+      name: typeof loc.name === 'string' && loc.name.trim() ? loc.name : loc.id,
+    };
+  });
+}
+
+function normalizeLocationDiscoveries(
+  locationId: string,
+  discoveries: LocationDiscoveryConfig[]
+): LocationDiscoveryConfig[] {
+  const seen = new Set<string>();
+  const clean: LocationDiscoveryConfig[] = [];
+  for (const discovery of discoveries) {
+    if (!discovery.clueId || seen.has(discovery.clueId)) continue;
+    seen.add(discovery.clueId);
+    clean.push({
+      ...discovery,
+      locationId,
+      clueId: discovery.clueId,
+      requiredClueIds: uniqueStrings(
+        stringList(discovery.requiredClueIds).filter((id) => id !== discovery.clueId)
+      ),
+      oncePerPlayer: true,
+    });
+  }
+  return clean;
+}
+
+export function writeLocationDiscoveries(
   configJson: EditorConfig | null | undefined,
+  locationId: string,
+  discoveries: LocationDiscoveryConfig[]
+): EditorConfig {
+  const cleanDiscoveries = normalizeLocationDiscoveries(locationId, discoveries);
+  const next = writeLocationClueIds(
+    configJson,
+    locationId,
+    cleanDiscoveries.map((discovery) => discovery.clueId)
+  );
+  const current = readModuleConfig(next, LOCATION_MODULE_ID);
+  const preservedRawDiscoveries = rawLocationDiscoveries(current[LOCATION_DISCOVERIES_KEY]).filter(
+    (raw) => !isRecord(raw) || raw.locationId !== locationId
+  );
+  const preservedValidDiscoveries = preservedRawDiscoveries
+    .map(validRawLocationDiscovery)
+    .filter((entry): entry is LocationDiscoveryConfig => !!entry);
+  const promotedLegacyDiscoveries = readLocationsConfig(next)
+    .filter((loc) => loc.id !== locationId)
+    .flatMap((loc) => {
+      const existingClueIds = new Set(
+        preservedValidDiscoveries
+          .filter((discovery) => discovery.locationId === loc.id)
+          .map((discovery) => discovery.clueId)
+      );
+      return readLegacyLocationClueIds(next, loc.id)
+        .filter((clueId) => !existingClueIds.has(clueId))
+        .map((clueId) => ({
+          locationId: loc.id,
+          clueId,
+          requiredClueIds: [],
+          oncePerPlayer: true,
+        }));
+    });
+
+  return writeModuleConfig(next, LOCATION_MODULE_ID, {
+    ...current,
+    locations: runtimeLocationDefs(current.locations, readLocationsConfig(next)),
+    [LOCATION_DISCOVERIES_KEY]: [
+      ...preservedRawDiscoveries,
+      ...promotedLegacyDiscoveries,
+      ...cleanDiscoveries,
+    ],
+  });
+}
+
+export function readCluePlacement(
+  configJson: EditorConfig | null | undefined
 ): Record<string, string> {
   const placement: Record<string, string> = {};
   const locations = readLocationsConfig(configJson);
@@ -315,13 +495,13 @@ export function readCluePlacement(
   const legacy = configJson?.clue_placement;
   if (!isRecord(legacy)) return {};
   return Object.fromEntries(
-    Object.entries(legacy).filter((e): e is [string, string] => typeof e[1] === 'string'),
+    Object.entries(legacy).filter((e): e is [string, string] => typeof e[1] === 'string')
   );
 }
 
 export function writeCluePlacement(
   configJson: EditorConfig | null | undefined,
-  placement: Record<string, string>,
+  placement: Record<string, string>
 ): EditorConfig {
   let next = normalizeConfigForSave(configJson);
   const locationIds = new Set([
@@ -332,36 +512,51 @@ export function writeCluePlacement(
     const ids = Object.entries(placement)
       .filter(([, locId]) => locId === locationId)
       .map(([clueId]) => clueId);
-    next = writeLocationClueIds(next, locationId, ids);
+    const existingByClueId = new Map(
+      readLocationDiscoveries(next, locationId).map((discovery) => [discovery.clueId, discovery])
+    );
+    next = writeLocationDiscoveries(
+      next,
+      locationId,
+      ids.map(
+        (clueId) =>
+          existingByClueId.get(clueId) ?? {
+            locationId,
+            clueId,
+            requiredClueIds: [],
+            oncePerPlayer: true,
+          }
+      )
+    );
   }
   return next;
 }
 
 export function readCharacterStartingClueMap(
-  configJson: EditorConfig | null | undefined,
+  configJson: EditorConfig | null | undefined
 ): Record<string, string[]> {
   const startingConfig = readModuleConfig(configJson, 'starting_clue');
   if (hasOwnKey(startingConfig, 'startingClues')) {
     return isRecord(startingConfig.startingClues)
       ? Object.fromEntries(
-        Object.entries(startingConfig.startingClues).map(([charId, ids]) => [
-          charId,
-          stringList(ids),
-        ]),
-      )
+          Object.entries(startingConfig.startingClues).map(([charId, ids]) => [
+            charId,
+            stringList(ids),
+          ])
+        )
       : {};
   }
 
   const source = configJson?.character_clues;
   if (!isRecord(source)) return {};
   return Object.fromEntries(
-    Object.entries(source).map(([charId, ids]) => [charId, stringList(ids)]),
+    Object.entries(source).map(([charId, ids]) => [charId, stringList(ids)])
   );
 }
 
 export function writeCharacterStartingClueMap(
   configJson: EditorConfig | null | undefined,
-  startingClues: Record<string, string[]>,
+  startingClues: Record<string, string[]>
 ): EditorConfig {
   const current = readModuleConfig(configJson, 'starting_clue');
   return writeModuleConfig(configJson, 'starting_clue', { ...current, startingClues });
@@ -376,16 +571,18 @@ function removeClueIdFromValue(value: unknown, clueId: string): unknown {
   }
   if (!isRecord(value)) return value;
 
+  if (value.clueId === clueId && typeof value.locationId === 'string') return undefined;
+
   return Object.fromEntries(
     Object.entries(value)
       .map(([key, child]) => [key, removeClueIdFromValue(child, clueId)] as const)
-      .filter(([, child]) => child !== undefined),
+      .filter(([, child]) => child !== undefined)
   );
 }
 
 export function removeClueReferencesFromConfig(
   configJson: EditorConfig | null | undefined,
-  clueId: string,
+  clueId: string
 ): EditorConfig {
   const normalized = normalizeConfigForSave(configJson);
   return removeClueIdFromValue(normalized, clueId) as EditorConfig;


### PR DESCRIPTION
## 요약

- `/editor/:id/locations` 장소 상세의 “조사 시 발견 단서” 카드가 `modules.location.config.discoveries[]` 런타임 계약을 저장하도록 연결했습니다.
- 기존 `locations[].locationClueConfig.clueIds`는 migration bridge로 계속 읽고, 저장 시 다른 장소의 legacy-only 배정도 runtime discovery로 승격해 손실을 막았습니다.
- `requiredClueIds` 조건 편집과 플레이어당 1회 발견 표시를 추가하고, 내부 에러 문자열 노출을 제거했습니다.
- 단서/장소 삭제 cleanup이 discovery 객체를 불완전하게 남기지 않도록 보강했습니다.

Closes #279
Refs #296

## 로컬 검증

- `pnpm --filter @mmp/web exec eslint src/features/editor/utils/configShape.ts`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/utils/__tests__/configShape.test.ts src/features/editor/utils/__tests__/configClueCleanup.test.ts` (68 tests)
- `cd apps/server && go test ./internal/domain/editor -run 'ClueReferences|LocationReferences|EntityReferences|Delete.*References'`\n- `cd apps/server && go test ./internal/module/crime_scene -run 'Location.*Discovery|LocationModule'`\n- `git diff --check`\n\n## PR 검증\n\n- CodeRabbit: APPROVED, unresolved threads 0\n- Codecov patch coverage: 99.37304%\n- CI: TypeScript Lint + Test + Build, Go Lint + Test, Coverage Regression Guard, Docker Build Check 통과\n- E2E — Stubbed Backend: chromium shard 1/2, report merge 통과\n- Security — Fast Feedback: gitleaks, govulncheck 통과\n\n## 후속\n\n- #296에서 `config_json` 저장 시 location discovery 참조 검증을 강화합니다.