### PR TITLE
fix(editor): #308 조건 소비처 계약 정렬

### DIFF
--- a/apps/web/src/features/editor/components/design/ConditionEdge.tsx
+++ b/apps/web/src/features/editor/components/design/ConditionEdge.tsx
@@ -10,7 +10,7 @@ import {
 // ---------------------------------------------------------------------------
 
 interface ConditionEdgeData {
-  condition?: string;
+  condition?: Record<string, unknown> | null;
   [key: string]: unknown;
 }
 

--- a/apps/web/src/features/editor/components/design/ConditionEdge.tsx
+++ b/apps/web/src/features/editor/components/design/ConditionEdge.tsx
@@ -4,6 +4,7 @@ import {
   getBezierPath,
   type EdgeProps,
 } from "@xyflow/react";
+import { isCompleteConditionGroupRecord } from "./condition/conditionTypes";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,7 +42,7 @@ export function ConditionEdge(props: EdgeProps) {
   });
 
   const edgeData = data as ConditionEdgeData | undefined;
-  const isDefault = !edgeData?.condition;
+  const isDefault = !isCompleteConditionGroupRecord(edgeData?.condition ?? null);
 
   const edgeStyle: React.CSSProperties = {
     ...style,

--- a/apps/web/src/features/editor/components/design/__tests__/ConditionEdge.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ConditionEdge.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { CSSProperties, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EdgeProps } from "@xyflow/react";
+import { ConditionEdge } from "../ConditionEdge";
+
+vi.mock("@xyflow/react", () => ({
+  BaseEdge: ({ style }: { style?: CSSProperties }) => (
+    <div data-testid="condition-edge-path" style={style} />
+  ),
+  EdgeLabelRenderer: ({ children }: { children: ReactNode }) => <>{children}</>,
+  getBezierPath: () => ["M0,0 C0,0 1,1 1,1", 0, 0],
+}));
+
+afterEach(() => cleanup());
+
+const baseProps = {
+  id: "edge-1",
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 10,
+  targetY: 10,
+  sourcePosition: "right",
+  targetPosition: "left",
+  source: "source",
+  target: "target",
+  selected: false,
+  animated: false,
+  markerStart: undefined,
+  markerEnd: undefined,
+  interactionWidth: 0,
+} as unknown as EdgeProps;
+
+const completeCondition = {
+  id: "group-1",
+  operator: "AND",
+  rules: [
+    {
+      id: "rule-1",
+      variable: "custom_flag",
+      target_flag_key: "route_open",
+      comparator: "=",
+      value: "true",
+    },
+  ],
+};
+
+describe("ConditionEdge", () => {
+  it("미완성 조건은 기본 이동 스타일로 렌더링한다", () => {
+    render(
+      <ConditionEdge
+        {...baseProps}
+        data={{ condition: { id: "draft", operator: "AND", rules: [] } }}
+      />,
+    );
+
+    const path = screen.getByTestId("condition-edge-path");
+    expect(path.style.stroke).toBe("rgb(100, 116, 139)");
+    expect(path.style.strokeDasharray).toBe("5 5");
+  });
+
+  it("완성된 공통 조건 그룹은 조건 이동 스타일로 렌더링한다", () => {
+    render(<ConditionEdge {...baseProps} data={{ condition: completeCondition }} />);
+
+    const path = screen.getByTestId("condition-edge-path");
+    expect(path.style.stroke).toBe("rgb(139, 92, 246)");
+    expect(path.style.strokeDasharray).toBe("");
+  });
+});

--- a/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
@@ -58,6 +58,26 @@ describe("missionAdapter", () => {
     });
   });
 
+  it("미션 조건 메모는 공백을 제거하고 빈 값은 runtime 후보에서 제외한다", () => {
+    expect(toMissionRuntimeDraft({
+      id: "m-trim",
+      type: "secret",
+      description: "비밀",
+      points: 1,
+      condition: "  토론 이후 공개  ",
+    })).toEqual(expect.objectContaining({
+      legacyConditionNote: "토론 이후 공개",
+    }));
+
+    expect(toMissionRuntimeDraft({
+      id: "m-empty",
+      type: "secret",
+      description: "비밀",
+      points: 1,
+      condition: "   ",
+    })).not.toHaveProperty("legacyConditionNote");
+  });
+
   it("새 미션을 자동 판정 타입으로 바꾸면 runtime verification은 auto가 된다", () => {
     vi.spyOn(crypto, "randomUUID").mockReturnValue("mission-new");
     const draft = createMissionDraft();

--- a/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
@@ -44,6 +44,7 @@ describe("missionAdapter", () => {
       description: "단서를 가진다",
       points: 7,
       targetClueId: "clue-1",
+      condition: "토론 이후 공개",
     })).toEqual({
       id: "m1",
       type: "hold_clue",
@@ -53,6 +54,7 @@ describe("missionAdapter", () => {
       resultVisibility: "result_only",
       engineOwner: "backend_engine",
       targetClueId: "clue-1",
+      legacyConditionNote: "토론 이후 공개",
     });
   });
 
@@ -112,7 +114,7 @@ describe("missionAdapter", () => {
   });
 
   it("제작자가 이해할 요약과 자동 판정 경고를 만든다", () => {
-    expect(toMissionViewModel({ id: "m2", type: "kill", description: "", points: -1 })).toEqual({
+    expect(toMissionViewModel({ id: "m2", type: "kill", description: "", points: -1, condition: "공모" })).toEqual({
       id: "m2",
       title: "미션 내용을 입력해 주세요",
       typeLabel: "살해",
@@ -125,6 +127,7 @@ describe("missionAdapter", () => {
       warnings: [
         "플레이어가 이해할 미션 내용을 입력해 주세요.",
         "투표형 미션은 대상 캐릭터를 선택해야 자동 판정할 수 있습니다.",
+        "미션 조건 메모는 제작자 참고용이며, 실제 진행 분기는 스토리 이동 조건에서 판정됩니다.",
       ],
     });
   });

--- a/apps/web/src/features/editor/entities/mission/missionAdapter.ts
+++ b/apps/web/src/features/editor/entities/mission/missionAdapter.ts
@@ -57,7 +57,7 @@ export interface MissionRuntimeDraft {
   engineOwner: MissionRuntimeOwner;
   targetCharacterId?: string;
   targetClueId?: string;
-  condition?: string;
+  legacyConditionNote?: string;
 }
 
 export interface MissionEngineAssignmentDraft {
@@ -179,7 +179,7 @@ export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
     engineOwner: "backend_engine",
     ...(mission.targetCharacterId ? { targetCharacterId: mission.targetCharacterId } : {}),
     ...(mission.targetClueId ? { targetClueId: mission.targetClueId } : {}),
-    ...(mission.condition ? { condition: mission.condition } : {}),
+    ...(mission.condition ? { legacyConditionNote: mission.condition } : {}),
   };
 }
 
@@ -261,6 +261,9 @@ function buildMissionWarnings(mission: Mission, runtimeDraft: MissionRuntimeDraf
   }
   if (runtimeDraft.type === "custom") {
     warnings.push("이 미션은 자동 판정 대신 플레이어 신고 또는 진행자 확인으로 처리됩니다.");
+  }
+  if (mission.condition?.trim()) {
+    warnings.push("미션 조건 메모는 제작자 참고용이며, 실제 진행 분기는 스토리 이동 조건에서 판정됩니다.");
   }
   return warnings;
 }

--- a/apps/web/src/features/editor/entities/mission/missionAdapter.ts
+++ b/apps/web/src/features/editor/entities/mission/missionAdapter.ts
@@ -169,6 +169,7 @@ export function getMissionVerificationOptions(
 
 export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
   const runtimeType = toRuntimeType(mission);
+  const legacyConditionNote = mission.condition?.trim();
   return {
     id: mission.id,
     type: runtimeType,
@@ -179,7 +180,7 @@ export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
     engineOwner: "backend_engine",
     ...(mission.targetCharacterId ? { targetCharacterId: mission.targetCharacterId } : {}),
     ...(mission.targetClueId ? { targetClueId: mission.targetClueId } : {}),
-    ...(mission.condition ? { legacyConditionNote: mission.condition } : {}),
+    ...(legacyConditionNote ? { legacyConditionNote } : {}),
   };
 }
 

--- a/apps/web/src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts
@@ -156,6 +156,26 @@ describe("phaseEntityAdapter", () => {
         id: "e2",
         source: "phase-1",
         target: "ending-1",
+        data: {
+          condition: {
+            id: "group-1",
+            operator: "AND",
+            rules: [
+              {
+                id: "rule-1",
+                variable: "custom_flag",
+                target_flag_key: "route_open",
+                comparator: "=",
+                value: "true",
+              },
+            ],
+          },
+        },
+      },
+      {
+        id: "e3",
+        source: "phase-1",
+        target: "ending-2",
         data: { condition: { type: "has_clue", clueId: "clue-1" } },
       },
     ];
@@ -170,7 +190,7 @@ describe("phaseEntityAdapter", () => {
       informationDeliveryCount: 1,
       enterActionLabels: ["BGM 재생"],
       exitActionLabels: ["채팅 닫기"],
-      defaultTransitionLabel: "기본 이동 1개",
+      defaultTransitionLabel: "기본 이동 2개",
       conditionalTransitionCount: 1,
     });
   });

--- a/apps/web/src/features/editor/entities/phase/phaseEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/phase/phaseEntityAdapter.ts
@@ -1,5 +1,6 @@
 import type { Edge } from "@xyflow/react";
 import type { FlowNodeData } from "../../flowTypes";
+import { isCompleteConditionGroupRecord } from "../../components/design/condition/conditionTypes";
 import {
   DELIVER_INFORMATION_ACTION,
   LEGACY_DELIVER_INFORMATION_ACTION,
@@ -100,6 +101,5 @@ function formatDefaultTransition(count: number): string {
 
 function hasEdgeCondition(edge: Edge): boolean {
   const condition = (edge.data as { condition?: unknown } | undefined)?.condition;
-  if (!condition || typeof condition !== "object") return false;
-  return Object.keys(condition).length > 0;
+  return isCompleteConditionGroupRecord(condition);
 }

--- a/apps/web/src/features/editor/entities/story/__tests__/storySceneAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/story/__tests__/storySceneAdapter.test.ts
@@ -6,6 +6,20 @@ import {
   toStorySceneFlowSummaryFromGraph,
 } from "../storySceneAdapter";
 
+const completeCondition = {
+  id: "group-1",
+  operator: "AND",
+  rules: [
+    {
+      id: "rule-1",
+      variable: "custom_flag",
+      target_flag_key: "route_open",
+      comparator: "=",
+      value: "true",
+    },
+  ],
+};
+
 describe("storySceneAdapter", () => {
   it("Flow phase node를 제작자용 스토리 장면 요약으로 변환한다", () => {
     const nodes: Node[] = [
@@ -46,13 +60,19 @@ describe("storySceneAdapter", () => {
         id: "edge-2",
         source: "scene-2",
         target: "ending-1",
+        data: { condition: completeCondition },
+      },
+      {
+        id: "edge-legacy",
+        source: "scene-2",
+        target: "ending-2",
         data: { condition: { op: "and", clauses: [{ fact: "has_clue" }] } },
       },
     ];
 
     expect(toStorySceneFlowSummary(nodes, edges)).toEqual({
       sceneCountLabel: "2개 장면",
-      transitionCountLabel: "2개 이동",
+      transitionCountLabel: "3개 이동",
       conditionalTransitionCountLabel: "조건 이동 1개",
       scenes: [
         {
@@ -69,7 +89,7 @@ describe("storySceneAdapter", () => {
           title: "토론",
           typeLabel: "토론",
           informationLabel: "0개 정보 공개",
-          transitionLabel: "기본 이동 없음 · 조건 이동 1개",
+          transitionLabel: "기본 이동 1개 · 조건 이동 1개",
           startActionLabel: "변화 없음",
           endActionLabel: "변화 1개",
         },
@@ -97,7 +117,7 @@ describe("storySceneAdapter", () => {
           theme_id: "theme-1",
           source_id: "scene-1",
           target_id: "ending-1",
-          condition: { op: "and", clauses: [{ fact: "accused" }] },
+          condition: completeCondition,
           label: null,
           sort_order: 1,
           created_at: "2026-05-05T00:00:00Z",

--- a/apps/web/src/features/editor/entities/story/storySceneAdapter.ts
+++ b/apps/web/src/features/editor/entities/story/storySceneAdapter.ts
@@ -4,6 +4,7 @@ import type {
   FlowGraphResponse,
   FlowNodeData,
 } from "../../flowTypes";
+import { isCompleteConditionGroupRecord } from "../../components/design/condition/conditionTypes";
 import { toPhaseEditorViewModel } from "../phase/phaseEntityAdapter";
 
 export interface StorySceneViewModel {
@@ -101,9 +102,5 @@ function toStorySceneEdge(edge: FlowEdgeResponse): Edge {
 
 function hasCompleteCondition(edge: Edge): boolean {
   const condition = (edge.data as { condition?: unknown } | undefined)?.condition;
-  return (
-    !!condition &&
-    typeof condition === "object" &&
-    Object.keys(condition).length > 0
-  );
+  return isCompleteConditionGroupRecord(condition);
 }


### PR DESCRIPTION
## 요약
- Story/Phase 요약이 완성된 공통 조건 그룹만 조건 이동으로 세도록 정렬했습니다.
- Mission 문자열 조건은 runtime 판정 조건이 아닌 legacyConditionNote로 분리해 #301 조건 계약과 충돌하지 않게 했습니다.
- Flow edge 조건 저장/검증과 backend scene transition 평가는 기존 공통 조건 계약 연결을 그대로 사용합니다.

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/hooks/__tests__/flowConverters.test.ts src/features/editor/entities/story/__tests__/storySceneAdapter.test.ts src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts src/features/editor/entities/mission/__tests__/missionAdapter.test.ts src/features/editor/components/design/condition/__tests__/conditionTypes.test.ts src/features/editor/entities/shared/__tests__/conditionAdapter.test.ts
- go test ./internal/domain/flow ./internal/engine

Closes #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 조건 처리 로직을 일관되게 개선해 조건 유무 판정 기준을 명확히 했습니다.
  * 에지 기본/조건 전환 판정 방식이 변경되어 전환 카운트 및 레이블이 조정됩니다.

* **New Features**
  * 미션 편집 시 입력된 조건 메모를 별도 보조 메모로 저장하고, 작성자용 안내 문구가 표시됩니다.
  * 에지의 시각적 스타일이 조건 완성도에 따라 정확히 반영됩니다.

* **Tests**
  * 조건 관련 동작을 검증하는 테스트들을 추가·갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->