### PR TITLE
chore(ci): #349 runner scanner 도구 pre-bake

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Verify image-resident toolchain
         if: github.event_name == 'pull_request'
         run: |
-          docker run --rm --entrypoint /bin/bash \
+          docker run --rm --platform linux/amd64 --entrypoint /bin/bash \
             ghcr.io/sabyunrepo/mmp-runner:${{ github.sha }} \
             -c '
               set -euo pipefail

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -80,6 +80,8 @@ jobs:
               # Toolchain pre-bake
               jq --version
               govulncheck -version
+              goose -version
+              osv-scanner --version
               ls /opt/hostedtoolcache/go/1.25.0/x64/bin/go
               ls /opt/hostedtoolcache/node/20.18.0/x64/bin/node
               # PATH가 image ENV로 설정 — go/node가 PATH로 직접 호출 가능해야

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -182,6 +182,10 @@ jobs:
       - name: Run migrations
         working-directory: apps/server
         run: |
+          if ! command -v goose >/dev/null 2>&1; then
+            echo "::warning::goose is missing from the current runner image; installing compatibility fallback"
+            go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+          fi
           goose -dir db/migrations postgres \
             "host=localhost port=5432 user=mmp password=mmp_e2e dbname=mmp_e2e sslmode=disable" \
             up
@@ -424,7 +428,12 @@ jobs:
         # blob report 의 record 된 testDir 가 4 path → "Blob reports were recorded
         # with different test directories" merge fail. -c 옵션으로 playwright.config.ts
         # 의 testDir 를 명시 강제 (resolve 시점 정규화).
-        run: pnpm exec playwright merge-reports --reporter html -c playwright.config.ts ../../all-blob-reports
+        run: |
+          if [ ! -d ../../all-blob-reports ] || [ -z "$(find ../../all-blob-reports -type f -name '*.zip' -print -quit)" ]; then
+            echo "::warning::No Playwright blob reports found; skipping HTML report merge"
+            exit 0
+          fi
+          pnpm exec playwright merge-reports --reporter html -c playwright.config.ts ../../all-blob-reports
 
       - name: Upload merged HTML report
         if: always()

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -179,9 +179,6 @@ jobs:
         working-directory: apps/server
         run: go build -o /tmp/mmp-server ./cmd/server
 
-      - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
-
       - name: Run migrations
         working-directory: apps/server
         run: |

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -86,18 +86,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup Go for osv-scanner
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          # osv-scanner v2.3.5 requires Go >= 1.26.1.
-          # Keep the project Go version in apps/server/go.mod; this job only
-          # uses Go to install the scanner CLI.
-          go-version: '1.26.2'
-          cache: false
-
-      - name: Install osv-scanner
-        run: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5
-
       - name: Run osv-scanner (warn-only, SARIF output)
         continue-on-error: true
         run: |

--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -39,8 +39,9 @@ jobs:
     name: govulncheck (Go SCA)
     runs-on: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ready-for-ci') && 'ubuntu-latest' || 'arc-runner-set' }}
     # Phase 22 W1.5 PR-8 fold-in (PR-170 8ce9c0b run cancelled at 5:13):
-    # containerized runner 의 setup-go cache miss + go install govulncheck +
+    # containerized runner 의 setup-go cache miss + scanner install +
     # scan 이 5분 timeout 초과. 10분 으로 상향 (cache warm-up 후 정상 ~3분).
+    # Phase 25 #349: govulncheck CLI 는 ARC runner image 에 pre-bake 한다.
     timeout-minutes: 10
     steps:
       - name: Full CI ready gate
@@ -64,9 +65,6 @@ jobs:
         with:
           go-version-file: apps/server/go.mod
           cache: false  # image-resident toolchain: avoid setup-go cache hangs on self-hosted runners.
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
       # Warn-only policy (Phase 18.7 Wave 2 onboarding, 6 weeks).
       # Existing vulns surface in logs without blocking merges; deps-bump

--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -31,7 +31,7 @@ RUN /opt/hostedtoolcache/go/${GO_VERSION}/x64/bin/go install \
 RUN /opt/hostedtoolcache/go/${GO_VERSION}/x64/bin/go install \
       github.com/pressly/goose/v3/cmd/goose@v${GOOSE_VERSION} \
     && cp /root/go/bin/goose /usr/local/bin/
-RUN curl -fsSL \
+RUN curl -fsSL --retry 3 --retry-all-errors --connect-timeout 10 --max-time 120 \
       "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64" \
       -o /usr/local/bin/osv-scanner \
     && echo "${OSV_SCANNER_LINUX_AMD64_SHA256}  /usr/local/bin/osv-scanner" | sha256sum -c - \

--- a/infra/runners/Dockerfile
+++ b/infra/runners/Dockerfile
@@ -10,6 +10,10 @@ FROM ubuntu:22.04 AS builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG GO_VERSION=1.25.0
 ARG NODE_VERSION=20.18.0
+ARG GOVULNCHECK_VERSION=1.3.0
+ARG GOOSE_VERSION=3.27.0
+ARG OSV_SCANNER_VERSION=2.3.5
+ARG OSV_SCANNER_LINUX_AMD64_SHA256=bb30c580afe5e757d3e959f4afd08a4795ea505ef84c46962b9a738aa573b41b
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl ca-certificates xz-utils \
     && rm -rf /var/lib/apt/lists/*
@@ -22,8 +26,16 @@ RUN mkdir -p /opt/hostedtoolcache/node/${NODE_VERSION}/x64 \
        | tar -xJf - -C /opt/hostedtoolcache/node/${NODE_VERSION}/x64 --strip-components=1 \
     && touch /opt/hostedtoolcache/node/${NODE_VERSION}/x64.complete
 RUN /opt/hostedtoolcache/go/${GO_VERSION}/x64/bin/go install \
-      golang.org/x/vuln/cmd/govulncheck@latest \
+      golang.org/x/vuln/cmd/govulncheck@v${GOVULNCHECK_VERSION} \
     && cp /root/go/bin/govulncheck /usr/local/bin/
+RUN /opt/hostedtoolcache/go/${GO_VERSION}/x64/bin/go install \
+      github.com/pressly/goose/v3/cmd/goose@v${GOOSE_VERSION} \
+    && cp /root/go/bin/goose /usr/local/bin/
+RUN curl -fsSL \
+      "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64" \
+      -o /usr/local/bin/osv-scanner \
+    && echo "${OSV_SCANNER_LINUX_AMD64_SHA256}  /usr/local/bin/osv-scanner" | sha256sum -c - \
+    && chmod 0755 /usr/local/bin/osv-scanner
 
 FROM ghcr.io/actions/actions-runner:latest
 ARG GO_VERSION=1.25.0
@@ -52,9 +64,11 @@ RUN rm -f /etc/apt/sources.list.d/git-core-ubuntu-ppa*.list /etc/apt/sources.lis
     && printf '%s\n' "chromium-webkit-system-deps" > /opt/mmp-runner/playwright-deps-ready \
     && rm -rf /var/lib/apt/lists/*
 
-# Phase 23 hostedtoolcache (Go 1.25 + Node 20.18) + govulncheck
+# Phase 23 hostedtoolcache (Go 1.25 + Node 20.18) + image-resident CLIs.
 COPY --from=builder /opt/hostedtoolcache /opt/hostedtoolcache
 COPY --from=builder /usr/local/bin/govulncheck /usr/local/bin/govulncheck
+COPY --from=builder /usr/local/bin/goose /usr/local/bin/goose
+COPY --from=builder /usr/local/bin/osv-scanner /usr/local/bin/osv-scanner
 
 # Phase 23 cleanup hook (EPHEMERAL fs 잔존 정리 — myoung34 잔재이지만 ARC도 호환)
 COPY --chmod=0755 infra/runners/hooks/job-started.sh /opt/runner-hooks/job-started.sh

--- a/infra/runners/README.md
+++ b/infra/runners/README.md
@@ -28,7 +28,7 @@ myoung34/github-runner 4 컨테이너 ephemeral pool. PR-164 fix를 넘어 runne
 
 이 pool은 **`ghcr.io/sabyunrepo/mmp-runner` Custom Image**로 가동합니다 (myoung34 base 직접 사용 X). 정공:
 
-- 사전 install: jq, govulncheck, Go 1.25, Node 20, Playwright deps
+- 사전 install: jq, govulncheck, goose, osv-scanner, Go 1.25, Node 20, Playwright deps
 - **Image-resident toolchain (Phase 23 follow-up)** — `PATH`에 Go/Node bin 추가, `GOMODCACHE`/`GOCACHE`/`PNPM_STORE_PATH` ENV pre-set, `apps/server/go.mod` deps `go mod download` pre-bake
 - docker GID 990 정착 (testcontainers-go + Trivy 자연 권한)
   - **GID 990 의미**: Dockerfile이 `groupadd -g 990 docker-host`로 group 생성 후 runner user에 가입. 사용자 host의 docker.sock GID와 매칭되어야 효력. `.env`의 `DOCKER_GID`가 dual-control 추가 안전망 (compose `group_add: ${DOCKER_GID}`)
@@ -126,6 +126,18 @@ Playwright system dependency marker:
 - Browser binaries still use `PLAYWRIGHT_BROWSERS_PATH=/opt/cache/playwright`,
   so Playwright package version drift stays controlled by the repo lockfile.
 
+Pre-baked CLI tools:
+- `govulncheck`: used by `security-fast.yml`; pinned in
+  `infra/runners/Dockerfile`; workflow must not run a per-job `go install` on
+  ARC.
+- `goose`: used by `e2e-stubbed.yml` migrations; required PR/full-CI path uses
+  the ARC image-resident binary.
+- `osv-scanner`: used by `security-deep.yml`; installed from the pinned
+  upstream release binary and SHA256 in `infra/runners/Dockerfile`, avoiding a
+  per-job Go 1.26 toolchain download just to build the scanner.
+- Optional/nightly workflows that still run on `ubuntu-latest` may keep local
+  install steps because they do not consume the ARC runner image.
+
 ### 환경변수 (image ENV로 정의 — Dockerfile)
 
 `setup-go`/`setup-node` 가 PATH 자동 hit:
@@ -159,6 +171,30 @@ GHA cache restore 가 일어나지 않음 → 매 run 의 ~913MB 다운로드 0.
 | 매 run GOMODCACHE 다운로드 | ~913MB (~13초) | **0 (image pre-bake)** |
 | Go toolchain mismatch fallback | 매 fire 마다 다운로드 후 named volume 비대 | image PATH 즉시 hit |
 | pnpm install 첫 run | GHA cache restore 의존 | named volume 영구 persist (4 runner 공유) |
+| security-fast scanner install | 매 fire 마다 `go install govulncheck` | image PATH 즉시 hit |
+| E2E migration CLI install | 매 shard 마다 `go install goose` | image PATH 즉시 hit |
+| security-deep OSV install | Go 1.26 setup + `go install osv-scanner` | pinned binary 즉시 hit |
+
+### #349 pre-bake 판단 기록
+
+이번 runner image 최적화에서 바로 pre-bake 하는 항목:
+- `goose`: 버전 고정(`v3.27.0`)이고 DB migration CLI라 workspace lockfile과
+  결합도가 낮다.
+- `osv-scanner`: `security-deep.yml`에서 scanner 설치만 위해 Go 1.26.2를
+  매번 내려받던 비용을 제거한다. Dockerfile의 release SHA256 검증으로
+  supply-chain drift를 줄인다.
+- `govulncheck`: 기존 image에 이미 들어가던 도구다. workflow install step만
+  제거해 image-resident 카논과 일치시킨다.
+
+이번 PR에서 pre-bake 하지 않는 항목:
+- Playwright browser binaries: 속도 이득은 크지만 image size가 빠르게 커지고,
+  repo의 Playwright package version과 browser revision이 lockstep으로 맞아야
+  한다. 현 단계에서는 `/opt/mmp-runner/playwright-deps-ready` system deps
+  marker와 `/opt/cache/playwright` cache를 유지한다.
+- `pnpm install` workspace deps: public PR cache poisoning과 secret residue
+  위험이 있어 image에 workspace `node_modules`를 굽지 않는다.
+- Trivy/gitleaks action 내부 바이너리: action이 관리하는 download/cache 영역이라
+  로그 기반 측정 후 별도 이슈에서 판단한다.
 
 ### 운영 카논 — image rebuild 후 cleanup
 


### PR DESCRIPTION
## 요약
- ARC runner image에 govulncheck, goose, osv-scanner를 pre-bake합니다.
- E2E/security workflow의 반복 CLI 설치 step을 제거합니다.
- build-runner-image PR 검증에 새 pre-baked CLI 확인을 추가합니다.

Refs #349

## 운영 적용
- 이 PR 머지 후 main의 build-runner-image workflow가 KT registry에 새 image를 push해야 합니다.
- push된 새 tag를 기준으로 infra/k8s/arc/values-runner-set.yaml의 registry.cloud.kt.com/dldxu5p5/mmp-runner tag를 갱신해야 합니다.
- ARC runner set rollout과 실제 CI run에서 새 image 사용을 확인한 뒤 #349를 닫습니다.

## 검증
- docker build --platform linux/amd64 -f infra/runners/Dockerfile -t mmp-runner:issue-349 .
- docker run --rm --platform linux/amd64 --entrypoint /bin/bash mmp-runner:issue-349 -lc 'set -euo pipefail; govulncheck -version; goose -version; osv-scanner --version; [ -f /opt/mmp-runner/playwright-deps-ready ]; go version; node --version'
- git diff --check

## CI scope
- workflow/infra 변경이라 PR 생성 후 CodeRabbit 확인, 이후 steward가 full CI 라벨/대기를 처리합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 러너 이미지에 govulncheck·goose·osv-scanner를 사전 포함해 워크플로우별 개별 설치 제거 및 이미지 내 버전 고정/검증 도입
  * 일부 워크플로우에서 필요한 바이너리를 없을 때만 설치하도록 변경

* **Bug Fixes**
  * 리포트 병합 단계가 결과 파일 유무를 확인해, 파일이 없으면 경고 후 정상 종료하도록 개선

* **Documentation**
  * 러너 이미지의 사전 설치 도구 목록과 워크플로우 사용 흐름 문서화 및 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->