### PR TITLE
feat(web): #282 ProblemDetail 복구 전략 연결

### DIFF
--- a/apps/web/src/features/editor/api/content.test.ts
+++ b/apps/web/src/features/editor/api/content.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const { mockGet, mockPut, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPut: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock("@/services/api", () => ({
+  api: { get: mockGet, put: mockPut, post: mockPost },
+}));
+
+let testQueryClient: QueryClient;
+
+vi.mock("@/services/queryClient", () => ({
+  get queryClient() {
+    return testQueryClient;
+  },
+}));
+
+import { useEditorContent } from "./content";
+import type { ContentResponse } from "./types";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    children,
+  );
+}
+
+describe("editor content API hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  it("uses the QueryClient default retry policy for content loads", async () => {
+    const retry = vi.fn((failureCount: number) => failureCount < 1);
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry, retryDelay: 0 }, mutations: { retry: false } },
+    });
+    const content: ContentResponse = {
+      id: "content-1",
+      theme_id: "theme-1",
+      key: "intro",
+      body: "환영합니다",
+      updated_at: "2026-05-05T00:00:00Z",
+    };
+    mockGet.mockRejectedValueOnce(new Error("temporary"));
+    mockGet.mockResolvedValueOnce(content);
+
+    const { result } = renderHook(() => useEditorContent("theme-1", "intro"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(mockGet).toHaveBeenCalledWith("/v1/editor/themes/theme-1/content/intro");
+    expect(retry).toHaveBeenCalled();
+    expect(result.current.data).toEqual(content);
+  });
+});

--- a/apps/web/src/features/editor/api/content.ts
+++ b/apps/web/src/features/editor/api/content.ts
@@ -18,7 +18,6 @@ export function useEditorContent(themeId: string, key: string) {
     queryKey: editorKeys.content(themeId, key),
     queryFn: () => api.get<ContentResponse>(`/v1/editor/themes/${themeId}/content/${key}`),
     enabled: !!themeId && !!key,
-    retry: false,
   });
 }
 

--- a/apps/web/src/features/editor/api/roleSheets.test.ts
+++ b/apps/web/src/features/editor/api/roleSheets.test.ts
@@ -67,6 +67,29 @@ describe("editor role sheet API hooks", () => {
     expect(result.current.data).toEqual(roleSheet);
   });
 
+  it("uses the QueryClient default retry policy for role sheet loads", async () => {
+    const retry = vi.fn((failureCount: number) => failureCount < 1);
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry, retryDelay: 0 }, mutations: { retry: false } },
+    });
+    const roleSheet: RoleSheetResponse = {
+      character_id: "char-1",
+      theme_id: "theme-1",
+      format: "markdown",
+      markdown: { body: "## 비밀" },
+    };
+    mockGet.mockRejectedValueOnce(new Error("temporary"));
+    mockGet.mockResolvedValueOnce(roleSheet);
+
+    const { result } = renderHook(() => useCharacterRoleSheet("char-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(retry).toHaveBeenCalled();
+    expect(result.current.data).toEqual(roleSheet);
+  });
+
   it("upserts a markdown role sheet and invalidates its query", async () => {
     const roleSheet: RoleSheetResponse = {
       character_id: "char-1",

--- a/apps/web/src/features/editor/api/roleSheets.ts
+++ b/apps/web/src/features/editor/api/roleSheets.ts
@@ -9,7 +9,6 @@ export function useCharacterRoleSheet(characterId: string) {
     queryKey: editorKeys.characterRoleSheet(characterId),
     queryFn: () => api.get<RoleSheetResponse>(`/v1/editor/characters/${characterId}/role-sheet`),
     enabled: !!characterId,
-    retry: false,
   });
 }
 

--- a/apps/web/src/lib/api-error.test.ts
+++ b/apps/web/src/lib/api-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { ApiError } from "@mmp/shared";
+
+import { ApiHttpError, isApiError } from "@/lib/api-error";
+
+describe("ApiHttpError", () => {
+  it("ProblemDetail 확장 필드를 throwable error에 보존한다", () => {
+    const problem: ApiError = {
+      type: "about:blank",
+      title: "Conflict",
+      status: 409,
+      detail: "stale editor config",
+      code: "EDITOR_CONFIG_VERSION_MISMATCH",
+      request_id: "req-123456",
+      trace_id: "trace-123456",
+      severity: "high",
+      retryable: false,
+      user_action: "reload_or_merge",
+    };
+
+    const error = new ApiHttpError(problem);
+
+    expect(error.apiError).toBe(problem);
+    expect(error.status).toBe(409);
+    expect(error.code).toBe("EDITOR_CONFIG_VERSION_MISMATCH");
+    expect(error.requestId).toBe("req-123456");
+    expect(error.traceId).toBe("trace-123456");
+    expect(error.severity).toBe("high");
+    expect(error.retryable).toBe(false);
+    expect(error.userAction).toBe("reload_or_merge");
+  });
+});
+
+describe("isApiError", () => {
+  it("ProblemDetail 최소 shape만 있으면 unknown 확장 필드를 보존할 수 있게 통과시킨다", () => {
+    expect(
+      isApiError({
+        type: "about:blank",
+        title: "Conflict",
+        status: 409,
+        detail: "stale editor config",
+        code: "EDITOR_CONFIG_VERSION_MISMATCH",
+        severity: "high",
+        retryable: false,
+        user_action: "reload_or_merge",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/api-error.ts
+++ b/apps/web/src/lib/api-error.ts
@@ -30,6 +30,18 @@ export class ApiHttpError extends Error {
   get requestId(): string | undefined {
     return this.apiError.request_id;
   }
+
+  get severity(): ApiError["severity"] {
+    return this.apiError.severity;
+  }
+
+  get retryable(): boolean | undefined {
+    return this.apiError.retryable;
+  }
+
+  get userAction(): string | undefined {
+    return this.apiError.user_action;
+  }
 }
 
 /** Type guard for ApiError shape. */

--- a/apps/web/src/lib/error-messages.ts
+++ b/apps/web/src/lib/error-messages.ts
@@ -38,6 +38,10 @@ const ERROR_MESSAGES: Record<string, string> = {
   MEDIA_REFERENCE_IN_USE: "이 미디어는 다른 곳에서 사용 중이라 삭제할 수 없습니다.",
   MEDIA_NOT_IN_THEME: "이 테마에 속하지 않은 미디어입니다.",
 
+  // Editor
+  EDITOR_CONFIG_VERSION_MISMATCH:
+    "다른 변경사항과 충돌했습니다. 최신 내용으로 새로고침 후 다시 저장해주세요.",
+
   // Generic
   BAD_REQUEST: "잘못된 요청입니다.",
   UNAUTHORIZED: "인증이 필요합니다.",

--- a/apps/web/src/lib/error-recovery.test.ts
+++ b/apps/web/src/lib/error-recovery.test.ts
@@ -42,6 +42,12 @@ describe("getRecoveryAction", () => {
       "retry-later",
     );
   });
+
+  it("429 rate limit은 입력 오류가 아니라 나중에 재시도할 오류로 분류한다", () => {
+    expect(getRecoveryAction(apiError({ status: 429, code: "RATE_LIMITED" }))).toBe(
+      "retry-later",
+    );
+  });
 });
 
 describe("getErrorRecoveryStrategy", () => {

--- a/apps/web/src/lib/error-recovery.test.ts
+++ b/apps/web/src/lib/error-recovery.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { ApiError } from "@mmp/shared";
+
+import {
+  getErrorRecoveryStrategy,
+  getRecoveryAction,
+  shouldRetryApiError,
+} from "@/lib/error-recovery";
+
+function apiError(overrides: Partial<ApiError>): ApiError {
+  return {
+    type: "about:blank",
+    title: "Bad Request",
+    status: 400,
+    detail: "bad request",
+    code: "BAD_REQUEST",
+    ...overrides,
+  };
+}
+
+describe("getRecoveryAction", () => {
+  it("backend user_action을 프론트 복구 액션으로 변환한다", () => {
+    expect(
+      getRecoveryAction(
+        apiError({
+          status: 409,
+          code: "EDITOR_CONFIG_VERSION_MISMATCH",
+          user_action: "reload_or_merge",
+        }),
+      ),
+    ).toBe("reload-or-merge");
+  });
+
+  it("user_action이 없으면 대표 code와 status로 fallback한다", () => {
+    expect(getRecoveryAction(apiError({ code: "MEDIA_REFERENCE_IN_USE" }))).toBe(
+      "review-references",
+    );
+    expect(getRecoveryAction(apiError({ status: 403, code: "FORBIDDEN" }))).toBe(
+      "request-access",
+    );
+    expect(getRecoveryAction(apiError({ status: 503, code: "SERVICE_UNAVAILABLE" }))).toBe(
+      "retry-later",
+    );
+  });
+});
+
+describe("getErrorRecoveryStrategy", () => {
+  it("login 액션은 토스트 대신 로그인 이동 surface를 선택한다", () => {
+    const strategy = getErrorRecoveryStrategy(
+      apiError({ status: 401, code: "AUTH_TOKEN_EXPIRED", user_action: "login" }),
+    );
+
+    expect(strategy.surface).toBe("redirect-login");
+    expect(strategy.retryable).toBe(false);
+  });
+
+  it("high severity 4xx는 더 오래 보이는 토스트로 표시한다", () => {
+    const strategy = getErrorRecoveryStrategy(
+      apiError({
+        status: 409,
+        code: "EDITOR_CONFIG_VERSION_MISMATCH",
+        severity: "high",
+        retryable: false,
+        user_action: "reload_or_merge",
+      }),
+    );
+
+    expect(strategy.surface).toBe("toast");
+    expect(strategy.action).toBe("reload-or-merge");
+    expect(strategy.duration).toBe(8000);
+    expect(strategy.capture).toBe(false);
+  });
+
+  it("5xx는 캡처와 수동 닫기 토스트 대상으로 분류한다", () => {
+    const strategy = getErrorRecoveryStrategy(
+      apiError({ status: 500, code: "INTERNAL_ERROR", severity: "high" }),
+    );
+
+    expect(strategy.action).toBe("retry-later");
+    expect(strategy.retryable).toBe(true);
+    expect(strategy.duration).toBe(Infinity);
+    expect(strategy.capture).toBe(true);
+  });
+});
+
+describe("shouldRetryApiError", () => {
+  it("retryable problem detail은 한 번만 조용히 재시도한다", () => {
+    const error = apiError({
+      status: 503,
+      code: "SERVICE_UNAVAILABLE",
+      retryable: true,
+      user_action: "retry_later",
+    });
+
+    expect(shouldRetryApiError(error, 0)).toBe(true);
+    expect(shouldRetryApiError(error, 1)).toBe(false);
+  });
+
+  it("입력/권한 오류는 retryable이 아니면 재시도하지 않는다", () => {
+    expect(shouldRetryApiError(apiError({ status: 422, code: "VALIDATION_ERROR" }), 0)).toBe(
+      false,
+    );
+    expect(shouldRetryApiError(apiError({ status: 403, code: "FORBIDDEN" }), 0)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/error-recovery.ts
+++ b/apps/web/src/lib/error-recovery.ts
@@ -1,0 +1,126 @@
+import type { ApiError } from "@mmp/shared";
+
+export type RecoverySurface = "redirect-login" | "toast";
+
+export type RecoveryAction =
+  | "fix-input"
+  | "login"
+  | "request-access"
+  | "refresh"
+  | "reload-or-merge"
+  | "review-references"
+  | "retry"
+  | "retry-later"
+  | "contact-support"
+  | "none";
+
+export interface ErrorRecoveryStrategy {
+  surface: RecoverySurface;
+  action: RecoveryAction;
+  retryable: boolean;
+  duration: number;
+  capture: boolean;
+}
+
+const DEFAULT_TOAST_DURATION_MS = 5000;
+const LOW_SEVERITY_DURATION_MS = 4000;
+const HIGH_SEVERITY_DURATION_MS = 8000;
+
+const ACTION_ALIASES: Record<string, RecoveryAction> = {
+  fix_input: "fix-input",
+  login: "login",
+  request_access: "request-access",
+  refresh: "refresh",
+  reload_or_merge: "reload-or-merge",
+  review_references: "review-references",
+  retry: "retry",
+  retry_later: "retry-later",
+  contact_support: "contact-support",
+  none: "none",
+};
+
+const CODE_ACTIONS: Record<string, RecoveryAction> = {
+  AUTH_TOKEN_EXPIRED: "login",
+  AUTH_TOKEN_INVALID: "login",
+  AUTH_TOKEN_MISSING: "login",
+  EDITOR_CONFIG_VERSION_MISMATCH: "reload-or-merge",
+  MEDIA_REFERENCE_IN_USE: "review-references",
+  SERVICE_UNAVAILABLE: "retry-later",
+  TIMEOUT: "retry",
+  VALIDATION_ERROR: "fix-input",
+};
+
+export function getErrorRecoveryStrategy(error: ApiError): ErrorRecoveryStrategy {
+  const action = getRecoveryAction(error);
+  const retryable = error.retryable ?? isImplicitlyRetryable(error);
+  const capture = error.status >= 500 || error.severity === "critical";
+
+  return {
+    surface: action === "login" || error.status === 401 ? "redirect-login" : "toast",
+    action,
+    retryable,
+    duration: getToastDuration(error),
+    capture,
+  };
+}
+
+export function shouldRetryApiError(error: ApiError, failureCount: number): boolean {
+  if (failureCount >= 1) {
+    return false;
+  }
+
+  const strategy = getErrorRecoveryStrategy(error);
+  if (strategy.surface === "redirect-login" || strategy.action === "request-access") {
+    return false;
+  }
+
+  return strategy.retryable;
+}
+
+export function getRecoveryAction(error: ApiError): RecoveryAction {
+  const explicit = error.user_action?.trim();
+  if (explicit && ACTION_ALIASES[explicit]) {
+    return ACTION_ALIASES[explicit];
+  }
+
+  if (error.code && CODE_ACTIONS[error.code]) {
+    return CODE_ACTIONS[error.code];
+  }
+
+  if (error.status === 401) {
+    return "login";
+  }
+  if (error.status === 403) {
+    return "request-access";
+  }
+  if (error.status === 408) {
+    return "retry";
+  }
+  if (error.status === 409) {
+    return "refresh";
+  }
+  if (error.status >= 500) {
+    return "retry-later";
+  }
+  if (error.status >= 400) {
+    return "fix-input";
+  }
+  return "none";
+}
+
+function getToastDuration(error: ApiError): number {
+  if (error.status >= 500 || error.severity === "critical") {
+    return Infinity;
+  }
+  if (error.severity === "high") {
+    return HIGH_SEVERITY_DURATION_MS;
+  }
+  if (error.severity === "low") {
+    return LOW_SEVERITY_DURATION_MS;
+  }
+  return DEFAULT_TOAST_DURATION_MS;
+}
+
+function isImplicitlyRetryable(error: ApiError): boolean {
+  return error.status >= 500 || error.status === 408 || error.code === "TIMEOUT";
+}

--- a/apps/web/src/lib/error-recovery.ts
+++ b/apps/web/src/lib/error-recovery.ts
@@ -99,6 +99,9 @@ export function getRecoveryAction(error: ApiError): RecoveryAction {
   if (error.status === 409) {
     return "refresh";
   }
+  if (error.status === 429) {
+    return "retry-later";
+  }
   if (error.status >= 500) {
     return "retry-later";
   }

--- a/apps/web/src/lib/show-error-toast.test.ts
+++ b/apps/web/src/lib/show-error-toast.test.ts
@@ -70,6 +70,28 @@ describe('showErrorToast', () => {
     expect(captureApiError).not.toHaveBeenCalled();
   });
 
+  it('high severity 4xx는 캡처 없이 더 오래 표시한다', () => {
+    showErrorToast(
+      apiError({
+        status: 409,
+        code: 'EDITOR_CONFIG_VERSION_MISMATCH',
+        severity: 'high',
+        retryable: false,
+        user_action: 'reload_or_merge',
+        request_id: 'request-123456789',
+      })
+    );
+
+    expect(captureApiError).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      '다른 변경사항과 충돌했습니다. 최신 내용으로 새로고침 후 다시 저장해주세요.',
+      {
+        description: 'Ref: request-',
+        duration: 8000,
+      }
+    );
+  });
+
   it('5xx 에러는 Sentry에 캡처하고 수동 닫기 토스트로 표시한다', () => {
     showErrorToast(
       apiError({

--- a/apps/web/src/lib/show-error-toast.ts
+++ b/apps/web/src/lib/show-error-toast.ts
@@ -1,17 +1,19 @@
 import { toast } from 'sonner';
 import type { ApiError } from '@mmp/shared';
 import { getUserMessage } from '@/lib/error-messages';
+import { getErrorRecoveryStrategy } from '@/lib/error-recovery';
 import { captureApiError } from '@/lib/sentry';
 
 /**
  * API 에러를 sonner 토스트로 표시한다.
- * - 401: 로그인 페이지로 리다이렉트
- * - 4xx: 5초 자동 닫힘
- * - 5xx: 수동 닫기 + trace_id 표시
+ * - recovery strategy가 login이면 로그인 페이지로 리다이렉트
+ * - severity/retryability에 따라 표시 시간과 Sentry 캡처를 결정
  */
 export function showErrorToast(error: ApiError): void {
+  const strategy = getErrorRecoveryStrategy(error);
+
   // 401은 토스트 대신 리다이렉트 (로그인 페이지에서는 루프 방지)
-  if (error.status === 401 && !window.location.pathname.startsWith('/login')) {
+  if (strategy.surface === 'redirect-login' && !window.location.pathname.startsWith('/login')) {
     window.location.href = '/login';
     return;
   }
@@ -20,20 +22,14 @@ export function showErrorToast(error: ApiError): void {
   const ref = getErrorReference(error);
   const description = ref ? `Ref: ${ref}` : undefined;
 
-  if (error.status >= 500) {
+  if (strategy.capture) {
     captureApiError(new Error(error.detail), error);
-    // 서버 에러: 수동 닫기, 더 오래 표시
-    toast.error(message, {
-      description,
-      duration: Infinity,
-    });
-  } else {
-    // 클라이언트 에러: 5초 후 자동 닫힘
-    toast.error(message, {
-      description,
-      duration: 5000,
-    });
   }
+
+  toast.error(message, {
+    description,
+    duration: strategy.duration,
+  });
 }
 
 export function getErrorReference(error: ApiError): string | undefined {

--- a/apps/web/src/services/queryClient.test.ts
+++ b/apps/web/src/services/queryClient.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { ApiError } from "@mmp/shared";
+
+import { ApiHttpError } from "@/lib/api-error";
+import { queryClient } from "@/services/queryClient";
+
+function apiError(overrides: Partial<ApiError>): ApiError {
+  return {
+    type: "about:blank",
+    title: "Service Unavailable",
+    status: 503,
+    detail: "temporarily unavailable",
+    code: "SERVICE_UNAVAILABLE",
+    ...overrides,
+  };
+}
+
+describe("queryClient retry policy", () => {
+  it("ProblemDetail retryable=true이면 첫 실패만 재시도한다", () => {
+    const retry = queryClient.getDefaultOptions().queries?.retry;
+    if (typeof retry !== "function") {
+      throw new Error("query retry policy must be a function");
+    }
+
+    const error = new ApiHttpError(apiError({ retryable: true, user_action: "retry_later" }));
+
+    expect(retry(0, error)).toBe(true);
+    expect(retry(1, error)).toBe(false);
+  });
+
+  it("ProblemDetail retryable=false이면 5xx여도 재시도하지 않는다", () => {
+    const retry = queryClient.getDefaultOptions().queries?.retry;
+    if (typeof retry !== "function") {
+      throw new Error("query retry policy must be a function");
+    }
+
+    const error = new ApiHttpError(apiError({ retryable: false }));
+
+    expect(retry(0, error)).toBe(false);
+  });
+});

--- a/apps/web/src/services/queryClient.ts
+++ b/apps/web/src/services/queryClient.ts
@@ -1,18 +1,15 @@
 import { QueryClient } from "@tanstack/react-query";
 import { showErrorToast } from "@/lib/show-error-toast";
 import { ApiHttpError } from "@/lib/api-error";
+import { shouldRetryApiError } from "@/lib/error-recovery";
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30 * 1000,
       retry: (failureCount, error) => {
-        if (
-          error instanceof ApiHttpError &&
-          error.status >= 400 &&
-          error.status < 500
-        ) {
-          return false;
+        if (error instanceof ApiHttpError) {
+          return shouldRetryApiError(error.apiError, failureCount);
         }
         return failureCount < 1;
       },


### PR DESCRIPTION
## 요약
- ProblemDetail의 `severity`, `retryable`, `user_action`을 프론트 복구 전략으로 변환하는 공통 유틸을 추가합니다.
- TanStack Query retry 정책이 상태 코드 추측 대신 backend 계약의 `retryable`을 우선 사용하게 했습니다.
- toast 표시 시간, Sentry 캡처, 로그인 이동 여부를 recovery strategy 기준으로 통일하고 대표 테스트를 추가했습니다.

## 검증
- `pnpm --filter @mmp/web exec vitest run src/lib/api-error.test.ts src/lib/error-recovery.test.ts src/lib/show-error-toast.test.ts src/services/queryClient.test.ts`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `git diff --check origin/main...HEAD`

## E2E 제외 사유
- 이번 PR은 화면 라우트나 사용자 입력 흐름을 새로 만들지 않고, 공통 에러 복구 정책과 toast/query retry adapter를 고정합니다. 사용자-visible 동작은 unit/component-level 테스트로 검증했습니다.

Closes #282
Refs #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 오류 발생 시 알림 노출 기간과 오류 캡처(전송) 동작이 상황별로 정확히 적용되도록 개선
  * 편집기 설정 버전 충돌 시 한국어 안내문 추가 및 저장 전 새로고침 권고 메시지 포함

* **새로운 기능**
  * 오류 유형별 자동 복구 전략 도입(리다이렉트, 토스트 알림, 재시도 등)
  * API 오류 재시도 정책을 상황에 따라 결정하도록 구성 가능하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->