### PR TITLE
ci: #318 Playwright deps shell timeout 적용

### DIFF
--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -300,9 +300,8 @@ jobs:
         continue-on-error: true
         working-directory: apps/web
         run: |
-          sudo apt-get update -y || true
-          pnpm exec playwright install-deps ${{ matrix.browser }} || \
-            echo "::warning::Playwright install-deps failed (likely fonts-freefont-ttf missing on ARC image); continuing without"
+          timeout 480s bash -lc 'sudo apt-get update -y || true; pnpm exec playwright install-deps ${{ matrix.browser }}' || \
+            echo "::warning::Playwright install-deps failed or timed out (likely ARC apt/deps flake); continuing without"
 
       - name: Install Playwright browsers for matrix
         working-directory: apps/web

--- a/.github/workflows/flaky-report.yml
+++ b/.github/workflows/flaky-report.yml
@@ -139,9 +139,8 @@ jobs:
         continue-on-error: true
         working-directory: apps/web
         run: |
-          sudo apt-get update -y || true
-          pnpm exec playwright install-deps chromium || \
-            echo "::warning::Playwright install-deps failed (likely fonts-freefont-ttf missing on ARC image); continuing without"
+          timeout 480s bash -lc 'sudo apt-get update -y || true; pnpm exec playwright install-deps chromium' || \
+            echo "::warning::Playwright install-deps failed or timed out (likely ARC apt/deps flake); continuing without"
 
       - name: Install Playwright browsers
         working-directory: apps/web

--- a/.github/workflows/phase-18.1-real-backend.yml
+++ b/.github/workflows/phase-18.1-real-backend.yml
@@ -168,9 +168,8 @@ jobs:
         continue-on-error: true
         working-directory: apps/web
         run: |
-          sudo apt-get update -y || true
-          pnpm exec playwright install-deps chromium webkit || \
-            echo "::warning::Playwright install-deps failed (likely fonts-freefont-ttf missing on ARC image); continuing without"
+          timeout 480s bash -lc 'sudo apt-get update -y || true; pnpm exec playwright install-deps chromium webkit' || \
+            echo "::warning::Playwright install-deps failed or timed out (likely ARC apt/deps flake); continuing without"
 
       - name: Install Playwright browsers
         # webkit added in Phase 18.7 Wave 3 PR-6 — nightly is the only matrix


### PR DESCRIPTION
## 요약
- Playwright `install-deps` best-effort 단계를 shell-level `timeout 480s`로 감쌌습니다.
- GitHub step-level timeout만으로 끊기지 않는 ARC runner apt/deps hang을 더 강하게 제한합니다.
- timeout/failure 후에도 warning만 남기고 browser install 및 실제 E2E 단계로 진행합니다.

## 배경
- #316 / PR #317의 `timeout-minutes`만으로는 PR #315 재실행에서 `Install Playwright system deps`가 계속 in_progress로 남았습니다.
- #315 병합 blocker를 풀기 위해 동일 패턴 3개 workflow에 shell-level guard를 추가합니다.

## 검증
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/e2e-stubbed.yml .github/workflows/phase-18.1-real-backend.yml .github/workflows/flaky-report.yml`\n- `git diff --check`\n\nCloses #318\nRelated: #315\nRelated: #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우의 Playwright 시스템 종속성 설치 단계를 개선했습니다. 설치 명령에 480초 타임아웃과 실패/타임아웃 시 경고 출력이 추가되어, 설치 오류가 발생해도 워크플로우가 계속 진행됩니다. 이로써 CI 파이프라인의 견고성과 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->