### PR TITLE
feat(server): #312 스토리 장면 runtime 계약 고정

### DIFF
--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -28,8 +28,9 @@ type ModuleConfig struct {
 // Only the fields needed for runtime wiring are declared here;
 // additional editor-only fields are ignored.
 type GameConfig struct {
-	Phases  []PhaseDefinition `json:"phases"`
-	Modules []ModuleConfig    `json:"modules"`
+	Phases           []PhaseDefinition `json:"phases"`
+	SceneTransitions []SceneTransition `json:"sceneTransitions,omitempty"`
+	Modules          []ModuleConfig    `json:"modules"`
 }
 
 // HostSubmittable is an optional interface for modules that can be submitted
@@ -49,8 +50,9 @@ func ParseGameConfig(raw json.RawMessage) (*GameConfig, error) {
 	dec.DisallowUnknownFields()
 
 	var wire struct {
-		Phases  []PhaseDefinition `json:"phases"`
-		Modules json.RawMessage   `json:"modules"`
+		Phases           []PhaseDefinition `json:"phases"`
+		SceneTransitions []SceneTransition `json:"sceneTransitions,omitempty"`
+		Modules          json.RawMessage   `json:"modules"`
 	}
 	if err := dec.Decode(&wire); err != nil {
 		return nil, apperror.New(apperror.ErrBadRequest, http.StatusBadRequest, "invalid game config: "+err.Error())
@@ -58,7 +60,10 @@ func ParseGameConfig(raw json.RawMessage) (*GameConfig, error) {
 	if err := rejectTrailingJSON(dec); err != nil {
 		return nil, apperror.New(apperror.ErrBadRequest, http.StatusBadRequest, "invalid game config: "+err.Error())
 	}
-	cfg := GameConfig{Phases: wire.Phases}
+	cfg := GameConfig{
+		Phases:           wire.Phases,
+		SceneTransitions: wire.SceneTransitions,
+	}
 	modules, err := parseModuleConfigs(wire.Modules)
 	if err != nil {
 		return nil, err

--- a/apps/server/internal/engine/factory_test.go
+++ b/apps/server/internal/engine/factory_test.go
@@ -20,6 +20,21 @@ func TestParseGameConfig_Valid(t *testing.T) {
 	}
 }
 
+func TestParseGameConfig_PreservesSceneTransitions(t *testing.T) {
+	data := []byte(`{"phases":[{"id":"intro","name":"Intro"},{"id":"invest","name":"Invest"}],"sceneTransitions":[{"id":"edge-1","from":"intro","to":"invest","label":"조사 시작","sortOrder":2}],"modules":[]}`)
+	cfg, err := ParseGameConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.SceneTransitions) != 1 {
+		t.Fatalf("expected 1 scene transition, got %d", len(cfg.SceneTransitions))
+	}
+	transition := cfg.SceneTransitions[0]
+	if transition.ID != "edge-1" || transition.From != "intro" || transition.To != "invest" || transition.SortOrder != 2 {
+		t.Fatalf("scene transition = %#v", transition)
+	}
+}
+
 func TestParseGameConfig_Empty(t *testing.T) {
 	data := []byte(`{"phases":[{"id":"p1","name":"Phase 1"}],"modules":[]}`)
 	cfg, err := ParseGameConfig(data)

--- a/apps/server/internal/engine/module_types.go
+++ b/apps/server/internal/engine/module_types.go
@@ -35,15 +35,27 @@ type GameState struct {
 type Phase string
 
 // PhaseDefinition describes a phase: its identifier, display name, and optional
-// transition rules expressed as JSON Logic payloads.
+// backend action payloads to dispatch when entering or leaving the phase.
 type PhaseDefinition struct {
 	ID          Phase  `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
-	// OnEnter is an optional JSON Logic rule evaluated when entering this phase.
+	// OnEnter is an optional configured action payload dispatched by the engine.
 	OnEnter json.RawMessage `json:"onEnter,omitempty"`
-	// OnExit is an optional JSON Logic rule evaluated when leaving this phase.
+	// OnExit is an optional configured action payload dispatched by the engine.
 	OnExit json.RawMessage `json:"onExit,omitempty"`
+}
+
+// SceneTransition is the backend runtime contract for graph-based story
+// movement. Frontend Flow data may author these edges, but PhaseEngine is the
+// source of truth for condition evaluation and the final phase mutation.
+type SceneTransition struct {
+	ID        string          `json:"id,omitempty"`
+	From      Phase           `json:"from"`
+	To        Phase           `json:"to"`
+	Label     string          `json:"label,omitempty"`
+	SortOrder int32           `json:"sortOrder,omitempty"`
+	Condition json.RawMessage `json:"condition,omitempty"`
 }
 
 // WinResult carries the outcome of a win-condition check.

--- a/apps/server/internal/engine/phase_engine.go
+++ b/apps/server/internal/engine/phase_engine.go
@@ -39,6 +39,7 @@ type PhaseEngine struct {
 	logger             Logger
 	playerInfoProvider PlayerInfoProvider
 	phases             []PhaseDefinition
+	sceneTransitions   []SceneTransition
 	current            int // index into phases, -1 = not started
 	currentRound       int32
 	started            bool

--- a/apps/server/internal/engine/scene_transitions.go
+++ b/apps/server/internal/engine/scene_transitions.go
@@ -1,0 +1,149 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// SetSceneTransitions installs graph-based story movement rules for the
+// session. The engine copies and validates the edges so runtime phase mutation
+// never depends on frontend-only state.
+func (e *PhaseEngine) SetSceneTransitions(transitions []SceneTransition) error {
+	for _, transition := range transitions {
+		if transition.From == "" {
+			return fmt.Errorf("engine: scene transition from phase is required")
+		}
+		if transition.To == "" {
+			return fmt.Errorf("engine: scene transition target phase is required")
+		}
+		if e.phaseIndex(transition.From) < 0 {
+			return fmt.Errorf("engine: scene transition source phase %q not found", transition.From)
+		}
+		if e.phaseIndex(transition.To) < 0 {
+			return fmt.Errorf("engine: scene transition target phase %q not found", transition.To)
+		}
+	}
+	e.sceneTransitions = append([]SceneTransition(nil), transitions...)
+	return nil
+}
+
+// AdvanceScene evaluates configured scene transitions from the current phase
+// and moves to the first matching target. If no scene graph is installed, it
+// preserves the legacy linear AdvancePhase behavior.
+func (e *PhaseEngine) AdvanceScene(ctx context.Context, conditionContext json.RawMessage) (bool, error) {
+	if !e.started || e.stopped {
+		return false, fmt.Errorf("engine: not running")
+	}
+	if len(e.sceneTransitions) == 0 {
+		return e.AdvancePhase(ctx)
+	}
+
+	oldIndex := e.current
+	oldRound := e.currentRound
+	oldPhase := e.phases[oldIndex]
+	candidates := e.sceneTransitionsFrom(oldPhase.ID)
+	if len(candidates) == 0 {
+		return e.completeFromCurrentPhase(ctx, oldPhase, oldRound)
+	}
+
+	transition, matched, err := e.matchSceneTransition(candidates, conditionContext)
+	if err != nil {
+		return false, err
+	}
+	if !matched {
+		return false, fmt.Errorf("engine: no matching scene transition from phase %q", oldPhase.ID)
+	}
+
+	targetIndex := e.phaseIndex(transition.To)
+	if targetIndex < 0 {
+		return false, fmt.Errorf("engine: scene transition target phase %q not found", transition.To)
+	}
+	if err := e.exitCurrentPhase(ctx); err != nil {
+		return false, err
+	}
+	e.current = targetIndex
+	e.currentRound = oldRound + 1
+	if err := e.enterCurrentPhase(ctx); err != nil {
+		e.current = oldIndex
+		e.currentRound = oldRound
+		e.auditEvent(ctx, "phase.enter_failed", map[string]any{
+			"from":  oldPhase.ID,
+			"to":    transition.To,
+			"error": err.Error(),
+		})
+		return false, err
+	}
+
+	newPhase := e.phases[e.current]
+	e.auditEvent(ctx, "phase.scene_transitioned", map[string]any{
+		"from":         oldPhase.ID,
+		"to":           newPhase.ID,
+		"round":        e.currentRound,
+		"transitionId": transition.ID,
+		"label":        transition.Label,
+	})
+	return true, nil
+}
+
+func (e *PhaseEngine) completeFromCurrentPhase(ctx context.Context, phase PhaseDefinition, oldRound int32) (bool, error) {
+	if err := e.exitCurrentPhase(ctx); err != nil {
+		return false, err
+	}
+	e.current = len(e.phases)
+	e.currentRound = oldRound
+	e.auditEvent(ctx, "engine.completed", map[string]any{
+		"sessionId": e.sessionID.String(),
+		"lastPhase": phase.ID,
+	})
+	return false, nil
+}
+
+func (e *PhaseEngine) sceneTransitionsFrom(phase Phase) []SceneTransition {
+	candidates := make([]SceneTransition, 0)
+	for _, transition := range e.sceneTransitions {
+		if transition.From == phase {
+			candidates = append(candidates, transition)
+		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].SortOrder < candidates[j].SortOrder
+	})
+	return candidates
+}
+
+func (e *PhaseEngine) matchSceneTransition(transitions []SceneTransition, conditionContext json.RawMessage) (SceneTransition, bool, error) {
+	for _, transition := range transitions {
+		match, err := e.sceneTransitionMatches(transition, conditionContext)
+		if err != nil {
+			return SceneTransition{}, false, err
+		}
+		if match {
+			return transition, true, nil
+		}
+	}
+	return SceneTransition{}, false, nil
+}
+
+func (e *PhaseEngine) sceneTransitionMatches(transition SceneTransition, conditionContext json.RawMessage) (bool, error) {
+	condition := bytes.TrimSpace(transition.Condition)
+	if len(condition) == 0 || bytes.Equal(condition, []byte("null")) {
+		return true, nil
+	}
+	result, err := EvaluateConditionGroup(condition, conditionContext)
+	if err != nil {
+		return false, fmt.Errorf("engine: scene transition %q condition failed: %w", transition.ID, err)
+	}
+	return result.Bool, nil
+}
+
+func (e *PhaseEngine) phaseIndex(phase Phase) int {
+	for idx, definition := range e.phases {
+		if definition.ID == phase {
+			return idx
+		}
+	}
+	return -1
+}

--- a/apps/server/internal/engine/scene_transitions_test.go
+++ b/apps/server/internal/engine/scene_transitions_test.go
@@ -1,0 +1,208 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPhaseEngine_AdvanceSceneSelectsFirstMatchingBackendCondition(t *testing.T) {
+	pe, audit := newTestPhaseEngine(t, nil, testPhaseDefinitions)
+	if err := pe.SetSceneTransitions([]SceneTransition{
+		{
+			ID:        "blocked",
+			From:      "intro",
+			To:        "vote",
+			SortOrder: 0,
+			Condition: sceneTransitionCustomFlagCondition("blocked_route", "true"),
+		},
+		{
+			ID:        "open",
+			From:      "intro",
+			To:        "invest",
+			Label:     "조사 장면으로 이동",
+			SortOrder: 1,
+			Condition: sceneTransitionCustomFlagCondition("open_route", "true"),
+		},
+	}); err != nil {
+		t.Fatalf("SetSceneTransitions: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	advanced, err := pe.AdvanceScene(ctx, json.RawMessage(`{"flags":{"blocked_route":false,"open_route":true}}`))
+	if err != nil || !advanced {
+		t.Fatalf("AdvanceScene: advanced=%v err=%v", advanced, err)
+	}
+	if got := pe.CurrentPhase().ID; got != "invest" {
+		t.Fatalf("CurrentPhase = %s, want invest", got)
+	}
+	if got := pe.CurrentRound(); got != 2 {
+		t.Fatalf("CurrentRound = %d, want 2", got)
+	}
+
+	events := audit.eventsOfType("phase.scene_transitioned")
+	if len(events) != 1 {
+		t.Fatalf("phase.scene_transitioned audits = %d, want 1", len(events))
+	}
+	var payload struct {
+		From         string `json:"from"`
+		To           string `json:"to"`
+		TransitionID string `json:"transitionId"`
+	}
+	if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal audit payload: %v", err)
+	}
+	if payload.From != "intro" || payload.To != "invest" || payload.TransitionID != "open" {
+		t.Fatalf("audit payload = %#v", payload)
+	}
+}
+
+func TestPhaseEngine_AdvanceSceneRejectsWhenNoConditionMatches(t *testing.T) {
+	pe, audit := newTestPhaseEngine(t, nil, testPhaseDefinitions)
+	if err := pe.SetSceneTransitions([]SceneTransition{
+		{
+			ID:        "locked",
+			From:      "intro",
+			To:        "invest",
+			Condition: sceneTransitionCustomFlagCondition("route_open", "true"),
+		},
+	}); err != nil {
+		t.Fatalf("SetSceneTransitions: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	advanced, err := pe.AdvanceScene(ctx, json.RawMessage(`{"flags":{"route_open":false}}`))
+	if err == nil || advanced {
+		t.Fatalf("AdvanceScene should reject without advancing, advanced=%v err=%v", advanced, err)
+	}
+	if !strings.Contains(err.Error(), "no matching scene transition") {
+		t.Fatalf("AdvanceScene error = %v", err)
+	}
+	if got := pe.CurrentPhase().ID; got != "intro" {
+		t.Fatalf("CurrentPhase = %s, want intro", got)
+	}
+	if got := pe.CurrentRound(); got != 1 {
+		t.Fatalf("CurrentRound = %d, want 1", got)
+	}
+	if got := len(audit.eventsOfType("phase.scene_transitioned")); got != 0 {
+		t.Fatalf("phase.scene_transitioned audits = %d, want 0", got)
+	}
+}
+
+func TestPhaseEngine_AdvanceSceneRunsExitAndEnterActions(t *testing.T) {
+	reactor := &stubFullModule{
+		stubCoreModule: stubCoreModule{name: "information_delivery"},
+		actions:        []PhaseAction{ActionDeliverInformation},
+	}
+	phases := []PhaseDefinition{
+		{
+			ID:      "intro",
+			Name:    "Intro",
+			OnExit:  json.RawMessage(`[{"type":"DELIVER_INFORMATION","params":{"deliveries":[{"id":"exit-intro"}]}}]`),
+			OnEnter: json.RawMessage(`[{"type":"DELIVER_INFORMATION","params":{"deliveries":[{"id":"enter-intro"}]}}]`),
+		},
+		{
+			ID:      "invest",
+			Name:    "Investigation",
+			OnEnter: json.RawMessage(`[{"type":"DELIVER_INFORMATION","params":{"deliveries":[{"id":"enter-invest"}]}}]`),
+		},
+	}
+	pe, _ := newTestPhaseEngine(t, []Module{reactor}, phases)
+	if err := pe.SetSceneTransitions([]SceneTransition{{ID: "default", From: "intro", To: "invest"}}); err != nil {
+		t.Fatalf("SetSceneTransitions: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	if _, err := pe.AdvanceScene(ctx, nil); err != nil {
+		t.Fatalf("AdvanceScene: %v", err)
+	}
+	if len(reactor.received) != 3 {
+		t.Fatalf("received actions = %#v, want 3 actions", reactor.received)
+	}
+	for idx, want := range []string{"enter-intro", "exit-intro", "enter-invest"} {
+		if ids := phaseActionDeliveryIDs(t, reactor.received[idx]); len(ids) != 1 || ids[0] != want {
+			t.Fatalf("action %d delivery IDs = %#v, want %s", idx, ids, want)
+		}
+	}
+}
+
+func TestPhaseEngine_AdvanceSceneRollsBackCurrentWhenTargetEnterFails(t *testing.T) {
+	hook := &failingEnterHookModule{stubCoreModule: stubCoreModule{name: "hook"}, failPhase: "invest"}
+	pe, audit := newTestPhaseEngine(t, []Module{hook}, testPhaseDefinitions)
+	if err := pe.SetSceneTransitions([]SceneTransition{{ID: "default", From: "intro", To: "invest"}}); err != nil {
+		t.Fatalf("SetSceneTransitions: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	advanced, err := pe.AdvanceScene(ctx, nil)
+	if err == nil || advanced {
+		t.Fatalf("AdvanceScene should fail without advancing, advanced=%v err=%v", advanced, err)
+	}
+	if got := pe.CurrentPhase().ID; got != "intro" {
+		t.Fatalf("CurrentPhase after failed advance = %s, want intro", got)
+	}
+	if got := pe.CurrentRound(); got != 1 {
+		t.Fatalf("CurrentRound after failed advance = %d, want 1", got)
+	}
+	if got := len(audit.eventsOfType("phase.scene_transitioned")); got != 0 {
+		t.Fatalf("phase.scene_transitioned audits = %d, want 0", got)
+	}
+}
+
+func TestPhaseEngine_AdvanceSceneFallsBackToLinearAdvanceWithoutSceneGraph(t *testing.T) {
+	pe, _ := newTestPhaseEngine(t, nil, testPhaseDefinitions)
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	advanced, err := pe.AdvanceScene(ctx, nil)
+	if err != nil || !advanced {
+		t.Fatalf("AdvanceScene fallback: advanced=%v err=%v", advanced, err)
+	}
+	if got := pe.CurrentPhase().ID; got != "invest" {
+		t.Fatalf("CurrentPhase = %s, want invest", got)
+	}
+}
+
+func sceneTransitionCustomFlagCondition(flagKey string, value string) json.RawMessage {
+	raw, err := json.Marshal(ConditionGroup{
+		ID:       "group-" + flagKey,
+		Operator: "AND",
+		Rules: []ConditionNode{{
+			Rule: &ConditionRule{
+				ID:            "rule-" + flagKey,
+				Variable:      "custom_flag",
+				TargetFlagKey: flagKey,
+				Comparator:    "=",
+				Value:         value,
+			},
+		}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}

--- a/apps/server/internal/module/progression/event_progression.go
+++ b/apps/server/internal/module/progression/event_progression.go
@@ -10,7 +10,8 @@ import (
 	"github.com/mmp-platform/server/internal/engine"
 )
 
-// EventProgressionModule manages non-linear phase progression driven by triggers.
+// EventProgressionModule validates non-linear progression requests driven by
+// triggers. PhaseEngine remains the source of truth for the final phase.
 //
 // PR-2a: declares public state — current phase, visited phase list, and
 // backtrack flag are shared by all players.
@@ -115,12 +116,10 @@ func (m *EventProgressionModule) HandleMessage(ctx context.Context, playerID uui
 		}
 
 		oldPhase := m.currentPhaseID
-		m.currentPhaseID = validTarget
-		m.visitedPhases = append(m.visitedPhases, validTarget)
 		m.mu.Unlock()
 
 		m.deps.EventBus.Publish(engine.Event{
-			Type: "event.phase_transition",
+			Type: "event.scene_transition_requested",
 			Payload: map[string]any{
 				"fromPhase": oldPhase,
 				"toPhase":   validTarget,
@@ -170,7 +169,18 @@ func (m *EventProgressionModule) Schema() json.RawMessage {
 
 // --- PhaseHookModule ---
 
-func (m *EventProgressionModule) OnPhaseEnter(_ context.Context, _ engine.Phase) error {
+func (m *EventProgressionModule) OnPhaseEnter(_ context.Context, phase engine.Phase) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	phaseID := string(phase)
+	if phaseID == "" {
+		return nil
+	}
+	m.currentPhaseID = phaseID
+	if len(m.visitedPhases) == 0 || m.visitedPhases[len(m.visitedPhases)-1] != phaseID {
+		m.visitedPhases = append(m.visitedPhases, phaseID)
+	}
 	return nil
 }
 

--- a/apps/server/internal/module/progression/event_progression_test.go
+++ b/apps/server/internal/module/progression/event_progression_test.go
@@ -56,7 +56,7 @@ func TestEventProgressionModule_HandleMessage(t *testing.T) {
 			graph:     map[string][]string{"start": {"middle"}},
 			initial:   "start",
 			triggerID: "middle",
-			wantEvent: "event.phase_transition",
+			wantEvent: "event.scene_transition_requested",
 		},
 		{
 			name:      "invalid trigger",
@@ -120,16 +120,60 @@ func TestEventProgressionModule_BacktrackPrevention(t *testing.T) {
 		t.Fatalf("Init() error = %v", err)
 	}
 
-	// A -> B should succeed
+	// A -> B should succeed as a transition request. The module state is not
+	// final until PhaseEngine enters B and calls the hook.
 	payload, _ := json.Marshal(map[string]string{"TriggerID": "B"})
 	if err := m.HandleMessage(context.Background(), uuid.New(), "event:trigger", payload); err != nil {
 		t.Fatalf("A->B transition error = %v", err)
+	}
+	if err := m.OnPhaseEnter(context.Background(), "B"); err != nil {
+		t.Fatalf("OnPhaseEnter(B) error = %v", err)
 	}
 
 	// B -> A should fail (backtrack)
 	payload, _ = json.Marshal(map[string]string{"TriggerID": "A"})
 	if err := m.HandleMessage(context.Background(), uuid.New(), "event:trigger", payload); err == nil {
 		t.Error("expected error for backtrack B->A, got nil")
+	}
+}
+
+func TestEventProgressionModule_TriggerRequestsDoNotMutateCurrentPhase(t *testing.T) {
+	deps := newTestDeps(t)
+	m := NewEventProgressionModule()
+
+	cfg := json.RawMessage(`{"InitialPhase":"start","AllowBacktrack":false,"Graph":{"start":["middle"]}}`)
+	if err := m.Init(context.Background(), deps, cfg); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	payload, _ := json.Marshal(map[string]string{"TriggerID": "middle"})
+	if err := m.HandleMessage(context.Background(), uuid.New(), "event:trigger", payload); err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+	raw, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState() error = %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("unmarshal error = %v", err)
+	}
+	if state["currentPhase"] != "start" {
+		t.Fatalf("currentPhase after request = %v, want start", state["currentPhase"])
+	}
+
+	if err := m.OnPhaseEnter(context.Background(), "middle"); err != nil {
+		t.Fatalf("OnPhaseEnter() error = %v", err)
+	}
+	raw, err = m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState() after enter error = %v", err)
+	}
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("unmarshal after enter error = %v", err)
+	}
+	if state["currentPhase"] != "middle" {
+		t.Fatalf("currentPhase after engine enter = %v, want middle", state["currentPhase"])
 	}
 }
 

--- a/apps/server/internal/session/session.go
+++ b/apps/server/internal/session/session.go
@@ -235,7 +235,7 @@ func (s *Session) handleMessage(msg SessionMessage) {
 
 	case KindAdvance:
 		var advanced bool
-		advanced, err = s.engine.AdvancePhase(msg.Ctx)
+		advanced, err = s.engine.AdvanceScene(msg.Ctx, nil)
 		if err == nil && advanced {
 			// Phase transition is a critical event — flush snapshot immediately.
 			s.flushSnapshot()

--- a/apps/server/internal/session/starter.go
+++ b/apps/server/internal/session/starter.go
@@ -102,6 +102,12 @@ func startModularGame(
 		gameCfg.Phases,
 	)
 	eng.SetPlayerInfoProvider(deps.PlayerInfoProvider)
+	if err := eng.SetSceneTransitions(gameCfg.SceneTransitions); err != nil {
+		logger.Error().Err(err).
+			Str("session_id", cfg.SessionID.String()).
+			Msg("startModularGame: invalid scene transitions")
+		return nil, errInvalidConfig
+	}
 
 	s := newSession(cfg.SessionID, eng, cfg.Players, logger)
 	s.onAbort = m.removeSession

--- a/apps/server/internal/session/starter.go
+++ b/apps/server/internal/session/starter.go
@@ -19,6 +19,9 @@ func cleanupOnStartFail(ctx context.Context, eng *engine.PhaseEngine, logger zer
 	if err := eng.Stop(ctx); err != nil {
 		logger.Warn().Err(err).Msg("startModularGame: cleanup engine stop error")
 	}
+	if bus := eng.EventBus(); bus != nil {
+		bus.Close()
+	}
 }
 
 // errGameRuntimeDisabled is returned when startModularGame is called but the
@@ -106,6 +109,7 @@ func startModularGame(
 		logger.Error().Err(err).
 			Str("session_id", cfg.SessionID.String()).
 			Msg("startModularGame: invalid scene transitions")
+		cleanupOnStartFail(ctx, eng, logger)
 		return nil, errInvalidConfig
 	}
 

--- a/apps/server/internal/session/starter_test.go
+++ b/apps/server/internal/session/starter_test.go
@@ -55,6 +55,25 @@ func minimalConfigJSON(t *testing.T) json.RawMessage {
 	return raw
 }
 
+func sceneTransitionConfigJSON(t *testing.T) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"phases": []map[string]any{
+			{"id": "intro", "name": "Introduction"},
+			{"id": "discussion", "name": "Discussion"},
+			{"id": "voting", "name": "Voting"},
+		},
+		"sceneTransitions": []map[string]any{
+			{"id": "intro-to-voting", "from": "intro", "to": "voting", "sortOrder": 0},
+		},
+		"modules": []any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal scene transition config: %v", err)
+	}
+	return raw
+}
+
 func newTestManager(t *testing.T) *SessionManager {
 	t.Helper()
 	logger := zerolog.Nop()
@@ -262,6 +281,86 @@ func TestStartModularGame_PhaseAdvance(t *testing.T) {
 	}
 
 	m.Stop(sessionID)
+}
+
+func TestStartModularGame_PhaseAdvanceUsesSceneTransitions(t *testing.T) {
+	m := newTestManager(t)
+	bc := &mockBroadcaster{}
+	sessionID := uuid.New()
+
+	cfg := StartConfig{
+		SessionID:   sessionID,
+		ThemeID:     uuid.New(),
+		FeatureFlag: true,
+		ConfigJSON:  sceneTransitionConfigJSON(t),
+		Broadcaster: bc,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	s, err := startModularGame(ctx, m, cfg, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("startModularGame failed: %v", err)
+	}
+	defer m.Stop(sessionID)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := s.Send(SessionMessage{
+		Kind: KindAdvance,
+		Ctx:  ctx,
+	}); err != nil {
+		t.Fatalf("Send KindAdvance failed: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	var enteredVoting bool
+	for _, call := range bc.snapshot() {
+		if call.sessionID != sessionID || call.env.Type != "phase:entered" {
+			continue
+		}
+		var payload struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(call.env.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal phase:entered payload: %v", err)
+		}
+		if payload.ID == "voting" {
+			enteredVoting = true
+		}
+	}
+	if !enteredVoting {
+		t.Fatal("expected scene transition to enter voting phase")
+	}
+}
+
+func TestStartModularGame_InvalidSceneTransitionConfig(t *testing.T) {
+	m := newTestManager(t)
+	raw, _ := json.Marshal(map[string]any{
+		"phases": []map[string]any{
+			{"id": "intro", "name": "Introduction"},
+		},
+		"sceneTransitions": []map[string]any{
+			{"id": "bad-edge", "from": "intro", "to": "missing"},
+		},
+		"modules": []any{},
+	})
+	cfg := StartConfig{
+		SessionID:   uuid.New(),
+		ThemeID:     uuid.New(),
+		FeatureFlag: true,
+		ConfigJSON:  raw,
+	}
+
+	_, err := startModularGame(context.Background(), m, cfg, zerolog.Nop())
+	if err == nil {
+		t.Fatal("expected invalid scene transition config error")
+	}
+	if m.Get(cfg.SessionID) != nil {
+		t.Fatal("session must not be registered on invalid scene transitions")
+	}
 }
 
 func TestStaticPlayerInfoProvider_ResolvesTargetCodeAndRuntimeInfo(t *testing.T) {


### PR DESCRIPTION
## 요약

- `configJson.sceneTransitions`를 backend runtime 입력으로 파싱/보존
- `PhaseEngine.AdvanceScene` 추가: 조건부 장면 이동은 backend condition evaluator가 판정하고, 이동 시 onExit/onEnter action과 hook을 실행
- `KindAdvance`를 scene graph-aware 경로로 연결하되, graph가 없으면 기존 선형 `AdvancePhase` 동작 유지
- `event_progression`은 phase를 직접 확정하지 않고 전환 요청만 발행하며, 실제 현재 phase는 `PhaseEngine` enter hook으로 동기화

## 경계

- 이번 PR은 #312 backend source-of-truth 계약 고정만 다룹니다.
- #300 트리거 블록 전체 runtime, #302 정보 공개 UX/runtime, #303 토론방, #305 연출 구현은 섞지 않았습니다.
- frontend `FlowSimulationPanel` 용어 혼선은 후속 #313으로 분리했습니다.

## 검증

- `cd apps/server && go test ./internal/engine ./internal/session ./internal/module/progression ./internal/module/progression/information_delivery ./internal/domain/flow`
- `cd apps/server && go test ./...`

Closes #312
Related: #313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 조건 기반 장면 전환(graph 기반) 지원으로 스토리 흐름을 유연하게 분기할 수 있습니다.
  * 서버가 장면 전환 설정을 로드·검증하여 세션 시작 시 적용합니다.

* **버그 수정 / 안정성**
  * 대상 단계 진입 실패 시 이전 상태로 자동 롤백됩니다.
  * 전환 트리 없는 경우 기존 선형 진행 방식으로 안전하게 대체됩니다.

* **행동·이벤트 변경**
  * 전환 요청은 즉시 현재 단계 변경을 일으키지 않고, 요청/엔터 이벤트로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->