### PR TITLE
feat(editor): 캐릭터 조건부 표시 계약 추가

### DIFF
--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -1370,6 +1370,18 @@ components:
         sort_order:
           type: integer
           minimum: 0
+        is_playable:
+          type: boolean
+        show_in_intro:
+          type: boolean
+        can_speak_in_reading:
+          type: boolean
+        is_voting_candidate:
+          type: boolean
+        alias_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/CharacterAliasRule"
 
     UpdateCharacterRequest:
       type: object
@@ -1392,6 +1404,38 @@ components:
         sort_order:
           type: integer
           minimum: 0
+        is_playable:
+          type: boolean
+        show_in_intro:
+          type: boolean
+        can_speak_in_reading:
+          type: boolean
+        is_voting_candidate:
+          type: boolean
+        alias_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/CharacterAliasRule"
+
+    CharacterAliasRule:
+      type: object
+      required: [id, priority, condition]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        display_name:
+          type: string
+          maxLength: 50
+        display_icon_url:
+          type: string
+          format: uri
+        priority:
+          type: integer
+          minimum: 0
+        condition:
+          type: object
 
     EditorThemeSummary:
       type: object
@@ -1450,7 +1494,7 @@ components:
 
     EditorCharacterResponse:
       type: object
-      required: [id, theme_id, name, is_culprit, mystery_role, sort_order]
+      required: [id, theme_id, name, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules]
       properties:
         id:
           type: string
@@ -1472,6 +1516,18 @@ components:
           enum: [suspect, culprit, accomplice, detective]
         sort_order:
           type: integer
+        is_playable:
+          type: boolean
+        show_in_intro:
+          type: boolean
+        can_speak_in_reading:
+          type: boolean
+        is_voting_candidate:
+          type: boolean
+        alias_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/CharacterAliasRule"
 
     RoleSheetMarkdown:
       type: object

--- a/apps/server/db/migrations/00035_character_alias_rules.sql
+++ b/apps/server/db/migrations/00035_character_alias_rules.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE theme_characters
+  ADD COLUMN alias_rules JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- +goose Down
+ALTER TABLE theme_characters
+  DROP COLUMN IF EXISTS alias_rules;

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -25,8 +25,8 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order;
 
 -- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 RETURNING *;
 
 -- name: UpdateTheme :one
@@ -48,7 +48,7 @@ RETURNING *;
 SELECT * FROM theme_characters WHERE id = $1;
 
 -- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11
+UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11, alias_rules = $12
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -276,18 +276,19 @@ type Theme struct {
 }
 
 type ThemeCharacter struct {
-	ID                uuid.UUID   `json:"id"`
-	ThemeID           uuid.UUID   `json:"theme_id"`
-	Name              string      `json:"name"`
-	Description       pgtype.Text `json:"description"`
-	ImageUrl          pgtype.Text `json:"image_url"`
-	IsCulprit         bool        `json:"is_culprit"`
-	SortOrder         int32       `json:"sort_order"`
-	MysteryRole       string      `json:"mystery_role"`
-	IsPlayable        bool        `json:"is_playable"`
-	ShowInIntro       bool        `json:"show_in_intro"`
-	CanSpeakInReading bool        `json:"can_speak_in_reading"`
-	IsVotingCandidate bool        `json:"is_voting_candidate"`
+	ID                uuid.UUID       `json:"id"`
+	ThemeID           uuid.UUID       `json:"theme_id"`
+	Name              string          `json:"name"`
+	Description       pgtype.Text     `json:"description"`
+	ImageUrl          pgtype.Text     `json:"image_url"`
+	IsCulprit         bool            `json:"is_culprit"`
+	SortOrder         int32           `json:"sort_order"`
+	MysteryRole       string          `json:"mystery_role"`
+	IsPlayable        bool            `json:"is_playable"`
+	ShowInIntro       bool            `json:"show_in_intro"`
+	CanSpeakInReading bool            `json:"can_speak_in_reading"`
+	IsVotingCandidate bool            `json:"is_voting_candidate"`
+	AliasRules        json.RawMessage `json:"alias_rules"`
 }
 
 type ThemeClue struct {

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -86,23 +86,24 @@ func (q *Queries) CreateTheme(ctx context.Context, arg CreateThemeParams) (Theme
 }
 
 const createThemeCharacter = `-- name: CreateThemeCharacter :one
-INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate
+INSERT INTO theme_characters (theme_id, name, description, image_url, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules
 `
 
 type CreateThemeCharacterParams struct {
-	ThemeID           uuid.UUID   `json:"theme_id"`
-	Name              string      `json:"name"`
-	Description       pgtype.Text `json:"description"`
-	ImageUrl          pgtype.Text `json:"image_url"`
-	IsCulprit         bool        `json:"is_culprit"`
-	MysteryRole       string      `json:"mystery_role"`
-	SortOrder         int32       `json:"sort_order"`
-	IsPlayable        bool        `json:"is_playable"`
-	ShowInIntro       bool        `json:"show_in_intro"`
-	CanSpeakInReading bool        `json:"can_speak_in_reading"`
-	IsVotingCandidate bool        `json:"is_voting_candidate"`
+	ThemeID           uuid.UUID       `json:"theme_id"`
+	Name              string          `json:"name"`
+	Description       pgtype.Text     `json:"description"`
+	ImageUrl          pgtype.Text     `json:"image_url"`
+	IsCulprit         bool            `json:"is_culprit"`
+	MysteryRole       string          `json:"mystery_role"`
+	SortOrder         int32           `json:"sort_order"`
+	IsPlayable        bool            `json:"is_playable"`
+	ShowInIntro       bool            `json:"show_in_intro"`
+	CanSpeakInReading bool            `json:"can_speak_in_reading"`
+	IsVotingCandidate bool            `json:"is_voting_candidate"`
+	AliasRules        json.RawMessage `json:"alias_rules"`
 }
 
 func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeCharacterParams) (ThemeCharacter, error) {
@@ -118,6 +119,7 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		arg.ShowInIntro,
 		arg.CanSpeakInReading,
 		arg.IsVotingCandidate,
+		arg.AliasRules,
 	)
 	var i ThemeCharacter
 	err := row.Scan(
@@ -133,6 +135,7 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		&i.ShowInIntro,
 		&i.CanSpeakInReading,
 		&i.IsVotingCandidate,
+		&i.AliasRules,
 	)
 	return i, err
 }
@@ -220,7 +223,7 @@ func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error
 }
 
 const getThemeCharacter = `-- name: GetThemeCharacter :one
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate FROM theme_characters WHERE id = $1
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules FROM theme_characters WHERE id = $1
 `
 
 func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCharacter, error) {
@@ -239,12 +242,13 @@ func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCha
 		&i.ShowInIntro,
 		&i.CanSpeakInReading,
 		&i.IsVotingCandidate,
+		&i.AliasRules,
 	)
 	return i, err
 }
 
 const getThemeCharacters = `-- name: GetThemeCharacters :many
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]ThemeCharacter, error) {
@@ -269,6 +273,7 @@ func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]
 			&i.ShowInIntro,
 			&i.CanSpeakInReading,
 			&i.IsVotingCandidate,
+			&i.AliasRules,
 		); err != nil {
 			return nil, err
 		}
@@ -527,23 +532,24 @@ func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme
 }
 
 const updateThemeCharacter = `-- name: UpdateThemeCharacter :one
-UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11
+UPDATE theme_characters SET name = $2, description = $3, image_url = $4, is_culprit = $5, mystery_role = $6, sort_order = $7, is_playable = $8, show_in_intro = $9, can_speak_in_reading = $10, is_voting_candidate = $11, alias_rules = $12
 WHERE id = $1
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules
 `
 
 type UpdateThemeCharacterParams struct {
-	ID                uuid.UUID   `json:"id"`
-	Name              string      `json:"name"`
-	Description       pgtype.Text `json:"description"`
-	ImageUrl          pgtype.Text `json:"image_url"`
-	IsCulprit         bool        `json:"is_culprit"`
-	MysteryRole       string      `json:"mystery_role"`
-	SortOrder         int32       `json:"sort_order"`
-	IsPlayable        bool        `json:"is_playable"`
-	ShowInIntro       bool        `json:"show_in_intro"`
-	CanSpeakInReading bool        `json:"can_speak_in_reading"`
-	IsVotingCandidate bool        `json:"is_voting_candidate"`
+	ID                uuid.UUID       `json:"id"`
+	Name              string          `json:"name"`
+	Description       pgtype.Text     `json:"description"`
+	ImageUrl          pgtype.Text     `json:"image_url"`
+	IsCulprit         bool            `json:"is_culprit"`
+	MysteryRole       string          `json:"mystery_role"`
+	SortOrder         int32           `json:"sort_order"`
+	IsPlayable        bool            `json:"is_playable"`
+	ShowInIntro       bool            `json:"show_in_intro"`
+	CanSpeakInReading bool            `json:"can_speak_in_reading"`
+	IsVotingCandidate bool            `json:"is_voting_candidate"`
+	AliasRules        json.RawMessage `json:"alias_rules"`
 }
 
 func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeCharacterParams) (ThemeCharacter, error) {
@@ -559,6 +565,7 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		arg.ShowInIntro,
 		arg.CanSpeakInReading,
 		arg.IsVotingCandidate,
+		arg.AliasRules,
 	)
 	var i ThemeCharacter
 	err := row.Scan(
@@ -574,6 +581,7 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		&i.ShowInIntro,
 		&i.CanSpeakInReading,
 		&i.IsVotingCandidate,
+		&i.AliasRules,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/image_service.go
+++ b/apps/server/internal/domain/editor/image_service.go
@@ -238,6 +238,7 @@ func (s *ImageService) ConfirmImageUpload(
 			ShowInIntro:       char.ShowInIntro,
 			CanSpeakInReading: char.CanSpeakInReading,
 			IsVotingCandidate: char.IsVotingCandidate,
+			AliasRules:        char.AliasRules,
 		})
 		if err != nil {
 			s.logger.Error().Err(err).Str("character_id", targetID.String()).Msg("failed to update character image_url")

--- a/apps/server/internal/domain/editor/image_service_test.go
+++ b/apps/server/internal/domain/editor/image_service_test.go
@@ -48,6 +48,9 @@ func TestConfirmImageUpload_PreservesExistingTargetFields(t *testing.T) {
 				if arg.MysteryRole != "detective" || arg.IsPlayable || arg.ShowInIntro || !arg.CanSpeakInReading || arg.IsVotingCandidate {
 					t.Fatalf("character fields not preserved: %+v", arg)
 				}
+				if string(arg.AliasRules) != `[{"id":"alias-1"}]` {
+					t.Fatalf("character alias rules not preserved: %s", string(arg.AliasRules))
+				}
 			},
 		},
 		{
@@ -108,6 +111,7 @@ func newFakeImageQueries(creatorID, themeID, charID, clueID, locationID uuid.UUI
 			ShowInIntro:       false,
 			CanSpeakInReading: true,
 			IsVotingCandidate: false,
+			AliasRules:        []byte(`[{"id":"alias-1"}]`),
 		},
 		clue:     db.ThemeClue{ID: clueID, ThemeID: themeID, Name: "단서", IsUsable: true, UseEffect: text("peek"), UseTarget: text("player"), UseConsumed: true, RevealRound: int4(2), HideRound: int4(5)},
 		location: db.ThemeLocation{ID: locationID, ThemeID: themeID, Name: "서재", RestrictedCharacters: text("char-a,char-b"), FromRound: int4(1), UntilRound: int4(4)},

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/engine"
 )
 
 const (
@@ -90,44 +91,49 @@ type ThemeSummary struct {
 }
 
 type CreateCharacterRequest struct {
-	Name              string  `json:"name" validate:"required,min=1,max=50"`
-	Description       *string `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string `json:"image_url" validate:"omitempty,url"`
-	IsCulprit         bool    `json:"is_culprit"`
-	MysteryRole       string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
-	SortOrder         int32   `json:"sort_order" validate:"min=0"`
-	IsPlayable        *bool   `json:"is_playable"`
-	ShowInIntro       *bool   `json:"show_in_intro"`
-	CanSpeakInReading *bool   `json:"can_speak_in_reading"`
-	IsVotingCandidate *bool   `json:"is_voting_candidate"`
+	Name              string               `json:"name" validate:"required,min=1,max=50"`
+	Description       *string              `json:"description" validate:"omitempty,max=2000"`
+	ImageURL          *string              `json:"image_url" validate:"omitempty,url"`
+	IsCulprit         bool                 `json:"is_culprit"`
+	MysteryRole       string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
+	SortOrder         int32                `json:"sort_order" validate:"min=0"`
+	IsPlayable        *bool                `json:"is_playable"`
+	ShowInIntro       *bool                `json:"show_in_intro"`
+	CanSpeakInReading *bool                `json:"can_speak_in_reading"`
+	IsVotingCandidate *bool                `json:"is_voting_candidate"`
+	AliasRules        []CharacterAliasRule `json:"alias_rules"`
 }
 
 type UpdateCharacterRequest struct {
-	Name              string  `json:"name" validate:"required,min=1,max=50"`
-	Description       *string `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string `json:"image_url" validate:"omitempty,url"`
-	IsCulprit         bool    `json:"is_culprit"`
-	MysteryRole       string  `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
-	SortOrder         int32   `json:"sort_order" validate:"min=0"`
-	IsPlayable        *bool   `json:"is_playable"`
-	ShowInIntro       *bool   `json:"show_in_intro"`
-	CanSpeakInReading *bool   `json:"can_speak_in_reading"`
-	IsVotingCandidate *bool   `json:"is_voting_candidate"`
+	Name              string               `json:"name" validate:"required,min=1,max=50"`
+	Description       *string              `json:"description" validate:"omitempty,max=2000"`
+	ImageURL          *string              `json:"image_url" validate:"omitempty,url"`
+	IsCulprit         bool                 `json:"is_culprit"`
+	MysteryRole       string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
+	SortOrder         int32                `json:"sort_order" validate:"min=0"`
+	IsPlayable        *bool                `json:"is_playable"`
+	ShowInIntro       *bool                `json:"show_in_intro"`
+	CanSpeakInReading *bool                `json:"can_speak_in_reading"`
+	IsVotingCandidate *bool                `json:"is_voting_candidate"`
+	AliasRules        []CharacterAliasRule `json:"alias_rules"`
 }
 
+type CharacterAliasRule = engine.CharacterAliasRule
+
 type CharacterResponse struct {
-	ID                uuid.UUID `json:"id"`
-	ThemeID           uuid.UUID `json:"theme_id"`
-	Name              string    `json:"name"`
-	Description       *string   `json:"description,omitempty"`
-	ImageURL          *string   `json:"image_url,omitempty"`
-	IsCulprit         bool      `json:"is_culprit"`
-	MysteryRole       string    `json:"mystery_role"`
-	SortOrder         int32     `json:"sort_order"`
-	IsPlayable        bool      `json:"is_playable"`
-	ShowInIntro       bool      `json:"show_in_intro"`
-	CanSpeakInReading bool      `json:"can_speak_in_reading"`
-	IsVotingCandidate bool      `json:"is_voting_candidate"`
+	ID                uuid.UUID            `json:"id"`
+	ThemeID           uuid.UUID            `json:"theme_id"`
+	Name              string               `json:"name"`
+	Description       *string              `json:"description,omitempty"`
+	ImageURL          *string              `json:"image_url,omitempty"`
+	IsCulprit         bool                 `json:"is_culprit"`
+	MysteryRole       string               `json:"mystery_role"`
+	SortOrder         int32                `json:"sort_order"`
+	IsPlayable        bool                 `json:"is_playable"`
+	ShowInIntro       bool                 `json:"show_in_intro"`
+	CanSpeakInReading bool                 `json:"can_speak_in_reading"`
+	IsVotingCandidate bool                 `json:"is_voting_candidate"`
+	AliasRules        []CharacterAliasRule `json:"alias_rules"`
 }
 
 // --- Service interface ---

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -37,6 +37,15 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		CanSpeakInReading: req.CanSpeakInReading,
 		IsVotingCandidate: req.IsVotingCandidate,
 	})
+	aliasRules, err := normalizeCharacterAliasRules(req.AliasRules)
+	if err != nil {
+		return nil, err
+	}
+	aliasRulesJSON, err := marshalCharacterAliasRules(aliasRules)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to marshal character alias rules")
+		return nil, apperror.Internal("failed to create character")
+	}
 
 	char, err := s.q.CreateThemeCharacter(ctx, db.CreateThemeCharacterParams{
 		ThemeID:           themeID,
@@ -50,6 +59,7 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		ShowInIntro:       visibilityPolicy.ShowInIntro,
 		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
 		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
+		AliasRules:        aliasRulesJSON,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create character")
@@ -86,6 +96,18 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		CanSpeakInReading: char.CanSpeakInReading,
 		IsVotingCandidate: char.IsVotingCandidate,
 	})
+	aliasRulesJSON := char.AliasRules
+	if req.AliasRules != nil {
+		aliasRules, err := normalizeCharacterAliasRules(req.AliasRules)
+		if err != nil {
+			return nil, err
+		}
+		aliasRulesJSON, err = marshalCharacterAliasRules(aliasRules)
+		if err != nil {
+			s.logger.Error().Err(err).Msg("failed to marshal character alias rules")
+			return nil, apperror.Internal("failed to update character")
+		}
+	}
 
 	updated, err := s.q.UpdateThemeCharacter(ctx, db.UpdateThemeCharacterParams{
 		ID:                charID,
@@ -99,6 +121,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		ShowInIntro:       visibilityPolicy.ShowInIntro,
 		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
 		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
+		AliasRules:        aliasRulesJSON,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update character")
@@ -196,6 +219,7 @@ func toCharacterResponse(c db.ThemeCharacter) *CharacterResponse {
 		ShowInIntro:       c.ShowInIntro,
 		CanSpeakInReading: c.CanSpeakInReading,
 		IsVotingCandidate: c.IsVotingCandidate,
+		AliasRules:        unmarshalCharacterAliasRules(c.AliasRules),
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_character_alias.go
+++ b/apps/server/internal/domain/editor/service_character_alias.go
@@ -1,0 +1,93 @@
+package editor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+const MaxCharacterAliasRules = 8
+
+func normalizeCharacterAliasRules(rules []CharacterAliasRule) ([]CharacterAliasRule, error) {
+	if rules == nil {
+		return nil, nil
+	}
+	if len(rules) > MaxCharacterAliasRules {
+		return nil, apperror.BadRequest(fmt.Sprintf("alias_rules supports at most %d rules", MaxCharacterAliasRules))
+	}
+	normalized := make([]CharacterAliasRule, 0, len(rules))
+	seen := make(map[string]struct{}, len(rules))
+	for i, rule := range rules {
+		clean, err := normalizeCharacterAliasRule(rule, i)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[clean.ID]; ok {
+			return nil, apperror.BadRequest(fmt.Sprintf("alias_rules[%d].id is duplicated", i))
+		}
+		seen[clean.ID] = struct{}{}
+		normalized = append(normalized, clean)
+	}
+	return normalized, nil
+}
+
+func normalizeCharacterAliasRule(rule CharacterAliasRule, index int) (CharacterAliasRule, error) {
+	rule.ID = strings.TrimSpace(rule.ID)
+	rule.Label = strings.TrimSpace(rule.Label)
+	if rule.ID == "" {
+		return CharacterAliasRule{}, apperror.BadRequest(fmt.Sprintf("alias_rules[%d].id is required", index))
+	}
+	if rule.Priority < 0 {
+		return CharacterAliasRule{}, apperror.BadRequest(fmt.Sprintf("alias_rules[%d].priority must be non-negative", index))
+	}
+	rule.DisplayName = trimOptionalText(rule.DisplayName)
+	rule.DisplayIconURL = trimOptionalText(rule.DisplayIconURL)
+	if rule.DisplayName == nil && rule.DisplayIconURL == nil {
+		return CharacterAliasRule{}, apperror.BadRequest(fmt.Sprintf("alias_rules[%d] requires display_name or display_icon_url", index))
+	}
+	if rule.DisplayName != nil && len([]rune(*rule.DisplayName)) > 50 {
+		return CharacterAliasRule{}, apperror.BadRequest(fmt.Sprintf("alias_rules[%d].display_name is too long", index))
+	}
+	if rule.DisplayIconURL != nil {
+		if _, err := url.ParseRequestURI(*rule.DisplayIconURL); err != nil {
+			return CharacterAliasRule{}, apperror.BadRequest(fmt.Sprintf("alias_rules[%d].display_icon_url must be a valid URL", index))
+		}
+	}
+	if len(rule.Condition) == 0 || string(rule.Condition) == "null" {
+		return CharacterAliasRule{}, apperror.BadRequest(fmt.Sprintf("alias_rules[%d].condition is required", index))
+	}
+	if _, err := engine.ParseConditionGroup(rule.Condition); err != nil {
+		return CharacterAliasRule{}, apperror.BadRequest(fmt.Sprintf("alias_rules[%d].condition invalid: %v", index, err))
+	}
+	return rule, nil
+}
+
+func trimOptionalText(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func marshalCharacterAliasRules(rules []CharacterAliasRule) (json.RawMessage, error) {
+	if rules == nil {
+		return json.RawMessage(`[]`), nil
+	}
+	raw, err := json.Marshal(rules)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func unmarshalCharacterAliasRules(raw json.RawMessage) []CharacterAliasRule {
+	return engine.ParseCharacterAliasRules(raw)
+}

--- a/apps/server/internal/domain/editor/service_character_alias_test.go
+++ b/apps/server/internal/domain/editor/service_character_alias_test.go
@@ -1,0 +1,210 @@
+package editor
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func TestResolveCharacterDisplay_AppliesHighestPriorityMatchingAlias(t *testing.T) {
+	icon := "https://cdn.example/revealed.webp"
+	base := engine.CharacterDisplayBase{
+		Name:     "홍길동",
+		ImageURL: strPtr("https://cdn.example/base.webp"),
+		AliasRules: []CharacterAliasRule{
+			{
+				ID:          "low",
+				DisplayName: strPtr("낮은 우선순위"),
+				Priority:    1,
+				Condition:   aliasCondition("identity_revealed", "true"),
+			},
+			{
+				ID:             "high",
+				DisplayName:    strPtr("밤의 목격자"),
+				DisplayIconURL: &icon,
+				Priority:       5,
+				Condition:      aliasCondition("identity_revealed", "true"),
+			},
+		},
+	}
+
+	got := engine.ResolveCharacterDisplay(base, json.RawMessage(`{"flags":{"identity_revealed":true}}`))
+
+	if got.Name != "밤의 목격자" {
+		t.Fatalf("Name = %q", got.Name)
+	}
+	if got.ImageURL == nil || *got.ImageURL != icon {
+		t.Fatalf("ImageURL = %#v", got.ImageURL)
+	}
+	if got.AppliedAliasRuleID == nil || *got.AppliedAliasRuleID != "high" {
+		t.Fatalf("AppliedAliasRuleID = %#v", got.AppliedAliasRuleID)
+	}
+}
+
+func TestResolveCharacterDisplay_FallsBackWhenConditionFailsOrInvalid(t *testing.T) {
+	base := engine.CharacterDisplayBase{
+		Name: "홍길동",
+		AliasRules: []CharacterAliasRule{
+			{
+				ID:          "false",
+				DisplayName: strPtr("숨겨진 이름"),
+				Priority:    10,
+				Condition:   aliasCondition("identity_revealed", "true"),
+			},
+			{
+				ID:          "invalid",
+				DisplayName: strPtr("깨진 이름"),
+				Priority:    20,
+				Condition:   json.RawMessage(`{"broken":true}`),
+			},
+		},
+	}
+
+	got := engine.ResolveCharacterDisplay(base, json.RawMessage(`{"flags":{"identity_revealed":false}}`))
+
+	if got.Name != "홍길동" {
+		t.Fatalf("Name = %q", got.Name)
+	}
+	if got.AppliedAliasRuleID != nil {
+		t.Fatalf("AppliedAliasRuleID = %#v", got.AppliedAliasRuleID)
+	}
+}
+
+func TestNormalizeCharacterAliasRules_ValidatesConditionAndDisplayValue(t *testing.T) {
+	longName := "가나다라마바사아자차카타파하가나다라마바사아자차카타파하가나다라마바사아자차카타파하가나다라마바사아자차카타파하"
+	valid := CharacterAliasRule{
+		ID:          "alias-1",
+		DisplayName: strPtr("별칭"),
+		Priority:    0,
+		Condition:   aliasCondition("identity_revealed", "true"),
+	}
+	tooMany := make([]CharacterAliasRule, MaxCharacterAliasRules+1)
+	for i := range tooMany {
+		rule := valid
+		rule.ID = string(rune('a' + i))
+		tooMany[i] = rule
+	}
+
+	tests := []struct {
+		name  string
+		rules []CharacterAliasRule
+	}{
+		{name: "missing display", rules: []CharacterAliasRule{{ID: "missing-display", Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
+		{name: "bad condition", rules: []CharacterAliasRule{{ID: "bad-condition", DisplayName: strPtr("별칭"), Priority: 0, Condition: json.RawMessage(`{"id":"g","operator":"AND","rules":[]}`)}}},
+		{name: "empty id", rules: []CharacterAliasRule{{ID: " ", DisplayName: strPtr("별칭"), Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
+		{name: "duplicated id", rules: []CharacterAliasRule{valid, valid}},
+		{name: "negative priority", rules: []CharacterAliasRule{{ID: "negative", DisplayName: strPtr("별칭"), Priority: -1, Condition: aliasCondition("identity_revealed", "true")}}},
+		{name: "long display name", rules: []CharacterAliasRule{{ID: "long", DisplayName: &longName, Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
+		{name: "invalid icon URL", rules: []CharacterAliasRule{{ID: "url", DisplayIconURL: strPtr("not a url"), Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
+		{name: "too many rules", rules: tooMany},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := normalizeCharacterAliasRules(tc.rules); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestResolveCharacterDisplay_AppliesNameOnlyIconOnlyAndNullContext(t *testing.T) {
+	icon := "https://cdn.example/icon.webp"
+	nameOnly := engine.ResolveCharacterDisplay(engine.CharacterDisplayBase{
+		Name: "기본",
+		AliasRules: []CharacterAliasRule{{
+			ID:          "name",
+			DisplayName: strPtr("별칭"),
+			Condition:   aliasCondition("identity_revealed", "true"),
+		}},
+	}, json.RawMessage(`{"flags":{"identity_revealed":true}}`))
+	if nameOnly.Name != "별칭" || nameOnly.ImageURL != nil {
+		t.Fatalf("name-only display mismatch: %+v", nameOnly)
+	}
+
+	iconOnly := engine.ResolveCharacterDisplay(engine.CharacterDisplayBase{
+		Name: "기본",
+		AliasRules: []CharacterAliasRule{{
+			ID:             "icon",
+			DisplayIconURL: &icon,
+			Condition:      aliasCondition("identity_revealed", "true"),
+		}},
+	}, json.RawMessage(`{"flags":{"identity_revealed":true}}`))
+	if iconOnly.Name != "기본" || iconOnly.ImageURL == nil || *iconOnly.ImageURL != icon {
+		t.Fatalf("icon-only display mismatch: %+v", iconOnly)
+	}
+
+	fallback := engine.ResolveCharacterDisplay(engine.CharacterDisplayBase{
+		Name: "기본",
+		AliasRules: []CharacterAliasRule{{
+			ID:          "name",
+			DisplayName: strPtr("별칭"),
+			Condition:   aliasCondition("identity_revealed", "true"),
+		}},
+	}, json.RawMessage(`null`))
+	if fallback.Name != "기본" || fallback.AppliedAliasRuleID != nil {
+		t.Fatalf("null context should fall back: %+v", fallback)
+	}
+}
+
+func TestService_CharacterAliasRulesContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	created, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{
+		Name: "홍길동",
+		AliasRules: []CharacterAliasRule{{
+			ID:          "identity-open",
+			Label:       "정체 공개",
+			DisplayName: strPtr("밤의 목격자"),
+			Priority:    2,
+			Condition:   aliasCondition("identity_revealed", "true"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateCharacter: %v", err)
+	}
+	if len(created.AliasRules) != 1 || *created.AliasRules[0].DisplayName != "밤의 목격자" {
+		t.Fatalf("created alias rules = %+v", created.AliasRules)
+	}
+
+	updated, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:        "홍길동",
+		MysteryRole: MysteryRoleSuspect,
+		SortOrder:   1,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter preserve alias rules: %v", err)
+	}
+	if len(updated.AliasRules) != 1 {
+		t.Fatalf("alias rules should be preserved: %+v", updated.AliasRules)
+	}
+
+	cleared, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:        "홍길동",
+		MysteryRole: MysteryRoleSuspect,
+		SortOrder:   1,
+		AliasRules:  []CharacterAliasRule{},
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter clear alias rules: %v", err)
+	}
+	if len(cleared.AliasRules) != 0 {
+		t.Fatalf("alias rules should be cleared: %+v", cleared.AliasRules)
+	}
+}
+
+func aliasCondition(flagKey string, value string) json.RawMessage {
+	return json.RawMessage(`{"id":"group-1","operator":"AND","rules":[{"id":"rule-1","variable":"custom_flag","target_flag_key":"` + flagKey + `","comparator":"=","value":"` + value + `"}]}`)
+}
+
+func strPtr(value string) *string {
+	return &value
+}

--- a/apps/server/internal/domain/editor/service_character_alias_test.go
+++ b/apps/server/internal/domain/editor/service_character_alias_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mmp-platform/server/internal/engine"
@@ -89,23 +90,28 @@ func TestNormalizeCharacterAliasRules_ValidatesConditionAndDisplayValue(t *testi
 	}
 
 	tests := []struct {
-		name  string
-		rules []CharacterAliasRule
+		name            string
+		rules           []CharacterAliasRule
+		wantErrContains string
 	}{
-		{name: "missing display", rules: []CharacterAliasRule{{ID: "missing-display", Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
-		{name: "bad condition", rules: []CharacterAliasRule{{ID: "bad-condition", DisplayName: strPtr("별칭"), Priority: 0, Condition: json.RawMessage(`{"id":"g","operator":"AND","rules":[]}`)}}},
-		{name: "empty id", rules: []CharacterAliasRule{{ID: " ", DisplayName: strPtr("별칭"), Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
-		{name: "duplicated id", rules: []CharacterAliasRule{valid, valid}},
-		{name: "negative priority", rules: []CharacterAliasRule{{ID: "negative", DisplayName: strPtr("별칭"), Priority: -1, Condition: aliasCondition("identity_revealed", "true")}}},
-		{name: "long display name", rules: []CharacterAliasRule{{ID: "long", DisplayName: &longName, Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
-		{name: "invalid icon URL", rules: []CharacterAliasRule{{ID: "url", DisplayIconURL: strPtr("not a url"), Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}},
-		{name: "too many rules", rules: tooMany},
+		{name: "missing display", rules: []CharacterAliasRule{{ID: "missing-display", Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}, wantErrContains: "display_name or display_icon_url"},
+		{name: "bad condition", rules: []CharacterAliasRule{{ID: "bad-condition", DisplayName: strPtr("별칭"), Priority: 0, Condition: json.RawMessage(`{"id":"g","operator":"AND","rules":[]}`)}}, wantErrContains: "condition invalid"},
+		{name: "empty id", rules: []CharacterAliasRule{{ID: " ", DisplayName: strPtr("별칭"), Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}, wantErrContains: "id is required"},
+		{name: "duplicated id", rules: []CharacterAliasRule{valid, valid}, wantErrContains: "duplicated"},
+		{name: "negative priority", rules: []CharacterAliasRule{{ID: "negative", DisplayName: strPtr("별칭"), Priority: -1, Condition: aliasCondition("identity_revealed", "true")}}, wantErrContains: "priority"},
+		{name: "long display name", rules: []CharacterAliasRule{{ID: "long", DisplayName: &longName, Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}, wantErrContains: "display_name is too long"},
+		{name: "invalid icon URL", rules: []CharacterAliasRule{{ID: "url", DisplayIconURL: strPtr("not a url"), Priority: 0, Condition: aliasCondition("identity_revealed", "true")}}, wantErrContains: "display_icon_url"},
+		{name: "too many rules", rules: tooMany, wantErrContains: "at most"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := normalizeCharacterAliasRules(tc.rules); err == nil {
+			_, err := normalizeCharacterAliasRules(tc.rules)
+			if err == nil {
 				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrContains) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErrContains, err)
 			}
 		})
 	}
@@ -186,7 +192,11 @@ func TestService_CharacterAliasRulesContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpdateCharacter preserve alias rules: %v", err)
 	}
-	if len(updated.AliasRules) != 1 {
+	if len(updated.AliasRules) != 1 ||
+		updated.AliasRules[0].ID != "identity-open" ||
+		updated.AliasRules[0].DisplayName == nil ||
+		*updated.AliasRules[0].DisplayName != "밤의 목격자" ||
+		updated.AliasRules[0].Priority != 2 {
 		t.Fatalf("alias rules should be preserved: %+v", updated.AliasRules)
 	}
 

--- a/apps/server/internal/domain/editor/service_character_alias_test.go
+++ b/apps/server/internal/domain/editor/service_character_alias_test.go
@@ -3,6 +3,7 @@ package editor
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/mmp-platform/server/internal/engine"
@@ -83,7 +84,7 @@ func TestNormalizeCharacterAliasRules_ValidatesConditionAndDisplayValue(t *testi
 	tooMany := make([]CharacterAliasRule, MaxCharacterAliasRules+1)
 	for i := range tooMany {
 		rule := valid
-		rule.ID = string(rune('a' + i))
+		rule.ID = fmt.Sprintf("alias-%d", i)
 		tooMany[i] = rule
 	}
 
@@ -171,7 +172,9 @@ func TestService_CharacterAliasRulesContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateCharacter: %v", err)
 	}
-	if len(created.AliasRules) != 1 || *created.AliasRules[0].DisplayName != "밤의 목격자" {
+	if len(created.AliasRules) != 1 ||
+		created.AliasRules[0].DisplayName == nil ||
+		*created.AliasRules[0].DisplayName != "밤의 목격자" {
 		t.Fatalf("created alias rules = %+v", created.AliasRules)
 	}
 

--- a/apps/server/internal/domain/theme/handler_test.go
+++ b/apps/server/internal/domain/theme/handler_test.go
@@ -253,5 +253,11 @@ func TestGetCharacters_Success(t *testing.T) {
 		if _, ok := entry["is_culprit"]; ok {
 			t.Errorf("character %d: is_culprit should not be present in public API response", i)
 		}
+		if _, ok := entry["mystery_role"]; ok {
+			t.Errorf("character %d: mystery_role should not be present in public API response", i)
+		}
+		if _, ok := entry["alias_rules"]; ok {
+			t.Errorf("character %d: alias_rules should not be present in public API response", i)
+		}
 	}
 }

--- a/apps/server/internal/domain/theme/service.go
+++ b/apps/server/internal/domain/theme/service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/engine"
 )
 
 // ThemeSummary is the compact representation used in list endpoints.
@@ -121,11 +122,16 @@ func (s *service) GetCharacters(ctx context.Context, themeID uuid.UUID) ([]Chara
 
 	result := make([]CharacterResponse, len(chars))
 	for i, c := range chars {
+		display := engine.ResolveCharacterDisplay(engine.CharacterDisplayBase{
+			Name:       c.Name,
+			ImageURL:   textToPtr(c.ImageUrl),
+			AliasRules: engine.ParseCharacterAliasRules(c.AliasRules),
+		}, json.RawMessage(`{}`))
 		result[i] = CharacterResponse{
 			ID:          c.ID,
-			Name:        c.Name,
+			Name:        display.Name,
 			Description: textToPtr(c.Description),
-			ImageURL:    textToPtr(c.ImageUrl),
+			ImageURL:    display.ImageURL,
 			SortOrder:   c.SortOrder,
 		}
 	}

--- a/apps/server/internal/domain/theme/service_test.go
+++ b/apps/server/internal/domain/theme/service_test.go
@@ -1,0 +1,82 @@
+package theme
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+func TestGetCharacters_UsesBackendDisplayResolverWithoutLeakingAliasRules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+
+	charID := f.createCharacter(t, themeID, "홍길동", json.RawMessage(`[{
+		"id":"alias-1",
+		"display_name":"숨겨진 별칭",
+		"priority":1,
+		"condition":{"id":"group-1","operator":"AND","rules":[{"id":"rule-1","variable":"custom_flag","target_flag_key":"revealed","comparator":"=","value":"true"}]}
+	}]`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	got, err := svc.GetCharacters(ctx, themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("characters len = %d", len(got))
+	}
+	if got[0].ID != charID || got[0].Name != "홍길동" {
+		t.Fatalf("public character display mismatch: %+v", got[0])
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal public characters: %v", err)
+	}
+	if jsonContainsKey(t, raw, "alias_rules") || jsonContainsKey(t, raw, "mystery_role") || jsonContainsKey(t, raw, "is_culprit") {
+		t.Fatalf("public characters leaked private fields: %s", string(raw))
+	}
+}
+
+func jsonContainsKey(t *testing.T, raw []byte, key string) bool {
+	t.Helper()
+	var rows []map[string]any
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		t.Fatalf("unmarshal rows: %v", err)
+	}
+	for _, row := range rows {
+		if _, ok := row[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *themeFixture) createCharacter(t *testing.T, themeID uuid.UUID, name string, aliasRules json.RawMessage) uuid.UUID {
+	t.Helper()
+	row, err := f.pool.Exec(context.Background(), `
+		INSERT INTO theme_characters (theme_id, name, alias_rules)
+		VALUES ($1, $2, $3)
+	`, themeID, name, aliasRules)
+	if err != nil {
+		t.Fatalf("create character: %v", err)
+	}
+	if row.RowsAffected() != 1 {
+		t.Fatalf("create character rows affected = %d", row.RowsAffected())
+	}
+	var id uuid.UUID
+	if err := f.pool.QueryRow(context.Background(), `
+		SELECT id FROM theme_characters WHERE theme_id = $1 AND name = $2
+	`, themeID, name).Scan(&id); err != nil {
+		t.Fatalf("read character id: %v", err)
+	}
+	return id
+}

--- a/apps/server/internal/domain/theme/test_fixture_test.go
+++ b/apps/server/internal/domain/theme/test_fixture_test.go
@@ -1,0 +1,98 @@
+package theme
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/pressly/goose/v3"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mmp-platform/server/internal/db"
+)
+
+type themeFixture struct {
+	pool *pgxpool.Pool
+	q    *db.Queries
+}
+
+func setupThemeFixture(t *testing.T) *themeFixture {
+	t.Helper()
+	ctx := context.Background()
+	pgC, err := postgres.Run(ctx,
+		"public.ecr.aws/docker/library/postgres:16-alpine",
+		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := pgC.Terminate(ctx); err != nil {
+			t.Logf("terminate container: %v", err)
+		}
+	})
+	connStr, err := pgC.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	sqlDB, err := sql.Open("pgx", connStr)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer sqlDB.Close()
+
+	goose.SetBaseFS(nil)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("goose.SetDialect: %v", err)
+	}
+	if err := goose.Up(sqlDB, migrationsPath()); err != nil {
+		t.Fatalf("goose.Up: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return &themeFixture{pool: pool, q: db.New(pool)}
+}
+
+func migrationsPath() string {
+	abs, err := filepath.Abs("../../../db/migrations")
+	if err != nil {
+		panic("migrationsPath: " + err.Error())
+	}
+	return abs
+}
+
+func (f *themeFixture) createUser(t *testing.T) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := f.pool.QueryRow(context.Background(), `
+		INSERT INTO users (nickname, email, provider, provider_id)
+		VALUES ($1, $2, 'local', $3)
+		RETURNING id
+	`, "tester", fmt.Sprintf("t%s@test.com", uuid.New().String()[:8]), uuid.New().String()).Scan(&id); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return id
+}
+
+func (f *themeFixture) createThemeForUser(t *testing.T, creatorID uuid.UUID) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := f.pool.QueryRow(context.Background(), `
+		INSERT INTO themes (creator_id, title, slug, min_players, max_players, duration_min, config_json)
+		VALUES ($1, 'Theme', $2, 2, 6, 60, '{}')
+		RETURNING id
+	`, creatorID, fmt.Sprintf("theme-%s", uuid.New().String()[:8])).Scan(&id); err != nil {
+		t.Fatalf("create theme: %v", err)
+	}
+	return id
+}

--- a/apps/server/internal/engine/character_display.go
+++ b/apps/server/internal/engine/character_display.go
@@ -1,0 +1,65 @@
+package engine
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+type CharacterAliasRule struct {
+	ID             string          `json:"id"`
+	Label          string          `json:"label,omitempty"`
+	DisplayName    *string         `json:"display_name,omitempty"`
+	DisplayIconURL *string         `json:"display_icon_url,omitempty"`
+	Priority       int32           `json:"priority"`
+	Condition      json.RawMessage `json:"condition"`
+}
+
+type CharacterDisplayBase struct {
+	Name       string
+	ImageURL   *string
+	AliasRules []CharacterAliasRule
+}
+
+type CharacterDisplay struct {
+	Name               string
+	ImageURL           *string
+	AppliedAliasRuleID *string
+}
+
+func ParseCharacterAliasRules(raw json.RawMessage) []CharacterAliasRule {
+	if len(raw) == 0 || string(raw) == "null" {
+		return []CharacterAliasRule{}
+	}
+	var rules []CharacterAliasRule
+	if err := json.Unmarshal(raw, &rules); err != nil {
+		return []CharacterAliasRule{}
+	}
+	return rules
+}
+
+func ResolveCharacterDisplay(base CharacterDisplayBase, context json.RawMessage) CharacterDisplay {
+	display := CharacterDisplay{Name: base.Name, ImageURL: base.ImageURL}
+	if len(base.AliasRules) == 0 || len(context) == 0 || string(context) == "null" {
+		return display
+	}
+	rules := append([]CharacterAliasRule(nil), base.AliasRules...)
+	sort.SliceStable(rules, func(i, j int) bool {
+		return rules[i].Priority > rules[j].Priority
+	})
+	for _, rule := range rules {
+		result, err := EvaluateConditionGroup(rule.Condition, context)
+		if err != nil || !result.Bool {
+			continue
+		}
+		if rule.DisplayName != nil {
+			display.Name = *rule.DisplayName
+		}
+		if rule.DisplayIconURL != nil {
+			display.ImageURL = rule.DisplayIconURL
+		}
+		ruleID := rule.ID
+		display.AppliedAliasRuleID = &ruleID
+		return display
+	}
+	return display
+}

--- a/apps/server/internal/engine/character_display_test.go
+++ b/apps/server/internal/engine/character_display_test.go
@@ -1,0 +1,98 @@
+package engine
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func strPtr(value string) *string {
+	return &value
+}
+
+func TestParseCharacterAliasRules(t *testing.T) {
+	rules := ParseCharacterAliasRules(json.RawMessage(`[
+		{"id":"alias-1","display_name":"목격자","priority":2,"condition":{"id":"group-1","operator":"AND","rules":[]}}
+	]`))
+
+	if len(rules) != 1 || rules[0].ID != "alias-1" || rules[0].DisplayName == nil || *rules[0].DisplayName != "목격자" {
+		t.Fatalf("ParseCharacterAliasRules() = %+v", rules)
+	}
+
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`), json.RawMessage(`{`)} {
+		if got := ParseCharacterAliasRules(raw); len(got) != 0 {
+			t.Fatalf("ParseCharacterAliasRules(%s) len = %d, want 0", string(raw), len(got))
+		}
+	}
+}
+
+func TestResolveCharacterDisplay_AppliesHighestPriorityMatchingRule(t *testing.T) {
+	baseIcon := "https://cdn.example/base.webp"
+	lowName := "낮은 우선순위"
+	highIcon := "https://cdn.example/high.webp"
+	highName := "밤의 목격자"
+
+	display := ResolveCharacterDisplay(CharacterDisplayBase{
+		Name:     "홍길동",
+		ImageURL: &baseIcon,
+		AliasRules: []CharacterAliasRule{
+			{
+				ID:          "low",
+				DisplayName: &lowName,
+				Priority:    1,
+				Condition:   matchingAliasCondition(),
+			},
+			{
+				ID:             "high",
+				DisplayName:    &highName,
+				DisplayIconURL: &highIcon,
+				Priority:       3,
+				Condition:      matchingAliasCondition(),
+			},
+		},
+	}, json.RawMessage(`{"flags":{"alias_ready":true}}`))
+
+	if display.Name != highName || display.ImageURL == nil || *display.ImageURL != highIcon {
+		t.Fatalf("ResolveCharacterDisplay() = %+v", display)
+	}
+	if display.AppliedAliasRuleID == nil || *display.AppliedAliasRuleID != "high" {
+		t.Fatalf("AppliedAliasRuleID = %v, want high", display.AppliedAliasRuleID)
+	}
+}
+
+func TestResolveCharacterDisplay_FallsBackWhenConditionMissesOrContextMissing(t *testing.T) {
+	base := CharacterDisplayBase{
+		Name:     "홍길동",
+		ImageURL: strPtr("https://cdn.example/base.webp"),
+		AliasRules: []CharacterAliasRule{{
+			ID:          "alias-1",
+			DisplayName: strPtr("목격자"),
+			Priority:    1,
+			Condition:   matchingAliasCondition(),
+		}},
+	}
+
+	for _, context := range []json.RawMessage{
+		nil,
+		json.RawMessage(`null`),
+		json.RawMessage(`{"flags":{"alias_ready":false}}`),
+	} {
+		display := ResolveCharacterDisplay(base, context)
+		if display.Name != base.Name || display.ImageURL != base.ImageURL || display.AppliedAliasRuleID != nil {
+			t.Fatalf("ResolveCharacterDisplay(%s) = %+v, want base display", string(context), display)
+		}
+	}
+}
+
+func matchingAliasCondition() json.RawMessage {
+	return json.RawMessage(`{
+		"id":"group-1",
+		"operator":"AND",
+		"rules":[{
+			"id":"rule-1",
+			"variable":"custom_flag",
+			"target_flag_key":"alias_ready",
+			"comparator":"=",
+			"value":"true"
+		}]
+	}`)
+}

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -54,9 +54,19 @@ export interface EditorCharacterResponse {
   show_in_intro: boolean;
   can_speak_in_reading: boolean;
   is_voting_candidate: boolean;
+  alias_rules?: CharacterAliasRule[];
 }
 
 export type MysteryRole = 'suspect' | 'culprit' | 'accomplice' | 'detective';
+
+export interface CharacterAliasRule {
+  id: string;
+  label?: string;
+  display_name?: string;
+  display_icon_url?: string;
+  priority: number;
+  condition: Record<string, unknown>;
+}
 
 export interface CreateThemeRequest {
   title: string;
@@ -91,6 +101,7 @@ export interface CreateCharacterRequest {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  alias_rules?: CharacterAliasRule[];
 }
 
 export interface UpdateCharacterRequest {
@@ -104,6 +115,7 @@ export interface UpdateCharacterRequest {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  alias_rules?: CharacterAliasRule[];
 }
 
 export interface CreateClueRequest {

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -57,7 +57,7 @@ export interface EditorCharacterResponse {
   endcard_title?: string | null;
   endcard_body?: string | null;
   endcard_image_url?: string | null;
-  alias_rules?: CharacterAliasRule[];
+  alias_rules: CharacterAliasRule[];
 }
 
 export type MysteryRole = 'suspect' | 'culprit' | 'accomplice' | 'detective';

--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { CharacterAliasRule } from '@/features/editor/api';
 import type { SelectOption } from './condition/ConditionRule';
 import { ConditionBuilder } from './condition/ConditionBuilder';
@@ -23,7 +24,11 @@ export function CharacterAliasRulesEditor({
   onChange,
   onSave,
 }: CharacterAliasRulesEditorProps) {
+  const [validationError, setValidationError] = useState<string | null>(null);
+
   const addRule = () => {
+    if (disabled) return;
+    setValidationError(null);
     onChange([
       ...rules,
       {
@@ -37,10 +42,24 @@ export function CharacterAliasRulesEditor({
     ]);
   };
   const updateRule = (index: number, patch: Partial<CharacterAliasRule>) => {
+    if (disabled) return;
+    setValidationError(null);
     onChange(rules.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)));
   };
   const removeRule = (index: number) => {
+    if (disabled) return;
+    setValidationError(null);
     onChange(rules.filter((_, i) => i !== index));
+  };
+  const handleSave = () => {
+    if (disabled) return;
+    const invalidRule = rules.find((rule) => !rule.display_name?.trim() && !rule.display_icon_url?.trim());
+    if (invalidRule) {
+      setValidationError('표시 이름 또는 표시 아이콘 URL을 입력하세요.');
+      return;
+    }
+    setValidationError(null);
+    onSave(normalizeCharacterAliasRules(rules));
   };
 
   return (
@@ -74,8 +93,9 @@ export function CharacterAliasRulesEditor({
                 규칙 이름
                 <input
                   value={rule.label ?? ''}
+                  disabled={disabled}
                   onChange={(event) => updateRule(index, { label: event.currentTarget.value })}
-                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
                 />
               </label>
               <label className="text-[11px] text-slate-400">
@@ -83,8 +103,9 @@ export function CharacterAliasRulesEditor({
                 <input
                   value={rule.display_name ?? ''}
                   placeholder={characterName}
+                  disabled={disabled}
                   onChange={(event) => updateRule(index, { display_name: event.currentTarget.value })}
-                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
                 />
               </label>
               <label className="text-[11px] text-slate-400">
@@ -93,8 +114,9 @@ export function CharacterAliasRulesEditor({
                   type="number"
                   min={0}
                   value={rule.priority}
+                  disabled={disabled}
                   onChange={(event) => updateRule(index, { priority: Number(event.currentTarget.value) || 0 })}
-                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
                 />
               </label>
             </div>
@@ -103,8 +125,9 @@ export function CharacterAliasRulesEditor({
               <input
                 value={rule.display_icon_url ?? ''}
                 placeholder={characterImageUrl ?? 'https://...'}
+                disabled={disabled}
                 onChange={(event) => updateRule(index, { display_icon_url: event.currentTarget.value })}
-                className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+                className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
               />
             </label>
             <div className="mt-3">
@@ -130,9 +153,12 @@ export function CharacterAliasRulesEditor({
       </div>
 
       <div className="mt-3 flex justify-end">
+        {validationError ? (
+          <p className="mr-auto self-center text-[11px] text-red-300">{validationError}</p>
+        ) : null}
         <button
           type="button"
-          onClick={() => onSave(normalizeCharacterAliasRules(rules))}
+          onClick={handleSave}
           disabled={disabled}
           className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-amber-400 disabled:cursor-default disabled:bg-slate-800 disabled:text-slate-500"
         >

--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -15,6 +15,17 @@ interface CharacterAliasRulesEditorProps {
   onSave: (rules: CharacterAliasRule[]) => void;
 }
 
+interface CharacterAliasRuleItemProps {
+  rule: CharacterAliasRule;
+  index: number;
+  characterName: string;
+  characterImageUrl?: string | null;
+  characterOptions: SelectOption[];
+  disabled: boolean;
+  onUpdate: (index: number, patch: Partial<CharacterAliasRule>) => void;
+  onRemove: (index: number) => void;
+}
+
 export function CharacterAliasRulesEditor({
   characterName,
   characterImageUrl,
@@ -91,68 +102,17 @@ export function CharacterAliasRulesEditor({
             조건부 표시 규칙이 없습니다.
           </p>
         ) : rules.map((rule, index) => (
-          <div key={rule.id} className="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
-            <div className="grid gap-2 sm:grid-cols-[1fr_1fr_5rem]">
-              <label className="text-[11px] text-slate-400">
-                규칙 이름
-                <input
-                  value={rule.label ?? ''}
-                  disabled={disabled}
-                  onChange={(event) => updateRule(index, { label: event.currentTarget.value })}
-                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
-                />
-              </label>
-              <label className="text-[11px] text-slate-400">
-                표시 이름
-                <input
-                  value={rule.display_name ?? ''}
-                  placeholder={characterName}
-                  disabled={disabled}
-                  onChange={(event) => updateRule(index, { display_name: event.currentTarget.value })}
-                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
-                />
-              </label>
-              <label className="text-[11px] text-slate-400">
-                우선순위
-                <input
-                  type="number"
-                  min={0}
-                  value={rule.priority}
-                  disabled={disabled}
-                  onChange={(event) => updateRule(index, { priority: Number(event.currentTarget.value) || 0 })}
-                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
-                />
-              </label>
-            </div>
-            <label className="mt-2 block text-[11px] text-slate-400">
-              표시 아이콘 URL
-              <input
-                value={rule.display_icon_url ?? ''}
-                placeholder={characterImageUrl ?? 'https://...'}
-                disabled={disabled}
-                onChange={(event) => updateRule(index, { display_icon_url: event.currentTarget.value })}
-                className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
-              />
-            </label>
-            <div className="mt-3">
-              <ConditionBuilder
-                label="표시 조건"
-                condition={rule.condition}
-                onChange={(condition) => updateRule(index, { condition })}
-                characters={characterOptions}
-              />
-            </div>
-            <div className="mt-3 flex justify-end">
-              <button
-                type="button"
-                onClick={() => removeRule(index)}
-                disabled={disabled}
-                className="rounded-md px-2 py-1 text-[11px] text-slate-500 transition hover:bg-red-950/40 hover:text-red-300"
-              >
-                삭제
-              </button>
-            </div>
-          </div>
+          <CharacterAliasRuleItem
+            key={rule.id}
+            rule={rule}
+            index={index}
+            characterName={characterName}
+            characterImageUrl={characterImageUrl}
+            characterOptions={characterOptions}
+            disabled={disabled}
+            onUpdate={updateRule}
+            onRemove={removeRule}
+          />
         ))}
       </div>
 
@@ -167,6 +127,82 @@ export function CharacterAliasRulesEditor({
           className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-amber-400 disabled:cursor-default disabled:bg-slate-800 disabled:text-slate-500"
         >
           플레이 중 표시 저장
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CharacterAliasRuleItem({
+  rule,
+  index,
+  characterName,
+  characterImageUrl,
+  characterOptions,
+  disabled,
+  onUpdate,
+  onRemove,
+}: CharacterAliasRuleItemProps) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
+      <div className="grid gap-2 sm:grid-cols-[1fr_1fr_5rem]">
+        <label className="text-[11px] text-slate-400">
+          규칙 이름
+          <input
+            value={rule.label ?? ''}
+            disabled={disabled}
+            onChange={(event) => onUpdate(index, { label: event.currentTarget.value })}
+            className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
+          />
+        </label>
+        <label className="text-[11px] text-slate-400">
+          표시 이름
+          <input
+            value={rule.display_name ?? ''}
+            placeholder={characterName}
+            disabled={disabled}
+            onChange={(event) => onUpdate(index, { display_name: event.currentTarget.value })}
+            className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
+          />
+        </label>
+        <label className="text-[11px] text-slate-400">
+          우선순위
+          <input
+            type="number"
+            min={0}
+            value={rule.priority}
+            disabled={disabled}
+            onChange={(event) => onUpdate(index, { priority: Number(event.currentTarget.value) || 0 })}
+            className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
+          />
+        </label>
+      </div>
+      <label className="mt-2 block text-[11px] text-slate-400">
+        표시 아이콘 URL
+        <input
+          value={rule.display_icon_url ?? ''}
+          placeholder={characterImageUrl ?? 'https://...'}
+          disabled={disabled}
+          onChange={(event) => onUpdate(index, { display_icon_url: event.currentTarget.value })}
+          className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
+        />
+      </label>
+      <div className="mt-3">
+        <ConditionBuilder
+          label="표시 조건"
+          condition={rule.condition}
+          onChange={(condition) => onUpdate(index, { condition })}
+          characters={characterOptions}
+        />
+      </div>
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={() => onRemove(index)}
+          disabled={disabled}
+          className="rounded-md px-2 py-1 text-[11px] text-slate-500 transition hover:bg-red-950/40 hover:text-red-300"
+        >
+          삭제
         </button>
       </div>
     </div>

--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -44,6 +44,7 @@ export function CharacterAliasRulesEditor({
   const addRule = () => {
     if (disabled) return;
     setValidationError(null);
+    const nextPriority = rules.reduce((max, rule) => Math.max(max, rule.priority), -1) + 1;
     onChange([
       ...rules,
       {
@@ -51,7 +52,7 @@ export function CharacterAliasRulesEditor({
         label: '',
         display_name: '',
         display_icon_url: '',
-        priority: rules.length,
+        priority: nextPriority,
         condition: groupToRecord(createDefaultAliasCondition()),
       },
     ]);
@@ -172,7 +173,7 @@ function CharacterAliasRuleItem({
             min={0}
             value={rule.priority}
             disabled={disabled}
-            onChange={(event) => onUpdate(index, { priority: Number(event.currentTarget.value) || 0 })}
+            onChange={(event) => onUpdate(index, { priority: normalizePriorityInput(event.currentTarget.value) })}
             className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
           />
         </label>
@@ -210,6 +211,14 @@ function CharacterAliasRuleItem({
 }
 
 let aliasRuleIdSeq = 0;
+
+function normalizePriorityInput(value: string): number {
+  const priority = Math.floor(Number(value));
+  if (Number.isNaN(priority)) {
+    return 0;
+  }
+  return Math.max(0, priority);
+}
 
 function createAliasRuleID(): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {

--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { CharacterAliasRule } from '@/features/editor/api';
 import type { SelectOption } from './condition/ConditionRule';
 import { ConditionBuilder } from './condition/ConditionBuilder';
@@ -25,6 +25,10 @@ export function CharacterAliasRulesEditor({
   onSave,
 }: CharacterAliasRulesEditorProps) {
   const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setValidationError(null);
+  }, [rules, characterName]);
 
   const addRule = () => {
     if (disabled) return;
@@ -169,11 +173,14 @@ export function CharacterAliasRulesEditor({
   );
 }
 
+let aliasRuleIdSeq = 0;
+
 function createAliasRuleID(): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
     return crypto.randomUUID();
   }
-  return `alias-${Date.now()}`;
+  aliasRuleIdSeq += 1;
+  return `alias-${Date.now()}-${aliasRuleIdSeq}`;
 }
 
 function createDefaultAliasCondition(): ConditionGroup {

--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -1,0 +1,165 @@
+import type { CharacterAliasRule } from '@/features/editor/api';
+import type { SelectOption } from './condition/ConditionRule';
+import { ConditionBuilder } from './condition/ConditionBuilder';
+import { groupToRecord, type ConditionGroup } from './condition/conditionTypes';
+import { normalizeCharacterAliasRules } from '@/features/editor/entities/character/characterEditorAdapter';
+
+interface CharacterAliasRulesEditorProps {
+  characterName: string;
+  characterImageUrl?: string | null;
+  rules: CharacterAliasRule[];
+  characterOptions: SelectOption[];
+  disabled: boolean;
+  onChange: (rules: CharacterAliasRule[]) => void;
+  onSave: (rules: CharacterAliasRule[]) => void;
+}
+
+export function CharacterAliasRulesEditor({
+  characterName,
+  characterImageUrl,
+  rules,
+  characterOptions,
+  disabled,
+  onChange,
+  onSave,
+}: CharacterAliasRulesEditorProps) {
+  const addRule = () => {
+    onChange([
+      ...rules,
+      {
+        id: createAliasRuleID(),
+        label: '',
+        display_name: '',
+        display_icon_url: '',
+        priority: rules.length,
+        condition: groupToRecord(createDefaultAliasCondition()),
+      },
+    ]);
+  };
+  const updateRule = (index: number, patch: Partial<CharacterAliasRule>) => {
+    onChange(rules.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)));
+  };
+  const removeRule = (index: number) => {
+    onChange(rules.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold text-slate-200">플레이 중 표시</p>
+          <p className="mt-1 text-[11px] leading-4 text-slate-500">
+            조건을 만족하면 기본 이름과 사진 대신 별칭과 아이콘을 보여줍니다.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={addRule}
+          disabled={disabled}
+          className="rounded-md border border-slate-700 px-2 py-1 text-[11px] font-medium text-slate-300 transition hover:border-amber-500/50 hover:text-amber-100 disabled:cursor-default disabled:opacity-50"
+        >
+          규칙 추가
+        </button>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {rules.length === 0 ? (
+          <p className="rounded-md border border-dashed border-slate-800 px-3 py-4 text-center text-xs text-slate-600">
+            조건부 표시 규칙이 없습니다.
+          </p>
+        ) : rules.map((rule, index) => (
+          <div key={rule.id} className="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
+            <div className="grid gap-2 sm:grid-cols-[1fr_1fr_5rem]">
+              <label className="text-[11px] text-slate-400">
+                규칙 이름
+                <input
+                  value={rule.label ?? ''}
+                  onChange={(event) => updateRule(index, { label: event.currentTarget.value })}
+                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+                />
+              </label>
+              <label className="text-[11px] text-slate-400">
+                표시 이름
+                <input
+                  value={rule.display_name ?? ''}
+                  placeholder={characterName}
+                  onChange={(event) => updateRule(index, { display_name: event.currentTarget.value })}
+                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+                />
+              </label>
+              <label className="text-[11px] text-slate-400">
+                우선순위
+                <input
+                  type="number"
+                  min={0}
+                  value={rule.priority}
+                  onChange={(event) => updateRule(index, { priority: Number(event.currentTarget.value) || 0 })}
+                  className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+                />
+              </label>
+            </div>
+            <label className="mt-2 block text-[11px] text-slate-400">
+              표시 아이콘 URL
+              <input
+                value={rule.display_icon_url ?? ''}
+                placeholder={characterImageUrl ?? 'https://...'}
+                onChange={(event) => updateRule(index, { display_icon_url: event.currentTarget.value })}
+                className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200"
+              />
+            </label>
+            <div className="mt-3">
+              <ConditionBuilder
+                label="표시 조건"
+                condition={rule.condition}
+                onChange={(condition) => updateRule(index, { condition })}
+                characters={characterOptions}
+              />
+            </div>
+            <div className="mt-3 flex justify-end">
+              <button
+                type="button"
+                onClick={() => removeRule(index)}
+                disabled={disabled}
+                className="rounded-md px-2 py-1 text-[11px] text-slate-500 transition hover:bg-red-950/40 hover:text-red-300"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={() => onSave(normalizeCharacterAliasRules(rules))}
+          disabled={disabled}
+          className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-amber-400 disabled:cursor-default disabled:bg-slate-800 disabled:text-slate-500"
+        >
+          플레이 중 표시 저장
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function createAliasRuleID(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `alias-${Date.now()}`;
+}
+
+function createDefaultAliasCondition(): ConditionGroup {
+  return {
+    id: createAliasRuleID(),
+    operator: 'AND',
+    rules: [{
+      id: createAliasRuleID(),
+      variable: 'custom_flag',
+      target_flag_key: 'alias_ready',
+      comparator: '=',
+      value: 'true',
+    }],
+  };
+}

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import { Edit3, Trash2 } from "lucide-react";
-import type { EditorCharacterResponse, EditorThemeResponse, MysteryRole } from "@/features/editor/api";
+import type { CharacterAliasRule, EditorCharacterResponse, EditorThemeResponse, MysteryRole } from "@/features/editor/api";
 import { useEditorCharacters, useEditorClues, useUpdateCharacter } from "@/features/editor/api";
 import { useCharacterConfigDebounce } from "@/features/editor/hooks/useCharacterConfigDebounce";
 import { CharacterDetailPanel } from "./CharacterDetailPanel";
@@ -10,6 +10,7 @@ import {
   writeCharacterStartingClueMap,
 } from "@/features/editor/utils/configShape";
 import {
+  buildCharacterAliasRulesUpdatePayload,
   buildCharacterVisibilityUpdatePayload,
   buildCharacterRoleUpdatePayload,
   getCharacterListBadges,
@@ -136,6 +137,21 @@ export function CharacterAssignPanel({
     [characters, updateCharacter],
   );
 
+  const handleAliasRulesSaveForChar = useCallback(
+    (characterId: string, rules: CharacterAliasRule[]) => {
+      if (updateCharacter.isPending) return;
+
+      const selected = characters?.find((char) => char.id === characterId);
+      if (!selected) return;
+
+      updateCharacter.mutate({
+        characterId: selected.id,
+        body: buildCharacterAliasRulesUpdatePayload(selected, rules),
+      });
+    },
+    [characters, updateCharacter],
+  );
+
   if (charsLoading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -221,6 +237,11 @@ export function CharacterAssignPanel({
               updateCharacter.isPending
                 ? undefined
                 : (field, value) => handleVisibilityChangeForChar(char.id, field, value)
+            }
+            onAliasRulesSave={
+              updateCharacter.isPending
+                ? undefined
+                : (rules) => handleAliasRulesSaveForChar(char.id, rules)
             }
           />
         )}

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Accordion } from '@/shared/components/ui';
 import type { CharacterAliasRule, MysteryRole } from '@/features/editor/api';
 import type { Mission } from './MissionEditor';
@@ -84,6 +84,7 @@ export function CharacterDetailPanel({
   onEndcardChange,
 }: CharacterDetailPanelProps) {
   const [aliasDrafts, setAliasDrafts] = useState<CharacterAliasRule[]>([]);
+  const aliasDraftCharacterIdRef = useRef<string | null>(null);
   const [endcardTitle, setEndcardTitle] = useState('');
   const [endcardBody, setEndcardBody] = useState('');
   const [endcardImageUrl, setEndcardImageUrl] = useState('');
@@ -93,8 +94,10 @@ export function CharacterDetailPanel({
   );
 
   useEffect(() => {
+    if (aliasDraftCharacterIdRef.current === (selectedChar?.id ?? null)) return;
+    aliasDraftCharacterIdRef.current = selectedChar?.id ?? null;
     setAliasDrafts(normalizeCharacterAliasRules(selectedChar?.alias_rules));
-  }, [selectedChar?.id, selectedChar?.alias_rules]);
+  }, [selectedChar]);
 
   useEffect(() => {
     setEndcardTitle(selectedChar?.endcard_title ?? '');

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -1,14 +1,17 @@
+import { useEffect, useMemo, useState } from 'react';
 import { Accordion } from '@/shared/components/ui';
-import type { MysteryRole } from '@/features/editor/api';
+import type { CharacterAliasRule, MysteryRole } from '@/features/editor/api';
 import type { Mission } from './MissionEditor';
 import { MissionEditor } from './MissionEditor';
 import { StartingClueAssigner } from './StartingClueAssigner';
 import { CharacterRoleSheetSection } from './CharacterRoleSheetSection';
+import { CharacterAliasRulesEditor } from './CharacterAliasRulesEditor';
 import {
   type CharacterVisibilityField,
   characterRoleOptions,
   getCharacterRoleOption,
   normalizeCharacterEditorRole,
+  normalizeCharacterAliasRules,
   toCharacterEditorViewModel,
 } from '@/features/editor/entities/character/characterEditorAdapter';
 
@@ -37,6 +40,7 @@ interface CharacterItem {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  alias_rules?: CharacterAliasRule[];
 }
 
 interface CharacterDetailPanelProps {
@@ -52,6 +56,7 @@ interface CharacterDetailPanelProps {
   onDeleteMission: (missionId: string) => void;
   onMysteryRoleChange?: (role: MysteryRole) => void;
   onVisibilityChange?: (field: CharacterVisibilityField, value: boolean) => void;
+  onAliasRulesSave?: (rules: CharacterAliasRule[]) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -71,7 +76,18 @@ export function CharacterDetailPanel({
   onDeleteMission,
   onMysteryRoleChange,
   onVisibilityChange,
+  onAliasRulesSave,
 }: CharacterDetailPanelProps) {
+  const [aliasDrafts, setAliasDrafts] = useState<CharacterAliasRule[]>([]);
+  const characterOptions = useMemo(
+    () => characters.map((char) => ({ id: char.id, name: char.name })),
+    [characters],
+  );
+
+  useEffect(() => {
+    setAliasDrafts(normalizeCharacterAliasRules(selectedChar?.alias_rules));
+  }, [selectedChar?.id, selectedChar?.alias_rules]);
+
   if (!selectedChar) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -95,6 +111,7 @@ export function CharacterDetailPanel({
     can_speak_in_reading: selectedChar.can_speak_in_reading ?? true,
     is_voting_candidate:
       selectedChar.is_voting_candidate ?? getCharacterRoleOption(selectedRole).defaultVotingCandidate,
+    alias_rules: selectedChar.alias_rules ?? [],
   });
 
   return (
@@ -186,6 +203,18 @@ export function CharacterDetailPanel({
                       {selectedChar.description || '공개 소개가 없습니다.'}
                     </p>
                   </div>
+                  <CharacterAliasRulesEditor
+                    characterName={selectedChar.name}
+                    characterImageUrl={selectedChar.image_url}
+                    rules={aliasDrafts}
+                    characterOptions={characterOptions}
+                    disabled={!onAliasRulesSave}
+                    onChange={setAliasDrafts}
+                    onSave={(rules) => {
+                      if (!onAliasRulesSave) return;
+                      onAliasRulesSave(rules);
+                    }}
+                  />
                 </div>
               </div>
             ),

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
@@ -126,8 +126,28 @@ describe('CharacterAliasRulesEditor', () => {
     expect((topLevelAddButton as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: '플레이 중 표시 저장' }) as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: '삭제' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText('표시 이름') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText('표시 아이콘 URL') as HTMLInputElement).disabled).toBe(true);
 
     fireEvent.click(screen.getByRole('button', { name: '삭제' }));
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('미완성 규칙은 조용히 삭제하지 않고 저장을 막는다', () => {
+    const onSave = vi.fn();
+    const rule: CharacterAliasRule = {
+      id: 'alias-1',
+      label: '정체 공개',
+      display_name: '',
+      display_icon_url: '',
+      priority: 1,
+      condition: { id: 'group-1', operator: 'AND', rules: [{ id: 'rule-1', variable: 'custom_flag', target_flag_key: 'alias_ready', comparator: '=', value: 'true' }] },
+    };
+
+    renderEditor({ rules: [rule], onSave });
+    fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('표시 이름 또는 표시 아이콘 URL을 입력하세요.')).toBeTruthy();
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CharacterAliasRulesEditor } from '../CharacterAliasRulesEditor';
+import type { CharacterAliasRule } from '@/features/editor/api';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const characterOptions = [{ id: 'char-1', name: '홍길동' }];
+
+function renderEditor(overrides: Partial<{
+  rules: CharacterAliasRule[];
+  disabled: boolean;
+  onChange: (rules: CharacterAliasRule[]) => void;
+  onSave: (rules: CharacterAliasRule[]) => void;
+}> = {}) {
+  const onChange = overrides.onChange ?? vi.fn();
+  const onSave = overrides.onSave ?? vi.fn();
+  render(
+    <CharacterAliasRulesEditor
+      characterName="홍길동"
+      characterImageUrl="https://cdn.example/base.webp"
+      rules={overrides.rules ?? []}
+      characterOptions={characterOptions}
+      disabled={overrides.disabled ?? false}
+      onChange={onChange}
+      onSave={onSave}
+    />,
+  );
+  return { onChange, onSave };
+}
+
+function renderStatefulEditor(initialRules: CharacterAliasRule[], onSave = vi.fn()) {
+  function Harness() {
+    const [rules, setRules] = useState(initialRules);
+    return (
+      <CharacterAliasRulesEditor
+        characterName="홍길동"
+        characterImageUrl="https://cdn.example/base.webp"
+        rules={rules}
+        characterOptions={characterOptions}
+        disabled={false}
+        onChange={setRules}
+        onSave={onSave}
+      />
+    );
+  }
+  render(<Harness />);
+  return { onSave };
+}
+
+describe('CharacterAliasRulesEditor', () => {
+  it('빈 상태에서 규칙을 추가하면 바로 완성 가능한 기본 조건을 만든다', () => {
+    const { onChange } = renderEditor();
+
+    fireEvent.click(screen.getByRole('button', { name: '규칙 추가' }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        label: '',
+        display_name: '',
+        display_icon_url: '',
+        priority: 0,
+        condition: expect.objectContaining({
+          operator: 'AND',
+          rules: [expect.objectContaining({
+            variable: 'custom_flag',
+            target_flag_key: 'alias_ready',
+            comparator: '=',
+            value: 'true',
+          })],
+        }),
+      }),
+    ]);
+  });
+
+  it('표시 이름, 아이콘, 우선순위를 수정해 저장한다', () => {
+    const onSave = vi.fn();
+    const rules: CharacterAliasRule[] = [{
+      id: 'alias-1',
+      label: '정체 공개',
+      display_name: '목격자',
+      display_icon_url: '',
+      priority: 1,
+      condition: {
+        id: 'group-1',
+        operator: 'AND',
+        rules: [{
+          id: 'rule-1',
+          variable: 'custom_flag',
+          target_flag_key: 'alias_ready',
+          comparator: '=',
+          value: 'true',
+        }],
+      },
+    }];
+
+    renderStatefulEditor(rules, onSave);
+    fireEvent.change(screen.getByLabelText('표시 이름'), { target: { value: '밤의 목격자' } });
+    fireEvent.change(screen.getByLabelText('표시 아이콘 URL'), { target: { value: 'https://cdn.example/night.webp' } });
+    fireEvent.change(screen.getByLabelText('우선순위'), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
+
+    expect(onSave).toHaveBeenCalledWith([expect.objectContaining({
+      id: 'alias-1',
+      display_name: '밤의 목격자',
+      display_icon_url: 'https://cdn.example/night.webp',
+      priority: 3,
+    })]);
+  });
+
+  it('규칙 삭제와 disabled 상태를 처리한다', () => {
+    const onChange = vi.fn();
+    const rule: CharacterAliasRule = {
+      id: 'alias-1',
+      display_name: '목격자',
+      priority: 1,
+      condition: { id: 'group-1', operator: 'AND', rules: [{ id: 'rule-1', variable: 'custom_flag', target_flag_key: 'alias_ready', comparator: '=', value: 'true' }] },
+    };
+
+    renderEditor({ rules: [rule], onChange, disabled: true });
+    const [topLevelAddButton] = screen.getAllByRole('button', { name: '규칙 추가' });
+    expect((topLevelAddButton as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: '플레이 중 표시 저장' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: '삭제' }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
@@ -150,4 +150,48 @@ describe('CharacterAliasRulesEditor', () => {
     expect(onSave).not.toHaveBeenCalled();
     expect(screen.getByText('표시 이름 또는 표시 아이콘 URL을 입력하세요.')).toBeTruthy();
   });
+
+  it('캐릭터가 바뀌면 이전 검증 메시지를 지운다', () => {
+    const incompleteRule: CharacterAliasRule = {
+      id: 'alias-1',
+      display_name: '',
+      display_icon_url: '',
+      priority: 1,
+      condition: { id: 'group-1', operator: 'AND', rules: [{ id: 'rule-1', variable: 'custom_flag', target_flag_key: 'alias_ready', comparator: '=', value: 'true' }] },
+    };
+    const completeRule: CharacterAliasRule = {
+      id: 'alias-2',
+      display_name: '목격자',
+      priority: 1,
+      condition: { id: 'group-1', operator: 'AND', rules: [{ id: 'rule-1', variable: 'custom_flag', target_flag_key: 'alias_ready', comparator: '=', value: 'true' }] },
+    };
+    const { rerender } = render(
+      <CharacterAliasRulesEditor
+        characterName="홍길동"
+        characterImageUrl="https://cdn.example/base.webp"
+        rules={[incompleteRule]}
+        characterOptions={characterOptions}
+        disabled={false}
+        onChange={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
+    expect(screen.getByText('표시 이름 또는 표시 아이콘 URL을 입력하세요.')).toBeTruthy();
+
+    rerender(
+      <CharacterAliasRulesEditor
+        characterName="김영희"
+        characterImageUrl="https://cdn.example/next.webp"
+        rules={[completeRule]}
+        characterOptions={characterOptions}
+        disabled={false}
+        onChange={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('표시 이름 또는 표시 아이콘 URL을 입력하세요.')).toBeNull();
+  });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
@@ -56,7 +56,8 @@ describe('CharacterAliasRulesEditor', () => {
   it('빈 상태에서 규칙을 추가하면 바로 완성 가능한 기본 조건을 만든다', () => {
     const { onChange } = renderEditor();
 
-    fireEvent.click(screen.getByRole('button', { name: '규칙 추가' }));
+    const [topLevelAddButton] = screen.getAllByRole('button', { name: '규칙 추가' });
+    fireEvent.click(topLevelAddButton);
 
     expect(onChange).toHaveBeenCalledWith([
       expect.objectContaining({
@@ -74,6 +75,34 @@ describe('CharacterAliasRulesEditor', () => {
           })],
         }),
       }),
+    ]);
+  });
+
+  it('새 규칙 우선순위는 기존 최대값 다음 번호로 만든다', () => {
+    const { onChange } = renderEditor({
+      rules: [
+        {
+          id: 'alias-1',
+          display_name: '목격자',
+          priority: 7,
+          condition: { id: 'group-1', operator: 'AND', rules: [{ id: 'rule-1', variable: 'custom_flag', target_flag_key: 'alias_ready', comparator: '=', value: 'true' }] },
+        },
+        {
+          id: 'alias-2',
+          display_name: '잠입자',
+          priority: 2,
+          condition: { id: 'group-2', operator: 'AND', rules: [{ id: 'rule-2', variable: 'custom_flag', target_flag_key: 'alias_ready', comparator: '=', value: 'true' }] },
+        },
+      ],
+    });
+
+    const [topLevelAddButton] = screen.getAllByRole('button', { name: '규칙 추가' });
+    fireEvent.click(topLevelAddButton);
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'alias-1', priority: 7 }),
+      expect.objectContaining({ id: 'alias-2', priority: 2 }),
+      expect.objectContaining({ priority: 8 }),
     ]);
   });
 
@@ -110,6 +139,28 @@ describe('CharacterAliasRulesEditor', () => {
       display_icon_url: 'https://cdn.example/night.webp',
       priority: 3,
     })]);
+  });
+
+  it('우선순위 입력은 음수와 소수를 즉시 0 이상의 정수로 정리한다', () => {
+    const onSave = vi.fn();
+    const rules: CharacterAliasRule[] = [{
+      id: 'alias-1',
+      display_name: '목격자',
+      priority: 1,
+      condition: {
+        id: 'group-1',
+        operator: 'AND',
+        rules: [{ id: 'rule-1', variable: 'custom_flag', target_flag_key: 'alias_ready', comparator: '=', value: 'true' }],
+      },
+    }];
+
+    renderStatefulEditor(rules, onSave);
+
+    fireEvent.change(screen.getByLabelText('우선순위'), { target: { value: '-3.8' } });
+    expect((screen.getByLabelText('우선순위') as HTMLInputElement).value).toBe('0');
+
+    fireEvent.change(screen.getByLabelText('우선순위'), { target: { value: '4.9' } });
+    expect((screen.getByLabelText('우선순위') as HTMLInputElement).value).toBe('4');
   });
 
   it('규칙 삭제와 disabled 상태를 처리한다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -207,6 +207,7 @@ describe('CharacterAssignPanel', () => {
         show_in_intro: true,
         can_speak_in_reading: true,
         is_voting_candidate: true,
+        alias_rules: [],
       },
     });
   });
@@ -229,7 +230,55 @@ describe('CharacterAssignPanel', () => {
         show_in_intro: true,
         can_speak_in_reading: true,
         is_voting_candidate: false,
+        alias_rules: [],
       },
+    });
+  });
+
+  it('조건부 표시 규칙을 저장한다', () => {
+    useEditorCharactersMock.mockReturnValue({
+      data: [{
+        ...mockCharacters[0],
+        alias_rules: [{
+          id: 'alias-1',
+          label: '정체 공개',
+          display_name: '밤의 목격자',
+          display_icon_url: '',
+          priority: 1,
+          condition: {
+            id: 'group-1',
+            operator: 'AND',
+            rules: [{
+              id: 'rule-1',
+              variable: 'character_alive',
+              target_character_id: 'char-1',
+              comparator: '=',
+              value: 'true',
+            }],
+          },
+        }],
+      }],
+      isLoading: false,
+    });
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    fireEvent.change(screen.getByLabelText('표시 이름'), { target: { value: '비밀 목격자' } });
+    fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      body: expect.objectContaining({
+        name: '홍길동',
+        mystery_role: 'culprit',
+        is_culprit: true,
+        alias_rules: [expect.objectContaining({
+          id: 'alias-1',
+          label: '정체 공개',
+          display_name: '비밀 목격자',
+          priority: 1,
+        })],
+      }),
     });
   });
 

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { EditorCharacterResponse } from '@/features/editor/api/types';
 import {
   buildCharacterVisibilityUpdatePayload,
+  buildCharacterAliasRulesUpdatePayload,
   getCharacterListBadges,
   buildCharacterRoleUpdatePayload,
   getCharacterRoleBadge,
@@ -23,6 +24,7 @@ function character(overrides: Partial<EditorCharacterResponse> = {}): EditorChar
     show_in_intro: true,
     can_speak_in_reading: true,
     is_voting_candidate: true,
+    alias_rules: [],
     ...overrides,
   };
 }
@@ -48,7 +50,52 @@ describe('characterEditorAdapter', () => {
       canSpeakInReading: true,
       isVotingCandidate: true,
       visibilityBadges: ['PC', '소개 표시', '읽기 대사', '투표 후보'],
+      aliasRules: [],
+      hasAliasRules: false,
     });
+  });
+
+  it('조건부 표시 규칙을 제작자용 ViewModel로 변환한다', () => {
+    const vm = toCharacterEditorViewModel(character({
+      alias_rules: [{
+        id: 'alias-1',
+        label: '정체 공개',
+        display_name: '밤의 목격자',
+        display_icon_url: 'https://cdn.example/witness.webp',
+        priority: 2,
+        condition: {
+          id: 'group-1',
+          operator: 'AND',
+          rules: [{
+            id: 'rule-1',
+            variable: 'character_alive',
+            target_character_id: 'char-1',
+            comparator: '=',
+            value: 'true',
+          }],
+        },
+      }],
+    }));
+
+    expect(vm.hasAliasRules).toBe(true);
+    expect(vm.aliasRules).toEqual([{
+      id: 'alias-1',
+      label: '정체 공개',
+      display_name: '밤의 목격자',
+      display_icon_url: 'https://cdn.example/witness.webp',
+      priority: 2,
+      condition: {
+        id: 'group-1',
+        operator: 'AND',
+        rules: [{
+          id: 'rule-1',
+          variable: 'character_alive',
+          target_character_id: 'char-1',
+          comparator: '=',
+          value: 'true',
+        }],
+      },
+    }]);
   });
 
   it('NPC 표시 정책을 제작자용 ViewModel 배지로 변환한다', () => {
@@ -89,6 +136,7 @@ describe('characterEditorAdapter', () => {
       show_in_intro: true,
       can_speak_in_reading: true,
       is_voting_candidate: true,
+      alias_rules: [],
     });
   });
 
@@ -105,6 +153,42 @@ describe('characterEditorAdapter', () => {
       show_in_intro: true,
       can_speak_in_reading: true,
       is_voting_candidate: false,
+    });
+  });
+
+  it('조건부 표시 저장 payload가 기존 역할과 노출 정책을 보존한다', () => {
+    const payload = buildCharacterAliasRulesUpdatePayload(character({ mystery_role: 'detective' }), [{
+      id: ' alias-1 ',
+      label: ' 공개 후 ',
+      display_name: ' 별칭 ',
+      priority: 1,
+      condition: {
+        id: 'group-1',
+        operator: 'AND',
+        rules: [{
+          id: 'rule-1',
+          variable: 'character_alive',
+          target_character_id: 'char-1',
+          comparator: '=',
+          value: 'true',
+        }],
+      },
+    }]);
+
+    expect(payload).toMatchObject({
+      name: '홍길동',
+      mystery_role: 'detective',
+      is_culprit: false,
+      is_playable: true,
+      show_in_intro: true,
+      can_speak_in_reading: true,
+      is_voting_candidate: true,
+      alias_rules: [{
+        id: 'alias-1',
+        label: '공개 후',
+        display_name: '별칭',
+        priority: 1,
+      }],
     });
   });
 });

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -1,4 +1,5 @@
 import type {
+  CharacterAliasRule,
   EditorCharacterResponse,
   MysteryRole,
   UpdateCharacterRequest,
@@ -31,6 +32,8 @@ export interface CharacterEditorViewModel {
   canSpeakInReading: boolean;
   isVotingCandidate: boolean;
   visibilityBadges: string[];
+  aliasRules: CharacterAliasRule[];
+  hasAliasRules: boolean;
 }
 
 export const characterRoleOptions: CharacterRoleOption[] = [
@@ -107,10 +110,43 @@ function getVisibilityBadges(visibility: ReturnType<typeof getCharacterVisibilit
   return badges;
 }
 
+export function normalizeCharacterAliasRules(rules: CharacterAliasRule[] | null | undefined): CharacterAliasRule[] {
+  if (!Array.isArray(rules)) return [];
+  return rules
+    .filter((rule) => rule && typeof rule.id === 'string' && rule.condition)
+    .map((rule) => ({
+      id: rule.id.trim(),
+      label: rule.label?.trim() || undefined,
+      display_name: rule.display_name?.trim() || undefined,
+      display_icon_url: rule.display_icon_url?.trim() || undefined,
+      priority: Number.isFinite(rule.priority) ? Math.max(0, Math.trunc(rule.priority)) : 0,
+      condition: rule.condition,
+    }))
+    .filter((rule) => Boolean(rule.id && (rule.display_name || rule.display_icon_url)));
+}
+
+function buildCharacterBaseUpdatePayload(character: EditorCharacterResponse, role = normalizeCharacterEditorRole(character)) {
+  const visibility = getCharacterVisibility(character, role);
+  return {
+    name: character.name,
+    description: character.description ?? undefined,
+    image_url: character.image_url ?? undefined,
+    is_culprit: role === 'culprit',
+    mystery_role: role,
+    sort_order: character.sort_order,
+    is_playable: visibility.isPlayable,
+    show_in_intro: visibility.showInIntro,
+    can_speak_in_reading: visibility.canSpeakInReading,
+    is_voting_candidate: visibility.isVotingCandidate,
+    alias_rules: normalizeCharacterAliasRules(character.alias_rules),
+  };
+}
+
 export function toCharacterEditorViewModel(character: EditorCharacterResponse): CharacterEditorViewModel {
   const role = normalizeCharacterEditorRole(character);
   const option = getCharacterRoleOption(role);
   const visibility = getCharacterVisibility(character, role);
+  const aliasRules = normalizeCharacterAliasRules(character.alias_rules);
 
   return {
     id: character.id,
@@ -131,6 +167,8 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     canSpeakInReading: visibility.canSpeakInReading,
     isVotingCandidate: visibility.isVotingCandidate,
     visibilityBadges: getVisibilityBadges(visibility),
+    aliasRules,
+    hasAliasRules: aliasRules.length > 0,
   };
 }
 
@@ -142,19 +180,8 @@ export function buildCharacterRoleUpdatePayload(
   character: EditorCharacterResponse,
   role: MysteryRole,
 ): UpdateCharacterRequest {
-  const visibility = getCharacterVisibility(character, role);
-
   return {
-    name: character.name,
-    description: character.description ?? undefined,
-    image_url: character.image_url ?? undefined,
-    is_culprit: role === 'culprit',
-    mystery_role: role,
-    sort_order: character.sort_order,
-    is_playable: visibility.isPlayable,
-    show_in_intro: visibility.showInIntro,
-    can_speak_in_reading: visibility.canSpeakInReading,
-    is_voting_candidate: visibility.isVotingCandidate,
+    ...buildCharacterBaseUpdatePayload(character, role),
   };
 }
 
@@ -178,13 +205,18 @@ export function buildCharacterVisibilityUpdatePayload(
   }
 
   return {
-    name: character.name,
-    description: character.description ?? undefined,
-    image_url: character.image_url ?? undefined,
-    is_culprit: role === 'culprit',
-    mystery_role: role,
-    sort_order: character.sort_order,
+    ...buildCharacterBaseUpdatePayload(character, role),
     ...next,
+  };
+}
+
+export function buildCharacterAliasRulesUpdatePayload(
+  character: EditorCharacterResponse,
+  aliasRules: CharacterAliasRule[],
+): UpdateCharacterRequest {
+  return {
+    ...buildCharacterBaseUpdatePayload(character),
+    alias_rules: normalizeCharacterAliasRules(aliasRules),
   };
 }
 

--- a/docs/plans/2026-05-05-issue-329-character-alias/checklist.md
+++ b/docs/plans/2026-05-05-issue-329-character-alias/checklist.md
@@ -1,0 +1,12 @@
+# Issue #329 Character Alias Checklist
+
+- [x] #301 조건 계약 재사용 여부 확인
+- [x] `theme_characters.alias_rules` 저장 계약 추가
+- [x] editor create/update/list DTO와 sqlc 생성 코드 정렬
+- [x] backend alias validation 및 조건 평가 helper 추가
+- [x] 소개/읽기/투표/결과 runtime 표시 경로 감사
+- [x] frontend API 타입과 character ViewModel/payload adapter 연결
+- [x] `CharacterDetailPanel` 제작 UI에 조건부 표시 규칙 저장 흐름 추가
+- [x] focused Go/Vitest/typecheck 검증
+- [x] 세션 스냅샷/WS에 player-facing 표시값을 주입하는 후속 Issue 생성 (#362)
+- [ ] PR 생성 후 CodeRabbit, full CI, Codecov 확인

--- a/docs/plans/2026-05-05-issue-329-character-alias/design.md
+++ b/docs/plans/2026-05-05-issue-329-character-alias/design.md
@@ -1,0 +1,34 @@
+# Issue #329 Character Alias Design
+
+## 목표
+
+조건부 이름/아이콘 표시를 캐릭터 엔티티의 제작 계약으로 고정한다. 제작자는 에디터에서 "플레이 중 표시" 규칙을 만들고, 백엔드는 같은 조건 계약으로 최종 표시값을 판정한다.
+
+## 결정
+
+- 저장 위치: `theme_characters.alias_rules` JSONB 배열.
+- 규칙 형태: `id`, `label`, `display_name`, `display_icon_url`, `priority`, `condition`.
+- 조건 계약: #301의 `engine.ConditionGroup`을 그대로 사용한다.
+- 우선순위: 조건을 만족하는 규칙 중 `priority`가 가장 높은 규칙 하나만 적용한다.
+- fallback: 조건 평가 실패, 조건 불충족, 규칙 없음이면 기본 `name`/`image_url`을 사용한다.
+- redaction 경계: public/player-facing API는 원본 규칙과 원본 스포일러 값을 직접 해석하지 않고, backend가 계산한 표시값만 내려주는 구조로 확장한다.
+
+## 제외
+
+- 결과 카드/감상 화면 UX는 #280/#330 범위다.
+- 투표/읽기/결과 화면 전체 표시 교체는 이번 PR에서 helper 계약까지만 고정하고, runtime snapshot 연결 PR에서 같은 helper를 사용한다.
+- 조건 빌더 자체 확장은 #301 후속 범위다.
+
+## Runtime 표시 경로 감사
+
+- 소개/읽기: `ReadingPanel`과 `ReadingOverlay`는 현재 role/section/line 중심이며 캐릭터 표시 이름/아이콘을 직접 받지 않는다.
+- 투표: `VotePanel`, `VotingPanel`, `VoteOptionList`는 `Player.nickname` 또는 voting module의 `targetCode` 결과를 표시한다. 공용 `Player` 타입에는 캐릭터 표시 이름/아이콘 필드가 없다.
+- 결과: `ResultBreakdownPanel`과 `resultBreakdownAdapter`는 투표 결과 ID를 `Player.nickname`으로 매핑한다.
+- Backend session: `session.PlayerState`와 `staticPlayerInfoProvider`는 `TargetCode`를 보유하지만, `theme_characters.alias_rules`를 로드해 player-facing 표시값으로 바꾸는 스냅샷 경로는 아직 없다.
+- 판단: 이번 PR은 조건부 표시의 저장/검증/제작 UI/source-of-truth helper를 고정한다. 실제 게임 화면 적용은 세션 스냅샷/WS에 `CharacterDisplay`를 주입하는 별도 runtime PR에서 처리해야 한다.
+
+## 검증
+
+- Go: alias rule validation, 저장/보존/삭제, 조건 평가 fallback.
+- Web: API DTO -> ViewModel -> 저장 payload 왕복, 제작자 UI 저장 액션.
+- TypeScript: `@mmp/web` typecheck.


### PR DESCRIPTION
## 요약

- `theme_characters.alias_rules` 저장 계약과 OpenAPI/sqlc/DTO를 추가했습니다.
- backend `CharacterDisplay` resolver로 조건부 이름/아이콘 우선순위와 fallback을 고정했습니다.
- 제작자 화면 `CharacterDetailPanel`에서 내부 JSON 없이 플레이 중 표시 규칙을 만들고 저장할 수 있게 연결했습니다.
- 실제 세션/WS/game UI 표시값 주입은 후속 Issue #362로 분리했습니다.

## 검증

- `go test ./internal/engine ./internal/domain/editor ./internal/domain/theme -run 'TestParseCharacterAliasRules|TestResolveCharacterDisplay|TestNormalizeCharacterAliasRules|TestService_CharacterAliasRulesContract|TestConfirmImageUpload_PreservesExistingTargetFields|TestGetCharacters'`\n- `pnpm --filter @mmp/web exec tsc --noEmit`\n- `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx`\n- `git diff --check HEAD~2..HEAD`\n- 참고: `vitest --coverage` focused 실행은 테스트 37개 통과 후 repo 전역 threshold가 전체 파일 기준으로 계산되어 실패했습니다. Full CI/Codecov에서 patch 기준을 확인합니다.\n\n## 범위 판단\n\n- #329는 저장 계약, 제작 UI, backend source-of-truth helper, public redaction 기준까지 닫습니다.\n- runtime 세션 스냅샷/WS/game UI 적용은 #362로 분리했습니다.\n\nCloses #329\nRefs #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캐릭터에 is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate 편집 플래그 추가 및 API/DB에 반영.
  * 캐릭터별 조건부 표시 규칙(alias_rules) 저장·편집·삭제 지원과 플레이 중 우선순위 기반 이름/아이콘 대체 적용.
  * 편집기 UI에 규칙 편집기와 규칙 전용 저장 흐름 도입.  

* **테스트**
  * 규칙 검증·정규화·적용 및 엔드투엔드 동작을 검증하는 단위·통합 테스트 추가.

* **문서**
  * 캐릭터 별칭 설계 문서와 구현 체크리스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->