### PR TITLE
feat(editor): #290 단서 조사 제작 용어 정렬

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -166,7 +166,7 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
       timeout: 10_000,
     });
     await expect(page.getByLabel("장소 목록")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByLabel("거실 조사 시 발견 단서")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel("거실 단서 조사")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText("저택 1층").first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/endings`);
@@ -390,7 +390,7 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await expect(page.getByLabel("장소 목록")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText("거실").first()).toBeVisible({ timeout: 3_000 });
     await expect(page.getByText("R2~4").first()).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByLabel("거실 조사 시 발견 단서")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByLabel("거실 단서 조사")).toBeVisible({ timeout: 3_000 });
     await expect(page.getByText(/접근 제한/).first()).toBeVisible({ timeout: 3_000 });
 
     // UI: 단서 chip/체크박스가 있으면 토글 + 즉시 반영

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -77,12 +77,12 @@ export function LocationClueAssignPanel({
       });
     updateConfig.mutate(nextConfig, {
       onSuccess: () => {
-        toast.success('장소 조사 단서가 저장되었습니다');
+        toast.success('단서 조사가 저장되었습니다');
         onChange?.(nextIds);
       },
       onError: () => {
         if (previous) queryClient.setQueryData(cacheKey, previous);
-        toast.error('장소 조사 단서 저장에 실패했습니다');
+        toast.error('단서 조사 저장에 실패했습니다');
       },
     });
   }
@@ -126,7 +126,7 @@ export function LocationClueAssignPanel({
   if (!allClues && isError) {
     return (
       <section
-        aria-label={`${location.name} 조사 시 발견 단서`}
+        aria-label={`${location.name} 단서 조사`}
         className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-center text-xs text-red-100"
       >
         <p>단서 목록을 불러오지 못했습니다.</p>
@@ -143,15 +143,18 @@ export function LocationClueAssignPanel({
 
   return (
     <section
-      aria-label={`${location.name} 조사 시 발견 단서`}
+      aria-label={`${location.name} 단서 조사`}
       className="rounded-lg border border-slate-800 bg-slate-950/70 p-3"
     >
       <header className="mb-3 flex flex-wrap items-center gap-2">
         <MapPin className="h-3.5 w-3.5 text-amber-500/70" />
-        <h4 className="text-sm font-semibold text-slate-200">{location.name} 조사 시 발견 단서</h4>
+        <h4 className="text-sm font-semibold text-slate-200">{location.name} 단서 조사</h4>
         <span className="text-xs text-slate-600">
           ({assignedIds.length}/{clues.length})
         </span>
+        <p className="basis-full text-xs text-slate-500">
+          이 장소를 조사했을 때 얻는 단서와 먼저 필요한 단서를 정합니다.
+        </p>
       </header>
       {clues.length === 0 ? (
         <EmptyClues />
@@ -198,7 +201,7 @@ export function LocationClueAssignPanel({
           <section className="rounded-lg border border-amber-500/20 bg-amber-950/10 p-2.5">
             <div className="mb-2 flex items-center justify-between gap-2">
               <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
-                조사 보상
+                조사 결과
               </p>
               <span className="text-[10px] text-slate-600">플레이어당 1회</span>
             </div>

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -423,7 +423,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
 
     const cached = qc.getQueryData<EditorThemeResponse>(cacheKey);
     expect(cached?.config_json).toEqual({}); // rolled back to baseTheme.config_json
-    expect(toastError).toHaveBeenCalledWith('장소 조사 단서 저장에 실패했습니다');
+    expect(toastError).toHaveBeenCalledWith('단서 조사 저장에 실패했습니다');
   });
 
   it('연속 토글에서 첫 mutation 실패 시 첫 토글 직전 상태로 rollback 된다 (M5 closure)', () => {
@@ -469,7 +469,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     // 핵심 검증: 첫 토글 직전 상태로 롤백 (빈 config_json).
     // 단일 rollbackRef 구현이었다면 두 번째 토글 직전 스냅샷(clue-1 포함)으로 잘못 복원됨.
     expect(cached?.config_json).toEqual({});
-    expect(toastError).toHaveBeenCalledWith('장소 조사 단서 저장에 실패했습니다');
+    expect(toastError).toHaveBeenCalledWith('단서 조사 저장에 실패했습니다');
   });
 
   it('theme 캐시가 없으면 mutate 만 호출되고 rollback 대상도 없다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -302,7 +302,7 @@ describe('LocationsSubTab', () => {
     it('location picker 를 통해 선택한 location 에 대해 LocationClueAssignPanel 이 렌더된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       fireEvent.click(screen.getByRole('button', { name: '주방 선택' }));
-      expect(screen.getByLabelText('주방 조사 시 발견 단서')).toBeDefined();
+      expect(screen.getByLabelText('주방 단서 조사')).toBeDefined();
       expect(screen.getByLabelText('단검 추가')).toBeDefined();
     });
 

--- a/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
@@ -38,13 +38,13 @@ const location = (id: string, name: string): LocationResponse => ({
 });
 
 describe('deckInvestigationAdapter', () => {
-  it('설정이 없으면 제작자가 바로 이해할 기본 토큰을 제공한다', () => {
+  it('설정이 없으면 제작자가 바로 이해할 기본 조사권을 제공한다', () => {
     expect(createDeckInvestigationDraft()).toMatchObject({
-      tokens: [{ id: 'investigation-token', name: '조사 토큰', defaultAmount: 0 }],
+      tokens: [{ id: 'investigation-token', name: '조사권', defaultAmount: 0 }],
       decks: [],
     });
     expect(readDeckInvestigationConfig(null)).toMatchObject({
-      tokens: [{ id: 'investigation-token', name: '조사 토큰' }],
+      tokens: [{ id: 'investigation-token', name: '조사권' }],
       decks: [],
     });
   });
@@ -169,8 +169,8 @@ describe('deckInvestigationAdapter', () => {
       locations: [location('loc-1', '응접실'), location('loc-2', '서재')],
     });
 
-    expect(vm.deckCountLabel).toBe('조사 덱 1개');
-    expect(vm.tokenCountLabel).toBe('토큰 1종');
+    expect(vm.deckCountLabel).toBe('단서 조사 1개');
+    expect(vm.tokenCountLabel).toBe('조사권 1종');
     expect(vm.decks[0]).toMatchObject({
       title: '응접실 조사',
       tokenLabel: '🪙 동전 1개 소비',

--- a/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
@@ -82,8 +82,8 @@ export interface DeckInvestigationRuntimeDraft {
 
 const DEFAULT_TOKEN: InvestigationTokenDraft = {
   id: 'investigation-token',
-  name: '조사 토큰',
-  iconLabel: '🔎',
+  name: '조사권',
+  iconLabel: '권',
   defaultAmount: 0,
 };
 
@@ -122,8 +122,8 @@ function normalizeToken(value: unknown, index: number): InvestigationTokenDraft 
     : 0;
   return {
     id: rawId || `token-${index + 1}`,
-    name: rawName || '조사 토큰',
-    iconLabel: rawIconLabel || '🔎',
+    name: rawName || '조사권',
+    iconLabel: rawIconLabel || '권',
     defaultAmount,
   };
 }
@@ -152,7 +152,7 @@ function normalizeDeck(value: unknown, index: number, fallbackTokenId: string): 
   const description = typeof value.description === 'string' ? value.description.trim() : '';
   const rawTokenId = typeof value.tokenId === 'string' ? value.tokenId.trim() : '';
   const id = rawId || `deck-${index + 1}`;
-  const title = rawTitle || '새 조사 덱';
+  const title = rawTitle || '새 단서 조사';
   const tokenId = rawTokenId || fallbackTokenId;
   const tokenCost = typeof value.tokenCost === 'number' && Number.isFinite(value.tokenCost)
     ? Math.max(0, Math.floor(value.tokenCost))
@@ -185,7 +185,7 @@ export function createDeckInvestigationDraft(): DeckInvestigationConfigDraft {
 export function createInvestigationDeckDraft(index = 0, tokenId = DEFAULT_TOKEN.id): InvestigationDeckDraft {
   return {
     id: `deck-${index + 1}`,
-    title: '새 조사 덱',
+    title: '새 단서 조사',
     description: '',
     tokenId,
     tokenCost: 1,
@@ -266,8 +266,8 @@ export function toDeckInvestigationViewModel(
     };
   });
   return {
-    deckCountLabel: `조사 덱 ${draft.decks.length}개`,
-    tokenCountLabel: `토큰 ${draft.tokens.length}종`,
+    deckCountLabel: `단서 조사 ${draft.decks.length}개`,
+    tokenCountLabel: `조사권 ${draft.tokens.length}종`,
     warnings,
     decks,
   };
@@ -279,16 +279,16 @@ function buildDeckWarnings(
   clueIds: Set<string>,
 ): string[] {
   const warnings: string[] = [];
-  if (!tokenById.has(deck.tokenId)) warnings.push('소비 토큰을 선택해야 합니다.');
-  if (deck.cards.length === 0) warnings.push('덱에 지급할 단서를 추가해야 합니다.');
+  if (!tokenById.has(deck.tokenId)) warnings.push('소비 조사권을 선택해야 합니다.');
+  if (deck.cards.length === 0) warnings.push('단서 조사에 지급할 단서를 추가해야 합니다.');
   const missingClueCount = deck.cards.filter((card) => !clueIds.has(card.clueId)).length;
   if (clueIds.size > 0 && missingClueCount > 0) warnings.push(`없는 단서 ${missingClueCount}개가 연결되어 있습니다.`);
-  if (deck.tokenCost < 0) warnings.push('소비 토큰 수는 0 이상이어야 합니다.');
+  if (deck.tokenCost < 0) warnings.push('소비 조사권 수는 0 이상이어야 합니다.');
   return warnings;
 }
 
 function formatTokenLabel(deck: InvestigationDeckDraft, token?: InvestigationTokenDraft): string {
-  const tokenName = token ? `${token.iconLabel} ${token.name}` : '토큰 미선택';
+  const tokenName = token ? `${token.iconLabel} ${token.name}` : '조사권 미선택';
   return `${tokenName} ${deck.tokenCost}개 소비`;
 }
 
@@ -296,10 +296,10 @@ function formatPlacementLabel(
   locationIds: string[],
   locationById: Map<string, LocationResponse>,
 ): string {
-  if (locationIds.length === 0) return '모든 배치 위치에서 실행 가능';
+  if (locationIds.length === 0) return '모든 단서 조사 위치에서 실행 가능';
   const names = locationIds.map((id) => locationById.get(id)?.name).filter((name): name is string => !!name);
   const shownCount = names.length;
-  if (shownCount === 0) return `${locationIds.length}개 위치에 배치`;
+  if (shownCount === 0) return `${locationIds.length}개 조사 위치에 배치`;
   if (shownCount <= 2 && shownCount === locationIds.length) return names.join(', ');
   const displayedCount = Math.min(2, shownCount);
   return `${names.slice(0, displayedCount).join(', ')} 외 ${locationIds.length - displayedCount}곳`;

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -73,7 +73,7 @@ describe('locationEntityAdapter', () => {
       imageUrl: 'https://cdn.example/study.webp',
       roundLabel: 'R2~4',
       accessLabel: '탐정 한나 접근 제한',
-      clueCountLabel: '조사 시 발견 단서 3개',
+      clueCountLabel: '단서 조사 3개',
       clueShortLabel: '단서 3개',
       badges: ['저택 1층', 'R2~4', '접근 제한 있음', '단서 3', '이미지 있음'],
     });

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -26,7 +26,7 @@ export function toLocationEditorViewModel(
       location.restricted_characters,
       options.characters ?? []
     ),
-    clueCountLabel: `조사 시 발견 단서 ${clueCount}개`,
+    clueCountLabel: `단서 조사 ${clueCount}개`,
     clueShortLabel: `단서 ${clueCount}개`,
     badges: buildLocationBadges(location, clueCount, options.mapName),
   };


### PR DESCRIPTION
## 요약
- 장소 하위 단서 획득 UI를 제품 용어인 단서 조사로 고정했습니다.
- 기존 deckInvestigation adapter는 내부 저장 key를 유지하되 제작자 표시명을 단서 조사/조사권으로 정리했습니다.
- /editor/{themeId}/locations 직접 URL smoke가 새 단서 조사 라벨을 확인하도록 갱신했습니다.

## 범위
- Refs #290
- Refs #304
- 이번 PR은 #290의 프론트 1차 연결/용어 정렬 범위입니다.
- backend runtime 접근 판정, 조사권 소비, 랜덤/순차 지급 실행은 #304 및 후속 backend 범위로 남깁니다.

## 검증
- pnpm --filter @mmp/web exec vitest run src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 에디터 UI의 한국어 용어와 문구를 일관되게 개선했습니다 — 위치 탭, 단서 조사 패널, 헤더/설명, 토스트 메시지, 조사권/단서 조사 등 표시 텍스트를 갱신했습니다.
* **테스트**
  * UI 및 어댑터 관련 테스트의 기대 문자열을 갱신해 변경된 레이블과 메시지를 반영했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #290