### PR TITLE
feat(editor): #300 트리거 배치 UI 연결

### DIFF
--- a/apps/server/internal/domain/editor/service_clue_cleanup.go
+++ b/apps/server/internal/domain/editor/service_clue_cleanup.go
@@ -50,7 +50,9 @@ func removeClueIDFromConfigValue(value any, clueID string) (any, bool) {
 		return items, changed
 	case map[string]any:
 		if placement, ok := v["placement"].(map[string]any); ok {
-			if entityID, ok := placement["entityId"].(string); ok && entityID == clueID {
+			entityID, hasEntityID := placement["entityId"].(string)
+			placementKind, hasKind := placement["kind"].(string)
+			if hasKind && placementKind == "clue" && hasEntityID && entityID == clueID {
 				return deletedConfigNode, true
 			}
 		}

--- a/apps/server/internal/domain/editor/service_clue_cleanup.go
+++ b/apps/server/internal/domain/editor/service_clue_cleanup.go
@@ -49,6 +49,11 @@ func removeClueIDFromConfigValue(value any, clueID string) (any, bool) {
 		}
 		return items, changed
 	case map[string]any:
+		if placement, ok := v["placement"].(map[string]any); ok {
+			if entityID, ok := placement["entityId"].(string); ok && entityID == clueID {
+				return deletedConfigNode, true
+			}
+		}
 		if currentClueID, ok := v["clueId"].(string); ok && currentClueID == clueID {
 			if _, hasLocation := v["locationId"].(string); hasLocation {
 				return deletedConfigNode, true

--- a/apps/server/internal/domain/editor/service_clue_cleanup_test.go
+++ b/apps/server/internal/domain/editor/service_clue_cleanup_test.go
@@ -15,6 +15,10 @@ func TestRemoveClueReferencesFromConfigJSON(t *testing.T) {
 		"modules": {
 			"starting_clue": {"enabled": true, "config": {"startingClues": {"char-1": ["11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333"]}}},
 			"clue_action": {"enabled": true, "config": {"targetClueId": "11111111-1111-1111-1111-111111111111", "rewards": ["11111111-1111-1111-1111-111111111111", "44444444-4444-4444-4444-444444444444"]}},
+			"event_progression": {"enabled": true, "config": {"Triggers": [
+				{"id":"deleted-clue-trigger","placement":{"kind":"clue","entityId":"11111111-1111-1111-1111-111111111111"},"actions":[{"type":"OPEN_VOTING"}]},
+				{"id":"kept-clue-trigger","placement":{"kind":"clue","entityId":"55555555-5555-5555-5555-555555555555"},"actions":[{"type":"MUTE_CHAT"}]}
+			]}},
 			"location": {"enabled": true, "config": {"discoveries": [
 				{"locationId":"loc-1","clueId":"11111111-1111-1111-1111-111111111111","requiredClueIds":["22222222-2222-2222-2222-222222222222"]},
 				{"locationId":"loc-1","clueId":"55555555-5555-5555-5555-555555555555","requiredClueIds":["11111111-1111-1111-1111-111111111111","22222222-2222-2222-2222-222222222222"]}
@@ -43,6 +47,16 @@ func TestRemoveClueReferencesFromConfigJSON(t *testing.T) {
 	discoveries := locationConfig["discoveries"].([]any)
 	if len(discoveries) != 1 {
 		t.Fatalf("expected only discovery with deleted clueId to be removed, got %#v", discoveries)
+	}
+	eventModule := modules["event_progression"].(map[string]any)
+	eventConfig := eventModule["config"].(map[string]any)
+	triggers := eventConfig["Triggers"].([]any)
+	if len(triggers) != 1 {
+		t.Fatalf("expected trigger placed on deleted clue to be removed, got %#v", triggers)
+	}
+	keptTrigger := triggers[0].(map[string]any)
+	if keptTrigger["id"] != "kept-clue-trigger" {
+		t.Fatalf("unexpected kept trigger: %#v", keptTrigger)
 	}
 	keptDiscovery := discoveries[0].(map[string]any)
 	if keptDiscovery["clueId"] != "55555555-5555-5555-5555-555555555555" {

--- a/apps/server/internal/domain/editor/service_entity_cleanup.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup.go
@@ -55,6 +55,11 @@ func removeEntityIDFromConfigValue(value any, entityID string) (any, bool) {
 		}
 		return items, changed
 	case map[string]any:
+		if placement, ok := v["placement"].(map[string]any); ok {
+			if placementEntityID, ok := placement["entityId"].(string); ok && placementEntityID == entityID {
+				return deletedConfigNode, true
+			}
+		}
 		if id, ok := v["id"].(string); ok && id == entityID {
 			return deletedConfigNode, true
 		}

--- a/apps/server/internal/domain/editor/service_entity_cleanup.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup.go
@@ -8,14 +8,14 @@ import (
 )
 
 func removeCharacterReferencesFromConfigJSON(raw json.RawMessage, characterID uuid.UUID) (json.RawMessage, bool, error) {
-	return removeEntityReferencesFromConfigJSON(raw, characterID.String())
+	return removeEntityReferencesFromConfigJSON(raw, characterID.String(), "character")
 }
 
 func removeLocationReferencesFromConfigJSON(raw json.RawMessage, locationID uuid.UUID) (json.RawMessage, bool, error) {
-	return removeEntityReferencesFromConfigJSON(raw, locationID.String())
+	return removeEntityReferencesFromConfigJSON(raw, locationID.String(), "location")
 }
 
-func removeEntityReferencesFromConfigJSON(raw json.RawMessage, entityID string) (json.RawMessage, bool, error) {
+func removeEntityReferencesFromConfigJSON(raw json.RawMessage, entityID string, placementKind string) (json.RawMessage, bool, error) {
 	if len(bytes.TrimSpace(raw)) == 0 {
 		return raw, false, nil
 	}
@@ -23,7 +23,7 @@ func removeEntityReferencesFromConfigJSON(raw json.RawMessage, entityID string) 
 	if err := json.Unmarshal(raw, &value); err != nil {
 		return nil, false, err
 	}
-	cleaned, changed := removeEntityIDFromConfigValue(value, entityID)
+	cleaned, changed := removeEntityIDFromConfigValue(value, entityID, placementKind)
 	if !changed {
 		return raw, false, nil
 	}
@@ -34,7 +34,7 @@ func removeEntityReferencesFromConfigJSON(raw json.RawMessage, entityID string) 
 	return encoded, true, nil
 }
 
-func removeEntityIDFromConfigValue(value any, entityID string) (any, bool) {
+func removeEntityIDFromConfigValue(value any, entityID string, placementKind string) (any, bool) {
 	switch v := value.(type) {
 	case nil:
 		return nil, false
@@ -47,7 +47,7 @@ func removeEntityIDFromConfigValue(value any, entityID string) (any, bool) {
 		changed := false
 		items := make([]any, 0, len(v))
 		for _, item := range v {
-			cleaned, itemChanged := removeEntityIDFromConfigValue(item, entityID)
+			cleaned, itemChanged := removeEntityIDFromConfigValue(item, entityID, placementKind)
 			changed = changed || itemChanged
 			if cleaned != deletedConfigNode {
 				items = append(items, cleaned)
@@ -56,7 +56,9 @@ func removeEntityIDFromConfigValue(value any, entityID string) (any, bool) {
 		return items, changed
 	case map[string]any:
 		if placement, ok := v["placement"].(map[string]any); ok {
-			if placementEntityID, ok := placement["entityId"].(string); ok && placementEntityID == entityID {
+			placementEntityID, hasEntityID := placement["entityId"].(string)
+			currentPlacementKind, hasKind := placement["kind"].(string)
+			if hasKind && currentPlacementKind == placementKind && hasEntityID && placementEntityID == entityID {
 				return deletedConfigNode, true
 			}
 		}
@@ -76,7 +78,7 @@ func removeEntityIDFromConfigValue(value any, entityID string) (any, bool) {
 				changed = true
 				continue
 			}
-			cleaned, childChanged := removeEntityIDFromConfigValue(child, entityID)
+			cleaned, childChanged := removeEntityIDFromConfigValue(child, entityID, placementKind)
 			changed = changed || childChanged
 			if cleaned != deletedConfigNode {
 				out[key] = cleaned

--- a/apps/server/internal/domain/editor/service_entity_cleanup_test.go
+++ b/apps/server/internal/domain/editor/service_entity_cleanup_test.go
@@ -83,6 +83,15 @@ func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
 						{"locationId": "%s", "clueId": "clue-2"}
 					]
 				}
+			},
+			"event_progression": {
+				"enabled": true,
+				"config": {
+					"Triggers": [
+						{"id":"deleted-location-trigger","placement":{"kind":"location","entityId":"%s"},"actions":[{"type":"OPEN_VOTING"}]},
+						{"id":"kept-location-trigger","placement":{"kind":"location","entityId":"%s"},"actions":[{"type":"MUTE_CHAT"}]}
+					]
+				}
 			}
 		},
 		"locationMeta": {
@@ -95,7 +104,7 @@ func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
 			"kept-clue": "%s"
 		},
 		"nullable": null
-	}`, locationID, keptLocationID, locationID, keptLocationID, locationID, keptLocationID, locationID, locationID, keptLocationID, locationID, keptLocationID))
+	}`, locationID, keptLocationID, locationID, keptLocationID, locationID, keptLocationID, locationID, keptLocationID, locationID, locationID, keptLocationID, locationID, keptLocationID))
 
 	cleaned, changed, err := removeLocationReferencesFromConfigJSON(raw, locationID)
 	if err != nil {
@@ -126,6 +135,16 @@ func TestRemoveLocationReferencesFromConfigJSON(t *testing.T) {
 	discoveries := locationConfig["discoveries"].([]any)
 	if len(discoveries) != 1 {
 		t.Fatalf("expected only discovery with deleted locationId to be removed, got %#v", discoveries)
+	}
+	eventModule := modules["event_progression"].(map[string]any)
+	eventConfig := eventModule["config"].(map[string]any)
+	triggers := eventConfig["Triggers"].([]any)
+	if len(triggers) != 1 {
+		t.Fatalf("expected trigger placed on deleted location to be removed, got %#v", triggers)
+	}
+	keptTrigger := triggers[0].(map[string]any)
+	if keptTrigger["id"] != "kept-location-trigger" {
+		t.Fatalf("unexpected kept trigger: %#v", keptTrigger)
 	}
 	keptDiscovery := discoveries[0].(map[string]any)
 	if keptDiscovery["locationId"] != keptLocationID.String() {

--- a/apps/server/internal/module/progression/event_progression.go
+++ b/apps/server/internal/module/progression/event_progression.go
@@ -43,11 +43,17 @@ type eventProgressionConfig struct {
 }
 
 type eventProgressionTrigger struct {
-	ID       string          `json:"id"`
-	From     string          `json:"from,omitempty"`
-	To       string          `json:"to,omitempty"`
-	Password string          `json:"password,omitempty"`
-	Actions  json.RawMessage `json:"actions,omitempty"`
+	ID        string                            `json:"id"`
+	From      string                            `json:"from,omitempty"`
+	To        string                            `json:"to,omitempty"`
+	Password  string                            `json:"password,omitempty"`
+	Actions   json.RawMessage                   `json:"actions,omitempty"`
+	Placement *eventProgressionTriggerPlacement `json:"placement,omitempty"`
+}
+
+type eventProgressionTriggerPlacement struct {
+	Kind     string `json:"kind"`
+	EntityID string `json:"entityId"`
 }
 
 // NewEventProgressionModule creates a new EventProgressionModule instance.
@@ -376,7 +382,14 @@ func (m *EventProgressionModule) Schema() json.RawMessage {
 						"from": {"type": "string"},
 						"to": {"type": "string"},
 						"password": {"type": "string"},
-						"actions": {"type": "array"}
+						"actions": {"type": "array"},
+						"placement": {
+							"type": "object",
+							"properties": {
+								"kind": {"type": "string", "enum": ["clue", "location"]},
+								"entityId": {"type": "string"}
+							}
+						}
 					}
 				}
 			}

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -150,9 +150,9 @@ function ClueUsageCard({ references }: { references: EntityReference[] }) {
         </p>
       ) : (
         <ul className="mt-3 space-y-2">
-          {references.map((ref) => (
+          {references.map((ref, index) => (
             <li
-              key={`${ref.sourceType}-${ref.sourceId}-${ref.relation}`}
+              key={`${ref.sourceType}-${ref.sourceId}-${ref.relation}-${index}`}
               className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-300"
             >
               {formatReference(ref)}

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -1,10 +1,22 @@
 import { useMemo, useState } from 'react';
 import { Edit3, Trash2 } from 'lucide-react';
-import type { ClueResponse, EditorCharacterResponse, LocationResponse } from '@/features/editor/api';
+import type {
+  ClueResponse,
+  EditorCharacterResponse,
+  LocationResponse,
+} from '@/features/editor/api';
 import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
-import { buildClueUsageMap, getClueBacklinks, type EntityReference } from '@/features/editor/utils/entityReferences';
-import { buildClueBadges, toClueEditorViewModel } from '@/features/editor/entities/clue/clueEntityAdapter';
+import {
+  buildClueUsageMap,
+  getClueBacklinks,
+  type EntityReference,
+} from '@/features/editor/utils/entityReferences';
+import {
+  buildClueBadges,
+  toClueEditorViewModel,
+} from '@/features/editor/entities/clue/clueEntityAdapter';
+import { EntityTriggerPlacementCard } from '@/features/editor/components/triggers/EntityTriggerPlacementCard';
 import { ClueRuntimeEffectCard } from './ClueRuntimeEffectCard';
 
 interface ClueEntityWorkspaceProps {
@@ -33,7 +45,7 @@ export function ClueEntityWorkspace({
   const [selectedId, setSelectedId] = useState(clues[0]?.id ?? '');
   const usageMap = useMemo(
     () => buildClueUsageMap({ configJson, clues, locations, characters }),
-    [configJson, clues, locations, characters],
+    [configJson, clues, locations, characters]
   );
 
   return (
@@ -53,6 +65,14 @@ export function ClueEntityWorkspace({
           <ClueRuntimeEffectCard
             clue={clue}
             clues={clues}
+            configJson={configJson}
+            onConfigChange={onConfigChange}
+            isSaving={isConfigSaving}
+          />
+          <EntityTriggerPlacementCard
+            entityKind="clue"
+            entityId={clue.id}
+            entityName={clue.name}
             configJson={configJson}
             onConfigChange={onConfigChange}
             isSaving={isConfigSaving}
@@ -78,7 +98,9 @@ function ClueDetailCard({
     <article className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">단서 상세</p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
+            단서 상세
+          </p>
           <h3 className="mt-1 text-xl font-bold text-slate-100">{clue.name}</h3>
           <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-400">
             {view.description}
@@ -90,7 +112,8 @@ function ClueDetailCard({
             onClick={() => onEdit(clue)}
             className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-200 hover:border-amber-500/50 hover:text-amber-300"
           >
-            <Edit3 className="h-3.5 w-3.5" />수정
+            <Edit3 className="h-3.5 w-3.5" />
+            수정
           </button>
           <button
             type="button"
@@ -98,7 +121,8 @@ function ClueDetailCard({
             aria-label={`${clue.name} 삭제`}
             className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-red-500/20 px-3 py-2 text-xs font-semibold text-red-300 hover:bg-red-500/10"
           >
-            <Trash2 className="h-3.5 w-3.5" />삭제
+            <Trash2 className="h-3.5 w-3.5" />
+            삭제
           </button>
         </div>
       </div>
@@ -117,7 +141,9 @@ function ClueUsageCard({ references }: { references: EntityReference[] }) {
   return (
     <aside className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
       <p className="text-sm font-semibold text-slate-200">이 단서가 쓰이는 곳</p>
-      <p className="mt-1 text-xs text-slate-500">삭제하거나 수정할 때 함께 확인해야 하는 연결입니다.</p>
+      <p className="mt-1 text-xs text-slate-500">
+        삭제하거나 수정할 때 함께 확인해야 하는 연결입니다.
+      </p>
       {references.length === 0 ? (
         <p className="mt-3 rounded-lg border border-dashed border-slate-800 px-3 py-6 text-center text-xs text-slate-600">
           아직 배치된 장소나 시작 단서가 없습니다.
@@ -125,7 +151,10 @@ function ClueUsageCard({ references }: { references: EntityReference[] }) {
       ) : (
         <ul className="mt-3 space-y-2">
           {references.map((ref) => (
-            <li key={`${ref.sourceType}-${ref.sourceId}-${ref.relation}`} className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-300">
+            <li
+              key={`${ref.sourceType}-${ref.sourceId}-${ref.relation}`}
+              className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-300"
+            >
               {formatReference(ref)}
             </li>
           ))}
@@ -150,5 +179,6 @@ function formatReference(ref: EntityReference) {
   if (ref.relation === 'starting_clue') return `${ref.sourceName}의 시작 단서`;
   if (ref.relation === 'combination_input') return `${ref.sourceName}의 조합 조건`;
   if (ref.relation === 'combination_output') return `${ref.sourceName}의 조합 보상`;
+  if (ref.relation === 'trigger') return `${ref.sourceName}의 트리거`;
   return `${ref.sourceName}의 연결 설정`;
 }

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -58,20 +58,30 @@ export function ClueListView({ themeId }: ClueListViewProps) {
   function handleDeleteConfirm() {
     if (!deletingClue) return;
     deleteClue.mutate(deletingClue.id, {
-      onSuccess: () => { toast.success('단서가 삭제되었습니다'); setDeletingClue(undefined); },
-      onError: (err) => { toast.error(err.message || '단서 삭제에 실패했습니다'); setDeletingClue(undefined); },
+      onSuccess: () => {
+        toast.success('단서가 삭제되었습니다');
+        setDeletingClue(undefined);
+      },
+      onError: (err) => {
+        toast.error(err.message || '단서 삭제에 실패했습니다');
+        setDeletingClue(undefined);
+      },
     });
   }
 
   function handleConfigChange(nextConfig: EditorConfig) {
     updateConfig.mutate(nextConfig, {
-      onSuccess: () => toast.success('단서 사용 효과가 저장되었습니다'),
-      onError: () => toast.error('단서 사용 효과 저장에 실패했습니다'),
+      onSuccess: () => toast.success('단서 설정이 저장되었습니다'),
+      onError: () => toast.error('단서 설정 저장에 실패했습니다'),
     });
   }
 
   if (isLoading) {
-    return <div className="flex items-center justify-center py-12"><Spinner size="lg" /></div>;
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
   }
 
   if (isError) {
@@ -82,26 +92,29 @@ export function ClueListView({ themeId }: ClueListViewProps) {
           <p className="mt-2 text-sm leading-6 text-red-200/80">
             네트워크나 권한 문제일 수 있습니다. 잠시 후 다시 시도해 주세요.
           </p>
-          <Button onClick={() => void refetch()}>
-            다시 시도
-          </Button>
+          <Button onClick={() => void refetch()}>다시 시도</Button>
         </div>
       </div>
     );
   }
 
   if (!clues) {
-    return <div className="flex items-center justify-center py-12"><Spinner size="lg" /></div>;
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
   }
 
-  const deletingReferences = deletingClue && clues
-    ? buildClueUsageMap({
-      configJson: theme?.config_json,
-      clues,
-      locations,
-      characters,
-    })[deletingClue.id]?.references ?? []
-    : [];
+  const deletingReferences =
+    deletingClue && clues
+      ? (buildClueUsageMap({
+          configJson: theme?.config_json,
+          clues,
+          locations,
+          characters,
+        })[deletingClue.id]?.references ?? [])
+      : [];
 
   return (
     <div className="px-4 py-6">
@@ -117,7 +130,12 @@ export function ClueListView({ themeId }: ClueListViewProps) {
         isConfigSaving={updateConfig.isPending}
       />
 
-      <ClueForm themeId={themeId} clue={editingClue} isOpen={isFormOpen} onClose={handleFormClose} />
+      <ClueForm
+        themeId={themeId}
+        clue={editingClue}
+        isOpen={isFormOpen}
+        onClose={handleFormClose}
+      />
 
       <Modal
         isOpen={!!deletingClue}
@@ -126,14 +144,22 @@ export function ClueListView({ themeId }: ClueListViewProps) {
         size="sm"
         footer={
           <>
-            <Button variant="ghost" onClick={() => setDeletingClue(undefined)} disabled={deleteClue.isPending}>취소</Button>
-            <Button variant="danger" isLoading={deleteClue.isPending} onClick={handleDeleteConfirm}>삭제</Button>
+            <Button
+              variant="ghost"
+              onClick={() => setDeletingClue(undefined)}
+              disabled={deleteClue.isPending}
+            >
+              취소
+            </Button>
+            <Button variant="danger" isLoading={deleteClue.isPending} onClick={handleDeleteConfirm}>
+              삭제
+            </Button>
           </>
         }
       >
         <p className="text-sm text-slate-300">
-          <span className="font-semibold text-slate-100">{deletingClue?.name}</span> 단서를 삭제하시겠습니까?
-          연결된 설정은 함께 정리되어, 없는 단서를 가리키는 문제가 남지 않습니다.
+          <span className="font-semibold text-slate-100">{deletingClue?.name}</span> 단서를
+          삭제하시겠습니까? 연결된 설정은 함께 정리되어, 없는 단서를 가리키는 문제가 남지 않습니다.
         </p>
         {deletingReferences.length > 0 ? (
           <div className="mt-4 rounded-lg border border-amber-500/20 bg-amber-500/10 p-3">
@@ -164,5 +190,6 @@ function formatDeleteReference(ref: EntityReference) {
   if (ref.relation === 'starting_clue') return `${ref.sourceName}의 시작 단서에서 제거됩니다.`;
   if (ref.relation === 'combination_input') return `${ref.sourceName}의 조합 조건에서 제거됩니다.`;
   if (ref.relation === 'combination_output') return `${ref.sourceName}의 조합 보상에서 제거됩니다.`;
+  if (ref.relation === 'trigger') return `${ref.sourceName}의 트리거에서 제거됩니다.`;
   return `${ref.sourceName}의 연결 설정에서 제거됩니다.`;
 }

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -167,8 +167,8 @@ export function ClueListView({ themeId }: ClueListViewProps) {
               함께 정리될 연결 {deletingReferences.length}곳
             </p>
             <ul className="mt-2 space-y-1.5 text-xs text-amber-100/80">
-              {deletingReferences.map((ref) => (
-                <li key={`${ref.sourceType}-${ref.sourceId}-${ref.relation}`}>
+              {deletingReferences.map((ref, index) => (
+                <li key={`${ref.sourceType}-${ref.sourceId}-${ref.relation}-${index}`}>
                   {formatDeleteReference(ref)}
                 </li>
               ))}

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { Image, Info, MapPin, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import type { EditorThemeResponse, MapResponse, LocationResponse } from '@/features/editor/api';
-import { useUpdateLocation } from '@/features/editor/api';
+import { useUpdateConfigJson, useUpdateLocation } from '@/features/editor/api';
 import { ImageUpload } from '@/features/editor/components/ImageUpload';
+import { EntityTriggerPlacementCard } from '@/features/editor/components/triggers/EntityTriggerPlacementCard';
 import { readLocationClueIds } from '@/features/editor/editorTypes';
+import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { toLocationEditorViewModel } from '@/features/editor/entities/location/locationEntityAdapter';
 import { AddNameInput } from './AddNameInput';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
@@ -130,6 +132,7 @@ function SelectedLocationDetail({
   location: LocationResponse;
 }) {
   const updateLocation = useUpdateLocation(themeId);
+  const updateConfig = useUpdateConfigJson(themeId);
   const [fromRoundInput, setFromRoundInput] = useState(roundToInput(location.from_round));
   const [untilRoundInput, setUntilRoundInput] = useState(roundToInput(location.until_round));
   const assignedCount = useMemo(
@@ -186,6 +189,13 @@ function SelectedLocationDetail({
     );
   }
 
+  function saveTriggerConfig(nextConfig: EditorConfig) {
+    updateConfig.mutate(nextConfig, {
+      onSuccess: () => toast.success('장소 트리거가 저장되었습니다'),
+      onError: () => toast.error('장소 트리거 저장에 실패했습니다'),
+    });
+  }
+
   return (
     <div className="space-y-4">
       <section className="rounded-lg border border-slate-800 bg-slate-950/70 p-4">
@@ -230,6 +240,14 @@ function SelectedLocationDetail({
           </div>
         </div>
       </section>
+      <EntityTriggerPlacementCard
+        entityKind="location"
+        entityId={location.id}
+        entityName={location.name}
+        configJson={theme.config_json}
+        onConfigChange={saveTriggerConfig}
+        isSaving={updateConfig.isPending}
+      />
       <LocationAccessPolicyPanel themeId={themeId} location={location} />
       <LocationClueAssignPanel themeId={themeId} theme={theme} location={location} />
     </div>

--- a/apps/web/src/features/editor/components/triggers/EntityTriggerPlacementCard.tsx
+++ b/apps/web/src/features/editor/components/triggers/EntityTriggerPlacementCard.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from 'react';
+import { KeyRound, Plus, Save, Trash2, Zap } from 'lucide-react';
+import { ActionListEditor } from '@/features/editor/components/design/ActionListEditor';
+import type { PhaseAction } from '@/features/editor/flowTypes';
+import type { EditorConfig } from '@/features/editor/utils/configShape';
+import {
+  readTriggersForPlacement,
+  writeTriggersForPlacement,
+  type EventProgressionTriggerConfig,
+  type TriggerPlacementKind,
+} from '@/features/editor/utils/eventProgressionConfig';
+
+interface EntityTriggerPlacementCardProps {
+  entityKind: TriggerPlacementKind;
+  entityId: string;
+  entityName: string;
+  configJson: EditorConfig | null | undefined;
+  onConfigChange?: (nextConfig: EditorConfig) => void;
+  isSaving?: boolean;
+}
+
+function createTrigger(
+  entityKind: TriggerPlacementKind,
+  entityId: string
+): EventProgressionTriggerConfig {
+  const id = `trigger-${entityKind}-${entityId}-${crypto.randomUUID()}`;
+  return {
+    id,
+    label: '',
+    actions: [],
+    placement: { kind: entityKind, entityId },
+  };
+}
+
+function isTriggerValid(trigger: EventProgressionTriggerConfig) {
+  return (trigger.actions ?? []).some((action) => action.type.trim().length > 0);
+}
+
+export function EntityTriggerPlacementCard({
+  entityKind,
+  entityId,
+  entityName,
+  configJson,
+  onConfigChange,
+  isSaving = false,
+}: EntityTriggerPlacementCardProps) {
+  const placement = useMemo(() => ({ kind: entityKind, entityId }), [entityKind, entityId]);
+  const savedTriggers = useMemo(
+    () => readTriggersForPlacement(configJson, placement),
+    [configJson, placement]
+  );
+  const [drafts, setDrafts] = useState<EventProgressionTriggerConfig[]>(savedTriggers);
+
+  useEffect(() => {
+    setDrafts(savedTriggers);
+  }, [savedTriggers]);
+
+  const title = entityKind === 'clue' ? '단서 트리거' : '장소 트리거';
+  const description =
+    entityKind === 'clue'
+      ? '플레이어가 이 단서를 확인하거나 입력을 통과했을 때 실행할 제작 규칙입니다.'
+      : '플레이어가 이 장소에 도달하거나 장소 단서를 발견했을 때 실행할 제작 규칙입니다.';
+  const canSave = !!onConfigChange && !isSaving && drafts.every(isTriggerValid);
+
+  function updateDraft(index: number, patch: Partial<EventProgressionTriggerConfig>) {
+    setDrafts((current) =>
+      current.map((trigger, i) => (i === index ? { ...trigger, ...patch } : trigger))
+    );
+  }
+
+  function handleAdd() {
+    setDrafts((current) => [...current, createTrigger(entityKind, entityId)]);
+  }
+
+  function handleRemove(index: number) {
+    setDrafts((current) => current.filter((_, i) => i !== index));
+  }
+
+  function handleSave() {
+    if (!canSave) return;
+    onConfigChange?.(writeTriggersForPlacement(configJson, placement, drafts));
+  }
+
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
+            진행 연결
+          </p>
+          <h4 className="mt-1 text-lg font-bold text-slate-100">{title}</h4>
+          <p className="mt-1 text-sm leading-6 text-slate-400">{description}</p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-sm font-semibold text-slate-200 hover:border-amber-500/50 hover:text-amber-300"
+          >
+            <Plus className="h-4 w-4" />
+            트리거 추가
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-amber-500/30 px-3 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
+          >
+            <Save className="h-4 w-4" />
+            {isSaving ? '저장 중' : '트리거 저장'}
+          </button>
+        </div>
+      </div>
+
+      {drafts.length === 0 ? (
+        <p className="mt-4 rounded-lg border border-dashed border-slate-800 px-3 py-6 text-center text-xs text-slate-600">
+          아직 {entityName}에 연결된 트리거가 없습니다.
+        </p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {drafts.map((trigger, index) => (
+            <TriggerDraftRow
+              key={trigger.id}
+              trigger={trigger}
+              index={index}
+              title={title}
+              onChange={(patch) => updateDraft(index, patch)}
+              onRemove={() => handleRemove(index)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TriggerDraftRow({
+  trigger,
+  index,
+  title,
+  onChange,
+  onRemove,
+}: {
+  trigger: EventProgressionTriggerConfig;
+  index: number;
+  title: string;
+  onChange: (patch: Partial<EventProgressionTriggerConfig>) => void;
+  onRemove: () => void;
+}) {
+  const actions = trigger.actions ?? [];
+
+  function handleActionChange(nextActions: PhaseAction[]) {
+    onChange({ actions: nextActions });
+  }
+
+  return (
+    <article className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-200">
+          <Zap className="h-4 w-4 text-amber-400" />
+          {title} {index + 1}
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`${title} ${index + 1} 삭제`}
+          className="inline-flex h-8 w-8 items-center justify-center rounded text-slate-500 hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      <label className="mt-3 block text-xs font-semibold text-slate-400">
+        화면 이름
+        <input
+          type="text"
+          value={trigger.label ?? ''}
+          onChange={(e) => onChange({ label: e.target.value })}
+          placeholder="예: 금고 암호 확인"
+          className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+        />
+      </label>
+
+      <label className="mt-3 block text-xs font-semibold text-slate-400">
+        <span className="inline-flex items-center gap-1.5">
+          <KeyRound className="h-3.5 w-3.5 text-amber-400" />
+          비밀번호
+        </span>
+        <input
+          type="text"
+          value={trigger.password ?? ''}
+          onChange={(e) => onChange({ password: e.target.value })}
+          placeholder="비워두면 즉시 실행"
+          className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+        />
+      </label>
+
+      <div className="mt-3">
+        <ActionListEditor
+          label={`${title} ${index + 1}`}
+          actions={actions}
+          onChange={handleActionChange}
+        />
+      </div>
+
+      {!isTriggerValid(trigger) && (
+        <p className="mt-2 text-xs text-amber-300">저장하려면 실행 결과를 하나 이상 추가하세요.</p>
+      )}
+    </article>
+  );
+}

--- a/apps/web/src/features/editor/components/triggers/__tests__/EntityTriggerPlacementCard.test.tsx
+++ b/apps/web/src/features/editor/components/triggers/__tests__/EntityTriggerPlacementCard.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EntityTriggerPlacementCard } from '../EntityTriggerPlacementCard';
+import { readModuleConfig } from '@/features/editor/utils/configShape';
+
+afterEach(cleanup);
+
+describe('EntityTriggerPlacementCard', () => {
+  it('adds a clue trigger and writes it to event_progression placement config', () => {
+    const onConfigChange = vi.fn();
+
+    render(
+      <EntityTriggerPlacementCard
+        entityKind="clue"
+        entityId="clue-1"
+        entityName="단검"
+        configJson={{}}
+        onConfigChange={onConfigChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '트리거 추가' }));
+    fireEvent.click(screen.getByRole('button', { name: '추가' }));
+    fireEvent.click(screen.getByRole('button', { name: '트리거 저장' }));
+
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    const [nextConfig] = onConfigChange.mock.calls[0];
+    expect(readModuleConfig(nextConfig, 'event_progression')).toMatchObject({
+      Triggers: [
+        {
+          placement: { kind: 'clue', entityId: 'clue-1' },
+          actions: [{ type: 'OPEN_VOTING' }],
+        },
+      ],
+    });
+  });
+
+  it('keeps save disabled until each trigger has at least one action', () => {
+    render(
+      <EntityTriggerPlacementCard
+        entityKind="location"
+        entityId="loc-1"
+        entityName="서재"
+        configJson={{}}
+        onConfigChange={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '트리거 추가' }));
+
+    expect(
+      (screen.getByRole('button', { name: '트리거 저장' }) as HTMLButtonElement).disabled
+    ).toBe(true);
+    expect(screen.getByText('저장하려면 실행 결과를 하나 이상 추가하세요.')).toBeDefined();
+  });
+});

--- a/apps/web/src/features/editor/utils/__tests__/entityReferences.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/entityReferences.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { ClueResponse, EditorCharacterResponse, LocationResponse } from '@/features/editor/api';
+import type {
+  ClueResponse,
+  EditorCharacterResponse,
+  LocationResponse,
+} from '@/features/editor/api';
 import { buildClueUsageMap, getClueBacklinks } from '../entityReferences';
 
 const clues = [
@@ -13,9 +17,7 @@ const locations = [
   { id: 'loc-2', name: '부엌' },
 ] as LocationResponse[];
 
-const characters = [
-  { id: 'char-1', name: '김철수' },
-] as EditorCharacterResponse[];
+const characters = [{ id: 'char-1', name: '김철수' }] as EditorCharacterResponse[];
 
 describe('entityReferences', () => {
   it('builds clue backlinks from location clue, evidence, and starting clue references', () => {
@@ -36,16 +38,34 @@ describe('entityReferences', () => {
             enabled: true,
             config: { startingClues: { 'char-1': ['clue-1'] } },
           },
+          event_progression: {
+            enabled: true,
+            config: {
+              Triggers: [
+                {
+                  id: 'trigger-clue-2',
+                  placement: { kind: 'clue', entityId: 'clue-2' },
+                  actions: [{ type: 'OPEN_VOTING' }],
+                },
+              ],
+            },
+          },
         },
       },
     });
 
     expect(getClueBacklinks(usage, 'clue-1')).toEqual([
       { sourceType: 'location', sourceId: 'loc-1', sourceName: '서재', relation: 'location_clue' },
-      { sourceType: 'character', sourceId: 'char-1', sourceName: '김철수', relation: 'starting_clue' },
+      {
+        sourceType: 'character',
+        sourceId: 'char-1',
+        sourceName: '김철수',
+        relation: 'starting_clue',
+      },
     ]);
     expect(getClueBacklinks(usage, 'clue-2')).toEqual([
       { sourceType: 'location', sourceId: 'loc-1', sourceName: '서재', relation: 'evidence' },
+      { sourceType: 'clue', sourceId: 'clue-2', sourceName: '피 묻은 칼', relation: 'trigger' },
     ]);
     expect(usage['clue-3'].isUnused).toBe(true);
   });

--- a/apps/web/src/features/editor/utils/__tests__/eventProgressionConfig.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/eventProgressionConfig.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  readEventProgressionTriggers,
+  readTriggersForPlacement,
+  writeTriggersForPlacement,
+} from '../eventProgressionConfig';
+import { readModuleConfig } from '../configShape';
+
+describe('eventProgressionConfig', () => {
+  it('reads only valid event progression triggers from the runtime module', () => {
+    const config = {
+      modules: {
+        event_progression: {
+          enabled: true,
+          config: {
+            Triggers: [
+              {
+                id: 'trigger-1',
+                label: '금고 암호',
+                password: '0427',
+                placement: { kind: 'clue', entityId: 'clue-1' },
+                actions: [{ id: 'action-1', type: 'OPEN_VOTING' }],
+              },
+              { id: '', actions: [{ type: 'OPEN_VOTING' }] },
+              { id: 'trigger-2', placement: { kind: 'bad', entityId: 'clue-1' } },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(readEventProgressionTriggers(config)).toEqual([
+      {
+        id: 'trigger-1',
+        label: '금고 암호',
+        password: '0427',
+        placement: { kind: 'clue', entityId: 'clue-1' },
+        actions: [{ id: 'action-1', type: 'OPEN_VOTING' }],
+      },
+      { id: 'trigger-2' },
+    ]);
+  });
+
+  it('writes triggers for one placement while preserving other runtime settings', () => {
+    const base = {
+      modules: {
+        event_progression: {
+          enabled: true,
+          config: {
+            InitialPhase: 'intro',
+            Triggers: [
+              {
+                id: 'keep-location',
+                placement: { kind: 'location', entityId: 'loc-1' },
+                actions: [{ type: 'MUTE_CHAT' }],
+              },
+              {
+                id: 'replace-clue',
+                placement: { kind: 'clue', entityId: 'clue-1' },
+                actions: [{ type: 'OPEN_VOTING' }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const next = writeTriggersForPlacement(base, { kind: 'clue', entityId: 'clue-1' }, [
+      {
+        id: 'new-clue-trigger',
+        label: '암호 입력',
+        password: '0427',
+        actions: [{ type: 'UNMUTE_CHAT' }],
+      },
+    ]);
+
+    expect(readTriggersForPlacement(next, { kind: 'clue', entityId: 'clue-1' })).toEqual([
+      {
+        id: 'new-clue-trigger',
+        label: '암호 입력',
+        password: '0427',
+        placement: { kind: 'clue', entityId: 'clue-1' },
+        actions: [{ type: 'UNMUTE_CHAT' }],
+      },
+    ]);
+    expect(readModuleConfig(next, 'event_progression')).toMatchObject({
+      InitialPhase: 'intro',
+      Triggers: [
+        {
+          id: 'keep-location',
+          placement: { kind: 'location', entityId: 'loc-1' },
+          actions: [{ type: 'MUTE_CHAT' }],
+        },
+        {
+          id: 'new-clue-trigger',
+          placement: { kind: 'clue', entityId: 'clue-1' },
+          actions: [{ type: 'UNMUTE_CHAT' }],
+        },
+      ],
+    });
+  });
+
+  it('preserves malformed and future triggers when writing one placement', () => {
+    const malformedTrigger = { placement: { kind: 'location', entityId: 'loc-1' }, custom: true };
+    const futureTrigger = {
+      id: 'future-trigger',
+      placement: { kind: 'room', entityId: 'room-1' },
+      customPayload: { mode: 'future' },
+    };
+    const next = writeTriggersForPlacement(
+      {
+        modules: {
+          event_progression: {
+            enabled: true,
+            config: {
+              Triggers: [
+                malformedTrigger,
+                futureTrigger,
+                {
+                  id: 'old-clue-trigger',
+                  placement: { kind: 'clue', entityId: 'clue-1' },
+                  actions: [{ type: 'OPEN_VOTING' }],
+                },
+              ],
+            },
+          },
+        },
+      },
+      { kind: 'clue', entityId: 'clue-1' },
+      [{ id: 'new-clue-trigger', actions: [{ type: 'UNMUTE_CHAT' }] }]
+    );
+
+    expect(readModuleConfig(next, 'event_progression')).toMatchObject({
+      Triggers: [
+        malformedTrigger,
+        futureTrigger,
+        {
+          id: 'new-clue-trigger',
+          placement: { kind: 'clue', entityId: 'clue-1' },
+          actions: [{ type: 'UNMUTE_CHAT' }],
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/features/editor/utils/__tests__/eventProgressionConfig.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/eventProgressionConfig.test.ts
@@ -19,7 +19,7 @@ describe('eventProgressionConfig', () => {
                 label: '금고 암호',
                 password: '0427',
                 placement: { kind: 'clue', entityId: 'clue-1' },
-                actions: [{ id: 'action-1', type: 'OPEN_VOTING' }],
+                actions: [{ id: 'action-1', type: ' OPEN_VOTING ' }],
               },
               { id: '', actions: [{ type: 'OPEN_VOTING' }] },
               { id: 'trigger-2', placement: { kind: 'bad', entityId: 'clue-1' } },

--- a/apps/web/src/features/editor/utils/entityReferences.ts
+++ b/apps/web/src/features/editor/utils/entityReferences.ts
@@ -9,6 +9,7 @@ import {
   readLocationClueIds,
   type EditorConfig,
 } from './configShape';
+import { readTriggersForPlacement } from './eventProgressionConfig';
 
 export type EntityReferenceSource = 'location' | 'character' | 'clue' | 'question';
 export type EntityReferenceRelation =
@@ -17,6 +18,7 @@ export type EntityReferenceRelation =
   | 'starting_clue'
   | 'combination_input'
   | 'combination_output'
+  | 'trigger'
   | 'question_choice';
 
 export interface EntityReference {
@@ -37,7 +39,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function stringList(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
 }
 
 function pushUnique(target: EntityReference[], ref: EntityReference) {
@@ -63,7 +67,7 @@ export function buildClueUsageMap(params: {
   const locationNames = new Map(locations.map((location) => [location.id, location.name]));
   const characterNames = new Map(characters.map((character) => [character.id, character.name]));
   const usage = Object.fromEntries(
-    clues.map((clue) => [clue.id, { clueId: clue.id, references: [], isUnused: true }]),
+    clues.map((clue) => [clue.id, { clueId: clue.id, references: [], isUnused: true }])
   ) as Record<string, ClueUsageSummary>;
 
   for (const location of readLocationsConfig(configJson)) {
@@ -88,7 +92,9 @@ export function buildClueUsageMap(params: {
     }
   }
 
-  for (const [characterId, assignedClueIds] of Object.entries(readCharacterStartingClueMap(configJson))) {
+  for (const [characterId, assignedClueIds] of Object.entries(
+    readCharacterStartingClueMap(configJson)
+  )) {
     const sourceName = characterNames.get(characterId) ?? characterId;
     for (const clueId of assignedClueIds) {
       if (!clueIds.has(clueId)) continue;
@@ -101,6 +107,17 @@ export function buildClueUsageMap(params: {
     }
   }
 
+  for (const clue of clues) {
+    const triggers = readTriggersForPlacement(configJson, { kind: 'clue', entityId: clue.id });
+    if (triggers.length === 0) continue;
+    pushUnique(usage[clue.id].references, {
+      sourceType: 'clue',
+      sourceId: clue.id,
+      sourceName: clue.name,
+      relation: 'trigger',
+    });
+  }
+
   for (const summary of Object.values(usage)) {
     summary.isUnused = summary.references.length === 0;
   }
@@ -110,7 +127,7 @@ export function buildClueUsageMap(params: {
 
 export function getClueBacklinks(
   usageMap: Record<string, ClueUsageSummary>,
-  clueId: string,
+  clueId: string
 ): EntityReference[] {
   return usageMap[clueId]?.references ?? [];
 }

--- a/apps/web/src/features/editor/utils/entityReferences.ts
+++ b/apps/web/src/features/editor/utils/entityReferences.ts
@@ -9,7 +9,7 @@ import {
   readLocationClueIds,
   type EditorConfig,
 } from './configShape';
-import { readTriggersForPlacement } from './eventProgressionConfig';
+import { readEventProgressionTriggers } from './eventProgressionConfig';
 
 export type EntityReferenceSource = 'location' | 'character' | 'clue' | 'question';
 export type EntityReferenceRelation =
@@ -66,6 +66,12 @@ export function buildClueUsageMap(params: {
   const clueIds = new Set(clues.map((clue) => clue.id));
   const locationNames = new Map(locations.map((location) => [location.id, location.name]));
   const characterNames = new Map(characters.map((character) => [character.id, character.name]));
+  const triggerClueIds = new Set(
+    readEventProgressionTriggers(configJson)
+      .filter((trigger) => trigger.placement?.kind === 'clue')
+      .map((trigger) => trigger.placement?.entityId)
+      .filter((id): id is string => typeof id === 'string' && clueIds.has(id))
+  );
   const usage = Object.fromEntries(
     clues.map((clue) => [clue.id, { clueId: clue.id, references: [], isUnused: true }])
   ) as Record<string, ClueUsageSummary>;
@@ -108,8 +114,7 @@ export function buildClueUsageMap(params: {
   }
 
   for (const clue of clues) {
-    const triggers = readTriggersForPlacement(configJson, { kind: 'clue', entityId: clue.id });
-    if (triggers.length === 0) continue;
+    if (!triggerClueIds.has(clue.id)) continue;
     pushUnique(usage[clue.id].references, {
       sourceType: 'clue',
       sourceId: clue.id,

--- a/apps/web/src/features/editor/utils/eventProgressionConfig.ts
+++ b/apps/web/src/features/editor/utils/eventProgressionConfig.ts
@@ -33,7 +33,7 @@ function normalizeAction(value: unknown): PhaseAction | null {
 
   return {
     ...(typeof value.id === 'string' ? { id: value.id } : {}),
-    type: value.type,
+    type: value.type.trim(),
     ...(isRecord(value.params) ? { params: value.params } : {}),
   };
 }

--- a/apps/web/src/features/editor/utils/eventProgressionConfig.ts
+++ b/apps/web/src/features/editor/utils/eventProgressionConfig.ts
@@ -1,0 +1,147 @@
+import type { PhaseAction } from '../flowTypes';
+import { readModuleConfig, writeModuleConfig, type EditorConfig } from './configShape';
+
+export const EVENT_PROGRESSION_MODULE_ID = 'event_progression';
+
+export type TriggerPlacementKind = 'clue' | 'location';
+
+export interface TriggerPlacementConfig extends EditorConfig {
+  kind: TriggerPlacementKind;
+  entityId: string;
+}
+
+export interface EventProgressionTriggerConfig extends EditorConfig {
+  id: string;
+  label?: string;
+  from?: string;
+  to?: string;
+  password?: string;
+  actions?: PhaseAction[];
+  placement?: TriggerPlacementConfig;
+}
+
+function isRecord(value: unknown): value is EditorConfig {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeAction(value: unknown): PhaseAction | null {
+  if (!isRecord(value) || typeof value.type !== 'string' || !value.type.trim()) return null;
+
+  return {
+    ...(typeof value.id === 'string' ? { id: value.id } : {}),
+    type: value.type,
+    ...(isRecord(value.params) ? { params: value.params } : {}),
+  };
+}
+
+function normalizePlacement(value: unknown): TriggerPlacementConfig | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.kind !== 'clue' && value.kind !== 'location') return undefined;
+  const entityId = cleanString(value.entityId);
+  if (!entityId) return undefined;
+  return { ...value, kind: value.kind, entityId };
+}
+
+function normalizeTrigger(value: unknown): EventProgressionTriggerConfig | null {
+  if (!isRecord(value)) return null;
+  const id = cleanString(value.id);
+  if (!id) return null;
+  const rest = { ...value };
+  delete rest.id;
+  delete rest.label;
+  delete rest.from;
+  delete rest.to;
+  delete rest.password;
+  delete rest.actions;
+  delete rest.placement;
+
+  const actions = Array.isArray(value.actions)
+    ? value.actions.map(normalizeAction).filter((action): action is PhaseAction => !!action)
+    : undefined;
+  const placement = normalizePlacement(value.placement);
+  const label = cleanString(value.label);
+  const from = cleanString(value.from);
+  const to = cleanString(value.to);
+  const password = typeof value.password === 'string' ? value.password : undefined;
+
+  return {
+    ...rest,
+    id,
+    ...(label ? { label } : {}),
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+    ...(password !== undefined ? { password } : {}),
+    ...(actions ? { actions } : {}),
+    ...(placement ? { placement } : {}),
+  };
+}
+
+function readRawEventProgressionTriggers(configJson: EditorConfig | null | undefined): unknown[] {
+  const config = readModuleConfig(configJson, EVENT_PROGRESSION_MODULE_ID);
+  return Array.isArray(config.Triggers) ? [...config.Triggers] : [];
+}
+
+function rawTriggerMatchesPlacement(value: unknown, placement: TriggerPlacementConfig): boolean {
+  if (!isRecord(value)) return false;
+  const triggerPlacement = normalizePlacement(value.placement);
+  return (
+    triggerPlacement?.kind === placement.kind && triggerPlacement.entityId === placement.entityId
+  );
+}
+
+export function readEventProgressionTriggers(
+  configJson: EditorConfig | null | undefined
+): EventProgressionTriggerConfig[] {
+  return readRawEventProgressionTriggers(configJson)
+    .map(normalizeTrigger)
+    .filter((trigger): trigger is EventProgressionTriggerConfig => !!trigger);
+}
+
+export function writeEventProgressionTriggers(
+  configJson: EditorConfig | null | undefined,
+  triggers: EventProgressionTriggerConfig[]
+): EditorConfig {
+  const current = readModuleConfig(configJson, EVENT_PROGRESSION_MODULE_ID);
+  const cleanTriggers = triggers
+    .map(normalizeTrigger)
+    .filter((trigger): trigger is EventProgressionTriggerConfig => !!trigger);
+
+  return writeModuleConfig(configJson, EVENT_PROGRESSION_MODULE_ID, {
+    ...current,
+    Triggers: cleanTriggers,
+  });
+}
+
+export function readTriggersForPlacement(
+  configJson: EditorConfig | null | undefined,
+  placement: TriggerPlacementConfig
+): EventProgressionTriggerConfig[] {
+  return readEventProgressionTriggers(configJson).filter(
+    (trigger) =>
+      trigger.placement?.kind === placement.kind &&
+      trigger.placement.entityId === placement.entityId
+  );
+}
+
+export function writeTriggersForPlacement(
+  configJson: EditorConfig | null | undefined,
+  placement: TriggerPlacementConfig,
+  nextPlacementTriggers: EventProgressionTriggerConfig[]
+): EditorConfig {
+  const otherTriggers = readRawEventProgressionTriggers(configJson).filter(
+    (trigger) => !rawTriggerMatchesPlacement(trigger, placement)
+  );
+  const placedTriggers = nextPlacementTriggers
+    .map((trigger) => normalizeTrigger({ ...trigger, placement }))
+    .filter((trigger): trigger is EventProgressionTriggerConfig => !!trigger);
+
+  const current = readModuleConfig(configJson, EVENT_PROGRESSION_MODULE_ID);
+  return writeModuleConfig(configJson, EVENT_PROGRESSION_MODULE_ID, {
+    ...current,
+    Triggers: [...otherTriggers, ...placedTriggers],
+  });
+}


### PR DESCRIPTION
## 요약
- 단서/장소 실제 제작 화면에 event_progression trigger placement 편집 카드를 연결했습니다.
- 배치별 trigger config 어댑터를 분리해 다른 trigger 설정을 보존하면서 해당 entity 배치만 갱신합니다.
- 단서/장소 삭제 cleanup에서 placement.entityId 기반 trigger가 함께 제거되도록 보강했습니다.

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/components/__tests__/CluesTab.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/components/triggers/__tests__/EntityTriggerPlacementCard.test.tsx src/features/editor/utils/__tests__/eventProgressionConfig.test.ts src/features/editor/utils/__tests__/entityReferences.test.ts src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
- go test ./cmd/server ./internal/domain/editor ./internal/module/progression ./internal/engine ./internal/session
- git diff --check

Closes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 단서/장소별 트리거 배치 기능 추가 — 배치별 트리거 생성·편집·삭제 및 라벨/암호/액션 설정 지원
  * 에디터에 트리거 편집 카드 및 배치 기반 저장 흐름 추가
  * 구성 읽기/쓰기 유틸 및 배치 단위 트리거 API 추가

* **개선 사항**
  * 단서/장소 삭제 시 관련 트리거를 자동으로 정리하도록 구성 정리 로직 강화
  * 단서 사용 맵에 트리거 기반 참조가 포함되도록 백링크 집계 개선

* **테스트**
  * 트리거 배치 동작과 정리/읽기·쓰기 유닛 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->