### PR TITLE
fix(server): #281 에러 계약 레지스트리 정합성 보강

### DIFF
--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -940,7 +940,7 @@ components:
     ProblemDetail:
       type: object
       description: RFC 9457 Problem Details
-      required: [type, title, status, detail, code]
+      required: [type, title, status, detail, code, timestamp]
       properties:
         type:
           type: string
@@ -989,7 +989,7 @@ components:
           description: Request identifier mirrored from X-Request-ID
         correlation_id:
           type: string
-          description: Correlation identifier for client support flows; mirrors request_id
+          description: Optional correlation identifier for client support flows; mirrors request_id when present
         timestamp:
           type: string
           format: date-time

--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -987,6 +987,13 @@ components:
         request_id:
           type: string
           description: Request identifier mirrored from X-Request-ID
+        correlation_id:
+          type: string
+          description: Correlation identifier for client support flows; mirrors request_id
+        timestamp:
+          type: string
+          format: date-time
+          description: UTC time when the problem response was generated
         severity:
           type: string
           enum: [critical, high, medium, low]

--- a/apps/server/internal/apperror/handler.go
+++ b/apps/server/internal/apperror/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
@@ -24,10 +25,13 @@ type problemResponse struct {
 	Extensions map[string]any `json:"extensions,omitempty"`
 	TraceID    string         `json:"trace_id,omitempty"`
 	RequestID  string         `json:"request_id,omitempty"`
-	Severity   Severity       `json:"severity,omitempty"`
-	Retryable  bool           `json:"retryable"`
-	UserAction string         `json:"user_action,omitempty"`
-	Debug      *debugInfo     `json:"debug,omitempty"`
+	// CorrelationID mirrors request_id for clients and logs that use correlation terminology.
+	CorrelationID string     `json:"correlation_id,omitempty"`
+	Timestamp     string     `json:"timestamp"`
+	Severity      Severity   `json:"severity,omitempty"`
+	Retryable     bool       `json:"retryable"`
+	UserAction    string     `json:"user_action,omitempty"`
+	Debug         *debugInfo `json:"debug,omitempty"`
 }
 
 // debugInfo holds development-only diagnostic information.
@@ -88,20 +92,23 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 
 	defn := definitionForResponse(appErr)
+	requestID := requestIDFrom(w, r)
 	resp := problemResponse{
-		Type:       typeURI,
-		Title:      appErr.Title,
-		Status:     appErr.Status,
-		Detail:     appErr.Detail,
-		Code:       appErr.Code,
-		Instance:   appErr.Instance,
-		Params:     appErr.Params,
-		Errors:     appErr.Errors,
-		Extensions: appErr.Extensions,
-		RequestID:  requestIDFrom(w, r),
-		Severity:   defn.Severity,
-		Retryable:  defn.Retryable,
-		UserAction: defn.UserAction,
+		Type:          typeURI,
+		Title:         appErr.Title,
+		Status:        appErr.Status,
+		Detail:        appErr.Detail,
+		Code:          appErr.Code,
+		Instance:      appErr.Instance,
+		Params:        appErr.Params,
+		Errors:        appErr.Errors,
+		Extensions:    appErr.Extensions,
+		RequestID:     requestID,
+		CorrelationID: requestID,
+		Timestamp:     time.Now().UTC().Format(time.RFC3339Nano),
+		Severity:      defn.Severity,
+		Retryable:     defn.Retryable,
+		UserAction:    defn.UserAction,
 	}
 
 	// Include trace_id in error response if OTel is active.

--- a/apps/server/internal/apperror/handler_test.go
+++ b/apps/server/internal/apperror/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestWriteError_AppError(t *testing.T) {
@@ -171,6 +172,10 @@ func TestWriteError_WithRequestIDAndRegistryMetadata(t *testing.T) {
 	if body["request_id"] != "req-123" {
 		t.Errorf("request_id = %v, want req-123", body["request_id"])
 	}
+	if body["correlation_id"] != "req-123" {
+		t.Errorf("correlation_id = %v, want req-123", body["correlation_id"])
+	}
+	assertRFC3339Timestamp(t, body["timestamp"])
 	if body["severity"] != string(SeverityHigh) {
 		t.Errorf("severity = %v, want %s", body["severity"], SeverityHigh)
 	}
@@ -202,6 +207,9 @@ func TestWriteError_UsesResponseRequestIDFromMiddleware(t *testing.T) {
 
 	if body["request_id"] != "middleware-generated" {
 		t.Errorf("request_id = %v, want middleware-generated", body["request_id"])
+	}
+	if body["correlation_id"] != "middleware-generated" {
+		t.Errorf("correlation_id = %v, want middleware-generated", body["correlation_id"])
 	}
 }
 
@@ -362,5 +370,17 @@ func TestWriteError_WrappedError_Logging(t *testing.T) {
 
 	if body["code"] != ErrInternal {
 		t.Errorf("expected code %q, got %v", ErrInternal, body["code"])
+	}
+}
+
+func assertRFC3339Timestamp(t *testing.T, value any) {
+	t.Helper()
+
+	raw, ok := value.(string)
+	if !ok || raw == "" {
+		t.Fatalf("timestamp = %v, want non-empty RFC3339 timestamp", value)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, raw); err != nil {
+		t.Fatalf("timestamp = %q, want RFC3339Nano: %v", raw, err)
 	}
 }

--- a/apps/server/internal/apperror/registry_test.go
+++ b/apps/server/internal/apperror/registry_test.go
@@ -2,6 +2,8 @@ package apperror
 
 import (
 	"net/http"
+	"os"
+	"regexp"
 	"testing"
 )
 
@@ -23,6 +25,64 @@ func TestLookupDefinition_KnownCode(t *testing.T) {
 	if defn.DefaultKR == "" {
 		t.Error("DefaultKR should be set for creator-facing message fallback")
 	}
+}
+
+func TestAllPublicErrorCodesHaveRegistryDefinition(t *testing.T) {
+	codes := errorCodesFromSource(t)
+	seen := make(map[string]struct{}, len(codes))
+	for _, code := range codes {
+		if _, duplicated := seen[code]; duplicated {
+			t.Fatalf("duplicate public error code in invariant list: %s", code)
+		}
+		seen[code] = struct{}{}
+
+		defn, ok := LookupDefinition(code)
+		if !ok {
+			t.Errorf("missing registry definition for %s", code)
+			continue
+		}
+		if defn.Code != code {
+			t.Errorf("%s definition Code = %s", code, defn.Code)
+		}
+		if defn.Domain == "" {
+			t.Errorf("%s definition Domain must be set", code)
+		}
+		if defn.Layer == "" {
+			t.Errorf("%s definition Layer must be set", code)
+		}
+		if defn.Severity == "" {
+			t.Errorf("%s definition Severity must be set", code)
+		}
+		if defn.HTTPStatus < 400 {
+			t.Errorf("%s definition HTTPStatus = %d, want >= 400", code, defn.HTTPStatus)
+		}
+		if defn.UserAction == "" {
+			t.Errorf("%s definition UserAction must be set", code)
+		}
+		if defn.DefaultKR == "" {
+			t.Errorf("%s definition DefaultKR must be set", code)
+		}
+	}
+}
+
+func errorCodesFromSource(t *testing.T) []string {
+	t.Helper()
+
+	source, err := os.ReadFile("codes.go")
+	if err != nil {
+		t.Fatalf("failed to read codes.go: %v", err)
+	}
+
+	matches := regexp.MustCompile(`Err[A-Za-z0-9_]+\s*=\s*"([^"]+)"`).FindAllSubmatch(source, -1)
+	if len(matches) == 0 {
+		t.Fatal("no public error codes found in codes.go")
+	}
+
+	codes := make([]string, 0, len(matches))
+	for _, match := range matches {
+		codes = append(codes, string(match[1]))
+	}
+	return codes
 }
 
 func TestDefinitionForResponse_PreservesOccurrenceStatus(t *testing.T) {

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -18,7 +18,7 @@ export interface ApiError {
   extensions?: Record<string, unknown>;
   request_id?: string;
   correlation_id?: string;
-  timestamp?: string;
+  timestamp: string;
   severity?: 'critical' | 'high' | 'medium' | 'low';
   retryable?: boolean;
   user_action?: string;

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -17,6 +17,8 @@ export interface ApiError {
   params?: Record<string, unknown>;
   extensions?: Record<string, unknown>;
   request_id?: string;
+  correlation_id?: string;
+  timestamp?: string;
   severity?: 'critical' | 'high' | 'medium' | 'low';
   retryable?: boolean;
   user_action?: string;


### PR DESCRIPTION
## 요약
- ProblemDetail 응답에 `correlation_id`와 `timestamp`를 추가해 지원/로그 추적 계약을 고정합니다.
- `codes.go`의 공개 에러 코드가 registry metadata를 빠짐없이 갖는지 테스트로 강제합니다.
- OpenAPI와 shared `ApiError` 타입을 실제 wire contract와 맞춥니다.

## 검증
- `cd apps/server && go test ./internal/apperror ./internal/httputil -run 'Test(WriteError|LookupDefinition|DefinitionForResponse|AllPublicErrorCodes|SeverityForStatus|DefaultActionForStatus|WrapHandler)' -cover`\n- `cd apps/server && go test ./internal/apperror ./internal/httputil ./internal/middleware ./internal/domain/editor -coverprofile=/tmp/issue281-server.out`\n- `pnpm --filter @mmp/web exec tsc --noEmit`\n- `git diff --check origin/main...HEAD`\n\n## E2E 제외 사유\n- 이번 변경은 순수 backend HTTP error contract와 shared 타입 보강입니다. 사용자 화면 플로우 변경이 없어 server unit/integration 및 TypeScript contract 검증으로 대체했습니다.\n\nCloses #281\nRefs #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * API 오류 응답에 추적 ID 필드(correlation_id) 추가(선택적)
  * API 오류 응답에 타임스탬프(timestamp) 추가 — 응답에 timestamp는 필수로 제공됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->