### PR TITLE
feat(editor): 배경 이미지·컬러 테마 연출 cue 연결

### DIFF
--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -262,7 +262,7 @@ func main() {
 
 	// 11.2. GameStarter for room service.
 	broadcaster := &hubBroadcaster{hub: wsHub}
-	gameStarter := session.NewGameStarter(sessionMgr, broadcaster, cfg.GameRuntimeV2, logger)
+	gameStarter := session.NewGameStarter(sessionMgr, broadcaster, cfg.GameRuntimeV2, mediaSvc, logger)
 	roomSvc := room.NewServiceWithStarter(pool, queries, logger, gameStarter)
 	roomHandler := room.NewHandler(roomSvc)
 

--- a/apps/server/db/migrations/00033_media_image_type.sql
+++ b/apps/server/db/migrations/00033_media_image_type.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+ALTER TABLE theme_media DROP CONSTRAINT valid_media_type;
+ALTER TABLE theme_media ADD CONSTRAINT valid_media_type CHECK (type IN ('BGM', 'SFX', 'VOICE', 'VIDEO', 'DOCUMENT', 'IMAGE'));
+
+-- +goose Down
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM theme_media WHERE type = 'IMAGE') THEN
+    RAISE EXCEPTION 'Cannot downgrade: IMAGE media exists';
+  END IF;
+END $$;
+
+ALTER TABLE theme_media DROP CONSTRAINT valid_media_type;
+ALTER TABLE theme_media ADD CONSTRAINT valid_media_type CHECK (type IN ('BGM', 'SFX', 'VOICE', 'VIDEO', 'DOCUMENT'));

--- a/apps/server/db/queries/media.sql
+++ b/apps/server/db/queries/media.sql
@@ -11,6 +11,13 @@ SELECT * FROM theme_media WHERE theme_id = $1 AND type = $2 ORDER BY sort_order,
 -- name: GetMedia :one
 SELECT * FROM theme_media WHERE id = $1;
 
+-- name: GetMediaForSession :one
+SELECT m.*
+FROM theme_media m
+JOIN game_sessions s ON s.theme_id = m.theme_id
+WHERE s.id = sqlc.arg('session_id')
+  AND m.id = sqlc.arg('media_id');
+
 -- name: CreateMedia :one
 INSERT INTO theme_media (theme_id, name, type, source_type, url, storage_key, duration, file_size, mime_type, tags, sort_order)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)

--- a/apps/server/internal/db/media.sql.go
+++ b/apps/server/internal/db/media.sql.go
@@ -168,6 +168,41 @@ func (q *Queries) GetMedia(ctx context.Context, id uuid.UUID) (ThemeMedium, erro
 	return i, err
 }
 
+const getMediaForSession = `-- name: GetMediaForSession :one
+SELECT m.id, m.theme_id, m.name, m.type, m.source_type, m.url, m.storage_key, m.duration, m.file_size, m.mime_type, m.tags, m.sort_order, m.created_at, m.updated_at
+FROM theme_media m
+JOIN game_sessions s ON s.theme_id = m.theme_id
+WHERE s.id = $1
+  AND m.id = $2
+`
+
+type GetMediaForSessionParams struct {
+	SessionID uuid.UUID `json:"session_id"`
+	MediaID   uuid.UUID `json:"media_id"`
+}
+
+func (q *Queries) GetMediaForSession(ctx context.Context, arg GetMediaForSessionParams) (ThemeMedium, error) {
+	row := q.db.QueryRow(ctx, getMediaForSession, arg.SessionID, arg.MediaID)
+	var i ThemeMedium
+	err := row.Scan(
+		&i.ID,
+		&i.ThemeID,
+		&i.Name,
+		&i.Type,
+		&i.SourceType,
+		&i.Url,
+		&i.StorageKey,
+		&i.Duration,
+		&i.FileSize,
+		&i.MimeType,
+		&i.Tags,
+		&i.SortOrder,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getMediaWithOwner = `-- name: GetMediaWithOwner :one
 
 SELECT m.id, m.theme_id, m.name, m.type, m.source_type, m.url, m.storage_key, m.duration, m.file_size, m.mime_type, m.tags, m.sort_order, m.created_at, m.updated_at FROM theme_media m

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -41,6 +41,7 @@ type MediaService interface {
 type mediaQueries interface {
 	GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error)
 	GetMedia(ctx context.Context, id uuid.UUID) (db.ThemeMedium, error)
+	GetMediaForSession(ctx context.Context, arg db.GetMediaForSessionParams) (db.ThemeMedium, error)
 	GetMediaWithOwner(ctx context.Context, arg db.GetMediaWithOwnerParams) (db.ThemeMedium, error)
 	ListMediaByTheme(ctx context.Context, themeID uuid.UUID) ([]db.ThemeMedium, error)
 	ListMediaByThemeAndType(ctx context.Context, arg db.ListMediaByThemeAndTypeParams) ([]db.ThemeMedium, error)
@@ -379,6 +380,10 @@ func (s *mediaService) UpdateMedia(ctx context.Context, creatorID, mediaID uuid.
 		return nil, apperror.Internal("failed to get media")
 	}
 
+	if req.Type != media.Type {
+		return nil, apperror.New(apperror.ErrMediaInvalidType, 422, "media type cannot be changed")
+	}
+
 	tags := req.Tags
 	if tags == nil {
 		tags = []string{}
@@ -524,13 +529,19 @@ func (s *mediaService) GetMediaPlayURL(ctx context.Context, sessionID, mediaID u
 }
 
 func (s *mediaService) ResolveMediaURL(ctx context.Context, sessionID, mediaID uuid.UUID, allowedTypes ...string) (string, string, error) {
-	_ = sessionID // sessionID reserved for future authorization (e.g. session→theme binding)
-	media, err := s.q.GetMedia(ctx, mediaID)
+	media, err := s.q.GetMediaForSession(ctx, db.GetMediaForSessionParams{
+		SessionID: sessionID,
+		MediaID:   mediaID,
+	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return "", "", apperror.NotFound("media not found")
 		}
-		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to get media")
+		s.logger.Error().
+			Err(err).
+			Str("session_id", sessionID.String()).
+			Str("media_id", mediaID.String()).
+			Msg("failed to get media for session")
 		return "", "", apperror.Internal("failed to get media")
 	}
 

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -32,6 +32,7 @@ type MediaService interface {
 	DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID) error
 	GetEditorMediaDownloadURL(ctx context.Context, creatorID, mediaID uuid.UUID) (*MediaDownloadURLResponse, error)
 	GetMediaPlayURL(ctx context.Context, sessionID, mediaID uuid.UUID) (string, error)
+	ResolveMediaURL(ctx context.Context, sessionID, mediaID uuid.UUID, allowedTypes ...string) (string, string, error)
 }
 
 // mediaQueries is the subset of db.Queries that mediaService depends on.
@@ -518,38 +519,55 @@ func (s *mediaService) GetEditorMediaDownloadURL(ctx context.Context, creatorID,
 // --- GetMediaPlayURL ---
 
 func (s *mediaService) GetMediaPlayURL(ctx context.Context, sessionID, mediaID uuid.UUID) (string, error) {
-	_ = sessionID // sessionID reserved for future authorization (e.g. session→theme binding)
+	url, _, err := s.ResolveMediaURL(ctx, sessionID, mediaID)
+	return url, err
+}
 
+func (s *mediaService) ResolveMediaURL(ctx context.Context, sessionID, mediaID uuid.UUID, allowedTypes ...string) (string, string, error) {
+	_ = sessionID // sessionID reserved for future authorization (e.g. session→theme binding)
 	media, err := s.q.GetMedia(ctx, mediaID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", apperror.NotFound("media not found")
+			return "", "", apperror.NotFound("media not found")
 		}
 		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to get media")
-		return "", apperror.Internal("failed to get media")
+		return "", "", apperror.Internal("failed to get media")
+	}
+
+	if len(allowedTypes) > 0 {
+		allowed := false
+		for _, t := range allowedTypes {
+			if media.Type == t {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return "", "", apperror.New(apperror.ErrMediaInvalidType, 422, "media type is not allowed for this action")
+		}
 	}
 
 	switch media.SourceType {
 	case SourceTypeYouTube:
 		if !media.Url.Valid {
-			return "", apperror.Internal("media has no url")
+			return "", "", apperror.Internal("media has no url")
 		}
-		return media.Url.String, nil
+		return media.Url.String, SourceTypeYouTube, nil
 	case SourceTypeFile:
 		if !media.StorageKey.Valid {
-			return "", apperror.Internal("media has no storage key")
+			return "", "", apperror.Internal("media has no storage key")
 		}
 		if err := s.requireStorage(); err != nil {
-			return "", err
+			return "", "", err
 		}
 		url, err := s.storage.GenerateDownloadURL(ctx, media.StorageKey.String, 15*time.Minute)
 		if err != nil {
 			s.logger.Error().Err(err).Str("storage_key", media.StorageKey.String).Msg("failed to generate download URL")
-			return "", apperror.Internal("failed to generate download URL")
+			return "", "", apperror.Internal("failed to generate download URL")
 		}
-		return url, nil
+		return url, SourceTypeFile, nil
 	default:
-		return "", apperror.Internal("unknown media source type")
+		return "", "", apperror.Internal("unknown media source type")
 	}
 }
 
@@ -654,6 +672,10 @@ func uploadExtensionFor(mediaType, mimeType string) (string, bool) {
 		ext, ok := AllowedDocumentMIMEs[mimeType]
 		return ext, ok
 	}
+	if mediaType == MediaTypeImage {
+		ext, ok := AllowedMediaImageMIMEs[mimeType]
+		return ext, ok
+	}
 	ext, ok := AllowedAudioMIMEs[mimeType]
 	return ext, ok
 }
@@ -661,6 +683,9 @@ func uploadExtensionFor(mediaType, mimeType string) (string, bool) {
 func validateMediaMagicBytes(header []byte, mediaType, declaredMime string) error {
 	if mediaType == MediaTypeDocument {
 		return validateDocumentMagicBytes(header, declaredMime)
+	}
+	if mediaType == MediaTypeImage {
+		return validateImageMagicBytes(header, declaredMime)
 	}
 	return validateAudioMagicBytes(header, declaredMime)
 }
@@ -690,6 +715,30 @@ func validateAudioMagicBytes(header []byte, declaredMime string) error {
 func validateDocumentMagicBytes(header []byte, declaredMime string) error {
 	if declaredMime == "application/pdf" && len(header) >= 5 && string(header[:5]) == "%PDF-" {
 		return nil
+	}
+	return apperror.New(apperror.ErrMediaInvalidType, 422, "file content does not match declared type")
+}
+
+func validateImageMagicBytes(header []byte, declaredMime string) error {
+	switch declaredMime {
+	case "image/jpeg":
+		if len(header) >= 3 && header[0] == 0xFF && header[1] == 0xD8 && header[2] == 0xFF {
+			return nil
+		}
+	case "image/png":
+		if len(header) >= 8 &&
+			header[0] == 0x89 &&
+			string(header[1:4]) == "PNG" &&
+			header[4] == 0x0D &&
+			header[5] == 0x0A &&
+			header[6] == 0x1A &&
+			header[7] == 0x0A {
+			return nil
+		}
+	case "image/webp":
+		if len(header) >= 12 && string(header[:4]) == "RIFF" && string(header[8:12]) == "WEBP" {
+			return nil
+		}
 	}
 	return apperror.New(apperror.ErrMediaInvalidType, 422, "file content does not match declared type")
 }

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -24,6 +24,7 @@ import (
 type fakeMediaQueries struct {
 	themes        map[uuid.UUID]db.Theme
 	media         map[uuid.UUID]db.ThemeMedium
+	sessions      map[uuid.UUID]db.GameSession
 	sections      map[uuid.UUID]db.ReadingSection
 	roleSheetRefs map[uuid.UUID][]db.FindRoleSheetReferencesForMediaRow
 }
@@ -32,6 +33,7 @@ func newFakeMediaQueries() *fakeMediaQueries {
 	return &fakeMediaQueries{
 		themes:        make(map[uuid.UUID]db.Theme),
 		media:         make(map[uuid.UUID]db.ThemeMedium),
+		sessions:      make(map[uuid.UUID]db.GameSession),
 		sections:      make(map[uuid.UUID]db.ReadingSection),
 		roleSheetRefs: make(map[uuid.UUID][]db.FindRoleSheetReferencesForMediaRow),
 	}
@@ -51,6 +53,18 @@ func (f *fakeMediaQueries) GetMedia(_ context.Context, id uuid.UUID) (db.ThemeMe
 		return db.ThemeMedium{}, pgx.ErrNoRows
 	}
 	return m, nil
+}
+
+func (f *fakeMediaQueries) GetMediaForSession(_ context.Context, arg db.GetMediaForSessionParams) (db.ThemeMedium, error) {
+	session, ok := f.sessions[arg.SessionID]
+	if !ok {
+		return db.ThemeMedium{}, pgx.ErrNoRows
+	}
+	media, ok := f.media[arg.MediaID]
+	if !ok || media.ThemeID != session.ThemeID {
+		return db.ThemeMedium{}, pgx.ErrNoRows
+	}
+	return media, nil
 }
 
 func (f *fakeMediaQueries) GetMediaWithOwner(_ context.Context, arg db.GetMediaWithOwnerParams) (db.ThemeMedium, error) {
@@ -281,6 +295,21 @@ func seedMedia(q *fakeMediaQueries, themeID uuid.UUID, mediaType string) uuid.UU
 	return id
 }
 
+func seedFileMedia(q *fakeMediaQueries, themeID uuid.UUID, mediaType string) uuid.UUID {
+	id := uuid.New()
+	q.media[id] = db.ThemeMedium{
+		ID:         id,
+		ThemeID:    themeID,
+		Name:       "media",
+		Type:       mediaType,
+		SourceType: SourceTypeFile,
+		StorageKey: pgtype.Text{String: "themes/" + themeID.String() + "/media/" + id.String() + ".png", Valid: true},
+		FileSize:   pgtype.Int8{Int64: 1024, Valid: true},
+		MimeType:   pgtype.Text{String: "image/png", Valid: true},
+	}
+	return id
+}
+
 func assertMediaAppCode(t *testing.T, err error, want string) {
 	t.Helper()
 	if err == nil {
@@ -293,6 +322,44 @@ func assertMediaAppCode(t *testing.T, err error, want string) {
 	if appErr.Code != want {
 		t.Fatalf("expected error code %q, got %q (detail=%s)", want, appErr.Code, appErr.Detail)
 	}
+}
+
+func TestMediaService_UpdateMedia_RejectsTypeChange(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeBGM)
+
+	_, err := svc.UpdateMedia(context.Background(), creatorID, mediaID, UpdateMediaRequest{
+		Name:      "relabel",
+		Type:      MediaTypeImage,
+		Tags:      []string{},
+		SortOrder: 0,
+	})
+	assertMediaAppCode(t, err, apperror.ErrMediaInvalidType)
+	if got := q.media[mediaID].Type; got != MediaTypeBGM {
+		t.Fatalf("media type changed to %q", got)
+	}
+}
+
+func TestMediaService_ResolveMediaURL_BindsMediaToSessionTheme(t *testing.T) {
+	svc, q, _, themeID := newMediaTestService(t)
+	otherThemeID := uuid.New()
+	q.themes[otherThemeID] = db.Theme{ID: otherThemeID, CreatorID: uuid.New()}
+	sessionID := uuid.New()
+	q.sessions[sessionID] = db.GameSession{ID: sessionID, ThemeID: themeID}
+	mediaID := seedFileMedia(q, themeID, MediaTypeImage)
+	otherMediaID := seedFileMedia(q, otherThemeID, MediaTypeImage)
+	svc.storage = newFakeStorageProvider()
+
+	url, sourceType, err := svc.ResolveMediaURL(context.Background(), sessionID, mediaID, MediaTypeImage)
+	if err != nil {
+		t.Fatalf("ResolveMediaURL same-theme media: %v", err)
+	}
+	if url == "" || sourceType != SourceTypeFile {
+		t.Fatalf("unexpected resolve result: url=%q sourceType=%q", url, sourceType)
+	}
+
+	_, _, err = svc.ResolveMediaURL(context.Background(), sessionID, otherMediaID, MediaTypeImage)
+	assertMediaAppCode(t, err, apperror.ErrNotFound)
 }
 
 // --- DeleteMedia reference-check tests ---

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -431,6 +431,55 @@ func TestMediaService_RequestUploadURL_DocumentPDFSuccess(t *testing.T) {
 	}
 }
 
+func TestMediaService_RequestUploadURL_ImageSuccess(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+
+	resp, err := svc.RequestUpload(context.Background(), creatorID, themeID, RequestMediaUploadRequest{
+		Name:     "background.png",
+		Type:     MediaTypeImage,
+		MimeType: "image/png",
+		FileSize: 1024,
+	})
+	if err != nil {
+		t.Fatalf("RequestUpload IMAGE/png: %v", err)
+	}
+	created := q.media[resp.UploadID]
+	if created.Type != MediaTypeImage || !created.StorageKey.Valid || !strings.HasSuffix(created.StorageKey.String, ".png") {
+		t.Fatalf("unexpected image media row: %#v", created)
+	}
+}
+
+func TestMediaService_ConfirmUpload_ImageMagicBytes(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	mediaID := uuid.New()
+	storageKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + ".png"
+	header := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 'b', 'o', 'd', 'y'}
+	q.media[mediaID] = db.ThemeMedium{
+		ID:         mediaID,
+		ThemeID:    themeID,
+		Name:       "background.png",
+		Type:       MediaTypeImage,
+		SourceType: SourceTypeFile,
+		StorageKey: pgtype.Text{String: storageKey, Valid: true},
+		FileSize:   pgtype.Int8{Int64: int64(len(header)), Valid: true},
+		MimeType:   pgtype.Text{String: "image/png", Valid: true},
+		Tags:       []string{},
+	}
+	st.objects[storageKey] = header
+
+	resp, err := svc.ConfirmUpload(context.Background(), creatorID, themeID, ConfirmUploadRequest{UploadID: mediaID})
+	if err != nil {
+		t.Fatalf("ConfirmUpload IMAGE/png: %v", err)
+	}
+	if resp.Type != MediaTypeImage || resp.MimeType == nil || *resp.MimeType != "image/png" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+}
+
 func TestMediaService_ConfirmUpload_DocumentPDFMagicBytes(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	st := newFakeStorageProvider()

--- a/apps/server/internal/domain/editor/media_types.go
+++ b/apps/server/internal/domain/editor/media_types.go
@@ -18,6 +18,7 @@ const (
 	MediaTypeVoice    = "VOICE"
 	MediaTypeVideo    = "VIDEO"
 	MediaTypeDocument = "DOCUMENT"
+	MediaTypeImage    = "IMAGE"
 
 	SourceTypeFile    = "FILE"
 	SourceTypeYouTube = "YOUTUBE"
@@ -35,9 +36,15 @@ var AllowedDocumentMIMEs = map[string]string{
 	"application/pdf": ".pdf",
 }
 
+var AllowedMediaImageMIMEs = map[string]string{
+	"image/jpeg": ".jpg",
+	"image/png":  ".png",
+	"image/webp": ".webp",
+}
+
 type RequestMediaUploadRequest struct {
 	Name     string `json:"name" validate:"required,min=1,max=200"`
-	Type     string `json:"type" validate:"required,oneof=BGM SFX VOICE VIDEO DOCUMENT"`
+	Type     string `json:"type" validate:"required,oneof=BGM SFX VOICE VIDEO DOCUMENT IMAGE"`
 	MimeType string `json:"mime_type" validate:"required"`
 	FileSize int64  `json:"file_size" validate:"required,min=1"`
 }
@@ -65,7 +72,7 @@ type CreateMediaYouTubeRequest struct {
 
 type UpdateMediaRequest struct {
 	Name      string   `json:"name" validate:"required,min=1,max=200"`
-	Type      string   `json:"type" validate:"required,oneof=BGM SFX VOICE VIDEO DOCUMENT"`
+	Type      string   `json:"type" validate:"required,oneof=BGM SFX VOICE VIDEO DOCUMENT IMAGE"`
 	Duration  *int32   `json:"duration,omitempty"`
 	Tags      []string `json:"tags" validate:"max=10,dive,max=50"`
 	SortOrder int32    `json:"sort_order" validate:"min=0"`

--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -200,6 +200,8 @@ func ensureImplicitPhaseActionModules(cfg *GameConfig) error {
 		ActionPlayMedia,
 		ActionSetBGM,
 		ActionStopAudio,
+		ActionSetBackground,
+		ActionSetThemeColor,
 	}
 	for _, action := range implicitActions {
 		moduleName, ok := ActionRequiresModule[action]

--- a/apps/server/internal/engine/factory_test.go
+++ b/apps/server/internal/engine/factory_test.go
@@ -237,6 +237,17 @@ func TestParseGameConfig_AddsAudioModuleForPresentationAction(t *testing.T) {
 	}
 }
 
+func TestParseGameConfig_AddsPresentationModuleForVisualActions(t *testing.T) {
+	data := []byte(`{"phases":[{"id":"intro","name":"Intro","onEnter":[{"type":"SET_BACKGROUND","params":{"mediaId":"image-1"}},{"type":"set_theme_color","params":{"themeToken":"tension"}}]}],"modules":[]}`)
+	cfg, err := ParseGameConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Modules) != 1 || cfg.Modules[0].Name != "presentation" {
+		t.Fatalf("implicit modules = %#v", cfg.Modules)
+	}
+}
+
 func TestParseGameConfig_DoesNotDuplicateImplicitEndingBranchModule(t *testing.T) {
 	data := []byte(`{"phases":[{"id":"final","name":"Final","onEnter":[{"type":"EVALUATE_ENDING"}]}],"modules":[{"name":"ending_branch","config":{"defaultEnding":"미해결"}}]}`)
 	cfg, err := ParseGameConfig(data)

--- a/apps/server/internal/engine/phase_actions.go
+++ b/apps/server/internal/engine/phase_actions.go
@@ -153,6 +153,8 @@ var legacyPhaseActionAliases = map[string]PhaseAction{
 	"set_bgm":             ActionSetBGM,
 	"play_sound":          ActionPlaySound,
 	"play_media":          ActionPlayMedia,
+	"set_background":      ActionSetBackground,
+	"set_theme_color":     ActionSetThemeColor,
 	"stop_bgm":            ActionStopAudio,
 	"stop_audio":          ActionStopAudio,
 	"broadcast":           ActionBroadcastMessage,

--- a/apps/server/internal/engine/phase_engine.go
+++ b/apps/server/internal/engine/phase_engine.go
@@ -38,6 +38,7 @@ type PhaseEngine struct {
 	audit              AuditLogger
 	logger             Logger
 	playerInfoProvider PlayerInfoProvider
+	mediaResolver      MediaResolver
 	phases             []PhaseDefinition
 	sceneTransitions   []SceneTransition
 	current            int // index into phases, -1 = not started
@@ -88,6 +89,10 @@ func (e *PhaseEngine) SetPlayerInfoProvider(provider PlayerInfoProvider) {
 	e.playerInfoProvider = provider
 }
 
+func (e *PhaseEngine) SetMediaResolver(resolver MediaResolver) {
+	e.mediaResolver = resolver
+}
+
 // Start initialises all modules and enters the first phase.
 func (e *PhaseEngine) Start(ctx context.Context, moduleConfigs map[string]json.RawMessage) error {
 	if e.started {
@@ -104,6 +109,7 @@ func (e *PhaseEngine) Start(ctx context.Context, moduleConfigs map[string]json.R
 		PlayerInfoProvider: e.playerInfoProvider,
 		ActionDispatcher:   e,
 		SceneController:    e,
+		MediaResolver:      e.mediaResolver,
 	}
 
 	for _, mod := range e.modules {

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -25,6 +25,8 @@ const (
 	ActionPlayMedia           PhaseAction = "PLAY_MEDIA"
 	ActionSetBGM              PhaseAction = "SET_BGM"
 	ActionStopAudio           PhaseAction = "STOP_AUDIO"
+	ActionSetBackground       PhaseAction = "SET_BACKGROUND"
+	ActionSetThemeColor       PhaseAction = "SET_THEME_COLOR"
 	ActionMuteChat            PhaseAction = "MUTE_CHAT"
 	ActionUnmuteChat          PhaseAction = "UNMUTE_CHAT"
 	ActionOpenGroupChat       PhaseAction = "OPEN_GROUP_CHAT"
@@ -72,6 +74,8 @@ var ActionRequiresModule = map[PhaseAction]string{
 	ActionPlayMedia:           "audio",
 	ActionSetBGM:              "audio",
 	ActionStopAudio:           "audio",
+	ActionSetBackground:       "presentation",
+	ActionSetThemeColor:       "presentation",
 }
 
 // --- Module Interfaces ---
@@ -181,6 +185,12 @@ type SceneController interface {
 	SkipToPhase(ctx context.Context, phaseID string) error
 }
 
+// MediaResolver resolves editor-managed media into runtime-safe URLs.
+// Runtime modules use this instead of trusting creator-facing action params.
+type MediaResolver interface {
+	ResolveMediaURL(ctx context.Context, sessionID, mediaID uuid.UUID, allowedTypes ...string) (url string, sourceType string, err error)
+}
+
 // ConfigSchema is an optional interface for modules that expose their settings schema.
 // Used by the editor to auto-generate UI.
 type ConfigSchema interface {
@@ -219,6 +229,7 @@ type ModuleDeps struct {
 	PlayerInfoProvider PlayerInfoProvider
 	ActionDispatcher   PhaseActionDispatcher
 	SceneController    SceneController
+	MediaResolver      MediaResolver
 }
 
 // ModuleFactory creates a new module instance per session (no singletons).

--- a/apps/server/internal/module/media/presentation.go
+++ b/apps/server/internal/module/media/presentation.go
@@ -45,10 +45,19 @@ func (m *PresentationModule) BuildState() (json.RawMessage, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return json.Marshal(map[string]any{
+	state := map[string]any{
 		"backgroundMediaId": m.backgroundMediaID,
 		"themeToken":        m.themeToken,
-	})
+	}
+	if m.backgroundMediaID != "" {
+		url, sourceType, err := m.resolveBackgroundLocked(context.Background(), m.backgroundMediaID)
+		if err != nil {
+			return nil, err
+		}
+		state["backgroundMediaUrl"] = url
+		state["backgroundSourceType"] = sourceType
+	}
+	return json.Marshal(state)
 }
 
 func (m *PresentationModule) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
@@ -89,11 +98,11 @@ func (m *PresentationModule) ReactTo(ctx context.Context, action engine.PhaseAct
 		if m.deps.MediaResolver == nil {
 			return fmt.Errorf("presentation: media resolver is not configured")
 		}
-		m.backgroundMediaID = p.MediaID
 		url, sourceType, err := m.deps.MediaResolver.ResolveMediaURL(ctx, m.deps.SessionID, mediaID, "IMAGE")
 		if err != nil {
 			return fmt.Errorf("presentation: resolve background media: %w", err)
 		}
+		m.backgroundMediaID = p.MediaID
 		params, _ := json.Marshal(map[string]any{
 			"mediaId":    p.MediaID,
 			"sourceType": sourceType,
@@ -123,6 +132,21 @@ func (m *PresentationModule) ReactTo(ctx context.Context, action engine.PhaseAct
 		Payload: json.RawMessage(action.Params),
 	})
 	return nil
+}
+
+func (m *PresentationModule) resolveBackgroundLocked(ctx context.Context, mediaIDText string) (string, string, error) {
+	mediaID, err := uuid.Parse(mediaIDText)
+	if err != nil {
+		return "", "", fmt.Errorf("presentation: invalid background mediaId")
+	}
+	if m.deps.MediaResolver == nil {
+		return "", "", fmt.Errorf("presentation: media resolver is not configured")
+	}
+	url, sourceType, err := m.deps.MediaResolver.ResolveMediaURL(ctx, m.deps.SessionID, mediaID, "IMAGE")
+	if err != nil {
+		return "", "", fmt.Errorf("presentation: resolve background media: %w", err)
+	}
+	return url, sourceType, nil
 }
 
 var (

--- a/apps/server/internal/module/media/presentation.go
+++ b/apps/server/internal/module/media/presentation.go
@@ -1,0 +1,132 @@
+package media
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func init() {
+	engine.Register("presentation", func() engine.Module { return NewPresentationModule() })
+}
+
+// PresentationModule reacts to visual presentation PhaseActions.
+//
+// The state is public: background and color-theme cues are intentionally shared
+// by every player in a session.
+type PresentationModule struct {
+	engine.PublicStateMarker
+
+	mu                sync.RWMutex
+	deps              engine.ModuleDeps
+	backgroundMediaID string
+	themeToken        string
+}
+
+func NewPresentationModule() *PresentationModule {
+	return &PresentationModule{}
+}
+
+func (m *PresentationModule) Name() string { return "presentation" }
+
+func (m *PresentationModule) Init(_ context.Context, deps engine.ModuleDeps, _ json.RawMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deps = deps
+	return nil
+}
+
+func (m *PresentationModule) BuildState() (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return json.Marshal(map[string]any{
+		"backgroundMediaId": m.backgroundMediaID,
+		"themeToken":        m.themeToken,
+	})
+}
+
+func (m *PresentationModule) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
+	return fmt.Errorf("presentation: no direct messages supported")
+}
+
+func (m *PresentationModule) Cleanup(_ context.Context) error {
+	return nil
+}
+
+func (m *PresentationModule) SupportedActions() []engine.PhaseAction {
+	return []engine.PhaseAction{
+		engine.ActionSetBackground,
+		engine.ActionSetThemeColor,
+	}
+}
+
+func (m *PresentationModule) ReactTo(ctx context.Context, action engine.PhaseActionPayload) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	eventType := ""
+	switch action.Action {
+	case engine.ActionSetBackground:
+		eventType = "presentation.set_background"
+		var p struct {
+			MediaID string `json:"mediaId"`
+		}
+		if len(action.Params) > 0 {
+			if err := json.Unmarshal(action.Params, &p); err != nil {
+				return fmt.Errorf("presentation: invalid SET_BACKGROUND params: %w", err)
+			}
+		}
+		mediaID, err := uuid.Parse(p.MediaID)
+		if err != nil {
+			return fmt.Errorf("presentation: SET_BACKGROUND requires mediaId")
+		}
+		if m.deps.MediaResolver == nil {
+			return fmt.Errorf("presentation: media resolver is not configured")
+		}
+		m.backgroundMediaID = p.MediaID
+		url, sourceType, err := m.deps.MediaResolver.ResolveMediaURL(ctx, m.deps.SessionID, mediaID, "IMAGE")
+		if err != nil {
+			return fmt.Errorf("presentation: resolve background media: %w", err)
+		}
+		params, _ := json.Marshal(map[string]any{
+			"mediaId":    p.MediaID,
+			"sourceType": sourceType,
+			"url":        url,
+		})
+		action.Params = params
+	case engine.ActionSetThemeColor:
+		eventType = "presentation.set_theme_color"
+		var p struct {
+			ThemeToken string `json:"themeToken"`
+		}
+		if len(action.Params) > 0 {
+			if err := json.Unmarshal(action.Params, &p); err != nil {
+				return fmt.Errorf("presentation: invalid SET_THEME_COLOR params: %w", err)
+			}
+		}
+		if p.ThemeToken == "" {
+			return fmt.Errorf("presentation: SET_THEME_COLOR requires themeToken")
+		}
+		m.themeToken = p.ThemeToken
+	default:
+		return fmt.Errorf("presentation: unsupported action %q", action.Action)
+	}
+
+	m.deps.EventBus.Publish(engine.Event{
+		Type:    eventType,
+		Payload: json.RawMessage(action.Params),
+	})
+	return nil
+}
+
+var (
+	_ engine.Module            = (*PresentationModule)(nil)
+	_ engine.PublicStateModule = (*PresentationModule)(nil)
+	_ engine.PhaseReactor      = (*PresentationModule)(nil)
+)

--- a/apps/server/internal/module/media/presentation_test.go
+++ b/apps/server/internal/module/media/presentation_test.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -73,12 +74,17 @@ func TestPresentationModule_ReactTo_SetBackground(t *testing.T) {
 	}
 	var parsed struct {
 		BackgroundMediaID string `json:"backgroundMediaId"`
+		BackgroundURL     string `json:"backgroundMediaUrl"`
+		BackgroundSource  string `json:"backgroundSourceType"`
 	}
 	if err := json.Unmarshal(state, &parsed); err != nil {
 		t.Fatalf("Unmarshal state: %v", err)
 	}
 	if parsed.BackgroundMediaID != mediaID.String() {
 		t.Fatalf("backgroundMediaId = %q, want %s", parsed.BackgroundMediaID, mediaID.String())
+	}
+	if parsed.BackgroundURL != "https://cdn.example/background.png" || parsed.BackgroundSource != "FILE" {
+		t.Fatalf("background snapshot = %#v", parsed)
 	}
 }
 
@@ -111,6 +117,37 @@ func TestPresentationModule_ReactTo_SetBackgroundRequiresResolverAndMediaID(t *t
 	}
 }
 
+func TestPresentationModule_ReactTo_SetBackgroundDoesNotCommitOnResolveFailure(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	deps.MediaResolver = &fakeMediaResolver{err: errors.New("missing media")}
+	m := NewPresentationModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	params, _ := json.Marshal(map[string]any{"mediaId": uuid.NewString()})
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionSetBackground,
+		Params: params,
+	}); err == nil {
+		t.Fatal("expected resolve error")
+	}
+
+	state, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	var parsed struct {
+		BackgroundMediaID string `json:"backgroundMediaId"`
+	}
+	if err := json.Unmarshal(state, &parsed); err != nil {
+		t.Fatalf("Unmarshal state: %v", err)
+	}
+	if parsed.BackgroundMediaID != "" {
+		t.Fatalf("backgroundMediaId = %q, want empty after failed resolve", parsed.BackgroundMediaID)
+	}
+}
+
 func TestPresentationModule_ReactTo_SetThemeColor(t *testing.T) {
 	deps, bus := newTestDeps(t)
 	m := NewPresentationModule()
@@ -132,8 +169,17 @@ func TestPresentationModule_ReactTo_SetThemeColor(t *testing.T) {
 	}
 
 	select {
-	case <-received:
-		// ok
+	case e := <-received:
+		payload, _ := e.Payload.(json.RawMessage)
+		var parsedPayload struct {
+			ThemeToken string `json:"themeToken"`
+		}
+		if err := json.Unmarshal(payload, &parsedPayload); err != nil {
+			t.Fatalf("Unmarshal payload: %v", err)
+		}
+		if parsedPayload.ThemeToken != "tension" {
+			t.Fatalf("payload themeToken = %q, want tension", parsedPayload.ThemeToken)
+		}
 	default:
 		t.Fatal("expected presentation.set_theme_color event")
 	}

--- a/apps/server/internal/module/media/presentation_test.go
+++ b/apps/server/internal/module/media/presentation_test.go
@@ -1,0 +1,170 @@
+package media
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+type fakeMediaResolver struct {
+	url        string
+	sourceType string
+	err        error
+	calledType string
+}
+
+func (f *fakeMediaResolver) ResolveMediaURL(_ context.Context, _ uuid.UUID, _ uuid.UUID, allowedTypes ...string) (string, string, error) {
+	if len(allowedTypes) > 0 {
+		f.calledType = allowedTypes[0]
+	}
+	return f.url, f.sourceType, f.err
+}
+
+func TestPresentationModule_ReactTo_SetBackground(t *testing.T) {
+	deps, bus := newTestDeps(t)
+	mediaID := uuid.New()
+	resolver := &fakeMediaResolver{url: "https://cdn.example/background.png", sourceType: "FILE"}
+	deps.MediaResolver = resolver
+	m := NewPresentationModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	received := make(chan engine.Event, 1)
+	bus.Subscribe("presentation.set_background", func(e engine.Event) {
+		received <- e
+	})
+
+	params, _ := json.Marshal(map[string]any{"mediaId": mediaID.String()})
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionSetBackground,
+		Params: params,
+	}); err != nil {
+		t.Fatalf("ReactTo: %v", err)
+	}
+
+	select {
+	case e := <-received:
+		payload, _ := e.Payload.(json.RawMessage)
+		var parsedPayload struct {
+			MediaID    string `json:"mediaId"`
+			SourceType string `json:"sourceType"`
+			URL        string `json:"url"`
+		}
+		if err := json.Unmarshal(payload, &parsedPayload); err != nil {
+			t.Fatalf("Unmarshal payload: %v", err)
+		}
+		if parsedPayload.MediaID != mediaID.String() || parsedPayload.URL == "" || parsedPayload.SourceType != "FILE" {
+			t.Fatalf("payload = %#v", parsedPayload)
+		}
+	default:
+		t.Fatal("expected presentation.set_background event")
+	}
+	if resolver.calledType != "IMAGE" {
+		t.Fatalf("allowed type = %q, want IMAGE", resolver.calledType)
+	}
+
+	state, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	var parsed struct {
+		BackgroundMediaID string `json:"backgroundMediaId"`
+	}
+	if err := json.Unmarshal(state, &parsed); err != nil {
+		t.Fatalf("Unmarshal state: %v", err)
+	}
+	if parsed.BackgroundMediaID != mediaID.String() {
+		t.Fatalf("backgroundMediaId = %q, want %s", parsed.BackgroundMediaID, mediaID.String())
+	}
+}
+
+func TestPresentationModule_ReactTo_SetBackgroundRequiresResolverAndMediaID(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	m := NewPresentationModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	params, _ := json.Marshal(map[string]any{"mediaId": uuid.NewString()})
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionSetBackground,
+		Params: params,
+	}); err == nil {
+		t.Fatal("expected missing resolver error")
+	}
+
+	deps.MediaResolver = &fakeMediaResolver{url: "https://cdn.example/background.png", sourceType: "FILE"}
+	m = NewPresentationModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init with resolver: %v", err)
+	}
+	params, _ = json.Marshal(map[string]any{"mediaId": ""})
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionSetBackground,
+		Params: params,
+	}); err == nil {
+		t.Fatal("expected missing mediaId error")
+	}
+}
+
+func TestPresentationModule_ReactTo_SetThemeColor(t *testing.T) {
+	deps, bus := newTestDeps(t)
+	m := NewPresentationModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	received := make(chan engine.Event, 1)
+	bus.Subscribe("presentation.set_theme_color", func(e engine.Event) {
+		received <- e
+	})
+
+	params, _ := json.Marshal(map[string]any{"themeToken": "tension"})
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionSetThemeColor,
+		Params: params,
+	}); err != nil {
+		t.Fatalf("ReactTo: %v", err)
+	}
+
+	select {
+	case <-received:
+		// ok
+	default:
+		t.Fatal("expected presentation.set_theme_color event")
+	}
+
+	state, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	var parsed struct {
+		ThemeToken string `json:"themeToken"`
+	}
+	if err := json.Unmarshal(state, &parsed); err != nil {
+		t.Fatalf("Unmarshal state: %v", err)
+	}
+	if parsed.ThemeToken != "tension" {
+		t.Fatalf("themeToken = %q, want tension", parsed.ThemeToken)
+	}
+}
+
+func TestPresentationModule_ReactTo_SetThemeColorRequiresToken(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	m := NewPresentationModule()
+	if err := m.Init(context.Background(), deps, nil); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	params, _ := json.Marshal(map[string]any{"themeToken": ""})
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionSetThemeColor,
+		Params: params,
+	}); err == nil {
+		t.Fatal("expected missing themeToken error")
+	}
+}

--- a/apps/server/internal/session/event_mapping.go
+++ b/apps/server/internal/session/event_mapping.go
@@ -44,6 +44,7 @@ var relayPrefixes = []string{
 	"reading.",
 	"ending.",
 	"audio.",
+	"presentation.",
 }
 
 // shouldRelay reports whether an engine event type should be broadcast

--- a/apps/server/internal/session/game_starter.go
+++ b/apps/server/internal/session/game_starter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine"
 	"github.com/rs/zerolog"
 )
 
@@ -11,10 +12,11 @@ import (
 // startModularGame. It satisfies the interface without the room package
 // needing to import the session package directly.
 type GameStarterAdapter struct {
-	manager     *SessionManager
-	broadcaster Broadcaster
-	featureFlag bool
-	logger      zerolog.Logger
+	manager       *SessionManager
+	broadcaster   Broadcaster
+	featureFlag   bool
+	mediaResolver engine.MediaResolver
+	logger        zerolog.Logger
 }
 
 // NewGameStarter creates a GameStarterAdapter. featureFlag mirrors
@@ -23,13 +25,15 @@ func NewGameStarter(
 	manager *SessionManager,
 	broadcaster Broadcaster,
 	featureFlag bool,
+	mediaResolver engine.MediaResolver,
 	logger zerolog.Logger,
 ) *GameStarterAdapter {
 	return &GameStarterAdapter{
-		manager:     manager,
-		broadcaster: broadcaster,
-		featureFlag: featureFlag,
-		logger:      logger.With().Str("component", "session.game_starter").Logger(),
+		manager:       manager,
+		broadcaster:   broadcaster,
+		featureFlag:   featureFlag,
+		mediaResolver: mediaResolver,
+		logger:        logger.With().Str("component", "session.game_starter").Logger(),
 	}
 }
 
@@ -38,12 +42,13 @@ func NewGameStarter(
 // scenario config. Returns errGameRuntimeDisabled when the feature flag is off.
 func (g *GameStarterAdapter) Start(ctx context.Context, roomID uuid.UUID, configJSON []byte) error {
 	cfg := StartConfig{
-		SessionID:   roomID,
-		ThemeID:     uuid.Nil, // resolved from configJSON by engine
-		Players:     nil,      // players joined via WS; session actor manages roster
-		ConfigJSON:  configJSON,
-		FeatureFlag: g.featureFlag,
-		Broadcaster: g.broadcaster,
+		SessionID:     roomID,
+		ThemeID:       uuid.Nil, // resolved from configJSON by engine
+		Players:       nil,      // players joined via WS; session actor manages roster
+		ConfigJSON:    configJSON,
+		FeatureFlag:   g.featureFlag,
+		Broadcaster:   g.broadcaster,
+		MediaResolver: g.mediaResolver,
 	}
 	_, err := startModularGame(ctx, g.manager, cfg, g.logger)
 	return err

--- a/apps/server/internal/session/starter.go
+++ b/apps/server/internal/session/starter.go
@@ -41,12 +41,13 @@ var errInvalidConfig = apperror.New(
 
 // StartConfig carries everything startModularGame needs.
 type StartConfig struct {
-	SessionID   uuid.UUID
-	ThemeID     uuid.UUID
-	Players     []PlayerState
-	ConfigJSON  json.RawMessage
-	FeatureFlag bool // game_runtime_v2 flag — off by default
-	Broadcaster Broadcaster
+	SessionID     uuid.UUID
+	ThemeID       uuid.UUID
+	Players       []PlayerState
+	ConfigJSON    json.RawMessage
+	FeatureFlag   bool // game_runtime_v2 flag — off by default
+	Broadcaster   Broadcaster
+	MediaResolver engine.MediaResolver
 }
 
 // startModularGame creates a Session, initialises the PhaseEngine with
@@ -81,6 +82,7 @@ func startModularGame(
 		EventBus:           bus,
 		Logger:             adapter,
 		PlayerInfoProvider: newStaticPlayerInfoProvider(cfg.Players),
+		MediaResolver:      cfg.MediaResolver,
 	}
 
 	modules, moduleConfigs, err := engine.BuildModules(ctx, gameCfg, deps)
@@ -105,6 +107,7 @@ func startModularGame(
 		gameCfg.Phases,
 	)
 	eng.SetPlayerInfoProvider(deps.PlayerInfoProvider)
+	eng.SetMediaResolver(deps.MediaResolver)
 	if err := eng.SetSceneTransitions(gameCfg.SceneTransitions); err != nil {
 		logger.Error().Err(err).
 			Str("session_id", cfg.SessionID.String()).

--- a/apps/server/internal/ws/envelope_catalog_s2c.go
+++ b/apps/server/internal/ws/envelope_catalog_s2c.go
@@ -48,6 +48,10 @@ func init() {
 		EventDef{Type: "audio.play_media", Direction: DirS2C, Category: "audio"},
 		EventDef{Type: "audio.stop", Direction: DirS2C, Category: "audio"},
 
+		// --- visual presentation cues (engine relay) ---
+		EventDef{Type: "presentation.set_background", Direction: DirS2C, Category: "presentation"},
+		EventDef{Type: "presentation.set_theme_color", Direction: DirS2C, Category: "presentation"},
+
 		// --- phase (engine relay) ---
 		EventDef{Type: "phase.advanced", Direction: DirS2C, Category: "phase"},
 		EventDef{Type: "phase:entered", Direction: DirS2C, Category: "phase",

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -91,7 +91,12 @@ function createDefaultParams(type: string): Record<string, unknown> | undefined 
 
 export function hasIncompletePresentationCueActions(actions: PhaseAction[]): boolean {
   return actions.some((action) => {
-    if (!getPresentationCueConfig(action.type)) return false;
+    const config = getPresentationCueConfig(action.type);
+    if (!config) return false;
+    if (config.kind === "theme") {
+      const themeToken = action.params?.themeToken;
+      return typeof themeToken !== "string" || themeToken.trim().length === 0;
+    }
     const mediaId = action.params?.mediaId;
     return typeof mediaId !== "string" || mediaId.trim().length === 0;
   });
@@ -169,6 +174,7 @@ function ActionRow({
 }
 
 interface PresentationCueConfig {
+  kind: "media" | "theme";
   buttonLabel: string;
   selectedLabel: string;
   dialogTitle: string;
@@ -178,6 +184,7 @@ interface PresentationCueConfig {
 
 const PRESENTATION_CUE_CONFIG: Record<string, PresentationCueConfig> = {
   SET_BGM: {
+    kind: "media",
     buttonLabel: "BGM 선택",
     selectedLabel: "BGM 선택됨",
     dialogTitle: "BGM 선택",
@@ -185,6 +192,7 @@ const PRESENTATION_CUE_CONFIG: Record<string, PresentationCueConfig> = {
     filterType: "BGM",
   },
   play_bgm: {
+    kind: "media",
     buttonLabel: "BGM 선택",
     selectedLabel: "BGM 선택됨",
     dialogTitle: "BGM 선택",
@@ -192,18 +200,21 @@ const PRESENTATION_CUE_CONFIG: Record<string, PresentationCueConfig> = {
     filterType: "BGM",
   },
   PLAY_SOUND: {
+    kind: "media",
     buttonLabel: "효과음 선택",
     selectedLabel: "효과음 선택됨",
     dialogTitle: "효과음 선택",
     useCase: "phase_sound_effect",
   },
   play_sound: {
+    kind: "media",
     buttonLabel: "효과음 선택",
     selectedLabel: "효과음 선택됨",
     dialogTitle: "효과음 선택",
     useCase: "phase_sound_effect",
   },
   PLAY_MEDIA: {
+    kind: "media",
     buttonLabel: "영상 선택",
     selectedLabel: "영상 선택됨",
     dialogTitle: "영상 선택",
@@ -211,11 +222,42 @@ const PRESENTATION_CUE_CONFIG: Record<string, PresentationCueConfig> = {
     filterType: "VIDEO",
   },
   play_media: {
+    kind: "media",
     buttonLabel: "영상 선택",
     selectedLabel: "영상 선택됨",
     dialogTitle: "영상 선택",
     useCase: "video_action",
     filterType: "VIDEO",
+  },
+  SET_BACKGROUND: {
+    kind: "media",
+    buttonLabel: "배경 이미지 선택",
+    selectedLabel: "배경 이미지 선택됨",
+    dialogTitle: "배경 이미지 선택",
+    useCase: "presentation_background",
+    filterType: "IMAGE",
+  },
+  set_background: {
+    kind: "media",
+    buttonLabel: "배경 이미지 선택",
+    selectedLabel: "배경 이미지 선택됨",
+    dialogTitle: "배경 이미지 선택",
+    useCase: "presentation_background",
+    filterType: "IMAGE",
+  },
+  SET_THEME_COLOR: {
+    kind: "theme",
+    buttonLabel: "",
+    selectedLabel: "",
+    dialogTitle: "",
+    useCase: "presentation_background",
+  },
+  set_theme_color: {
+    kind: "theme",
+    buttonLabel: "",
+    selectedLabel: "",
+    dialogTitle: "",
+    useCase: "presentation_background",
   },
 };
 
@@ -242,6 +284,33 @@ function PresentationCueFields({
 
   const params = action.params ?? {};
   const mediaId = typeof params.mediaId === "string" ? params.mediaId : null;
+
+  if (config.kind === "theme") {
+    const themeToken = typeof params.themeToken === "string" ? params.themeToken : "";
+    return (
+      <div className="rounded border border-slate-800 bg-slate-950/80 p-2">
+        <span className="text-[11px] text-slate-500">화면 분위기를 선택하세요</span>
+        <div className="mt-2 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+          {THEME_COLOR_PRESETS.map((preset) => (
+            <button
+              key={preset.value}
+              type="button"
+              onClick={() => onParamsChange({ ...params, themeToken: preset.value })}
+              aria-pressed={themeToken === preset.value}
+              className={`flex items-center gap-1.5 rounded border px-2 py-1 text-[11px] transition-colors ${
+                themeToken === preset.value
+                  ? "border-amber-400 bg-amber-500/10 text-amber-200"
+                  : "border-slate-700 text-slate-300 hover:border-slate-500"
+              }`}
+            >
+              <span className={`h-3 w-3 shrink-0 rounded-full ${preset.swatchClass}`} />
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="rounded border border-slate-800 bg-slate-950/80 p-2">
@@ -278,3 +347,10 @@ function PresentationCueFields({
     </div>
   );
 }
+
+const THEME_COLOR_PRESETS = [
+  { value: "noir", label: "누아르", swatchClass: "bg-slate-700" },
+  { value: "tension", label: "긴장", swatchClass: "bg-red-500" },
+  { value: "calm", label: "차분", swatchClass: "bg-cyan-500" },
+  { value: "reveal", label: "폭로", swatchClass: "bg-amber-400" },
+] as const;

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -1,4 +1,4 @@
-import { Plus, Trash2 } from "lucide-react";
+import { Check, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import type { PhaseAction } from "../../flowTypes";
 import {
@@ -292,20 +292,31 @@ function PresentationCueFields({
         <span className="text-[11px] text-slate-500">화면 분위기를 선택하세요</span>
         <div className="mt-2 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
           {THEME_COLOR_PRESETS.map((preset) => (
-            <button
-              key={preset.value}
-              type="button"
-              onClick={() => onParamsChange({ ...params, themeToken: preset.value })}
-              aria-pressed={themeToken === preset.value}
-              className={`flex items-center gap-1.5 rounded border px-2 py-1 text-[11px] transition-colors ${
-                themeToken === preset.value
-                  ? "border-amber-400 bg-amber-500/10 text-amber-200"
-                  : "border-slate-700 text-slate-300 hover:border-slate-500"
-              }`}
-            >
-              <span className={`h-3 w-3 shrink-0 rounded-full ${preset.swatchClass}`} />
-              {preset.label}
-            </button>
+            (() => {
+              const isSelected = themeToken === preset.value;
+              return (
+                <button
+                  key={preset.value}
+                  type="button"
+                  onClick={() => onParamsChange({ ...params, themeToken: preset.value })}
+                  aria-pressed={isSelected}
+                  className={`flex items-center gap-1.5 rounded border px-2 py-1 text-[11px] transition-colors ${
+                    isSelected
+                      ? "border-amber-400 bg-amber-500/10 text-amber-200"
+                      : "border-slate-700 text-slate-300 hover:border-slate-500"
+                  }`}
+                >
+                  <span className={`h-3 w-3 shrink-0 rounded-full ${preset.swatchClass}`} />
+                  <span>{preset.label}</span>
+                  {isSelected ? (
+                    <>
+                      <Check className="h-3 w-3 shrink-0" aria-hidden="true" />
+                      <span className="sr-only">선택됨</span>
+                    </>
+                  ) : null}
+                </button>
+              );
+            })()
           ))}
         </div>
       </div>

--- a/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
@@ -95,6 +95,43 @@ describe("ActionListEditor", () => {
     ]);
   });
 
+  it("배경 이미지 실행 결과를 이미지 picker의 params.mediaId로 저장한다", () => {
+    const onChange = vi.fn();
+    render(
+      <ActionListEditor
+        label="장면 시작 트리거"
+        actions={[{ id: "bg", type: "SET_BACKGROUND", params: {} }]}
+        onChange={onChange}
+        themeId="theme-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배경 이미지 선택" }));
+    fireEvent.click(screen.getByRole("button", { name: "장면 시작 트리거 1 배경 이미지 선택" }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      { id: "bg", type: "SET_BACKGROUND", params: { mediaId: "media-1" } },
+    ]);
+  });
+
+  it("컬러 테마 실행 결과를 preset token으로 저장한다", () => {
+    const onChange = vi.fn();
+    render(
+      <ActionListEditor
+        label="장면 시작 트리거"
+        actions={[{ id: "theme", type: "SET_THEME_COLOR", params: {} }]}
+        onChange={onChange}
+        themeId="theme-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "긴장" }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      { id: "theme", type: "SET_THEME_COLOR", params: { themeToken: "tension" } },
+    ]);
+  });
+
   it("themeId가 없으면 미디어 선택 버튼을 비활성화하고 안내문을 보여준다", () => {
     render(
       <ActionListEditor
@@ -118,6 +155,14 @@ describe("ActionListEditor", () => {
       hasIncompletePresentationCueActions([
         { id: "bgm", type: "SET_BGM", params: { mediaId: "media-1" } },
         { id: "vote", type: "OPEN_VOTING" },
+      ]),
+    ).toBe(false);
+    expect(
+      hasIncompletePresentationCueActions([{ id: "theme", type: "SET_THEME_COLOR", params: {} }]),
+    ).toBe(true);
+    expect(
+      hasIncompletePresentationCueActions([
+        { id: "theme", type: "SET_THEME_COLOR", params: { themeToken: "noir" } },
       ]),
     ).toBe(false);
   });

--- a/apps/web/src/features/editor/components/media/MediaCard.tsx
+++ b/apps/web/src/features/editor/components/media/MediaCard.tsx
@@ -1,4 +1,4 @@
-import { FileText, Music, Mic, Volume2, Video, Pause, Play, Youtube } from "lucide-react";
+import { FileText, Image, Music, Mic, Volume2, Video, Pause, Play, Youtube } from "lucide-react";
 import type { MediaResponse, MediaType } from "@/features/editor/mediaApi";
 import { extractYouTubeVideoId } from "@/features/audio/YouTubePlayer";
 
@@ -32,6 +32,7 @@ const TYPE_BADGE: Record<string, string> = {
   VOICE: "bg-emerald-500/20 text-emerald-300",
   VIDEO: "bg-rose-500/20 text-rose-300",
   DOCUMENT: "bg-violet-500/20 text-violet-300",
+  IMAGE: "bg-teal-500/20 text-teal-300",
 };
 
 const TYPE_LABEL: Record<string, string> = {
@@ -40,6 +41,7 @@ const TYPE_LABEL: Record<string, string> = {
   VOICE: "VOICE",
   VIDEO: "VIDEO",
   DOCUMENT: "DOCUMENT",
+  IMAGE: "IMAGE",
 };
 
 function TypeIcon({ type }: { type: MediaType | "VIDEO" }) {
@@ -54,6 +56,8 @@ function TypeIcon({ type }: { type: MediaType | "VIDEO" }) {
       return <Video className="h-6 w-6 text-rose-400" />;
     case "DOCUMENT":
       return <FileText className="h-6 w-6 text-violet-400" />;
+    case "IMAGE":
+      return <Image className="h-6 w-6 text-teal-400" />;
   }
 }
 
@@ -76,7 +80,7 @@ export function MediaCard({
   const duration = formatDuration(media.duration);
   const badgeClass = TYPE_BADGE[media.type] ?? "bg-slate-700 text-slate-300";
   const badgeLabel = TYPE_LABEL[media.type] ?? media.type;
-  const canPreview = !isYouTube && media.type !== "DOCUMENT" && !!media.url;
+  const canPreview = !isYouTube && media.type !== "DOCUMENT" && media.type !== "IMAGE" && !!media.url;
 
   return (
     <div

--- a/apps/web/src/features/editor/components/media/MediaToolbar.tsx
+++ b/apps/web/src/features/editor/components/media/MediaToolbar.tsx
@@ -21,6 +21,7 @@ const PILLS: Array<{ value: MediaFilter; label: string }> = [
   { value: "VOICE", label: "음성" },
   { value: "VIDEO", label: "비디오" },
   { value: "DOCUMENT", label: "문서" },
+  { value: "IMAGE", label: "이미지" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
@@ -25,10 +25,9 @@ export interface MediaUploadModalProps {
 }
 
 const MAX_SIZE = 20 * 1024 * 1024;
-// Must match backend `AllowedAudioMIMEs` exactly. Adding formats here without
-// backend support causes confusing "rejected after upload" errors.
-const ALLOWED_MIME = ["audio/mpeg", "audio/wav", "audio/ogg"];
-const ACCEPT_ATTR = ALLOWED_MIME.join(",");
+const AUDIO_MIME = ["audio/mpeg", "audio/wav", "audio/ogg"];
+const IMAGE_MIME = ["image/jpeg", "image/png", "image/webp"];
+const ACCEPT_ATTR = [...AUDIO_MIME, ...IMAGE_MIME].join(",");
 
 // ---------------------------------------------------------------------------
 // MediaUploadModal
@@ -85,12 +84,14 @@ export function MediaUploadModal({
       setError("파일 크기는 20MB 이하여야 합니다");
       return;
     }
-    if (!ALLOWED_MIME.includes(f.type)) {
-      setError("지원하지 않는 파일 형식입니다 (MP3, WAV, OGG)");
+    const nextType = inferUploadType(f.type);
+    if (!nextType) {
+      setError("지원하지 않는 파일 형식입니다 (MP3, WAV, OGG, JPG, PNG, WEBP)");
       return;
     }
     setError(null);
     setFile(f);
+    setType(nextType);
     const defaultName = f.name.replace(/\.[^.]+$/, "");
     setName((prev) => (prev ? prev : defaultName));
   };
@@ -214,7 +215,7 @@ export function MediaUploadModal({
               <p className="text-sm text-slate-400">
                 파일을 드래그하거나 클릭하여 선택
               </p>
-              <p className="mt-1 text-xs text-slate-500">(MP3, WAV, OGG)</p>
+              <p className="mt-1 text-xs text-slate-500">(MP3, WAV, OGG, JPG, PNG, WEBP)</p>
             </>
           )}
         </div>
@@ -261,6 +262,7 @@ export function MediaUploadModal({
                 <option value="BGM">배경음악</option>
                 <option value="SFX">효과음</option>
                 <option value="VOICE">음성</option>
+                <option value="IMAGE">이미지</option>
               </select>
             </div>
           </div>
@@ -323,4 +325,10 @@ export function MediaUploadModal({
       </div>
     </div>
   );
+}
+
+function inferUploadType(mimeType: string): MediaType | null {
+  if (AUDIO_MIME.includes(mimeType)) return "BGM";
+  if (IMAGE_MIME.includes(mimeType)) return "IMAGE";
+  return null;
 }

--- a/apps/web/src/features/editor/components/media/ResourcePicker.tsx
+++ b/apps/web/src/features/editor/components/media/ResourcePicker.tsx
@@ -1,5 +1,6 @@
 import {
   FileAudio,
+  Image,
   FileText,
   Film,
   Mic,
@@ -41,6 +42,8 @@ function MediaTypeIcon({ type }: { type: MediaType }) {
       return <Film className="h-5 w-5 text-rose-400" />;
     case "DOCUMENT":
       return <FileText className="h-5 w-5 text-violet-400" />;
+    case "IMAGE":
+      return <Image className="h-5 w-5 text-teal-400" />;
     default:
       return <FileAudio className="h-5 w-5 text-slate-400" />;
   }

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -182,6 +182,24 @@ describe("MediaUploadModal", () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
+  it("이미지 파일은 IMAGE 타입으로 자동 설정해 업로드한다", async () => {
+    mockedUpload.mockResolvedValueOnce({});
+    renderModal(true);
+    const input = screen.getByTestId(
+      "media-upload-input",
+    ) as HTMLInputElement;
+    const file = makeFile("background.png", 1024, "image/png");
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect((screen.getByLabelText("유형") as HTMLSelectElement).value).toBe("IMAGE");
+
+    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+
+    await waitFor(() => expect(mockedUpload).toHaveBeenCalledTimes(1));
+    expect(mockedUpload.mock.calls[0][0].type).toBe("IMAGE");
+  });
+
+
   it("progress bar updates from onProgress", async () => {
     mockedUpload.mockImplementationOnce(async (params: any) => {
       params.onProgress?.(42);

--- a/apps/web/src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts
@@ -71,6 +71,25 @@ describe("mediaResourceAdapter", () => {
     expect(vm.unselectableReason).toContain("이미지 업로드 흐름");
   });
 
+  it("presentation_background는 IMAGE 리소스만 선택 가능하게 한다", () => {
+    const imageMedia: MediaResponse = {
+      ...baseMedia,
+      id: "image-1",
+      name: "응접실 배경",
+      type: "IMAGE",
+      mime_type: "image/png",
+    };
+
+    expect(getAllowedMediaTypesForUseCase("presentation_background")).toEqual(["IMAGE"]);
+    expect(isMediaSelectableForUseCase(imageMedia, "presentation_background")).toBe(true);
+    expect(isMediaSelectableForUseCase(baseMedia, "presentation_background")).toBe(false);
+    expect(toMediaResourceViewModel(imageMedia, { useCase: "presentation_background" })).toMatchObject({
+      typeLabel: "이미지",
+      isSelectable: true,
+    });
+  });
+
+
   it("검색어로 이름, 라벨, 태그를 필터링한다", () => {
     const resources = [
       toMediaResourceViewModel(baseMedia),

--- a/apps/web/src/features/editor/entities/mediaResource/mediaResourceAdapter.ts
+++ b/apps/web/src/features/editor/entities/mediaResource/mediaResourceAdapter.ts
@@ -10,6 +10,7 @@ export type MediaResourceUseCase =
   | "role_sheet_document"
   | "story_voice"
   | "location_image"
+  | "presentation_background"
   | "video_action";
 
 export interface MediaResourceViewModel {
@@ -34,6 +35,7 @@ const TYPE_LABEL: Record<MediaType, string> = {
   VOICE: "음성/내레이션",
   VIDEO: "영상",
   DOCUMENT: "문서",
+  IMAGE: "이미지",
 };
 
 const SOURCE_LABEL: Record<MediaSourceType, string> = {
@@ -47,6 +49,7 @@ const USE_CASE_ALLOWED_TYPES: Record<MediaResourceUseCase, MediaType[]> = {
   role_sheet_document: ["DOCUMENT"],
   story_voice: ["VOICE", "SFX"],
   location_image: [],
+  presentation_background: ["IMAGE"],
   video_action: ["VIDEO"],
 };
 
@@ -57,6 +60,7 @@ const USE_CASE_EMPTY_REASON: Record<MediaResourceUseCase, string> = {
   story_voice: "스토리 음성에는 음성/내레이션 또는 효과음만 선택할 수 있어요.",
   location_image:
     "장소 이미지는 현재 이미지 업로드 흐름에서 선택해요. 공통 이미지 리소스는 후속 작업에서 연결합니다.",
+  presentation_background: "배경 연출에는 이미지 리소스만 선택할 수 있어요.",
   video_action: "영상 액션에는 영상 리소스만 선택할 수 있어요.",
 };
 

--- a/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
@@ -32,7 +32,14 @@ describe("actionAdapter", () => {
       "PLAY_SOUND",
       "PLAY_MEDIA",
       "STOP_AUDIO",
+      "SET_BACKGROUND",
+      "SET_THEME_COLOR",
     ]);
+  });
+
+  it("visual presentation action label을 제작자용 문구로 제공한다", () => {
+    expect(getCreatorActionLabel("SET_BACKGROUND")).toBe("배경 이미지 변경");
+    expect(getCreatorActionLabel("set_theme_color")).toBe("화면 색상 테마 변경");
   });
 
   it("정보 전달은 phase summary의 일반 action 목록에서 제외할 수 있다", () => {

--- a/apps/web/src/features/editor/entities/shared/actionAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/actionAdapter.ts
@@ -17,6 +17,8 @@ export const CREATOR_ACTION_OPTIONS: CreatorActionOption[] = [
   { value: "PLAY_SOUND", label: "효과음 재생" },
   { value: "PLAY_MEDIA", label: "영상 재생" },
   { value: "STOP_AUDIO", label: "BGM/효과음 정지" },
+  { value: "SET_BACKGROUND", label: "배경 이미지 변경" },
+  { value: "SET_THEME_COLOR", label: "화면 색상 테마 변경" },
 ];
 
 const ACTION_LABELS = new Map<string, string>([
@@ -33,6 +35,8 @@ const ACTION_LABELS = new Map<string, string>([
   ["play_bgm", "BGM 재생"],
   ["play_sound", "효과음 재생"],
   ["play_media", "영상 재생"],
+  ["set_background", "배경 이미지 변경"],
+  ["set_theme_color", "화면 색상 테마 변경"],
   ["stop_bgm", "BGM 정지"],
 ]);
 

--- a/apps/web/src/features/editor/mediaApi.ts
+++ b/apps/web/src/features/editor/mediaApi.ts
@@ -7,7 +7,7 @@ import { queryClient } from "@/services/queryClient";
 // Types — match backend snake_case JSON exactly
 // ---------------------------------------------------------------------------
 
-export type MediaType = "BGM" | "SFX" | "VOICE" | "VIDEO" | "DOCUMENT";
+export type MediaType = "BGM" | "SFX" | "VOICE" | "VIDEO" | "DOCUMENT" | "IMAGE";
 export type MediaSourceType = "FILE" | "YOUTUBE";
 
 export interface MediaResponse {

--- a/apps/web/src/features/presentation/PresentationLayer.test.tsx
+++ b/apps/web/src/features/presentation/PresentationLayer.test.tsx
@@ -51,10 +51,12 @@ describe("PresentationLayer", () => {
       </PresentationLayer>,
     );
 
-    handlers.get(WsEventType.PRESENTATION_SET_BACKGROUND)!(
-      { mediaId: "image-1", url: "https://cdn.example/bg.png" },
-      1,
-    );
+    act(() => {
+      handlers.get(WsEventType.PRESENTATION_SET_BACKGROUND)!(
+        { mediaId: "image-1", url: "https://cdn.example/bg.png" },
+        1,
+      );
+    });
     fireEvent.click(screen.getByRole("button", { name: "주요 행동" }));
 
     expect(onClick).toHaveBeenCalledTimes(1);

--- a/apps/web/src/features/presentation/PresentationLayer.test.tsx
+++ b/apps/web/src/features/presentation/PresentationLayer.test.tsx
@@ -1,0 +1,62 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { WsEventType } from "@mmp/shared";
+
+const handlers = new Map<string, (payload: unknown, seq: number) => void>();
+
+vi.mock("@/hooks/useWsEvent", () => ({
+  useWsEvent: (
+    _endpoint: "game" | "social",
+    eventType: string,
+    handler: (payload: unknown, seq: number) => void,
+  ) => {
+    handlers.set(eventType, handler);
+  },
+}));
+
+import { PresentationLayer } from "./PresentationLayer";
+
+describe("PresentationLayer", () => {
+  beforeEach(() => {
+    handlers.clear();
+  });
+
+  it("presentation WS cue로 배경과 컬러 테마 상태를 갱신한다", () => {
+    const { container } = render(
+      <PresentationLayer>
+        <button type="button">채팅 열기</button>
+      </PresentationLayer>,
+    );
+
+    act(() => {
+      handlers.get(WsEventType.PRESENTATION_SET_BACKGROUND)!(
+        { mediaId: "image-1", url: "https://cdn.example/bg.png" },
+        1,
+      );
+      handlers.get(WsEventType.PRESENTATION_SET_THEME_COLOR)!({ themeToken: "tension" }, 2);
+    });
+
+    const root = container.firstElementChild;
+    expect(root?.getAttribute("data-presentation-theme")).toBe("tension");
+    expect(root?.outerHTML).not.toContain("image-1");
+  });
+
+  it("배경 layer가 자식 UI 클릭을 가로막지 않는다", () => {
+    const onClick = vi.fn();
+    render(
+      <PresentationLayer>
+        <button type="button" onClick={onClick}>
+          주요 행동
+        </button>
+      </PresentationLayer>,
+    );
+
+    handlers.get(WsEventType.PRESENTATION_SET_BACKGROUND)!(
+      { mediaId: "image-1", url: "https://cdn.example/bg.png" },
+      1,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "주요 행동" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/presentation/PresentationLayer.tsx
+++ b/apps/web/src/features/presentation/PresentationLayer.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { WsEventType } from "@mmp/shared";
+
+import { useWsEvent } from "@/hooks/useWsEvent";
+
+interface BackgroundPayload {
+  mediaId?: string;
+  url?: string;
+}
+
+interface ThemeColorPayload {
+  themeToken?: string;
+}
+
+interface PresentationState {
+  backgroundMediaId: string | null;
+  backgroundUrl: string | null;
+  themeToken: string;
+}
+
+const THEME_CLASS: Record<string, string> = {
+  noir: "from-slate-950 via-slate-950 to-slate-900",
+  tension: "from-slate-950 via-red-950/70 to-slate-950",
+  calm: "from-slate-950 via-cyan-950/50 to-slate-950",
+  reveal: "from-slate-950 via-amber-950/40 to-slate-950",
+};
+
+export function PresentationLayer({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<PresentationState>({
+    backgroundMediaId: null,
+    backgroundUrl: null,
+    themeToken: "noir",
+  });
+
+  useWsEvent<BackgroundPayload>(
+    "game",
+    WsEventType.PRESENTATION_SET_BACKGROUND,
+    (payload) => {
+      setState((prev) => ({
+        ...prev,
+        backgroundMediaId: payload.mediaId ?? null,
+        backgroundUrl: payload.url ?? null,
+      }));
+    },
+  );
+
+  useWsEvent<ThemeColorPayload>(
+    "game",
+    WsEventType.PRESENTATION_SET_THEME_COLOR,
+    (payload) => {
+      setState((prev) => ({
+        ...prev,
+        themeToken: payload.themeToken || "noir",
+      }));
+    },
+  );
+
+  const themeClass = THEME_CLASS[state.themeToken] ?? THEME_CLASS.noir;
+
+  return (
+    <div
+      className="relative isolate h-screen overflow-hidden bg-slate-950"
+      data-presentation-theme={state.themeToken}
+    >
+      <div
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-0 -z-20 bg-gradient-to-br ${themeClass}`}
+      />
+      {state.backgroundUrl ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 bg-cover bg-center opacity-35"
+          style={{ backgroundImage: `url(${state.backgroundUrl})` }}
+        />
+      ) : null}
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 bg-slate-950/45" />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -25,6 +25,7 @@ import {
   ResultBreakdownPanel,
 } from "@/features/game/components";
 import { AudioProvider } from "@/features/audio/AudioProvider";
+import { PresentationLayer } from "@/features/presentation/PresentationLayer";
 import { GameErrorBoundary } from "@/components/error";
 
 // ---------------------------------------------------------------------------
@@ -149,7 +150,8 @@ function GamePageInner({ sessionId, isChatOpen, setIsChatOpen }: GamePageInnerPr
         </div>
       </div>
     )}
-    <div className="flex h-screen flex-col bg-slate-950">
+    <PresentationLayer>
+    <div className="flex h-full flex-col bg-slate-950/90">
       {/* 상단: GameHUD */}
       <Suspense fallback={null}>
         <GameHUD />
@@ -216,6 +218,7 @@ function GamePageInner({ sessionId, isChatOpen, setIsChatOpen }: GamePageInnerPr
         </div>
       )}
     </div>
+    </PresentationLayer>
     </GameErrorBoundary>
     </AudioProvider>
   );

--- a/packages/shared/src/ws/types.generated.ts
+++ b/packages/shared/src/ws/types.generated.ts
@@ -7,7 +7,7 @@
 // Any hand edit will be overwritten by the next go generate run.
 // Phase 19 PR-1 (2026-04-18).
 //
-// Catalog: 133 events (active=128, stub=3, deprec=2) · 10 //wsgen:payload structs.
+// Catalog: 135 events (active=130, stub=3, deprec=2) · 10 //wsgen:payload structs.
 
 /* eslint-disable */
 /* prettier-ignore */
@@ -240,6 +240,10 @@ export const WsEventType = {
   PLAYER_LEFT: "player.left",
   /** BIDI · system */
   PONG: "pong",
+  /** S2C · presentation */
+  PRESENTATION_SET_BACKGROUND: "presentation.set_background",
+  /** S2C · presentation */
+  PRESENTATION_SET_THEME_COLOR: "presentation.set_theme_color",
   /** S2C · reading */
   READING_COMPLETED: "reading.completed",
   /** S2C · reading */
@@ -447,6 +451,8 @@ export const WsEventDirection: Readonly<Record<WsEventType, "c2s" | "s2c" | "bid
   "player.joined": "s2c",
   "player.left": "s2c",
   "pong": "bidi",
+  "presentation.set_background": "s2c",
+  "presentation.set_theme_color": "s2c",
   "reading.completed": "s2c",
   "reading.line_changed": "s2c",
   "reading.paused": "s2c",
@@ -584,6 +590,8 @@ export const WsEventCategory: Readonly<Record<WsEventType, string>> = {
   "player.joined": "player",
   "player.left": "player",
   "pong": "system",
+  "presentation.set_background": "presentation",
+  "presentation.set_theme_color": "presentation",
   "reading.completed": "reading",
   "reading.line_changed": "reading",
   "reading.paused": "reading",
@@ -721,6 +729,8 @@ export const WsEventStatus: Readonly<Record<WsEventType, "active" | "stub" | "de
   "player.joined": "active",
   "player.left": "active",
   "pong": "active",
+  "presentation.set_background": "active",
+  "presentation.set_theme_color": "active",
   "reading.completed": "active",
   "reading.line_changed": "active",
   "reading.paused": "active",


### PR DESCRIPTION
## 요약
- `IMAGE` media type과 업로드/검증/migration 계약을 추가했습니다.
- `SET_BACKGROUND`, `SET_THEME_COLOR` phase action과 `presentation.*` runtime WS 계약을 추가했습니다.
- 에디터 action UI에서 배경 이미지 picker와 컬러 테마 preset을 raw JSON 없이 설정하도록 연결했습니다.
- 게임 화면에 pointer-events 없는 presentation background layer를 추가했습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx src/features/editor/components/design/__tests__/ActionListEditor.test.tsx src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts src/features/editor/entities/shared/__tests__/actionAdapter.test.ts src/features/presentation/PresentationLayer.test.tsx`
- `go test ./internal/domain/editor ./internal/engine ./internal/module/media ./internal/session ./internal/ws`
- `git diff --check`

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지 미디어 업로드 및 미리보기 지원 추가
  * 프레젠테이션 레이어 도입 — 런타임에 배경 이미지와 테마 색상 동적 적용
  * 배경 이미지 변경 및 테마 색상 액션 추가 — 크리에이터용 UI/액션 확장
  * 에디터/미디어 UI 개선 — 이미지 필터, 업로드 모달 및 미디어 카드 표시 강화

* **테스트**
  * 이미지 관련 서버·클라이언트 단위 테스트 및 통합 시나리오 추가

* **데이터베이스**
  * 이미지 타입 허용을 위한 마이그레이션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->