### PR TITLE
feat(editor): #302 스토리 정보 공개 UI 연결

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -140,6 +140,8 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
       timeout: 10_000,
     });
     await expect(page.getByPlaceholder("마크다운으로 스토리를 작성하세요...")).toBeVisible();
+    await expect(page.getByText("장면별 정보 공개 설정")).toBeVisible();
+    await expect(page.getByRole("button", { name: /조사 단계/ })).toBeVisible();
 
     await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
     await expect(page.getByRole("tab", { name: "등장인물", selected: true })).toBeVisible({

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -201,7 +201,12 @@ export function StoryTab({ themeId }: StoryTabProps) {
           <ReadingSectionList themeId={themeId} />
         </div>
 
-        <StoryInformationDeliverySection themeId={themeId} graph={flowGraph} />
+        <StoryInformationDeliverySection
+          themeId={themeId}
+          graph={flowGraph}
+          isLoading={isFlowLoading}
+          isError={isFlowError}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/StoryTab.tsx
+++ b/apps/web/src/features/editor/components/StoryTab.tsx
@@ -8,6 +8,7 @@ import { useAutoSave } from '@/features/editor/hooks/useAutoSave';
 import { toStorySceneFlowSummaryFromGraph } from '@/features/editor/entities/story/storySceneAdapter';
 import { StorySceneSummary } from './design/StorySceneSummary';
 import { ReadingSectionList } from './reading/ReadingSectionList';
+import { StoryInformationDeliverySection } from './design/StoryInformationDeliverySection';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -199,6 +200,8 @@ export function StoryTab({ themeId }: StoryTabProps) {
         <div className="border-t border-slate-800 px-5 py-6">
           <ReadingSectionList themeId={themeId} />
         </div>
+
+        <StoryInformationDeliverySection themeId={themeId} graph={flowGraph} />
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/StoryTab.test.tsx
@@ -26,6 +26,12 @@ vi.mock("@/features/editor/components/reading/ReadingSectionList", () => ({
   ),
 }));
 
+vi.mock("@/features/editor/components/design/StoryInformationDeliverySection", () => ({
+  StoryInformationDeliverySection: ({ themeId }: { themeId: string }) => (
+    <div data-testid="story-information-delivery-section">{themeId}</div>
+  ),
+}));
+
 import { StoryTab } from "../StoryTab";
 
 afterEach(() => {
@@ -64,6 +70,7 @@ describe("StoryTab", () => {
     expect(screen.getByText("1개 장면")).toBeDefined();
     expect(screen.getAllByText("오프닝").length).toBeGreaterThan(0);
     expect(screen.getByTestId("reading-section-list").textContent).toBe("theme-1");
+    expect(screen.getByTestId("story-information-delivery-section").textContent).toBe("theme-1");
   });
 
   it("장면 구성을 불러오는 동안 빈 장면 요약을 보여주지 않는다", async () => {

--- a/apps/web/src/features/editor/components/design/StoryInformationDeliverySection.tsx
+++ b/apps/web/src/features/editor/components/design/StoryInformationDeliverySection.tsx
@@ -12,16 +12,20 @@ import { InformationDeliveryPanel } from "./InformationDeliveryPanel";
 interface StoryInformationDeliverySectionProps {
   themeId: string;
   graph: FlowGraphResponse | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
 }
 
 export function StoryInformationDeliverySection({
   themeId,
   graph,
+  isLoading = false,
+  isError = false,
 }: StoryInformationDeliverySectionProps) {
   const scenes = useMemo(() => getSceneNodes(graph), [graph]);
   const [selectedSceneId, setSelectedSceneId] = useState<string | null>(null);
   const updateNode = useUpdateFlowNode(themeId);
-  const selectedScene = scenes.find((scene) => scene.id === (selectedSceneId ?? scenes[0]?.id));
+  const selectedScene = scenes.find((scene) => scene.id === selectedSceneId) ?? scenes[0];
 
   const updateScene = (patch: Partial<FlowNodeData>) => {
     if (!selectedScene) return;
@@ -53,7 +57,17 @@ export function StoryInformationDeliverySection({
         <SceneCountBadge count={scenes.length} />
       </div>
 
-      {scenes.length === 0 ? (
+      {isLoading ? (
+        <SectionStatusMessage
+          message="정보 공개 설정에 사용할 장면을 불러오는 중입니다."
+          status="loading"
+        />
+      ) : isError ? (
+        <SectionStatusMessage
+          message="정보 공개 설정에 사용할 장면을 불러오지 못했습니다."
+          status="error"
+        />
+      ) : scenes.length === 0 ? (
         <div className="rounded border border-dashed border-slate-800 bg-slate-950/50 px-3 py-4 text-xs leading-5 text-slate-400">
           스토리 진행에서 장면을 추가하면 정보 공개 대상을 설정할 수 있습니다.
         </div>
@@ -75,6 +89,26 @@ export function StoryInformationDeliverySection({
         </div>
       )}
     </section>
+  );
+}
+
+function SectionStatusMessage({
+  message,
+  status,
+}: {
+  message: string;
+  status: "loading" | "error";
+}) {
+  const isError = status === "error";
+  return (
+    <div
+      className="rounded border border-slate-800 bg-slate-950/60 px-3 py-4 text-xs leading-5 text-slate-400"
+      role={isError ? "alert" : "status"}
+      aria-live={isError ? "assertive" : "polite"}
+      aria-atomic="true"
+    >
+      {message}
+    </div>
   );
 }
 

--- a/apps/web/src/features/editor/components/design/StoryInformationDeliverySection.tsx
+++ b/apps/web/src/features/editor/components/design/StoryInformationDeliverySection.tsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { useUpdateFlowNode } from "../../flowApi";
+import type {
+  FlowGraphResponse,
+  FlowNodeData,
+  FlowNodeResponse,
+} from "../../flowTypes";
+import { toPhaseEditorViewModel } from "../../entities/phase/phaseEntityAdapter";
+import { InformationDeliveryPanel } from "./InformationDeliveryPanel";
+
+interface StoryInformationDeliverySectionProps {
+  themeId: string;
+  graph: FlowGraphResponse | undefined;
+}
+
+export function StoryInformationDeliverySection({
+  themeId,
+  graph,
+}: StoryInformationDeliverySectionProps) {
+  const scenes = useMemo(() => getSceneNodes(graph), [graph]);
+  const [selectedSceneId, setSelectedSceneId] = useState<string | null>(null);
+  const updateNode = useUpdateFlowNode(themeId);
+  const selectedScene = scenes.find((scene) => scene.id === (selectedSceneId ?? scenes[0]?.id));
+
+  const updateScene = (patch: Partial<FlowNodeData>) => {
+    if (!selectedScene) return;
+    updateNode.mutate(
+      {
+        nodeId: selectedScene.id,
+        body: { data: { ...selectedScene.data, ...patch } },
+      },
+      {
+        onError: () => toast.error("정보 공개 설정 저장에 실패했습니다"),
+      },
+    );
+  };
+
+  return (
+    <section className="space-y-4 border-t border-slate-800 px-5 py-6">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
+            정보 공개
+          </p>
+          <h3 className="mt-1 text-sm font-semibold text-slate-100">
+            장면별 정보 공개 설정
+          </h3>
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-slate-400">
+            스토리 정보 묶음을 장면에 연결하고, 전체 플레이어 또는 캐릭터별 공개 대상을 정합니다.
+          </p>
+        </div>
+        <SceneCountBadge count={scenes.length} />
+      </div>
+
+      {scenes.length === 0 ? (
+        <div className="rounded border border-dashed border-slate-800 bg-slate-950/50 px-3 py-4 text-xs leading-5 text-slate-400">
+          스토리 진행에서 장면을 추가하면 정보 공개 대상을 설정할 수 있습니다.
+        </div>
+      ) : (
+        <div className="grid gap-4 xl:grid-cols-[minmax(220px,300px)_minmax(0,1fr)]">
+          <SceneSelector
+            scenes={scenes}
+            selectedSceneId={selectedScene?.id}
+            onSelect={setSelectedSceneId}
+          />
+          {selectedScene && (
+            <InformationDeliveryPanel
+              key={selectedScene.id}
+              themeId={themeId}
+              phaseData={selectedScene.data}
+              onChange={updateScene}
+            />
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function getSceneNodes(graph: FlowGraphResponse | undefined): FlowNodeResponse[] {
+  return (graph?.nodes ?? [])
+    .filter((node) => node.type === "phase")
+    .sort((left, right) => {
+      if (left.position_y !== right.position_y) return left.position_y - right.position_y;
+      if (left.position_x !== right.position_x) return left.position_x - right.position_x;
+      return left.id.localeCompare(right.id);
+    });
+}
+
+function SceneCountBadge({ count }: { count: number }) {
+  return (
+    <div className="w-fit rounded border border-slate-800 bg-slate-950/70 px-3 py-2 text-xs">
+      <p className="text-[10px] text-slate-500">설정 가능 장면</p>
+      <p className="mt-0.5 whitespace-nowrap text-slate-100">{count}개</p>
+    </div>
+  );
+}
+
+interface SceneSelectorProps {
+  scenes: FlowNodeResponse[];
+  selectedSceneId: string | undefined;
+  onSelect: (sceneId: string) => void;
+}
+
+function SceneSelector({ scenes, selectedSceneId, onSelect }: SceneSelectorProps) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-2">
+      <p className="px-2 py-1 text-[11px] font-medium text-slate-400">장면 선택</p>
+      <div className="mt-1 grid gap-1">
+        {scenes.map((scene) => {
+          const viewModel = toPhaseEditorViewModel(scene.data, []);
+          const selected = scene.id === selectedSceneId;
+          return (
+            <button
+              key={scene.id}
+              type="button"
+              onClick={() => onSelect(scene.id)}
+              aria-pressed={selected}
+              className={`rounded px-3 py-2 text-left text-xs transition-colors ${
+                selected
+                  ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40"
+                  : "bg-slate-900 text-slate-300 hover:bg-slate-800"
+              }`}
+            >
+              <span className="block truncate font-medium">{viewModel.title}</span>
+              <span className="mt-0.5 block truncate text-[10px] text-slate-400">
+                {viewModel.phaseTypeLabel} · {viewModel.informationDeliveryCount}개 정보 공개
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/__tests__/StoryInformationDeliverySection.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/StoryInformationDeliverySection.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { FlowGraphResponse } from "../../../flowTypes";
+import { DELIVER_INFORMATION_ACTION } from "../phaseEditorAdapter";
+import { StoryInformationDeliverySection } from "../StoryInformationDeliverySection";
+
+const { mutateMock, useEditorCharactersMock, useReadingSectionsMock } = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  useEditorCharactersMock: vi.fn(),
+  useReadingSectionsMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+vi.mock("../../../flowApi", () => ({
+  useUpdateFlowNode: () => ({ mutate: mutateMock }),
+}));
+
+vi.mock("../../../api", () => ({
+  useEditorCharacters: () => useEditorCharactersMock(),
+}));
+
+vi.mock("../../../readingApi", () => ({
+  useReadingSections: () => useReadingSectionsMock(),
+}));
+
+vi.stubGlobal("crypto", { randomUUID: () => "delivery-new" });
+
+const graph: FlowGraphResponse = {
+  nodes: [
+    {
+      id: "scene-2",
+      theme_id: "theme-1",
+      type: "phase",
+      data: { label: "조사 시작", phase_type: "investigation" },
+      position_x: 120,
+      position_y: 200,
+      created_at: "2026-05-05T00:00:00Z",
+      updated_at: "2026-05-05T00:00:00Z",
+    },
+    {
+      id: "scene-1",
+      theme_id: "theme-1",
+      type: "phase",
+      data: { label: "오프닝", phase_type: "story_progression" },
+      position_x: 100,
+      position_y: 100,
+      created_at: "2026-05-05T00:00:00Z",
+      updated_at: "2026-05-05T00:00:00Z",
+    },
+  ],
+  edges: [],
+};
+
+beforeEach(() => {
+  mutateMock.mockClear();
+  useEditorCharactersMock.mockReturnValue({
+    data: [{ id: "char-1", name: "탐정 A" }],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  useReadingSectionsMock.mockReturnValue({
+    data: [{ id: "rs-1", name: "공통 규칙", lines: [{ Text: "규칙" }] }],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("StoryInformationDeliverySection", () => {
+  it("스토리 탭에서 장면을 선택해 정보 공개 설정을 저장한다", () => {
+    render(<StoryInformationDeliverySection themeId="theme-1" graph={graph} />);
+
+    expect(screen.getByText("장면별 정보 공개 설정")).toBeDefined();
+    expect(screen.getByText("오프닝")).toBeDefined();
+    expect(screen.getByText("조사 시작")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /조사 시작/ }));
+    fireEvent.click(screen.getByRole("button", { name: "전체 전달" }));
+    fireEvent.click(screen.getByRole("button", { name: /공통 규칙/ }));
+
+    expect(mutateMock).toHaveBeenLastCalledWith(
+      {
+        nodeId: "scene-2",
+        body: {
+          data: {
+            label: "조사 시작",
+            phase_type: "investigation",
+            onEnter: [
+              {
+                id: "delivery-new",
+                type: DELIVER_INFORMATION_ACTION,
+                params: {
+                  deliveries: [
+                    {
+                      id: "delivery-new",
+                      target: { type: "all_players" },
+                      reading_section_ids: ["rs-1"],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      expect.any(Object),
+    );
+  });
+
+  it("장면이 없으면 정보 공개 설정 대신 빈 상태를 보여준다", () => {
+    render(<StoryInformationDeliverySection themeId="theme-1" graph={{ nodes: [], edges: [] }} />);
+
+    expect(screen.getByText("0개")).toBeDefined();
+    expect(screen.getByText("스토리 진행에서 장면을 추가하면 정보 공개 대상을 설정할 수 있습니다.")).toBeDefined();
+    expect(screen.queryByText("장면 선택")).toBeNull();
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/StoryInformationDeliverySection.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/StoryInformationDeliverySection.test.tsx
@@ -24,8 +24,6 @@ vi.mock("../../../readingApi", () => ({
   useReadingSections: () => useReadingSectionsMock(),
 }));
 
-vi.stubGlobal("crypto", { randomUUID: () => "delivery-new" });
-
 const graph: FlowGraphResponse = {
   nodes: [
     {
@@ -53,6 +51,7 @@ const graph: FlowGraphResponse = {
 };
 
 beforeEach(() => {
+  vi.stubGlobal("crypto", { randomUUID: () => "delivery-new" });
   mutateMock.mockClear();
   useEditorCharactersMock.mockReturnValue({
     data: [{ id: "char-1", name: "탐정 A" }],
@@ -71,6 +70,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("StoryInformationDeliverySection", () => {
@@ -120,5 +120,60 @@ describe("StoryInformationDeliverySection", () => {
     expect(screen.getByText("0개")).toBeDefined();
     expect(screen.getByText("스토리 진행에서 장면을 추가하면 정보 공개 대상을 설정할 수 있습니다.")).toBeDefined();
     expect(screen.queryByText("장면 선택")).toBeNull();
+  });
+
+  it("장면을 불러오는 동안 빈 상태와 구분되는 로딩 상태를 보여준다", () => {
+    render(<StoryInformationDeliverySection themeId="theme-1" graph={undefined} isLoading />);
+
+    expect(screen.getByRole("status").textContent).toContain("정보 공개 설정에 사용할 장면을 불러오는 중입니다.");
+    expect(screen.queryByText("스토리 진행에서 장면을 추가하면 정보 공개 대상을 설정할 수 있습니다.")).toBeNull();
+  });
+
+  it("장면 로드 실패를 빈 상태와 구분되는 오류 상태로 보여준다", () => {
+    render(<StoryInformationDeliverySection themeId="theme-1" graph={undefined} isError />);
+
+    expect(screen.getByRole("alert").textContent).toContain("정보 공개 설정에 사용할 장면을 불러오지 못했습니다.");
+    expect(screen.queryByText("스토리 진행에서 장면을 추가하면 정보 공개 대상을 설정할 수 있습니다.")).toBeNull();
+  });
+
+  it("선택된 장면이 사라지면 첫 장면으로 되돌려 정보 공개 패널을 유지한다", () => {
+    const { rerender } = render(<StoryInformationDeliverySection themeId="theme-1" graph={graph} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /조사 시작/ }));
+
+    rerender(<StoryInformationDeliverySection themeId="theme-1" graph={{ nodes: [graph.nodes[1]], edges: [] }} />);
+
+    expect(screen.getByRole("button", { name: /오프닝/ }).getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "전체 전달" }));
+    fireEvent.click(screen.getByRole("button", { name: /공통 규칙/ }));
+
+    expect(mutateMock).toHaveBeenLastCalledWith(
+      {
+        nodeId: "scene-1",
+        body: {
+          data: {
+            label: "오프닝",
+            phase_type: "story_progression",
+            onEnter: [
+              {
+                id: "delivery-new",
+                type: DELIVER_INFORMATION_ACTION,
+                params: {
+                  deliveries: [
+                    {
+                      id: "delivery-new",
+                      target: { type: "all_players" },
+                      reading_section_ids: ["rs-1"],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      expect.any(Object),
+    );
   });
 });


### PR DESCRIPTION
## 요약
- 스토리 탭에 장면별 정보 공개 설정 섹션을 추가했습니다.
- 기존 게임설계 페이즈의 InformationDeliveryPanel 저장 계약을 재사용해 flow node onEnter DELIVER_INFORMATION 패치를 저장합니다.
- /editor/{themeId}/story 직접 URL smoke에 새 섹션 노출 검증을 추가했습니다.

## 범위
- Refs #302
- 이번 PR은 #302의 프론트 1차 연결 범위입니다.
- backend runtime delivery/redaction 계약과 실제 플레이어 전달 처리는 후속 범위로 남깁니다.

## 검증
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/StoryInformationDeliverySection.test.tsx src/features/editor/components/__tests__/StoryTab.test.tsx src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web run _bootstrap:ws-client
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 스토리 편집기에 “장면별 정보 공개 설정” 패널이 추가되어 장면별 전달 방식 선택, 장면 카운트·레이블 확인 및 관련 버튼(예: 조사 단계) 노출이 가능해졌습니다.

* **개선**
  * 장면이 제거되더라도 선택이 자동으로 남은 첫 장면으로 전환되어 안전하게 유지됩니다.
  * 로딩·오류 상태에서 적절한 상태 메시지 표시가 추가되었습니다.

* **테스트**
  * 단위 및 E2E 테스트가 추가되어 패널 텍스트·버튼 표시, 장면 동작, 로딩/오류 상태를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #302