### PR TITLE
fix(editor): #296 장소 조사 discovery 저장 검증 강화

### DIFF
--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -65,6 +65,159 @@ func validateConfigShape(raw json.RawMessage) error {
 	if err := validateClueInteractionConfigShape(cfg); err != nil {
 		return err
 	}
+	if _, err := extractLocationDiscoveryRefs(cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+type locationDiscoveryRef struct {
+	index           int
+	locationID      string
+	clueID          string
+	requiredClueIDs []string
+}
+
+func extractLocationDiscoveryRefs(cfg map[string]any) ([]locationDiscoveryRef, error) {
+	modules, ok := cfg["modules"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	rawModule, exists := modules["location"]
+	if !exists {
+		return nil, nil
+	}
+	module, ok := rawModule.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("config_json: modules.location must be an object")
+	}
+	moduleConfigRaw, exists := module["config"]
+	if !exists {
+		return nil, nil
+	}
+	if moduleConfigRaw == nil {
+		return nil, fmt.Errorf("config_json: modules.location.config cannot be null")
+	}
+	moduleConfig, ok := moduleConfigRaw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("config_json: modules.location.config must be an object")
+	}
+	rawDiscoveries, exists := moduleConfig["discoveries"]
+	if !exists {
+		return nil, nil
+	}
+	if rawDiscoveries == nil {
+		return nil, fmt.Errorf("config_json: modules.location.config.discoveries cannot be null")
+	}
+	discoveries, ok := rawDiscoveries.([]any)
+	if !ok {
+		return nil, fmt.Errorf("config_json: modules.location.config.discoveries must be an array")
+	}
+	refs := make([]locationDiscoveryRef, 0, len(discoveries))
+	for i, rawDiscovery := range discoveries {
+		discovery, ok := rawDiscovery.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d] must be an object", i)
+		}
+		locationID, ok := discovery["locationId"].(string)
+		if !ok || locationID == "" {
+			return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d].locationId is required", i)
+		}
+		clueID, ok := discovery["clueId"].(string)
+		if !ok || clueID == "" {
+			return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d].clueId is required", i)
+		}
+		ref := locationDiscoveryRef{index: i, locationID: locationID, clueID: clueID}
+		if requiredRaw, exists := discovery["requiredClueIds"]; exists {
+			if requiredRaw == nil {
+				return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d].requiredClueIds cannot be null", i)
+			}
+			required, ok := requiredRaw.([]any)
+			if !ok {
+				return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d].requiredClueIds must be an array", i)
+			}
+			ref.requiredClueIDs = make([]string, 0, len(required))
+			for j, rawRequired := range required {
+				requiredID, ok := rawRequired.(string)
+				if !ok || requiredID == "" {
+					return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d].requiredClueIds[%d] must be a string", i, j)
+				}
+				ref.requiredClueIDs = append(ref.requiredClueIDs, requiredID)
+			}
+		}
+		if oncePerPlayer, exists := discovery["oncePerPlayer"]; exists {
+			if oncePerPlayer == nil {
+				return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d].oncePerPlayer cannot be null", i)
+			}
+			if _, ok := oncePerPlayer.(bool); !ok {
+				return nil, fmt.Errorf("config_json: modules.location.config.discoveries[%d].oncePerPlayer must be boolean", i)
+			}
+		}
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+var errConfigVersionConflict = errors.New("editor config version conflict")
+
+func (s *service) validateLocationDiscoveryReferences(ctx context.Context, q *db.Queries, themeID uuid.UUID, raw json.RawMessage) error {
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return fmt.Errorf("config_json: invalid JSON: %w", err)
+	}
+	refs, err := extractLocationDiscoveryRefs(cfg)
+	if err != nil {
+		return err
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+
+	locations, err := q.ListLocationsByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to validate location discoveries locations")
+		return apperror.Internal("failed to validate location discoveries")
+	}
+	locationIDs := make(map[string]struct{}, len(locations))
+	for _, loc := range locations {
+		locationIDs[loc.ID.String()] = struct{}{}
+	}
+
+	clues, err := q.ListCluesByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to validate location discoveries clues")
+		return apperror.Internal("failed to validate location discoveries")
+	}
+	clueIDs := make(map[string]struct{}, len(clues))
+	for _, clue := range clues {
+		clueIDs[clue.ID.String()] = struct{}{}
+	}
+
+	for _, ref := range refs {
+		parsedLocationID, err := uuid.Parse(ref.locationID)
+		if err != nil {
+			return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].locationId must be a valid location id", ref.index))
+		}
+		if _, ok := locationIDs[parsedLocationID.String()]; !ok {
+			return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].locationId must belong to this theme", ref.index))
+		}
+		parsedClueID, err := uuid.Parse(ref.clueID)
+		if err != nil {
+			return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].clueId must be a valid clue id", ref.index))
+		}
+		if _, ok := clueIDs[parsedClueID.String()]; !ok {
+			return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].clueId must belong to this theme", ref.index))
+		}
+		for j, requiredClueID := range ref.requiredClueIDs {
+			parsedRequiredClueID, err := uuid.Parse(requiredClueID)
+			if err != nil {
+				return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].requiredClueIds[%d] must be a valid clue id", ref.index, j))
+			}
+			if _, ok := clueIDs[parsedRequiredClueID.String()]; !ok {
+				return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].requiredClueIds[%d] must belong to this theme", ref.index, j))
+			}
+		}
+	}
 	return nil
 }
 
@@ -191,14 +344,38 @@ func (s *service) UpdateConfigJson(ctx context.Context, creatorID, themeID uuid.
 		s.preUpdateHook(ctx, themeID)
 	}
 
-	updated, err := s.q.UpdateThemeConfigJson(ctx, db.UpdateThemeConfigJsonParams{
-		ID:         themeID,
-		ConfigJson: config,
-		Version:    theme.Version,
+	var updated db.Theme
+	err = pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(ctx, `SELECT 1 FROM themes WHERE id = $1 FOR UPDATE`, themeID).Scan(new(int)); err != nil {
+			return err
+		}
+
+		qtx := s.q.WithTx(tx)
+		if err := s.validateLocationDiscoveryReferences(ctx, qtx, themeID, config); err != nil {
+			return err
+		}
+
+		var updateErr error
+		updated, updateErr = qtx.UpdateThemeConfigJson(ctx, db.UpdateThemeConfigJsonParams{
+			ID:         themeID,
+			ConfigJson: config,
+			Version:    theme.Version,
+		})
+		if errors.Is(updateErr, pgx.ErrNoRows) {
+			return errConfigVersionConflict
+		}
+		return updateErr
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, errConfigVersionConflict) {
 			return nil, s.buildConfigVersionConflict(ctx, themeID, theme.Version)
+		}
+		var appErr *apperror.AppError
+		if errors.As(err, &appErr) {
+			return nil, appErr
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("theme not found")
 		}
 		s.logger.Error().Err(err).Msg("failed to update config")
 		return nil, apperror.Internal("failed to update config")

--- a/apps/server/internal/domain/editor/service_location_discovery_validation_test.go
+++ b/apps/server/internal/domain/editor/service_location_discovery_validation_test.go
@@ -1,0 +1,323 @@
+package editor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mmp-platform/server/internal/apperror"
+)
+
+func TestUpdateConfigJson_ValidatesLocationDiscoveries(t *testing.T) {
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
+	if err != nil {
+		t.Fatalf("CreateMap: %v", err)
+	}
+	locationResp, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "서재"})
+	if err != nil {
+		t.Fatalf("CreateLocation: %v", err)
+	}
+	discoveryClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "혈흔", Level: 1})
+	if err != nil {
+		t.Fatalf("CreateClue discovery: %v", err)
+	}
+	requiredClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "장갑", Level: 1})
+	if err != nil {
+		t.Fatalf("CreateClue required: %v", err)
+	}
+
+	valid := json.RawMessage(fmt.Sprintf(`{
+		"modules": {
+			"location": {
+				"enabled": true,
+				"config": {
+					"discoveries": [{
+						"locationId": "%s",
+						"clueId": "%s",
+						"requiredClueIds": ["%s"],
+						"oncePerPlayer": true
+					}]
+				}
+			}
+		}
+	}`, locationResp.ID, discoveryClue.ID, requiredClue.ID))
+	updated, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, valid)
+	if err != nil {
+		t.Fatalf("valid location discovery config must save: %v", err)
+	}
+	if updated.Version <= 1 {
+		t.Fatalf("expected version bump for valid discovery config, got %d", updated.Version)
+	}
+
+	otherCreatorID := f.createUser(t)
+	otherThemeID := f.createThemeForUser(t, otherCreatorID)
+	otherMap, err := f.svc.CreateMap(ctx, otherCreatorID, otherThemeID, CreateMapRequest{Name: "다른 지도"})
+	if err != nil {
+		t.Fatalf("CreateMap other: %v", err)
+	}
+	otherLocation, err := f.svc.CreateLocation(ctx, otherCreatorID, otherThemeID, otherMap.ID, CreateLocationRequest{Name: "다른 장소"})
+	if err != nil {
+		t.Fatalf("CreateLocation other: %v", err)
+	}
+	otherClue, err := f.svc.CreateClue(ctx, otherCreatorID, otherThemeID, CreateClueRequest{Name: "다른 단서", Level: 1})
+	if err != nil {
+		t.Fatalf("CreateClue other: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		input json.RawMessage
+		want  string
+	}{
+		{
+			name: "location module must be object",
+			input: json.RawMessage(`{
+				"modules": {"location": true}
+			}`),
+			want: "modules.location must be an object",
+		},
+		{
+			name: "location config must be object",
+			input: json.RawMessage(`{
+				"modules": {"location": {"enabled": true, "config": []}}
+			}`),
+			want: "modules.location.config must be an object",
+		},
+		{
+			name: "discoveries must be array",
+			input: json.RawMessage(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": {}}}}
+			}`),
+			want: "discoveries must be an array",
+		},
+		{
+			name: "discovery must be object",
+			input: json.RawMessage(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": ["bad"]}}}
+			}`),
+			want: "modules.location.config.discoveries[0] must be an object",
+		},
+		{
+			name: "missing location id",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"clueId": "%s"
+				}]}}}
+			}`, discoveryClue.ID)),
+			want: "modules.location.config.discoveries[0].locationId is required",
+		},
+		{
+			name: "invalid location id format",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "library",
+					"clueId": "%s"
+				}]}}}
+			}`, discoveryClue.ID)),
+			want: "modules.location.config.discoveries[0].locationId must be a valid location id",
+		},
+		{
+			name: "location id must belong to theme",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s",
+					"clueId": "%s"
+				}]}}}
+			}`, otherLocation.ID, discoveryClue.ID)),
+			want: "modules.location.config.discoveries[0].locationId must belong to this theme",
+		},
+		{
+			name: "missing clue id",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s"
+				}]}}}
+			}`, locationResp.ID)),
+			want: "modules.location.config.discoveries[0].clueId is required",
+		},
+		{
+			name: "invalid clue id format",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s",
+					"clueId": "blood"
+				}]}}}
+			}`, locationResp.ID)),
+			want: "modules.location.config.discoveries[0].clueId must be a valid clue id",
+		},
+		{
+			name: "clue id must belong to theme",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s",
+					"clueId": "%s"
+				}]}}}
+			}`, locationResp.ID, otherClue.ID)),
+			want: "modules.location.config.discoveries[0].clueId must belong to this theme",
+		},
+		{
+			name: "required clue ids must be array",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s",
+					"clueId": "%s",
+					"requiredClueIds": {}
+				}]}}}
+			}`, locationResp.ID, discoveryClue.ID)),
+			want: "modules.location.config.discoveries[0].requiredClueIds must be an array",
+		},
+		{
+			name: "required clue id must be valid uuid",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s",
+					"clueId": "%s",
+					"requiredClueIds": ["note"]
+				}]}}}
+			}`, locationResp.ID, discoveryClue.ID)),
+			want: "modules.location.config.discoveries[0].requiredClueIds[0] must be a valid clue id",
+		},
+		{
+			name: "required clue id must belong to theme",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s",
+					"clueId": "%s",
+					"requiredClueIds": ["%s"]
+				}]}}}
+			}`, locationResp.ID, discoveryClue.ID, otherClue.ID)),
+			want: "modules.location.config.discoveries[0].requiredClueIds[0] must belong to this theme",
+		},
+		{
+			name: "once per player must be boolean",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+					"locationId": "%s",
+					"clueId": "%s",
+					"oncePerPlayer": "yes"
+				}]}}}
+			}`, locationResp.ID, discoveryClue.ID)),
+			want: "modules.location.config.discoveries[0].oncePerPlayer must be boolean",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, tc.input)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			var appErr *apperror.AppError
+			if !errors.As(err, &appErr) {
+				t.Fatalf("expected *apperror.AppError for %s, got %T: %v", tc.name, err, err)
+			}
+			if appErr.Status != http.StatusBadRequest {
+				t.Fatalf("expected status 400 for %s, got %d", tc.name, appErr.Status)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected error to contain %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestUpdateConfigJson_LocationDiscoveriesSurviveDeleteCleanup(t *testing.T) {
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
+	if err != nil {
+		t.Fatalf("CreateMap: %v", err)
+	}
+	deletedLocation, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "삭제 장소"})
+	if err != nil {
+		t.Fatalf("CreateLocation deleted: %v", err)
+	}
+	keptLocation, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "남길 장소"})
+	if err != nil {
+		t.Fatalf("CreateLocation kept: %v", err)
+	}
+	deletedClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "삭제 단서", Level: 1})
+	if err != nil {
+		t.Fatalf("CreateClue deleted: %v", err)
+	}
+	keptClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "남길 단서", Level: 1})
+	if err != nil {
+		t.Fatalf("CreateClue kept: %v", err)
+	}
+
+	config := json.RawMessage(fmt.Sprintf(`{
+		"modules": {
+			"location": {
+				"enabled": true,
+				"config": {
+					"discoveries": [
+						{"locationId": "%s", "clueId": "%s", "requiredClueIds": ["%s"], "oncePerPlayer": true},
+						{"locationId": "%s", "clueId": "%s", "requiredClueIds": ["%s"], "oncePerPlayer": true}
+					]
+				}
+			}
+		}
+	}`, deletedLocation.ID, deletedClue.ID, keptClue.ID, keptLocation.ID, keptClue.ID, deletedClue.ID))
+	if _, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, config); err != nil {
+		t.Fatalf("UpdateConfigJson valid discoveries: %v", err)
+	}
+
+	if err := f.svc.DeleteLocation(ctx, creatorID, deletedLocation.ID); err != nil {
+		t.Fatalf("DeleteLocation: %v", err)
+	}
+	if err := f.svc.DeleteClue(ctx, creatorID, deletedClue.ID); err != nil {
+		t.Fatalf("DeleteClue: %v", err)
+	}
+
+	theme, err := f.svc.GetTheme(ctx, creatorID, themeID)
+	if err != nil {
+		t.Fatalf("GetTheme: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(theme.ConfigJson, &decoded); err != nil {
+		t.Fatalf("unmarshal config_json: %v", err)
+	}
+	if jsonConfigContainsStringOrKey(decoded, deletedLocation.ID.String()) {
+		t.Fatalf("deleted location id still present in config_json: %s", string(theme.ConfigJson))
+	}
+	if jsonConfigContainsStringOrKey(decoded, deletedClue.ID.String()) {
+		t.Fatalf("deleted clue id still present in config_json: %s", string(theme.ConfigJson))
+	}
+	if !jsonConfigContainsStringOrKey(decoded, keptLocation.ID.String()) {
+		t.Fatalf("kept location id was removed from config_json: %s", string(theme.ConfigJson))
+	}
+	if !jsonConfigContainsStringOrKey(decoded, keptClue.ID.String()) {
+		t.Fatalf("kept clue id was removed from config_json: %s", string(theme.ConfigJson))
+	}
+
+	modules := decoded["modules"].(map[string]any)
+	locationModule := modules["location"].(map[string]any)
+	locationConfig := locationModule["config"].(map[string]any)
+	discoveries := locationConfig["discoveries"].([]any)
+	if len(discoveries) != 1 {
+		t.Fatalf("expected one kept discovery after cleanup, got %#v", discoveries)
+	}
+	keptDiscovery := discoveries[0].(map[string]any)
+	if keptDiscovery["locationId"] != keptLocation.ID.String() {
+		t.Fatalf("unexpected kept discovery locationId: %#v", keptDiscovery)
+	}
+	if keptDiscovery["clueId"] != keptClue.ID.String() {
+		t.Fatalf("unexpected kept discovery clueId: %#v", keptDiscovery)
+	}
+	requiredClueIDs := keptDiscovery["requiredClueIds"].([]any)
+	if len(requiredClueIDs) != 0 {
+		t.Fatalf("deleted required clue id should be removed, got %#v", requiredClueIDs)
+	}
+}

--- a/apps/server/internal/domain/editor/service_location_discovery_validation_test.go
+++ b/apps/server/internal/domain/editor/service_location_discovery_validation_test.go
@@ -9,15 +9,63 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/mmp-platform/server/internal/apperror"
 )
 
 func TestUpdateConfigJson_ValidatesLocationDiscoveries(t *testing.T) {
+	fixture := setupLocationDiscoveryValidationFixture(t)
+	assertValidLocationDiscoveryConfig(t, fixture)
+	assertInvalidLocationDiscoveryConfigs(t, fixture)
+}
+
+func TestUpdateConfigJson_LocationDiscoveriesSurviveDeleteCleanup(t *testing.T) {
+	fixture := setupLocationDiscoveryValidationFixture(t)
+	config := locationDiscoveryCleanupConfig(fixture)
+	if _, err := fixture.f.svc.UpdateConfigJson(fixture.ctx, fixture.creatorID, fixture.themeID, config); err != nil {
+		t.Fatalf("UpdateConfigJson valid discoveries: %v", err)
+	}
+
+	if err := fixture.f.svc.DeleteLocation(fixture.ctx, fixture.creatorID, fixture.deletedLocation.ID); err != nil {
+		t.Fatalf("DeleteLocation: %v", err)
+	}
+	if err := fixture.f.svc.DeleteClue(fixture.ctx, fixture.creatorID, fixture.deletedClue.ID); err != nil {
+		t.Fatalf("DeleteClue: %v", err)
+	}
+
+	assertLocationDiscoveryCleanupResult(t, fixture)
+}
+
+type locationDiscoveryValidationFixture struct {
+	f               *testFixture
+	ctx             context.Context
+	creatorID       uuid.UUID
+	themeID         uuid.UUID
+	location        *LocationResponse
+	discoveryClue   *ClueResponse
+	requiredClue    *ClueResponse
+	otherLocation   *LocationResponse
+	otherClue       *ClueResponse
+	deletedLocation *LocationResponse
+	keptLocation    *LocationResponse
+	deletedClue     *ClueResponse
+	keptClue        *ClueResponse
+}
+
+type locationDiscoveryInvalidCase struct {
+	name  string
+	input json.RawMessage
+	want  string
+}
+
+func setupLocationDiscoveryValidationFixture(t *testing.T) locationDiscoveryValidationFixture {
+	t.Helper()
+
 	f := setupFixture(t)
 	ctx := context.Background()
 	creatorID := f.createUser(t)
 	themeID := f.createThemeForUser(t, creatorID)
-
 	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
 	if err != nil {
 		t.Fatalf("CreateMap: %v", err)
@@ -35,29 +83,6 @@ func TestUpdateConfigJson_ValidatesLocationDiscoveries(t *testing.T) {
 		t.Fatalf("CreateClue required: %v", err)
 	}
 
-	valid := json.RawMessage(fmt.Sprintf(`{
-		"modules": {
-			"location": {
-				"enabled": true,
-				"config": {
-					"discoveries": [{
-						"locationId": "%s",
-						"clueId": "%s",
-						"requiredClueIds": ["%s"],
-						"oncePerPlayer": true
-					}]
-				}
-			}
-		}
-	}`, locationResp.ID, discoveryClue.ID, requiredClue.ID))
-	updated, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, valid)
-	if err != nil {
-		t.Fatalf("valid location discovery config must save: %v", err)
-	}
-	if updated.Version <= 1 {
-		t.Fatalf("expected version bump for valid discovery config, got %d", updated.Version)
-	}
-
 	otherCreatorID := f.createUser(t)
 	otherThemeID := f.createThemeForUser(t, otherCreatorID)
 	otherMap, err := f.svc.CreateMap(ctx, otherCreatorID, otherThemeID, CreateMapRequest{Name: "다른 지도"})
@@ -73,11 +98,83 @@ func TestUpdateConfigJson_ValidatesLocationDiscoveries(t *testing.T) {
 		t.Fatalf("CreateClue other: %v", err)
 	}
 
-	cases := []struct {
-		name  string
-		input json.RawMessage
-		want  string
-	}{
+	deletedLocation, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "삭제 장소"})
+	if err != nil {
+		t.Fatalf("CreateLocation deleted: %v", err)
+	}
+	keptLocation, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "남길 장소"})
+	if err != nil {
+		t.Fatalf("CreateLocation kept: %v", err)
+	}
+	deletedClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "삭제 단서", Level: 1})
+	if err != nil {
+		t.Fatalf("CreateClue deleted: %v", err)
+	}
+	keptClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "남길 단서", Level: 1})
+	if err != nil {
+		t.Fatalf("CreateClue kept: %v", err)
+	}
+
+	return locationDiscoveryValidationFixture{
+		f:               f,
+		ctx:             ctx,
+		creatorID:       creatorID,
+		themeID:         themeID,
+		location:        locationResp,
+		discoveryClue:   discoveryClue,
+		requiredClue:    requiredClue,
+		otherLocation:   otherLocation,
+		otherClue:       otherClue,
+		deletedLocation: deletedLocation,
+		keptLocation:    keptLocation,
+		deletedClue:     deletedClue,
+		keptClue:        keptClue,
+	}
+}
+
+func assertValidLocationDiscoveryConfig(t *testing.T, fixture locationDiscoveryValidationFixture) {
+	t.Helper()
+
+	valid := json.RawMessage(fmt.Sprintf(`{
+			"modules": {
+				"location": {
+					"enabled": true,
+					"config": {
+						"discoveries": [{
+							"locationId": "%s",
+						"clueId": "%s",
+						"requiredClueIds": ["%s"],
+						"oncePerPlayer": true
+					}]
+					}
+				}
+			}
+		}`, fixture.location.ID, fixture.discoveryClue.ID, fixture.requiredClue.ID))
+	updated, err := fixture.f.svc.UpdateConfigJson(fixture.ctx, fixture.creatorID, fixture.themeID, valid)
+	if err != nil {
+		t.Fatalf("valid location discovery config must save: %v", err)
+	}
+	if updated.Version <= 1 {
+		t.Fatalf("expected version bump for valid discovery config, got %d", updated.Version)
+	}
+}
+
+func assertInvalidLocationDiscoveryConfigs(t *testing.T, fixture locationDiscoveryValidationFixture) {
+	t.Helper()
+	cases := append(locationDiscoveryShapeCases(), locationDiscoveryLocationCases(fixture)...)
+	cases = append(cases, locationDiscoveryClueCases(fixture)...)
+	cases = append(cases, locationDiscoveryRequiredClueCases(fixture)...)
+	cases = append(cases, locationDiscoveryOptionCases(fixture)...)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertUpdateConfigReturnsBadRequest(t, fixture, tc.input, tc.want)
+		})
+	}
+}
+
+func locationDiscoveryShapeCases() []locationDiscoveryInvalidCase {
+	return []locationDiscoveryInvalidCase{
 		{
 			name: "location module must be object",
 			input: json.RawMessage(`{
@@ -106,182 +203,170 @@ func TestUpdateConfigJson_ValidatesLocationDiscoveries(t *testing.T) {
 			}`),
 			want: "modules.location.config.discoveries[0] must be an object",
 		},
+	}
+}
+
+func locationDiscoveryLocationCases(fixture locationDiscoveryValidationFixture) []locationDiscoveryInvalidCase {
+	return []locationDiscoveryInvalidCase{
 		{
 			name: "missing location id",
 			input: json.RawMessage(fmt.Sprintf(`{
-				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"clueId": "%s"
-				}]}}}
-			}`, discoveryClue.ID)),
+					"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+						"clueId": "%s"
+					}]}}}
+				}`, fixture.discoveryClue.ID)),
 			want: "modules.location.config.discoveries[0].locationId is required",
 		},
 		{
 			name: "invalid location id format",
 			input: json.RawMessage(fmt.Sprintf(`{
-				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "library",
-					"clueId": "%s"
-				}]}}}
-			}`, discoveryClue.ID)),
+					"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+						"locationId": "library",
+						"clueId": "%s"
+					}]}}}
+				}`, fixture.discoveryClue.ID)),
 			want: "modules.location.config.discoveries[0].locationId must be a valid location id",
 		},
 		{
 			name: "location id must belong to theme",
 			input: json.RawMessage(fmt.Sprintf(`{
-				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s",
-					"clueId": "%s"
-				}]}}}
-			}`, otherLocation.ID, discoveryClue.ID)),
+					"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+						"locationId": "%s",
+						"clueId": "%s"
+					}]}}}
+				}`, fixture.otherLocation.ID, fixture.discoveryClue.ID)),
 			want: "modules.location.config.discoveries[0].locationId must belong to this theme",
 		},
+	}
+}
+
+func locationDiscoveryClueCases(fixture locationDiscoveryValidationFixture) []locationDiscoveryInvalidCase {
+	return []locationDiscoveryInvalidCase{
 		{
 			name: "missing clue id",
 			input: json.RawMessage(fmt.Sprintf(`{
-				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s"
-				}]}}}
-			}`, locationResp.ID)),
+					"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+						"locationId": "%s"
+					}]}}}
+				}`, fixture.location.ID)),
 			want: "modules.location.config.discoveries[0].clueId is required",
 		},
 		{
 			name: "invalid clue id format",
 			input: json.RawMessage(fmt.Sprintf(`{
-				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s",
-					"clueId": "blood"
-				}]}}}
-			}`, locationResp.ID)),
+					"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+						"locationId": "%s",
+						"clueId": "blood"
+					}]}}}
+				}`, fixture.location.ID)),
 			want: "modules.location.config.discoveries[0].clueId must be a valid clue id",
 		},
 		{
 			name: "clue id must belong to theme",
 			input: json.RawMessage(fmt.Sprintf(`{
-				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s",
-					"clueId": "%s"
-				}]}}}
-			}`, locationResp.ID, otherClue.ID)),
+					"modules": {"location": {"enabled": true, "config": {"discoveries": [{
+						"locationId": "%s",
+						"clueId": "%s"
+					}]}}}
+				}`, fixture.location.ID, fixture.otherClue.ID)),
 			want: "modules.location.config.discoveries[0].clueId must belong to this theme",
 		},
+	}
+}
+
+func locationDiscoveryRequiredClueCases(fixture locationDiscoveryValidationFixture) []locationDiscoveryInvalidCase {
+	return []locationDiscoveryInvalidCase{
 		{
 			name: "required clue ids must be array",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s",
-					"clueId": "%s",
-					"requiredClueIds": {}
-				}]}}}
-			}`, locationResp.ID, discoveryClue.ID)),
+						"locationId": "%s",
+						"clueId": "%s",
+						"requiredClueIds": {}
+					}]}}}
+				}`, fixture.location.ID, fixture.discoveryClue.ID)),
 			want: "modules.location.config.discoveries[0].requiredClueIds must be an array",
 		},
 		{
 			name: "required clue id must be valid uuid",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s",
-					"clueId": "%s",
-					"requiredClueIds": ["note"]
-				}]}}}
-			}`, locationResp.ID, discoveryClue.ID)),
+						"locationId": "%s",
+						"clueId": "%s",
+						"requiredClueIds": ["note"]
+					}]}}}
+				}`, fixture.location.ID, fixture.discoveryClue.ID)),
 			want: "modules.location.config.discoveries[0].requiredClueIds[0] must be a valid clue id",
 		},
 		{
 			name: "required clue id must belong to theme",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s",
-					"clueId": "%s",
-					"requiredClueIds": ["%s"]
-				}]}}}
-			}`, locationResp.ID, discoveryClue.ID, otherClue.ID)),
+						"locationId": "%s",
+						"clueId": "%s",
+						"requiredClueIds": ["%s"]
+					}]}}}
+				}`, fixture.location.ID, fixture.discoveryClue.ID, fixture.otherClue.ID)),
 			want: "modules.location.config.discoveries[0].requiredClueIds[0] must belong to this theme",
 		},
+	}
+}
+
+func locationDiscoveryOptionCases(fixture locationDiscoveryValidationFixture) []locationDiscoveryInvalidCase {
+	return []locationDiscoveryInvalidCase{
 		{
 			name: "once per player must be boolean",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {"location": {"enabled": true, "config": {"discoveries": [{
-					"locationId": "%s",
-					"clueId": "%s",
-					"oncePerPlayer": "yes"
-				}]}}}
-			}`, locationResp.ID, discoveryClue.ID)),
+						"locationId": "%s",
+						"clueId": "%s",
+						"oncePerPlayer": "yes"
+					}]}}}
+			}`, fixture.location.ID, fixture.discoveryClue.ID)),
 			want: "modules.location.config.discoveries[0].oncePerPlayer must be boolean",
 		},
 	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, tc.input)
-			if err == nil {
-				t.Fatalf("expected error for %s, got nil", tc.name)
-			}
-			var appErr *apperror.AppError
-			if !errors.As(err, &appErr) {
-				t.Fatalf("expected *apperror.AppError for %s, got %T: %v", tc.name, err, err)
-			}
-			if appErr.Status != http.StatusBadRequest {
-				t.Fatalf("expected status 400 for %s, got %d", tc.name, appErr.Status)
-			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Errorf("expected error to contain %q, got: %v", tc.want, err)
-			}
-		})
+}
+
+func assertUpdateConfigReturnsBadRequest(t *testing.T, fixture locationDiscoveryValidationFixture, input json.RawMessage, want string) {
+	t.Helper()
+
+	_, err := fixture.f.svc.UpdateConfigJson(fixture.ctx, fixture.creatorID, fixture.themeID, input)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var appErr *apperror.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *apperror.AppError, got %T: %v", err, err)
+	}
+	if appErr.Status != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", appErr.Status)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("expected error to contain %q, got: %v", want, err)
 	}
 }
 
-func TestUpdateConfigJson_LocationDiscoveriesSurviveDeleteCleanup(t *testing.T) {
-	f := setupFixture(t)
-	ctx := context.Background()
-	creatorID := f.createUser(t)
-	themeID := f.createThemeForUser(t, creatorID)
-
-	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
-	if err != nil {
-		t.Fatalf("CreateMap: %v", err)
-	}
-	deletedLocation, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "삭제 장소"})
-	if err != nil {
-		t.Fatalf("CreateLocation deleted: %v", err)
-	}
-	keptLocation, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "남길 장소"})
-	if err != nil {
-		t.Fatalf("CreateLocation kept: %v", err)
-	}
-	deletedClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "삭제 단서", Level: 1})
-	if err != nil {
-		t.Fatalf("CreateClue deleted: %v", err)
-	}
-	keptClue, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{Name: "남길 단서", Level: 1})
-	if err != nil {
-		t.Fatalf("CreateClue kept: %v", err)
-	}
-
-	config := json.RawMessage(fmt.Sprintf(`{
-		"modules": {
-			"location": {
-				"enabled": true,
-				"config": {
-					"discoveries": [
+func locationDiscoveryCleanupConfig(fixture locationDiscoveryValidationFixture) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(`{
+			"modules": {
+				"location": {
+					"enabled": true,
+					"config": {
+						"discoveries": [
 						{"locationId": "%s", "clueId": "%s", "requiredClueIds": ["%s"], "oncePerPlayer": true},
 						{"locationId": "%s", "clueId": "%s", "requiredClueIds": ["%s"], "oncePerPlayer": true}
 					]
+					}
 				}
 			}
-		}
-	}`, deletedLocation.ID, deletedClue.ID, keptClue.ID, keptLocation.ID, keptClue.ID, deletedClue.ID))
-	if _, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, config); err != nil {
-		t.Fatalf("UpdateConfigJson valid discoveries: %v", err)
-	}
+		}`, fixture.deletedLocation.ID, fixture.deletedClue.ID, fixture.keptClue.ID, fixture.keptLocation.ID, fixture.keptClue.ID, fixture.deletedClue.ID))
+}
 
-	if err := f.svc.DeleteLocation(ctx, creatorID, deletedLocation.ID); err != nil {
-		t.Fatalf("DeleteLocation: %v", err)
-	}
-	if err := f.svc.DeleteClue(ctx, creatorID, deletedClue.ID); err != nil {
-		t.Fatalf("DeleteClue: %v", err)
-	}
+func assertLocationDiscoveryCleanupResult(t *testing.T, fixture locationDiscoveryValidationFixture) {
+	t.Helper()
 
-	theme, err := f.svc.GetTheme(ctx, creatorID, themeID)
+	theme, err := fixture.f.svc.GetTheme(fixture.ctx, fixture.creatorID, fixture.themeID)
 	if err != nil {
 		t.Fatalf("GetTheme: %v", err)
 	}
@@ -289,16 +374,16 @@ func TestUpdateConfigJson_LocationDiscoveriesSurviveDeleteCleanup(t *testing.T) 
 	if err := json.Unmarshal(theme.ConfigJson, &decoded); err != nil {
 		t.Fatalf("unmarshal config_json: %v", err)
 	}
-	if jsonConfigContainsStringOrKey(decoded, deletedLocation.ID.String()) {
+	if jsonConfigContainsStringOrKey(decoded, fixture.deletedLocation.ID.String()) {
 		t.Fatalf("deleted location id still present in config_json: %s", string(theme.ConfigJson))
 	}
-	if jsonConfigContainsStringOrKey(decoded, deletedClue.ID.String()) {
+	if jsonConfigContainsStringOrKey(decoded, fixture.deletedClue.ID.String()) {
 		t.Fatalf("deleted clue id still present in config_json: %s", string(theme.ConfigJson))
 	}
-	if !jsonConfigContainsStringOrKey(decoded, keptLocation.ID.String()) {
+	if !jsonConfigContainsStringOrKey(decoded, fixture.keptLocation.ID.String()) {
 		t.Fatalf("kept location id was removed from config_json: %s", string(theme.ConfigJson))
 	}
-	if !jsonConfigContainsStringOrKey(decoded, keptClue.ID.String()) {
+	if !jsonConfigContainsStringOrKey(decoded, fixture.keptClue.ID.String()) {
 		t.Fatalf("kept clue id was removed from config_json: %s", string(theme.ConfigJson))
 	}
 
@@ -310,10 +395,10 @@ func TestUpdateConfigJson_LocationDiscoveriesSurviveDeleteCleanup(t *testing.T) 
 		t.Fatalf("expected one kept discovery after cleanup, got %#v", discoveries)
 	}
 	keptDiscovery := discoveries[0].(map[string]any)
-	if keptDiscovery["locationId"] != keptLocation.ID.String() {
+	if keptDiscovery["locationId"] != fixture.keptLocation.ID.String() {
 		t.Fatalf("unexpected kept discovery locationId: %#v", keptDiscovery)
 	}
-	if keptDiscovery["clueId"] != keptClue.ID.String() {
+	if keptDiscovery["clueId"] != fixture.keptClue.ID.String() {
 		t.Fatalf("unexpected kept discovery clueId: %#v", keptDiscovery)
 	}
 	requiredClueIDs := keptDiscovery["requiredClueIds"].([]any)


### PR DESCRIPTION
## 요약

- `UpdateConfigJson` 저장 경계에서 `modules.location.config.discoveries[]` shape를 검증합니다.
- `locationId`, `clueId`, `requiredClueIds[]`가 같은 theme의 실제 장소/단서인지 확인한 뒤 저장합니다.
- 유효한 discovery 저장과 invalid location/clue/required clue/shape 거부 테스트를 추가했습니다.

Closes #296

## 검증

- `cd apps/server && go test ./internal/domain/editor -run 'ConfigJson|LocationDiscovery' -count=1`\n- `cd apps/server && go test ./internal/module/crime_scene -run 'Location.*Discovery|LocationModule' -count=1`\n- `git diff --check`\n\n## 리뷰\n\n- backend reviewer: 중대 이슈 없음. 남은 리스크는 저장 시 locations/clues 목록 조회 2회이며, 현재 editor 제한 범위에서는 허용 가능한 비용으로 판단했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 위치 발견(discoveries) 설정 유효성이 더 엄격해져 locationId/clueId 형식 및 테마 소속 일치, requiredClueIds 배열 요소·타입, oncePerPlayer 불리언을 검증하고 잘못된 참조가 포함된 구성은 거부됩니다.
  * 구성 업데이트가 DB 트랜잭션과 잠금을 통해 원자적으로 처리되며 버전 충돌과 조회 실패가 명확히 매핑됩니다.

* **테스트**
  * 정상·오류 입력과 삭제 후 정리 동작을 검증하는 통합 스타일의 포괄적 테스트들이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->