### PR TITLE
feat(editor): #306 등장인물 유형 계약 연결

### DIFF
--- a/apps/server/db/migrations/00032_character_visibility_policy.sql
+++ b/apps/server/db/migrations/00032_character_visibility_policy.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+ALTER TABLE theme_characters
+  ADD COLUMN is_playable BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN show_in_intro BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN can_speak_in_reading BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN is_voting_candidate BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE theme_characters
+SET is_voting_candidate = FALSE
+WHERE mystery_role = 'detective';
+
+CREATE INDEX idx_theme_characters_visibility
+  ON theme_characters(theme_id, is_playable, show_in_intro, is_voting_candidate);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_theme_characters_visibility;
+
+ALTER TABLE theme_characters
+  DROP COLUMN IF EXISTS is_voting_candidate,
+  DROP COLUMN IF EXISTS can_speak_in_reading,
+  DROP COLUMN IF EXISTS show_in_intro,
+  DROP COLUMN IF EXISTS is_playable;

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -25,8 +25,8 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order;
 
 -- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 RETURNING *;
 
 -- name: UpdateTheme :one
@@ -48,7 +48,7 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE id = $1;
 
 -- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7
+UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -276,14 +276,18 @@ type Theme struct {
 }
 
 type ThemeCharacter struct {
-	ID          uuid.UUID   `json:"id"`
-	ThemeID     uuid.UUID   `json:"theme_id"`
-	Name        string      `json:"name"`
-	Description pgtype.Text `json:"description"`
-	ImageUrl    pgtype.Text `json:"image_url"`
-	IsCulprit   bool        `json:"is_culprit"`
-	SortOrder   int32       `json:"sort_order"`
-	MysteryRole string      `json:"mystery_role"`
+	ID                uuid.UUID   `json:"id"`
+	ThemeID           uuid.UUID   `json:"theme_id"`
+	Name              string      `json:"name"`
+	Description       pgtype.Text `json:"description"`
+	ImageUrl          pgtype.Text `json:"image_url"`
+	IsCulprit         bool        `json:"is_culprit"`
+	SortOrder         int32       `json:"sort_order"`
+	MysteryRole       string      `json:"mystery_role"`
+	IsPlayable        bool        `json:"is_playable"`
+	ShowInIntro       bool        `json:"show_in_intro"`
+	CanSpeakInReading bool        `json:"can_speak_in_reading"`
+	IsVotingCandidate bool        `json:"is_voting_candidate"`
 }
 
 type ThemeClue struct {

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -86,19 +86,23 @@ func (q *Queries) CreateTheme(ctx context.Context, arg CreateThemeParams) (Theme
 }
 
 const createThemeCharacter = `-- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role
+INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate
 `
 
 type CreateThemeCharacterParams struct {
-	ThemeID     uuid.UUID   `json:"theme_id"`
-	Name        string      `json:"name"`
-	Description pgtype.Text `json:"description"`
-	ImageUrl    pgtype.Text `json:"image_url"`
-	IsCulprit   bool        `json:"is_culprit"`
-	MysteryRole string      `json:"mystery_role"`
-	SortOrder   int32       `json:"sort_order"`
+	ThemeID           uuid.UUID   `json:"theme_id"`
+	Name              string      `json:"name"`
+	Description       pgtype.Text `json:"description"`
+	ImageUrl          pgtype.Text `json:"image_url"`
+	IsCulprit         bool        `json:"is_culprit"`
+	MysteryRole       string      `json:"mystery_role"`
+	SortOrder         int32       `json:"sort_order"`
+	IsPlayable        bool        `json:"is_playable"`
+	ShowInIntro       bool        `json:"show_in_intro"`
+	CanSpeakInReading bool        `json:"can_speak_in_reading"`
+	IsVotingCandidate bool        `json:"is_voting_candidate"`
 }
 
 func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeCharacterParams) (ThemeCharacter, error) {
@@ -110,6 +114,10 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		arg.IsCulprit,
 		arg.MysteryRole,
 		arg.SortOrder,
+		arg.IsPlayable,
+		arg.ShowInIntro,
+		arg.CanSpeakInReading,
+		arg.IsVotingCandidate,
 	)
 	var i ThemeCharacter
 	err := row.Scan(
@@ -121,6 +129,10 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		&i.IsCulprit,
 		&i.SortOrder,
 		&i.MysteryRole,
+		&i.IsPlayable,
+		&i.ShowInIntro,
+		&i.CanSpeakInReading,
+		&i.IsVotingCandidate,
 	)
 	return i, err
 }
@@ -208,7 +220,7 @@ func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error
 }
 
 const getThemeCharacter = `-- name: GetThemeCharacter :one
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role FROM theme_characters WHERE id = $1
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate FROM theme_characters WHERE id = $1
 `
 
 func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCharacter, error) {
@@ -223,12 +235,16 @@ func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCha
 		&i.IsCulprit,
 		&i.SortOrder,
 		&i.MysteryRole,
+		&i.IsPlayable,
+		&i.ShowInIntro,
+		&i.CanSpeakInReading,
+		&i.IsVotingCandidate,
 	)
 	return i, err
 }
 
 const getThemeCharacters = `-- name: GetThemeCharacters :many
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]ThemeCharacter, error) {
@@ -249,6 +265,10 @@ func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]
 			&i.IsCulprit,
 			&i.SortOrder,
 			&i.MysteryRole,
+			&i.IsPlayable,
+			&i.ShowInIntro,
+			&i.CanSpeakInReading,
+			&i.IsVotingCandidate,
 		); err != nil {
 			return nil, err
 		}
@@ -507,19 +527,23 @@ func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme
 }
 
 const updateThemeCharacter = `-- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7
+UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11
 WHERE id = $1
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate
 `
 
 type UpdateThemeCharacterParams struct {
-	ID          uuid.UUID   `json:"id"`
-	Name        string      `json:"name"`
-	Description pgtype.Text `json:"description"`
-	ImageUrl    pgtype.Text `json:"image_url"`
-	IsCulprit   bool        `json:"is_culprit"`
-	MysteryRole string      `json:"mystery_role"`
-	SortOrder   int32       `json:"sort_order"`
+	ID                uuid.UUID   `json:"id"`
+	Name              string      `json:"name"`
+	Description       pgtype.Text `json:"description"`
+	ImageUrl          pgtype.Text `json:"image_url"`
+	IsCulprit         bool        `json:"is_culprit"`
+	MysteryRole       string      `json:"mystery_role"`
+	SortOrder         int32       `json:"sort_order"`
+	IsPlayable        bool        `json:"is_playable"`
+	ShowInIntro       bool        `json:"show_in_intro"`
+	CanSpeakInReading bool        `json:"can_speak_in_reading"`
+	IsVotingCandidate bool        `json:"is_voting_candidate"`
 }
 
 func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeCharacterParams) (ThemeCharacter, error) {
@@ -531,6 +555,10 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		arg.IsCulprit,
 		arg.MysteryRole,
 		arg.SortOrder,
+		arg.IsPlayable,
+		arg.ShowInIntro,
+		arg.CanSpeakInReading,
+		arg.IsVotingCandidate,
 	)
 	var i ThemeCharacter
 	err := row.Scan(
@@ -542,6 +570,10 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		&i.IsCulprit,
 		&i.SortOrder,
 		&i.MysteryRole,
+		&i.IsPlayable,
+		&i.ShowInIntro,
+		&i.CanSpeakInReading,
+		&i.IsVotingCandidate,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/image_service.go
+++ b/apps/server/internal/domain/editor/image_service.go
@@ -227,13 +227,17 @@ func (s *ImageService) ConfirmImageUpload(
 			return nil, apperror.NotFound("character not found")
 		}
 		_, err = s.q.UpdateThemeCharacter(ctx, db.UpdateThemeCharacterParams{
-			ID:          char.ID,
-			Name:        char.Name,
-			Description: char.Description,
-			ImageUrl:    pgtype.Text{String: downloadURL, Valid: true},
-			IsCulprit:   char.IsCulprit,
-			MysteryRole: char.MysteryRole,
-			SortOrder:   char.SortOrder,
+			ID:                char.ID,
+			Name:              char.Name,
+			Description:       char.Description,
+			ImageUrl:          pgtype.Text{String: downloadURL, Valid: true},
+			IsCulprit:         char.IsCulprit,
+			MysteryRole:       char.MysteryRole,
+			SortOrder:         char.SortOrder,
+			IsPlayable:        char.IsPlayable,
+			ShowInIntro:       char.ShowInIntro,
+			CanSpeakInReading: char.CanSpeakInReading,
+			IsVotingCandidate: char.IsVotingCandidate,
 		})
 		if err != nil {
 			s.logger.Error().Err(err).Str("character_id", targetID.String()).Msg("failed to update character image_url")

--- a/apps/server/internal/domain/editor/image_service_test.go
+++ b/apps/server/internal/domain/editor/image_service_test.go
@@ -41,11 +41,12 @@ func TestConfirmImageUpload_PreservesExistingTargetFields(t *testing.T) {
 		assert    func(*testing.T, *fakeImageQueries)
 	}{
 		{
-			name:      "character mystery role",
+			name:      "character visibility fields",
 			uploadKey: "themes/11111111-1111-1111-1111-111111111111/characters/22222222-2222-2222-2222-222222222222/avatar.webp",
 			assert: func(t *testing.T, q *fakeImageQueries) {
-				if q.updateCharacterArg.MysteryRole != "detective" {
-					t.Fatalf("MysteryRole = %q", q.updateCharacterArg.MysteryRole)
+				arg := q.updateCharacterArg
+				if arg.MysteryRole != "detective" || arg.IsPlayable || arg.ShowInIntro || !arg.CanSpeakInReading || arg.IsVotingCandidate {
+					t.Fatalf("character fields not preserved: %+v", arg)
 				}
 			},
 		},
@@ -96,10 +97,20 @@ type fakeImageQueries struct {
 
 func newFakeImageQueries(creatorID, themeID, charID, clueID, locationID uuid.UUID) *fakeImageQueries {
 	return &fakeImageQueries{
-		theme:     db.Theme{ID: themeID, CreatorID: creatorID},
-		character: db.ThemeCharacter{ID: charID, ThemeID: themeID, Name: "탐정", MysteryRole: "detective", IsCulprit: true},
-		clue:      db.ThemeClue{ID: clueID, ThemeID: themeID, Name: "단서", IsUsable: true, UseEffect: text("peek"), UseTarget: text("player"), UseConsumed: true, RevealRound: int4(2), HideRound: int4(5)},
-		location:  db.ThemeLocation{ID: locationID, ThemeID: themeID, Name: "서재", RestrictedCharacters: text("char-a,char-b"), FromRound: int4(1), UntilRound: int4(4)},
+		theme: db.Theme{ID: themeID, CreatorID: creatorID},
+		character: db.ThemeCharacter{
+			ID:                charID,
+			ThemeID:           themeID,
+			Name:              "탐정",
+			MysteryRole:       "detective",
+			IsCulprit:         true,
+			IsPlayable:        false,
+			ShowInIntro:       false,
+			CanSpeakInReading: true,
+			IsVotingCandidate: false,
+		},
+		clue:     db.ThemeClue{ID: clueID, ThemeID: themeID, Name: "단서", IsUsable: true, UseEffect: text("peek"), UseTarget: text("player"), UseConsumed: true, RevealRound: int4(2), HideRound: int4(5)},
+		location: db.ThemeLocation{ID: locationID, ThemeID: themeID, Name: "서재", RestrictedCharacters: text("char-a,char-b"), FromRound: int4(1), UntilRound: int4(4)},
 	}
 }
 

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -90,32 +90,44 @@ type ThemeSummary struct {
 }
 
 type CreateCharacterRequest struct {
-	Name        string  `json:"name" validate:"required,min=1,max=50"`
-	Description *string `json:"description" validate:"omitempty,max=2000"`
-	ImageURL    *string `json:"image_url" validate:"omitempty,url"`
-	IsCulprit   bool    `json:"is_culprit"`
-	MysteryRole string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
-	SortOrder   int32   `json:"sort_order" validate:"min=0"`
+	Name              string  `json:"name" validate:"required,min=1,max=50"`
+	Description       *string `json:"description" validate:"omitempty,max=2000"`
+	ImageURL          *string `json:"image_url" validate:"omitempty,url"`
+	IsCulprit         bool    `json:"is_culprit"`
+	MysteryRole       string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
+	SortOrder         int32   `json:"sort_order" validate:"min=0"`
+	IsPlayable        *bool   `json:"is_playable"`
+	ShowInIntro       *bool   `json:"show_in_intro"`
+	CanSpeakInReading *bool   `json:"can_speak_in_reading"`
+	IsVotingCandidate *bool   `json:"is_voting_candidate"`
 }
 
 type UpdateCharacterRequest struct {
-	Name        string  `json:"name" validate:"required,min=1,max=50"`
-	Description *string `json:"description" validate:"omitempty,max=2000"`
-	ImageURL    *string `json:"image_url" validate:"omitempty,url"`
-	IsCulprit   bool    `json:"is_culprit"`
-	MysteryRole string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
-	SortOrder   int32   `json:"sort_order" validate:"min=0"`
+	Name              string  `json:"name" validate:"required,min=1,max=50"`
+	Description       *string `json:"description" validate:"omitempty,max=2000"`
+	ImageURL          *string `json:"image_url" validate:"omitempty,url"`
+	IsCulprit         bool    `json:"is_culprit"`
+	MysteryRole       string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
+	SortOrder         int32   `json:"sort_order" validate:"min=0"`
+	IsPlayable        *bool   `json:"is_playable"`
+	ShowInIntro       *bool   `json:"show_in_intro"`
+	CanSpeakInReading *bool   `json:"can_speak_in_reading"`
+	IsVotingCandidate *bool   `json:"is_voting_candidate"`
 }
 
 type CharacterResponse struct {
-	ID          uuid.UUID `json:"id"`
-	ThemeID     uuid.UUID `json:"theme_id"`
-	Name        string    `json:"name"`
-	Description *string   `json:"description,omitempty"`
-	ImageURL    *string   `json:"image_url,omitempty"`
-	IsCulprit   bool      `json:"is_culprit"`
-	MysteryRole string    `json:"mystery_role"`
-	SortOrder   int32     `json:"sort_order"`
+	ID                uuid.UUID `json:"id"`
+	ThemeID           uuid.UUID `json:"theme_id"`
+	Name              string    `json:"name"`
+	Description       *string   `json:"description,omitempty"`
+	ImageURL          *string   `json:"image_url,omitempty"`
+	IsCulprit         bool      `json:"is_culprit"`
+	MysteryRole       string    `json:"mystery_role"`
+	SortOrder         int32     `json:"sort_order"`
+	IsPlayable        bool      `json:"is_playable"`
+	ShowInIntro       bool      `json:"show_in_intro"`
+	CanSpeakInReading bool      `json:"can_speak_in_reading"`
+	IsVotingCandidate bool      `json:"is_voting_candidate"`
 }
 
 // --- Service interface ---

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -31,15 +31,25 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 	if err != nil {
 		return nil, err
 	}
+	visibilityPolicy := BuildCharacterVisibilityPolicy(rolePolicy, CharacterVisibilityInput{
+		IsPlayable:        req.IsPlayable,
+		ShowInIntro:       req.ShowInIntro,
+		CanSpeakInReading: req.CanSpeakInReading,
+		IsVotingCandidate: req.IsVotingCandidate,
+	})
 
 	char, err := s.q.CreateThemeCharacter(ctx, db.CreateThemeCharacterParams{
-		ThemeID:     themeID,
-		Name:        req.Name,
-		Description: ptrToText(req.Description),
-		ImageUrl:    ptrToText(req.ImageURL),
-		IsCulprit:   rolePolicy.IsCulprit,
-		MysteryRole: rolePolicy.MysteryRole,
-		SortOrder:   req.SortOrder,
+		ThemeID:           themeID,
+		Name:              req.Name,
+		Description:       ptrToText(req.Description),
+		ImageUrl:          ptrToText(req.ImageURL),
+		IsCulprit:         rolePolicy.IsCulprit,
+		MysteryRole:       rolePolicy.MysteryRole,
+		SortOrder:         req.SortOrder,
+		IsPlayable:        visibilityPolicy.IsPlayable,
+		ShowInIntro:       visibilityPolicy.ShowInIntro,
+		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
+		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create character")
@@ -65,15 +75,30 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 	if err != nil {
 		return nil, err
 	}
+	visibilityPolicy := BuildCharacterVisibilityPolicyWithDefaults(CharacterVisibilityInput{
+		IsPlayable:        req.IsPlayable,
+		ShowInIntro:       req.ShowInIntro,
+		CanSpeakInReading: req.CanSpeakInReading,
+		IsVotingCandidate: req.IsVotingCandidate,
+	}, CharacterVisibilityPolicy{
+		IsPlayable:        char.IsPlayable,
+		ShowInIntro:       char.ShowInIntro,
+		CanSpeakInReading: char.CanSpeakInReading,
+		IsVotingCandidate: char.IsVotingCandidate,
+	})
 
 	updated, err := s.q.UpdateThemeCharacter(ctx, db.UpdateThemeCharacterParams{
-		ID:          charID,
-		Name:        req.Name,
-		Description: ptrToText(req.Description),
-		ImageUrl:    ptrToText(req.ImageURL),
-		IsCulprit:   rolePolicy.IsCulprit,
-		MysteryRole: rolePolicy.MysteryRole,
-		SortOrder:   req.SortOrder,
+		ID:                charID,
+		Name:              req.Name,
+		Description:       ptrToText(req.Description),
+		ImageUrl:          ptrToText(req.ImageURL),
+		IsCulprit:         rolePolicy.IsCulprit,
+		MysteryRole:       rolePolicy.MysteryRole,
+		SortOrder:         req.SortOrder,
+		IsPlayable:        visibilityPolicy.IsPlayable,
+		ShowInIntro:       visibilityPolicy.ShowInIntro,
+		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
+		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update character")
@@ -159,14 +184,18 @@ func (s *service) ListCharacters(ctx context.Context, creatorID, themeID uuid.UU
 
 func toCharacterResponse(c db.ThemeCharacter) *CharacterResponse {
 	return &CharacterResponse{
-		ID:          c.ID,
-		ThemeID:     c.ThemeID,
-		Name:        c.Name,
-		Description: textToPtr(c.Description),
-		ImageURL:    textToPtr(c.ImageUrl),
-		IsCulprit:   c.IsCulprit,
-		MysteryRole: c.MysteryRole,
-		SortOrder:   c.SortOrder,
+		ID:                c.ID,
+		ThemeID:           c.ThemeID,
+		Name:              c.Name,
+		Description:       textToPtr(c.Description),
+		ImageURL:          textToPtr(c.ImageUrl),
+		IsCulprit:         c.IsCulprit,
+		MysteryRole:       c.MysteryRole,
+		SortOrder:         c.SortOrder,
+		IsPlayable:        c.IsPlayable,
+		ShowInIntro:       c.ShowInIntro,
+		CanSpeakInReading: c.CanSpeakInReading,
+		IsVotingCandidate: c.IsVotingCandidate,
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -96,6 +96,82 @@ func TestCharacterRolePolicy(t *testing.T) {
 	}
 }
 
+func TestCharacterVisibilityPolicy(t *testing.T) {
+	tests := []struct {
+		name  string
+		role  string
+		input CharacterVisibilityInput
+		want  CharacterVisibilityPolicy
+	}{
+		{
+			name: "playable suspect is visible and voting candidate by default",
+			role: MysteryRoleSuspect,
+			want: CharacterVisibilityPolicy{
+				IsPlayable:        true,
+				ShowInIntro:       true,
+				CanSpeakInReading: true,
+				IsVotingCandidate: true,
+			},
+		},
+		{
+			name: "detective is excluded from voting by default",
+			role: MysteryRoleDetective,
+			want: CharacterVisibilityPolicy{
+				IsPlayable:        true,
+				ShowInIntro:       true,
+				CanSpeakInReading: true,
+				IsVotingCandidate: false,
+			},
+		},
+		{
+			name: "npc is not voting candidate unless creator opts in",
+			role: MysteryRoleSuspect,
+			input: CharacterVisibilityInput{
+				IsPlayable: boolPtr(false),
+			},
+			want: CharacterVisibilityPolicy{
+				IsPlayable:        false,
+				ShowInIntro:       true,
+				CanSpeakInReading: true,
+				IsVotingCandidate: false,
+			},
+		},
+		{
+			name: "creator overrides npc exposure independently",
+			role: MysteryRoleSuspect,
+			input: CharacterVisibilityInput{
+				IsPlayable:        boolPtr(false),
+				ShowInIntro:       boolPtr(false),
+				CanSpeakInReading: boolPtr(true),
+				IsVotingCandidate: boolPtr(true),
+			},
+			want: CharacterVisibilityPolicy{
+				IsPlayable:        false,
+				ShowInIntro:       false,
+				CanSpeakInReading: true,
+				IsVotingCandidate: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rolePolicy, err := BuildCharacterRolePolicy(tc.role, false)
+			if err != nil {
+				t.Fatalf("BuildCharacterRolePolicy: %v", err)
+			}
+			got := BuildCharacterVisibilityPolicy(rolePolicy, tc.input)
+			if got != tc.want {
+				t.Fatalf("policy = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
 func TestService_CreateCharacter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -118,6 +194,9 @@ func TestService_CreateCharacter(t *testing.T) {
 	}
 	if resp.ThemeID != themeID {
 		t.Errorf("themeID mismatch")
+	}
+	if !resp.IsPlayable || !resp.ShowInIntro || !resp.CanSpeakInReading || !resp.IsVotingCandidate {
+		t.Errorf("default visibility policy not applied: %+v", resp)
 	}
 }
 
@@ -179,6 +258,77 @@ func TestService_UpdateCharacter(t *testing.T) {
 	}
 	if !updated.IsCulprit {
 		t.Error("IsCulprit should be true")
+	}
+	if !updated.IsPlayable || !updated.ShowInIntro || !updated.CanSpeakInReading || !updated.IsVotingCandidate {
+		t.Errorf("update should preserve default playable visibility: %+v", updated)
+	}
+}
+
+func TestService_CreateCharacterNPCVisibility(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	resp, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{
+		Name:              "피해자",
+		IsPlayable:        boolPtr(false),
+		ShowInIntro:       boolPtr(true),
+		CanSpeakInReading: boolPtr(true),
+		SortOrder:         2,
+	})
+	if err != nil {
+		t.Fatalf("CreateCharacter: %v", err)
+	}
+
+	if resp.IsPlayable {
+		t.Fatal("NPC should not be playable")
+	}
+	if !resp.ShowInIntro || !resp.CanSpeakInReading {
+		t.Fatalf("NPC intro/reading policy mismatch: %+v", resp)
+	}
+	if resp.IsVotingCandidate {
+		t.Fatal("NPC should be excluded from voting by default")
+	}
+}
+
+func TestService_UpdateCharacterPreservesVisibilityWhenOmitted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	created, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{
+		Name:        "피해자",
+		IsPlayable:  boolPtr(false),
+		ShowInIntro: boolPtr(false),
+		SortOrder:   3,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	updated, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:        "피해자 수정",
+		MysteryRole: created.MysteryRole,
+		IsCulprit:   created.IsCulprit,
+		SortOrder:   created.SortOrder,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter: %v", err)
+	}
+
+	if updated.IsPlayable || updated.ShowInIntro || updated.IsVotingCandidate {
+		t.Fatalf("visibility should be preserved when omitted: %+v", updated)
+	}
+	if !updated.CanSpeakInReading {
+		t.Fatalf("reading policy should remain enabled: %+v", updated)
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -168,6 +168,25 @@ func TestCharacterVisibilityPolicy(t *testing.T) {
 	}
 }
 
+func TestCharacterVisibilityPolicyWithDefaultsDisablesVotingWhenPlayableTurnsOff(t *testing.T) {
+	got := BuildCharacterVisibilityPolicyWithDefaults(
+		CharacterVisibilityInput{IsPlayable: boolPtr(false)},
+		CharacterVisibilityPolicy{
+			IsPlayable:        true,
+			ShowInIntro:       true,
+			CanSpeakInReading: true,
+			IsVotingCandidate: true,
+		},
+	)
+
+	if got.IsPlayable || got.IsVotingCandidate {
+		t.Fatalf("NPC conversion should disable voting by default: %+v", got)
+	}
+	if !got.ShowInIntro || !got.CanSpeakInReading {
+		t.Fatalf("unrelated visibility fields should be preserved: %+v", got)
+	}
+}
+
 func boolPtr(value bool) *bool {
 	return &value
 }

--- a/apps/server/internal/domain/editor/service_character_policy.go
+++ b/apps/server/internal/domain/editor/service_character_policy.go
@@ -56,11 +56,17 @@ func BuildCharacterVisibilityPolicy(rolePolicy CharacterRolePolicy, input Charac
 }
 
 func BuildCharacterVisibilityPolicyWithDefaults(input CharacterVisibilityInput, defaults CharacterVisibilityPolicy) CharacterVisibilityPolicy {
+	isPlayable := boolPtrValue(input.IsPlayable, defaults.IsPlayable)
+	votingFallback := defaults.IsVotingCandidate
+	if input.IsPlayable != nil && !isPlayable && input.IsVotingCandidate == nil {
+		votingFallback = false
+	}
+
 	return CharacterVisibilityPolicy{
-		IsPlayable:        boolPtrValue(input.IsPlayable, defaults.IsPlayable),
+		IsPlayable:        isPlayable,
 		ShowInIntro:       boolPtrValue(input.ShowInIntro, defaults.ShowInIntro),
 		CanSpeakInReading: boolPtrValue(input.CanSpeakInReading, defaults.CanSpeakInReading),
-		IsVotingCandidate: boolPtrValue(input.IsVotingCandidate, defaults.IsVotingCandidate),
+		IsVotingCandidate: boolPtrValue(input.IsVotingCandidate, votingFallback),
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_character_policy.go
+++ b/apps/server/internal/domain/editor/service_character_policy.go
@@ -16,6 +16,20 @@ type CharacterRolePolicy struct {
 	DefaultVotingCandidate bool
 }
 
+type CharacterVisibilityInput struct {
+	IsPlayable        *bool
+	ShowInIntro       *bool
+	CanSpeakInReading *bool
+	IsVotingCandidate *bool
+}
+
+type CharacterVisibilityPolicy struct {
+	IsPlayable        bool
+	ShowInIntro       bool
+	CanSpeakInReading bool
+	IsVotingCandidate bool
+}
+
 func BuildCharacterRolePolicy(role string, legacyIsCulprit bool) (CharacterRolePolicy, error) {
 	normalized, err := normalizeCharacterMysteryRole(role, legacyIsCulprit)
 	if err != nil {
@@ -28,6 +42,33 @@ func BuildCharacterRolePolicy(role string, legacyIsCulprit bool) (CharacterRoleP
 		IsSpoiler:              normalized == MysteryRoleCulprit || normalized == MysteryRoleAccomplice || normalized == MysteryRoleDetective,
 		DefaultVotingCandidate: normalized != MysteryRoleDetective,
 	}, nil
+}
+
+func BuildCharacterVisibilityPolicy(rolePolicy CharacterRolePolicy, input CharacterVisibilityInput) CharacterVisibilityPolicy {
+	isPlayable := boolPtrValue(input.IsPlayable, true)
+
+	return CharacterVisibilityPolicy{
+		IsPlayable:        isPlayable,
+		ShowInIntro:       boolPtrValue(input.ShowInIntro, true),
+		CanSpeakInReading: boolPtrValue(input.CanSpeakInReading, true),
+		IsVotingCandidate: boolPtrValue(input.IsVotingCandidate, isPlayable && rolePolicy.DefaultVotingCandidate),
+	}
+}
+
+func BuildCharacterVisibilityPolicyWithDefaults(input CharacterVisibilityInput, defaults CharacterVisibilityPolicy) CharacterVisibilityPolicy {
+	return CharacterVisibilityPolicy{
+		IsPlayable:        boolPtrValue(input.IsPlayable, defaults.IsPlayable),
+		ShowInIntro:       boolPtrValue(input.ShowInIntro, defaults.ShowInIntro),
+		CanSpeakInReading: boolPtrValue(input.CanSpeakInReading, defaults.CanSpeakInReading),
+		IsVotingCandidate: boolPtrValue(input.IsVotingCandidate, defaults.IsVotingCandidate),
+	}
+}
+
+func boolPtrValue(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
 }
 
 func normalizeCharacterMysteryRole(role string, legacyIsCulprit bool) (string, error) {

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -50,6 +50,10 @@ export interface EditorCharacterResponse {
   is_culprit: boolean;
   mystery_role: MysteryRole;
   sort_order: number;
+  is_playable: boolean;
+  show_in_intro: boolean;
+  can_speak_in_reading: boolean;
+  is_voting_candidate: boolean;
 }
 
 export type MysteryRole = 'suspect' | 'culprit' | 'accomplice' | 'detective';
@@ -83,6 +87,10 @@ export interface CreateCharacterRequest {
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
   sort_order?: number;
+  is_playable?: boolean;
+  show_in_intro?: boolean;
+  can_speak_in_reading?: boolean;
+  is_voting_candidate?: boolean;
 }
 
 export interface UpdateCharacterRequest {
@@ -92,6 +100,10 @@ export interface UpdateCharacterRequest {
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
   sort_order?: number;
+  is_playable?: boolean;
+  show_in_intro?: boolean;
+  can_speak_in_reading?: boolean;
+  is_voting_candidate?: boolean;
 }
 
 export interface CreateClueRequest {

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -123,6 +123,8 @@ export function CharacterAssignPanel({
 
   const handleVisibilityChangeForChar = useCallback(
     (characterId: string, field: CharacterVisibilityField, value: boolean) => {
+      if (updateCharacter.isPending) return;
+
       const selected = characters?.find((char) => char.id === characterId);
       if (!selected) return;
 
@@ -215,7 +217,11 @@ export function CharacterAssignPanel({
             onChangeMission={(missionId, field, value) => handleMissionChangeForChar(char.id, missionId, field, value)}
             onDeleteMission={(missionId) => handleDeleteMissionForChar(char.id, missionId)}
             onMysteryRoleChange={(role) => handleMysteryRoleChangeForChar(char.id, role)}
-            onVisibilityChange={(field, value) => handleVisibilityChangeForChar(char.id, field, value)}
+            onVisibilityChange={
+              updateCharacter.isPending
+                ? undefined
+                : (field, value) => handleVisibilityChangeForChar(char.id, field, value)
+            }
           />
         )}
       />

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -10,8 +10,10 @@ import {
   writeCharacterStartingClueMap,
 } from "@/features/editor/utils/configShape";
 import {
+  buildCharacterVisibilityUpdatePayload,
   buildCharacterRoleUpdatePayload,
-  getCharacterRoleBadge,
+  getCharacterListBadges,
+  type CharacterVisibilityField,
 } from "@/features/editor/entities/character/characterEditorAdapter";
 import {
   createMissionDraft,
@@ -119,6 +121,19 @@ export function CharacterAssignPanel({
     [characters, updateCharacter],
   );
 
+  const handleVisibilityChangeForChar = useCallback(
+    (characterId: string, field: CharacterVisibilityField, value: boolean) => {
+      const selected = characters?.find((char) => char.id === characterId);
+      if (!selected) return;
+
+      updateCharacter.mutate({
+        characterId: selected.id,
+        body: buildCharacterVisibilityUpdatePayload(selected, field, value),
+      });
+    },
+    [characters, updateCharacter],
+  );
+
   if (charsLoading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -162,7 +177,7 @@ export function CharacterAssignPanel({
         getItemId={(char) => char.id}
         getItemTitle={(char) => char.name}
         getItemDescription={(char) => char.description ?? ''}
-        getItemBadges={(char) => [getCharacterRoleBadge(char)]}
+        getItemBadges={getCharacterListBadges}
         renderItemActions={(char) => (
           <div className="flex gap-1">
             {onEdit && (
@@ -200,6 +215,7 @@ export function CharacterAssignPanel({
             onChangeMission={(missionId, field, value) => handleMissionChangeForChar(char.id, missionId, field, value)}
             onDeleteMission={(missionId) => handleDeleteMissionForChar(char.id, missionId)}
             onMysteryRoleChange={(role) => handleMysteryRoleChangeForChar(char.id, role)}
+            onVisibilityChange={(field, value) => handleVisibilityChangeForChar(char.id, field, value)}
           />
         )}
       />

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -5,9 +5,11 @@ import { MissionEditor } from './MissionEditor';
 import { StartingClueAssigner } from './StartingClueAssigner';
 import { CharacterRoleSheetSection } from './CharacterRoleSheetSection';
 import {
+  type CharacterVisibilityField,
   characterRoleOptions,
   getCharacterRoleOption,
   normalizeCharacterEditorRole,
+  toCharacterEditorViewModel,
 } from '@/features/editor/entities/character/characterEditorAdapter';
 
 // ---------------------------------------------------------------------------
@@ -24,11 +26,17 @@ interface ClueItem {
 
 interface CharacterItem {
   id: string;
+  theme_id?: string;
   name: string;
   description?: string | null;
   image_url?: string | null;
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
+  sort_order?: number;
+  is_playable?: boolean;
+  show_in_intro?: boolean;
+  can_speak_in_reading?: boolean;
+  is_voting_candidate?: boolean;
 }
 
 interface CharacterDetailPanelProps {
@@ -43,6 +51,7 @@ interface CharacterDetailPanelProps {
   onChangeMission: (missionId: string, field: keyof Mission, value: string | number) => void;
   onDeleteMission: (missionId: string) => void;
   onMysteryRoleChange?: (role: MysteryRole) => void;
+  onVisibilityChange?: (field: CharacterVisibilityField, value: boolean) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -61,6 +70,7 @@ export function CharacterDetailPanel({
   onChangeMission,
   onDeleteMission,
   onMysteryRoleChange,
+  onVisibilityChange,
 }: CharacterDetailPanelProps) {
   if (!selectedChar) {
     return (
@@ -71,6 +81,21 @@ export function CharacterDetailPanel({
   }
 
   const selectedRole: MysteryRole = normalizeCharacterEditorRole(selectedChar);
+  const selectedView = toCharacterEditorViewModel({
+    id: selectedChar.id,
+    theme_id: selectedChar.theme_id ?? '',
+    name: selectedChar.name,
+    description: selectedChar.description ?? null,
+    image_url: selectedChar.image_url ?? null,
+    is_culprit: Boolean(selectedChar.is_culprit),
+    mystery_role: selectedRole,
+    sort_order: selectedChar.sort_order ?? 0,
+    is_playable: selectedChar.is_playable ?? true,
+    show_in_intro: selectedChar.show_in_intro ?? true,
+    can_speak_in_reading: selectedChar.can_speak_in_reading ?? true,
+    is_voting_candidate:
+      selectedChar.is_voting_candidate ?? getCharacterRoleOption(selectedRole).defaultVotingCandidate,
+  });
 
   return (
     <div className="max-w-5xl space-y-4">
@@ -85,7 +110,7 @@ export function CharacterDetailPanel({
           {
             id: 'base',
             title: '기본 정보',
-            subtitle: `${getCharacterRoleOption(selectedRole).label} · 공개 소개`,
+            subtitle: `${selectedView.roleLabel} · ${selectedView.characterTypeLabel}`,
             defaultOpen: true,
             forceOpen: true,
             children: (
@@ -120,6 +145,39 @@ export function CharacterDetailPanel({
                           </button>
                         );
                       })}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">등장인물 유형</p>
+                    <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                      <VisibilityToggle
+                        label="플레이어 캐릭터"
+                        description="참가자가 선택하고 플레이하는 인물입니다."
+                        checked={selectedView.isPlayable}
+                        disabled={!onVisibilityChange}
+                        onChange={(checked) => onVisibilityChange?.('is_playable', checked)}
+                      />
+                      <VisibilityToggle
+                        label="등장인물 소개에 표시"
+                        description="플레이 중 공개 소개 화면에 노출합니다."
+                        checked={selectedView.showInIntro}
+                        disabled={!onVisibilityChange}
+                        onChange={(checked) => onVisibilityChange?.('show_in_intro', checked)}
+                      />
+                      <VisibilityToggle
+                        label="읽기 대사에 사용"
+                        description="스토리 읽기 화면에서 이 인물의 대사를 사용할 수 있습니다."
+                        checked={selectedView.canSpeakInReading}
+                        disabled={!onVisibilityChange}
+                        onChange={(checked) => onVisibilityChange?.('can_speak_in_reading', checked)}
+                      />
+                      <VisibilityToggle
+                        label="투표 후보에 포함"
+                        description="투표 단계에서 선택 가능한 대상으로 표시합니다."
+                        checked={selectedView.isVotingCandidate}
+                        disabled={!onVisibilityChange}
+                        onChange={(checked) => onVisibilityChange?.('is_voting_candidate', checked)}
+                      />
                     </div>
                   </div>
                   <div>
@@ -178,5 +236,31 @@ export function CharacterDetailPanel({
         ]}
       />
     </div>
+  );
+}
+
+interface VisibilityToggleProps {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function VisibilityToggle({ label, description, checked, disabled, onChange }: VisibilityToggleProps) {
+  return (
+    <label className="flex min-h-24 items-start gap-3 rounded-lg border border-slate-800 bg-slate-950 p-3 text-left">
+      <input
+        type="checkbox"
+        className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-900 text-amber-500 focus:ring-amber-500"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.currentTarget.checked)}
+      />
+      <span>
+        <span className="block text-xs font-semibold text-slate-200">{label}</span>
+        <span className="mt-1 block text-[11px] leading-4 text-slate-500">{description}</span>
+      </span>
+    </label>
   );
 }

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -16,6 +16,7 @@ const {
   useUpsertCharacterRoleSheetMock,
   upsertRoleSheetMutateMock,
   updateCharacterMutateMock,
+  updateCharacterPendingMock,
   uploadMediaFileMock,
   useMediaDownloadUrlMock,
 } = vi.hoisted(() => ({
@@ -27,6 +28,7 @@ const {
   useUpsertCharacterRoleSheetMock: vi.fn(),
   upsertRoleSheetMutateMock: vi.fn(),
   updateCharacterMutateMock: vi.fn(),
+  updateCharacterPendingMock: { value: false },
   uploadMediaFileMock: vi.fn(),
   useMediaDownloadUrlMock: vi.fn(),
 }));
@@ -49,7 +51,7 @@ vi.mock('@/features/editor/api', () => ({
   useUpdateConfigJson: () => useUpdateConfigJsonMock(),
   useCharacterRoleSheet: (characterId: string) => useCharacterRoleSheetMock(characterId),
   useUpsertCharacterRoleSheet: (characterId: string) => useUpsertCharacterRoleSheetMock(characterId),
-  useUpdateCharacter: () => ({ mutate: updateCharacterMutateMock, isPending: false }),
+  useUpdateCharacter: () => ({ mutate: updateCharacterMutateMock, isPending: updateCharacterPendingMock.value }),
 }));
 
 vi.mock('@/features/editor/mediaApi', () => ({
@@ -171,6 +173,7 @@ describe('CharacterAssignPanel', () => {
     useCharacterRoleSheetMock.mockReturnValue({ data: { format: 'markdown', markdown: { body: '' } }, isLoading: false });
     useUpsertCharacterRoleSheetMock.mockReturnValue({ mutate: upsertRoleSheetMutateMock, isPending: false });
     useMediaDownloadUrlMock.mockReturnValue({ data: undefined, isLoading: false, isError: false, refetch: vi.fn() });
+    updateCharacterPendingMock.value = false;
   });
 
   it('공통 엔티티 Shell로 캐릭터 목록과 상세를 렌더링한다', () => {
@@ -228,6 +231,19 @@ describe('CharacterAssignPanel', () => {
         is_voting_candidate: false,
       },
     });
+  });
+
+  it('등장인물 유형 저장 중에는 추가 토글을 막는다', () => {
+    updateCharacterPendingMock.value = true;
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+
+    const playableToggle = screen.getByLabelText(/플레이어 캐릭터/) as HTMLInputElement;
+    expect(playableToggle.disabled).toBe(true);
+    fireEvent.click(playableToggle);
+
+    expect(updateCharacterMutateMock).not.toHaveBeenCalled();
   });
 
 

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -70,8 +70,34 @@ import { CharacterAssignPanel } from '../../design/CharacterAssignPanel';
 // ---------------------------------------------------------------------------
 
 const mockCharacters = [
-  { id: 'char-1', name: '홍길동', description: null, image_url: null, is_culprit: true, mystery_role: 'culprit' as const, sort_order: 0 },
-  { id: 'char-2', name: '김철수', description: null, image_url: null, is_culprit: false, mystery_role: 'suspect' as const, sort_order: 1 },
+  {
+    id: 'char-1',
+    theme_id: 'theme-1',
+    name: '홍길동',
+    description: null,
+    image_url: null,
+    is_culprit: true,
+    mystery_role: 'culprit' as const,
+    sort_order: 0,
+    is_playable: true,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: true,
+  },
+  {
+    id: 'char-2',
+    theme_id: 'theme-1',
+    name: '김철수',
+    description: null,
+    image_url: null,
+    is_culprit: false,
+    mystery_role: 'suspect' as const,
+    sort_order: 1,
+    is_playable: false,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: false,
+  },
 ];
 
 const mockClues = [
@@ -174,6 +200,32 @@ describe('CharacterAssignPanel', () => {
         is_culprit: false,
         mystery_role: 'accomplice',
         sort_order: 0,
+        is_playable: true,
+        show_in_intro: true,
+        can_speak_in_reading: true,
+        is_voting_candidate: true,
+      },
+    });
+  });
+
+  it('등장인물 유형을 NPC로 변경하면 투표 후보를 함께 끈다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    fireEvent.click(screen.getByLabelText(/플레이어 캐릭터/));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      body: {
+        name: '홍길동',
+        description: undefined,
+        image_url: undefined,
+        is_culprit: true,
+        mystery_role: 'culprit',
+        sort_order: 0,
+        is_playable: false,
+        show_in_intro: true,
+        can_speak_in_reading: true,
+        is_voting_candidate: false,
       },
     });
   });

--- a/apps/web/src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx
@@ -31,6 +31,10 @@ const characters: EditorCharacterResponse[] = [
     is_culprit: false,
     mystery_role: 'suspect',
     sort_order: 0,
+    is_playable: true,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: true,
   },
   {
     id: 'char-2',
@@ -41,6 +45,10 @@ const characters: EditorCharacterResponse[] = [
     is_culprit: false,
     mystery_role: 'detective',
     sort_order: 1,
+    is_playable: true,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: false,
   },
 ];
 

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { EditorCharacterResponse } from '@/features/editor/api/types';
 import {
+  buildCharacterVisibilityUpdatePayload,
+  getCharacterListBadges,
   buildCharacterRoleUpdatePayload,
   getCharacterRoleBadge,
   normalizeCharacterEditorRole,
@@ -17,6 +19,10 @@ function character(overrides: Partial<EditorCharacterResponse> = {}): EditorChar
     is_culprit: false,
     mystery_role: 'suspect',
     sort_order: 3,
+    is_playable: true,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: true,
     ...overrides,
   };
 }
@@ -36,7 +42,32 @@ describe('characterEditorAdapter', () => {
       isSpoilerRole: true,
       isDefaultVotingCandidate: false,
       hasPublicIntro: true,
+      isPlayable: true,
+      characterTypeLabel: 'PC',
+      showInIntro: true,
+      canSpeakInReading: true,
+      isVotingCandidate: true,
+      visibilityBadges: ['PC', '소개 표시', '읽기 대사', '투표 후보'],
     });
+  });
+
+  it('NPC 표시 정책을 제작자용 ViewModel 배지로 변환한다', () => {
+    const vm = toCharacterEditorViewModel(character({
+      is_playable: false,
+      show_in_intro: false,
+      can_speak_in_reading: true,
+      is_voting_candidate: false,
+    }));
+
+    expect(vm).toMatchObject({
+      isPlayable: false,
+      characterTypeLabel: 'NPC',
+      showInIntro: false,
+      canSpeakInReading: true,
+      isVotingCandidate: false,
+      visibilityBadges: ['NPC', '읽기 대사'],
+    });
+    expect(getCharacterListBadges(character({ is_playable: false }))).toEqual(['용의자', 'NPC']);
   });
 
   it('legacy is_culprit 플래그만 있어도 범인 역할로 보존한다', () => {
@@ -54,11 +85,26 @@ describe('characterEditorAdapter', () => {
       is_culprit: false,
       mystery_role: 'accomplice',
       sort_order: 3,
+      is_playable: true,
+      show_in_intro: true,
+      can_speak_in_reading: true,
+      is_voting_candidate: true,
     });
   });
 
   it('범인으로 변경할 때만 legacy is_culprit를 true로 보낸다', () => {
     expect(buildCharacterRoleUpdatePayload(character(), 'culprit').is_culprit).toBe(true);
     expect(buildCharacterRoleUpdatePayload(character(), 'detective').is_culprit).toBe(false);
+  });
+
+  it('NPC로 전환할 때 투표 후보를 함께 끈다', () => {
+    const payload = buildCharacterVisibilityUpdatePayload(character(), 'is_playable', false);
+
+    expect(payload).toMatchObject({
+      is_playable: false,
+      show_in_intro: true,
+      can_speak_in_reading: true,
+      is_voting_candidate: false,
+    });
   });
 });

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -25,6 +25,12 @@ export interface CharacterEditorViewModel {
   isSpoilerRole: boolean;
   isDefaultVotingCandidate: boolean;
   hasPublicIntro: boolean;
+  isPlayable: boolean;
+  characterTypeLabel: string;
+  showInIntro: boolean;
+  canSpeakInReading: boolean;
+  isVotingCandidate: boolean;
+  visibilityBadges: string[];
 }
 
 export const characterRoleOptions: CharacterRoleOption[] = [
@@ -62,6 +68,12 @@ const roleOptionMap = new Map<MysteryRole, CharacterRoleOption>(
   characterRoleOptions.map((option) => [option.value, option]),
 );
 
+export type CharacterVisibilityField =
+  | 'is_playable'
+  | 'show_in_intro'
+  | 'can_speak_in_reading'
+  | 'is_voting_candidate';
+
 export function getCharacterRoleOption(role: MysteryRole): CharacterRoleOption {
   return roleOptionMap.get(role) ?? roleOptionMap.get('suspect')!;
 }
@@ -71,9 +83,34 @@ export function normalizeCharacterEditorRole(character: { mystery_role?: Mystery
   return character.is_culprit ? 'culprit' : 'suspect';
 }
 
+function boolOrDefault(value: boolean | undefined | null, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function getCharacterVisibility(character: Partial<EditorCharacterResponse>, role: MysteryRole) {
+  const roleOption = getCharacterRoleOption(role);
+  const isPlayable = boolOrDefault(character.is_playable, true);
+
+  return {
+    isPlayable,
+    showInIntro: boolOrDefault(character.show_in_intro, true),
+    canSpeakInReading: boolOrDefault(character.can_speak_in_reading, true),
+    isVotingCandidate: boolOrDefault(character.is_voting_candidate, isPlayable && roleOption.defaultVotingCandidate),
+  };
+}
+
+function getVisibilityBadges(visibility: ReturnType<typeof getCharacterVisibility>): string[] {
+  const badges = [visibility.isPlayable ? 'PC' : 'NPC'];
+  if (visibility.showInIntro) badges.push('소개 표시');
+  if (visibility.canSpeakInReading) badges.push('읽기 대사');
+  if (visibility.isVotingCandidate) badges.push('투표 후보');
+  return badges;
+}
+
 export function toCharacterEditorViewModel(character: EditorCharacterResponse): CharacterEditorViewModel {
   const role = normalizeCharacterEditorRole(character);
   const option = getCharacterRoleOption(role);
+  const visibility = getCharacterVisibility(character, role);
 
   return {
     id: character.id,
@@ -88,6 +125,12 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     isSpoilerRole: option.spoiler,
     isDefaultVotingCandidate: option.defaultVotingCandidate,
     hasPublicIntro: Boolean(character.description?.trim() || character.image_url),
+    isPlayable: visibility.isPlayable,
+    characterTypeLabel: visibility.isPlayable ? 'PC' : 'NPC',
+    showInIntro: visibility.showInIntro,
+    canSpeakInReading: visibility.canSpeakInReading,
+    isVotingCandidate: visibility.isVotingCandidate,
+    visibilityBadges: getVisibilityBadges(visibility),
   };
 }
 
@@ -99,6 +142,8 @@ export function buildCharacterRoleUpdatePayload(
   character: EditorCharacterResponse,
   role: MysteryRole,
 ): UpdateCharacterRequest {
+  const visibility = getCharacterVisibility(character, role);
+
   return {
     name: character.name,
     description: character.description ?? undefined,
@@ -106,9 +151,49 @@ export function buildCharacterRoleUpdatePayload(
     is_culprit: role === 'culprit',
     mystery_role: role,
     sort_order: character.sort_order,
+    is_playable: visibility.isPlayable,
+    show_in_intro: visibility.showInIntro,
+    can_speak_in_reading: visibility.canSpeakInReading,
+    is_voting_candidate: visibility.isVotingCandidate,
+  };
+}
+
+export function buildCharacterVisibilityUpdatePayload(
+  character: EditorCharacterResponse,
+  field: CharacterVisibilityField,
+  value: boolean,
+): UpdateCharacterRequest {
+  const role = normalizeCharacterEditorRole(character);
+  const visibility = getCharacterVisibility(character, role);
+  const next = {
+    is_playable: visibility.isPlayable,
+    show_in_intro: visibility.showInIntro,
+    can_speak_in_reading: visibility.canSpeakInReading,
+    is_voting_candidate: visibility.isVotingCandidate,
+    [field]: value,
+  };
+
+  if (field === 'is_playable' && !value) {
+    next.is_voting_candidate = false;
+  }
+
+  return {
+    name: character.name,
+    description: character.description ?? undefined,
+    image_url: character.image_url ?? undefined,
+    is_culprit: role === 'culprit',
+    mystery_role: role,
+    sort_order: character.sort_order,
+    ...next,
   };
 }
 
 export function getCharacterRoleBadge(character: { mystery_role?: MysteryRole | null; is_culprit?: boolean | null }): string {
   return getCharacterRoleOption(normalizeCharacterEditorRole(character)).label;
+}
+
+export function getCharacterListBadges(character: EditorCharacterResponse): string[] {
+  const role = normalizeCharacterEditorRole(character);
+  const visibility = getCharacterVisibility(character, role);
+  return [getCharacterRoleBadge(character), visibility.isPlayable ? 'PC' : 'NPC'];
 }

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -18,6 +18,10 @@ const characters: EditorCharacterResponse[] = [
     is_culprit: false,
     mystery_role: 'detective',
     sort_order: 0,
+    is_playable: true,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: false,
   },
   {
     id: 'char-2',
@@ -28,6 +32,10 @@ const characters: EditorCharacterResponse[] = [
     is_culprit: false,
     mystery_role: 'suspect',
     sort_order: 1,
+    is_playable: true,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: true,
   },
 ];
 

--- a/apps/web/src/features/game/utils/__tests__/votingCandidates.test.ts
+++ b/apps/web/src/features/game/utils/__tests__/votingCandidates.test.ts
@@ -3,10 +3,16 @@ import { PlayerRole, type Player } from "@mmp/shared";
 import {
   countExcludedDetectives,
   filterVotingCandidates,
+  isEligibleCharacterCandidate,
   readVotingCandidatePolicy,
 } from "../votingCandidates";
 
-function player(overrides: Partial<Player>): Player {
+type CandidatePlayer = Player & {
+  isPlayable?: boolean;
+  isVotingCandidate?: boolean;
+};
+
+function player(overrides: Partial<CandidatePlayer>): CandidatePlayer {
   return {
     id: "p-1",
     nickname: "플레이어",
@@ -73,6 +79,23 @@ describe("votingCandidates", () => {
         includeDeadPlayers: true,
       }).map((p) => p.id),
     ).toEqual(["me", "detective", "dead"]);
+  });
+
+  it("excludes backend-marked NPC or non-candidate characters before phase policy", () => {
+    const players = [
+      player({ id: "npc", nickname: "피해자", isPlayable: false }),
+      player({ id: "hidden", nickname: "진행자", isVotingCandidate: false }),
+      player({ id: "suspect", nickname: "용의자", role: PlayerRole.CIVILIAN }),
+    ];
+
+    expect(isEligibleCharacterCandidate(players[0])).toBe(false);
+    expect(
+      filterVotingCandidates(players, null, {
+        includeDetective: true,
+        includeSelf: true,
+        includeDeadPlayers: true,
+      }).map((p) => p.id),
+    ).toEqual(["suspect"]);
   });
 
   it("counts detectives hidden by the current policy", () => {

--- a/apps/web/src/features/game/utils/votingCandidates.ts
+++ b/apps/web/src/features/game/utils/votingCandidates.ts
@@ -6,6 +6,11 @@ export interface VotingCandidatePolicy {
   includeDeadPlayers: boolean;
 }
 
+type CandidatePlayer = Player & {
+  isPlayable?: boolean;
+  isVotingCandidate?: boolean;
+};
+
 export const DEFAULT_VOTING_CANDIDATE_POLICY: VotingCandidatePolicy = {
   includeDetective: false,
   includeSelf: false,
@@ -41,12 +46,19 @@ export function isDetectivePlayer(player: Player): boolean {
   return player.role === PlayerRole.DETECTIVE;
 }
 
+export function isEligibleCharacterCandidate(player: CandidatePlayer): boolean {
+  if (player.isPlayable === false) return false;
+  if (player.isVotingCandidate === false) return false;
+  return true;
+}
+
 export function filterVotingCandidates(
-  players: Player[],
+  players: CandidatePlayer[],
   myPlayerId: string | null,
   policy: VotingCandidatePolicy,
-): Player[] {
+): CandidatePlayer[] {
   return players.filter((player) => {
+    if (!isEligibleCharacterCandidate(player)) return false;
     if (!policy.includeDeadPlayers && !player.isAlive) return false;
     if (!policy.includeSelf && player.id === myPlayerId) return false;
     if (!policy.includeDetective && isDetectivePlayer(player)) return false;
@@ -55,12 +67,13 @@ export function filterVotingCandidates(
 }
 
 export function countExcludedDetectives(
-  players: Player[],
+  players: CandidatePlayer[],
   myPlayerId: string | null,
   policy: VotingCandidatePolicy,
 ): number {
   if (policy.includeDetective) return 0;
   return players.filter((player) => {
+    if (!isEligibleCharacterCandidate(player)) return false;
     if (!isDetectivePlayer(player)) return false;
     if (!policy.includeDeadPlayers && !player.isAlive) return false;
     if (!policy.includeSelf && player.id === myPlayerId) return false;


### PR DESCRIPTION
## 요약

- Character Entity에 PC/NPC visibility 저장 계약을 추가했습니다.
- 제작자 캐릭터 화면에서 플레이어 캐릭터, 소개 표시, 읽기 대사, 투표 후보 포함 여부를 조절할 수 있게 연결했습니다.
- 투표 후보 필터가 backend-marked NPC/non-candidate 값을 먼저 존중하도록 보강했습니다.
- 조건부 이름·아이콘은 #329, 캐릭터 엔드카드는 #330으로 분리했습니다.

## 검증

- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/game/utils/__tests__/votingCandidates.test.ts
- pnpm --filter @mmp/web exec vitest run src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx
- go test ./internal/domain/editor
- git diff --check

Closes #306
Refs #329
Refs #330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 등장인물 가시성 옵션 추가: 플레이 가능, 도입부 노출, 추리 단계 발언 가능, 투표 후보자 자격
  * 에디터 UI에 "등장인물 유형" 섹션 및 토글 추가(배지 표시·즉시 업데이트 비활성화 처리 포함)
  * NPC는 기본적으로 투표 후보자에서 제외되며, 투표 후보자 필터가 비플레이어/비후보자도 제외하도록 개선됨
  * 등장인물 생성·수정·이미지 업로드 시 가시성 옵션이 보존되어 응답에 노출됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->