### PR TITLE
fix(editor): #313 Flow 순서 점검 패널 용어 분리

### DIFF
--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -14,7 +14,7 @@ import { StartNode } from "./StartNode";
 import { PhaseNode } from "./PhaseNode";
 import { EndingNode } from "./EndingNode";
 import { NodeDetailPanel } from "./NodeDetailPanel";
-import { FlowSimulationPanel } from "./FlowSimulationPanel";
+import { FlowOrderReviewPanel } from "./FlowOrderReviewPanel";
 import { StorySceneSummary } from "./StorySceneSummary";
 import { branchNodeTypes, conditionEdgeTypes } from "./flowNodeRegistry";
 import type { FlowNodeType } from "../../flowTypes";
@@ -46,7 +46,7 @@ interface FlowCanvasProps {
 
 export function FlowCanvas({ themeId }: FlowCanvasProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
-  const [showSim, setShowSim] = useState(false);
+  const [showOrderReview, setShowOrderReview] = useState(false);
   const [highlightId, setHighlightId] = useState<string | null>(null);
 
   const {
@@ -124,8 +124,11 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
         isSaving={isSaving}
         onApplyPreset={applyPreset}
         hasNodes={nodes.length > 0}
-        onToggleSimulation={() => setShowSim((v) => !v)}
-        isSimulating={showSim}
+        onToggleOrderReview={() => {
+          if (showOrderReview) setHighlightId(null);
+          setShowOrderReview((v) => !v);
+        }}
+        isOrderReviewing={showOrderReview}
       />
       <StorySceneSummary nodes={nodes} edges={edges} />
       <div data-testid="flow-workspace" className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
@@ -160,18 +163,18 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
 
         {/* Side panels */}
         <div className="flex max-h-[55vh] w-full shrink-0 flex-col overflow-y-auto border-t border-slate-800 bg-slate-900 lg:max-h-none lg:w-72 lg:border-l lg:border-t-0">
-          {!showSim && !selectedNode && (
+          {!showOrderReview && !selectedNode && (
             <div className="p-4 text-sm leading-6 text-slate-400">
               장면이나 결말을 선택하면 세부 설정을 편집할 수 있습니다.
             </div>
           )}
-          {showSim && (
+          {showOrderReview && (
             <div className="border-b border-slate-800 p-3">
-              <FlowSimulationPanel
+              <FlowOrderReviewPanel
                 nodes={nodes}
                 edges={edges}
                 onHighlight={setHighlightId}
-                onClose={() => { setShowSim(false); setHighlightId(null); }}
+                onClose={() => { setShowOrderReview(false); setHighlightId(null); }}
               />
             </div>
           )}

--- a/apps/web/src/features/editor/components/design/FlowOrderReviewPanel.tsx
+++ b/apps/web/src/features/editor/components/design/FlowOrderReviewPanel.tsx
@@ -7,7 +7,7 @@ import type { FlowNodeData } from "../../flowTypes";
 // Types
 // ---------------------------------------------------------------------------
 
-interface FlowSimulationPanelProps {
+interface FlowOrderReviewPanelProps {
   nodes: Node[];
   edges: Edge[];
   onHighlight: (nodeId: string | null) => void;
@@ -15,10 +15,10 @@ interface FlowSimulationPanelProps {
 }
 
 // ---------------------------------------------------------------------------
-// Topological sort (Start → ... → Ending)
+// Topological order review (Start -> ... -> Ending)
 // ---------------------------------------------------------------------------
 
-function topoSort(nodes: Node[], edges: Edge[]): Node[] {
+function topoSort(nodes: Node[], edges: Edge[]): { sorted: Node[]; hasCycle: boolean } {
   const adj = new Map<string, string[]>();
   const inDeg = new Map<string, number>();
   for (const n of nodes) {
@@ -47,15 +47,15 @@ function topoSort(nodes: Node[], edges: Edge[]): Node[] {
 }
 
 // ---------------------------------------------------------------------------
-// FlowSimulationPanel
+// FlowOrderReviewPanel
 // ---------------------------------------------------------------------------
 
-export function FlowSimulationPanel({
+export function FlowOrderReviewPanel({
   nodes,
   edges,
   onHighlight,
   onClose,
-}: FlowSimulationPanelProps) {
+}: FlowOrderReviewPanelProps) {
   const { sorted, hasCycle } = useMemo(() => topoSort(nodes, edges), [nodes, edges]);
   const phases = useMemo(
     () => sorted.filter((n) => n.type === "phase"),
@@ -102,12 +102,16 @@ export function FlowSimulationPanel({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Play className="h-3.5 w-3.5 text-amber-400" />
-          <span className="text-xs font-medium text-slate-300">흐름 시뮬레이션</span>
+          <span className="text-xs font-medium text-slate-300">흐름 순서 점검</span>
         </div>
         <button type="button" onClick={handleClose} aria-label="닫기" className="text-slate-500 hover:text-slate-300">
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
+
+      <p className="text-[10px] leading-4 text-slate-500">
+        저장된 노드 연결 순서만 훑어봅니다. 조건과 트리거의 실제 통과 여부는 게임 중 서버가 판정합니다.
+      </p>
 
       {/* Cycle warning */}
       {hasCycle && (

--- a/apps/web/src/features/editor/components/design/FlowToolbar.tsx
+++ b/apps/web/src/features/editor/components/design/FlowToolbar.tsx
@@ -13,8 +13,8 @@ interface FlowToolbarProps {
   isSaving: boolean;
   onApplyPreset?: (nodes: Node[], edges: Edge[]) => void;
   hasNodes?: boolean;
-  onToggleSimulation?: () => void;
-  isSimulating?: boolean;
+  onToggleOrderReview?: () => void;
+  isOrderReviewing?: boolean;
 }
 
 interface NodeOption {
@@ -39,8 +39,8 @@ export function FlowToolbar({
   isSaving,
   onApplyPreset,
   hasNodes,
-  onToggleSimulation,
-  isSimulating,
+  onToggleOrderReview,
+  isOrderReviewing,
 }: FlowToolbarProps) {
   const [open, setOpen] = useState(false);
   const [presetOpen, setPresetOpen] = useState(false);
@@ -141,19 +141,19 @@ export function FlowToolbar({
         </div>
       )}
 
-      {/* Simulation toggle */}
-      {onToggleSimulation && (
+      {/* Order review toggle */}
+      {onToggleOrderReview && (
         <button
           type="button"
-          onClick={onToggleSimulation}
+          onClick={onToggleOrderReview}
           className={`flex items-center gap-1.5 rounded border px-3 py-1.5 text-xs transition-colors ${
-            isSimulating
+            isOrderReviewing
               ? "border-amber-600 bg-amber-950/30 text-amber-400"
               : "border-slate-700 bg-slate-800 text-slate-300 hover:border-amber-500 hover:text-amber-400"
           }`}
         >
           <Play className="h-3.5 w-3.5" />
-          시뮬레이션
+          순서 점검
         </button>
       )}
 

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -15,8 +15,25 @@ const { saveMock, useFlowDataMock } = vi.hoisted(() => ({
 // ---------------------------------------------------------------------------
 
 vi.mock('@xyflow/react', () => ({
-  ReactFlow: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="react-flow">{children}</div>
+  ReactFlow: ({
+    children,
+    nodes = [],
+    nodeClassName,
+  }: {
+    children?: React.ReactNode;
+    nodes?: Array<{ id: string }>;
+    nodeClassName?: (node: { id: string }) => string;
+  }) => (
+    <div data-testid="react-flow">
+      {nodes.map((node) => (
+        <div
+          key={node.id}
+          data-testid={`rf-node-${node.id}`}
+          className={nodeClassName?.(node) ?? ""}
+        />
+      ))}
+      {children}
+    </div>
   ),
   Background: () => <div data-testid="rf-background" />,
   MiniMap: () => <div data-testid="rf-minimap" />,
@@ -122,6 +139,41 @@ describe('FlowCanvas', () => {
     expect(screen.getByTestId('rf-background')).toBeDefined();
     expect(screen.getByTestId('rf-minimap')).toBeDefined();
     expect(screen.getByTestId('rf-controls')).toBeDefined();
+  });
+
+  it('순서 점검 패널을 툴바로 닫으면 노드 하이라이트를 해제한다', () => {
+    useFlowDataMock.mockReturnValue({
+      nodes: [
+        {
+          id: 'p1',
+          type: 'phase',
+          position: { x: 0, y: 0 },
+          data: { label: '오프닝', duration: 5 },
+        },
+        {
+          id: 'p2',
+          type: 'phase',
+          position: { x: 100, y: 0 },
+          data: { label: '조사', duration: 10 },
+        },
+      ],
+      edges: [{ id: 'e-p1-p2', source: 'p1', target: 'p2' }],
+      onNodesChange: vi.fn(),
+      onEdgesChange: vi.fn(),
+      onConnect: vi.fn(),
+      isLoading: false,
+      isSaving: false,
+      save: saveMock,
+    });
+
+    render(<FlowCanvas themeId="theme-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '순서 점검' }));
+    fireEvent.click(screen.getByTitle('다음'));
+    expect(screen.getByTestId('rf-node-p2').className).toContain('!ring-2');
+
+    fireEvent.click(screen.getByRole('button', { name: '순서 점검' }));
+    expect(screen.getByTestId('rf-node-p2').className).not.toContain('!ring-2');
   });
 });
 

--- a/apps/web/src/features/editor/components/design/__tests__/FlowOrderReviewPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowOrderReviewPanel.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { FlowSimulationPanel } from "../FlowSimulationPanel";
+import { FlowOrderReviewPanel } from "../FlowOrderReviewPanel";
 import type { Node, Edge } from "@xyflow/react";
 
 afterEach(cleanup);
@@ -18,10 +18,10 @@ const makeEdges = (): Edge[] => [
   { id: "e-p2-e1", source: "p2", target: "e1" },
 ];
 
-describe("FlowSimulationPanel", () => {
+describe("FlowOrderReviewPanel", () => {
   it("페이즈 노드가 없으면 빈 상태 메시지를 표시한다", () => {
     render(
-      <FlowSimulationPanel
+      <FlowOrderReviewPanel
         nodes={[]}
         edges={[]}
         onHighlight={vi.fn()}
@@ -33,7 +33,7 @@ describe("FlowSimulationPanel", () => {
 
   it("첫 페이즈 이름과 진행도를 표시한다", () => {
     render(
-      <FlowSimulationPanel
+      <FlowOrderReviewPanel
         nodes={makeNodes()}
         edges={makeEdges()}
         onHighlight={vi.fn()}
@@ -47,7 +47,7 @@ describe("FlowSimulationPanel", () => {
   it("다음 버튼 클릭 시 다음 페이즈로 이동한다", () => {
     const onHighlight = vi.fn();
     render(
-      <FlowSimulationPanel
+      <FlowOrderReviewPanel
         nodes={makeNodes()}
         edges={makeEdges()}
         onHighlight={onHighlight}
@@ -61,7 +61,7 @@ describe("FlowSimulationPanel", () => {
 
   it("총 소요시간을 표시한다", () => {
     render(
-      <FlowSimulationPanel
+      <FlowOrderReviewPanel
         nodes={makeNodes()}
         edges={makeEdges()}
         onHighlight={vi.fn()}
@@ -71,11 +71,27 @@ describe("FlowSimulationPanel", () => {
     expect(screen.getByText(/총 15분/)).toBeDefined();
   });
 
+  it("조건과 트리거 결과를 확정하지 않는 순서 점검 문구를 표시한다", () => {
+    render(
+      <FlowOrderReviewPanel
+        nodes={makeNodes()}
+        edges={[
+          ...makeEdges(),
+          { id: "conditional", source: "p1", target: "p2", data: { condition: { id: "c1" } } },
+        ]}
+        onHighlight={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("흐름 순서 점검")).toBeDefined();
+    expect(screen.getByText(/조건과 트리거의 실제 통과 여부는 게임 중 서버가 판정합니다/)).toBeDefined();
+  });
+
   it("닫기 시 하이라이트를 해제한다", () => {
     const onHighlight = vi.fn();
     const onClose = vi.fn();
     render(
-      <FlowSimulationPanel
+      <FlowOrderReviewPanel
         nodes={makeNodes()}
         edges={makeEdges()}
         onHighlight={onHighlight}


### PR DESCRIPTION
## 요약
- 제작 화면의 Flow 패널 명칭을 `시뮬레이션`에서 `순서 점검`으로 낮췄습니다.
- 조건/트리거 실제 통과 여부는 게임 중 서버 런타임이 판정한다는 경계 문구를 추가했습니다.
- `FlowSimulationPanel`을 `FlowOrderReviewPanel`로 rename하고 관련 회귀 테스트를 보강했습니다.

## 범위
- Frontend editor UI terminology only
- Backend/runtime 계약, Flow DTO, 저장 계약 변경 없음

## 검증
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/FlowOrderReviewPanel.test.tsx`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `git diff --check`

Closes #313
Related: #300
Related: #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 플로우 편집기에 "순서 점검" 패널을 추가했습니다. 저장된 노드 연결 순서를 검토하고 단계별 진행을 확인할 수 있으며, 순환 여부를 감지해 경고를 표시합니다. 조건 판정 결과는 게임 실행 시 서버에서 결정됩니다.
* **개선**
  * 툴바에서 순서 점검 토글을 제공하고 패널 열기/닫기 시 노드 하이라이트 상태를 적절히 초기화합니다.
* **테스트**
  * 순서 점검 동작과 하이라이트/닫기 동작을 검증하는 테스트를 추가/갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->