### PR TITLE
feat(editor): 연출 미디어 참조 삭제 보호

### DIFF
--- a/apps/server/internal/domain/editor/media_reference_scanner.go
+++ b/apps/server/internal/domain/editor/media_reference_scanner.go
@@ -20,21 +20,25 @@ func mediaReferenceParams(refs []mediaReferenceInfo) []map[string]string {
 	return out
 }
 
-func findMediaReferencesInThemeConfig(raw json.RawMessage, mediaID uuid.UUID) []mediaReferenceInfo {
+func findMediaReferencesInThemeConfig(raw json.RawMessage, mediaID uuid.UUID) ([]mediaReferenceInfo, error) {
 	if len(raw) == 0 || string(raw) == "null" {
-		return nil
+		return nil, nil
 	}
 	var cfg struct {
 		Phases  json.RawMessage         `json:"phases"`
 		Modules map[string]configModule `json:"modules"`
 	}
 	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return nil
+		return nil, fmt.Errorf("parse theme config: %w", err)
 	}
 
 	mediaIDText := mediaID.String()
 	refs := []mediaReferenceInfo{}
-	for _, phase := range parseConfigMediaPhases(cfg.Phases) {
+	phases, err := parseConfigMediaPhases(cfg.Phases)
+	if err != nil {
+		return nil, fmt.Errorf("parse theme config phases: %w", err)
+	}
+	for _, phase := range phases {
 		phaseID := phase.ID
 		if phaseID == "" {
 			phaseID = phase.Name
@@ -42,57 +46,69 @@ func findMediaReferencesInThemeConfig(raw json.RawMessage, mediaID uuid.UUID) []
 		if phaseID == "" {
 			phaseID = "phase"
 		}
-		refs = append(refs, findMediaReferencesInActionConfig(
+		phaseRefs, err := findMediaReferencesInActionConfig(
 			phase.OnEnter,
 			mediaIDText,
 			"phase_action",
 			phaseID+":onEnter",
-			fmt.Sprintf("%s 시작 트리거에서 %s으로 사용 중", phaseDisplayName(phase), mediaActionPurpose(phase.OnEnter, mediaIDText)),
-		)...)
-		refs = append(refs, findMediaReferencesInActionConfig(
+			fmt.Sprintf("%s 시작 트리거", phaseDisplayName(phase)),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("parse phase %q onEnter media actions: %w", phaseID, err)
+		}
+		refs = append(refs, phaseRefs...)
+		phaseRefs, err = findMediaReferencesInActionConfig(
 			phase.OnExit,
 			mediaIDText,
 			"phase_action",
 			phaseID+":onExit",
-			fmt.Sprintf("%s 종료 트리거에서 %s으로 사용 중", phaseDisplayName(phase), mediaActionPurpose(phase.OnExit, mediaIDText)),
-		)...)
+			fmt.Sprintf("%s 종료 트리거", phaseDisplayName(phase)),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("parse phase %q onExit media actions: %w", phaseID, err)
+		}
+		refs = append(refs, phaseRefs...)
 	}
 
 	eventModule, ok := cfg.Modules["event_progression"]
 	if !ok || len(eventModule.Config) == 0 {
-		return refs
+		return refs, nil
 	}
 	var eventCfg struct {
 		Triggers []configMediaTrigger `json:"Triggers"`
 	}
 	if err := json.Unmarshal(eventModule.Config, &eventCfg); err != nil {
-		return refs
+		return nil, fmt.Errorf("parse event_progression config: %w", err)
 	}
 	for _, trigger := range eventCfg.Triggers {
 		triggerID := trigger.ID
 		if triggerID == "" {
 			triggerID = "trigger"
 		}
-		refs = append(refs, findMediaReferencesInActionConfig(
+		triggerRefs, err := findMediaReferencesInActionConfig(
 			trigger.Actions,
 			mediaIDText,
 			"event_progression_trigger_action",
 			triggerID,
-			fmt.Sprintf("%s 실행 결과에서 %s으로 사용 중", triggerDisplayName(trigger), mediaActionPurpose(trigger.Actions, mediaIDText)),
-		)...)
+			fmt.Sprintf("%s 실행 결과", triggerDisplayName(trigger)),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("parse event_progression trigger %q media actions: %w", triggerID, err)
+		}
+		refs = append(refs, triggerRefs...)
 	}
-	return refs
+	return refs, nil
 }
 
-func parseConfigMediaPhases(raw json.RawMessage) []configMediaPhase {
+func parseConfigMediaPhases(raw json.RawMessage) ([]configMediaPhase, error) {
 	if len(raw) == 0 || string(raw) == "null" {
-		return nil
+		return nil, nil
 	}
 	var phases []configMediaPhase
 	if err := json.Unmarshal(raw, &phases); err != nil {
-		return nil
+		return nil, err
 	}
-	return phases
+	return phases, nil
 }
 
 type configModule struct {
@@ -119,14 +135,21 @@ type configMediaAction struct {
 	Params json.RawMessage `json:"params"`
 }
 
-func findMediaReferencesInActionConfig(raw json.RawMessage, mediaID string, refType string, ownerID string, label string) []mediaReferenceInfo {
-	actions := parseConfigMediaActions(raw)
+func findMediaReferencesInActionConfig(raw json.RawMessage, mediaID string, refType string, ownerID string, ownerLabel string) ([]mediaReferenceInfo, error) {
+	actions, err := parseConfigMediaActions(raw)
+	if err != nil {
+		return nil, err
+	}
 	if len(actions) == 0 {
-		return nil
+		return nil, nil
 	}
 	refs := []mediaReferenceInfo{}
 	for i, action := range actions {
-		if actionMediaID(action) != mediaID {
+		actionID, err := actionMediaID(action)
+		if err != nil {
+			return nil, fmt.Errorf("parse action %d params: %w", i, err)
+		}
+		if actionID != mediaID {
 			continue
 		}
 		refID := ownerID
@@ -138,40 +161,40 @@ func findMediaReferencesInActionConfig(raw json.RawMessage, mediaID string, refT
 		refs = append(refs, mediaReferenceInfo{
 			Type: refType,
 			ID:   refID,
-			Name: label,
+			Name: fmt.Sprintf("%s에서 %s으로 사용 중", ownerLabel, mediaActionLabel(action)),
 		})
 	}
-	return refs
+	return refs, nil
 }
 
-func parseConfigMediaActions(raw json.RawMessage) []configMediaAction {
+func parseConfigMediaActions(raw json.RawMessage) ([]configMediaAction, error) {
 	if len(raw) == 0 || string(raw) == "null" {
-		return nil
+		return nil, nil
 	}
 	var direct []configMediaAction
 	if err := json.Unmarshal(raw, &direct); err == nil {
-		return direct
+		return direct, nil
 	}
 	var wrapped struct {
 		Actions []configMediaAction `json:"actions"`
 	}
 	if err := json.Unmarshal(raw, &wrapped); err == nil {
-		return wrapped.Actions
+		return wrapped.Actions, nil
 	}
-	return nil
+	return nil, fmt.Errorf("parse media actions")
 }
 
-func actionMediaID(action configMediaAction) string {
+func actionMediaID(action configMediaAction) (string, error) {
 	if len(action.Params) == 0 || string(action.Params) == "null" {
-		return ""
+		return "", nil
 	}
 	var params struct {
 		MediaID string `json:"mediaId"`
 	}
 	if err := json.Unmarshal(action.Params, &params); err != nil {
-		return ""
+		return "", err
 	}
-	return params.MediaID
+	return params.MediaID, nil
 }
 
 func phaseDisplayName(phase configMediaPhase) string {
@@ -192,15 +215,6 @@ func triggerDisplayName(trigger configMediaTrigger) string {
 		return trigger.ID
 	}
 	return "트리거"
-}
-
-func mediaActionPurpose(raw json.RawMessage, mediaID string) string {
-	for _, action := range parseConfigMediaActions(raw) {
-		if actionMediaID(action) == mediaID {
-			return mediaActionLabel(action)
-		}
-	}
-	return "미디어"
 }
 
 func mediaActionLabel(action configMediaAction) string {

--- a/apps/server/internal/domain/editor/media_reference_scanner.go
+++ b/apps/server/internal/domain/editor/media_reference_scanner.go
@@ -1,0 +1,223 @@
+package editor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func mediaReferenceParams(refs []mediaReferenceInfo) []map[string]string {
+	out := make([]map[string]string, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, map[string]string{
+			"type": ref.Type,
+			"id":   ref.ID,
+			"name": ref.Name,
+		})
+	}
+	return out
+}
+
+func findMediaReferencesInThemeConfig(raw json.RawMessage, mediaID uuid.UUID) []mediaReferenceInfo {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var cfg struct {
+		Phases  json.RawMessage         `json:"phases"`
+		Modules map[string]configModule `json:"modules"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil
+	}
+
+	mediaIDText := mediaID.String()
+	refs := []mediaReferenceInfo{}
+	for _, phase := range parseConfigMediaPhases(cfg.Phases) {
+		phaseID := phase.ID
+		if phaseID == "" {
+			phaseID = phase.Name
+		}
+		if phaseID == "" {
+			phaseID = "phase"
+		}
+		refs = append(refs, findMediaReferencesInActionConfig(
+			phase.OnEnter,
+			mediaIDText,
+			"phase_action",
+			phaseID+":onEnter",
+			fmt.Sprintf("%s 시작 트리거에서 %s으로 사용 중", phaseDisplayName(phase), mediaActionPurpose(phase.OnEnter, mediaIDText)),
+		)...)
+		refs = append(refs, findMediaReferencesInActionConfig(
+			phase.OnExit,
+			mediaIDText,
+			"phase_action",
+			phaseID+":onExit",
+			fmt.Sprintf("%s 종료 트리거에서 %s으로 사용 중", phaseDisplayName(phase), mediaActionPurpose(phase.OnExit, mediaIDText)),
+		)...)
+	}
+
+	eventModule, ok := cfg.Modules["event_progression"]
+	if !ok || len(eventModule.Config) == 0 {
+		return refs
+	}
+	var eventCfg struct {
+		Triggers []configMediaTrigger `json:"Triggers"`
+	}
+	if err := json.Unmarshal(eventModule.Config, &eventCfg); err != nil {
+		return refs
+	}
+	for _, trigger := range eventCfg.Triggers {
+		triggerID := trigger.ID
+		if triggerID == "" {
+			triggerID = "trigger"
+		}
+		refs = append(refs, findMediaReferencesInActionConfig(
+			trigger.Actions,
+			mediaIDText,
+			"event_progression_trigger_action",
+			triggerID,
+			fmt.Sprintf("%s 실행 결과에서 %s으로 사용 중", triggerDisplayName(trigger), mediaActionPurpose(trigger.Actions, mediaIDText)),
+		)...)
+	}
+	return refs
+}
+
+func parseConfigMediaPhases(raw json.RawMessage) []configMediaPhase {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var phases []configMediaPhase
+	if err := json.Unmarshal(raw, &phases); err != nil {
+		return nil
+	}
+	return phases
+}
+
+type configModule struct {
+	Config json.RawMessage `json:"config"`
+}
+
+type configMediaPhase struct {
+	ID      string          `json:"id"`
+	Name    string          `json:"name"`
+	OnEnter json.RawMessage `json:"onEnter"`
+	OnExit  json.RawMessage `json:"onExit"`
+}
+
+type configMediaTrigger struct {
+	ID      string          `json:"id"`
+	Label   string          `json:"label"`
+	Actions json.RawMessage `json:"actions"`
+}
+
+type configMediaAction struct {
+	ID     string          `json:"id"`
+	Type   string          `json:"type"`
+	Action string          `json:"action"`
+	Params json.RawMessage `json:"params"`
+}
+
+func findMediaReferencesInActionConfig(raw json.RawMessage, mediaID string, refType string, ownerID string, label string) []mediaReferenceInfo {
+	actions := parseConfigMediaActions(raw)
+	if len(actions) == 0 {
+		return nil
+	}
+	refs := []mediaReferenceInfo{}
+	for i, action := range actions {
+		if actionMediaID(action) != mediaID {
+			continue
+		}
+		refID := ownerID
+		if action.ID != "" {
+			refID += ":" + action.ID
+		} else {
+			refID += fmt.Sprintf(":%d", i)
+		}
+		refs = append(refs, mediaReferenceInfo{
+			Type: refType,
+			ID:   refID,
+			Name: label,
+		})
+	}
+	return refs
+}
+
+func parseConfigMediaActions(raw json.RawMessage) []configMediaAction {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var direct []configMediaAction
+	if err := json.Unmarshal(raw, &direct); err == nil {
+		return direct
+	}
+	var wrapped struct {
+		Actions []configMediaAction `json:"actions"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil {
+		return wrapped.Actions
+	}
+	return nil
+}
+
+func actionMediaID(action configMediaAction) string {
+	if len(action.Params) == 0 || string(action.Params) == "null" {
+		return ""
+	}
+	var params struct {
+		MediaID string `json:"mediaId"`
+	}
+	if err := json.Unmarshal(action.Params, &params); err != nil {
+		return ""
+	}
+	return params.MediaID
+}
+
+func phaseDisplayName(phase configMediaPhase) string {
+	if phase.Name != "" {
+		return phase.Name
+	}
+	if phase.ID != "" {
+		return phase.ID
+	}
+	return "단계"
+}
+
+func triggerDisplayName(trigger configMediaTrigger) string {
+	if trigger.Label != "" {
+		return trigger.Label
+	}
+	if trigger.ID != "" {
+		return trigger.ID
+	}
+	return "트리거"
+}
+
+func mediaActionPurpose(raw json.RawMessage, mediaID string) string {
+	for _, action := range parseConfigMediaActions(raw) {
+		if actionMediaID(action) == mediaID {
+			return mediaActionLabel(action)
+		}
+	}
+	return "미디어"
+}
+
+func mediaActionLabel(action configMediaAction) string {
+	actionType := strings.ToUpper(strings.TrimSpace(action.Action))
+	if actionType == "" {
+		actionType = strings.ToUpper(strings.TrimSpace(action.Type))
+	}
+	switch actionType {
+	case "SET_BACKGROUND":
+		return "배경 이미지"
+	case "SET_BGM", "PLAY_BGM":
+		return "BGM"
+	case "PLAY_SOUND", "SET_SFX":
+		return "효과음"
+	case "PLAY_MEDIA", "SET_VIDEO":
+		return "영상"
+	default:
+		return "미디어"
+	}
+}

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -479,7 +479,12 @@ func (s *mediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.
 		s.logger.Error().Err(err).Str("theme_id", media.ThemeID.String()).Msg("failed to get theme for media references")
 		return apperror.Internal("failed to check media references")
 	}
-	refList = append(refList, findMediaReferencesInThemeConfig(theme.ConfigJson, mediaID)...)
+	configRefs, err := findMediaReferencesInThemeConfig(theme.ConfigJson, mediaID)
+	if err != nil {
+		s.logger.Warn().Err(err).Str("media_id", mediaID.String()).Msg("failed to scan theme config media references")
+		return apperror.New(apperror.ErrValidation, 422, "theme config contains invalid media references")
+	}
+	refList = append(refList, configRefs...)
 
 	if len(refList) > 0 {
 		return apperror.New(apperror.ErrMediaReferenceInUse, 409, "media is referenced by editor content").

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -62,6 +62,12 @@ type mediaService struct {
 	logger  zerolog.Logger
 }
 
+type mediaReferenceInfo struct {
+	Type string
+	ID   string
+	Name string
+}
+
 // NewMediaService constructs a MediaService.
 // Theme ownership checks are performed directly via db.Queries to minimize the dependency surface.
 func NewMediaService(q *db.Queries, storageProvider storage.Provider, logger zerolog.Logger) MediaService {
@@ -428,6 +434,8 @@ func (s *mediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.
 		return apperror.Internal("failed to get media")
 	}
 
+	refList := []mediaReferenceInfo{}
+
 	// Block deletion if the media is referenced by any reading section
 	// (either as bgmMediaId or inside a line's voiceMediaId).
 	refs, err := s.q.FindMediaReferencesInReadingSections(ctx, db.FindMediaReferencesInReadingSectionsParams{
@@ -439,16 +447,13 @@ func (s *mediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.
 		return apperror.Internal("failed to check media references")
 	}
 	if len(refs) > 0 {
-		refList := make([]map[string]string, len(refs))
-		for i, r := range refs {
-			refList[i] = map[string]string{
-				"type": "reading_section",
-				"id":   r.ID.String(),
-				"name": r.Name,
-			}
+		for _, r := range refs {
+			refList = append(refList, mediaReferenceInfo{
+				Type: "reading_section",
+				ID:   r.ID.String(),
+				Name: r.Name,
+			})
 		}
-		return apperror.New(apperror.ErrMediaReferenceInUse, 409, "media is referenced by reading sections").
-			WithParams(map[string]any{"references": refList})
 	}
 
 	roleSheetRefs, err := s.q.FindRoleSheetReferencesForMedia(ctx, db.FindRoleSheetReferencesForMediaParams{
@@ -460,16 +465,25 @@ func (s *mediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.
 		return apperror.Internal("failed to check media references")
 	}
 	if len(roleSheetRefs) > 0 {
-		refList := make([]map[string]string, len(roleSheetRefs))
-		for i, r := range roleSheetRefs {
-			refList[i] = map[string]string{
-				"type": "role_sheet",
-				"id":   r.Key,
-				"name": r.Key,
-			}
+		for _, r := range roleSheetRefs {
+			refList = append(refList, mediaReferenceInfo{
+				Type: "role_sheet",
+				ID:   r.Key,
+				Name: r.Key,
+			})
 		}
-		return apperror.New(apperror.ErrMediaReferenceInUse, 409, "media is referenced by role sheets").
-			WithParams(map[string]any{"references": refList})
+	}
+
+	theme, err := s.q.GetTheme(ctx, media.ThemeID)
+	if err != nil {
+		s.logger.Error().Err(err).Str("theme_id", media.ThemeID.String()).Msg("failed to get theme for media references")
+		return apperror.Internal("failed to check media references")
+	}
+	refList = append(refList, findMediaReferencesInThemeConfig(theme.ConfigJson, mediaID)...)
+
+	if len(refList) > 0 {
+		return apperror.New(apperror.ErrMediaReferenceInUse, 409, "media is referenced by editor content").
+			WithParams(map[string]any{"references": mediaReferenceParams(refList)})
 	}
 
 	if media.SourceType == SourceTypeFile && media.StorageKey.Valid && s.storage != nil {

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -563,18 +563,53 @@ func TestMediaService_Delete_BlockedByEventProgressionTriggerMediaReference(t *t
 	}
 }
 
-func TestMediaService_Delete_IgnoresMalformedConfigMediaReferenceScan(t *testing.T) {
+func TestMediaService_Delete_LabelsMultipleActionReferencesByActionPurpose(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeImage)
+	theme := q.themes[themeID]
+	theme.ConfigJson = json.RawMessage(fmt.Sprintf(`{
+		"phases": [
+			{
+				"id": "finale",
+				"name": "마지막 단계",
+				"onEnter": [
+					{"id":"bg","type":"SET_BACKGROUND","params":{"mediaId":%q}},
+					{"id":"video","type":"PLAY_MEDIA","params":{"mediaId":%q}}
+				]
+			}
+		],
+		"modules": {}
+	}`, mediaID.String(), mediaID.String()))
+	q.themes[themeID] = theme
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+
+	var appErr *apperror.AppError
+	_ = errors.As(err, &appErr)
+	refs := appErr.Params["references"].([]map[string]string)
+	if len(refs) != 2 {
+		t.Fatalf("expected two phase references, got %#v", refs)
+	}
+	if !strings.Contains(refs[0]["name"], "배경 이미지") {
+		t.Fatalf("first reference should use background label: %#v", refs[0])
+	}
+	if !strings.Contains(refs[1]["name"], "영상") {
+		t.Fatalf("second reference should use video label: %#v", refs[1])
+	}
+}
+
+func TestMediaService_Delete_BlocksMalformedConfigMediaReferenceScan(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	mediaID := seedMedia(q, themeID, MediaTypeBGM)
 	theme := q.themes[themeID]
 	theme.ConfigJson = json.RawMessage(`{"phases": "malformed", "modules": {"event_progression": {"config": "malformed"}}}`)
 	q.themes[themeID] = theme
 
-	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID); err != nil {
-		t.Fatalf("malformed config should not block media deletion, got %v", err)
-	}
-	if _, ok := q.media[mediaID]; ok {
-		t.Fatalf("media should have been deleted")
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	assertMediaAppCode(t, err, apperror.ErrValidation)
+	if _, ok := q.media[mediaID]; !ok {
+		t.Fatalf("media should not have been deleted")
 	}
 }
 

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -456,6 +457,124 @@ func TestMediaService_Delete_BlockedByRoleSheetReference(t *testing.T) {
 	}
 	if _, ok := q.media[mediaID]; !ok {
 		t.Fatalf("media should not have been deleted")
+	}
+}
+
+func TestMediaService_Delete_BlockedByPhaseOnEnterMediaReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeBGM)
+	theme := q.themes[themeID]
+	theme.ConfigJson = json.RawMessage(fmt.Sprintf(`{
+		"phases": [
+			{
+				"id": "investigation",
+				"name": "조사 단계",
+				"onEnter": [{"id":"bgm","type":"SET_BGM","params":{"mediaId":%q}}]
+			}
+		],
+		"modules": {}
+	}`, mediaID.String()))
+	q.themes[themeID] = theme
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+
+	var appErr *apperror.AppError
+	_ = errors.As(err, &appErr)
+	refs := appErr.Params["references"].([]map[string]string)
+	if len(refs) != 1 {
+		t.Fatalf("expected one phase reference, got %#v", refs)
+	}
+	if refs[0]["type"] != "phase_action" || refs[0]["id"] != "investigation:onEnter:bgm" {
+		t.Fatalf("unexpected phase reference: %#v", refs[0])
+	}
+	if !strings.Contains(refs[0]["name"], "조사 단계 시작 트리거") || !strings.Contains(refs[0]["name"], "BGM") {
+		t.Fatalf("unexpected creator label: %#v", refs[0])
+	}
+	if _, ok := q.media[mediaID]; !ok {
+		t.Fatalf("media should not have been deleted")
+	}
+}
+
+func TestMediaService_Delete_BlockedByPhaseOnExitMediaReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeSFX)
+	theme := q.themes[themeID]
+	theme.ConfigJson = json.RawMessage(fmt.Sprintf(`{
+		"phases": [
+			{
+				"id": "debate",
+				"name": "토론 단계",
+				"onExit": {"actions": [{"id":"sfx","type":"PLAY_SOUND","params":{"mediaId":%q}}]}
+			}
+		],
+		"modules": {}
+	}`, mediaID.String()))
+	q.themes[themeID] = theme
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+
+	var appErr *apperror.AppError
+	_ = errors.As(err, &appErr)
+	refs := appErr.Params["references"].([]map[string]string)
+	if len(refs) != 1 || refs[0]["type"] != "phase_action" || refs[0]["id"] != "debate:onExit:sfx" {
+		t.Fatalf("unexpected phase reference: %#v", refs)
+	}
+	if !strings.Contains(refs[0]["name"], "토론 단계 종료 트리거") || !strings.Contains(refs[0]["name"], "효과음") {
+		t.Fatalf("unexpected creator label: %#v", refs[0])
+	}
+}
+
+func TestMediaService_Delete_BlockedByEventProgressionTriggerMediaReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeImage)
+	theme := q.themes[themeID]
+	theme.ConfigJson = json.RawMessage(fmt.Sprintf(`{
+		"phases": [],
+		"modules": {
+			"event_progression": {
+				"enabled": true,
+				"config": {
+					"Triggers": [
+						{
+							"id": "reveal-room",
+							"label": "비밀 토론방 공개",
+							"actions": [{"id":"bg","type":"SET_BACKGROUND","params":{"mediaId":%q}}]
+						}
+					]
+				}
+			}
+		}
+	}`, mediaID.String()))
+	q.themes[themeID] = theme
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+
+	var appErr *apperror.AppError
+	_ = errors.As(err, &appErr)
+	refs := appErr.Params["references"].([]map[string]string)
+	if len(refs) != 1 || refs[0]["type"] != "event_progression_trigger_action" || refs[0]["id"] != "reveal-room:bg" {
+		t.Fatalf("unexpected event trigger reference: %#v", refs)
+	}
+	if !strings.Contains(refs[0]["name"], "비밀 토론방 공개 실행 결과") || !strings.Contains(refs[0]["name"], "배경 이미지") {
+		t.Fatalf("unexpected creator label: %#v", refs[0])
+	}
+}
+
+func TestMediaService_Delete_IgnoresMalformedConfigMediaReferenceScan(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeBGM)
+	theme := q.themes[themeID]
+	theme.ConfigJson = json.RawMessage(`{"phases": "malformed", "modules": {"event_progression": {"config": "malformed"}}}`)
+	q.themes[themeID] = theme
+
+	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID); err != nil {
+		t.Fatalf("malformed config should not block media deletion, got %v", err)
+	}
+	if _, ok := q.media[mediaID]; ok {
+		t.Fatalf("media should have been deleted")
 	}
 }
 

--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react";
-import { X, Trash2, Save } from "lucide-react";
-import { toast } from "sonner";
+import { useEffect, useState } from 'react';
+import { AlertTriangle, X, Trash2, Save } from 'lucide-react';
+import { toast } from 'sonner';
 import {
   useDeleteMedia,
   useUpdateMedia,
   type MediaReferenceInfo,
   type MediaResponse,
   type UpdateMediaRequest,
-} from "@/features/editor/mediaApi";
-import { ApiHttpError } from "@/lib/api-error";
+} from '@/features/editor/mediaApi';
+import { ApiHttpError } from '@/lib/api-error';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,18 +26,20 @@ export interface MediaDetailProps {
 
 export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const [name, setName] = useState(media.name);
-  const [tagsText, setTagsText] = useState((media.tags ?? []).join(", "));
+  const [tagsText, setTagsText] = useState((media.tags ?? []).join(', '));
   const [sortOrder, setSortOrder] = useState<number>(media.sort_order);
   const [duration, setDuration] = useState<string>(
-    media.duration != null ? String(media.duration) : "",
+    media.duration != null ? String(media.duration) : ''
   );
+  const [referenceWarning, setReferenceWarning] = useState<MediaReferenceInfo[] | null>(null);
 
   // Reset local state when selected media changes
   useEffect(() => {
     setName(media.name);
-    setTagsText((media.tags ?? []).join(", "));
+    setTagsText((media.tags ?? []).join(', '));
     setSortOrder(media.sort_order);
-    setDuration(media.duration != null ? String(media.duration) : "");
+    setDuration(media.duration != null ? String(media.duration) : '');
+    setReferenceWarning(null);
   }, [media.id, media.name, media.tags, media.sort_order, media.duration]);
 
   const updateMutation = useUpdateMedia(themeId);
@@ -46,16 +48,16 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const handleSave = () => {
     const trimmedName = name.trim();
     if (!trimmedName) {
-      toast.error("이름은 필수입니다");
+      toast.error('이름은 필수입니다');
       return;
     }
     const tags = tagsText
-      .split(",")
+      .split(',')
       .map((t) => t.trim())
       .filter(Boolean);
     const durationNum = duration.trim() ? Number(duration) : undefined;
     if (durationNum != null && (!Number.isFinite(durationNum) || durationNum < 0)) {
-      toast.error("길이는 0 이상 숫자여야 합니다");
+      toast.error('길이는 0 이상 숫자여야 합니다');
       return;
     }
     const patch: UpdateMediaRequest = {
@@ -68,35 +70,29 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
     updateMutation.mutate(
       { id: media.id, patch },
       {
-        onSuccess: () => toast.success("미디어가 저장되었습니다"),
-        onError: () => toast.error("미디어 저장에 실패했습니다"),
-      },
+        onSuccess: () => toast.success('미디어가 저장되었습니다'),
+        onError: () => toast.error('미디어 저장에 실패했습니다'),
+      }
     );
   };
 
   const handleDelete = async () => {
-    if (typeof window !== "undefined") {
+    setReferenceWarning(null);
+    if (typeof window !== 'undefined') {
       const ok = window.confirm(`"${media.name}"을(를) 삭제하시겠습니까?`);
       if (!ok) return;
     }
     try {
       await deleteMutation.mutateAsync(media.id);
-      toast.success("미디어가 삭제되었습니다");
+      toast.success('미디어가 삭제되었습니다');
       onClose();
     } catch (err) {
-      if (err instanceof ApiHttpError && err.apiError.code === "MEDIA_REFERENCE_IN_USE") {
-        const refs = err.apiError.params?.references as
-          | MediaReferenceInfo[]
-          | undefined;
-        const refList = refs?.map((r) => `- ${r.name}`).join("\n") ?? "";
-        if (typeof window !== "undefined") {
-          window.alert(
-            `이 미디어는 다음 리딩 섹션에서 사용 중입니다:\n${refList}`,
-          );
-        }
+      if (err instanceof ApiHttpError && err.apiError.code === 'MEDIA_REFERENCE_IN_USE') {
+        const refs = err.apiError.params?.references as MediaReferenceInfo[] | undefined;
+        setReferenceWarning(refs?.length ? refs : []);
         return;
       }
-      toast.error("미디어 삭제에 실패했습니다");
+      toast.error('미디어 삭제에 실패했습니다');
     }
   };
 
@@ -104,9 +100,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
     <div className="flex h-full flex-col gap-3">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h3 className="text-xs font-mono uppercase tracking-widest text-slate-500">
-          미디어 상세
-        </h3>
+        <h3 className="text-xs font-mono uppercase tracking-widest text-slate-500">미디어 상세</h3>
         <button
           type="button"
           onClick={onClose}
@@ -178,6 +172,33 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
           {media.mime_type && <div>mime: {media.mime_type}</div>}
           {media.file_size != null && <div>size: {media.file_size} B</div>}
         </div>
+
+        {referenceWarning && (
+          <div
+            role="alert"
+            className="rounded-sm border border-amber-700/70 bg-amber-950/30 px-3 py-2 text-xs text-amber-100"
+          >
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-none text-amber-400" />
+              <div className="min-w-0 space-y-1">
+                <p className="font-medium">이 미디어는 아직 삭제할 수 없습니다.</p>
+                <p className="text-[11px] text-amber-200/80">
+                  먼저 아래 제작 요소에서 이 미디어 연결을 해제하세요.
+                </p>
+                {referenceWarning.length > 0 && (
+                  <ul className="space-y-1 pt-1">
+                    {referenceWarning.map((ref, index) => (
+                      <li key={`${ref.type}-${ref.id}-${index}`} className="break-words">
+                        <span className="font-medium">{mediaReferenceTypeLabel(ref.type)}</span>:{' '}
+                        {ref.name}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Actions */}
@@ -203,4 +224,20 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
       </div>
     </div>
   );
+}
+
+function mediaReferenceTypeLabel(type: string): string {
+  switch (type) {
+    case 'reading_section':
+      return '리딩 섹션';
+    case 'role_sheet':
+      return '역할지';
+    case 'phase_action':
+      return '단계 연출';
+    case 'event_trigger_action':
+    case 'event_progression_trigger_action':
+      return '트리거 연출';
+    default:
+      return '사용 위치';
+  }
 }

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -25,7 +25,7 @@ const {
   toastError: vi.fn(),
 }));
 
-vi.mock("@/features/editor/mediaApi", () => ({
+vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
   useUpdateMedia: () => useUpdateMediaMock(),
   useDeleteMedia: () => useDeleteMediaMock(),
@@ -34,14 +34,14 @@ vi.mock("@/features/editor/mediaApi", () => ({
   useCreateYouTubeMedia: () => useCreateYouTubeMediaMock(),
 }));
 
-vi.mock("sonner", () => ({
+vi.mock('sonner', () => ({
   toast: { success: toastSuccess, error: toastError },
 }));
 
 // HTMLAudioElement isn't available in JSDOM by default for our needs;
 // stub it so usePreviewPlayer can construct without throwing.
 class FakeAudio {
-  src = "";
+  src = '';
   paused = true;
   addEventListener() {}
   removeEventListener() {}
@@ -57,8 +57,9 @@ globalThis.Audio = FakeAudio;
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { MediaTab } from "../MediaTab";
-import type { MediaResponse } from "@/features/editor/mediaApi";
+import { MediaTab } from '../MediaTab';
+import type { MediaResponse } from '@/features/editor/mediaApi';
+import { ApiHttpError } from '@/lib/api-error';
 
 // ---------------------------------------------------------------------------
 // Mock data
@@ -66,32 +67,32 @@ import type { MediaResponse } from "@/features/editor/mediaApi";
 
 const mockMedia: MediaResponse[] = [
   {
-    id: "media-1",
-    theme_id: "theme-1",
-    name: "오프닝 BGM",
-    type: "BGM",
-    source_type: "FILE",
-    url: "https://example.com/bgm.mp3",
+    id: 'media-1',
+    theme_id: 'theme-1',
+    name: '오프닝 BGM',
+    type: 'BGM',
+    source_type: 'FILE',
+    url: 'https://example.com/bgm.mp3',
     duration: 125,
     file_size: 1234567,
-    mime_type: "audio/mpeg",
-    tags: ["오프닝"],
+    mime_type: 'audio/mpeg',
+    tags: ['오프닝'],
     sort_order: 1,
-    created_at: "2026-04-05T00:00:00Z",
+    created_at: '2026-04-05T00:00:00Z',
   },
   {
-    id: "media-2",
-    theme_id: "theme-1",
-    name: "문 닫는 소리",
-    type: "SFX",
-    source_type: "FILE",
-    url: "https://example.com/sfx.mp3",
+    id: 'media-2',
+    theme_id: 'theme-1',
+    name: '문 닫는 소리',
+    type: 'SFX',
+    source_type: 'FILE',
+    url: 'https://example.com/sfx.mp3',
     duration: 3,
     file_size: 1024,
-    mime_type: "audio/mpeg",
+    mime_type: 'audio/mpeg',
     tags: [],
     sort_order: 2,
-    created_at: "2026-04-05T00:00:00Z",
+    created_at: '2026-04-05T00:00:00Z',
   },
 ];
 
@@ -128,8 +129,8 @@ afterEach(() => {
 // MediaTab
 // =========================================================================
 
-describe("MediaTab", () => {
-  it("로딩 중일 때 스피너를 표시한다", () => {
+describe('MediaTab', () => {
+  it('로딩 중일 때 스피너를 표시한다', () => {
     useMediaListMock.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -137,10 +138,10 @@ describe("MediaTab", () => {
     });
 
     render(<MediaTab themeId="theme-1" />);
-    expect(screen.getByRole("status", { name: "미디어 로딩 중" })).toBeDefined();
+    expect(screen.getByRole('status', { name: '미디어 로딩 중' })).toBeDefined();
   });
 
-  it("미디어가 없을 때 빈 상태를 표시한다", () => {
+  it('미디어가 없을 때 빈 상태를 표시한다', () => {
     useMediaListMock.mockReturnValue({
       data: [],
       isLoading: false,
@@ -148,10 +149,10 @@ describe("MediaTab", () => {
     });
 
     render(<MediaTab themeId="theme-1" />);
-    expect(screen.getByText("미디어 없음")).toBeDefined();
+    expect(screen.getByText('미디어 없음')).toBeDefined();
   });
 
-  it("미디어 카드 목록을 렌더링한다", () => {
+  it('미디어 카드 목록을 렌더링한다', () => {
     useMediaListMock.mockReturnValue({
       data: mockMedia,
       isLoading: false,
@@ -159,17 +160,17 @@ describe("MediaTab", () => {
     });
 
     render(<MediaTab themeId="theme-1" />);
-    expect(screen.getByText("오프닝 BGM")).toBeDefined();
-    expect(screen.getByText("문 닫는 소리")).toBeDefined();
+    expect(screen.getByText('오프닝 BGM')).toBeDefined();
+    expect(screen.getByText('문 닫는 소리')).toBeDefined();
     // Type badges — "BGM" also appears in toolbar pill, so use getAllByText
-    expect(screen.getAllByText("BGM").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText("SFX").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('BGM').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('SFX').length).toBeGreaterThanOrEqual(1);
     // Duration formatted mm:ss
-    expect(screen.getByText("2:05")).toBeDefined();
-    expect(screen.getByText("0:03")).toBeDefined();
+    expect(screen.getByText('2:05')).toBeDefined();
+    expect(screen.getByText('0:03')).toBeDefined();
   });
 
-  it("필터 변경 시 useMediaList를 새로운 타입으로 호출한다", () => {
+  it('필터 변경 시 useMediaList를 새로운 타입으로 호출한다', () => {
     useMediaListMock.mockReturnValue({
       data: mockMedia,
       isLoading: false,
@@ -179,16 +180,16 @@ describe("MediaTab", () => {
     render(<MediaTab themeId="theme-1" />);
 
     // 초기에는 'all' → undefined
-    expect(useMediaListMock).toHaveBeenLastCalledWith("theme-1", undefined);
+    expect(useMediaListMock).toHaveBeenLastCalledWith('theme-1', undefined);
 
     // BGM 필터 클릭 — pill button (효과음/음성과 분리되도록 BGM 정확 매칭)
-    const bgmPill = screen.getByRole("button", { name: "BGM", pressed: false });
+    const bgmPill = screen.getByRole('button', { name: 'BGM', pressed: false });
     fireEvent.click(bgmPill);
 
-    expect(useMediaListMock).toHaveBeenLastCalledWith("theme-1", "BGM");
+    expect(useMediaListMock).toHaveBeenLastCalledWith('theme-1', 'BGM');
   });
 
-  it("카드 클릭 시 상세 패널이 열린다", () => {
+  it('카드 클릭 시 상세 패널이 열린다', () => {
     useMediaListMock.mockReturnValue({
       data: mockMedia,
       isLoading: false,
@@ -198,20 +199,20 @@ describe("MediaTab", () => {
     render(<MediaTab themeId="theme-1" />);
 
     // Detail not visible
-    expect(screen.queryByText("미디어 상세")).toBeNull();
+    expect(screen.queryByText('미디어 상세')).toBeNull();
 
     // Click first card — name text is inside button
-    const card = screen.getByText("오프닝 BGM").closest("[role='button']") as HTMLElement | null;
+    const card = screen.getByText('오프닝 BGM').closest("[role='button']") as HTMLElement | null;
     expect(card).not.toBeNull();
     fireEvent.click(card!);
 
     // Detail visible
-    expect(screen.getByText("미디어 상세")).toBeDefined();
+    expect(screen.getByText('미디어 상세')).toBeDefined();
     // Editable name input pre-filled
-    expect(screen.getByDisplayValue("오프닝 BGM")).toBeDefined();
+    expect(screen.getByDisplayValue('오프닝 BGM')).toBeDefined();
   });
 
-  it("상세 닫기 버튼이 선택을 해제한다", () => {
+  it('상세 닫기 버튼이 선택을 해제한다', () => {
     useMediaListMock.mockReturnValue({
       data: mockMedia,
       isLoading: false,
@@ -221,18 +222,79 @@ describe("MediaTab", () => {
     render(<MediaTab themeId="theme-1" />);
 
     // Open detail
-    const card = screen.getByText("오프닝 BGM").closest("[role='button']") as HTMLElement | null;
+    const card = screen.getByText('오프닝 BGM').closest("[role='button']") as HTMLElement | null;
     fireEvent.click(card!);
-    expect(screen.getByText("미디어 상세")).toBeDefined();
+    expect(screen.getByText('미디어 상세')).toBeDefined();
 
     // Close
-    const closeBtn = screen.getByRole("button", { name: "상세 닫기" });
+    const closeBtn = screen.getByRole('button', { name: '상세 닫기' });
     fireEvent.click(closeBtn);
 
-    expect(screen.queryByText("미디어 상세")).toBeNull();
+    expect(screen.queryByText('미디어 상세')).toBeNull();
   });
 
-  it("업로드와 YouTube 버튼이 렌더링된다", () => {
+  it('참조 중인 미디어 삭제가 차단되면 제작 위치를 상세 패널에 표시한다', async () => {
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+    const deleteMutation = {
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockRejectedValue(
+        new ApiHttpError({
+          status: 409,
+          title: 'Conflict',
+          detail: 'media is referenced by editor content',
+          code: 'MEDIA_REFERENCE_IN_USE',
+          params: {
+            references: [
+              {
+                type: 'phase_action',
+                id: 'phase-open:onEnter:0',
+                name: '오프닝 시작 트리거에서 BGM으로 사용 중',
+              },
+              {
+                type: 'event_progression_trigger_action',
+                id: 'trigger-secret-room:0',
+                name: '비밀 토론방 공개 실행 결과에서 배경 이미지로 사용 중',
+              },
+            ],
+          },
+        })
+      ),
+      isPending: false,
+    };
+    useDeleteMediaMock.mockReturnValue(deleteMutation);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    try {
+      render(<MediaTab themeId="theme-1" />);
+
+      const card = screen.getByText('오프닝 BGM').closest("[role='button']") as HTMLElement | null;
+      fireEvent.click(card!);
+      fireEvent.click(screen.getByRole('button', { name: '삭제' }));
+
+      const warning = await screen.findByRole('alert');
+      expect(warning.textContent).toContain('이 미디어는 아직 삭제할 수 없습니다.');
+      expect(screen.getByText(/단계 연출/)).toBeDefined();
+      expect(screen.getByText(/오프닝 시작 트리거에서 BGM으로 사용 중/)).toBeDefined();
+      expect(screen.getByText(/트리거 연출/)).toBeDefined();
+      expect(
+        screen.getByText(/비밀 토론방 공개 실행 결과에서 배경 이미지로 사용 중/)
+      ).toBeDefined();
+      expect(screen.queryByText(/phase-open/)).toBeNull();
+      expect(screen.queryByText(/trigger-secret-room/)).toBeNull();
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(alertSpy).not.toHaveBeenCalled();
+    } finally {
+      confirmSpy.mockRestore();
+      alertSpy.mockRestore();
+    }
+  });
+
+  it('업로드와 YouTube 버튼이 렌더링된다', () => {
     useMediaListMock.mockReturnValue({
       data: [],
       isLoading: false,
@@ -242,15 +304,15 @@ describe("MediaTab", () => {
     render(<MediaTab themeId="theme-1" />);
 
     // D3/D4 will hook actual modals; for now just verify buttons exist & clickable
-    const uploadBtn = screen.getByRole("button", { name: /파일 업로드/ });
-    const ytBtn = screen.getByRole("button", { name: /YouTube/ });
+    const uploadBtn = screen.getByRole('button', { name: /파일 업로드/ });
+    const ytBtn = screen.getByRole('button', { name: /YouTube/ });
     expect(uploadBtn).toBeDefined();
     expect(ytBtn).toBeDefined();
     fireEvent.click(uploadBtn);
     fireEvent.click(ytBtn);
   });
 
-  it("에러 발생 시 에러 메시지를 표시한다", () => {
+  it('에러 발생 시 에러 메시지를 표시한다', () => {
     useMediaListMock.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -258,6 +320,6 @@ describe("MediaTab", () => {
     });
 
     render(<MediaTab themeId="theme-1" />);
-    expect(screen.getByText("미디어 목록을 불러오지 못했습니다")).toBeDefined();
+    expect(screen.getByText('미디어 목록을 불러오지 못했습니다')).toBeDefined();
   });
 });


### PR DESCRIPTION
## 요약
- phase onEnter/onExit action과 event progression trigger action의 params.mediaId 참조를 media 삭제 guard에 포함했습니다.
- 참조 중인 미디어 삭제 시 backend 409 references를 제작자용 문구로 반환하고, media 상세 패널에서 참조 위치를 안내합니다.
- phase/trigger 참조 삭제 차단 Go 테스트와 media 삭제 경고 Vitest를 추가했습니다.

## 검증
- go test ./internal/domain/editor -run 'TestMediaService_Delete_BlockedBy.*Reference|TestMediaService_Delete_IgnoresMalformedConfigMediaReferenceScan|TestMediaService_Delete_Success_NoReferences'
- go test ./internal/domain/editor
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/media/__tests__/MediaTab.test.tsx src/features/editor/mediaApi.test.ts
- pnpm --filter @mmp/web exec tsc --noEmit
- git diff --check

Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 테마 설정(phase onEnter/onExit) 및 이벤트 진행 트리거에서 미디어 참조를 감지합니다.
  * 미디어 삭제 시 인라인 경고로 어떤 콘텐츠가 참조하는지 사람 읽기 형식으로 표시합니다.

* **버그 수정**
  * 손상된 테마 설정 파싱 시 검증 오류로 처리하여 삭제를 차단합니다.

* **테스트**
  * 테마 구성 참조 차단, 다중 액션 라벨링, 손상된 구성 처리 등을 검증하는 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->