### PR TITLE
chore(ci): #352 Playwright deps를 runner image에 사전 포함

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -87,6 +87,8 @@ jobs:
               node --version | grep -q "v20"
               # Image-resident GOMODCACHE pre-bake (apps/server/go.mod deps)
               [ -d /home/runner/go/pkg/mod/cache ] || (echo "FAIL: GOMODCACHE pre-bake missing" && exit 1)
+              # E2E workflows skip per-job apt install when this marker exists.
+              [ -f /opt/mmp-runner/playwright-deps-ready ] || (echo "FAIL: Playwright deps marker missing" && exit 1)
               # Hook 실행 후에도 pre-bake 데이터 보존 (image-resident 카논)
               touch /home/runner/go/pkg/mod/cache/sentinel
               bash /opt/runner-hooks/job-started.sh

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -300,6 +300,10 @@ jobs:
         continue-on-error: true
         working-directory: apps/web
         run: |
+          if [ -f /opt/mmp-runner/playwright-deps-ready ]; then
+            echo "Playwright system deps are pre-baked in the ARC runner image"
+            exit 0
+          fi
           timeout 480s bash -lc 'sudo apt-get update -y || true; pnpm exec playwright install-deps ${{ matrix.browser }}' || \
             echo "::warning::Playwright install-deps failed or timed out (likely ARC apt/deps flake); continuing without"
 

--- a/.github/workflows/flaky-report.yml
+++ b/.github/workflows/flaky-report.yml
@@ -139,6 +139,10 @@ jobs:
         continue-on-error: true
         working-directory: apps/web
         run: |
+          if [ -f /opt/mmp-runner/playwright-deps-ready ]; then
+            echo "Playwright system deps are pre-baked in the ARC runner image"
+            exit 0
+          fi
           timeout 480s bash -lc 'sudo apt-get update -y || true; pnpm exec playwright install-deps chromium' || \
             echo "::warning::Playwright install-deps failed or timed out (likely ARC apt/deps flake); continuing without"
 

--- a/.github/workflows/phase-18.1-real-backend.yml
+++ b/.github/workflows/phase-18.1-real-backend.yml
@@ -168,6 +168,10 @@ jobs:
         continue-on-error: true
         working-directory: apps/web
         run: |
+          if [ -f /opt/mmp-runner/playwright-deps-ready ]; then
+            echo "Playwright system deps are pre-baked in the ARC runner image"
+            exit 0
+          fi
           timeout 480s bash -lc 'sudo apt-get update -y || true; pnpm exec playwright install-deps chromium webkit' || \
             echo "::warning::Playwright install-deps failed or timed out (likely ARC apt/deps flake); continuing without"
 

--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -32,9 +32,12 @@ USER root
 
 # Phase 23 OS deps (jq + Playwright runtime libs) + docker CLI (DinD 사이드카 통신)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      jq libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
-      libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \
-      libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
+      jq libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 \
+      libcups2 libdbus-1-3 libdrm2 libx11-6 libx11-xcb1 libxcb1 \
+      libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \
+      libxrandr2 libxrender1 libxshmfence1 libxtst6 libgbm1 \
+      libgtk-3-0 libpango-1.0-0 libcairo2 libasound2t64 \
+      fonts-liberation fonts-noto-color-emoji fonts-unifont xdg-utils \
       build-essential \
       ca-certificates curl gnupg git \
     && install -m 0755 -d /etc/apt/keyrings \
@@ -44,6 +47,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli docker-buildx-plugin \
+    && mkdir -p /opt/mmp-runner \
+    && printf '%s\n' "chromium-webkit-system-deps" > /opt/mmp-runner/playwright-deps-ready \
     && rm -rf /var/lib/apt/lists/*
 
 # Phase 23 hostedtoolcache (Go 1.25 + Node 20.18) + govulncheck

--- a/infra/runners/README.md
+++ b/infra/runners/README.md
@@ -119,6 +119,13 @@ docker compose up -d
 | `go-build-cache` | `/home/runner/.cache/go-build` | Go build artifact cache |
 | `pnpm-store` | `/home/runner/.pnpm-store` | pnpm content-addressable store (workspace deps) |
 
+Playwright system dependency marker:
+- `/opt/mmp-runner/playwright-deps-ready`
+- E2E workflows detect this marker and skip the per-job `apt-get update` +
+  `playwright install-deps` fallback on ARC runners.
+- Browser binaries still use `PLAYWRIGHT_BROWSERS_PATH=/opt/cache/playwright`,
+  so Playwright package version drift stays controlled by the repo lockfile.
+
 ### 환경변수 (image ENV로 정의 — Dockerfile)
 
 `setup-go`/`setup-node` 가 PATH 자동 hit:


### PR DESCRIPTION
## 요약
- ARC runner image에 Playwright headless runtime dependency와 /opt/mmp-runner/playwright-deps-ready marker 추가
- E2E 관련 workflow가 marker 존재 시 per-job apt-get update + playwright install-deps fallback을 skip
- build-runner-image 검증에 marker 확인 추가

## 검증
- git diff --check HEAD~1 HEAD
- Ruby YAML parse: build-runner-image, e2e-stubbed, flaky-report, phase-18.1-real-backend
- docker buildx build --check -f infra/runners/Dockerfile .
- docker buildx build --load -f infra/runners/Dockerfile -t mmp-runner:playwright-deps-check .
- docker run marker 확인: /opt/mmp-runner/playwright-deps-ready 출력 확인

## 이미지 push
- 로컬 KT push 시도는 no basic auth credentials로 실패
- main merge 후 build-runner-image workflow가 repo secret으로 registry.cloud.kt.com/dldxu5p5/mmp-runner:latest 및 SHA tag를 push하는 경로 사용

Closes #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 워크플로우 최적화: E2E 테스트 실행 시 불필요한 의존성 재설치를 방지하여 파이프라인 성능을 개선했습니다. 사전 준비된 환경을 감지하고 중복 설치 단계를 건너뛰는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->