### PR TITLE
feat(editor): #301 공통 조건 계약 고정

### DIFF
--- a/apps/server/internal/domain/flow/condition_validation_test.go
+++ b/apps/server/internal/domain/flow/condition_validation_test.go
@@ -1,0 +1,61 @@
+package flow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/apperror"
+)
+
+func TestValidateEdgeCondition_AcceptsSharedConditionContract(t *testing.T) {
+	condition := json.RawMessage(`{
+		"id":"group-1",
+		"operator":"AND",
+		"rules":[
+			{"id":"rule-1","variable":"custom_flag","target_flag_key":"manual_override","comparator":"=","value":"true"}
+		]
+	}`)
+	if err := ValidateEdgeCondition(condition); err != nil {
+		t.Fatalf("ValidateEdgeCondition: %v", err)
+	}
+}
+
+func TestValidateEdgeCondition_RejectsInvalidCondition(t *testing.T) {
+	err := ValidateEdgeCondition(json.RawMessage(`{
+		"id":"group-1",
+		"operator":"AND",
+		"rules":[
+			{"id":"rule-1","variable":"raw_engine_key","comparator":"=","value":"x"}
+		]
+	}`))
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 400 {
+		t.Fatalf("expected 400, got %d", appErr.Status)
+	}
+}
+
+func TestValidateSaveRequest_ValidatesEdgeCondition(t *testing.T) {
+	startID := uuid.New()
+	endingID := uuid.New()
+	req := SaveFlowRequest{
+		Nodes: []FlowNodeInput{
+			{ID: &startID, Type: NodeTypeStart},
+			{ID: &endingID, Type: NodeTypeEnding},
+		},
+		Edges: []FlowEdgeInput{{
+			SourceID:  startID,
+			TargetID:  endingID,
+			Condition: json.RawMessage(`{"id":"group-1","operator":"OR","rules":[]}`),
+		}},
+	}
+	if err := validateSaveRequest(req); err == nil {
+		t.Fatal("expected invalid condition error")
+	}
+}

--- a/apps/server/internal/domain/flow/condition_validation_test.go
+++ b/apps/server/internal/domain/flow/condition_validation_test.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
@@ -29,16 +30,7 @@ func TestValidateEdgeCondition_RejectsInvalidCondition(t *testing.T) {
 			{"id":"rule-1","variable":"raw_engine_key","comparator":"=","value":"x"}
 		]
 	}`))
-	if err == nil {
-		t.Fatal("expected validation error")
-	}
-	appErr, ok := err.(*apperror.AppError)
-	if !ok {
-		t.Fatalf("expected AppError, got %T", err)
-	}
-	if appErr.Status != 400 {
-		t.Fatalf("expected 400, got %d", appErr.Status)
-	}
+	assertBadRequest(t, err)
 }
 
 func TestValidateSaveRequest_ValidatesEdgeCondition(t *testing.T) {
@@ -55,7 +47,19 @@ func TestValidateSaveRequest_ValidatesEdgeCondition(t *testing.T) {
 			Condition: json.RawMessage(`{"id":"group-1","operator":"OR","rules":[]}`),
 		}},
 	}
-	if err := validateSaveRequest(req); err == nil {
-		t.Fatal("expected invalid condition error")
+	assertBadRequest(t, validateSaveRequest(req))
+}
+
+func assertBadRequest(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != http.StatusBadRequest {
+		t.Fatalf("expected %d, got %d", http.StatusBadRequest, appErr.Status)
 	}
 }

--- a/apps/server/internal/domain/flow/service.go
+++ b/apps/server/internal/domain/flow/service.go
@@ -136,10 +136,16 @@ func (s *serviceImpl) DeleteNode(ctx context.Context, _, nodeID uuid.UUID) error
 }
 
 func (s *serviceImpl) CreateEdge(ctx context.Context, _, themeID uuid.UUID, req CreateEdgeRequest) (*FlowEdge, error) {
+	if err := ValidateEdgeCondition(req.Condition); err != nil {
+		return nil, err
+	}
 	return insertEdge(ctx, s.pool, themeID, req.SourceID, req.TargetID, req.Condition, req.Label, req.SortOrder)
 }
 
 func (s *serviceImpl) UpdateEdge(ctx context.Context, _, edgeID uuid.UUID, req UpdateEdgeRequest) (*FlowEdge, error) {
+	if err := ValidateEdgeCondition(req.Condition); err != nil {
+		return nil, err
+	}
 	row := s.pool.QueryRow(ctx,
 		`UPDATE flow_edges SET source_id=$2, target_id=$3, condition=$4, label=$5, sort_order=$6 WHERE id=$1 RETURNING *`,
 		edgeID, req.SourceID, req.TargetID, req.Condition, req.Label, req.SortOrder,
@@ -167,6 +173,9 @@ func validateSaveRequest(req SaveFlowRequest) error {
 	}
 	edges := make([]FlowEdge, len(req.Edges))
 	for i, e := range req.Edges {
+		if err := ValidateEdgeCondition(e.Condition); err != nil {
+			return err
+		}
 		edges[i] = FlowEdge{SourceID: e.SourceID, TargetID: e.TargetID}
 	}
 	return ValidateDAG(nodes, edges)

--- a/apps/server/internal/domain/flow/validate.go
+++ b/apps/server/internal/domain/flow/validate.go
@@ -1,8 +1,11 @@
 package flow
 
 import (
+	"encoding/json"
+
 	"github.com/google/uuid"
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/engine"
 )
 
 // ValidateDAG validates the flow graph: exactly one start node and no cycles.
@@ -72,4 +75,14 @@ func ValidateNodeType(t string) error {
 	default:
 		return apperror.BadRequest("invalid node type: " + t)
 	}
+}
+
+func ValidateEdgeCondition(condition json.RawMessage) error {
+	if len(condition) == 0 || string(condition) == "null" {
+		return nil
+	}
+	if _, err := engine.ParseConditionGroup(condition); err != nil {
+		return apperror.BadRequest("invalid edge condition: " + err.Error())
+	}
+	return nil
 }

--- a/apps/server/internal/engine/condition_contract.go
+++ b/apps/server/internal/engine/condition_contract.go
@@ -1,0 +1,306 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	ConditionSchemaVersion = 1
+	MaxConditionDepth      = 3
+)
+
+type ConditionGroup struct {
+	ID       string          `json:"id"`
+	Operator string          `json:"operator"`
+	Rules    []ConditionNode `json:"rules"`
+}
+
+type ConditionNode struct {
+	Group *ConditionGroup
+	Rule  *ConditionRule
+}
+
+type ConditionRule struct {
+	ID                string `json:"id"`
+	Variable          string `json:"variable"`
+	TargetCharacterID string `json:"target_character_id,omitempty"`
+	TargetMissionID   string `json:"target_mission_id,omitempty"`
+	TargetClueID      string `json:"target_clue_id,omitempty"`
+	TargetTriggerID   string `json:"target_trigger_id,omitempty"`
+	TargetTokenID     string `json:"target_token_id,omitempty"`
+	TargetSceneID     string `json:"target_scene_id,omitempty"`
+	TargetRoomID      string `json:"target_room_id,omitempty"`
+	TargetLocationID  string `json:"target_location_id,omitempty"`
+	TargetFlagKey     string `json:"target_flag_key,omitempty"`
+	Comparator        string `json:"comparator"`
+	Value             string `json:"value"`
+}
+
+func (n *ConditionNode) UnmarshalJSON(data []byte) error {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+	if _, ok := probe["operator"]; ok {
+		var group ConditionGroup
+		if err := json.Unmarshal(data, &group); err != nil {
+			return err
+		}
+		n.Group = &group
+		return nil
+	}
+	var rule ConditionRule
+	if err := json.Unmarshal(data, &rule); err != nil {
+		return err
+	}
+	n.Rule = &rule
+	return nil
+}
+
+func (n ConditionNode) MarshalJSON() ([]byte, error) {
+	switch {
+	case n.Group != nil:
+		return json.Marshal(n.Group)
+	case n.Rule != nil:
+		return json.Marshal(n.Rule)
+	default:
+		return []byte("null"), nil
+	}
+}
+
+func ParseConditionGroup(raw json.RawMessage) (ConditionGroup, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ConditionGroup{}, fmt.Errorf("condition: group is required")
+	}
+	var group ConditionGroup
+	if err := json.Unmarshal(raw, &group); err != nil {
+		return ConditionGroup{}, fmt.Errorf("condition: invalid group JSON: %w", err)
+	}
+	if err := ValidateConditionGroup(group); err != nil {
+		return ConditionGroup{}, err
+	}
+	return group, nil
+}
+
+func ValidateConditionGroup(group ConditionGroup) error {
+	return validateConditionGroup(group, 0)
+}
+
+func EvaluateConditionGroup(raw json.RawMessage, context json.RawMessage) (EvalResult, error) {
+	group, err := ParseConditionGroup(raw)
+	if err != nil {
+		return EvalResult{}, err
+	}
+	logic, err := ConditionGroupToJSONLogic(group)
+	if err != nil {
+		return EvalResult{}, err
+	}
+	evaluator := NewRuleEvaluator()
+	evaluator.SetContextRaw(context)
+	return evaluator.Evaluate(logic)
+}
+
+func ConditionGroupToJSONLogic(group ConditionGroup) (json.RawMessage, error) {
+	logic, err := conditionGroupLogic(group)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(logic)
+}
+
+func validateConditionGroup(group ConditionGroup, depth int) error {
+	if depth > MaxConditionDepth {
+		return fmt.Errorf("condition: max depth %d exceeded", MaxConditionDepth)
+	}
+	if group.ID == "" {
+		return fmt.Errorf("condition: group id is required")
+	}
+	if group.Operator != "AND" && group.Operator != "OR" {
+		return fmt.Errorf("condition: group %q has unsupported operator %q", group.ID, group.Operator)
+	}
+	if len(group.Rules) == 0 {
+		return fmt.Errorf("condition: group %q requires at least one rule", group.ID)
+	}
+	for _, node := range group.Rules {
+		switch {
+		case node.Group != nil:
+			if err := validateConditionGroup(*node.Group, depth+1); err != nil {
+				return err
+			}
+		case node.Rule != nil:
+			if err := validateConditionRule(*node.Rule); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("condition: group %q contains empty node", group.ID)
+		}
+	}
+	return nil
+}
+
+func validateConditionRule(rule ConditionRule) error {
+	if rule.ID == "" {
+		return fmt.Errorf("condition: rule id is required")
+	}
+	if _, ok := conditionVariablePaths[rule.Variable]; !ok {
+		return fmt.Errorf("condition: rule %q has unsupported variable %q", rule.ID, rule.Variable)
+	}
+	if _, ok := conditionComparators[rule.Comparator]; !ok {
+		return fmt.Errorf("condition: rule %q has unsupported comparator %q", rule.ID, rule.Comparator)
+	}
+	if targetValue(rule) == "" {
+		return fmt.Errorf("condition: rule %q requires target for %q", rule.ID, rule.Variable)
+	}
+	return nil
+}
+
+func conditionGroupLogic(group ConditionGroup) (any, error) {
+	nodes := make([]any, 0, len(group.Rules))
+	for _, node := range group.Rules {
+		if node.Group != nil {
+			child, err := conditionGroupLogic(*node.Group)
+			if err != nil {
+				return nil, err
+			}
+			nodes = append(nodes, child)
+			continue
+		}
+		if node.Rule == nil {
+			return nil, fmt.Errorf("condition: group %q contains empty node", group.ID)
+		}
+		rule, err := conditionRuleLogic(*node.Rule)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, rule)
+	}
+	if len(nodes) == 0 {
+		return true, nil
+	}
+	key := strings.ToLower(group.Operator)
+	return map[string]any{key: nodes}, nil
+}
+
+func conditionRuleLogic(rule ConditionRule) (any, error) {
+	pathBuilder, ok := conditionVariablePaths[rule.Variable]
+	if !ok {
+		return nil, fmt.Errorf("condition: rule %q has unsupported variable %q", rule.ID, rule.Variable)
+	}
+	comparator, ok := conditionComparators[rule.Comparator]
+	if !ok {
+		return nil, fmt.Errorf("condition: rule %q has unsupported comparator %q", rule.ID, rule.Comparator)
+	}
+	path := pathBuilder(rule)
+	if path == "" {
+		return nil, fmt.Errorf("condition: rule %q requires target for %q", rule.ID, rule.Variable)
+	}
+	return map[string]any{comparator: []any{
+		map[string]any{"var": path},
+		coerceConditionValue(rule.Value),
+	}}, nil
+}
+
+func targetValue(rule ConditionRule) string {
+	switch rule.Variable {
+	case "mission_status":
+		return allTargets(rule.TargetCharacterID, rule.TargetMissionID)
+	case "character_alive":
+		return rule.TargetCharacterID
+	case "vote_target":
+		return "vote_target"
+	case "clue_held":
+		return allTargets(rule.TargetCharacterID, rule.TargetClueID)
+	case "trigger_count":
+		return rule.TargetTriggerID
+	case "investigation_token":
+		return allTargets(rule.TargetCharacterID, rule.TargetTokenID)
+	case "scene_visit_count":
+		return rule.TargetSceneID
+	case "room_state":
+		return rule.TargetRoomID
+	case "location_state":
+		return rule.TargetLocationID
+	case "custom_flag":
+		return rule.TargetFlagKey
+	default:
+		return ""
+	}
+}
+
+func allTargets(values ...string) string {
+	for _, value := range values {
+		if value == "" {
+			return ""
+		}
+	}
+	return "ok"
+}
+
+func coerceConditionValue(value string) any {
+	switch value {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+	var number json.Number
+	if err := json.Unmarshal([]byte(value), &number); err == nil {
+		return number
+	}
+	return value
+}
+
+var conditionComparators = map[string]string{
+	"=":  "==",
+	"!=": "!=",
+	">":  ">",
+	"<":  "<",
+	">=": ">=",
+	"<=": "<=",
+}
+
+var conditionVariablePaths = map[string]func(ConditionRule) string{
+	"mission_status": func(rule ConditionRule) string {
+		return joinConditionPath("missions", rule.TargetCharacterID, rule.TargetMissionID, "status")
+	},
+	"character_alive": func(rule ConditionRule) string {
+		return joinConditionPath("characters", rule.TargetCharacterID, "alive")
+	},
+	"vote_target": func(ConditionRule) string {
+		return "votes.target"
+	},
+	"clue_held": func(rule ConditionRule) string {
+		return joinConditionPath("clues.heldByCharacter", rule.TargetCharacterID, rule.TargetClueID)
+	},
+	"trigger_count": func(rule ConditionRule) string {
+		return joinConditionPath("triggers", rule.TargetTriggerID, "count")
+	},
+	"investigation_token": func(rule ConditionRule) string {
+		return joinConditionPath("tokens.byCharacter", rule.TargetCharacterID, rule.TargetTokenID)
+	},
+	"scene_visit_count": func(rule ConditionRule) string {
+		return joinConditionPath("scenes", rule.TargetSceneID, "visitCount")
+	},
+	"room_state": func(rule ConditionRule) string {
+		return joinConditionPath("rooms", rule.TargetRoomID, "state")
+	},
+	"location_state": func(rule ConditionRule) string {
+		return joinConditionPath("locations", rule.TargetLocationID, "state")
+	},
+	"custom_flag": func(rule ConditionRule) string {
+		return joinConditionPath("flags", rule.TargetFlagKey)
+	},
+}
+
+func joinConditionPath(parts ...string) string {
+	clean := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return ""
+		}
+		clean = append(clean, part)
+	}
+	return strings.Join(clean, ".")
+}

--- a/apps/server/internal/engine/condition_contract_test.go
+++ b/apps/server/internal/engine/condition_contract_test.go
@@ -1,0 +1,133 @@
+package engine
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestConditionGroupToJSONLogic_EvaluatesSharedMMPShape(t *testing.T) {
+	raw := json.RawMessage(`{
+		"id":"group-1",
+		"operator":"AND",
+		"rules":[
+			{"id":"rule-1","variable":"clue_held","target_character_id":"character-1","target_clue_id":"clue-1","comparator":"=","value":"true"},
+			{"id":"rule-2","variable":"investigation_token","target_character_id":"character-1","target_token_id":"basic-token","comparator":">=","value":"2"},
+			{"id":"group-2","operator":"OR","rules":[
+				{"id":"rule-3","variable":"scene_visit_count","target_scene_id":"scene-1","comparator":">","value":"0"},
+				{"id":"rule-4","variable":"custom_flag","target_flag_key":"manual_override","comparator":"=","value":"true"}
+			]}
+		]
+	}`)
+
+	result, err := EvaluateConditionGroup(raw, json.RawMessage(`{
+		"clues":{"heldByCharacter":{"character-1":{"clue-1":true}}},
+		"tokens":{"byCharacter":{"character-1":{"basic-token":2}}},
+		"scenes":{"scene-1":{"visitCount":1}},
+		"flags":{"manual_override":false}
+	}`))
+	if err != nil {
+		t.Fatalf("EvaluateConditionGroup: %v", err)
+	}
+	if !result.Bool {
+		t.Fatalf("condition should evaluate true, raw=%s", result.Value)
+	}
+}
+
+func TestParseConditionGroup_RejectsInvalidContract(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "unknown variable",
+			raw:  `{"id":"g1","operator":"AND","rules":[{"id":"r1","variable":"raw_engine_key","comparator":"=","value":"x"}]}`,
+		},
+		{
+			name: "missing token target",
+			raw:  `{"id":"g1","operator":"AND","rules":[{"id":"r1","variable":"investigation_token","target_character_id":"c1","comparator":">","value":"0"}]}`,
+		},
+		{
+			name: "too deep",
+			raw:  `{"id":"g0","operator":"AND","rules":[{"id":"g1","operator":"AND","rules":[{"id":"g2","operator":"AND","rules":[{"id":"g3","operator":"AND","rules":[{"id":"g4","operator":"AND","rules":[]}]}]}]}]}`,
+		},
+		{
+			name: "empty group",
+			raw:  `{"id":"g1","operator":"OR","rules":[]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ParseConditionGroup(json.RawMessage(tt.raw)); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestConditionNode_MarshalPreservesSharedShape(t *testing.T) {
+	raw := json.RawMessage(`{
+		"id":"group-1",
+		"operator":"AND",
+		"rules":[
+			{"id":"rule-1","variable":"custom_flag","target_flag_key":"manual_override","comparator":"=","value":"true"}
+		]
+	}`)
+	group, err := ParseConditionGroup(raw)
+	if err != nil {
+		t.Fatalf("ParseConditionGroup: %v", err)
+	}
+	encoded, err := json.Marshal(group)
+	if err != nil {
+		t.Fatalf("Marshal group: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Decode marshalled group: %v", err)
+	}
+	rules := decoded["rules"].([]any)
+	rule := rules[0].(map[string]any)
+	if _, leaked := rule["Rule"]; leaked {
+		t.Fatalf("marshalled condition leaked Go wrapper shape: %s", encoded)
+	}
+	if rule["variable"] != "custom_flag" {
+		t.Fatalf("marshalled rule lost shared condition shape: %s", encoded)
+	}
+}
+
+func TestConditionGroupToJSONLogic_UsesCanonicalContextPaths(t *testing.T) {
+	group, err := ParseConditionGroup(json.RawMessage(`{
+		"id":"group-1",
+		"operator":"OR",
+		"rules":[
+			{"id":"rule-1","variable":"trigger_count","target_trigger_id":"trigger-1","comparator":">=","value":"1"},
+			{"id":"rule-2","variable":"room_state","target_room_id":"room-1","comparator":"=","value":"open"},
+			{"id":"rule-3","variable":"location_state","target_location_id":"location-1","comparator":"!=","value":"locked"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ParseConditionGroup: %v", err)
+	}
+
+	logic, err := ConditionGroupToJSONLogic(group)
+	if err != nil {
+		t.Fatalf("ConditionGroupToJSONLogic: %v", err)
+	}
+	if !IsValid(logic) {
+		t.Fatalf("generated JSONLogic must be valid: %s", logic)
+	}
+
+	evaluator := NewRuleEvaluator()
+	evaluator.SetContextRaw(json.RawMessage(`{
+		"triggers":{"trigger-1":{"count":0}},
+		"rooms":{"room-1":{"state":"closed"}},
+		"locations":{"location-1":{"state":"open"}}
+	}`))
+	result, err := evaluator.Evaluate(logic)
+	if err != nil {
+		t.Fatalf("Evaluate generated logic: %v", err)
+	}
+	if !result.Bool {
+		t.Fatalf("OR condition should evaluate true via location state, raw=%s", result.Value)
+	}
+}

--- a/apps/server/internal/engine/condition_contract_test.go
+++ b/apps/server/internal/engine/condition_contract_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -115,6 +116,15 @@ func TestConditionGroupToJSONLogic_UsesCanonicalContextPaths(t *testing.T) {
 	}
 	if !IsValid(logic) {
 		t.Fatalf("generated JSONLogic must be valid: %s", logic)
+	}
+	for _, path := range []string{
+		"triggers.trigger-1.count",
+		"rooms.room-1.state",
+		"locations.location-1.state",
+	} {
+		if !strings.Contains(string(logic), path) {
+			t.Fatalf("generated JSONLogic missing canonical path %q: %s", path, logic)
+		}
 	}
 
 	evaluator := NewRuleEvaluator()

--- a/apps/web/src/features/editor/components/design/__tests__/BranchWiring.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/BranchWiring.test.tsx
@@ -112,10 +112,15 @@ describe("useEdgeCondition", () => {
     );
     const setEdges = vi.fn();
     const getNodes = vi.fn(() => []);
+    const input = [
+      { id: "edge-1", source: "node-1", target: "node-2", data: {} },
+      { id: "edge-2", source: "node-2", target: "node-3", data: {} },
+    ];
+    const getEdges = vi.fn(() => input);
     const autoSave = vi.fn();
 
     const { result } = renderHook(() =>
-      useEdgeCondition(setEdges, getNodes, autoSave),
+      useEdgeCondition(setEdges, getNodes, getEdges, autoSave),
     );
 
     act(() => {
@@ -123,13 +128,7 @@ describe("useEdgeCondition", () => {
     });
 
     expect(setEdges).toHaveBeenCalledOnce();
-
-    // Simulate the setEdges updater to verify edge transformation
-    const updater = setEdges.mock.calls[0][0] as (
-      eds: { id: string; data: Record<string, unknown> }[],
-    ) => unknown[];
-    const input = [{ id: "edge-1", data: {} }, { id: "edge-2", data: {} }];
-    const result2 = updater(input);
+    const result2 = setEdges.mock.calls[0][0] as typeof input;
     expect(result2[0]).toMatchObject({
       id: "edge-1",
       type: "condition",
@@ -146,10 +145,14 @@ describe("useEdgeCondition", () => {
     );
     const setEdges = vi.fn();
     const getNodes = vi.fn(() => []);
+    const input = [
+      { id: "edge-1", source: "node-1", target: "node-2", data: {} },
+    ];
+    const getEdges = vi.fn(() => input);
     const autoSave = vi.fn();
 
     const { result } = renderHook(() =>
-      useEdgeCondition(setEdges, getNodes, autoSave),
+      useEdgeCondition(setEdges, getNodes, getEdges, autoSave),
     );
 
     const incompleteCondition = {
@@ -170,18 +173,36 @@ describe("useEdgeCondition", () => {
     });
 
     expect(setEdges).toHaveBeenCalledOnce();
-
-    const updater = setEdges.mock.calls[0][0] as (
-      eds: { id: string; data: Record<string, unknown> }[],
-    ) => unknown[];
-    const input = [{ id: "edge-1", data: {} }];
-    const result2 = updater(input);
+    const result2 = setEdges.mock.calls[0][0] as typeof input;
 
     expect(result2[0]).toMatchObject({
       id: "edge-1",
       type: "condition",
       data: { condition: incompleteCondition },
     });
+    expect(autoSave).not.toHaveBeenCalled();
+  });
+
+  it("대상 엣지가 없으면 상태와 저장을 변경하지 않는다", async () => {
+    const { useEdgeCondition } = await import(
+      "../../../hooks/useEdgeCondition"
+    );
+    const setEdges = vi.fn();
+    const getNodes = vi.fn(() => []);
+    const getEdges = vi.fn(() => [
+      { id: "edge-2", source: "node-2", target: "node-3", data: {} },
+    ]);
+    const autoSave = vi.fn();
+
+    const { result } = renderHook(() =>
+      useEdgeCondition(setEdges, getNodes, getEdges, autoSave),
+    );
+
+    act(() => {
+      result.current.updateEdgeCondition("edge-1", validCondition);
+    });
+
+    expect(setEdges).not.toHaveBeenCalled();
     expect(autoSave).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/BranchWiring.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/BranchWiring.test.tsx
@@ -63,6 +63,20 @@ const baseFlowData = {
   updateEdgeCondition: vi.fn(),
 };
 
+const validCondition = {
+  id: "group-1",
+  operator: "AND",
+  rules: [
+    {
+      id: "rule-1",
+      variable: "custom_flag",
+      target_flag_key: "manual_override",
+      comparator: "=",
+      value: "true",
+    },
+  ],
+};
+
 beforeEach(() => {
   useFlowDataMock.mockReturnValue(baseFlowData);
 });
@@ -105,7 +119,7 @@ describe("useEdgeCondition", () => {
     );
 
     act(() => {
-      result.current.updateEdgeCondition("edge-1", { key: "value" });
+      result.current.updateEdgeCondition("edge-1", validCondition);
     });
 
     expect(setEdges).toHaveBeenCalledOnce();
@@ -119,9 +133,56 @@ describe("useEdgeCondition", () => {
     expect(result2[0]).toMatchObject({
       id: "edge-1",
       type: "condition",
-      data: { condition: { key: "value" } },
+      data: { condition: validCondition },
     });
     expect(result2[1]).toEqual(input[1]);
+    expect(autoSave).toHaveBeenCalledOnce();
+    expect(autoSave).toHaveBeenCalledWith([], result2);
+  });
+
+  it("미완성 조건은 엣지 draft만 갱신하고 autoSave로 보내지 않는다", async () => {
+    const { useEdgeCondition } = await import(
+      "../../../hooks/useEdgeCondition"
+    );
+    const setEdges = vi.fn();
+    const getNodes = vi.fn(() => []);
+    const autoSave = vi.fn();
+
+    const { result } = renderHook(() =>
+      useEdgeCondition(setEdges, getNodes, autoSave),
+    );
+
+    const incompleteCondition = {
+      id: "group-1",
+      operator: "AND",
+      rules: [
+        {
+          id: "rule-1",
+          variable: "scene_visit_count",
+          comparator: ">=",
+          value: "1",
+        },
+      ],
+    };
+
+    act(() => {
+      result.current.updateEdgeCondition("edge-1", incompleteCondition);
+    });
+
+    expect(setEdges).toHaveBeenCalledOnce();
+
+    const updater = setEdges.mock.calls[0][0] as (
+      eds: { id: string; data: Record<string, unknown> }[],
+    ) => unknown[];
+    const input = [{ id: "edge-1", data: {} }];
+    const result2 = updater(input);
+
+    expect(result2[0]).toMatchObject({
+      id: "edge-1",
+      type: "condition",
+      data: { condition: incompleteCondition },
+    });
+    expect(autoSave).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/features/editor/components/design/condition/ConditionBuilder.tsx
+++ b/apps/web/src/features/editor/components/design/condition/ConditionBuilder.tsx
@@ -16,6 +16,11 @@ interface ConditionBuilderProps {
   characters?: SelectOption[];
   missions?: SelectOption[];
   clues?: SelectOption[];
+  triggers?: SelectOption[];
+  tokens?: SelectOption[];
+  scenes?: SelectOption[];
+  rooms?: SelectOption[];
+  locations?: SelectOption[];
   label?: string;
 }
 
@@ -29,6 +34,11 @@ export function ConditionBuilder({
   characters = [],
   missions = [],
   clues = [],
+  triggers = [],
+  tokens = [],
+  scenes = [],
+  rooms = [],
+  locations = [],
   label,
 }: ConditionBuilderProps) {
   const group: ConditionGroup = recordToGroup(condition);
@@ -71,6 +81,11 @@ export function ConditionBuilder({
         characters={characters}
         missions={missions}
         clues={clues}
+        triggers={triggers}
+        tokens={tokens}
+        scenes={scenes}
+        rooms={rooms}
+        locations={locations}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/design/condition/ConditionGroup.tsx
+++ b/apps/web/src/features/editor/components/design/condition/ConditionGroup.tsx
@@ -1,6 +1,11 @@
 import { Plus, PlusSquare, Trash2 } from "lucide-react";
 import type { ConditionRule, ConditionGroup } from "./conditionTypes";
-import { isGroup, createEmptyRule, createEmptyGroup } from "./conditionTypes";
+import {
+  isGroup,
+  createEmptyRule,
+  createEmptyGroup,
+  MAX_CONDITION_DEPTH,
+} from "./conditionTypes";
 import { ConditionRuleRow } from "./ConditionRule";
 import type { SelectOption } from "./ConditionRule";
 
@@ -26,8 +31,6 @@ interface ConditionGroupProps {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const MAX_DEPTH = 3;
 
 function operatorCls(active: boolean) {
   return active
@@ -163,7 +166,7 @@ export function ConditionGroupBlock({
           <Plus className="h-3 w-3" />
           규칙 추가
         </button>
-        {depth < MAX_DEPTH && (
+        {depth < MAX_CONDITION_DEPTH && (
           <button
             type="button"
             onClick={addGroup}

--- a/apps/web/src/features/editor/components/design/condition/ConditionGroup.tsx
+++ b/apps/web/src/features/editor/components/design/condition/ConditionGroup.tsx
@@ -16,6 +16,11 @@ interface ConditionGroupProps {
   characters?: SelectOption[];
   missions?: SelectOption[];
   clues?: SelectOption[];
+  triggers?: SelectOption[];
+  tokens?: SelectOption[];
+  scenes?: SelectOption[];
+  rooms?: SelectOption[];
+  locations?: SelectOption[];
 }
 
 // ---------------------------------------------------------------------------
@@ -42,6 +47,11 @@ export function ConditionGroupBlock({
   characters = [],
   missions = [],
   clues = [],
+  triggers = [],
+  tokens = [],
+  scenes = [],
+  rooms = [],
+  locations = [],
 }: ConditionGroupProps) {
   const updateItem = (
     index: number,
@@ -118,6 +128,11 @@ export function ConditionGroupBlock({
               characters={characters}
               missions={missions}
               clues={clues}
+              triggers={triggers}
+              tokens={tokens}
+              scenes={scenes}
+              rooms={rooms}
+              locations={locations}
             />
           ) : (
             <ConditionRuleRow
@@ -128,6 +143,11 @@ export function ConditionGroupBlock({
               characters={characters}
               missions={missions}
               clues={clues}
+              triggers={triggers}
+              tokens={tokens}
+              scenes={scenes}
+              rooms={rooms}
+              locations={locations}
             />
           ),
         )}

--- a/apps/web/src/features/editor/components/design/condition/ConditionRule.tsx
+++ b/apps/web/src/features/editor/components/design/condition/ConditionRule.tsx
@@ -21,6 +21,11 @@ interface ConditionRuleProps {
   characters?: SelectOption[];
   missions?: SelectOption[];
   clues?: SelectOption[];
+  triggers?: SelectOption[];
+  tokens?: SelectOption[];
+  scenes?: SelectOption[];
+  rooms?: SelectOption[];
+  locations?: SelectOption[];
 }
 
 // ---------------------------------------------------------------------------
@@ -29,6 +34,39 @@ interface ConditionRuleProps {
 
 const selectCls =
   "rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-300 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950";
+
+const targetFieldByVariable: Partial<Record<ConditionRule["variable"], keyof ConditionRule>> = {
+  trigger_count: "target_trigger_id",
+  investigation_token: "target_token_id",
+  scene_visit_count: "target_scene_id",
+  room_state: "target_room_id",
+  location_state: "target_location_id",
+  custom_flag: "target_flag_key",
+};
+
+const targetOptionsByKind = {
+  trigger: "triggers",
+  token: "tokens",
+  scene: "scenes",
+  room: "rooms",
+  location: "locations",
+} as const;
+
+function resetTargets(variable: ConditionRule["variable"]): Partial<ConditionRule> {
+  return {
+    variable,
+    target_character_id: undefined,
+    target_mission_id: undefined,
+    target_clue_id: undefined,
+    target_trigger_id: undefined,
+    target_token_id: undefined,
+    target_scene_id: undefined,
+    target_room_id: undefined,
+    target_location_id: undefined,
+    target_flag_key: undefined,
+    value: "",
+  };
+}
 
 // ---------------------------------------------------------------------------
 // ConditionRuleRow
@@ -41,8 +79,14 @@ export function ConditionRuleRow({
   characters = [],
   missions = [],
   clues = [],
+  triggers = [],
+  tokens = [],
+  scenes = [],
+  rooms = [],
+  locations = [],
 }: ConditionRuleProps) {
   const meta = CONDITION_VARIABLES.find((v) => v.value === rule.variable);
+  const optionSets = { triggers, tokens, scenes, rooms, locations };
 
   const update = (patch: Partial<ConditionRule>) =>
     onChange({ ...rule, ...patch });
@@ -54,13 +98,7 @@ export function ConditionRuleRow({
         className={selectCls}
         value={rule.variable}
         onChange={(e) =>
-          update({
-            variable: e.target.value as ConditionRule["variable"],
-            target_character_id: undefined,
-            target_mission_id: undefined,
-            target_clue_id: undefined,
-            value: "",
-          })
+          update(resetTargets(e.target.value as ConditionRule["variable"]))
         }
         aria-label="변수"
       >
@@ -122,6 +160,32 @@ export function ConditionRuleRow({
         </select>
       )}
 
+      {meta?.targetLabel && meta.targetKind === "flag" && targetFieldByVariable[rule.variable] && (
+        <input
+          className={`${selectCls} w-32`}
+          value={String(rule[targetFieldByVariable[rule.variable]!] ?? "")}
+          onChange={(e) => update({ [targetFieldByVariable[rule.variable]!]: e.target.value })}
+          placeholder={meta.targetLabel}
+          aria-label={meta.targetLabel}
+        />
+      )}
+
+      {meta?.targetLabel && meta.targetKind && meta.targetKind !== "flag" && targetFieldByVariable[rule.variable] && (
+        <select
+          className={selectCls}
+          value={String(rule[targetFieldByVariable[rule.variable]!] ?? "")}
+          onChange={(e) => update({ [targetFieldByVariable[rule.variable]!]: e.target.value })}
+          aria-label={meta.targetLabel}
+        >
+          <option value="">{meta.targetLabel} 선택</option>
+          {optionSets[targetOptionsByKind[meta.targetKind]].map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+      )}
+
       {/* Comparator */}
       <select
         className={selectCls}
@@ -139,13 +203,40 @@ export function ConditionRuleRow({
       </select>
 
       {/* Value */}
-      <input
-        className={`${selectCls} w-24`}
-        value={rule.value}
-        onChange={(e) => update({ value: e.target.value })}
-        placeholder="값"
-        aria-label="값"
-      />
+      {meta?.valueSelect === "boolean" ? (
+        <select
+          className={selectCls}
+          value={rule.value}
+          onChange={(e) => update({ value: e.target.value })}
+          aria-label={meta.valueLabel}
+        >
+          <option value="">값 선택</option>
+          <option value="true">예</option>
+          <option value="false">아니오</option>
+        </select>
+      ) : meta?.valueSelect === "character" ? (
+        <select
+          className={selectCls}
+          value={rule.value}
+          onChange={(e) => update({ value: e.target.value })}
+          aria-label={meta.valueLabel}
+        >
+          <option value="">캐릭터 선택</option>
+          {characters.map((character) => (
+            <option key={character.id} value={character.id}>
+              {character.name}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          className={`${selectCls} w-24`}
+          value={rule.value}
+          onChange={(e) => update({ value: e.target.value })}
+          placeholder={meta?.valueLabel ?? "값"}
+          aria-label={meta?.valueLabel ?? "값"}
+        />
+      )}
 
       {/* Delete */}
       <button

--- a/apps/web/src/features/editor/components/design/condition/__tests__/ConditionRule.test.tsx
+++ b/apps/web/src/features/editor/components/design/condition/__tests__/ConditionRule.test.tsx
@@ -72,15 +72,17 @@ describe("ConditionRuleRow", () => {
     expect(screen.getByRole("combobox", { name: "단서" })).toBeDefined();
   });
 
-  it("vote_target일 때 추가 select가 표시되지 않는다", () => {
+  it("vote_target일 때 투표 대상 캐릭터를 제작자용 선택지로 표시한다", () => {
     render(
       <ConditionRuleRow
         rule={makeRule({ variable: "vote_target" })}
         onChange={vi.fn()}
         onDelete={vi.fn()}
+        characters={[{ id: "c1", name: "탐정" }]}
       />,
     );
-    expect(screen.queryByRole("combobox", { name: "캐릭터" })).toBeNull();
+    expect(screen.getByRole("combobox", { name: "캐릭터" })).toBeDefined();
+    expect(screen.getByRole("option", { name: "탐정" })).toBeDefined();
     expect(screen.queryByRole("combobox", { name: "미션" })).toBeNull();
     expect(screen.queryByRole("combobox", { name: "단서" })).toBeNull();
   });
@@ -107,11 +109,55 @@ describe("ConditionRuleRow", () => {
         onDelete={vi.fn()}
       />,
     );
-    fireEvent.change(screen.getByRole("textbox", { name: "값" }), {
+    fireEvent.change(screen.getByRole("textbox", { name: "상태" }), {
       target: { value: "success" },
     });
     expect(onChange).toHaveBeenCalledOnce();
     const [updated] = onChange.mock.calls[0] as [ConditionRule];
     expect(updated.value).toBe("success");
+  });
+
+  it("조사권 조건은 제작자용 선택지로 조사권과 수량을 편집한다", () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionRuleRow
+        rule={makeRule({ variable: "investigation_token", comparator: ">=", value: "1" })}
+        onChange={onChange}
+        onDelete={vi.fn()}
+        tokens={[{ id: "basic-token", name: "기본 조사권" }]}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "조사권" }), {
+      target: { value: "basic-token" },
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+    const [updated] = onChange.mock.calls[0] as [ConditionRule];
+    expect(updated.target_token_id).toBe("basic-token");
+  });
+
+  it("변수를 바꾸면 이전 target 값을 제거한다", () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionRuleRow
+        rule={makeRule({
+          variable: "clue_held",
+          target_character_id: "character-1",
+          target_clue_id: "clue-1",
+          value: "true",
+        })}
+        onChange={onChange}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "변수" }), {
+      target: { value: "scene_visit_count" },
+    });
+    const [updated] = onChange.mock.calls[0] as [ConditionRule];
+    expect(updated.variable).toBe("scene_visit_count");
+    expect(updated.target_character_id).toBeUndefined();
+    expect(updated.target_clue_id).toBeUndefined();
+    expect(updated.value).toBe("");
   });
 });

--- a/apps/web/src/features/editor/components/design/condition/__tests__/ConditionRule.test.tsx
+++ b/apps/web/src/features/editor/components/design/condition/__tests__/ConditionRule.test.tsx
@@ -154,6 +154,7 @@ describe("ConditionRuleRow", () => {
     fireEvent.change(screen.getByRole("combobox", { name: "변수" }), {
       target: { value: "scene_visit_count" },
     });
+    expect(onChange).toHaveBeenCalledOnce();
     const [updated] = onChange.mock.calls[0] as [ConditionRule];
     expect(updated.variable).toBe("scene_visit_count");
     expect(updated.target_character_id).toBeUndefined();

--- a/apps/web/src/features/editor/components/design/condition/__tests__/conditionTypes.test.ts
+++ b/apps/web/src/features/editor/components/design/condition/__tests__/conditionTypes.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCompleteConditionGroupRecord,
+  isConditionGroupRecord,
+  recordToGroup,
+  type ConditionGroup,
+} from "../conditionTypes";
+
+describe("conditionTypes", () => {
+  it("MMP 조건 그룹 shape를 공통 계약으로 검증한다", () => {
+    const condition: ConditionGroup = {
+      id: "group-1",
+      operator: "AND",
+      rules: [
+        {
+          id: "rule-1",
+          variable: "investigation_token",
+          target_character_id: "character-1",
+          target_token_id: "basic-token",
+          comparator: ">=",
+          value: "1",
+        },
+      ],
+    };
+
+    expect(isConditionGroupRecord(condition)).toBe(true);
+    expect(recordToGroup(condition).rules).toHaveLength(1);
+  });
+
+  it("unknown variable과 과도한 중첩은 빈 제작자 그룹으로 되돌린다", () => {
+    const badVariable = {
+      id: "group-1",
+      operator: "AND",
+      rules: [{ id: "rule-1", variable: "raw_engine_key", comparator: "=", value: "x" }],
+    };
+    const tooDeep = {
+      id: "g0",
+      operator: "AND",
+      rules: [{
+        id: "g1",
+        operator: "AND",
+        rules: [{
+          id: "g2",
+          operator: "AND",
+          rules: [{
+            id: "g3",
+            operator: "AND",
+            rules: [{
+              id: "g4",
+              operator: "AND",
+              rules: [],
+            }],
+          }],
+        }],
+      }],
+    };
+    const missingTarget = {
+      id: "group-1",
+      operator: "AND",
+      rules: [{
+        id: "rule-1",
+        variable: "investigation_token",
+        target_character_id: "character-1",
+        comparator: ">=",
+        value: "1",
+      }],
+    };
+
+    expect(isConditionGroupRecord(badVariable)).toBe(false);
+    expect(isConditionGroupRecord(missingTarget)).toBe(true);
+    expect(isCompleteConditionGroupRecord(missingTarget)).toBe(false);
+    expect(isConditionGroupRecord(tooDeep)).toBe(false);
+    expect(recordToGroup(badVariable).operator).toBe("AND");
+    expect(recordToGroup(tooDeep).rules).toHaveLength(1);
+  });
+});

--- a/apps/web/src/features/editor/components/design/condition/conditionTypes.ts
+++ b/apps/web/src/features/editor/components/design/condition/conditionTypes.ts
@@ -7,9 +7,14 @@ export type ConditionVariable =
   | "character_alive"
   | "vote_target"
   | "clue_held"
+  | "trigger_count"
+  | "investigation_token"
+  | "scene_visit_count"
+  | "room_state"
+  | "location_state"
   | "custom_flag";
 
-export type ConditionComparator = "=" | "!=" | ">" | "<";
+export type ConditionComparator = "=" | "!=" | ">" | "<" | ">=" | "<=";
 
 export interface ConditionRule {
   id: string;
@@ -17,6 +22,12 @@ export interface ConditionRule {
   target_character_id?: string;
   target_mission_id?: string;
   target_clue_id?: string;
+  target_trigger_id?: string;
+  target_token_id?: string;
+  target_scene_id?: string;
+  target_room_id?: string;
+  target_location_id?: string;
+  target_flag_key?: string;
   comparator: ConditionComparator;
   value: string;
 }
@@ -26,6 +37,9 @@ export interface ConditionGroup {
   operator: "AND" | "OR";
   rules: (ConditionRule | ConditionGroup)[];
 }
+
+export const CONDITION_SCHEMA_VERSION = 1;
+export const MAX_CONDITION_DEPTH = 3;
 
 // ---------------------------------------------------------------------------
 // Variable metadata
@@ -37,14 +51,23 @@ export interface ConditionVariableMeta {
   needsCharacter: boolean;
   needsMission: boolean;
   needsClue: boolean;
+  valueSelect?: "character" | "boolean";
+  targetLabel?: string;
+  targetKind?: "trigger" | "token" | "scene" | "room" | "location" | "flag";
+  valueLabel?: string;
 }
 
 export const CONDITION_VARIABLES: ConditionVariableMeta[] = [
-  { value: "mission_status",  label: "미션 결과",     needsCharacter: true,  needsMission: true,  needsClue: false },
-  { value: "character_alive", label: "캐릭터 생존",   needsCharacter: true,  needsMission: false, needsClue: false },
-  { value: "vote_target",     label: "투표 대상",     needsCharacter: false, needsMission: false, needsClue: false },
-  { value: "clue_held",       label: "단서 보유",     needsCharacter: true,  needsMission: false, needsClue: true  },
-  { value: "custom_flag",     label: "커스텀 플래그", needsCharacter: false, needsMission: false, needsClue: false },
+  { value: "mission_status",      label: "미션 결과",       needsCharacter: true,  needsMission: true,  needsClue: false, valueLabel: "상태" },
+  { value: "character_alive",     label: "캐릭터 생존",     needsCharacter: true,  needsMission: false, needsClue: false, valueSelect: "boolean", valueLabel: "true/false" },
+  { value: "vote_target",         label: "투표 대상",       needsCharacter: false, needsMission: false, needsClue: false, valueSelect: "character", valueLabel: "캐릭터" },
+  { value: "clue_held",           label: "단서 보유",       needsCharacter: true,  needsMission: false, needsClue: true, valueSelect: "boolean", valueLabel: "true/false" },
+  { value: "trigger_count",       label: "트리거 실행 횟수", needsCharacter: false, needsMission: false, needsClue: false, targetLabel: "트리거", targetKind: "trigger", valueLabel: "횟수" },
+  { value: "investigation_token", label: "조사권 수",       needsCharacter: true,  needsMission: false, needsClue: false, targetLabel: "조사권", targetKind: "token", valueLabel: "수량" },
+  { value: "scene_visit_count",   label: "장면 반복 횟수",   needsCharacter: false, needsMission: false, needsClue: false, targetLabel: "장면", targetKind: "scene", valueLabel: "횟수" },
+  { value: "room_state",          label: "토론방 상태",     needsCharacter: false, needsMission: false, needsClue: false, targetLabel: "토론방", targetKind: "room", valueLabel: "상태" },
+  { value: "location_state",      label: "장소 상태",       needsCharacter: false, needsMission: false, needsClue: false, targetLabel: "장소", targetKind: "location", valueLabel: "상태" },
+  { value: "custom_flag",         label: "커스텀 플래그",   needsCharacter: false, needsMission: false, needsClue: false, targetLabel: "플래그 이름", targetKind: "flag", valueLabel: "값" },
 ];
 
 export const COMPARATOR_LABELS: Record<ConditionComparator, string> = {
@@ -52,15 +75,15 @@ export const COMPARATOR_LABELS: Record<ConditionComparator, string> = {
   "!=": "≠",
   ">":  ">",
   "<":  "<",
+  ">=": "≥",
+  "<=": "≤",
 };
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-export function isGroup(
-  item: ConditionRule | ConditionGroup,
-): item is ConditionGroup {
+export function isGroup(item: ConditionRule | ConditionGroup): item is ConditionGroup {
   return "operator" in item;
 }
 
@@ -90,8 +113,71 @@ export function groupToRecord(
 export function recordToGroup(
   raw: Record<string, unknown> | null,
 ): ConditionGroup {
-  if (raw && typeof raw === "object" && "operator" in raw) {
+  if (isConditionGroupRecord(raw)) {
     return raw as unknown as ConditionGroup;
   }
   return createEmptyGroup();
+}
+
+export function isConditionGroupRecord(raw: unknown, depth = 0, requireComplete = false): raw is ConditionGroup {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw) || depth > MAX_CONDITION_DEPTH) {
+    return false;
+  }
+  const candidate = raw as Record<string, unknown>;
+  if (typeof candidate.id !== "string" || !["AND", "OR"].includes(String(candidate.operator))) {
+    return false;
+  }
+  if (!Array.isArray(candidate.rules) || candidate.rules.length === 0) return false;
+  return candidate.rules.every((item) =>
+    isConditionRuleRecord(item, requireComplete) || isConditionGroupRecord(item, depth + 1, requireComplete),
+  );
+}
+
+export function isConditionRuleRecord(raw: unknown, requireComplete = false): raw is ConditionRule {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false;
+  const candidate = raw as Record<string, unknown>;
+  const variables = new Set(CONDITION_VARIABLES.map((item) => item.value));
+  const comparators = new Set(Object.keys(COMPARATOR_LABELS));
+  if (
+    typeof candidate.id === "string" &&
+    typeof candidate.variable === "string" &&
+    variables.has(candidate.variable as ConditionVariable) &&
+    typeof candidate.comparator === "string" &&
+    comparators.has(candidate.comparator) &&
+    typeof candidate.value === "string"
+  ) {
+    return !requireComplete || hasRequiredConditionTargets(candidate as unknown as ConditionRule);
+  }
+  return false;
+}
+
+export function isCompleteConditionGroupRecord(raw: unknown): raw is ConditionGroup {
+  return isConditionGroupRecord(raw, 0, true);
+}
+
+export function hasRequiredConditionTargets(rule: ConditionRule): boolean {
+  switch (rule.variable) {
+    case "mission_status":
+      return Boolean(rule.target_character_id && rule.target_mission_id);
+    case "character_alive":
+      return Boolean(rule.target_character_id);
+    case "vote_target":
+      return Boolean(rule.value);
+    case "clue_held":
+      return Boolean(rule.target_character_id && rule.target_clue_id);
+    case "trigger_count":
+      return Boolean(rule.target_trigger_id);
+    case "investigation_token":
+      return Boolean(rule.target_character_id && rule.target_token_id);
+    case "scene_visit_count":
+      return Boolean(rule.target_scene_id);
+    case "room_state":
+      return Boolean(rule.target_room_id);
+    case "location_state":
+      return Boolean(rule.target_location_id);
+    case "custom_flag":
+      return Boolean(rule.target_flag_key);
+    default:
+      return false;
+  }
 }

--- a/apps/web/src/features/editor/entities/shared/__tests__/conditionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/conditionAdapter.test.ts
@@ -8,6 +8,8 @@ import {
 describe("conditionAdapter", () => {
   it("조건 변수와 그룹을 제작자용 문구로 변환한다", () => {
     expect(getConditionVariableLabel("clue_held")).toBe("단서 보유");
+    expect(getConditionVariableLabel("investigation_token")).toBe("조사권 수");
+    expect(getConditionVariableLabel("trigger_count")).toBe("트리거 실행 횟수");
     expect(getConditionVariableLabel("raw_engine_key")).toBe("직접 설정한 조건");
     expect(getConditionOperatorLabel("OR")).toBe("하나 이상");
   });

--- a/apps/web/src/features/editor/entities/shared/conditionAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/conditionAdapter.ts
@@ -6,6 +6,11 @@ const CONDITION_VARIABLE_LABELS: Record<string, string> = {
   character_alive: "캐릭터 생존",
   vote_target: "투표 대상",
   clue_held: "단서 보유",
+  trigger_count: "트리거 실행 횟수",
+  investigation_token: "조사권 수",
+  scene_visit_count: "장면 반복 횟수",
+  room_state: "토론방 상태",
+  location_state: "장소 상태",
   custom_flag: "직접 설정한 조건",
 };
 

--- a/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
@@ -24,6 +24,20 @@ const baseEdge: FlowEdgeResponse = {
   created_at: "2026-01-01T00:00:00Z",
 };
 
+const completeCondition = {
+  id: "group-1",
+  operator: "AND",
+  rules: [
+    {
+      id: "rule-1",
+      variable: "custom_flag",
+      target_flag_key: "manual_override",
+      comparator: "=",
+      value: "true",
+    },
+  ],
+};
+
 describe("toReactFlowNode", () => {
   it("maps server node to ReactFlow node", () => {
     const result = toReactFlowNode(baseNode);
@@ -64,5 +78,40 @@ describe("toSaveRequest", () => {
     expect(req.edges[0].source_id).toBe("node-1");
     expect(req.edges[0].target_id).toBe("node-2");
     expect(req.edges[0].sort_order).toBe(0);
+  });
+
+  it("완성된 조건만 저장 요청에 포함한다", () => {
+    const rfNode = toReactFlowNode(baseNode);
+    const rfEdge = {
+      ...toReactFlowEdge(baseEdge),
+      data: { condition: completeCondition },
+    };
+    const req = toSaveRequest([rfNode], [rfEdge]);
+
+    expect(req.edges[0].condition).toEqual(completeCondition);
+  });
+
+  it("미완성 조건 draft는 저장 요청에서 제외한다", () => {
+    const rfNode = toReactFlowNode(baseNode);
+    const rfEdge = {
+      ...toReactFlowEdge(baseEdge),
+      data: {
+        condition: {
+          id: "group-1",
+          operator: "AND",
+          rules: [
+            {
+              id: "rule-1",
+              variable: "scene_visit_count",
+              comparator: ">=",
+              value: "1",
+            },
+          ],
+        },
+      },
+    };
+    const req = toSaveRequest([rfNode], [rfEdge]);
+
+    expect(req.edges[0].condition).toBeNull();
   });
 });

--- a/apps/web/src/features/editor/hooks/flowConverters.ts
+++ b/apps/web/src/features/editor/hooks/flowConverters.ts
@@ -4,6 +4,7 @@ import type {
   FlowEdgeResponse,
   SaveFlowRequest,
 } from "../flowTypes";
+import { isCompleteConditionGroupRecord } from "../components/design/condition/conditionTypes";
 
 // ---------------------------------------------------------------------------
 // Converters: server ↔ ReactFlow
@@ -41,11 +42,16 @@ export function toSaveRequest(nodes: Node[], edges: Edge[]): SaveFlowRequest {
       id: e.id,
       source_id: e.source,
       target_id: e.target,
-      condition:
-        (e.data as { condition?: Record<string, unknown> } | undefined)
-          ?.condition ?? null,
+      condition: toPersistedCondition(e.data),
       label: typeof e.label === "string" ? e.label : null,
       sort_order: i,
     })),
   };
+}
+
+function toPersistedCondition(data: Edge["data"]): Record<string, unknown> | null {
+  const condition =
+    (data as { condition?: Record<string, unknown> } | undefined)?.condition ??
+    null;
+  return isCompleteConditionGroupRecord(condition) ? condition : null;
 }

--- a/apps/web/src/features/editor/hooks/useEdgeCondition.ts
+++ b/apps/web/src/features/editor/hooks/useEdgeCondition.ts
@@ -3,6 +3,7 @@ import type { Edge } from "@xyflow/react";
 import { isCompleteConditionGroupRecord } from "../components/design/condition/conditionTypes";
 
 type SetEdges = React.Dispatch<React.SetStateAction<Edge[]>>;
+type GetEdges = () => Edge[];
 type AutoSave = (nodes: unknown[], edges: Edge[]) => void;
 
 // ---------------------------------------------------------------------------
@@ -12,24 +13,27 @@ type AutoSave = (nodes: unknown[], edges: Edge[]) => void;
 export function useEdgeCondition(
   setEdges: SetEdges,
   getNodes: () => unknown[],
+  getEdges: GetEdges,
   autoSave: AutoSave,
 ) {
   const updateEdgeCondition = useCallback(
     (edgeId: string, condition: Record<string, unknown>) => {
       const shouldAutoSave = isCompleteConditionGroupRecord(condition);
-      setEdges((eds) => {
-        const next = eds.map((e) =>
-          e.id === edgeId
-            ? { ...e, data: { ...e.data, condition }, type: "condition" }
-            : e,
-        );
-        if (shouldAutoSave) {
-          autoSave(getNodes(), next);
-        }
-        return next;
+      let changed = false;
+      const next = getEdges().map((e) => {
+        if (e.id !== edgeId) return e;
+        changed = true;
+        return { ...e, data: { ...e.data, condition }, type: "condition" };
       });
+
+      if (!changed) return;
+
+      setEdges(next);
+      if (shouldAutoSave) {
+        autoSave(getNodes(), next);
+      }
     },
-    [setEdges, getNodes, autoSave],
+    [setEdges, getNodes, getEdges, autoSave],
   );
 
   return { updateEdgeCondition };

--- a/apps/web/src/features/editor/hooks/useEdgeCondition.ts
+++ b/apps/web/src/features/editor/hooks/useEdgeCondition.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import type { Edge } from "@xyflow/react";
+import { isCompleteConditionGroupRecord } from "../components/design/condition/conditionTypes";
 
 type SetEdges = React.Dispatch<React.SetStateAction<Edge[]>>;
 type AutoSave = (nodes: unknown[], edges: Edge[]) => void;
@@ -15,13 +16,16 @@ export function useEdgeCondition(
 ) {
   const updateEdgeCondition = useCallback(
     (edgeId: string, condition: Record<string, unknown>) => {
+      const shouldAutoSave = isCompleteConditionGroupRecord(condition);
       setEdges((eds) => {
         const next = eds.map((e) =>
           e.id === edgeId
             ? { ...e, data: { ...e.data, condition }, type: "condition" }
             : e,
         );
-        autoSave(getNodes(), next);
+        if (shouldAutoSave) {
+          autoSave(getNodes(), next);
+        }
         return next;
       });
     },

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -181,8 +181,16 @@ export function useFlowData(themeId: string) {
 
   const nodesRef = useRef(nodes);
   nodesRef.current = nodes;
+  const edgesRef = useRef(edges);
+  edgesRef.current = edges;
   const getNodes = useCallback(() => nodesRef.current, []);
-  const { updateEdgeCondition } = useEdgeCondition(setEdges, getNodes, autoSave);
+  const getEdges = useCallback(() => edgesRef.current, []);
+  const { updateEdgeCondition } = useEdgeCondition(
+    setEdges,
+    getNodes,
+    getEdges,
+    autoSave,
+  );
   const { applyPreset } = useApplyPreset(setNodes, setEdges, autoSave);
 
   return {


### PR DESCRIPTION
## 요약

- #301 공통 조건 그룹 계약을 frontend/backend에 추가했습니다.
- 조건 빌더가 MMP 용어 변수 목록(트리거 실행 횟수, 조사권 수, 장면 반복 횟수, 토론방/장소 상태 등)을 제작자용 라벨로 다루게 했습니다.
- backend `engine`에 조건 그룹 검증/JSONLogic 변환/평가 경계를 추가하고, Flow edge 저장 경계에서 invalid condition을 400으로 거부하게 했습니다.
- #301 범위 밖으로 확인된 Flow/Mission 소비처 migration과 edge ID UI 누출은 #308, #309로 분리했습니다.

Closes #301
Refs #308
Refs #309

## 검증

- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/condition/__tests__/ConditionBuilder.test.tsx src/features/editor/components/design/condition/__tests__/ConditionRule.test.tsx src/features/editor/components/design/condition/__tests__/conditionTypes.test.ts src/features/editor/entities/shared/__tests__/conditionAdapter.test.ts`
- `cd apps/server && go test ./internal/engine ./internal/domain/flow ./internal/module/decision/ending_branch -count=1`

## E2E 미작성 사유

이번 PR은 새 route나 실제 사용자 저장 화면을 추가하지 않고, 조건 계약/검증/컴포넌트 단위 동작을 고정하는 contract PR입니다. 사용자 흐름 E2E는 Flow/Mission 소비처 연결 이슈 #308에서 route 저장 흐름과 함께 추가하는 편이 맞아, 이번 PR은 focused Vitest와 Go contract test로 대체했습니다.

## PR 경계

- 포함: 공통 조건 shape, frontend draft/complete validation 분리, backend condition contract, Flow edge condition 저장 검증
- 제외: Flow/Phase runtime transition 연결, Mission 문자열 조건 migration, 조건 분기 패널 edge ID 표시 개선


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 조건 변수 5종(트리거 횟수, 조사권, 장면/방/위치 상태) 및 비교연산자 >=/<= 추가
  * 에디터에서 트리거·조사권·장면·방·위치 선택 옵션 노출

* **개선**
  * 조건 빌더: 변수 유형에 맞는 입력(UI)이 자동 제공(드롭다운/불리언/텍스트 등)
  * 자동저장: 조건이 완전한 경우에만 자동저장 실행

* **버그 픽스 / 검증**
  * 엣지(연결) 조건 검증 강화 — 잘못된 조건은 서버/저장 시 조기 차단

* **테스트**
  * 조건 파싱·검증·평가 관련 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->