### PR TITLE
ci: #316 Playwright deps 단계 timeout 추가

### DIFF
--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -296,6 +296,8 @@ jobs:
       # install + always-required browser install. Browsers themselves do not
       # need that font (chromium ships its own fallbacks for headless QA).
       - name: Install Playwright system deps (best-effort)
+        timeout-minutes: 8
+        continue-on-error: true
         working-directory: apps/web
         run: |
           sudo apt-get update -y || true

--- a/.github/workflows/flaky-report.yml
+++ b/.github/workflows/flaky-report.yml
@@ -135,6 +135,8 @@ jobs:
       # `--with-deps` split into best-effort deps step (fonts-freefont-ttf
       # deprecated on ARC runner image) + always-required browser install.
       - name: Install Playwright system deps (best-effort)
+        timeout-minutes: 8
+        continue-on-error: true
         working-directory: apps/web
         run: |
           sudo apt-get update -y || true

--- a/.github/workflows/phase-18.1-real-backend.yml
+++ b/.github/workflows/phase-18.1-real-backend.yml
@@ -164,6 +164,8 @@ jobs:
             # `--with-deps` split into best-effort deps step (fonts-freefont-ttf
       # deprecated on ARC runner image) + always-required browser install.
       - name: Install Playwright system deps (best-effort)
+        timeout-minutes: 8
+        continue-on-error: true
         working-directory: apps/web
         run: |
           sudo apt-get update -y || true


### PR DESCRIPTION
## 요약
- E2E, flaky report, nightly real-backend workflow의 Playwright system deps 단계에 `timeout-minutes: 8`을 추가했습니다.
- 동일 단계에 `continue-on-error: true`를 추가해 ARC runner/apt deps hang이 browser install과 실제 E2E 실행을 무기한 막지 않게 했습니다.

## 배경
- PR #315에서 `E2E (chromium shard 1)`이 앱 E2E 실행 전 `Install Playwright system deps (best-effort)` 단계에 반복적으로 장시간 머물렀습니다.
- 같은 커밋의 shard 2는 실제 E2E까지 통과했으므로 코드 실패보다 runner deps flake로 판단했습니다.

## 검증
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/e2e-stubbed.yml .github/workflows/phase-18.1-real-backend.yml .github/workflows/flaky-report.yml`\n- `git diff --check`\n\nCloses #316\nRelated: #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 워크플로우의 Playwright 시스템 종속성 설치 단계를 개선하여 타임아웃이나 오류 발생 시 전체 작업이 실패하지 않도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->