### PR TITLE
ci: #320 ready-for-ci self-hosted fallback 복구

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   go-check:
     name: Go Lint + Test
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
     defaults:
       run:
         working-directory: apps/server
@@ -223,7 +223,7 @@ jobs:
 
   ts-check:
     name: TypeScript Lint + Test + Build
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - name: Full CI ready gate
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
@@ -302,7 +302,7 @@ jobs:
     #   Phase 21: Go 70% / FE Lines 65% / FE Branches 85% (+15%p — 하한 상향 전 반드시 테스트 보강)
     #   하한 상향 전에 반드시 추가 테스트 PR 로 baseline 끌어올리기.
     name: Coverage Regression Guard
-    runs-on: arc-runner-set
+    runs-on: self-hosted
     needs: [go-check, ts-check]
     steps:
       - name: Harden Runner
@@ -377,7 +377,7 @@ jobs:
 
   docker-build:
     name: Docker Build Check
-    runs-on: arc-runner-set
+    runs-on: self-hosted
     needs: [go-check, ts-check]
     permissions:
       contents: read

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -51,7 +51,7 @@ concurrency:
 jobs:
   e2e:
     name: E2E (${{ matrix.browser }} shard ${{ matrix.shard }})
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
     # H-1: fork PR 의 untrusted code 가 shared named volume (playwright-cache/hostedtool-cache) 에
     # 악성 binary 를 심어 4 runner 횡전파하는 cache poisoning 차단.
     # fork PR 은 cache mount runner 를 우회 (skip). main / same-repo PR 만 실행.
@@ -387,7 +387,7 @@ jobs:
     # H-1 consistency: e2e 와 동일 fork PR 게이트 (cache mount runner 일관성).
     if: (always()) && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ready-for-ci')))
     needs: [e2e]
-    runs-on: arc-runner-set
+    runs-on: self-hosted
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   govulncheck:
     name: govulncheck (Go SCA)
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
     # Phase 22 W1.5 PR-8 fold-in (PR-170 8ce9c0b run cancelled at 5:13):
     # containerized runner 의 setup-go cache miss + go install govulncheck +
     # scan 이 5분 timeout 초과. 10분 으로 상향 (cache warm-up 후 정상 ~3분).


### PR DESCRIPTION
## 요약
- `ready-for-ci` full CI가 현재 등록된 `self-hosted` runner에 배정되도록 workflow `runs-on`을 조정했습니다.
- `ci.yml`, `e2e-stubbed.yml`, `security-fast.yml`의 `arc-runner-set` 요구를 제거했습니다.
- required check 이름과 라벨 정책은 변경하지 않았습니다.

## 배경
- PR #319의 full CI가 장시간 queued 상태에 머물렀습니다.
- GitHub runner API 확인 결과 현재 repo runner는 `sabyun` 1대이며 labels는 `self-hosted`, `Linux`, `X64`뿐입니다.
- workflow가 `arc-runner-set`을 요구해 label mismatch로 jobs가 배정되지 않았습니다.

## 검증
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/ci.yml .github/workflows/e2e-stubbed.yml .github/workflows/security-fast.yml`\n- `git diff --check`\n- `rg -n "arc-runner-set" .github/workflows/ci.yml .github/workflows/e2e-stubbed.yml .github/workflows/security-fast.yml`\n\nCloses #320\nRelated: #315\nRelated: #318\nRelated: #319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 워크플로우의 작업 실행 환경을 최적화했습니다. 빌드, 테스트 및 보안 검사 프로세스의 안정성과 효율성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->