### PR TITLE
docs(pr): 이슈 자동 종료 연결 규칙 명시

### DIFF
--- a/.codex/skills/mmp-pr-lifecycle/SKILL.md
+++ b/.codex/skills/mmp-pr-lifecycle/SKILL.md
@@ -14,6 +14,9 @@ description: Use when creating, reviewing, updating, labeling, checking, or merg
    - run focused checks for the changed scope
    - run/perform code review using available review skill or manual review
    - write PR title/body in Korean
+   - link the GitHub issue in the PR body:
+     - use `Closes #<issue>` when the PR completes the issue so GitHub closes it on merge
+     - use `Refs #<issue>` only for partial PRs that must leave the issue open
    - do **not** add `ready-for-ci`
 3. PR sequence:
    - create PR without CI label
@@ -35,6 +38,7 @@ description: Use when creating, reviewing, updating, labeling, checking, or merg
 
 ## Done
 - PR has Korean title/body.
+- Completed issues are linked with `Closes #<issue>` and are confirmed closed after merge.
 - CodeRabbit valid feedback is fixed or explicitly rejected with reason.
 - `ready-for-ci` was added only after review cleanup.
 - CI and Codecov evidence is reported before merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ When:
 Do:
 1. 작업 계획 문서와 GitHub Issue를 상호 링크한다.
 2. PR 본문에 `Closes #번호` 또는 `Refs #번호`를 명시한다.
+   - 해당 PR이 이슈를 완료하면 반드시 `Closes #번호`를 사용해 merge 시 자동 close되게 한다.
+   - 일부만 처리하는 PR은 `Refs #번호`를 사용해 이슈가 조기 종료되지 않게 한다.
 3. 작업 중 scope가 바뀌면 Issue checklist 또는 plan 문서를 먼저 갱신한다.
 4. 완료 보고에는 닫힌 Issue, 남은 Issue, 다음 권장 Issue를 포함한다.
 5. 새 Issue를 만들거나 기존 Issue를 재설계할 때는 가능한 경우 `mmp-issue-planning` skill을 사용한다.


### PR DESCRIPTION
## 요약
- 완료 PR은 Closes #번호로 이슈를 연결해 merge 시 자동 close되도록 명시했습니다.
- 부분 PR은 Refs #번호로 남겨 이슈가 조기 종료되지 않게 하는 기준을 AGENTS와 PR lifecycle skill에 추가했습니다.

## 검증
- git diff --check

Refs self-improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * PR 본문에서 GitHub 이슈를 연결할 때 사용할 수 있는 규칙이 추가되었습니다.
  * 완료된 이슈는 `Closes #<이슈번호>`, 부분 처리된 이슈는 `Refs #<이슈번호>`로 구분하여 표기하는 방식이 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->