### PR TITLE
feat(editor): #303 토론방 정책 연결

### DIFF
--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -210,6 +210,9 @@ func ensureImplicitPhaseActionModules(cfg *GameConfig) error {
 			cfg.Modules = append(cfg.Modules, ModuleConfig{Name: moduleName})
 		}
 	}
+	if phasesUseDiscussionRoomPolicy(cfg.Phases) && !hasModuleConfig(cfg.Modules, "group_chat") {
+		cfg.Modules = append(cfg.Modules, ModuleConfig{Name: "group_chat"})
+	}
 	return nil
 }
 
@@ -228,6 +231,15 @@ func phasesUseAction(phases []PhaseDefinition, action PhaseAction) (bool, error)
 		}
 	}
 	return false, nil
+}
+
+func phasesUseDiscussionRoomPolicy(phases []PhaseDefinition) bool {
+	for _, phase := range phases {
+		if phase.DiscussionRoomPolicy != nil && phase.DiscussionRoomPolicy.Enabled {
+			return true
+		}
+	}
+	return false
 }
 
 func rawUsesAction(raw json.RawMessage, action PhaseAction) (bool, error) {

--- a/apps/server/internal/engine/factory_test.go
+++ b/apps/server/internal/engine/factory_test.go
@@ -237,6 +237,20 @@ func TestParseGameConfig_DoesNotDuplicateImplicitEndingBranchModule(t *testing.T
 	}
 }
 
+func TestParseGameConfig_AddsGroupChatModuleForDiscussionRoomPolicy(t *testing.T) {
+	data := []byte(`{"phases":[{"id":"discussion","name":"Discussion","discussionRoomPolicy":{"enabled":true,"mainRoomName":"추리 회의"}}],"modules":[]}`)
+	cfg, err := ParseGameConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Modules) != 1 || cfg.Modules[0].Name != "group_chat" {
+		t.Fatalf("implicit modules = %#v", cfg.Modules)
+	}
+	if cfg.Phases[0].DiscussionRoomPolicy == nil || cfg.Phases[0].DiscussionRoomPolicy.MainRoomName != "추리 회의" {
+		t.Fatalf("discussion room policy = %#v", cfg.Phases[0].DiscussionRoomPolicy)
+	}
+}
+
 func TestParseGameConfig_InvalidPhaseActionConfigFailsEarly(t *testing.T) {
 	data := []byte(`{"phases":[{"id":"p1","name":"Phase 1","onEnter":"not-actions"}],"modules":[]}`)
 	_, err := ParseGameConfig(data)

--- a/apps/server/internal/engine/module_types.go
+++ b/apps/server/internal/engine/module_types.go
@@ -44,6 +44,20 @@ type PhaseDefinition struct {
 	OnEnter json.RawMessage `json:"onEnter,omitempty"`
 	// OnExit is an optional configured action payload dispatched by the engine.
 	OnExit json.RawMessage `json:"onExit,omitempty"`
+	// DiscussionRoomPolicy is the creator-authored room policy for this scene.
+	// PhaseEngine dispatches it to the group_chat runtime on phase enter so the
+	// backend remains the final source of truth for room access.
+	DiscussionRoomPolicy *DiscussionRoomPolicy `json:"discussionRoomPolicy,omitempty"`
+}
+
+type DiscussionRoomPolicy struct {
+	Enabled             bool            `json:"enabled"`
+	MainRoomName        string          `json:"mainRoomName,omitempty"`
+	PrivateRoomsEnabled bool            `json:"privateRoomsEnabled,omitempty"`
+	PrivateRoomName     string          `json:"privateRoomName,omitempty"`
+	Availability        string          `json:"availability,omitempty"`
+	ConditionalRoomName string          `json:"conditionalRoomName,omitempty"`
+	Condition           json.RawMessage `json:"condition,omitempty"`
 }
 
 // SceneTransition is the backend runtime contract for graph-based story

--- a/apps/server/internal/engine/phase_actions.go
+++ b/apps/server/internal/engine/phase_actions.go
@@ -16,11 +16,33 @@ func (e *PhaseEngine) enterCurrentPhase(ctx context.Context) error {
 	if err := e.dispatchConfiguredActions(ctx, phase.OnEnter); err != nil {
 		return err
 	}
+	if err := e.dispatchDiscussionRoomPolicy(ctx, phase.DiscussionRoomPolicy); err != nil {
+		return err
+	}
 	e.eventBus.Publish(Event{
 		Type:    "phase:entered",
 		Payload: e.CurrentPhase(),
 	})
 	return nil
+}
+
+func (e *PhaseEngine) dispatchDiscussionRoomPolicy(ctx context.Context, policy *DiscussionRoomPolicy) error {
+	if policy == nil {
+		return nil
+	}
+	if !policy.Enabled {
+		if _, ok := e.moduleMap["group_chat"]; !ok {
+			return nil
+		}
+	}
+	params, err := json.Marshal(policy)
+	if err != nil {
+		return fmt.Errorf("engine: invalid discussion room policy: %w", err)
+	}
+	return e.DispatchAction(ctx, PhaseActionPayload{
+		Action: ActionApplyDiscussionRoom,
+		Params: params,
+	})
 }
 
 func (e *PhaseEngine) exitCurrentPhase(ctx context.Context) error {

--- a/apps/server/internal/engine/phase_engine_hooks_test.go
+++ b/apps/server/internal/engine/phase_engine_hooks_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -10,6 +11,15 @@ type hookRecordingModule struct {
 	stubCoreModule
 	entered []Phase
 	exited  []Phase
+}
+
+type failingReactorModule struct {
+	stubFullModule
+}
+
+func (f *failingReactorModule) ReactTo(_ context.Context, action PhaseActionPayload) error {
+	f.received = append(f.received, action)
+	return fmt.Errorf("forced reactor failure")
 }
 
 func (h *hookRecordingModule) OnPhaseEnter(_ context.Context, phase Phase) error {
@@ -104,6 +114,84 @@ func TestPhaseEngine_NormalizesLegacyPhaseActionTypes(t *testing.T) {
 	}
 	if len(textChat.received) != 1 || textChat.received[0].Action != ActionMuteChat {
 		t.Fatalf("OnExit legacy action = %#v", textChat.received)
+	}
+}
+
+func TestPhaseEngine_DispatchesDiscussionRoomPolicyAfterOnEnterActions(t *testing.T) {
+	groupChat := &stubFullModule{
+		stubCoreModule: stubCoreModule{name: "group_chat"},
+		actions:        []PhaseAction{ActionApplyDiscussionRoom},
+	}
+	textChat := &stubFullModule{
+		stubCoreModule: stubCoreModule{name: "text_chat"},
+		actions:        []PhaseAction{ActionUnmuteChat},
+	}
+	phases := []PhaseDefinition{
+		{
+			ID:   "discussion",
+			Name: "Discussion",
+			DiscussionRoomPolicy: &DiscussionRoomPolicy{
+				Enabled:             true,
+				MainRoomName:        "추리 회의",
+				PrivateRoomsEnabled: true,
+				PrivateRoomName:     "밀담방",
+				Availability:        "phase_active",
+			},
+			OnEnter: json.RawMessage(`[{"type":"enable_chat"}]`),
+		},
+	}
+	pe, _ := newTestPhaseEngine(t, []Module{groupChat, textChat}, phases)
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	if len(groupChat.received) != 1 || groupChat.received[0].Action != ActionApplyDiscussionRoom {
+		t.Fatalf("discussion policy action = %#v", groupChat.received)
+	}
+	var params DiscussionRoomPolicy
+	if err := json.Unmarshal(groupChat.received[0].Params, &params); err != nil {
+		t.Fatalf("unmarshal discussion policy params: %v", err)
+	}
+	if !params.Enabled || params.MainRoomName != "추리 회의" || params.PrivateRoomName != "밀담방" {
+		t.Fatalf("policy params = %#v", params)
+	}
+	if len(textChat.received) != 1 || textChat.received[0].Action != ActionUnmuteChat {
+		t.Fatalf("onEnter action = %#v", textChat.received)
+	}
+}
+
+func TestPhaseEngine_SkipsDiscussionRoomPolicyWhenOnEnterFails(t *testing.T) {
+	groupChat := &stubFullModule{
+		stubCoreModule: stubCoreModule{name: "group_chat"},
+		actions:        []PhaseAction{ActionApplyDiscussionRoom},
+	}
+	failing := &failingReactorModule{
+		stubFullModule: stubFullModule{
+			stubCoreModule: stubCoreModule{name: "text_chat"},
+			actions:        []PhaseAction{ActionUnmuteChat},
+		},
+	}
+	phases := []PhaseDefinition{
+		{
+			ID:   "discussion",
+			Name: "Discussion",
+			DiscussionRoomPolicy: &DiscussionRoomPolicy{
+				Enabled:      true,
+				MainRoomName: "추리 회의",
+				Availability: "phase_active",
+			},
+			OnEnter: json.RawMessage(`[{"type":"enable_chat"}]`),
+		},
+	}
+	pe, _ := newTestPhaseEngine(t, []Module{groupChat, failing}, phases)
+	err := pe.Start(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected OnEnter failure")
+	}
+	if len(groupChat.received) != 0 {
+		t.Fatalf("discussion policy should not apply after OnEnter failure: %#v", groupChat.received)
 	}
 }
 

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -29,6 +29,7 @@ const (
 	ActionUnmuteChat          PhaseAction = "UNMUTE_CHAT"
 	ActionOpenGroupChat       PhaseAction = "OPEN_GROUP_CHAT"
 	ActionCloseGroupChat      PhaseAction = "CLOSE_GROUP_CHAT"
+	ActionApplyDiscussionRoom PhaseAction = "APPLY_DISCUSSION_ROOM_POLICY"
 	ActionLockModule          PhaseAction = "LOCK_MODULE"
 	ActionUnlockModule        PhaseAction = "UNLOCK_MODULE"
 )
@@ -64,6 +65,7 @@ var ActionRequiresModule = map[PhaseAction]string{
 	ActionUnmuteChat:          "text_chat",
 	ActionOpenGroupChat:       "group_chat",
 	ActionCloseGroupChat:      "group_chat",
+	ActionApplyDiscussionRoom: "group_chat",
 	ActionDeliverInformation:  "information_delivery",
 	ActionEvaluateEnding:      "ending_branch",
 }

--- a/apps/server/internal/module/communication/group_chat.go
+++ b/apps/server/internal/module/communication/group_chat.go
@@ -43,12 +43,13 @@ type GroupRoom struct {
 }
 
 type discussionRoomPolicy struct {
-	Enabled             bool   `json:"enabled"`
-	MainRoomName        string `json:"mainRoomName"`
-	PrivateRoomsEnabled bool   `json:"privateRoomsEnabled"`
-	PrivateRoomName     string `json:"privateRoomName"`
-	Availability        string `json:"availability"`
-	ConditionalRoomName string `json:"conditionalRoomName"`
+	Enabled             bool            `json:"enabled"`
+	MainRoomName        string          `json:"mainRoomName"`
+	PrivateRoomsEnabled bool            `json:"privateRoomsEnabled"`
+	PrivateRoomName     string          `json:"privateRoomName"`
+	Availability        string          `json:"availability"`
+	ConditionalRoomName string          `json:"conditionalRoomName"`
+	Condition           json.RawMessage `json:"condition,omitempty"`
 }
 
 // RoomState holds runtime state for a single group chat room.

--- a/apps/server/internal/module/communication/group_chat.go
+++ b/apps/server/internal/module/communication/group_chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -39,6 +40,15 @@ type GroupRoom struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
 	MaxMembers int    `json:"maxMembers"`
+}
+
+type discussionRoomPolicy struct {
+	Enabled             bool   `json:"enabled"`
+	MainRoomName        string `json:"mainRoomName"`
+	PrivateRoomsEnabled bool   `json:"privateRoomsEnabled"`
+	PrivateRoomName     string `json:"privateRoomName"`
+	Availability        string `json:"availability"`
+	ConditionalRoomName string `json:"conditionalRoomName"`
 }
 
 // RoomState holds runtime state for a single group chat room.
@@ -279,11 +289,73 @@ func (m *GroupChatModule) ReactTo(_ context.Context, action engine.PhaseActionPa
 	case engine.ActionUnmuteChat:
 		m.isMuted = false
 		m.mu.Unlock()
+	case engine.ActionApplyDiscussionRoom:
+		var policy discussionRoomPolicy
+		if len(action.Params) > 0 {
+			if err := json.Unmarshal(action.Params, &policy); err != nil {
+				m.mu.Unlock()
+				return fmt.Errorf("group_chat: invalid discussion room policy: %w", err)
+			}
+		}
+		m.applyDiscussionRoomPolicy(policy)
+		m.mu.Unlock()
+		m.deps.EventBus.Publish(engine.Event{
+			Type: "groupchat.policy_applied",
+			Payload: map[string]any{
+				"enabled": policy.Enabled,
+				"isOpen":  policy.Enabled && policy.Availability != "condition",
+			},
+		})
 	default:
 		m.mu.Unlock()
 		return fmt.Errorf("group_chat: unsupported action %q", action.Action)
 	}
 	return nil
+}
+
+func (m *GroupChatModule) applyDiscussionRoomPolicy(policy discussionRoomPolicy) {
+	m.playerRoom = make(map[uuid.UUID]string)
+	m.rooms = make(map[string]*RoomState)
+	m.config.Rooms = nil
+	m.isOpen = false
+
+	if !policy.Enabled {
+		return
+	}
+
+	rooms := []GroupRoom{{
+		ID:   "main",
+		Name: discussionRoomName(policy.MainRoomName, "전체 토론"),
+	}}
+	if policy.PrivateRoomsEnabled {
+		rooms = append(rooms, GroupRoom{
+			ID:   "private",
+			Name: discussionRoomName(policy.PrivateRoomName, "밀담방"),
+		})
+	}
+	if policy.Availability == "condition" && strings.TrimSpace(policy.ConditionalRoomName) != "" {
+		rooms = append(rooms, GroupRoom{
+			ID:   "conditional",
+			Name: strings.TrimSpace(policy.ConditionalRoomName),
+		})
+	}
+
+	m.config.Rooms = rooms
+	for _, room := range rooms {
+		m.rooms[room.ID] = &RoomState{
+			Members:  make([]uuid.UUID, 0),
+			Messages: make([]ChatMessage, 0),
+		}
+	}
+	m.isOpen = policy.Availability != "condition"
+}
+
+func discussionRoomName(value string, fallback string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
 }
 
 // SupportedActions returns the phase actions this module handles.
@@ -293,6 +365,7 @@ func (m *GroupChatModule) SupportedActions() []engine.PhaseAction {
 		engine.ActionCloseGroupChat,
 		engine.ActionMuteChat,
 		engine.ActionUnmuteChat,
+		engine.ActionApplyDiscussionRoom,
 	}
 }
 

--- a/apps/server/internal/module/communication/group_chat_test.go
+++ b/apps/server/internal/module/communication/group_chat_test.go
@@ -273,8 +273,138 @@ func TestGroupChatModule_BuildState(t *testing.T) {
 func TestGroupChatModule_SupportedActions(t *testing.T) {
 	m := NewGroupChatModule()
 	actions := m.SupportedActions()
-	if len(actions) != 4 {
-		t.Fatalf("expected 4 supported actions, got %d", len(actions))
+	if len(actions) != 5 {
+		t.Fatalf("expected 5 supported actions, got %d", len(actions))
+	}
+}
+
+func TestGroupChatModule_ApplyDiscussionRoomPolicyOpensPhaseRooms(t *testing.T) {
+	m, deps := initGroupChat(t)
+	var applied bool
+	deps.EventBus.Subscribe("groupchat.policy_applied", func(_ engine.Event) {
+		applied = true
+	})
+
+	payload := json.RawMessage(`{
+		"enabled": true,
+		"mainRoomName": "추리 회의",
+		"privateRoomsEnabled": true,
+		"privateRoomName": "2인 밀담",
+		"availability": "phase_active"
+	}`)
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionApplyDiscussionRoom,
+		Params: payload,
+	}); err != nil {
+		t.Fatalf("apply policy: %v", err)
+	}
+
+	if !applied {
+		t.Fatal("expected groupchat.policy_applied event")
+	}
+
+	state, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	var s groupChatState
+	if err := json.Unmarshal(state, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !s.IsOpen {
+		t.Fatal("expected room policy to open phase-active discussion rooms")
+	}
+	if len(s.Rooms) != 2 {
+		t.Fatalf("rooms = %d, want 2: %+v", len(s.Rooms), s.Rooms)
+	}
+	if s.Rooms[0].ID != "main" || s.Rooms[0].Name != "추리 회의" {
+		t.Fatalf("main room not normalized: %+v", s.Rooms[0])
+	}
+	if s.Rooms[1].ID != "private" || s.Rooms[1].Name != "2인 밀담" {
+		t.Fatalf("private room not normalized: %+v", s.Rooms[1])
+	}
+}
+
+func TestGroupChatModule_ApplyDiscussionRoomPolicyConditionKeepsRoomsClosed(t *testing.T) {
+	m, _ := initGroupChat(t)
+
+	payload := json.RawMessage(`{
+		"enabled": true,
+		"mainRoomName": "전체 토론",
+		"availability": "condition",
+		"conditionalRoomName": "비밀 토론"
+	}`)
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionApplyDiscussionRoom,
+		Params: payload,
+	}); err != nil {
+		t.Fatalf("apply policy: %v", err)
+	}
+
+	state, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	var s groupChatState
+	if err := json.Unmarshal(state, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.IsOpen {
+		t.Fatal("condition-gated discussion rooms must remain closed until runtime trigger opens them")
+	}
+	if len(s.Rooms) != 2 {
+		t.Fatalf("rooms = %d, want main + conditional: %+v", len(s.Rooms), s.Rooms)
+	}
+	if s.Rooms[1].ID != "conditional" || s.Rooms[1].Name != "비밀 토론" {
+		t.Fatalf("conditional room not exposed as metadata: %+v", s.Rooms[1])
+	}
+
+	err = m.HandleMessage(context.Background(), uuid.New(), "groupchat:join", json.RawMessage(`{"roomId":"main"}`))
+	if err == nil {
+		t.Fatal("expected backend to reject room join while condition-gated room is closed")
+	}
+}
+
+func TestGroupChatModule_BuildStateFor_PolicyGeneratedPrivateRoomRedactsMessages(t *testing.T) {
+	m, _ := initGroupChat(t)
+	payload := json.RawMessage(`{
+		"enabled": true,
+		"mainRoomName": "추리 회의",
+		"privateRoomsEnabled": true,
+		"privateRoomName": "밀담",
+		"availability": "phase_active"
+	}`)
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionApplyDiscussionRoom,
+		Params: payload,
+	}); err != nil {
+		t.Fatalf("apply policy: %v", err)
+	}
+
+	alice := uuid.New()
+	bob := uuid.New()
+	if err := m.HandleMessage(context.Background(), alice, "groupchat:join",
+		json.RawMessage(`{"roomId":"private"}`)); err != nil {
+		t.Fatalf("alice join private: %v", err)
+	}
+	if err := m.HandleMessage(context.Background(), bob, "groupchat:join",
+		json.RawMessage(`{"roomId":"main"}`)); err != nil {
+		t.Fatalf("bob join main: %v", err)
+	}
+	if err := m.HandleMessage(context.Background(), alice, "groupchat:send",
+		json.RawMessage(`{"roomId":"private","message":"밀담 내용","characterCode":"A"}`)); err != nil {
+		t.Fatalf("alice send private: %v", err)
+	}
+
+	bobData, err := m.BuildStateFor(bob)
+	if err != nil {
+		t.Fatalf("BuildStateFor bob: %v", err)
+	}
+	if bytes.Contains(bobData, []byte("밀담 내용")) {
+		t.Fatalf("policy-generated private room leaked message: %s", bobData)
+	}
+	if bytes.Contains(bobData, []byte(alice.String())) {
+		t.Fatalf("policy-generated private room leaked member uuid: %s", bobData)
 	}
 }
 

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -20,6 +20,7 @@
  *  8. 장소 탭 locations[].clueIds (PR-6)
  *  9. 템플릿 탭 GET /api/v1/templates (PR-1)
  */
+import AxeBuilder from "@axe-core/playwright";
 import { test, expect, type Page, type Request } from "@playwright/test";
 import {
   BASE,
@@ -376,7 +377,7 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
     await tryClickTab(page, /흐름|flow/i);
 
-    const node = page.locator('[data-id="phase-1"], .react-flow__node').first();
+    const node = page.locator('[data-id="phase-1"]').first();
     await expect(node).toBeVisible({ timeout: 10_000 });
     await node.click();
 
@@ -386,6 +387,13 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await page.getByLabel("메인 토론방").fill("추리 회의");
     await page.getByLabel("이용 가능 시점").selectOption("condition");
     await page.getByLabel("조건부 방명").fill("비밀 토론");
+
+    const a11y = await new AxeBuilder({ page })
+      .include('[data-testid="discussion-room-policy-panel"]')
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(a11y.violations).toEqual([]);
 
     await expect.poll(() => state.flowPatchCalls).toBeGreaterThanOrEqual(1);
     const patch = state.lastFlowNodePatchBody as

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -391,7 +391,6 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     const a11y = await new AxeBuilder({ page })
       .include('[data-testid="discussion-room-policy-panel"]')
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-      .disableRules(["color-contrast"])
       .analyze();
     expect(a11y.violations).toEqual([]);
 

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -372,6 +372,34 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     expect(putSeen).toEqual([]);
   });
 
+  test("[7A] 흐름 장면 토론방 정책은 flow node PATCH 로 저장된다", async ({ page }) => {
+    await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
+    await tryClickTab(page, /흐름|flow/i);
+
+    const node = page.locator('[data-id="phase-1"], .react-flow__node').first();
+    await expect(node).toBeVisible({ timeout: 10_000 });
+    await node.click();
+
+    const discussionToggle = page.getByRole("checkbox", { name: /토론방/ });
+    await expect(discussionToggle).toBeVisible({ timeout: 5_000 });
+    await discussionToggle.check();
+    await page.getByLabel("메인 토론방").fill("추리 회의");
+    await page.getByLabel("이용 가능 시점").selectOption("condition");
+    await page.getByLabel("조건부 방명").fill("비밀 토론");
+
+    await expect.poll(() => state.flowPatchCalls).toBeGreaterThanOrEqual(1);
+    const patch = state.lastFlowNodePatchBody as
+      | { data?: { discussionRoomPolicy?: Record<string, unknown> } }
+      | null;
+    expect(patch?.data?.discussionRoomPolicy).toMatchObject({
+      enabled: true,
+      mainRoomName: "추리 회의",
+      availability: "condition",
+      conditionalRoomName: "비밀 토론",
+    });
+    expect(state.flowPutCalls).toBe(0);
+  });
+
   test("[8] 장소 탭 — locations[].clueIds 구조 UI 로드 (network-only)", async ({ page }) => {
     test.info().annotations.push({ type: "soft-skip", description: "tryClickTab + chip soft" });
     const locReq = page

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -17,7 +17,7 @@ export const CLUE_ID = "cccccccc-0000-0000-0000-000000000001";
 export const REWARD_CLUE_ID = "cccccccc-0000-0000-0000-000000000002";
 export const MAP_ID = "bbbbbbbb-0000-0000-0000-000000000001";
 export const LOCATION_ID = "dddddddd-0000-0000-0000-000000000001";
-export const FLOW_NODE_ID = "eeeeeeee-0000-0000-0000-000000000001";
+export const FLOW_NODE_ID = "phase-1";
 
 export interface RecordedRequest {
   url: string;
@@ -35,6 +35,7 @@ export interface MockState {
   conflictCountdown: number;
   flowPatchCalls: number;
   flowPutCalls: number;
+  lastFlowNodePatchBody: Record<string, unknown> | null;
   characterUpdateCalls: number;
   lastCharacterUpdateBody: Record<string, unknown> | null;
   characterMysteryRole: "suspect" | "culprit" | "accomplice" | "detective";
@@ -58,6 +59,7 @@ export function freshState(): MockState {
     conflictCountdown: 1,
     flowPatchCalls: 0,
     flowPutCalls: 0,
+    lastFlowNodePatchBody: null,
     characterUpdateCalls: 0,
     lastCharacterUpdateBody: null,
     characterMysteryRole: "detective",
@@ -420,11 +422,22 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
   await page.route(`**/v1/editor/themes/${THEME_ID}/flow/nodes/${FLOW_NODE_ID}`, async (r) => {
     const method = r.request().method();
     if (method === "PATCH") {
+      const body = JSON.parse(r.request().postData() ?? "{}") as Record<string, unknown>;
       state.flowPatchCalls += 1;
+      state.lastFlowNodePatchBody = body;
       return r.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ id: FLOW_NODE_ID, updated: true }),
+        body: JSON.stringify({
+          id: FLOW_NODE_ID,
+          theme_id: THEME_ID,
+          type: "phase",
+          data: body.data ?? {},
+          position_x: 120,
+          position_y: 120,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
       });
     }
     if (method === "PUT") {

--- a/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
@@ -1,0 +1,121 @@
+import type { DiscussionRoomAvailability, DiscussionRoomPolicy } from "../../flowTypes";
+import {
+  normalizeDiscussionRoomPolicy,
+  patchDiscussionRoomPolicy,
+} from "../../entities/phase/discussionRoomPolicyAdapter";
+
+interface DiscussionRoomPolicyPanelProps {
+  policy: DiscussionRoomPolicy | undefined;
+  onChange: (policy: DiscussionRoomPolicy) => void;
+}
+
+export function DiscussionRoomPolicyPanel({ policy, onChange }: DiscussionRoomPolicyPanelProps) {
+  const normalized = normalizeDiscussionRoomPolicy(policy);
+
+  const update = (patch: Partial<DiscussionRoomPolicy>) => {
+    onChange(patchDiscussionRoomPolicy(normalized, patch));
+  };
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+      <div className="flex flex-col gap-3">
+        <label className="flex items-start gap-3">
+          <input
+            type="checkbox"
+            className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-950 text-amber-400"
+            checked={normalized.enabled}
+            onChange={(event) => update({ enabled: event.target.checked })}
+          />
+          <span>
+            <span className="block text-sm font-semibold text-slate-100">토론방</span>
+            <span className="block text-xs leading-5 text-slate-500">
+              이 장면에서 플레이어가 모여 대화할 공간을 정합니다.
+            </span>
+          </span>
+        </label>
+
+        {normalized.enabled && (
+          <div className="grid gap-3">
+            <LabeledTextInput
+              label="메인 토론방"
+              value={normalized.mainRoomName}
+              placeholder="전체 토론"
+              onChange={(mainRoomName) => update({ mainRoomName })}
+            />
+
+            <label className="flex items-start gap-3 rounded border border-slate-800 bg-slate-900/40 px-3 py-2">
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-950 text-amber-400"
+                checked={normalized.privateRoomsEnabled}
+                onChange={(event) => update({ privateRoomsEnabled: event.target.checked })}
+              />
+              <span>
+                <span className="block text-xs font-semibold text-slate-200">밀담방 허용</span>
+                <span className="block text-xs leading-5 text-slate-500">
+                  소수 인원이 따로 이야기할 수 있는 방을 함께 엽니다.
+                </span>
+              </span>
+            </label>
+
+            {normalized.privateRoomsEnabled && (
+              <LabeledTextInput
+                label="밀담방 이름"
+                value={normalized.privateRoomName}
+                placeholder="밀담방"
+                onChange={(privateRoomName) => update({ privateRoomName })}
+              />
+            )}
+
+            <label className="grid gap-1 text-xs text-slate-400">
+              <span className="font-medium text-slate-300">이용 가능 시점</span>
+              <select
+                className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                value={normalized.availability}
+                onChange={(event) =>
+                  update({ availability: event.target.value as DiscussionRoomAvailability })
+                }
+              >
+                <option value="phase_active">장면 시작 시 바로 열기</option>
+                <option value="condition">트리거가 열 때까지 대기</option>
+              </select>
+            </label>
+
+            {normalized.availability === "condition" && (
+              <LabeledTextInput
+                label="조건부 방명"
+                value={normalized.conditionalRoomName ?? ""}
+                placeholder="비밀 토론"
+                onChange={(conditionalRoomName) => update({ conditionalRoomName })}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function LabeledTextInput({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="grid gap-1 text-xs text-slate-400">
+      <span className="font-medium text-slate-300">{label}</span>
+      <input
+        className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </label>
+  );
+}

--- a/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
@@ -17,7 +17,10 @@ export function DiscussionRoomPolicyPanel({ policy, onChange }: DiscussionRoomPo
   };
 
   return (
-    <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+    <section
+      data-testid="discussion-room-policy-panel"
+      className="rounded-lg border border-slate-800 bg-slate-950/60 p-3"
+    >
       <div className="flex flex-col gap-3">
         <label className="flex items-start gap-3">
           <input

--- a/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
@@ -31,7 +31,7 @@ export function DiscussionRoomPolicyPanel({ policy, onChange }: DiscussionRoomPo
           />
           <span>
             <span className="block text-sm font-semibold text-slate-100">토론방</span>
-            <span className="block text-xs leading-5 text-slate-500">
+            <span className="block text-xs leading-5 text-slate-400">
               이 장면에서 플레이어가 모여 대화할 공간을 정합니다.
             </span>
           </span>
@@ -55,7 +55,7 @@ export function DiscussionRoomPolicyPanel({ policy, onChange }: DiscussionRoomPo
               />
               <span>
                 <span className="block text-xs font-semibold text-slate-200">밀담방 허용</span>
-                <span className="block text-xs leading-5 text-slate-500">
+                <span className="block text-xs leading-5 text-slate-400">
                   소수 인원이 따로 이야기할 수 있는 방을 함께 엽니다.
                 </span>
               </span>

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -19,6 +19,8 @@ import {
 import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
 import { PhasePanelTimerSettings } from "./PhasePanelTimerSettings";
 import { PhasePanelAdvanceToggle } from "./PhasePanelAdvanceToggle";
+import { DiscussionRoomPolicyPanel } from "./DiscussionRoomPolicyPanel";
+import { formatDiscussionRoomSummary } from "../../entities/phase/discussionRoomPolicyAdapter";
 
 interface PhaseNodePanelProps {
   node: Node;
@@ -105,6 +107,13 @@ export function PhaseNodePanel({ node, themeId, onUpdate, edges = [] }: PhaseNod
 
       <div className="border-t border-slate-800" />
 
+      <DiscussionRoomPolicyPanel
+        policy={data.discussionRoomPolicy}
+        onChange={(discussionRoomPolicy) => handleChange({ discussionRoomPolicy })}
+      />
+
+      <div className="border-t border-slate-800" />
+
       <ActionListEditor
         label="장면 시작 트리거"
         actions={(data.onEnter as PhaseAction[]) ?? []}
@@ -148,6 +157,7 @@ function PhaseSummaryCard({ viewModel }: { viewModel: PhaseEditorViewModel }) {
           value={`${viewModel.defaultTransitionLabel} · 조건 이동 ${viewModel.conditionalTransitionCount}개`}
         />
         <SummaryRow label="정보 전달" value={`${viewModel.informationDeliveryCount}개 설정`} />
+        <SummaryRow label="토론방" value={formatDiscussionRoomSummary(viewModel.discussionRoomPolicy)} />
         <SummaryRow label="시작 트리거" value={enterActions} />
         <SummaryRow label="종료 트리거" value={exitActions} />
       </dl>

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -101,4 +101,72 @@ describe("PhaseNodePanel extended fields", () => {
     expect(screen.getByText("장면 종료 트리거")).toBeDefined();
     expect(screen.getAllByText("트리거 실행 결과 없음")).toHaveLength(2);
   });
+
+  it("토론방 정책을 장면 데이터로 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({
+          discussionRoomPolicy: {
+            enabled: true,
+            mainRoomName: "전체 토론",
+            privateRoomsEnabled: false,
+            privateRoomName: "밀담방",
+            availability: "phase_active",
+          },
+        })}
+        themeId="t1"
+        onUpdate={onUpdate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("메인 토론방"), {
+      target: { value: "추리 회의" },
+    });
+
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: {
+        enabled: true,
+        mainRoomName: "추리 회의",
+        privateRoomsEnabled: false,
+        privateRoomName: "밀담방",
+        availability: "phase_active",
+        conditionalRoomName: "",
+      },
+    });
+  });
+
+  it("조건부 토론방 이름을 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({
+          discussionRoomPolicy: {
+            enabled: true,
+            mainRoomName: "전체 토론",
+            privateRoomsEnabled: false,
+            privateRoomName: "밀담방",
+            availability: "condition",
+          },
+        })}
+        themeId="t1"
+        onUpdate={onUpdate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("조건부 방명"), {
+      target: { value: "비밀 토론" },
+    });
+
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: {
+        enabled: true,
+        mainRoomName: "전체 토론",
+        privateRoomsEnabled: false,
+        privateRoomName: "밀담방",
+        availability: "condition",
+        conditionalRoomName: "비밀 토론",
+      },
+    });
+  });
 });

--- a/apps/web/src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDiscussionRoomSummary,
+  normalizeDiscussionRoomPolicy,
+  patchDiscussionRoomPolicy,
+} from "../discussionRoomPolicyAdapter";
+
+describe("discussionRoomPolicyAdapter", () => {
+  it("빈 정책을 제작자 기본값으로 정규화한다", () => {
+    expect(normalizeDiscussionRoomPolicy(undefined)).toEqual({
+      enabled: false,
+      mainRoomName: "전체 토론",
+      privateRoomsEnabled: false,
+      privateRoomName: "밀담방",
+      availability: "phase_active",
+      conditionalRoomName: "",
+    });
+  });
+
+  it("조건부 토론방 이름과 밀담 설정을 저장 가능한 정책으로 병합한다", () => {
+    expect(
+      patchDiscussionRoomPolicy(
+        { enabled: true, mainRoomName: " 전체 토론 " },
+        {
+          privateRoomsEnabled: true,
+          privateRoomName: " 비밀 회의 ",
+          availability: "condition",
+          conditionalRoomName: " 단서 공개 후 ",
+        },
+      ),
+    ).toEqual({
+      enabled: true,
+      mainRoomName: "전체 토론",
+      privateRoomsEnabled: true,
+      privateRoomName: "비밀 회의",
+      availability: "condition",
+      conditionalRoomName: "단서 공개 후",
+    });
+  });
+
+  it("제작자 요약 문구를 만든다", () => {
+    expect(formatDiscussionRoomSummary(undefined)).toBe("토론방 사용 안 함");
+    expect(
+      formatDiscussionRoomSummary({
+        enabled: true,
+        mainRoomName: "추리 회의",
+        privateRoomsEnabled: true,
+        privateRoomName: "밀담",
+        availability: "phase_active",
+      }),
+    ).toBe("장면 시작 시 · 추리 회의, 밀담");
+  });
+});

--- a/apps/web/src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts
@@ -49,5 +49,15 @@ describe("discussionRoomPolicyAdapter", () => {
         availability: "phase_active",
       }),
     ).toBe("장면 시작 시 · 추리 회의, 밀담");
+    expect(
+      formatDiscussionRoomSummary({
+        enabled: true,
+        mainRoomName: "추리 회의",
+        privateRoomsEnabled: false,
+        privateRoomName: "밀담",
+        availability: "condition",
+        conditionalRoomName: "비밀 토론",
+      }),
+    ).toBe("트리거가 열 때까지 대기 · 추리 회의, 비밀 토론");
   });
 });

--- a/apps/web/src/features/editor/entities/phase/discussionRoomPolicyAdapter.ts
+++ b/apps/web/src/features/editor/entities/phase/discussionRoomPolicyAdapter.ts
@@ -1,0 +1,47 @@
+import type { DiscussionRoomPolicy } from "../../flowTypes";
+
+export const DEFAULT_DISCUSSION_ROOM_POLICY: DiscussionRoomPolicy = {
+  enabled: false,
+  mainRoomName: "전체 토론",
+  privateRoomsEnabled: false,
+  privateRoomName: "밀담방",
+  availability: "phase_active",
+  conditionalRoomName: "",
+};
+
+export function normalizeDiscussionRoomPolicy(
+  policy: Partial<DiscussionRoomPolicy> | null | undefined,
+): DiscussionRoomPolicy {
+  return {
+    ...DEFAULT_DISCUSSION_ROOM_POLICY,
+    ...policy,
+    mainRoomName: cleanName(policy?.mainRoomName, DEFAULT_DISCUSSION_ROOM_POLICY.mainRoomName),
+    privateRoomName: cleanName(policy?.privateRoomName, DEFAULT_DISCUSSION_ROOM_POLICY.privateRoomName),
+    availability: policy?.availability === "condition" ? "condition" : "phase_active",
+    conditionalRoomName: policy?.conditionalRoomName?.trim() ?? "",
+  };
+}
+
+export function patchDiscussionRoomPolicy(
+  current: Partial<DiscussionRoomPolicy> | null | undefined,
+  patch: Partial<DiscussionRoomPolicy>,
+): DiscussionRoomPolicy {
+  return normalizeDiscussionRoomPolicy({ ...normalizeDiscussionRoomPolicy(current), ...patch });
+}
+
+export function formatDiscussionRoomSummary(policy: DiscussionRoomPolicy | null | undefined): string {
+  const normalized = normalizeDiscussionRoomPolicy(policy);
+  if (!normalized.enabled) return "토론방 사용 안 함";
+  const rooms = [normalized.mainRoomName];
+  if (normalized.privateRoomsEnabled) rooms.push(normalized.privateRoomName);
+  if (normalized.availability === "condition" && normalized.conditionalRoomName) {
+    rooms.push(normalized.conditionalRoomName);
+  }
+  const availability = normalized.availability === "condition" ? "트리거 대기" : "장면 시작 시";
+  return `${availability} · ${rooms.join(", ")}`;
+}
+
+function cleanName(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}

--- a/apps/web/src/features/editor/entities/phase/discussionRoomPolicyAdapter.ts
+++ b/apps/web/src/features/editor/entities/phase/discussionRoomPolicyAdapter.ts
@@ -37,7 +37,7 @@ export function formatDiscussionRoomSummary(policy: DiscussionRoomPolicy | null 
   if (normalized.availability === "condition" && normalized.conditionalRoomName) {
     rooms.push(normalized.conditionalRoomName);
   }
-  const availability = normalized.availability === "condition" ? "트리거 대기" : "장면 시작 시";
+  const availability = normalized.availability === "condition" ? "트리거가 열 때까지 대기" : "장면 시작 시";
   return `${availability} · ${rooms.join(", ")}`;
 }
 

--- a/apps/web/src/features/editor/entities/phase/phaseEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/phase/phaseEntityAdapter.ts
@@ -13,6 +13,7 @@ import {
   type InformationRecipientType,
 } from "../shared/informationDeliveryAdapter";
 import { toCreatorActionLabels } from "../shared/actionAdapter";
+import type { DiscussionRoomPolicy } from "../../flowTypes";
 
 const PHASE_TYPE_LABELS: Record<string, string> = {
   investigation: "수사",
@@ -36,6 +37,7 @@ export interface PhaseEditorViewModel {
   exitActionLabels: string[];
   defaultTransitionLabel: string;
   conditionalTransitionCount: number;
+  discussionRoomPolicy?: DiscussionRoomPolicy;
 }
 
 export {
@@ -75,6 +77,7 @@ export function toPhaseEditorViewModel(
     }),
     defaultTransitionLabel: formatDefaultTransition(defaultEdges.length),
     conditionalTransitionCount: conditionalEdges.length,
+    discussionRoomPolicy: data.discussionRoomPolicy,
   };
 }
 

--- a/apps/web/src/features/editor/flowTypes.ts
+++ b/apps/web/src/features/editor/flowTypes.ts
@@ -10,6 +10,17 @@ export interface PhaseAction {
   params?: Record<string, unknown>;
 }
 
+export type DiscussionRoomAvailability = "phase_active" | "condition";
+
+export interface DiscussionRoomPolicy {
+  enabled: boolean;
+  mainRoomName: string;
+  privateRoomsEnabled: boolean;
+  privateRoomName: string;
+  availability: DiscussionRoomAvailability;
+  conditionalRoomName?: string;
+}
+
 export interface FlowNodeData {
   label?: string;
   phase_type?: string;
@@ -25,6 +36,7 @@ export interface FlowNodeData {
   warningAt?: number;
   onEnter?: PhaseAction[];
   onExit?: PhaseAction[];
+  discussionRoomPolicy?: DiscussionRoomPolicy;
 }
 
 export interface FlowNodeResponse {


### PR DESCRIPTION
## 요약

- 장면 설정에 토론방 정책 UI를 추가해 제작자가 메인 토론방, 밀담방, 트리거 대기 방명을 설정할 수 있게 했습니다.
- backend PhaseEngine이 장면 진입 후 group_chat runtime에 정책을 전달하고, group_chat이 방 open/closed 상태와 join 접근을 최종 판정하도록 연결했습니다.
- policy-generated room redaction과 editor E2E 저장 경로를 테스트로 고정했습니다.

Closes #303

## 검증

- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts
- go test ./internal/engine ./internal/module/communication
- go test ./internal/session
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium

## 리뷰 반영

- 조건부 토론방 문구를 실제 계약에 맞춰 "트리거가 열 때까지 대기"로 낮췄습니다.
- OnEnter 실패 시 토론방 정책이 먼저 적용되지 않도록 dispatch 순서를 조정했습니다.
- 새 토론방 UI E2E와 policy-generated private room redaction 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장면 편집기에 토론방 정책 편집 패널 추가(메인/비공개/조건부 방, 활성화 토글) 및 요약 행("토론방") 표시
  * 흐름 노드에 discussionRoomPolicy 필드 지원 및 입력값 정규화·병합 로직 추가
  * 토론방 정책이 활성인 장면에서 서버가 자동으로 그룹 채팅 토론방을 생성·적용하고 상태에 반영(조건부 가용성 지원)

* **테스트**
  * 정책 UI·정규화·E2E 접근성·저장 흐름 테스트 추가
  * 엔진에서 OnEnter 후 정책 적용 순서 및 실패 시 적용 건너뛰기 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->