### PR TITLE
fix(editor): #309 조건 분기 edge ID 노출 제거

### DIFF
--- a/apps/web/src/features/editor/components/design/BranchNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/BranchNodePanel.tsx
@@ -1,7 +1,8 @@
-import type { Node, Edge } from "@xyflow/react";
-import { GitBranch } from "lucide-react";
-import { ConditionBuilder } from "./condition/ConditionBuilder";
-import { useFlowConditionData } from "@/features/editor/hooks/useFlowConditionData";
+import type { Node, Edge } from '@xyflow/react';
+import { GitBranch } from 'lucide-react';
+import { ConditionBuilder } from './condition/ConditionBuilder';
+import { useFlowConditionData } from '@/features/editor/hooks/useFlowConditionData';
+import { describeConditionRecord } from '../../entities/shared/conditionAdapter';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,10 +19,12 @@ interface BranchNodePanelProps {
   themeId: string;
   onUpdate: (nodeId: string, data: Partial<BranchNodeData>) => void;
   edges: Edge[];
-  onEdgeConditionChange: (
-    edgeId: string,
-    condition: Record<string, unknown>,
-  ) => void;
+  onEdgeConditionChange: (edgeId: string, condition: Record<string, unknown>) => void;
+}
+
+function getEdgeDisplayName(edge: Edge, index: number): string {
+  const label = (edge.data as { label?: unknown } | undefined)?.label;
+  return typeof label === 'string' && label.trim() ? label.trim() : `분기 ${index + 1}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -52,7 +55,7 @@ export function BranchNodePanel({
         <label className="text-[11px] text-slate-400">라벨</label>
         <input
           className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-          value={nodeData.label ?? ""}
+          value={nodeData.label ?? ''}
           onChange={(e) => onUpdate(node.id, { label: e.target.value })}
           placeholder="분기 이름"
         />
@@ -61,20 +64,16 @@ export function BranchNodePanel({
       {/* Default edge */}
       {outEdges.length > 0 && (
         <div className="flex flex-col gap-1">
-          <label className="text-[11px] text-slate-400">
-            기본 경로 (조건 없이 통과)
-          </label>
+          <label className="text-[11px] text-slate-400">기본 경로 (조건 없이 통과)</label>
           <select
             className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-300 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-            value={nodeData.default_edge_id ?? ""}
-            onChange={(e) =>
-              onUpdate(node.id, { default_edge_id: e.target.value })
-            }
+            value={nodeData.default_edge_id ?? ''}
+            onChange={(e) => onUpdate(node.id, { default_edge_id: e.target.value })}
           >
             <option value="">없음</option>
-            {outEdges.map((e) => (
+            {outEdges.map((e, index) => (
               <option key={e.id} value={e.id}>
-                {(e.data as { label?: string } | undefined)?.label ?? e.id}
+                {getEdgeDisplayName(e, index)}
               </option>
             ))}
           </select>
@@ -84,20 +83,18 @@ export function BranchNodePanel({
       {/* Per-edge condition builders */}
       {outEdges.length > 0 && (
         <div className="flex flex-col gap-3">
-          <span className="text-[11px] font-medium text-slate-400">
-            엣지별 조건
-          </span>
-          {outEdges.map((e) => {
+          <span className="text-[11px] font-medium text-slate-400">엣지별 조건</span>
+          {outEdges.map((e, index) => {
             const isDefault = e.id === nodeData.default_edge_id;
-            const edgeLabel =
-              (e.data as { label?: string } | undefined)?.label ?? e.id;
+            const edgeLabel = getEdgeDisplayName(e, index);
             const edgeCond =
-              (e.data as { condition?: Record<string, unknown> } | undefined)
-                ?.condition ?? null;
+              (e.data as { condition?: Record<string, unknown> } | undefined)?.condition ?? null;
+            const conditionSummary = isDefault ? '기본 경로' : describeConditionRecord(edgeCond);
             return (
               <div key={e.id} className="flex flex-col gap-2">
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <span className="text-[11px] text-slate-300">{edgeLabel}</span>
+                  <span className="text-[10px] text-slate-500">{conditionSummary}</span>
                   {isDefault && (
                     <span className="rounded bg-slate-700 px-1.5 py-0.5 text-[9px] text-slate-400">
                       기본

--- a/apps/web/src/features/editor/components/design/BranchNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/BranchNodePanel.tsx
@@ -41,6 +41,7 @@ export function BranchNodePanel({
   const nodeData = node.data as BranchNodeData;
   const outEdges = edges.filter((e) => e.source === node.id);
   const { characters, clues } = useFlowConditionData(themeId);
+  const defaultEdgeSelectId = `branch-default-edge-${node.id}`;
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -64,8 +65,11 @@ export function BranchNodePanel({
       {/* Default edge */}
       {outEdges.length > 0 && (
         <div className="flex flex-col gap-1">
-          <label className="text-[11px] text-slate-400">기본 경로 (조건 없이 통과)</label>
+          <label htmlFor={defaultEdgeSelectId} className="text-[11px] text-slate-400">
+            기본 경로 (조건 없이 통과)
+          </label>
           <select
+            id={defaultEdgeSelectId}
             className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-300 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
             value={nodeData.default_edge_id ?? ''}
             onChange={(e) => onUpdate(node.id, { default_edge_id: e.target.value })}

--- a/apps/web/src/features/editor/components/design/__tests__/BranchNodePanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/BranchNodePanel.test.tsx
@@ -40,6 +40,7 @@ describe('BranchNodePanel', () => {
     ]);
 
     expect(screen.getAllByText('분기 1').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('기본 경로 (조건 없이 통과)')).toBeDefined();
     expect(container.textContent).not.toContain('edge-internal-123');
   });
 

--- a/apps/web/src/features/editor/components/design/__tests__/BranchNodePanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/BranchNodePanel.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Edge, Node } from '@xyflow/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BranchNodePanel } from '../BranchNodePanel';
+
+vi.mock('@/features/editor/hooks/useFlowConditionData', () => ({
+  useFlowConditionData: () => ({ characters: [], clues: [] }),
+}));
+
+const baseNode: Node = {
+  id: 'branch-node',
+  type: 'branch',
+  position: { x: 0, y: 0 },
+  data: { label: '조건 분기' },
+};
+
+function renderPanel(edges: Edge[]) {
+  return render(
+    <BranchNodePanel
+      node={baseNode}
+      themeId="theme-1"
+      edges={edges}
+      onUpdate={vi.fn()}
+      onEdgeConditionChange={vi.fn()}
+    />
+  );
+}
+
+describe('BranchNodePanel', () => {
+  afterEach(() => cleanup());
+
+  it('라벨 없는 edge를 내부 ID 대신 제작자용 분기명으로 표시한다', () => {
+    const { container } = renderPanel([
+      {
+        id: 'edge-internal-123',
+        source: 'branch-node',
+        target: 'phase-a',
+        data: {},
+      },
+    ]);
+
+    expect(screen.getAllByText('분기 1').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toContain('edge-internal-123');
+  });
+
+  it('조건 요약을 raw JSON 없이 표시한다', () => {
+    const { container } = renderPanel([
+      {
+        id: 'edge-with-condition',
+        source: 'branch-node',
+        target: 'phase-a',
+        data: {
+          condition: {
+            operator: 'OR',
+            rules: [{ id: 'rule-1' }],
+          },
+        },
+      },
+    ]);
+
+    expect(screen.getByText('하나 이상 · 1개 규칙')).toBeDefined();
+    expect(container.textContent).not.toContain('edge-with-condition');
+  });
+});


### PR DESCRIPTION
## 요약
- 조건 분기 패널에서 라벨 없는 edge를 내부 ID 대신 제작자용 "분기 N"으로 표시합니다.
- 조건 상태를 raw JSON이나 edge id가 아닌 요약 문장으로 보여줍니다.
- 저장 값은 기존 edge.id를 유지해 Flow 저장 계약을 바꾸지 않습니다.

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/BranchNodePanel.test.tsx src/features/editor/entities/shared/__tests__/conditionAdapter.test.ts

## E2E 미작성 사유
- 새 라우트나 저장 흐름이 아니라 기본 화면의 표시 문구 누출 제거입니다. focused component test로 사용자에게 보이는 텍스트를 검증했습니다.

Closes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 분기 목록에서 각 경로의 표시명이 자동 생성되어 빈 레이블도 의미 있게 표시됨(예: "분기 1").
  * 기본 경로 레이블이 접근성에 맞게 연결되고, 모든 분기에서 조건 요약이 함께 표시되어 이해도가 향상됨.

* **테스트**
  * 분기 라벨 및 조건 요약의 렌더링 동작을 검증하는 테스트 추가됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->