### PR TITLE
chore(pr): #335 steward PR 최신화 기준 명시

### DIFF
--- a/.codex/skills/mmp-pr-lifecycle/SKILL.md
+++ b/.codex/skills/mmp-pr-lifecycle/SKILL.md
@@ -51,7 +51,9 @@ description: Use when creating, reviewing, updating, labeling, checking, or merg
    - A steward may report `MERGE_READY` for `code-rabbit-only` only when latest head SHA was checked, unresolved threads are 0, CodeRabbit is clear, light checks are green, focused local validation for changed scripts/config/docs is recorded, and the handoff scope says `code-rabbit-only`.
    - If main Codex pushes an additional commit to a steward-managed PR, re-handoff the latest head to the steward for CodeRabbit/check waiting instead of running repeated watcher polling in the main thread.
    - After reading the steward's final result, call `close_agent` for that steward before spawning more agents or moving to the next PR.
-   - After any steward-managed PR is merged, main Codex pulls `origin/main` and rebases or merges it into active feature worktrees before continuing implementation.
+   - After any steward-managed PR is merged, main Codex pulls `origin/main`.
+   - Do not automatically rebase or merge `origin/main` into active PR branches that are already under steward review/CI. Update an active branch only when GitHub reports a merge conflict or up-to-date requirement, the merged main change touches the same files/shared contracts or a stacked parent branch, CI/Codecov failure is caused by main drift, or the user explicitly asks for the branch refresh.
+   - If no branch-refresh trigger exists, preserve the active PR head and let the steward finish the current review/CI cycle. Resolve any remaining conflict at the merge decision point.
 
 ## Done
 - PR has Korean title/body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ Do:
 6. 병렬 실행 계획이 필요한 경우 `.codex/agents/mmp-parallel-coordinator.toml` 역할을 먼저 사용해 read-heavy audit, write ownership, 중단 조건, 메인 통합 체크리스트를 만든다.
 7. 기본 병렬화 순서는 `parallel-coordinator → 필요한 reviewer/worker 병렬 실행 → 메인 Codex 취합 → 충돌 없는 구현 → focused 검증`이다.
 8. PR 대기 시간이 다음 이슈 진행을 막을 때는 `.codex/agents/mmp-ci-steward.toml` 역할에 단일 PR의 CodeRabbit/Codecov/CI 보정만 위임할 수 있다. 메인 Codex는 별도 worktree/branch에서 다음 이슈를 진행하고, steward PR merge 후 `origin/main`을 가져온다.
-9. 이미 steward가 맡아 CodeRabbit/CI가 도는 PR branch는 관성적으로 rebase/merge하지 않는다. 최신화는 GitHub가 merge conflict 또는 up-to-date branch를 요구하거나, merge된 main 변경이 같은 파일/공유 계약/stacked parent에 영향을 주거나, CI/Codecov 실패 원인이 main drift일 때만 수행한다. 명확한 트리거가 없으면 기존 head를 유지하고 merge 시점에 충돌 여부를 판단한다.
+9. 이미 steward가 맡아 CodeRabbit/CI가 도는 PR branch는 관성적으로 rebase/merge하지 않는다. 최신화는 GitHub가 merge conflict 또는 up-to-date 요구를 하거나, merge된 main 변경이 같은 파일/공유 계약/stacked parent에 영향을 주거나, CI/Codecov 실패 원인이 main drift이거나, 사용자가 명시적으로 최신화를 요청할 때만 수행한다. 명확한 트리거가 없으면 기존 head를 유지하고 merge 시점에 충돌 여부를 판단한다.
 10. Steward-managed PR에 메인 Codex가 추가 커밋, rebase, merge commit을 push한 경우, 메인 thread가 watcher로 반복 대기하지 말고 최신 head 확인을 steward에게 다시 맡긴다. 메인 Codex는 단발 상태 확인과 최종 merge 판단만 맡는다.
 11. 메인 Codex thread는 `scripts/mmp-pr-watch.sh`를 직접 장시간 실행하지 않는다. `scripts/mmp-pr-status.sh <PR>` 또는 `gh pr view` 같은 단발 조회만 사용하고, 30초 이상 대기가 필요하면 CI steward에 위임한다.
 12. 새 sub-agent spawn이 슬롯 제한으로 막히면 먼저 기존 agent들을 `wait_agent`로 상태 확인하고, `completed` 상태인 agent는 즉시 `close_agent`로 해제한다. 앞으로도 sub-agent 최종 결과를 취합한 직후 `close_agent`까지 실행해야 해당 작업이 완료된 것으로 본다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,11 @@ Do:
 5. MMP 전용 리뷰에는 가능한 경우 `.codex/agents/mmp-frontend-editor-reviewer.toml`, `.codex/agents/mmp-backend-engine-reviewer.toml`, `.codex/agents/mmp-test-coverage-reviewer.toml` 역할을 사용한다.
 6. 병렬 실행 계획이 필요한 경우 `.codex/agents/mmp-parallel-coordinator.toml` 역할을 먼저 사용해 read-heavy audit, write ownership, 중단 조건, 메인 통합 체크리스트를 만든다.
 7. 기본 병렬화 순서는 `parallel-coordinator → 필요한 reviewer/worker 병렬 실행 → 메인 Codex 취합 → 충돌 없는 구현 → focused 검증`이다.
-8. PR 대기 시간이 다음 이슈 진행을 막을 때는 `.codex/agents/mmp-ci-steward.toml` 역할에 단일 PR의 CodeRabbit/Codecov/CI 보정만 위임할 수 있다. 메인 Codex는 별도 worktree/branch에서 다음 이슈를 진행하고, steward PR merge 후 `origin/main`을 가져와 진행 중인 worktree에 반영한다.
-9. Steward-managed PR에 메인 Codex가 추가 커밋을 push한 경우, 메인 thread가 watcher로 반복 대기하지 말고 최신 head 확인을 steward에게 다시 맡긴다. 메인 Codex는 단발 상태 확인과 최종 merge 판단만 맡는다.
-10. 메인 Codex thread는 `scripts/mmp-pr-watch.sh`를 직접 장시간 실행하지 않는다. `scripts/mmp-pr-status.sh <PR>` 또는 `gh pr view` 같은 단발 조회만 사용하고, 30초 이상 대기가 필요하면 CI steward에 위임한다.
-11. 새 sub-agent spawn이 슬롯 제한으로 막히면 먼저 기존 agent들을 `wait_agent`로 상태 확인하고, `completed` 상태인 agent는 즉시 `close_agent`로 해제한다. 앞으로도 sub-agent 최종 결과를 취합한 직후 `close_agent`까지 실행해야 해당 작업이 완료된 것으로 본다.
+8. PR 대기 시간이 다음 이슈 진행을 막을 때는 `.codex/agents/mmp-ci-steward.toml` 역할에 단일 PR의 CodeRabbit/Codecov/CI 보정만 위임할 수 있다. 메인 Codex는 별도 worktree/branch에서 다음 이슈를 진행하고, steward PR merge 후 `origin/main`을 가져온다.
+9. 이미 steward가 맡아 CodeRabbit/CI가 도는 PR branch는 관성적으로 rebase/merge하지 않는다. 최신화는 GitHub가 merge conflict 또는 up-to-date branch를 요구하거나, merge된 main 변경이 같은 파일/공유 계약/stacked parent에 영향을 주거나, CI/Codecov 실패 원인이 main drift일 때만 수행한다. 명확한 트리거가 없으면 기존 head를 유지하고 merge 시점에 충돌 여부를 판단한다.
+10. Steward-managed PR에 메인 Codex가 추가 커밋, rebase, merge commit을 push한 경우, 메인 thread가 watcher로 반복 대기하지 말고 최신 head 확인을 steward에게 다시 맡긴다. 메인 Codex는 단발 상태 확인과 최종 merge 판단만 맡는다.
+11. 메인 Codex thread는 `scripts/mmp-pr-watch.sh`를 직접 장시간 실행하지 않는다. `scripts/mmp-pr-status.sh <PR>` 또는 `gh pr view` 같은 단발 조회만 사용하고, 30초 이상 대기가 필요하면 CI steward에 위임한다.
+12. 새 sub-agent spawn이 슬롯 제한으로 막히면 먼저 기존 agent들을 `wait_agent`로 상태 확인하고, `completed` 상태인 agent는 즉시 `close_agent`로 해제한다. 앞으로도 sub-agent 최종 결과를 취합한 직후 `close_agent`까지 실행해야 해당 작업이 완료된 것으로 본다.
 
 Done when:
 - 위임한 범위, sub-agent 결과 요약, 메인 Codex의 최종 판단이 분리되어 보고된다.

--- a/scripts/mmp-ci-steward-handoff.sh
+++ b/scripts/mmp-ci-steward-handoff.sh
@@ -152,9 +152,10 @@ $ci_instruction
 - Required workflow set: CI, E2E — Stubbed Backend, Security — Fast Feedback.
 - gitleaks, File Size Guard, ci-hooks, module-isolation, build-runner-image 등은 이 steward의 full-CI 완료 판정용 required set이 아닙니다. PR checks에 보이면 참고하되, 위 required set 누락 여부를 기준으로 행동하세요.
 - 이전 보고 이후 메인 Codex가 추가 커밋을 push했다면 최신 Head SHA 기준으로 CodeRabbit/check 상태를 다시 확인합니다.
+- base/main 최신화, rebase, merge commit, force-push는 steward의 기본 책임이 아닙니다. 메인 Codex가 명시적으로 최신 head를 다시 위임한 경우에만 그 head를 기준으로 대기/검증합니다.
 
 ## Steward 금지 범위
-- PR merge, PR 생성, Issue 생성, force-push, destructive git, secret 조회, unrelated branch/worktree 수정은 금지입니다.
+- PR merge, PR 생성, Issue 생성, force-push, destructive git, secret 조회, unrelated branch/worktree 수정, 임의 branch 최신화는 금지입니다.
 - 테스트 스킵, coverage 약화, 유효한 리뷰 무시도 금지입니다.
 
 ## 메인 Codex 복귀 조건


### PR DESCRIPTION
## 요약
- steward가 맡은 PR branch를 관성적으로 rebase/merge하지 않는 기준을 AGENTS와 PR lifecycle skill에 명시합니다.
- branch 최신화 트리거를 merge conflict, up-to-date 요구, 공유 계약/stacked parent 영향, main drift 기반 CI 실패, 사용자 명시 요청으로 제한합니다.
- steward handoff prompt에 base/main 최신화와 임의 branch 최신화가 steward 기본 책임이 아님을 추가합니다.

## 검증
- bash -n scripts/mmp-ci-steward-handoff.sh
- shellcheck scripts/mmp-ci-steward-handoff.sh
- git diff --check

Refs #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 스튜어드 관리 PR 병합 후 불필요한 자동 리베이스/병합 방지 및 활성 브랜치의 헤드 보존 규칙 명확화
  * GitHub 충돌/업투데이트 요구, 메인 변경의 공유계약 영향, CI/Codecov 실패, 또는 사용자가 요청한 경우에만 동기화 수행
  * 메인 푸시 시 워처 대기 대신 스튜어드가 최신화 확인을 담당하도록 변경
  * 장시간 watch 금지 및 에이전트 대기/해제( wait_agent/close_agent ) 절차 명확화
  * 스튜어드 금지 항목 확대(비밀 조회, 임의 브랜치 최신화, 테스트 건너뛰기, 커버리지 약화, 무시된 리뷰)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->