### PR TITLE
chore(pr): #341 steward strict 최신화 처리

### DIFF
--- a/.codex/agents/mmp-ci-steward.toml
+++ b/.codex/agents/mmp-ci-steward.toml
@@ -24,12 +24,14 @@ Allowed:
 9. For `code-rabbit-only`, do not add `ready-for-ci`, do not dispatch workflows, and do not wait for missing heavy-CI contexts. Use `MMP_CI_STEWARD=1 scripts/mmp-pr-watch.sh <PR_NUMBER> --code-rabbit-only` plus focused local validation for changed scripts/config/docs.
 10. If CI or Codecov fails on a `full-ci` PR, inspect logs/comments, fix valid failures on the target branch, push, then restart from CodeRabbit/head SHA verification.
 11. If main Codex pushes a new commit after your previous report, restart from the latest PR head SHA and re-check CodeRabbit/check state before reporting again.
+12. Check whether the base branch requires strict up-to-date status checks. If `main` protection has `required_status_checks.strict=true` and `mergeable_state=behind` / `mergeStateStatus=BEHIND`, update the PR branch yourself with `gh pr update-branch <PR_NUMBER>` or by running the watcher with `--update-branch-if-needed`, then restart from the new head SHA. If the update fails or creates conflicts, report `BLOCKED` with the exact failure. If strict status checks are not enabled, treat `BEHIND` with `MERGEABLE` as informational unless GitHub reports a merge conflict, an explicit up-to-date requirement, a stacked parent/base change that affects this branch, or CI/Codecov evidence tied to main drift.
 
 Forbidden:
 - Do not merge PRs.
 - Do not create PRs or GitHub issues.
 - Do not force-push, reset, checkout away unrelated user changes, delete branches, or run destructive git commands.
 - Do not modify unrelated issue branches or worktrees.
+- Do not manually rebase or create local merge commits for branch refresh. Use only GitHub's PR branch update (`gh pr update-branch <PR_NUMBER>`) when strict up-to-date checks require it.
 - Do not skip tests, weaken coverage, or dismiss valid review findings without technical reason.
 - Do not inspect secrets or deployment credentials.
 
@@ -42,6 +44,7 @@ Completion rules:
 - For `full-ci`, if `ready-for-ci` is applied but required workflows are missing or in progress, continue watching with `--trigger-missing-workflows`; do not stop. Treat missing required workflows as something to dispatch, not something to passively wait for.
 - For `code-rabbit-only`, report `MERGE_READY` only when current head SHA checked, unresolved review threads are 0, CodeRabbit is clear, light checks are green, focused local validation is recorded, and `scripts/mmp-pr-ci-scope.sh` says `code-rabbit-only`.
 - For `code-rabbit-only`, missing heavy-CI required contexts are expected path-filter behavior. Do not call that a CI failure and do not wait on those contexts.
+- Do not report `MERGE_READY` when `main` requires strict up-to-date status checks and the PR is still behind `main`; update the branch first, then verify the new head.
 - If you cannot continue because of permission, timeout, external outage, ambiguous product decision, or repeated CI failure requiring main/user judgment, report `BLOCKED`.
 - If you pushed a fix and are waiting for CodeRabbit/CI to re-run, report `NEEDS_FIX` only when the next concrete wait/re-handoff is required; include the latest pushed SHA.
 

--- a/.codex/skills/mmp-pr-lifecycle/SKILL.md
+++ b/.codex/skills/mmp-pr-lifecycle/SKILL.md
@@ -40,7 +40,7 @@ description: Use when creating, reviewing, updating, labeling, checking, or merg
 7. CI steward handoff:
    - Use when PR review/CI waiting would block starting the next issue and the user has approved agent delegation.
    - Generate a copy-ready handoff with `scripts/mmp-ci-steward-handoff.sh <PR>`.
-   - The steward owns only the target PR branch/worktree: CodeRabbit fixes, focused checks, Codecov/CI fixes, push commits, and `ready-for-ci` through `scripts/pr-ready-for-ci-guard.sh --apply <PR>`.
+   - The steward owns only the target PR branch/worktree: CodeRabbit fixes, focused checks, Codecov/CI fixes, push commits, strict up-to-date branch refresh through `gh pr update-branch <PR>`, and `ready-for-ci` through `scripts/pr-ready-for-ci-guard.sh --apply <PR>`.
    - Main Codex continues the next issue only from a separate worktree/branch based on `origin/main` unless intentionally stacking work.
    - Merge authority stays with main Codex until the user explicitly changes the policy. When the steward reports `MERGE_READY`, main Codex verifies the scope-specific gate, then merges.
    - The handoff must include `scripts/mmp-pr-ci-scope.sh <PR>` output.
@@ -52,7 +52,8 @@ description: Use when creating, reviewing, updating, labeling, checking, or merg
    - If main Codex pushes an additional commit to a steward-managed PR, re-handoff the latest head to the steward for CodeRabbit/check waiting instead of running repeated watcher polling in the main thread.
    - After reading the steward's final result, call `close_agent` for that steward before spawning more agents or moving to the next PR.
    - After any steward-managed PR is merged, main Codex pulls `origin/main`.
-   - Do not automatically rebase or merge `origin/main` into active PR branches that are already under steward review/CI. Update an active branch only when GitHub reports a merge conflict or up-to-date requirement, the merged main change touches the same files/shared contracts or a stacked parent branch, CI/Codecov failure is caused by main drift, or the user explicitly asks for the branch refresh.
+   - Do not automatically rebase or merge `origin/main` into active PR branches that are already under steward review/CI. Update an active branch only when GitHub reports a merge conflict or up-to-date requirement, `main` branch protection has `required_status_checks.strict=true` and the PR is behind, the merged main change touches the same files/shared contracts or a stacked parent branch, CI/Codecov failure is caused by main drift, or the user explicitly asks for the branch refresh.
+   - In this repo, `main` currently requires strict up-to-date status checks. Therefore `mergeable_state=behind` / `mergeStateStatus=BEHIND` can block merge even when `mergeable=MERGEABLE`; the steward should update the PR branch with `gh pr update-branch <PR>` or `MMP_CI_STEWARD=1 scripts/mmp-pr-watch.sh <PR> --update-branch-if-needed ...`, then restart latest-head review/CI verification.
    - If no branch-refresh trigger exists, preserve the active PR head and let the steward finish the current review/CI cycle. Resolve any remaining conflict at the merge decision point.
 
 ## Done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ Do:
 6. 병렬 실행 계획이 필요한 경우 `.codex/agents/mmp-parallel-coordinator.toml` 역할을 먼저 사용해 read-heavy audit, write ownership, 중단 조건, 메인 통합 체크리스트를 만든다.
 7. 기본 병렬화 순서는 `parallel-coordinator → 필요한 reviewer/worker 병렬 실행 → 메인 Codex 취합 → 충돌 없는 구현 → focused 검증`이다.
 8. PR 대기 시간이 다음 이슈 진행을 막을 때는 `.codex/agents/mmp-ci-steward.toml` 역할에 단일 PR의 CodeRabbit/Codecov/CI 보정만 위임할 수 있다. 메인 Codex는 별도 worktree/branch에서 다음 이슈를 진행하고, steward PR merge 후 `origin/main`을 가져온다.
-9. 이미 steward가 맡아 CodeRabbit/CI가 도는 PR branch는 관성적으로 rebase/merge하지 않는다. 최신화는 GitHub가 merge conflict 또는 up-to-date 요구를 하거나, merge된 main 변경이 같은 파일/공유 계약/stacked parent에 영향을 주거나, CI/Codecov 실패 원인이 main drift이거나, 사용자가 명시적으로 최신화를 요청할 때만 수행한다. 명확한 트리거가 없으면 기존 head를 유지하고 merge 시점에 충돌 여부를 판단한다.
+9. 이미 steward가 맡아 CodeRabbit/CI가 도는 PR branch는 관성적으로 rebase/merge하지 않는다. 다만 이 repo의 `main`은 required status checks의 `strict`가 켜져 있어 PR이 base보다 뒤처지면 `mergeable=MERGEABLE`이어도 merge gate에서 막힐 수 있다. 최신화는 GitHub가 merge conflict 또는 up-to-date 요구를 하거나, `main` branch protection의 strict status check가 켜진 상태에서 PR이 behind이거나, merge된 main 변경이 같은 파일/공유 계약/stacked parent에 영향을 주거나, CI/Codecov 실패 원인이 main drift이거나, 사용자가 명시적으로 최신화를 요청할 때만 수행한다. CI steward는 이 strict/behind 조합을 감지하면 `gh pr update-branch <PR>` 또는 `scripts/mmp-pr-watch.sh <PR> --update-branch-if-needed`로 직접 branch update를 수행하고, 새 head 기준으로 CodeRabbit/CI를 처음부터 다시 확인한다. local rebase, local merge commit, force-push는 금지한다.
 10. Steward-managed PR에 메인 Codex가 추가 커밋, rebase, merge commit을 push한 경우, 메인 thread가 watcher로 반복 대기하지 말고 최신 head 확인을 steward에게 다시 맡긴다. 메인 Codex는 단발 상태 확인과 최종 merge 판단만 맡는다.
 11. 메인 Codex thread는 `scripts/mmp-pr-watch.sh`를 직접 장시간 실행하지 않는다. `scripts/mmp-pr-status.sh <PR>` 또는 `gh pr view` 같은 단발 조회만 사용하고, 30초 이상 대기가 필요하면 CI steward에 위임한다.
 12. 새 sub-agent spawn이 슬롯 제한으로 막히면 먼저 기존 agent들을 `wait_agent`로 상태 확인하고, `completed` 상태인 agent는 즉시 `close_agent`로 해제한다. 앞으로도 sub-agent 최종 결과를 취합한 직후 `close_agent`까지 실행해야 해당 작업이 완료된 것으로 본다.
@@ -138,7 +138,7 @@ Done when:
 - 완료된 sub-agent가 `close_agent`로 해제되어 다음 작업 슬롯을 막지 않는다.
 
 Avoid:
-- secret 조회, destructive command, PR 생성, merge, 배포 트리거를 sub-agent에 맡기지 않는다. 단, CI steward는 `scripts/pr-ready-for-ci-guard.sh --apply <PR>`를 통과한 경우에만 `ready-for-ci` 라벨을 붙일 수 있다.
+- secret 조회, destructive command, PR 생성, merge, 배포 트리거를 sub-agent에 맡기지 않는다. 단, CI steward는 `scripts/pr-ready-for-ci-guard.sh --apply <PR>`를 통과한 경우에만 `ready-for-ci` 라벨을 붙일 수 있고, strict up-to-date merge gate 해소가 필요할 때만 `gh pr update-branch <PR>`를 실행할 수 있다.
 - 다음 로컬 작업이 바로 막히는 critical path를 불필요하게 위임하지 않는다.
 - API DTO, frontend adapter/ViewModel mapping, migration, PR/CI 라벨 전환처럼 공유 계약을 바꾸는 작업은 최종 통합 전까지 여러 agent가 동시에 수정하지 않는다.
 

--- a/scripts/mmp-ci-steward-handoff.sh
+++ b/scripts/mmp-ci-steward-handoff.sh
@@ -12,6 +12,7 @@ CI steward handoff prompt를 출력합니다.
 
 Steward의 범위:
 - 단일 PR branch/worktree의 CodeRabbit, Codecov, CI 보정
+- strict up-to-date merge gate 발생 시 GitHub PR branch update
 - focused validation 및 fix commit push
 - ready-for-ci guard 통과 후 라벨 적용
 
@@ -74,6 +75,8 @@ repo_root="$(git rev-parse --show-toplevel)"
 current_branch="$(git branch --show-current)"
 
 pr_json="$(gh pr view "$pr_number" --json number,title,url,state,headRefName,headRefOid,baseRefName,mergeStateStatus,reviewDecision,labels)"
+pull_json="$(gh api "repos/$owner/$repo/pulls/$pr_number")"
+protection_json="$(gh api "repos/$owner/$repo/branches/$(printf '%s' "$pr_json" | jq -r '.baseRefName')/protection" 2>/dev/null || printf '{}')"
 number="$(printf '%s' "$pr_json" | jq -r '.number')"
 title="$(printf '%s' "$pr_json" | jq -r '.title')"
 url="$(printf '%s' "$pr_json" | jq -r '.url')"
@@ -82,6 +85,8 @@ head="$(printf '%s' "$pr_json" | jq -r '.headRefName')"
 head_sha="$(printf '%s' "$pr_json" | jq -r '.headRefOid')"
 base="$(printf '%s' "$pr_json" | jq -r '.baseRefName')"
 merge_state="$(printf '%s' "$pr_json" | jq -r '.mergeStateStatus // "UNKNOWN"')"
+mergeable_state="$(printf '%s' "$pull_json" | jq -r '.mergeable_state // "unknown"')"
+strict_status_checks="$(printf '%s' "$protection_json" | jq -r '.required_status_checks.strict // false')"
 review_decision="$(printf '%s' "$pr_json" | jq -r '.reviewDecision // "UNKNOWN"')"
 labels="$(printf '%s' "$pr_json" | jq -r '[.labels[].name] | if length == 0 then "없음" else join(", ") end')"
 
@@ -96,13 +101,13 @@ if [[ "$CI_SCOPE" == "code-rabbit-only" ]]; then
   steward_mode="code-rabbit-only exception"
   ci_instruction="이 PR은 heavy CI path filter에 걸리는 파일이 없습니다. ready-for-ci 라벨, workflow_dispatch, full CI 대기를 하지 마세요. CodeRabbit clear + unresolved 0 + light checks + 변경 스크립트/설정 focused validation이 완료 조건입니다."
   merge_ready_rule="MERGE_READY: code-rabbit-only exception 근거 확인, unresolved thread 0, CodeRabbit clear, light checks pass, changed scripts/config focused validation pass. ready-for-ci 라벨과 required workflow green은 요구하지 않습니다."
-  copy_ready_rule="이 PR은 code-rabbit-only exception입니다. MMP_CI_STEWARD=1 scripts/mmp-pr-watch.sh $number --code-rabbit-only 로 CodeRabbit/threads만 확인하고, ready-for-ci 라벨이나 workflow_dispatch/full CI는 실행하지 마세요."
+  copy_ready_rule="이 PR은 code-rabbit-only exception입니다. MMP_CI_STEWARD=1 scripts/mmp-pr-watch.sh $number --code-rabbit-only --update-branch-if-needed 로 CodeRabbit/threads와 strict up-to-date 상태만 확인하고, ready-for-ci 라벨이나 workflow_dispatch/full CI는 실행하지 마세요."
   full_ci_wait_rule="이 PR에서는 full CI required workflow 대기를 하지 마세요. missing heavy-CI context는 path-filter 기대 동작입니다."
 else
   steward_mode="full-ci"
   ci_instruction="이 PR은 heavy CI trigger path를 변경했습니다. CodeRabbit 정리 후 scripts/pr-ready-for-ci-guard.sh --apply $number 로 ready-for-ci 라벨을 붙이고, scripts/mmp-pr-watch.sh $number --trigger-missing-workflows 로 현재 head SHA의 required workflow를 확인하세요."
   merge_ready_rule="MERGE_READY: unresolved thread 0, CodeRabbit clear, ready-for-ci label present, required checks green, Codecov 기준 충족 또는 비대상 근거 확인."
-  copy_ready_rule="CodeRabbit 통과 후 scripts/pr-ready-for-ci-guard.sh --apply $number 와 MMP_CI_STEWARD=1 scripts/mmp-pr-watch.sh $number --trigger-missing-workflows 를 이어서 실행하세요."
+  copy_ready_rule="CodeRabbit 통과 후 scripts/pr-ready-for-ci-guard.sh --apply $number 와 MMP_CI_STEWARD=1 scripts/mmp-pr-watch.sh $number --trigger-missing-workflows --update-branch-if-needed 를 이어서 실행하세요."
   full_ci_wait_rule="라벨 이벤트만 기다리지 마세요. required workflow(CI, E2E — Stubbed Backend, Security — Fast Feedback)가 현재 head SHA에 없으면 watcher가 workflow_dispatch로 생성해야 합니다."
 fi
 state_note=""
@@ -124,6 +129,8 @@ $state_note
 - Branch: $head -> $base
 - Head SHA: $head_sha
 - Merge state: $merge_state
+- REST mergeable_state: $mergeable_state
+- Base requires up-to-date checks: $strict_status_checks
 - Review decision: $review_decision
 - Labels: $labels
 - CodeRabbit latest: $latest_coderabbit
@@ -143,6 +150,7 @@ $ci_instruction
 ## Steward 허용 범위
 - 이 PR branch/worktree에서만 CodeRabbit, CI, Codecov 원인을 확인하고 수정합니다.
 - 타당한 리뷰/실패만 고치고 focused validation을 실행한 뒤 fix commit을 push할 수 있습니다.
+- Base requires up-to-date checks가 true이고 REST mergeable_state가 behind이면 steward가 gh pr update-branch $number 로 branch update를 수행한 뒤 새 Head SHA 기준으로 처음부터 다시 확인합니다.
 - full-ci PR에서는 CodeRabbit 정리 후 반드시 scripts/pr-ready-for-ci-guard.sh --apply $number 로 ready-for-ci 라벨을 붙입니다.
 - code-rabbit-only exception PR에서는 ready-for-ci 라벨과 workflow_dispatch를 실행하지 않습니다.
 - watcher는 CI steward 전용입니다. 메인 Codex thread에서 직접 실행하지 않습니다.
@@ -152,10 +160,10 @@ $ci_instruction
 - Required workflow set: CI, E2E — Stubbed Backend, Security — Fast Feedback.
 - gitleaks, File Size Guard, ci-hooks, module-isolation, build-runner-image 등은 이 steward의 full-CI 완료 판정용 required set이 아닙니다. PR checks에 보이면 참고하되, 위 required set 누락 여부를 기준으로 행동하세요.
 - 이전 보고 이후 메인 Codex가 추가 커밋을 push했다면 최신 Head SHA 기준으로 CodeRabbit/check 상태를 다시 확인합니다.
-- base/main 최신화, rebase, merge commit, force-push는 steward의 기본 책임이 아닙니다. 메인 Codex가 명시적으로 최신 head를 다시 위임한 경우에만 그 head를 기준으로 대기/검증합니다.
+- local rebase, local merge commit, force-push는 금지입니다. Strict up-to-date gate 해소에는 gh pr update-branch $number 만 사용합니다.
 
 ## Steward 금지 범위
-- PR merge, PR 생성, Issue 생성, force-push, destructive git, secret 조회, unrelated branch/worktree 수정, 임의 branch 최신화는 금지입니다.
+- PR merge, PR 생성, Issue 생성, force-push, destructive git, secret 조회, unrelated branch/worktree 수정, 임의 branch 최신화는 금지입니다. 단, 위 strict up-to-date 조건을 만족한 대상 PR의 gh pr update-branch 실행은 허용합니다.
 - 테스트 스킵, coverage 약화, 유효한 리뷰 무시도 금지입니다.
 
 ## 메인 Codex 복귀 조건

--- a/scripts/mmp-pr-ci-scope.sh
+++ b/scripts/mmp-pr-ci-scope.sh
@@ -26,6 +26,15 @@ require_cmd() {
   fi
 }
 
+join_by_comma() {
+  if [[ "$#" -eq 0 ]]; then
+    return 0
+  fi
+
+  local IFS=,
+  printf '%s' "$*"
+}
+
 format="text"
 from_stdin="0"
 pr_number=""
@@ -115,13 +124,15 @@ fi
 
 heavy=()
 light=()
-for file in "${files[@]}"; do
-  if reason="$(heavy_reason_for_path "$file")"; then
-    heavy+=("$file:$reason")
-  else
-    light+=("$file")
-  fi
-done
+if [[ "${#files[@]}" -gt 0 ]]; then
+  for file in "${files[@]}"; do
+    if reason="$(heavy_reason_for_path "$file")"; then
+      heavy+=("$file:$reason")
+    else
+      light+=("$file")
+    fi
+  done
+fi
 
 if [[ "${#heavy[@]}" -gt 0 ]]; then
   scope="full-ci"
@@ -130,11 +141,20 @@ else
 fi
 
 if [[ "$format" == "env" ]]; then
+  heavy_files=""
+  light_files=""
+  if [[ "${#heavy[@]}" -gt 0 ]]; then
+    heavy_files="$(join_by_comma "${heavy[@]}")"
+  fi
+  if [[ "${#light[@]}" -gt 0 ]]; then
+    light_files="$(join_by_comma "${light[@]}")"
+  fi
+
   printf 'CI_SCOPE=%q\n' "$scope"
   printf 'CI_HEAVY_COUNT=%q\n' "${#heavy[@]}"
   printf 'CI_LIGHT_COUNT=%q\n' "${#light[@]}"
-  printf 'CI_HEAVY_FILES=%q\n' "$(IFS=','; printf '%s' "${heavy[*]}")"
-  printf 'CI_LIGHT_FILES=%q\n' "$(IFS=','; printf '%s' "${light[*]}")"
+  printf 'CI_HEAVY_FILES=%q\n' "$heavy_files"
+  printf 'CI_LIGHT_FILES=%q\n' "$light_files"
 else
   printf 'CI scope: %s\n' "$scope"
   if [[ "${#heavy[@]}" -gt 0 ]]; then

--- a/scripts/mmp-pr-status.sh
+++ b/scripts/mmp-pr-status.sh
@@ -41,6 +41,7 @@ owner="$(gh repo view --json owner --jq '.owner.login')"
 repo="$(gh repo view --json name --jq '.name')"
 
 pr_json="$(gh pr view "$pr_number" --json number,title,url,headRefName,baseRefName,mergeStateStatus,reviewDecision,labels)"
+pull_json="$(gh api "repos/$owner/$repo/pulls/$pr_number")"
 
 number="$(printf '%s' "$pr_json" | jq -r '.number')"
 title="$(printf '%s' "$pr_json" | jq -r '.title')"
@@ -48,6 +49,9 @@ url="$(printf '%s' "$pr_json" | jq -r '.url')"
 head="$(printf '%s' "$pr_json" | jq -r '.headRefName')"
 base="$(printf '%s' "$pr_json" | jq -r '.baseRefName')"
 merge_state="$(printf '%s' "$pr_json" | jq -r '.mergeStateStatus // "UNKNOWN"')"
+mergeable_state="$(printf '%s' "$pull_json" | jq -r '.mergeable_state // "unknown"')"
+protection_json="$(gh api "repos/$owner/$repo/branches/$base/protection" 2>/dev/null || printf '{}')"
+strict_status_checks="$(printf '%s' "$protection_json" | jq -r '.required_status_checks.strict // false')"
 review_decision="$(printf '%s' "$pr_json" | jq -r '.reviewDecision // "UNKNOWN"')"
 labels="$(printf '%s' "$pr_json" | jq -r '[.labels[].name] | if length == 0 then "없음" else join(", ") end')"
 
@@ -112,6 +116,8 @@ cat <<MSG
 - Branch: $head -> $base
 - Labels: $labels
 - Merge state: $merge_state
+- REST mergeable_state: $mergeable_state
+- Base requires up-to-date checks: $strict_status_checks
 - Review decision: $review_decision
 - CI scope: $CI_SCOPE
 - Heavy CI trigger files: ${CI_HEAVY_FILES:-없음}

--- a/scripts/mmp-pr-watch.sh
+++ b/scripts/mmp-pr-watch.sh
@@ -19,6 +19,9 @@ Options:
                            Default: CI,E2E — Stubbed Backend,Security — Fast Feedback
   --trigger-missing-workflows
                            Trigger missing required workflows once CodeRabbit is clear
+  --update-branch-if-needed
+                           If base branch requires strict up-to-date checks and PR is behind,
+                           update the PR branch through GitHub and restart latest-head waiting
   --code-rabbit-only       Stop once CodeRabbit is clear and review threads are resolved
   --no-notify              Do not send macOS notification / terminal bell
   -h, --help               Show help
@@ -111,11 +114,24 @@ latest_workflow_rows() {
     | jq -r --arg head_sha "$head_sha" '.[] | select(.headSha == $head_sha) | [.workflowName, .status, (if (.conclusion == null or .conclusion == "") then "none" else .conclusion end), (.databaseId|tostring), .url, .createdAt, .headSha] | @tsv'
 }
 
+base_requires_up_to_date_checks() {
+  local owner="$1"
+  local repo="$2"
+  local base="$3"
+  local protection_json
+  if ! protection_json="$(gh_retry api "repos/$owner/$repo/branches/$base/protection" 2>/dev/null)"; then
+    printf 'false'
+    return 0
+  fi
+  printf '%s' "$protection_json" | jq -r '.required_status_checks.strict // false'
+}
+
 interval=60
 timeout=3600
 workflow_csv="CI,E2E — Stubbed Backend,Security — Fast Feedback"
 notify_enabled=1
 trigger_missing_workflows=0
+update_branch_if_needed=0
 code_rabbit_only=0
 pr_number=""
 
@@ -135,6 +151,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --trigger-missing-workflows)
       trigger_missing_workflows=1
+      shift
+      ;;
+    --update-branch-if-needed)
+      update_branch_if_needed=1
       shift
       ;;
     --code-rabbit-only)
@@ -216,8 +236,27 @@ while :; do
     sleep "$interval"
     continue
   fi
+  if ! pull_json="$(gh_retry api "repos/$owner/$repo/pulls/$pr_number")"; then
+    echo "⚠️ PR REST 상태 조회 실패; 다음 주기에 재시도합니다." >&2
+    sleep "$interval"
+    continue
+  fi
   branch="$(printf '%s' "$pr_json" | jq -r '.headRefName')"
   head_sha="$(printf '%s' "$pr_json" | jq -r '.headRefOid')"
+  base_branch="$(printf '%s' "$pull_json" | jq -r '.base.ref')"
+  mergeable_state="$(printf '%s' "$pull_json" | jq -r '.mergeable_state // "unknown"')"
+  strict_status_checks="$(base_requires_up_to_date_checks "$owner" "$repo" "$base_branch")"
+  if [[ "$update_branch_if_needed" == "1" && "$strict_status_checks" == "true" && "$mergeable_state" == "behind" ]]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] PR #$pr_number sha=${head_sha:0:7} is behind $base_branch and strict status checks are enabled. Updating branch through GitHub..."
+    if gh_retry pr update-branch "$pr_number" >/dev/null; then
+      triggered_workflows="|"
+      sleep "$interval"
+      continue
+    fi
+    notify "MMP PR branch update failed" "PR #$pr_number could not be updated"
+    scripts/mmp-pr-status.sh "$pr_number" || true
+    exit 2
+  fi
   labels_csv="$(printf '%s' "$pr_json" | jq -r '.labels | join(",")')"
   latest_coderabbit="$(printf '%s' "$pr_json" | jq -r '.latestCodeRabbit')"
   checks_json="$(gh_retry pr checks "$pr_number" --json name,bucket || true)"
@@ -255,7 +294,7 @@ while :; do
 
   timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
   if [[ "$code_rabbit_only" == "1" ]]; then
-    echo "[$timestamp] PR #$pr_number sha=${head_sha:0:7} CodeRabbit=$latest_coderabbit/$coderabbit_bucket threads=$unresolved_threads/$total_threads labels=${labels_csv:-없음}"
+    echo "[$timestamp] PR #$pr_number sha=${head_sha:0:7} mergeable_state=$mergeable_state strict=$strict_status_checks CodeRabbit=$latest_coderabbit/$coderabbit_bucket threads=$unresolved_threads/$total_threads labels=${labels_csv:-없음}"
     if [[ "$coderabbit_clear" == "1" ]]; then
       notify "MMP PR CodeRabbit clear" "PR #$pr_number CodeRabbit clear and review threads resolved"
       scripts/mmp-pr-status.sh "$pr_number" || true
@@ -310,7 +349,7 @@ while :; do
   done
 
   timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
-  echo "[$timestamp] PR #$pr_number sha=${head_sha:0:7} CodeRabbit=$latest_coderabbit/$coderabbit_bucket threads=$unresolved_threads/$total_threads labels=${labels_csv:-없음} workflows: ${workflow_summary[*]}"
+  echo "[$timestamp] PR #$pr_number sha=${head_sha:0:7} mergeable_state=$mergeable_state strict=$strict_status_checks CodeRabbit=$latest_coderabbit/$coderabbit_bucket threads=$unresolved_threads/$total_threads labels=${labels_csv:-없음} workflows: ${workflow_summary[*]}"
 
   if [[ "$workflow_failure" == "1" ]]; then
     notify "MMP CI failed" "PR #$pr_number has failed CI"


### PR DESCRIPTION
## 요약
- mmp-pr-ci-scope env 출력에서 빈 배열이 macOS bash set -u로 깨지는 문제를 수정했습니다.
- CI steward가 main strict up-to-date 보호 규칙과 behind 상태를 감지해 gh pr update-branch로 직접 최신화하도록 규칙과 handoff를 보강했습니다.
- PR status/handoff/watch 출력에 REST mergeable_state와 base strict status 정보를 추가했습니다.

## 검증
- bash -n scripts/mmp-pr-ci-scope.sh scripts/mmp-pr-watch.sh scripts/mmp-pr-status.sh scripts/mmp-ci-steward-handoff.sh scripts/pr-ready-for-ci-guard.sh
- printf '' | scripts/mmp-pr-ci-scope.sh --stdin --format env
- printf 'AGENTS.md\n.codex/agents/mmp-ci-steward.toml\n' | scripts/mmp-pr-ci-scope.sh --stdin --format env
- printf 'apps/web/src/foo.ts\n' | scripts/mmp-pr-ci-scope.sh --stdin --format env
- scripts/mmp-pr-status.sh 340
- scripts/mmp-ci-steward-handoff.sh 340
- git diff --check

## CI scope
- code-rabbit-only: 운영/스크립트/agent 규칙 변경이며 app runtime path는 변경하지 않습니다.

Closes #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **문서화**
  * CI steward의 strict up-to-date 브랜치 체크 절차 및 제약사항을 명확히 했습니다.
  * PR 라이프사이클과 CI steward 권한 범위 규칙을 업데이트했습니다.

* **기능 개선**
  * 브랜치 보호 설정 및 merge 상태를 더 정확히 감지하도록 개선했습니다.
  * PR 브랜치가 behind 상태일 때 자동으로 최신화하는 옵션을 추가했습니다.
  * PR 상태 리포팅에 merge 가능성 및 up-to-date 체크 요구사항을 포함했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->