### PR TITLE
chore(ci): #354 runner image apt source hardening

### DIFF
--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -31,7 +31,8 @@ ARG NODE_VERSION=20.18.0
 USER root
 
 # Phase 23 OS deps (jq + Playwright runtime libs) + docker CLI (DinD 사이드카 통신)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN rm -f /etc/apt/sources.list.d/git-core-ubuntu-ppa*.list /etc/apt/sources.list.d/git-core-ubuntu-ppa*.sources \
+    && apt-get update && apt-get install -y --no-install-recommends \
       jq libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 \
       libcups2 libdbus-1-3 libdrm2 libx11-6 libx11-xcb1 libxcb1 \
       libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \


### PR DESCRIPTION
## 요약
- ARC runner image build가 inherited git-core PPA 지연에 묶이지 않도록 apt install 전 PPA source를 제거합니다.
- `.list`와 `.sources` 양쪽 파일명을 모두 제거해 actions-runner base image 변경에도 안전하게 대응합니다.

## 검증
- `git diff --check`
- `docker buildx build --check --platform linux/amd64 -f infra/runners/Dockerfile .`

Closes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 환경의 패키지 설치 프로세스를 개선하여 기존 소스 목록 충돌을 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->