### PR TITLE
feat(editor): #300 트리거 실행 계약 정렬

### DIFF
--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: apps/server/go.mod
-          cache-dependency-path: apps/server/go.sum
+          cache: false  # image-resident toolchain: avoid setup-go cache hangs on self-hosted runners.
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/apps/server/internal/engine/factory_test.go
+++ b/apps/server/internal/engine/factory_test.go
@@ -204,6 +204,17 @@ func TestParseGameConfig_AddsInformationDeliveryModuleForPhaseAction(t *testing.
 	}
 }
 
+func TestParseGameConfig_AddsInformationDeliveryModuleForLegacyPhaseAction(t *testing.T) {
+	data := []byte(`{"phases":[{"id":"p1","name":"Phase 1","onEnter":[{"type":"deliver_information","params":{"deliveries":[]}}]}],"modules":[]}`)
+	cfg, err := ParseGameConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Modules) != 1 || cfg.Modules[0].Name != "information_delivery" {
+		t.Fatalf("implicit modules = %#v", cfg.Modules)
+	}
+}
+
 func TestParseGameConfig_AddsEndingBranchModuleForEvaluateEndingAction(t *testing.T) {
 	data := []byte(`{"phases":[{"id":"final","name":"Final","onEnter":[{"type":"EVALUATE_ENDING"}]}],"modules":[]}`)
 	cfg, err := ParseGameConfig(data)

--- a/apps/server/internal/engine/phase_actions.go
+++ b/apps/server/internal/engine/phase_actions.go
@@ -120,6 +120,24 @@ type configuredPhaseAction struct {
 	Params json.RawMessage `json:"params,omitempty"`
 }
 
+var legacyPhaseActionAliases = map[string]PhaseAction{
+	"deliver_information": ActionDeliverInformation,
+	"enable_voting":       ActionOpenVoting,
+	"disable_voting":      ActionCloseVoting,
+	"enable_chat":         ActionUnmuteChat,
+	"disable_chat":        ActionMuteChat,
+	"play_bgm":            ActionSetBGM,
+	"stop_bgm":            ActionStopAudio,
+	"broadcast":           ActionBroadcastMessage,
+}
+
+func normalizeConfiguredPhaseAction(actionType string) PhaseAction {
+	if action, ok := legacyPhaseActionAliases[actionType]; ok {
+		return action
+	}
+	return PhaseAction(actionType)
+}
+
 func parseConfiguredPhaseActions(raw json.RawMessage) ([]PhaseActionPayload, error) {
 	var wrapped struct {
 		Actions []configuredPhaseAction `json:"actions"`
@@ -144,7 +162,7 @@ func parseConfiguredPhaseActions(raw json.RawMessage) ([]PhaseActionPayload, err
 			actionType = action.Type
 		}
 		out = append(out, PhaseActionPayload{
-			Action: PhaseAction(actionType),
+			Action: normalizeConfiguredPhaseAction(actionType),
 			Target: action.Target,
 			Params: action.Params,
 		})

--- a/apps/server/internal/engine/phase_actions.go
+++ b/apps/server/internal/engine/phase_actions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime/debug"
+	"strings"
 )
 
 func (e *PhaseEngine) enterCurrentPhase(ctx context.Context) error {
@@ -132,10 +133,11 @@ var legacyPhaseActionAliases = map[string]PhaseAction{
 }
 
 func normalizeConfiguredPhaseAction(actionType string) PhaseAction {
-	if action, ok := legacyPhaseActionAliases[actionType]; ok {
+	normalized := strings.ToLower(strings.TrimSpace(actionType))
+	if action, ok := legacyPhaseActionAliases[normalized]; ok {
 		return action
 	}
-	return PhaseAction(actionType)
+	return PhaseAction(strings.ToUpper(normalized))
 }
 
 func parseConfiguredPhaseActions(raw json.RawMessage) ([]PhaseActionPayload, error) {

--- a/apps/server/internal/engine/phase_engine_hooks_test.go
+++ b/apps/server/internal/engine/phase_engine_hooks_test.go
@@ -71,6 +71,71 @@ func TestPhaseEngine_PhaseHooksAndOnEnterActions(t *testing.T) {
 	}
 }
 
+func TestPhaseEngine_NormalizesLegacyPhaseActionTypes(t *testing.T) {
+	voting := &stubFullModule{
+		stubCoreModule: stubCoreModule{name: "voting"},
+		actions:        []PhaseAction{ActionOpenVoting},
+	}
+	textChat := &stubFullModule{
+		stubCoreModule: stubCoreModule{name: "text_chat"},
+		actions:        []PhaseAction{ActionMuteChat},
+	}
+	phases := []PhaseDefinition{
+		{
+			ID:      "intro",
+			Name:    "Intro",
+			OnEnter: json.RawMessage(`[{"type":"enable_voting"}]`),
+			OnExit:  json.RawMessage(`{"actions":[{"type":"disable_chat"}]}`),
+		},
+		{ID: "next", Name: "Next"},
+	}
+	pe, _ := newTestPhaseEngine(t, []Module{voting, textChat}, phases)
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	if len(voting.received) != 1 || voting.received[0].Action != ActionOpenVoting {
+		t.Fatalf("OnEnter legacy action = %#v", voting.received)
+	}
+	if _, err := pe.AdvancePhase(ctx); err != nil {
+		t.Fatalf("AdvancePhase: %v", err)
+	}
+	if len(textChat.received) != 1 || textChat.received[0].Action != ActionMuteChat {
+		t.Fatalf("OnExit legacy action = %#v", textChat.received)
+	}
+}
+
+func TestParseConfiguredPhaseActions_NormalizesLegacyAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want PhaseAction
+	}{
+		{name: "deliver information", raw: `[{"type":"deliver_information"}]`, want: ActionDeliverInformation},
+		{name: "open voting", raw: `[{"type":"enable_voting"}]`, want: ActionOpenVoting},
+		{name: "close voting", raw: `[{"type":"disable_voting"}]`, want: ActionCloseVoting},
+		{name: "unmute chat", raw: `[{"type":"enable_chat"}]`, want: ActionUnmuteChat},
+		{name: "mute chat", raw: `[{"type":"disable_chat"}]`, want: ActionMuteChat},
+		{name: "set bgm", raw: `[{"type":"play_bgm"}]`, want: ActionSetBGM},
+		{name: "stop audio", raw: `[{"type":"stop_bgm"}]`, want: ActionStopAudio},
+		{name: "broadcast", raw: `[{"type":"broadcast"}]`, want: ActionBroadcastMessage},
+		{name: "wrapped action", raw: `{"actions":[{"type":"disable_chat"}]}`, want: ActionMuteChat},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actions, err := parseConfiguredPhaseActions(json.RawMessage(tt.raw))
+			if err != nil {
+				t.Fatalf("parseConfiguredPhaseActions: %v", err)
+			}
+			if len(actions) != 1 || actions[0].Action != tt.want {
+				t.Fatalf("actions = %#v, want action %q", actions, tt.want)
+			}
+		})
+	}
+}
+
 func phaseActionDeliveryIDs(t *testing.T, action PhaseActionPayload) []string {
 	t.Helper()
 	var params struct {

--- a/apps/server/internal/engine/phase_engine_hooks_test.go
+++ b/apps/server/internal/engine/phase_engine_hooks_test.go
@@ -122,6 +122,8 @@ func TestParseConfiguredPhaseActions_NormalizesLegacyAliases(t *testing.T) {
 		{name: "stop audio", raw: `[{"type":"stop_bgm"}]`, want: ActionStopAudio},
 		{name: "broadcast", raw: `[{"type":"broadcast"}]`, want: ActionBroadcastMessage},
 		{name: "wrapped action", raw: `{"actions":[{"type":"disable_chat"}]}`, want: ActionMuteChat},
+		{name: "lowercase canonical", raw: `[{"type":"evaluate_ending"}]`, want: ActionEvaluateEnding},
+		{name: "trimmed uppercase canonical", raw: `[{"type":" SET_BGM "}]`, want: ActionSetBGM},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -1,6 +1,9 @@
 import { Plus, Trash2 } from "lucide-react";
 import type { PhaseAction } from "../../flowTypes";
-import { getVisibleCreatorActionOptions } from "../../entities/shared/actionAdapter";
+import {
+  getCreatorActionLabel,
+  getVisibleCreatorActionOptions,
+} from "../../entities/shared/actionAdapter";
 
 interface ActionListEditorProps {
   label: string;
@@ -49,35 +52,71 @@ export function ActionListEditor({
         </button>
       </div>
 
-      {visibleActions.length === 0 && <p className="text-[10px] text-slate-600">액션 없음</p>}
+      {visibleActions.length === 0 && (
+        <p className="text-[10px] text-slate-600">트리거 실행 결과 없음</p>
+      )}
 
       {visibleActions.map(({ action, index: idx }) => (
-        <div
+        <ActionRow
           key={action.id ?? idx}
-          className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-900 px-2 py-1.5"
-        >
-          <select
-            value={action.type}
-            onChange={(e) => handleTypeChange(idx, e.target.value)}
-            aria-label={`${label} ${idx + 1} 액션 타입`}
-            className="flex-1 bg-transparent text-xs text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
-          >
-            {visibleActionTypes.map((actionType) => (
-              <option key={actionType.value} value={actionType.value}>
-                {actionType.label}
-              </option>
-            ))}
-          </select>
-          <button
-            type="button"
-            onClick={() => handleRemove(idx)}
-            aria-label={`${label} ${idx + 1} 삭제`}
-            className="text-slate-500 transition-colors hover:text-red-400"
-          >
-            <Trash2 className="h-3 w-3" />
-          </button>
-        </div>
+          action={action}
+          index={idx}
+          label={label}
+          visibleActionTypes={visibleActionTypes}
+          onTypeChange={handleTypeChange}
+          onRemove={handleRemove}
+        />
       ))}
+    </div>
+  );
+}
+
+interface ActionRowProps {
+  action: PhaseAction;
+  index: number;
+  label: string;
+  visibleActionTypes: ReturnType<typeof getVisibleCreatorActionOptions>;
+  onTypeChange: (index: number, type: string) => void;
+  onRemove: (index: number) => void;
+}
+
+function ActionRow({
+  action,
+  index,
+  label,
+  visibleActionTypes,
+  onTypeChange,
+  onRemove,
+}: ActionRowProps) {
+  const hasCurrentOption = visibleActionTypes.some((actionType) => actionType.value === action.type);
+  const fallbackLabel = getCreatorActionLabel(action.type);
+  const options = hasCurrentOption
+    ? visibleActionTypes
+    : visibleActionTypes.filter((actionType) => actionType.label !== fallbackLabel);
+
+  return (
+    <div className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-900 px-2 py-1.5">
+      <select
+        value={action.type}
+        onChange={(e) => onTypeChange(index, e.target.value)}
+        aria-label={`${label} ${index + 1} 실행 결과`}
+        className="flex-1 bg-transparent text-xs text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
+      >
+        {!hasCurrentOption && <option value={action.type}>{fallbackLabel}</option>}
+        {options.map((actionType) => (
+          <option key={actionType.value} value={actionType.value}>
+            {actionType.label}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={() => onRemove(index)}
+        aria-label={`${label} ${index + 1} 삭제`}
+        className="text-slate-500 transition-colors hover:text-red-400"
+      >
+        <Trash2 className="h-3 w-3" />
+      </button>
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -110,7 +110,7 @@ function ActionRow({
         type="button"
         onClick={() => onRemove(index)}
         aria-label={`${label} ${index + 1} 삭제`}
-        className="text-slate-500 transition-colors hover:text-red-400"
+        className="inline-flex h-9 w-9 items-center justify-center rounded text-slate-500 transition-colors hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
       >
         <Trash2 className="h-3 w-3" />
       </button>

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -90,9 +90,6 @@ function ActionRow({
 }: ActionRowProps) {
   const hasCurrentOption = visibleActionTypes.some((actionType) => actionType.value === action.type);
   const fallbackLabel = getCreatorActionLabel(action.type);
-  const options = hasCurrentOption
-    ? visibleActionTypes
-    : visibleActionTypes.filter((actionType) => actionType.label !== fallbackLabel);
 
   return (
     <div className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-900 px-2 py-1.5">
@@ -102,8 +99,8 @@ function ActionRow({
         aria-label={`${label} ${index + 1} 실행 결과`}
         className="flex-1 bg-transparent text-xs text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset"
       >
-        {!hasCurrentOption && <option value={action.type}>{fallbackLabel}</option>}
-        {options.map((actionType) => (
+        {!hasCurrentOption && <option value={action.type}>{fallbackLabel} (기존값)</option>}
+        {visibleActionTypes.map((actionType) => (
           <option key={actionType.value} value={actionType.value}>
             {actionType.label}
           </option>

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -106,13 +106,13 @@ export function PhaseNodePanel({ node, themeId, onUpdate, edges = [] }: PhaseNod
       <div className="border-t border-slate-800" />
 
       <ActionListEditor
-        label="장면 시작 때 적용"
+        label="장면 시작 트리거"
         actions={(data.onEnter as PhaseAction[]) ?? []}
         onChange={(actions) => handleChange({ onEnter: actions })}
         hiddenTypes={[DELIVER_INFORMATION_ACTION, "deliver_information"]}
       />
       <ActionListEditor
-        label="장면 종료 때 적용"
+        label="장면 종료 트리거"
         actions={(data.onExit as PhaseAction[]) ?? []}
         onChange={(actions) => handleChange({ onExit: actions })}
       />
@@ -148,8 +148,8 @@ function PhaseSummaryCard({ viewModel }: { viewModel: PhaseEditorViewModel }) {
           value={`${viewModel.defaultTransitionLabel} · 조건 이동 ${viewModel.conditionalTransitionCount}개`}
         />
         <SummaryRow label="정보 전달" value={`${viewModel.informationDeliveryCount}개 설정`} />
-        <SummaryRow label="시작 시 실행" value={enterActions} />
-        <SummaryRow label="종료 시 실행" value={exitActions} />
+        <SummaryRow label="시작 트리거" value={enterActions} />
+        <SummaryRow label="종료 트리거" value={exitActions} />
       </dl>
     </section>
   );

--- a/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ActionListEditor } from "../ActionListEditor";
+
+afterEach(cleanup);
+
+describe("ActionListEditor", () => {
+  it("새 트리거 실행 결과를 backend action 계약값으로 추가한다", () => {
+    const onChange = vi.fn();
+
+    render(<ActionListEditor label="장면 시작 트리거" actions={[]} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "추가" }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "OPEN_VOTING" }),
+    ]);
+    expect(screen.queryByText("OPEN_VOTING")).toBeNull();
+  });
+
+  it("legacy action 값도 제작자용 라벨로 보여준다", () => {
+    render(
+      <ActionListEditor
+        label="장면 종료 트리거"
+        actions={[{ id: "a1", type: "disable_chat" }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const select = screen.getByRole("combobox", { name: "장면 종료 트리거 1 실행 결과" });
+    expect(select).toHaveProperty("value", "disable_chat");
+    expect(screen.getAllByRole("option", { name: "채팅 닫기" })).toHaveLength(1);
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
@@ -29,6 +29,7 @@ describe("ActionListEditor", () => {
 
     const select = screen.getByRole("combobox", { name: "장면 종료 트리거 1 실행 결과" });
     expect(select).toHaveProperty("value", "disable_chat");
-    expect(screen.getAllByRole("option", { name: "채팅 닫기" })).toHaveLength(1);
+    expect(screen.getByRole("option", { name: "채팅 닫기 (기존값)" })).toBeDefined();
+    expect(screen.getByRole("option", { name: "채팅 닫기" })).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -89,7 +89,7 @@ describe("PhaseNodePanel extended fields", () => {
     expect(screen.queryByPlaceholderText("30")).toBeNull();
   });
 
-  it("장면 시작/종료 적용 섹션이 렌더링된다", () => {
+  it("장면 시작/종료 트리거 섹션이 렌더링된다", () => {
     renderWithQC(
       <PhaseNodePanel
         node={makeNode()}
@@ -97,7 +97,8 @@ describe("PhaseNodePanel extended fields", () => {
         onUpdate={vi.fn()}
       />,
     );
-    expect(screen.getByText("장면 시작 때 적용")).toBeDefined();
-    expect(screen.getByText("장면 종료 때 적용")).toBeDefined();
+    expect(screen.getByText("장면 시작 트리거")).toBeDefined();
+    expect(screen.getByText("장면 종료 트리거")).toBeDefined();
+    expect(screen.getAllByText("트리거 실행 결과 없음")).toHaveLength(2);
   });
 });

--- a/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
@@ -16,21 +16,35 @@ describe("actionAdapter", () => {
   it("정보 전달 action의 legacy/current 타입을 동일하게 판정한다", () => {
     expect(isInformationDeliveryAction({ type: DELIVER_INFORMATION_ACTION })).toBe(true);
     expect(isInformationDeliveryAction({ type: "deliver_information" })).toBe(true);
-    expect(isInformationDeliveryAction({ type: "play_bgm" })).toBe(false);
+    expect(isInformationDeliveryAction({ type: "SET_BGM" })).toBe(false);
   });
 
   it("hidden type을 제외한 선택 옵션을 반환한다", () => {
-    expect(getVisibleCreatorActionOptions(["play_bgm"]).map((option) => option.value)).not.toContain(
-      "play_bgm",
+    expect(getVisibleCreatorActionOptions(["SET_BGM"]).map((option) => option.value)).not.toContain(
+      "SET_BGM",
     );
+    expect(getVisibleCreatorActionOptions().map((option) => option.value)).toEqual([
+      "OPEN_VOTING",
+      "CLOSE_VOTING",
+      "UNMUTE_CHAT",
+      "MUTE_CHAT",
+      "STOP_AUDIO",
+    ]);
   });
 
   it("정보 전달은 phase summary의 일반 action 목록에서 제외할 수 있다", () => {
     expect(
       toCreatorActionLabels(
-        [{ type: "play_bgm" }, { type: DELIVER_INFORMATION_ACTION }, { type: "disable_chat" }],
+        [{ type: "SET_BGM" }, { type: DELIVER_INFORMATION_ACTION }, { type: "MUTE_CHAT" }],
         { excludeInformationDelivery: true },
       ),
     ).toEqual(["BGM 재생", "채팅 닫기"]);
+  });
+
+  it("legacy 소문자 action도 기존 저장 데이터용 라벨을 유지한다", () => {
+    expect(toCreatorActionLabels([{ type: "play_bgm" }, { type: "disable_chat" }])).toEqual([
+      "BGM 재생",
+      "채팅 닫기",
+    ]);
   });
 });

--- a/apps/web/src/features/editor/entities/shared/actionAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/actionAdapter.ts
@@ -9,19 +9,27 @@ export const DELIVER_INFORMATION_ACTION = "DELIVER_INFORMATION";
 export const LEGACY_DELIVER_INFORMATION_ACTION = "deliver_information";
 
 export const CREATOR_ACTION_OPTIONS: CreatorActionOption[] = [
-  { value: "broadcast", label: "공지 전달" },
-  { value: "enable_voting", label: "투표 시작" },
-  { value: "disable_voting", label: "투표 종료" },
-  { value: "enable_chat", label: "채팅 열기" },
-  { value: "disable_chat", label: "채팅 닫기" },
-  { value: "play_bgm", label: "BGM 재생" },
-  { value: "stop_bgm", label: "BGM 정지" },
+  { value: "OPEN_VOTING", label: "투표 시작" },
+  { value: "CLOSE_VOTING", label: "투표 종료" },
+  { value: "UNMUTE_CHAT", label: "채팅 열기" },
+  { value: "MUTE_CHAT", label: "채팅 닫기" },
+  { value: "STOP_AUDIO", label: "BGM/효과음 정지" },
 ];
 
 const ACTION_LABELS = new Map<string, string>([
   ...CREATOR_ACTION_OPTIONS.map((option) => [option.value, option.label] as const),
   [DELIVER_INFORMATION_ACTION, "정보 전달"],
   [LEGACY_DELIVER_INFORMATION_ACTION, "정보 전달"],
+  ["SET_BGM", "BGM 재생"],
+  ["OPEN_GROUP_CHAT", "토론방 열기"],
+  ["CLOSE_GROUP_CHAT", "토론방 닫기"],
+  ["broadcast", "공지 전달"],
+  ["enable_voting", "투표 시작"],
+  ["disable_voting", "투표 종료"],
+  ["enable_chat", "채팅 열기"],
+  ["disable_chat", "채팅 닫기"],
+  ["play_bgm", "BGM 재생"],
+  ["stop_bgm", "BGM 정지"],
 ]);
 
 export function getCreatorActionLabel(type: string): string {


### PR DESCRIPTION
## 요약
- 장면 시작/종료 제작 UI를 트리거 용어로 정리했습니다.
- 새로 추가하는 트리거 실행 결과는 backend PhaseAction 계약값으로 저장되게 했습니다.
- 기존 소문자 phase action 저장값은 backend runtime에서 정규화해 이전 제작 데이터가 no-op으로 떨어지지 않게 했습니다.

## 범위 결정
- 이번 PR은 #300 PR 1의 첫 단위로, 실제 제작 화면의 route/page migration 흐름에서 트리거 계약을 고정합니다.
- BGM 재생, 공지, 토론방 이동, 비밀번호/버튼/다중 결과, 단서/장소 배치는 파라미터 UI와 별도 runtime 정책이 필요하므로 #302/#303/#305 및 #300 후속 PR 범위로 유지합니다.

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/entities/shared/__tests__/actionAdapter.test.ts src/features/editor/components/design/__tests__/ActionListEditor.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
- go test ./internal/engine
- git diff --check

Refs #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 레거시 액션 식별자도 인식하는 하위 호환 동작 추가

* **개선 사항**
  * 액션 타입 정규화 및 라벨 매핑 확장으로 편집기 옵션과 표시 개선
  * 액션 목록 UI: 빈 상태 메시지("트리거 실행 결과 없음") 및 셀렉트 레이블("실행 결과") 반영
  * 페이즈 에디터 트리거 라벨 텍스트 업데이트("장면 시작 트리거"/"장면 종료 트리거")

* **테스트**
  * 레거시/현행 액션 명칭 정규화 및 에디터 동작 관련 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->