### PR TITLE
hotfix(ci): #347 full CI runner를 arc-runner-set으로 복구

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   go-check:
     name: Go Lint + Test
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     defaults:
       run:
         working-directory: apps/server
@@ -223,7 +223,7 @@ jobs:
 
   ts-check:
     name: TypeScript Lint + Test + Build
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     steps:
       - name: Full CI ready gate
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
@@ -302,7 +302,7 @@ jobs:
     #   Phase 21: Go 70% / FE Lines 65% / FE Branches 85% (+15%p — 하한 상향 전 반드시 테스트 보강)
     #   하한 상향 전에 반드시 추가 테스트 PR 로 baseline 끌어올리기.
     name: Coverage Regression Guard
-    runs-on: self-hosted
+    runs-on: arc-runner-set
     needs: [go-check, ts-check]
     steps:
       - name: Harden Runner
@@ -377,7 +377,7 @@ jobs:
 
   docker-build:
     name: Docker Build Check
-    runs-on: self-hosted
+    runs-on: arc-runner-set
     needs: [go-check, ts-check]
     permissions:
       contents: read

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -51,7 +51,7 @@ concurrency:
 jobs:
   e2e:
     name: E2E (${{ matrix.browser }} shard ${{ matrix.shard }})
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     # H-1: fork PR 의 untrusted code 가 shared named volume (playwright-cache/hostedtool-cache) 에
     # 악성 binary 를 심어 4 runner 횡전파하는 cache poisoning 차단.
     # fork PR 은 cache mount runner 를 우회 (skip). main / same-repo PR 만 실행.
@@ -386,7 +386,7 @@ jobs:
     # H-1 consistency: e2e 와 동일 fork PR 게이트 (cache mount runner 일관성).
     if: (always()) && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'ready-for-ci')))
     needs: [e2e]
-    runs-on: self-hosted
+    runs-on: arc-runner-set
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   govulncheck:
     name: govulncheck (Go SCA)
-    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     # Phase 22 W1.5 PR-8 fold-in (PR-170 8ce9c0b run cancelled at 5:13):
     # containerized runner 의 setup-go cache miss + go install govulncheck +
     # scan 이 5분 timeout 초과. 10분 으로 상향 (cache warm-up 후 정상 ~3분).


### PR DESCRIPTION
## 요약
- ready-for-ci full CI job이 잘못된 generic self-hosted runner로 대기하던 회귀를 복구합니다.
- CI, E2E, Security full CI 경로와 후속 required jobs를 실제 ARC RunnerScaleSet label인 arc-runner-set으로 되돌립니다.
- 원인 commit은 f93f32d / PR #321의 ready-for-ci self-hosted fallback 변경입니다.

## 검증
- rg -n "runs-on:.*self-hosted|runs-on: self-hosted" .github/workflows/ci.yml .github/workflows/e2e-stubbed.yml .github/workflows/security-fast.yml
- ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "yaml ok: #{p}" }' .github/workflows/ci.yml .github/workflows/e2e-stubbed.yml .github/workflows/security-fast.yml
- git diff --check

## CI scope
- full-ci: workflow-definition 변경입니다.

Closes #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 워크플로우의 러너 구성을 업데이트했습니다. 여러 지속적 통합 작업의 실행 환경 설정이 변경되었으며, 라벨 조건에 따른 적절한 실행 경로가 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->