### PR TITLE
feat(editor): 캐릭터 결과 카드 계약 추가

### DIFF
--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -1360,6 +1360,15 @@ components:
         image_url:
           type: string
           format: uri
+        endcard_title:
+          type: string
+          maxLength: 80
+        endcard_body:
+          type: string
+          maxLength: 3000
+        endcard_image_url:
+          type: string
+          format: uri
         is_culprit:
           type: boolean
           default: false
@@ -1382,6 +1391,15 @@ components:
           type: string
           maxLength: 2000
         image_url:
+          type: string
+          format: uri
+        endcard_title:
+          type: string
+          maxLength: 80
+        endcard_body:
+          type: string
+          maxLength: 3000
+        endcard_image_url:
           type: string
           format: uri
         is_culprit:
@@ -1463,6 +1481,13 @@ components:
         description:
           type: string
         image_url:
+          type: string
+          format: uri
+        endcard_title:
+          type: string
+        endcard_body:
+          type: string
+        endcard_image_url:
           type: string
           format: uri
         is_culprit:

--- a/apps/server/db/migrations/00034_character_endcard_fields.sql
+++ b/apps/server/db/migrations/00034_character_endcard_fields.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE theme_characters
+  ADD COLUMN endcard_title TEXT,
+  ADD COLUMN endcard_body TEXT,
+  ADD COLUMN endcard_image_url TEXT;
+
+-- +goose Down
+ALTER TABLE theme_characters
+  DROP COLUMN IF EXISTS endcard_image_url,
+  DROP COLUMN IF EXISTS endcard_body,
+  DROP COLUMN IF EXISTS endcard_title;

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -25,8 +25,12 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order;
 
 -- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+INSERT INTO theme_characters (
+  theme_id, name, description, image_url, is_culprit, mystery_role, sort_order,
+  is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate,
+  endcard_title, endcard_body, endcard_image_url
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 RETURNING *;
 
 -- name: UpdateTheme :one
@@ -48,7 +52,20 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE id = $1;
 
 -- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11
+UPDATE theme_characters SET
+  name = $2,
+  description = $3,
+  image_url = $4,
+  is_culprit = $5,
+  mystery_role = $6,
+  sort_order = $7,
+  is_playable = $8,
+  show_in_intro = $9,
+  can_speak_in_reading = $10,
+  is_voting_candidate = $11,
+  endcard_title = $12,
+  endcard_body = $13,
+  endcard_image_url = $14
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -288,6 +288,9 @@ type ThemeCharacter struct {
 	ShowInIntro       bool        `json:"show_in_intro"`
 	CanSpeakInReading bool        `json:"can_speak_in_reading"`
 	IsVotingCandidate bool        `json:"is_voting_candidate"`
+	EndcardTitle      pgtype.Text `json:"endcard_title"`
+	EndcardBody       pgtype.Text `json:"endcard_body"`
+	EndcardImageUrl   pgtype.Text `json:"endcard_image_url"`
 }
 
 type ThemeClue struct {

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -86,9 +86,13 @@ func (q *Queries) CreateTheme(ctx context.Context, arg CreateThemeParams) (Theme
 }
 
 const createThemeCharacter = `-- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate
+INSERT INTO theme_characters (
+  theme_id, name, description, image_url, is_culprit, mystery_role, sort_order,
+  is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate,
+  endcard_title, endcard_body, endcard_image_url
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url
 `
 
 type CreateThemeCharacterParams struct {
@@ -103,6 +107,9 @@ type CreateThemeCharacterParams struct {
 	ShowInIntro       bool        `json:"show_in_intro"`
 	CanSpeakInReading bool        `json:"can_speak_in_reading"`
 	IsVotingCandidate bool        `json:"is_voting_candidate"`
+	EndcardTitle      pgtype.Text `json:"endcard_title"`
+	EndcardBody       pgtype.Text `json:"endcard_body"`
+	EndcardImageUrl   pgtype.Text `json:"endcard_image_url"`
 }
 
 func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeCharacterParams) (ThemeCharacter, error) {
@@ -118,6 +125,9 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		arg.ShowInIntro,
 		arg.CanSpeakInReading,
 		arg.IsVotingCandidate,
+		arg.EndcardTitle,
+		arg.EndcardBody,
+		arg.EndcardImageUrl,
 	)
 	var i ThemeCharacter
 	err := row.Scan(
@@ -133,6 +143,9 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		&i.ShowInIntro,
 		&i.CanSpeakInReading,
 		&i.IsVotingCandidate,
+		&i.EndcardTitle,
+		&i.EndcardBody,
+		&i.EndcardImageUrl,
 	)
 	return i, err
 }
@@ -220,7 +233,7 @@ func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error
 }
 
 const getThemeCharacter = `-- name: GetThemeCharacter :one
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate FROM theme_characters WHERE id = $1
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url FROM theme_characters WHERE id = $1
 `
 
 func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCharacter, error) {
@@ -239,12 +252,15 @@ func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCha
 		&i.ShowInIntro,
 		&i.CanSpeakInReading,
 		&i.IsVotingCandidate,
+		&i.EndcardTitle,
+		&i.EndcardBody,
+		&i.EndcardImageUrl,
 	)
 	return i, err
 }
 
 const getThemeCharacters = `-- name: GetThemeCharacters :many
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]ThemeCharacter, error) {
@@ -269,6 +285,9 @@ func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]
 			&i.ShowInIntro,
 			&i.CanSpeakInReading,
 			&i.IsVotingCandidate,
+			&i.EndcardTitle,
+			&i.EndcardBody,
+			&i.EndcardImageUrl,
 		); err != nil {
 			return nil, err
 		}
@@ -527,9 +546,22 @@ func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme
 }
 
 const updateThemeCharacter = `-- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11
+UPDATE theme_characters SET
+  name = $2,
+  description = $3,
+  image_url = $4,
+  is_culprit = $5,
+  mystery_role = $6,
+  sort_order = $7,
+  is_playable = $8,
+  show_in_intro = $9,
+  can_speak_in_reading = $10,
+  is_voting_candidate = $11,
+  endcard_title = $12,
+  endcard_body = $13,
+  endcard_image_url = $14
 WHERE id = $1
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url
 `
 
 type UpdateThemeCharacterParams struct {
@@ -544,6 +576,9 @@ type UpdateThemeCharacterParams struct {
 	ShowInIntro       bool        `json:"show_in_intro"`
 	CanSpeakInReading bool        `json:"can_speak_in_reading"`
 	IsVotingCandidate bool        `json:"is_voting_candidate"`
+	EndcardTitle      pgtype.Text `json:"endcard_title"`
+	EndcardBody       pgtype.Text `json:"endcard_body"`
+	EndcardImageUrl   pgtype.Text `json:"endcard_image_url"`
 }
 
 func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeCharacterParams) (ThemeCharacter, error) {
@@ -559,6 +594,9 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		arg.ShowInIntro,
 		arg.CanSpeakInReading,
 		arg.IsVotingCandidate,
+		arg.EndcardTitle,
+		arg.EndcardBody,
+		arg.EndcardImageUrl,
 	)
 	var i ThemeCharacter
 	err := row.Scan(
@@ -574,6 +612,9 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		&i.ShowInIntro,
 		&i.CanSpeakInReading,
 		&i.IsVotingCandidate,
+		&i.EndcardTitle,
+		&i.EndcardBody,
+		&i.EndcardImageUrl,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/handler_test.go
+++ b/apps/server/internal/domain/editor/handler_test.go
@@ -298,6 +298,35 @@ func TestUpdateCharacter_Success(t *testing.T) {
 	}
 }
 
+func TestUpdateCharacter_AllowsEmptyEndcardImageURL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockService(ctrl)
+
+	mock.EXPECT().
+		UpdateCharacter(gomock.Any(), gomock.Eq(extCreatorID), gomock.Eq(extCharID), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, _ uuid.UUID, req editor.UpdateCharacterRequest) (*editor.CharacterResponse, error) {
+			if req.EndcardImageURL == nil || *req.EndcardImageURL != "" {
+				t.Fatalf("expected empty endcard image URL to reach service, got %+v", req.EndcardImageURL)
+			}
+			return extSampleCharResponse(), nil
+		}).Times(1)
+
+	h := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
+
+	body := `{"name":"Detective Updated","is_culprit":false,"sort_order":1,"endcard_image_url":""}`
+	r := httptest.NewRequest(http.MethodPut, "/editor/characters/"+extCharID.String(), bytes.NewBufferString(body))
+	r.Header.Set("Content-Type", "application/json")
+	r = withExtAuth(r)
+	r = extChiContext(r, map[string]string{"id": extCharID.String()})
+	w := httptest.NewRecorder()
+
+	h.UpdateCharacter(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestDeleteCharacter_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := mocks.NewMockService(ctrl)

--- a/apps/server/internal/domain/editor/image_service.go
+++ b/apps/server/internal/domain/editor/image_service.go
@@ -238,6 +238,9 @@ func (s *ImageService) ConfirmImageUpload(
 			ShowInIntro:       char.ShowInIntro,
 			CanSpeakInReading: char.CanSpeakInReading,
 			IsVotingCandidate: char.IsVotingCandidate,
+			EndcardTitle:      char.EndcardTitle,
+			EndcardBody:       char.EndcardBody,
+			EndcardImageUrl:   char.EndcardImageUrl,
 		})
 		if err != nil {
 			s.logger.Error().Err(err).Str("character_id", targetID.String()).Msg("failed to update character image_url")

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -100,6 +100,9 @@ type CreateCharacterRequest struct {
 	ShowInIntro       *bool   `json:"show_in_intro"`
 	CanSpeakInReading *bool   `json:"can_speak_in_reading"`
 	IsVotingCandidate *bool   `json:"is_voting_candidate"`
+	EndcardTitle      *string `json:"endcard_title" validate:"omitempty,max=80"`
+	EndcardBody       *string `json:"endcard_body" validate:"omitempty,max=3000"`
+	EndcardImageURL   *string `json:"endcard_image_url" validate:"omitempty,url"`
 }
 
 type UpdateCharacterRequest struct {
@@ -113,6 +116,9 @@ type UpdateCharacterRequest struct {
 	ShowInIntro       *bool   `json:"show_in_intro"`
 	CanSpeakInReading *bool   `json:"can_speak_in_reading"`
 	IsVotingCandidate *bool   `json:"is_voting_candidate"`
+	EndcardTitle      *string `json:"endcard_title" validate:"omitempty,max=80"`
+	EndcardBody       *string `json:"endcard_body" validate:"omitempty,max=3000"`
+	EndcardImageURL   *string `json:"endcard_image_url" validate:"omitempty,url"`
 }
 
 type CharacterResponse struct {
@@ -128,6 +134,9 @@ type CharacterResponse struct {
 	ShowInIntro       bool      `json:"show_in_intro"`
 	CanSpeakInReading bool      `json:"can_speak_in_reading"`
 	IsVotingCandidate bool      `json:"is_voting_candidate"`
+	EndcardTitle      *string   `json:"endcard_title,omitempty"`
+	EndcardBody       *string   `json:"endcard_body,omitempty"`
+	EndcardImageURL   *string   `json:"endcard_image_url,omitempty"`
 }
 
 // --- Service interface ---

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -102,7 +102,7 @@ type CreateCharacterRequest struct {
 	IsVotingCandidate *bool   `json:"is_voting_candidate"`
 	EndcardTitle      *string `json:"endcard_title" validate:"omitempty,max=80"`
 	EndcardBody       *string `json:"endcard_body" validate:"omitempty,max=3000"`
-	EndcardImageURL   *string `json:"endcard_image_url" validate:"omitempty,url"`
+	EndcardImageURL   *string `json:"endcard_image_url" validate:"omitempty,optional_url"`
 }
 
 type UpdateCharacterRequest struct {
@@ -118,7 +118,7 @@ type UpdateCharacterRequest struct {
 	IsVotingCandidate *bool   `json:"is_voting_candidate"`
 	EndcardTitle      *string `json:"endcard_title" validate:"omitempty,max=80"`
 	EndcardBody       *string `json:"endcard_body" validate:"omitempty,max=3000"`
-	EndcardImageURL   *string `json:"endcard_image_url" validate:"omitempty,url"`
+	EndcardImageURL   *string `json:"endcard_image_url" validate:"omitempty,optional_url"`
 }
 
 type CharacterResponse struct {

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
@@ -50,6 +51,9 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		ShowInIntro:       visibilityPolicy.ShowInIntro,
 		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
 		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
+		EndcardTitle:      ptrToText(req.EndcardTitle),
+		EndcardBody:       ptrToText(req.EndcardBody),
+		EndcardImageUrl:   ptrToText(req.EndcardImageURL),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create character")
@@ -99,6 +103,9 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		ShowInIntro:       visibilityPolicy.ShowInIntro,
 		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
 		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
+		EndcardTitle:      characterEndcardText(req.EndcardTitle, char.EndcardTitle),
+		EndcardBody:       characterEndcardText(req.EndcardBody, char.EndcardBody),
+		EndcardImageUrl:   characterEndcardText(req.EndcardImageURL, char.EndcardImageUrl),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update character")
@@ -196,7 +203,20 @@ func toCharacterResponse(c db.ThemeCharacter) *CharacterResponse {
 		ShowInIntro:       c.ShowInIntro,
 		CanSpeakInReading: c.CanSpeakInReading,
 		IsVotingCandidate: c.IsVotingCandidate,
+		EndcardTitle:      textToPtr(c.EndcardTitle),
+		EndcardBody:       textToPtr(c.EndcardBody),
+		EndcardImageURL:   textToPtr(c.EndcardImageUrl),
 	}
+}
+
+func characterEndcardText(next *string, current pgtype.Text) pgtype.Text {
+	if next == nil {
+		return current
+	}
+	if *next == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *next, Valid: true}
 }
 
 // --- Module schemas ---

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -191,6 +191,10 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
+func textPtr(value string) *string {
+	return &value
+}
+
 func TestService_CreateCharacter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -280,6 +284,87 @@ func TestService_UpdateCharacter(t *testing.T) {
 	}
 	if !updated.IsPlayable || !updated.ShowInIntro || !updated.CanSpeakInReading || !updated.IsVotingCandidate {
 		t.Errorf("update should preserve default playable visibility: %+v", updated)
+	}
+}
+
+func TestService_CharacterEndcardContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	created, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{
+		Name:            "탐정",
+		EndcardTitle:    textPtr("탐정의 결말"),
+		EndcardBody:     textPtr("사건 이후에도 기록을 이어간다."),
+		EndcardImageURL: textPtr("https://cdn.example/endcard.webp"),
+	})
+	if err != nil {
+		t.Fatalf("CreateCharacter: %v", err)
+	}
+	if created.EndcardTitle == nil || *created.EndcardTitle != "탐정의 결말" {
+		t.Fatalf("EndcardTitle mismatch: %+v", created.EndcardTitle)
+	}
+	if created.EndcardBody == nil || *created.EndcardBody != "사건 이후에도 기록을 이어간다." {
+		t.Fatalf("EndcardBody mismatch: %+v", created.EndcardBody)
+	}
+	if created.EndcardImageURL == nil || *created.EndcardImageURL != "https://cdn.example/endcard.webp" {
+		t.Fatalf("EndcardImageURL mismatch: %+v", created.EndcardImageURL)
+	}
+
+	updated, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:            "탐정 수정",
+		MysteryRole:     created.MysteryRole,
+		IsCulprit:       created.IsCulprit,
+		SortOrder:       created.SortOrder,
+		EndcardTitle:    textPtr("탐정의 후일담"),
+		EndcardBody:     created.EndcardBody,
+		EndcardImageURL: created.EndcardImageURL,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter: %v", err)
+	}
+	if updated.EndcardTitle == nil || *updated.EndcardTitle != "탐정의 후일담" {
+		t.Fatalf("updated EndcardTitle mismatch: %+v", updated.EndcardTitle)
+	}
+
+	listed, err := f.svc.ListCharacters(ctx, creatorID, themeID)
+	if err != nil {
+		t.Fatalf("ListCharacters: %v", err)
+	}
+	if len(listed) != 1 || listed[0].EndcardBody == nil || *listed[0].EndcardBody != "사건 이후에도 기록을 이어간다." {
+		t.Fatalf("list endcard body mismatch: %+v", listed)
+	}
+
+	preserved, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:        "탐정 이름만 수정",
+		MysteryRole: updated.MysteryRole,
+		IsCulprit:   updated.IsCulprit,
+		SortOrder:   updated.SortOrder,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter preserve: %v", err)
+	}
+	if preserved.EndcardTitle == nil || *preserved.EndcardTitle != "탐정의 후일담" {
+		t.Fatalf("omitted endcard title should be preserved: %+v", preserved.EndcardTitle)
+	}
+
+	cleared, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:         preserved.Name,
+		MysteryRole:  preserved.MysteryRole,
+		IsCulprit:    preserved.IsCulprit,
+		SortOrder:    preserved.SortOrder,
+		EndcardTitle: textPtr(""),
+		EndcardBody:  textPtr(""),
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter clear: %v", err)
+	}
+	if cleared.EndcardTitle != nil || cleared.EndcardBody != nil {
+		t.Fatalf("empty endcard fields should clear stored values: %+v", cleared)
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -369,6 +369,20 @@ func TestService_CharacterEndcardContract(t *testing.T) {
 	if cleared.EndcardImageURL == nil || *cleared.EndcardImageURL != "https://cdn.example/endcard.webp" {
 		t.Fatalf("omitted endcard image url should be preserved: %+v", cleared.EndcardImageURL)
 	}
+
+	clearedImage, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:            cleared.Name,
+		MysteryRole:     cleared.MysteryRole,
+		IsCulprit:       cleared.IsCulprit,
+		SortOrder:       cleared.SortOrder,
+		EndcardImageURL: textPtr(""),
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter clear image: %v", err)
+	}
+	if clearedImage.EndcardImageURL != nil {
+		t.Fatalf("empty endcard image url should clear stored value: %+v", clearedImage.EndcardImageURL)
+	}
 }
 
 func TestService_CreateCharacterNPCVisibility(t *testing.T) {

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -366,6 +366,9 @@ func TestService_CharacterEndcardContract(t *testing.T) {
 	if cleared.EndcardTitle != nil || cleared.EndcardBody != nil {
 		t.Fatalf("empty endcard fields should clear stored values: %+v", cleared)
 	}
+	if cleared.EndcardImageURL == nil || *cleared.EndcardImageURL != "https://cdn.example/endcard.webp" {
+		t.Fatalf("omitted endcard image url should be preserved: %+v", cleared.EndcardImageURL)
+	}
 }
 
 func TestService_CreateCharacterNPCVisibility(t *testing.T) {

--- a/apps/server/internal/httputil/json.go
+++ b/apps/server/internal/httputil/json.go
@@ -4,12 +4,41 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/url"
+	"reflect"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/mmp-platform/server/internal/apperror"
 )
 
-var validate = validator.New()
+var validate = newValidator()
+
+func newValidator() *validator.Validate {
+	v := validator.New()
+	if err := v.RegisterValidation("optional_url", validateOptionalURL); err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func validateOptionalURL(fl validator.FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return true
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return false
+	}
+	rawURL := field.String()
+	if rawURL == "" {
+		return true
+	}
+	parsed, err := url.Parse(rawURL)
+	return err == nil && parsed.Scheme != "" && parsed.Host != ""
+}
 
 // maxBodySize is the maximum allowed request body size (1 MB).
 const maxBodySize = 1 << 20

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -54,6 +54,9 @@ export interface EditorCharacterResponse {
   show_in_intro: boolean;
   can_speak_in_reading: boolean;
   is_voting_candidate: boolean;
+  endcard_title?: string | null;
+  endcard_body?: string | null;
+  endcard_image_url?: string | null;
 }
 
 export type MysteryRole = 'suspect' | 'culprit' | 'accomplice' | 'detective';
@@ -91,6 +94,9 @@ export interface CreateCharacterRequest {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  endcard_title?: string;
+  endcard_body?: string;
+  endcard_image_url?: string;
 }
 
 export interface UpdateCharacterRequest {
@@ -104,6 +110,9 @@ export interface UpdateCharacterRequest {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  endcard_title?: string;
+  endcard_body?: string;
+  endcard_image_url?: string;
 }
 
 export interface CreateClueRequest {

--- a/apps/web/src/features/editor/components/CharacterForm.tsx
+++ b/apps/web/src/features/editor/components/CharacterForm.tsx
@@ -74,6 +74,12 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
     if (Object.keys(validationErrors).length > 0) return;
 
     if (isEditMode) {
+      const nextMysteryRole = isCulprit
+        ? 'culprit'
+        : character.mystery_role === 'culprit'
+          ? 'suspect'
+          : character.mystery_role;
+
       updateCharacter.mutate(
         {
           characterId: character.id,
@@ -83,6 +89,14 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
             image_url: imageUrl || undefined,
             is_culprit: isCulprit,
             sort_order: sortOrder,
+            mystery_role: nextMysteryRole,
+            is_playable: character.is_playable,
+            show_in_intro: character.show_in_intro,
+            can_speak_in_reading: character.can_speak_in_reading,
+            is_voting_candidate: character.is_voting_candidate,
+            endcard_title: character.endcard_title ?? undefined,
+            endcard_body: character.endcard_body ?? undefined,
+            endcard_image_url: character.endcard_image_url ?? undefined,
           },
         },
         {

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -12,6 +12,7 @@ import {
 import {
   buildCharacterVisibilityUpdatePayload,
   buildCharacterRoleUpdatePayload,
+  buildCharacterEndcardUpdatePayload,
   getCharacterListBadges,
   type CharacterVisibilityField,
 } from "@/features/editor/entities/character/characterEditorAdapter";
@@ -136,6 +137,21 @@ export function CharacterAssignPanel({
     [characters, updateCharacter],
   );
 
+  const handleEndcardChangeForChar = useCallback(
+    (characterId: string, values: { title: string; body: string; imageUrl: string }) => {
+      if (updateCharacter.isPending) return;
+
+      const selected = characters?.find((char) => char.id === characterId);
+      if (!selected) return;
+
+      updateCharacter.mutate({
+        characterId: selected.id,
+        body: buildCharacterEndcardUpdatePayload(selected, values),
+      });
+    },
+    [characters, updateCharacter],
+  );
+
   if (charsLoading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -221,6 +237,11 @@ export function CharacterAssignPanel({
               updateCharacter.isPending
                 ? undefined
                 : (field, value) => handleVisibilityChangeForChar(char.id, field, value)
+            }
+            onEndcardChange={
+              updateCharacter.isPending
+                ? undefined
+                : (values) => handleEndcardChangeForChar(char.id, values)
             }
           />
         )}

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Accordion } from '@/shared/components/ui';
 import type { MysteryRole } from '@/features/editor/api';
 import type { Mission } from './MissionEditor';
@@ -37,6 +38,9 @@ interface CharacterItem {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  endcard_title?: string | null;
+  endcard_body?: string | null;
+  endcard_image_url?: string | null;
 }
 
 interface CharacterDetailPanelProps {
@@ -52,6 +56,7 @@ interface CharacterDetailPanelProps {
   onDeleteMission: (missionId: string) => void;
   onMysteryRoleChange?: (role: MysteryRole) => void;
   onVisibilityChange?: (field: CharacterVisibilityField, value: boolean) => void;
+  onEndcardChange?: (values: { title: string; body: string; imageUrl: string }) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -71,7 +76,18 @@ export function CharacterDetailPanel({
   onDeleteMission,
   onMysteryRoleChange,
   onVisibilityChange,
+  onEndcardChange,
 }: CharacterDetailPanelProps) {
+  const [endcardTitle, setEndcardTitle] = useState('');
+  const [endcardBody, setEndcardBody] = useState('');
+  const [endcardImageUrl, setEndcardImageUrl] = useState('');
+
+  useEffect(() => {
+    setEndcardTitle(selectedChar?.endcard_title ?? '');
+    setEndcardBody(selectedChar?.endcard_body ?? '');
+    setEndcardImageUrl(selectedChar?.endcard_image_url ?? '');
+  }, [selectedChar?.id, selectedChar?.endcard_title, selectedChar?.endcard_body, selectedChar?.endcard_image_url]);
+
   if (!selectedChar) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -95,7 +111,14 @@ export function CharacterDetailPanel({
     can_speak_in_reading: selectedChar.can_speak_in_reading ?? true,
     is_voting_candidate:
       selectedChar.is_voting_candidate ?? getCharacterRoleOption(selectedRole).defaultVotingCandidate,
+    endcard_title: selectedChar.endcard_title ?? null,
+    endcard_body: selectedChar.endcard_body ?? null,
+    endcard_image_url: selectedChar.endcard_image_url ?? null,
   });
+  const endcardDirty =
+    endcardTitle !== (selectedChar.endcard_title ?? '') ||
+    endcardBody !== (selectedChar.endcard_body ?? '') ||
+    endcardImageUrl !== (selectedChar.endcard_image_url ?? '');
 
   return (
     <div className="max-w-5xl space-y-4">
@@ -186,6 +209,67 @@ export function CharacterDetailPanel({
                       {selectedChar.description || '공개 소개가 없습니다.'}
                     </p>
                   </div>
+                </div>
+              </div>
+            ),
+          },
+          {
+            id: 'endcard',
+            title: '결과 카드',
+            subtitle: selectedView.hasEndcard ? '작성됨' : '비어 있음',
+            defaultOpen: true,
+            children: (
+              <div className="space-y-3">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <label className="block">
+                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">제목</span>
+                    <input
+                      type="text"
+                      value={endcardTitle}
+                      maxLength={80}
+                      disabled={!onEndcardChange}
+                      onChange={(event) => setEndcardTitle(event.currentTarget.value)}
+                      className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-200 outline-none transition focus:border-amber-500/60 disabled:opacity-70"
+                      placeholder={`${selectedChar.name}의 후일담`}
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">이미지 URL</span>
+                    <input
+                      type="url"
+                      value={endcardImageUrl}
+                      disabled={!onEndcardChange}
+                      onChange={(event) => setEndcardImageUrl(event.currentTarget.value)}
+                      className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-200 outline-none transition focus:border-amber-500/60 disabled:opacity-70"
+                      placeholder="https://..."
+                    />
+                  </label>
+                </div>
+                <label className="block">
+                  <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">본문</span>
+                  <textarea
+                    value={endcardBody}
+                    maxLength={3000}
+                    rows={5}
+                    disabled={!onEndcardChange}
+                    onChange={(event) => setEndcardBody(event.currentTarget.value)}
+                    className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm leading-5 text-slate-200 outline-none transition focus:border-amber-500/60 disabled:opacity-70"
+                    placeholder="게임 종료 후 이 인물에게 보여줄 내용을 작성하세요."
+                  />
+                </label>
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    disabled={!onEndcardChange || !endcardDirty}
+                    onClick={() => onEndcardChange?.({
+                      title: endcardTitle,
+                      body: endcardBody,
+                      imageUrl: endcardImageUrl,
+                    })}
+                    className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:border-slate-800 disabled:bg-slate-950 disabled:text-slate-600"
+                  >
+                    결과 카드 저장
+                  </button>
                 </div>
               </div>
             ),

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -246,6 +246,41 @@ describe('CharacterAssignPanel', () => {
     expect(updateCharacterMutateMock).not.toHaveBeenCalled();
   });
 
+  it('결과 카드 내용을 캐릭터 저장 계약으로 보낸다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+
+    fireEvent.change(screen.getByRole('textbox', { name: '제목' }), {
+      target: { value: '범인의 후일담' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: '이미지 URL' }), {
+      target: { value: 'https://cdn.example/endcard.webp' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: '본문' }), {
+      target: { value: '사건 이후의 선택을 보여준다.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '결과 카드 저장' }));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      body: {
+        name: '홍길동',
+        description: undefined,
+        image_url: undefined,
+        is_culprit: true,
+        mystery_role: 'culprit',
+        sort_order: 0,
+        is_playable: true,
+        show_in_intro: true,
+        can_speak_in_reading: true,
+        is_voting_candidate: true,
+        endcard_title: '범인의 후일담',
+        endcard_body: '사건 이후의 선택을 보여준다.',
+        endcard_image_url: 'https://cdn.example/endcard.webp',
+      },
+    });
+  });
+
 
   it('선택한 캐릭터가 목록에서 사라지면 현재 상세 캐릭터 ID로 저장한다', async () => {
     let currentCharacters = mockCharacters;

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { EditorCharacterResponse } from '@/features/editor/api/types';
 import {
   buildCharacterVisibilityUpdatePayload,
+  buildCharacterEndcardUpdatePayload,
   getCharacterListBadges,
   buildCharacterRoleUpdatePayload,
   getCharacterRoleBadge,
@@ -23,6 +24,9 @@ function character(overrides: Partial<EditorCharacterResponse> = {}): EditorChar
     show_in_intro: true,
     can_speak_in_reading: true,
     is_voting_candidate: true,
+    endcard_title: null,
+    endcard_body: null,
+    endcard_image_url: null,
     ...overrides,
   };
 }
@@ -48,6 +52,21 @@ describe('characterEditorAdapter', () => {
       canSpeakInReading: true,
       isVotingCandidate: true,
       visibilityBadges: ['PC', '소개 표시', '읽기 대사', '투표 후보'],
+    });
+  });
+
+  it('결과 카드 필드를 제작자용 ViewModel로 변환한다', () => {
+    const vm = toCharacterEditorViewModel(character({
+      endcard_title: '홍길동의 후일담',
+      endcard_body: '사건 이후에도 단서를 정리한다.',
+      endcard_image_url: 'https://cdn.example/endcard.webp',
+    }));
+
+    expect(vm).toMatchObject({
+      endcardTitle: '홍길동의 후일담',
+      endcardBody: '사건 이후에도 단서를 정리한다.',
+      endcardImageUrl: 'https://cdn.example/endcard.webp',
+      hasEndcard: true,
     });
   });
 
@@ -97,6 +116,21 @@ describe('characterEditorAdapter', () => {
     expect(buildCharacterRoleUpdatePayload(character(), 'detective').is_culprit).toBe(false);
   });
 
+  it('역할 변경 저장 payload에서 기존 결과 카드 내용을 보존한다', () => {
+    const payload = buildCharacterRoleUpdatePayload(character({
+      endcard_title: '결과 제목',
+      endcard_body: '결과 본문',
+      endcard_image_url: 'https://cdn.example/result.webp',
+    }), 'detective');
+
+    expect(payload).toMatchObject({
+      mystery_role: 'detective',
+      endcard_title: '결과 제목',
+      endcard_body: '결과 본문',
+      endcard_image_url: 'https://cdn.example/result.webp',
+    });
+  });
+
   it('NPC로 전환할 때 투표 후보를 함께 끈다', () => {
     const payload = buildCharacterVisibilityUpdatePayload(character(), 'is_playable', false);
 
@@ -105,6 +139,50 @@ describe('characterEditorAdapter', () => {
       show_in_intro: true,
       can_speak_in_reading: true,
       is_voting_candidate: false,
+    });
+  });
+
+  it('등장인물 유형 변경 저장 payload에서 기존 결과 카드 내용을 보존한다', () => {
+    const payload = buildCharacterVisibilityUpdatePayload(character({
+      endcard_title: '결과 제목',
+      endcard_body: '결과 본문',
+    }), 'show_in_intro', false);
+
+    expect(payload).toMatchObject({
+      show_in_intro: false,
+      endcard_title: '결과 제목',
+      endcard_body: '결과 본문',
+    });
+  });
+
+  it('결과 카드 저장 payload를 만든다', () => {
+    const payload = buildCharacterEndcardUpdatePayload(character({ is_playable: false }), {
+      title: '  새 결말  ',
+      body: '  공개되는 후일담  ',
+      imageUrl: '  https://cdn.example/new.webp  ',
+    });
+
+    expect(payload).toMatchObject({
+      name: '홍길동',
+      mystery_role: 'suspect',
+      is_playable: false,
+      endcard_title: '새 결말',
+      endcard_body: '공개되는 후일담',
+      endcard_image_url: 'https://cdn.example/new.webp',
+    });
+  });
+
+  it('빈 결과 카드 저장 payload는 빈 문자열을 유지해 backend clear 계약을 사용한다', () => {
+    const payload = buildCharacterEndcardUpdatePayload(character(), {
+      title: ' ',
+      body: ' ',
+      imageUrl: ' ',
+    });
+
+    expect(payload).toMatchObject({
+      endcard_title: '',
+      endcard_body: '',
+      endcard_image_url: '',
     });
   });
 });

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -31,6 +31,10 @@ export interface CharacterEditorViewModel {
   canSpeakInReading: boolean;
   isVotingCandidate: boolean;
   visibilityBadges: string[];
+  endcardTitle: string;
+  endcardBody: string;
+  endcardImageUrl: string | null;
+  hasEndcard: boolean;
 }
 
 export const characterRoleOptions: CharacterRoleOption[] = [
@@ -107,6 +111,17 @@ function getVisibilityBadges(visibility: ReturnType<typeof getCharacterVisibilit
   return badges;
 }
 
+function getExistingEndcardPayload(character: EditorCharacterResponse): Pick<
+  UpdateCharacterRequest,
+  'endcard_title' | 'endcard_body' | 'endcard_image_url'
+> {
+  return {
+    ...(character.endcard_title ? { endcard_title: character.endcard_title } : {}),
+    ...(character.endcard_body ? { endcard_body: character.endcard_body } : {}),
+    ...(character.endcard_image_url ? { endcard_image_url: character.endcard_image_url } : {}),
+  };
+}
+
 export function toCharacterEditorViewModel(character: EditorCharacterResponse): CharacterEditorViewModel {
   const role = normalizeCharacterEditorRole(character);
   const option = getCharacterRoleOption(role);
@@ -131,6 +146,10 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     canSpeakInReading: visibility.canSpeakInReading,
     isVotingCandidate: visibility.isVotingCandidate,
     visibilityBadges: getVisibilityBadges(visibility),
+    endcardTitle: character.endcard_title?.trim() ?? '',
+    endcardBody: character.endcard_body?.trim() ?? '',
+    endcardImageUrl: character.endcard_image_url,
+    hasEndcard: Boolean(character.endcard_title?.trim() || character.endcard_body?.trim() || character.endcard_image_url),
   };
 }
 
@@ -155,6 +174,7 @@ export function buildCharacterRoleUpdatePayload(
     show_in_intro: visibility.showInIntro,
     can_speak_in_reading: visibility.canSpeakInReading,
     is_voting_candidate: visibility.isVotingCandidate,
+    ...getExistingEndcardPayload(character),
   };
 }
 
@@ -185,6 +205,34 @@ export function buildCharacterVisibilityUpdatePayload(
     mystery_role: role,
     sort_order: character.sort_order,
     ...next,
+    ...getExistingEndcardPayload(character),
+  };
+}
+
+export function buildCharacterEndcardUpdatePayload(
+  character: EditorCharacterResponse,
+  values: { title: string; body: string; imageUrl: string },
+): UpdateCharacterRequest {
+  const role = normalizeCharacterEditorRole(character);
+  const visibility = getCharacterVisibility(character, role);
+  const title = values.title.trim();
+  const body = values.body.trim();
+  const imageUrl = values.imageUrl.trim();
+
+  return {
+    name: character.name,
+    description: character.description ?? undefined,
+    image_url: character.image_url ?? undefined,
+    is_culprit: role === 'culprit',
+    mystery_role: role,
+    sort_order: character.sort_order,
+    is_playable: visibility.isPlayable,
+    show_in_intro: visibility.showInIntro,
+    can_speak_in_reading: visibility.canSpeakInReading,
+    is_voting_candidate: visibility.isVotingCandidate,
+    endcard_title: title,
+    endcard_body: body,
+    endcard_image_url: imageUrl,
   };
 }
 

--- a/docs/plans/2026-05-05-issue-330-character-endcards/design.md
+++ b/docs/plans/2026-05-05-issue-330-character-endcards/design.md
@@ -1,0 +1,20 @@
+# Issue #330 Character Endcards
+
+## 결정
+
+- 엔드카드는 Character Entity가 소유한다.
+- 기존 `name`/`description`/`image_url`은 공개 소개 필드로 유지한다.
+- `endcard_title`/`endcard_body`/`endcard_image_url`은 결과 이후 표시할 스포일러 가능 필드로 분리한다.
+- #280은 RESULT/감상 화면의 전체 레이아웃, GM override, 공유 정책, 공개 타이밍을 계속 소유한다.
+
+## 이번 PR 범위
+
+- `theme_characters` 저장 계약에 결과 카드 필드를 추가한다.
+- editor character API request/response와 frontend type/adapter를 확장한다.
+- 실제 `/editor/:id/characters` 제작 화면의 캐릭터 상세에 결과 카드 섹션을 추가한다.
+- 역할 변경, PC/NPC visibility 변경, 기본 캐릭터 수정이 기존 결과 카드 값을 지우지 않도록 보존한다.
+
+## 후속 연결
+
+- player-aware RESULT redaction과 카드 표시 위치는 #280에서 backend runtime response를 기준으로 연결한다.
+- ending node id cleanup/source-of-truth는 #293 PR 완료 후 그 계약을 따른다.


### PR DESCRIPTION
## 요약
- 캐릭터 엔티티에 결과 카드 저장 계약(endcard_title/body/image_url)을 추가합니다.
- 실제 /editor/:id/characters 제작 화면의 캐릭터 상세에서 결과 카드를 작성/저장할 수 있게 연결합니다.
- RESULT 런타임 공개 정책은 #280 소유로 분리하고, 기존 역할/유형/이미지 수정이 결과 카드를 지우지 않도록 보존합니다.

Closes #330
Refs #280

## 검증
- go test ./internal/domain/editor
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/__tests__/CharactersTab.test.tsx src/features/editor/components/__tests__/Editor.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캐릭터 편집기에서 결과 카드(End Card) 필드 추가: 제목, 본문, 이미지 URL을 설정·저장·편집 가능
  * 편집/업데이트 흐름이 기존 결과 카드 내용을 보존하거나 빈값으로 명시적 삭제할 수 있도록 개선

* **문서**
  * 결과 카드 설계 문서 추가

* **테스트**
  * 결과 카드 생성·갱신·보존·삭제 동작을 검증하는 통합 및 단위 테스트 추가

* **기타**
  * 이미지 URL 처리 유효성 검증이 빈값/널을 허용하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->