### PR TITLE
feat(editor): #299 스토리 장면 제작 경로 연결

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -175,6 +175,13 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     });
     await expect(page.getByTestId("ending-entity-panel")).toBeVisible({ timeout: 10_000 });
 
+    await page.goto(`${BASE}/editor/${THEME_ID}/design/flow`);
+    await expect(page.getByRole("tab", { name: "게임설계", selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("장면 흐름")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("스토리 장면 구성")).toBeVisible({ timeout: 10_000 });
+
     await page.goto(`${BASE}/editor/${THEME_ID}/media`);
     await expect(page.getByRole("tab", { name: "미디어", selected: true })).toBeVisible({
       timeout: 10_000,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -156,6 +156,7 @@ export function App() {
                 <Route path="/game/:id" element={<GamePage />} />
                 <Route path="/editor/:id" element={<EditorPage />} />
                 <Route path="/editor/:id/:tab" element={<EditorPage />} />
+                <Route path="/editor/:id/design/:designTab" element={<EditorPage />} />
                 <Route element={<MainLayout />}>
                   <Route path="/" element={<LobbyPage />} />
                   <Route path="/lobby" element={<LobbyPage />} />

--- a/apps/web/src/features/editor/components/DesignTab.tsx
+++ b/apps/web/src/features/editor/components/DesignTab.tsx
@@ -41,7 +41,7 @@ export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
 
   const handleSubTabClick = (key: DesignSubTab) => {
     setActiveSubTab(key);
-    navigate(`/editor/${themeId}/${key}`);
+    navigate(`/editor/${themeId}/design/${key}`);
   };
 
   return (

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -102,10 +102,10 @@ export function StoryTab({ themeId }: StoryTabProps) {
   });
 
   const charCount = markdown.length;
-  const storySceneSummary = useMemo(() => {
-    if (isFlowLoading || isFlowError) return null;
-    return toStorySceneFlowSummaryFromGraph(flowGraph);
-  }, [flowGraph, isFlowError, isFlowLoading]);
+  const storySceneSummary = useMemo(
+    () => toStorySceneFlowSummaryFromGraph(flowGraph),
+    [flowGraph],
+  );
 
   const previewHtml = useMemo(() => {
     if (!markdown) return '';
@@ -160,9 +160,9 @@ export function StoryTab({ themeId }: StoryTabProps) {
             message="스토리 장면 구성을 불러오지 못했습니다."
             status="error"
           />
-        ) : storySceneSummary ? (
+        ) : (
           <StorySceneSummary summary={storySceneSummary} />
-        ) : null}
+        )}
 
         <div className="flex min-h-[40vh] flex-col lg:flex-row">
           {/* Editor pane */}

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -3,7 +3,10 @@ import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { Columns2, AlignLeft, Eye } from 'lucide-react';
 import { useEditorContent, useUpsertContent } from '@/features/editor/api';
+import { useFlowGraph } from '@/features/editor/flowApi';
 import { useAutoSave } from '@/features/editor/hooks/useAutoSave';
+import { toStorySceneFlowSummaryFromGraph } from '@/features/editor/entities/story/storySceneAdapter';
+import { StorySceneSummary } from './design/StorySceneSummary';
 import { ReadingSectionList } from './reading/ReadingSectionList';
 
 // ---------------------------------------------------------------------------
@@ -54,6 +57,7 @@ function ViewToggleBtn({ mode, current, icon, label, onClick }: ViewToggleProps)
 
 export function StoryTab({ themeId }: StoryTabProps) {
   const { data: contentData } = useEditorContent(themeId, 'story');
+  const { data: flowGraph } = useFlowGraph(themeId);
   const upsertContent = useUpsertContent(themeId, 'story');
 
   const [markdown, setMarkdown] = useState('');
@@ -72,6 +76,10 @@ export function StoryTab({ themeId }: StoryTabProps) {
   });
 
   const charCount = markdown.length;
+  const storySceneSummary = useMemo(
+    () => toStorySceneFlowSummaryFromGraph(flowGraph),
+    [flowGraph],
+  );
 
   const previewHtml = useMemo(() => {
     if (!markdown) return '';
@@ -116,36 +124,38 @@ export function StoryTab({ themeId }: StoryTabProps) {
 
       {/* Editor / Preview panes */}
       <div className="flex flex-1 flex-col overflow-y-auto">
-       <div className="flex min-h-[40vh]">
-        {/* Editor pane */}
-        {showEditor && (
-          <div className={`flex flex-col ${viewMode === 'split' ? 'w-1/2 border-r border-slate-800' : 'w-full'}`}>
-            <textarea
-              value={markdown}
-              onChange={(e) => setMarkdown(e.target.value)}
-              placeholder="마크다운으로 스토리를 작성하세요..."
-              spellCheck={false}
-              className="flex-1 resize-none bg-slate-950 px-5 py-4 font-mono text-sm leading-relaxed text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
-            />
-          </div>
-        )}
+        <StorySceneSummary summary={storySceneSummary} />
 
-        {/* Preview pane */}
-        {showPreview && (
-          <div className={`overflow-y-auto ${viewMode === 'split' ? 'w-1/2' : 'w-full'}`}>
-            {previewHtml ? (
-              <div
-                className="prose prose-invert prose-sm prose-headings:font-mono prose-strong:text-amber-400 max-w-none px-5 py-4"
-                dangerouslySetInnerHTML={{ __html: previewHtml }}
+        <div className="flex min-h-[40vh] flex-col lg:flex-row">
+          {/* Editor pane */}
+          {showEditor && (
+            <div className={`flex min-h-[32vh] flex-col ${viewMode === 'split' ? 'lg:w-1/2 lg:border-r lg:border-slate-800' : 'w-full'}`}>
+              <textarea
+                value={markdown}
+                onChange={(e) => setMarkdown(e.target.value)}
+                placeholder="마크다운으로 스토리를 작성하세요..."
+                spellCheck={false}
+                className="flex-1 resize-none bg-slate-950 px-5 py-4 font-mono text-sm leading-relaxed text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
               />
-            ) : (
-              <div className="flex items-center justify-center py-20 text-xs font-mono uppercase tracking-widest text-slate-700">
-                미리보기 없음
-              </div>
-            )}
-          </div>
-        )}
-       </div>
+            </div>
+          )}
+
+          {/* Preview pane */}
+          {showPreview && (
+            <div className={`min-h-[32vh] overflow-y-auto ${viewMode === 'split' ? 'border-t border-slate-800 lg:w-1/2 lg:border-t-0' : 'w-full'}`}>
+              {previewHtml ? (
+                <div
+                  className="prose prose-invert prose-sm prose-headings:font-mono prose-strong:text-amber-400 max-w-none px-5 py-4"
+                  dangerouslySetInnerHTML={{ __html: previewHtml }}
+                />
+              ) : (
+                <div className="flex items-center justify-center py-20 text-xs font-mono uppercase tracking-widest text-slate-700">
+                  미리보기 없음
+                </div>
+              )}
+            </div>
+          )}
+        </div>
 
         {/* Reading sections — Phase 7.7 */}
         <div className="border-t border-slate-800 px-5 py-6">

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -51,9 +51,21 @@ function ViewToggleBtn({ mode, current, icon, label, onClick }: ViewToggleProps)
   );
 }
 
-function StorySceneSummaryStatus({ message }: { message: string }) {
+function StorySceneSummaryStatus({
+  message,
+  status,
+}: {
+  message: string;
+  status: 'loading' | 'error';
+}) {
+  const isError = status === 'error';
   return (
-    <div className="border-b border-slate-800 bg-slate-950 px-5 py-4">
+    <div
+      className="border-b border-slate-800 bg-slate-950 px-5 py-4"
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      aria-atomic="true"
+    >
       <div className="rounded-sm border border-slate-800 bg-slate-900/45 px-4 py-3 text-xs text-slate-400">
         {message}
       </div>
@@ -139,9 +151,15 @@ export function StoryTab({ themeId }: StoryTabProps) {
       {/* Editor / Preview panes */}
       <div className="flex flex-1 flex-col overflow-y-auto">
         {isFlowLoading ? (
-          <StorySceneSummaryStatus message="스토리 장면 구성을 불러오는 중입니다." />
+          <StorySceneSummaryStatus
+            message="스토리 장면 구성을 불러오는 중입니다."
+            status="loading"
+          />
         ) : isFlowError ? (
-          <StorySceneSummaryStatus message="스토리 장면 구성을 불러오지 못했습니다." />
+          <StorySceneSummaryStatus
+            message="스토리 장면 구성을 불러오지 못했습니다."
+            status="error"
+          />
         ) : storySceneSummary ? (
           <StorySceneSummary summary={storySceneSummary} />
         ) : null}

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -51,13 +51,27 @@ function ViewToggleBtn({ mode, current, icon, label, onClick }: ViewToggleProps)
   );
 }
 
+function StorySceneSummaryStatus({ message }: { message: string }) {
+  return (
+    <div className="border-b border-slate-800 bg-slate-950 px-5 py-4">
+      <div className="rounded-sm border border-slate-800 bg-slate-900/45 px-4 py-3 text-xs text-slate-400">
+        {message}
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // StoryTab
 // ---------------------------------------------------------------------------
 
 export function StoryTab({ themeId }: StoryTabProps) {
   const { data: contentData } = useEditorContent(themeId, 'story');
-  const { data: flowGraph } = useFlowGraph(themeId);
+  const {
+    data: flowGraph,
+    isLoading: isFlowLoading,
+    isError: isFlowError,
+  } = useFlowGraph(themeId);
   const upsertContent = useUpsertContent(themeId, 'story');
 
   const [markdown, setMarkdown] = useState('');
@@ -76,10 +90,10 @@ export function StoryTab({ themeId }: StoryTabProps) {
   });
 
   const charCount = markdown.length;
-  const storySceneSummary = useMemo(
-    () => toStorySceneFlowSummaryFromGraph(flowGraph),
-    [flowGraph],
-  );
+  const storySceneSummary = useMemo(() => {
+    if (isFlowLoading || isFlowError) return null;
+    return toStorySceneFlowSummaryFromGraph(flowGraph);
+  }, [flowGraph, isFlowError, isFlowLoading]);
 
   const previewHtml = useMemo(() => {
     if (!markdown) return '';
@@ -124,7 +138,13 @@ export function StoryTab({ themeId }: StoryTabProps) {
 
       {/* Editor / Preview panes */}
       <div className="flex flex-1 flex-col overflow-y-auto">
-        <StorySceneSummary summary={storySceneSummary} />
+        {isFlowLoading ? (
+          <StorySceneSummaryStatus message="스토리 장면 구성을 불러오는 중입니다." />
+        ) : isFlowError ? (
+          <StorySceneSummaryStatus message="스토리 장면 구성을 불러오지 못했습니다." />
+        ) : storySceneSummary ? (
+          <StorySceneSummary summary={storySceneSummary} />
+        ) : null}
 
         <div className="flex min-h-[40vh] flex-col lg:flex-row">
           {/* Editor pane */}

--- a/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
@@ -1,5 +1,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const useFlowGraphMock = vi.fn();
 
 vi.mock("@/features/editor/api", () => ({
   useEditorContent: () => ({
@@ -11,23 +13,7 @@ vi.mock("@/features/editor/api", () => ({
 }));
 
 vi.mock("@/features/editor/flowApi", () => ({
-  useFlowGraph: () => ({
-    data: {
-      nodes: [
-        {
-          id: "scene-1",
-          theme_id: "theme-1",
-          type: "phase",
-          data: { label: "오프닝", phase_type: "story_progression" },
-          position_x: 100,
-          position_y: 100,
-          created_at: "2026-05-05T00:00:00Z",
-          updated_at: "2026-05-05T00:00:00Z",
-        },
-      ],
-      edges: [],
-    },
-  }),
+  useFlowGraph: () => useFlowGraphMock(),
 }));
 
 vi.mock("@/features/editor/hooks/useAutoSave", () => ({
@@ -48,6 +34,28 @@ afterEach(() => {
 });
 
 describe("StoryTab", () => {
+  beforeEach(() => {
+    useFlowGraphMock.mockReturnValue({
+      data: {
+        nodes: [
+          {
+            id: "scene-1",
+            theme_id: "theme-1",
+            type: "phase",
+            data: { label: "오프닝", phase_type: "story_progression" },
+            position_x: 100,
+            position_y: 100,
+            created_at: "2026-05-05T00:00:00Z",
+            updated_at: "2026-05-05T00:00:00Z",
+          },
+        ],
+        edges: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+  });
+
   it("스토리 원고와 장면 기반 진행 요약을 함께 렌더링한다", async () => {
     render(<StoryTab themeId="theme-1" />);
 
@@ -56,5 +64,31 @@ describe("StoryTab", () => {
     expect(screen.getByText("1개 장면")).toBeDefined();
     expect(screen.getAllByText("오프닝").length).toBeGreaterThan(0);
     expect(screen.getByTestId("reading-section-list").textContent).toBe("theme-1");
+  });
+
+  it("장면 구성을 불러오는 동안 빈 장면 요약을 보여주지 않는다", async () => {
+    useFlowGraphMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<StoryTab themeId="theme-1" />);
+
+    expect(await screen.findByText("스토리 장면 구성을 불러오는 중입니다.")).toBeDefined();
+    expect(screen.queryByText("0개 장면")).toBeNull();
+  });
+
+  it("장면 구성 로드 실패를 빈 장면 상태와 분리한다", async () => {
+    useFlowGraphMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<StoryTab themeId="theme-1" />);
+
+    expect(await screen.findByText("스토리 장면 구성을 불러오지 못했습니다.")).toBeDefined();
+    expect(screen.queryByText("0개 장면")).toBeNull();
   });
 });

--- a/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/editor/api", () => ({
+  useEditorContent: () => ({
+    data: { body: "# 오프닝\n\n플레이어가 저택에 도착한다." },
+  }),
+  useUpsertContent: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/editor/flowApi", () => ({
+  useFlowGraph: () => ({
+    data: {
+      nodes: [
+        {
+          id: "scene-1",
+          theme_id: "theme-1",
+          type: "phase",
+          data: { label: "오프닝", phase_type: "story_progression" },
+          position_x: 100,
+          position_y: 100,
+          created_at: "2026-05-05T00:00:00Z",
+          updated_at: "2026-05-05T00:00:00Z",
+        },
+      ],
+      edges: [],
+    },
+  }),
+}));
+
+vi.mock("@/features/editor/hooks/useAutoSave", () => ({
+  useAutoSave: vi.fn(),
+}));
+
+vi.mock("@/features/editor/components/reading/ReadingSectionList", () => ({
+  ReadingSectionList: ({ themeId }: { themeId: string }) => (
+    <div data-testid="reading-section-list">{themeId}</div>
+  ),
+}));
+
+import { StoryTab } from "../StoryTab";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("StoryTab", () => {
+  it("스토리 원고와 장면 기반 진행 요약을 함께 렌더링한다", async () => {
+    render(<StoryTab themeId="theme-1" />);
+
+    expect(await screen.findByDisplayValue(/플레이어가 저택에 도착한다/)).toBeDefined();
+    expect(screen.getByText("스토리 장면 구성")).toBeDefined();
+    expect(screen.getByText("1개 장면")).toBeDefined();
+    expect(screen.getAllByText("오프닝").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("reading-section-list").textContent).toBe("theme-1");
+  });
+});

--- a/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
@@ -95,4 +95,17 @@ describe("StoryTab", () => {
     expect(screen.getByRole("alert").getAttribute("aria-atomic")).toBe("true");
     expect(screen.queryByText("0개 장면")).toBeNull();
   });
+
+  it("장면이 없으면 빈 장면 요약을 명시적으로 보여준다", async () => {
+    useFlowGraphMock.mockReturnValue({
+      data: { nodes: [], edges: [] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<StoryTab themeId="theme-1" />);
+
+    expect(await screen.findByText("0개 장면")).toBeDefined();
+    expect(screen.getByText("장면을 추가하면 스토리 진행 구성이 여기에 표시됩니다.")).toBeDefined();
+  });
 });

--- a/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
@@ -76,6 +76,8 @@ describe("StoryTab", () => {
     render(<StoryTab themeId="theme-1" />);
 
     expect(await screen.findByText("스토리 장면 구성을 불러오는 중입니다.")).toBeDefined();
+    expect(screen.getByRole("status").getAttribute("aria-live")).toBe("polite");
+    expect(screen.getByRole("status").getAttribute("aria-atomic")).toBe("true");
     expect(screen.queryByText("0개 장면")).toBeNull();
   });
 
@@ -89,6 +91,8 @@ describe("StoryTab", () => {
     render(<StoryTab themeId="theme-1" />);
 
     expect(await screen.findByText("스토리 장면 구성을 불러오지 못했습니다.")).toBeDefined();
+    expect(screen.getByRole("alert").getAttribute("aria-live")).toBe("assertive");
+    expect(screen.getByRole("alert").getAttribute("aria-atomic")).toBe("true");
     expect(screen.queryByText("0개 장면")).toBeNull();
   });
 });

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -15,6 +15,7 @@ import { PhaseNode } from "./PhaseNode";
 import { EndingNode } from "./EndingNode";
 import { NodeDetailPanel } from "./NodeDetailPanel";
 import { FlowSimulationPanel } from "./FlowSimulationPanel";
+import { StorySceneSummary } from "./StorySceneSummary";
 import { branchNodeTypes, conditionEdgeTypes } from "./flowNodeRegistry";
 import type { FlowNodeType } from "../../flowTypes";
 
@@ -126,6 +127,7 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
         onToggleSimulation={() => setShowSim((v) => !v)}
         isSimulating={showSim}
       />
+      <StorySceneSummary nodes={nodes} edges={edges} />
       <div data-testid="flow-workspace" className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
         {/* Canvas */}
         <div
@@ -160,7 +162,7 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
         <div className="flex max-h-[55vh] w-full shrink-0 flex-col overflow-y-auto border-t border-slate-800 bg-slate-900 lg:max-h-none lg:w-72 lg:border-l lg:border-t-0">
           {!showSim && !selectedNode && (
             <div className="p-4 text-sm leading-6 text-slate-400">
-              페이즈나 결말 노드를 선택하면 세부 설정을 편집할 수 있습니다.
+              장면이나 결말을 선택하면 세부 설정을 편집할 수 있습니다.
             </div>
           )}
           {showSim && (

--- a/apps/web/src/features/editor/components/design/FlowSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/FlowSubTab.tsx
@@ -9,11 +9,11 @@ export function FlowSubTab({ themeId }: FlowSubTabProps) {
     <div className="flex h-full min-h-0 flex-col bg-slate-950">
       <header className="shrink-0 border-b border-slate-800 bg-slate-900/70 px-4 py-3 lg:px-6">
         <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
-          페이즈 entity
+          스토리 제작
         </p>
-        <h2 className="mt-1 text-lg font-semibold text-slate-100">페이즈 흐름</h2>
+        <h2 className="mt-1 text-lg font-semibold text-slate-100">장면 흐름</h2>
         <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
-          페이즈는 게임 진행 순서를 화살표로 연결합니다. 노드를 선택하면 아래 또는 오른쪽에서 세부 설정을 편집할 수 있습니다.
+          장면은 게임 진행 순서를 화살표로 연결합니다. 장면을 선택하면 아래 또는 오른쪽에서 정보 공개와 시작/종료 실행을 편집할 수 있습니다.
         </p>
       </header>
       <div className="min-h-0 flex-1">

--- a/apps/web/src/features/editor/components/design/FlowToolbar.tsx
+++ b/apps/web/src/features/editor/components/design/FlowToolbar.tsx
@@ -24,7 +24,7 @@ interface NodeOption {
 }
 
 const NODE_OPTIONS: NodeOption[] = [
-  { type: "phase", label: "페이즈", description: "게임 단계" },
+  { type: "phase", label: "장면", description: "스토리 진행" },
   { type: "branch", label: "분기", description: "조건 분기" },
   { type: "ending", label: "엔딩", description: "게임 종료" },
 ];
@@ -76,7 +76,7 @@ export function FlowToolbar({
           className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs text-slate-300 transition-colors hover:border-amber-500 hover:text-amber-400"
         >
           <Plus className="h-3.5 w-3.5" />
-          노드 추가
+          항목 추가
           <ChevronDown className="h-3 w-3" />
         </button>
 

--- a/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
@@ -33,7 +33,7 @@ export function NodeDetailPanel({
   if (!node) {
     return (
       <div className="flex h-full items-center justify-center p-4">
-        <span className="text-xs text-slate-500">편집할 페이즈나 결말 노드를 선택하세요</span>
+        <span className="text-xs text-slate-500">편집할 장면이나 결말을 선택하세요</span>
       </div>
     );
   }

--- a/apps/web/src/features/editor/components/design/PhaseNode.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNode.tsx
@@ -26,7 +26,7 @@ export function PhaseNode({
       <div className="flex items-center gap-2">
         <Layers className="h-4 w-4 shrink-0 text-amber-400" />
         <span className="text-xs font-medium text-slate-200">
-          {data.label ?? "새 페이즈"}
+          {data.label ?? "새 장면"}
         </span>
       </div>
 

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -70,7 +70,7 @@ export function PhaseNodePanel({ node, themeId, onUpdate, edges = [] }: PhaseNod
   return (
     <div className="flex flex-col gap-3 p-4">
       <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-        페이즈 설정
+        장면 설정
       </h3>
 
       <PhaseSummaryCard viewModel={viewModel} />
@@ -106,13 +106,13 @@ export function PhaseNodePanel({ node, themeId, onUpdate, edges = [] }: PhaseNod
       <div className="border-t border-slate-800" />
 
       <ActionListEditor
-        label="진입 액션 (onEnter)"
+        label="장면 시작 때 적용"
         actions={(data.onEnter as PhaseAction[]) ?? []}
         onChange={(actions) => handleChange({ onEnter: actions })}
         hiddenTypes={[DELIVER_INFORMATION_ACTION, "deliver_information"]}
       />
       <ActionListEditor
-        label="퇴장 액션 (onExit)"
+        label="장면 종료 때 적용"
         actions={(data.onExit as PhaseAction[]) ?? []}
         onChange={(actions) => handleChange({ onExit: actions })}
       />
@@ -124,16 +124,16 @@ export function PhaseNodePanel({ node, themeId, onUpdate, edges = [] }: PhaseNod
 function PhaseSummaryCard({ viewModel }: { viewModel: PhaseEditorViewModel }) {
   const enterActions = viewModel.enterActionLabels.length > 0
     ? viewModel.enterActionLabels.join(", ")
-    : "추가 실행 없음";
+    : "시작 변화 없음";
   const exitActions = viewModel.exitActionLabels.length > 0
     ? viewModel.exitActionLabels.join(", ")
-    : "종료 실행 없음";
+    : "마무리 변화 없음";
 
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
       <div className="flex flex-col gap-1">
         <p className="text-[11px] font-semibold uppercase tracking-wider text-amber-300/80">
-          페이즈 요약
+          장면 요약
         </p>
         <h4 className="text-sm font-semibold text-slate-100">{viewModel.title}</h4>
         <p className="text-xs leading-5 text-slate-500">

--- a/apps/web/src/features/editor/components/design/PhasePanelBasicInfo.tsx
+++ b/apps/web/src/features/editor/components/design/PhasePanelBasicInfo.tsx
@@ -31,7 +31,7 @@ export function PhasePanelBasicInfo({
           value={label ?? ""}
           onChange={(e) => onChange({ label: e.target.value })}
           onBlur={onFlush}
-          placeholder="페이즈 이름"
+          placeholder="장면 이름"
           className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
         />
       </div>

--- a/apps/web/src/features/editor/components/design/StorySceneSummary.tsx
+++ b/apps/web/src/features/editor/components/design/StorySceneSummary.tsx
@@ -1,0 +1,91 @@
+import type { Edge, Node } from "@xyflow/react";
+import {
+  toStorySceneFlowSummary,
+  type StorySceneFlowSummary,
+} from "../../entities/story/storySceneAdapter";
+
+interface StorySceneSummaryProps {
+  nodes?: Node[];
+  edges?: Edge[];
+  summary?: StorySceneFlowSummary;
+}
+
+export function StorySceneSummary({
+  nodes = [],
+  edges = [],
+  summary,
+}: StorySceneSummaryProps) {
+  const resolvedSummary = summary ?? toStorySceneFlowSummary(nodes, edges);
+  const previewScenes = resolvedSummary.scenes.slice(0, 4);
+
+  return (
+    <section className="border-b border-slate-800 bg-slate-900/60 px-4 py-3 lg:px-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
+            스토리 구성
+          </p>
+          <h3 className="mt-1 text-sm font-semibold text-slate-100">스토리 장면 구성</h3>
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-slate-400">
+            장면은 플레이어가 실제로 지나가는 진행 단위입니다. 이 화면에서 장면 순서,
+            조건 이동, 정보 공개, 시작/마무리 변화를 함께 점검합니다.
+          </p>
+        </div>
+
+        <div className="grid min-w-0 grid-cols-3 gap-2 text-xs">
+          <SummaryPill label="장면" value={resolvedSummary.sceneCountLabel} />
+          <SummaryPill label="이동" value={resolvedSummary.transitionCountLabel} />
+          <SummaryPill label="조건" value={resolvedSummary.conditionalTransitionCountLabel} />
+        </div>
+      </div>
+
+      {previewScenes.length > 0 ? (
+        <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+          {previewScenes.map((scene) => (
+            <article
+              key={scene.id}
+              className="min-w-0 rounded border border-slate-800 bg-slate-950/70 p-3"
+            >
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <h4 className="truncate text-xs font-semibold text-slate-100">
+                  {scene.title}
+                </h4>
+                <span className="shrink-0 rounded bg-slate-800 px-2 py-0.5 text-[10px] text-slate-300">
+                  {scene.typeLabel}
+                </span>
+              </div>
+              <dl className="mt-2 grid gap-1 text-[11px] leading-5 text-slate-400">
+                <SceneFact label="정보" value={scene.informationLabel} />
+                <SceneFact label="이동" value={scene.transitionLabel} />
+                <SceneFact label="시작 변화" value={scene.startActionLabel} />
+                <SceneFact label="마무리 변화" value={scene.endActionLabel} />
+              </dl>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-3 rounded border border-dashed border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-500">
+          장면을 추가하면 스토리 진행 구성이 여기에 표시됩니다.
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SummaryPill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-slate-800 bg-slate-950/70 px-3 py-2">
+      <p className="text-[10px] text-slate-500">{label}</p>
+      <p className="mt-0.5 whitespace-nowrap text-slate-100">{value}</p>
+    </div>
+  );
+}
+
+function SceneFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-2">
+      <dt className="shrink-0 text-slate-500">{label}</dt>
+      <dd className="truncate text-slate-300">{value}</dd>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
@@ -160,7 +160,7 @@ describe('DesignTab', () => {
 
     fireEvent.click(screen.getByText('흐름'));
     expect(screen.getByText('FlowSubTab 콘텐츠')).toBeDefined();
-    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/flow');
+    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/design/flow');
   });
 
   it('장소 탭 클릭 시 장소 콘텐츠로 전환된다', () => {
@@ -168,7 +168,7 @@ describe('DesignTab', () => {
 
     fireEvent.click(screen.getByText('장소'));
     expect(screen.getByText('LocationsSubTab 콘텐츠')).toBeDefined();
-    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/locations');
+    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/design/locations');
   });
 
   it('결말 탭 클릭 시 결말 entity 콘텐츠로 전환된다', () => {
@@ -176,7 +176,7 @@ describe('DesignTab', () => {
 
     fireEvent.click(screen.getByText('결말'));
     expect(screen.getByText('EndingEntitySubTab 콘텐츠')).toBeDefined();
-    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/endings');
+    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/design/endings');
   });
 
   it.each([

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -85,6 +85,31 @@ describe('FlowCanvas', () => {
     expect(screen.getByTestId('react-flow')).toBeDefined();
   });
 
+  it('장면 노드가 있으면 스토리 장면 요약을 렌더링한다', () => {
+    useFlowDataMock.mockReturnValue({
+      nodes: [
+        {
+          id: 'scene-1',
+          type: 'phase',
+          position: { x: 0, y: 0 },
+          data: { label: '오프닝', phase_type: 'story_progression' },
+        },
+      ],
+      edges: [],
+      onNodesChange: vi.fn(),
+      onEdgesChange: vi.fn(),
+      onConnect: vi.fn(),
+      isLoading: false,
+      isSaving: false,
+      save: saveMock,
+    });
+
+    render(<FlowCanvas themeId="theme-1" />);
+    expect(screen.getByText('스토리 장면 구성')).toBeDefined();
+    expect(screen.getByText('1개 장면')).toBeDefined();
+    expect(screen.getByText('오프닝')).toBeDefined();
+  });
+
   it('모바일 우선 세로 레이아웃을 사용하고 데스크톱에서만 2열로 바뀐다', () => {
     render(<FlowCanvas themeId="theme-1" />);
     const workspace = screen.getByTestId('flow-workspace');
@@ -127,12 +152,12 @@ describe('FlowToolbar', () => {
     expect(screen.getByText('저장 중...')).toBeDefined();
   });
 
-  it('노드 추가 버튼 클릭 시 드롭다운이 열린다', () => {
+  it('항목 추가 버튼 클릭 시 드롭다운이 열린다', () => {
     render(
       <FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={false} />,
     );
-    fireEvent.click(screen.getByText('노드 추가'));
-    expect(screen.getByText('페이즈')).toBeDefined();
+    fireEvent.click(screen.getByText('항목 추가'));
+    expect(screen.getByText('장면')).toBeDefined();
     expect(screen.getByText('분기')).toBeDefined();
     expect(screen.getByText('엔딩')).toBeDefined();
   });
@@ -142,8 +167,8 @@ describe('FlowToolbar', () => {
     render(
       <FlowToolbar onAddNode={onAddNode} onSave={vi.fn()} isSaving={false} />,
     );
-    fireEvent.click(screen.getByText('노드 추가'));
-    fireEvent.click(screen.getByText('페이즈'));
+    fireEvent.click(screen.getByText('항목 추가'));
+    fireEvent.click(screen.getByText('장면'));
     expect(onAddNode).toHaveBeenCalledWith('phase');
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/FlowSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowSubTab.test.tsx
@@ -33,8 +33,8 @@ afterEach(() => {
 describe('FlowSubTab', () => {
   it('FlowCanvas를 렌더링한다', () => {
     render(<FlowSubTab themeId="theme-1" />);
-    expect(screen.getByText('페이즈 흐름')).toBeDefined();
-    expect(screen.getByText(/페이즈는 게임 진행 순서를 화살표로 연결합니다/)).toBeDefined();
+    expect(screen.getByText('장면 흐름')).toBeDefined();
+    expect(screen.getByText(/장면은 게임 진행 순서를 화살표로 연결합니다/)).toBeDefined();
     expect(screen.getByTestId('flow-canvas')).toBeDefined();
   });
 

--- a/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
@@ -7,7 +7,7 @@ import type { Node } from "@xyflow/react";
 // ---------------------------------------------------------------------------
 
 vi.mock("../PhaseNodePanel", () => ({
-  PhaseNodePanel: () => <div>페이즈 설정</div>,
+  PhaseNodePanel: () => <div>장면 설정</div>,
 }));
 
 // ---------------------------------------------------------------------------
@@ -43,7 +43,7 @@ function makeNode(type: string, data: Record<string, unknown> = {}): Node {
 // ---------------------------------------------------------------------------
 
 describe("NodeDetailPanel", () => {
-  it("node가 null이면 '편집할 페이즈나 결말 노드를 선택하세요' 를 표시한다", () => {
+  it("node가 null이면 '편집할 장면이나 결말을 선택하세요' 를 표시한다", () => {
     render(
       <NodeDetailPanel
         node={null}
@@ -52,7 +52,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText("편집할 페이즈나 결말 노드를 선택하세요")).toBeDefined();
+    expect(screen.getByText("편집할 장면이나 결말을 선택하세요")).toBeDefined();
   });
 
   it("start 노드이면 편집 불가 메시지를 표시한다", () => {
@@ -88,7 +88,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText("페이즈 설정")).toBeDefined();
+    expect(screen.getByText("장면 설정")).toBeDefined();
   });
 
   it("phase 노드에는 삭제 버튼이 있다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNode.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNode.test.tsx
@@ -50,9 +50,9 @@ function makeProps(data: Record<string, unknown> = {}, selected = false) {
 // ---------------------------------------------------------------------------
 
 describe("PhaseNode", () => {
-  it("기본 라벨 '새 페이즈'를 렌더링한다", () => {
+  it("기본 라벨 '새 장면'을 렌더링한다", () => {
     render(<PhaseNode {...makeProps()} />);
-    expect(screen.getByText("새 페이즈")).toBeDefined();
+    expect(screen.getByText("새 장면")).toBeDefined();
   });
 
   it("data.label이 있으면 해당 라벨을 렌더링한다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx
@@ -95,7 +95,7 @@ describe("PhaseNodePanel debounce + onBlur flush", () => {
       />,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.change(labelInput, { target: { value: "수사 페이즈" } });
 
     // 500ms old threshold — must NOT fire (regression guard).
@@ -120,7 +120,7 @@ describe("PhaseNodePanel debounce + onBlur flush", () => {
       />,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.change(labelInput, { target: { value: "A" } });
     await act(async () => { vi.advanceTimersByTime(1000); });
     fireEvent.change(labelInput, { target: { value: "AB" } });
@@ -139,7 +139,7 @@ describe("PhaseNodePanel debounce + onBlur flush", () => {
       />,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.change(labelInput, { target: { value: "즉시" } });
     expect(mutateMock).not.toHaveBeenCalled();
 
@@ -180,7 +180,7 @@ describe("PhaseNodePanel debounce + onBlur flush", () => {
       />,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.blur(labelInput);
     expect(mutateMock).not.toHaveBeenCalled();
   });
@@ -203,7 +203,7 @@ describe("PhaseNodePanel optimistic update + rollback", () => {
       </QueryClientProvider>,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.change(labelInput, { target: { value: "낙관" } });
     fireEvent.blur(labelInput); // flush
 
@@ -228,7 +228,7 @@ describe("PhaseNodePanel optimistic update + rollback", () => {
       </QueryClientProvider>,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.change(labelInput, { target: { value: "실패할 라벨" } });
     fireEvent.blur(labelInput); // flush → mutate → onError → rollback
 
@@ -253,7 +253,7 @@ describe("PhaseNodePanel optimistic update + rollback", () => {
       </QueryClientProvider>,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.change(labelInput, { target: { value: "unmount-flush" } });
     // Do NOT advance timers or blur — leave a pending write.
     expect(mutateMock).not.toHaveBeenCalled();
@@ -279,7 +279,7 @@ describe("PhaseNodePanel optimistic update + rollback", () => {
       </QueryClientProvider>,
     );
 
-    const labelInput = screen.getByPlaceholderText("페이즈 이름");
+    const labelInput = screen.getByPlaceholderText("장면 이름");
     fireEvent.change(labelInput, { target: { value: "cache-less" } });
     fireEvent.blur(labelInput);
 

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -89,7 +89,7 @@ describe("PhaseNodePanel extended fields", () => {
     expect(screen.queryByPlaceholderText("30")).toBeNull();
   });
 
-  it("onEnter 액션 섹션이 렌더링된다", () => {
+  it("장면 시작/종료 적용 섹션이 렌더링된다", () => {
     renderWithQC(
       <PhaseNodePanel
         node={makeNode()}
@@ -97,7 +97,7 @@ describe("PhaseNodePanel extended fields", () => {
         onUpdate={vi.fn()}
       />,
     );
-    expect(screen.getByText("진입 액션 (onEnter)")).toBeDefined();
-    expect(screen.getByText("퇴장 액션 (onExit)")).toBeDefined();
+    expect(screen.getByText("장면 시작 때 적용")).toBeDefined();
+    expect(screen.getByText("장면 종료 때 적용")).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
@@ -81,7 +81,7 @@ function buildEndingWarnings(
     warnings.push(`${missingContent}개 결말은 이름 또는 본문이 비어 있습니다.`);
   }
   if (connectedCount === 0) {
-    warnings.push("페이즈 흐름에서 결말로 이어지는 경로가 아직 없습니다.");
+    warnings.push("장면 흐름에서 결말로 이어지는 경로가 아직 없습니다.");
   }
   return warnings;
 }

--- a/apps/web/src/features/editor/entities/phase/phaseEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/phase/phaseEntityAdapter.ts
@@ -58,7 +58,7 @@ export function toPhaseEditorViewModel(
   const conditionalEdges = outgoingEdges.filter(hasEdgeCondition);
 
   return {
-    title: data.label?.trim() || "새 페이즈",
+    title: data.label?.trim() || "새 장면",
     phaseType,
     phaseTypeLabel: PHASE_TYPE_LABELS[phaseType] ?? "직접 설정한 페이즈",
     durationLabel: formatMinutes(data.duration),

--- a/apps/web/src/features/editor/entities/story/__tests__/storySceneAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/story/__tests__/storySceneAdapter.test.ts
@@ -1,0 +1,120 @@
+import type { Edge, Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import { DELIVER_INFORMATION_ACTION } from "../../shared/actionAdapter";
+import {
+  toStorySceneFlowSummary,
+  toStorySceneFlowSummaryFromGraph,
+} from "../storySceneAdapter";
+
+describe("storySceneAdapter", () => {
+  it("Flow phase node를 제작자용 스토리 장면 요약으로 변환한다", () => {
+    const nodes: Node[] = [
+      { id: "start", type: "start", position: { x: 0, y: 0 }, data: {} },
+      {
+        id: "scene-2",
+        type: "phase",
+        position: { x: 200, y: 100 },
+        data: { label: "토론", phase_type: "discussion", onExit: [{ type: "disable_chat" }] },
+      },
+      {
+        id: "scene-1",
+        type: "phase",
+        position: { x: 100, y: 50 },
+        data: {
+          label: "오프닝",
+          phase_type: "story_progression",
+          onEnter: [
+            { type: "play_bgm" },
+            {
+              type: DELIVER_INFORMATION_ACTION,
+              params: {
+                deliveries: [
+                  {
+                    target: { type: "all_players" },
+                    reading_section_ids: ["reading-1"],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ];
+    const edges: Edge[] = [
+      { id: "edge-1", source: "scene-1", target: "scene-2" },
+      {
+        id: "edge-2",
+        source: "scene-2",
+        target: "ending-1",
+        data: { condition: { op: "and", clauses: [{ fact: "has_clue" }] } },
+      },
+    ];
+
+    expect(toStorySceneFlowSummary(nodes, edges)).toEqual({
+      sceneCountLabel: "2개 장면",
+      transitionCountLabel: "2개 이동",
+      conditionalTransitionCountLabel: "조건 이동 1개",
+      scenes: [
+        {
+          id: "scene-1",
+          title: "오프닝",
+          typeLabel: "스토리 진행",
+          informationLabel: "1개 정보 공개",
+          transitionLabel: "기본 이동 1개 · 조건 이동 0개",
+          startActionLabel: "변화 1개",
+          endActionLabel: "변화 없음",
+        },
+        {
+          id: "scene-2",
+          title: "토론",
+          typeLabel: "토론",
+          informationLabel: "0개 정보 공개",
+          transitionLabel: "기본 이동 없음 · 조건 이동 1개",
+          startActionLabel: "변화 없음",
+          endActionLabel: "변화 1개",
+        },
+      ],
+    });
+  });
+
+  it("API graph 응답의 source_id/target_id 조건 이동을 장면 요약으로 변환한다", () => {
+    const summary = toStorySceneFlowSummaryFromGraph({
+      nodes: [
+        {
+          id: "scene-1",
+          theme_id: "theme-1",
+          type: "phase",
+          data: { label: "수사", phase_type: "investigation" },
+          position_x: 0,
+          position_y: 0,
+          created_at: "2026-05-05T00:00:00Z",
+          updated_at: "2026-05-05T00:00:00Z",
+        },
+      ],
+      edges: [
+        {
+          id: "edge-1",
+          theme_id: "theme-1",
+          source_id: "scene-1",
+          target_id: "ending-1",
+          condition: { op: "and", clauses: [{ fact: "accused" }] },
+          label: null,
+          sort_order: 1,
+          created_at: "2026-05-05T00:00:00Z",
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      sceneCountLabel: "1개 장면",
+      transitionCountLabel: "1개 이동",
+      conditionalTransitionCountLabel: "조건 이동 1개",
+      scenes: [
+        {
+          title: "수사",
+          transitionLabel: "기본 이동 없음 · 조건 이동 1개",
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/features/editor/entities/story/storySceneAdapter.ts
+++ b/apps/web/src/features/editor/entities/story/storySceneAdapter.ts
@@ -1,0 +1,109 @@
+import type { Edge, Node } from "@xyflow/react";
+import type {
+  FlowEdgeResponse,
+  FlowGraphResponse,
+  FlowNodeData,
+} from "../../flowTypes";
+import { toPhaseEditorViewModel } from "../phase/phaseEntityAdapter";
+
+export interface StorySceneViewModel {
+  id: string;
+  title: string;
+  typeLabel: string;
+  informationLabel: string;
+  transitionLabel: string;
+  startActionLabel: string;
+  endActionLabel: string;
+}
+
+export interface StorySceneFlowSummary {
+  scenes: StorySceneViewModel[];
+  sceneCountLabel: string;
+  transitionCountLabel: string;
+  conditionalTransitionCountLabel: string;
+}
+
+export function toStorySceneFlowSummary(
+  nodes: Node[],
+  edges: Edge[],
+): StorySceneFlowSummary {
+  const scenes = nodes
+    .filter((node) => node.type === "phase")
+    .sort(compareSceneNodes)
+    .map((node) => toStorySceneViewModel(node, edges));
+  const conditionalCount = edges.filter(hasCompleteCondition).length;
+
+  return {
+    scenes,
+    sceneCountLabel: `${scenes.length}개 장면`,
+    transitionCountLabel: `${edges.length}개 이동`,
+    conditionalTransitionCountLabel: conditionalCount === 0
+      ? "조건 이동 없음"
+      : `조건 이동 ${conditionalCount}개`,
+  };
+}
+
+export function toStorySceneFlowSummaryFromGraph(
+  graph: FlowGraphResponse | undefined,
+): StorySceneFlowSummary {
+  return toStorySceneFlowSummary(
+    (graph?.nodes ?? []).map((node) => ({
+      id: node.id,
+      type: node.type,
+      position: { x: node.position_x, y: node.position_y },
+      data: node.data,
+    })),
+    (graph?.edges ?? []).map(toStorySceneEdge),
+  );
+}
+
+function toStorySceneViewModel(node: Node, edges: Edge[]): StorySceneViewModel {
+  const outgoingEdges = edges.filter((edge) => edge.source === node.id);
+  const phaseViewModel = toPhaseEditorViewModel(
+    node.data as FlowNodeData,
+    outgoingEdges,
+  );
+
+  return {
+    id: node.id,
+    title: phaseViewModel.title,
+    typeLabel: phaseViewModel.phaseTypeLabel,
+    informationLabel: `${phaseViewModel.informationDeliveryCount}개 정보 공개`,
+    transitionLabel: [
+      phaseViewModel.defaultTransitionLabel,
+      `조건 이동 ${phaseViewModel.conditionalTransitionCount}개`,
+    ].join(" · "),
+    startActionLabel: formatActionCount(phaseViewModel.enterActionLabels.length),
+    endActionLabel: formatActionCount(phaseViewModel.exitActionLabels.length),
+  };
+}
+
+function compareSceneNodes(left: Node, right: Node): number {
+  if (left.position.y !== right.position.y) return left.position.y - right.position.y;
+  if (left.position.x !== right.position.x) return left.position.x - right.position.x;
+  return left.id.localeCompare(right.id);
+}
+
+function formatActionCount(count: number): string {
+  if (count === 0) return "변화 없음";
+  return `변화 ${count}개`;
+}
+
+function toStorySceneEdge(edge: FlowEdgeResponse): Edge {
+  return {
+    id: edge.id,
+    source: edge.source_id,
+    target: edge.target_id,
+    label: edge.label ?? undefined,
+    data: { condition: edge.condition, sort_order: edge.sort_order },
+  };
+}
+
+function hasCompleteCondition(edge: Edge): boolean {
+  const condition = (edge.data as { condition?: unknown } | undefined)?.condition;
+  return (
+    !!condition &&
+    typeof condition === "object" &&
+    Object.keys(condition).length > 0
+  );
+}

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -113,7 +113,7 @@ export function useFlowData(themeId: string) {
       createNode.mutate(
         {
           type,
-          data: { label: type === "phase" ? "새 페이즈" : undefined },
+          data: { label: type === "phase" ? "새 장면" : undefined },
           position_x: position.x,
           position_y: position.y,
         },

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -4,6 +4,7 @@ export type DesignSubTab = "modules" | "flow" | "locations" | "endings";
 
 const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
   overview: "overview",
+  design: "design",
   story: "story",
   characters: "characters",
   clues: "clues",
@@ -19,6 +20,7 @@ const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
 };
 
 const DESIGN_ROUTE_SUBTAB_MAP: Record<string, DesignSubTab> = {
+  design: "modules",
   modules: "modules",
   flow: "flow",
   locations: "locations",

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -6,15 +6,20 @@ import { readEditorTabFromRouteSegment } from "@/features/editor/routeSegments";
 import { useEditorUI } from "@/features/editor/stores/editorUIStore";
 
 export default function EditorPage() {
-  const { id, tab } = useParams<{ id: string; tab?: string }>();
+  const { id, tab, designTab } = useParams<{
+    id: string;
+    tab?: string;
+    designTab?: string;
+  }>();
   const setActiveTab = useEditorUI((state) => state.setActiveTab);
+  const routeSegment = designTab ?? tab;
 
   useEffect(() => {
-    setActiveTab(readEditorTabFromRouteSegment(tab));
-  }, [setActiveTab, tab]);
+    setActiveTab(readEditorTabFromRouteSegment(routeSegment));
+  }, [setActiveTab, routeSegment]);
 
   if (id) {
-    return <ThemeEditor themeId={id} routeSegment={tab} />;
+    return <ThemeEditor themeId={id} routeSegment={routeSegment} />;
   }
 
   return <EditorDashboard />;

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -51,6 +51,7 @@ describe('EditorPage', () => {
   });
 
   it.each([
+    ['design', 'design'],
     ['story', 'story'],
     ['characters', 'characters'],
     ['clues', 'clues'],
@@ -65,6 +66,15 @@ describe('EditorPage', () => {
 
     expect(screen.getByText(new RegExp(`테마 에디터 theme-1 ${segment}`))).toBeDefined();
     expect(setActiveTabMock).toHaveBeenCalledWith(expectedTab);
+  });
+
+  it('design 하위 route segment를 실제 DesignTab subtab segment로 전달한다', () => {
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: 'design', designTab: 'flow' });
+
+    render(<EditorPage />);
+
+    expect(screen.getByText(/테마 에디터 theme-1 flow/)).toBeDefined();
+    expect(setActiveTabMock).toHaveBeenCalledWith('design');
   });
 
   it('modules 라우트 segment를 design 탭으로 매핑한다', () => {


### PR DESCRIPTION
## 요약
- /editor/:id/story 와 /editor/:id/design/flow 에 Flow 기반 스토리 장면 요약을 표시합니다.
- /editor/:id/design/:designTab 직접 URL을 추가하고 DesignTab 클릭 URL도 같은 체계로 맞췄습니다.
- phase/node/onEnter/onExit 중심 문구를 제작자용 장면/시작 변화/마무리 변화 표현으로 정리했습니다.

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/components/__tests__/StoryTab.test.tsx src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/design/__tests__/FlowSubTab.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx src/features/editor/components/design/__tests__/PhaseNode.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx src/features/editor/entities/story/__tests__/storySceneAdapter.test.ts src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --grep "직접 URL" --project=chromium

## 참고
- 전체 Playwright grep 실행에서 로컬 Firefox 바이너리 누락으로 firefox shard만 실행 전 실패했고, 동일 smoke는 Chromium에서 통과했습니다.
- backend runtime 장면 전환 판정은 #299 본문 PR2 범위로 이어갑니다.

Refs #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 스토리 장면 구성 요약 영역 추가: 장면/전환/조건부 전환 메트릭과 최대 4개 장면 미리보기 제공
  * 편집기에서 /editor/:id/design/:designTab 경로 지원 추가

* **개선 사항**
  * 편집기 전반 용어를 "페이즈"에서 "장면"으로 일괄 변경(레이블·플레이스홀더·문구)
  * 편집/미리보기 분할 레이아웃의 반응형 동작 및 관련 UI 문구 개선

* **테스트**
  * 요약 UI, 라우팅, 편집기 컴포넌트 관련 테스트 추가 및 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->