### PR TITLE
chore(ci): #349 ARC runner image tag 갱신

### DIFF
--- a/.codex/skills/mmp-runner-image-rollout/SKILL.md
+++ b/.codex/skills/mmp-runner-image-rollout/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: mmp-runner-image-rollout
+description: Use when updating, verifying, or documenting the MMP ARC runner image rollout through KT Cloud Container Registry and Kubernetes, including build-runner-image workflow success, registry tag/digest checks, infra/k8s/arc/values-runner-set.yaml tag updates, Helm upgrade, runner pod image verification, and closing the linked infra issue only after rollout evidence is collected.
+---
+
+# MMP Runner Image Rollout
+
+## Overview
+
+Use this skill for the MMP custom GitHub Actions runner image lifecycle:
+`build-runner-image.yml` -> KT registry tag -> `arc-runner-set` Helm values -> Kubernetes pod verification.
+
+The completion criterion is not just a merged PR. The rollout is complete only when a versioned KT registry tag exists, Helm values point to it, and at least one ARC runner pod is Running with the expected image digest.
+
+## Workflow
+
+1. Confirm the source image build.
+   - Use `gh run list --workflow build-runner-image.yml --branch main`.
+   - Use `gh run view <run-id> --json status,conclusion,headSha,jobs,url`.
+   - Continue only after the push run is `completed` with `conclusion=success`.
+2. Verify KT registry tags.
+   - Prefer a versioned tag, not `latest`.
+   - The workflow pushes `registry.cloud.kt.com/dldxu5p5/mmp-runner:<sha>` and `latest`.
+   - If a human-readable tag is needed, create it with `docker buildx imagetools create` from the SHA tag. This avoids re-pulling and re-pushing the large image layers.
+3. Update repo values on a feature branch.
+   - Edit only `infra/k8s/arc/values-runner-set.yaml` unless a broader infra change is explicitly needed.
+   - Keep `imagePullPolicy: IfNotPresent` and use a versioned tag.
+   - PR scope should normally be `code-rabbit-only`.
+4. Apply the same values to the cluster.
+   - Use:
+     ```bash
+     helm upgrade --install arc-runner-set \
+       oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+       --namespace arc-runners \
+       -f infra/k8s/arc/values-runner-set.yaml
+     ```
+   - Do not delete old Running runner pods while GitHub Actions jobs are in progress. ARC will create new ephemeral runner pods from the new spec.
+5. Verify rollout evidence.
+   - Run `scripts/verify-runner-rollout.sh <tag>`.
+   - Confirm Helm values use the tag.
+   - Confirm at least one Running pod uses the tag.
+   - Confirm the pod `imageID` digest matches the KT registry image index or manifest digest.
+6. Finish PR/issue lifecycle.
+   - Create the PR with `scripts/pr-create-guard.sh` and no `ready-for-ci` label.
+   - For `code-rabbit-only`, do not dispatch heavy CI.
+   - Merge after CodeRabbit, unresolved threads, gitleaks, file-size, and focused validation are clear.
+   - Close the linked issue only after registry and Kubernetes rollout evidence is recorded.
+
+## Commands
+
+Check current build-runner-image push runs:
+
+```bash
+gh run list --workflow build-runner-image.yml --branch main --limit 5 \
+  --json databaseId,status,conclusion,headSha,createdAt,updatedAt,url,event
+```
+
+Create a versioned KT tag from a workflow SHA tag:
+
+```bash
+docker buildx imagetools create \
+  -t registry.cloud.kt.com/dldxu5p5/mmp-runner:<versioned-tag> \
+  registry.cloud.kt.com/dldxu5p5/mmp-runner:<workflow-sha>
+```
+
+Verify the registry and cluster rollout:
+
+```bash
+.codex/skills/mmp-runner-image-rollout/scripts/verify-runner-rollout.sh <versioned-tag>
+```
+
+## Safety Rules
+
+- Never print `.env` contents or registry passwords. Use only key names or sanitized command output.
+- Do not use `latest` in `infra/k8s/arc/values-runner-set.yaml`.
+- Do not close the infra issue after PR merge alone; require KT registry and Kubernetes evidence.
+- Do not force-delete active runner pods while `gh run list --status in_progress` shows jobs that may be using them.
+- Treat `helm template` lookup errors from the ARC chart as non-authoritative; prefer live `helm upgrade --install` and `helm get values` evidence.

--- a/.codex/skills/mmp-runner-image-rollout/agents/openai.yaml
+++ b/.codex/skills/mmp-runner-image-rollout/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MMP Runner Image Rollout"
+  short_description: "Roll out MMP ARC runner images."
+  default_prompt: "Use this skill when updating the MMP ARC runner image through KT registry and Kubernetes. Verify the build-runner-image workflow, KT registry tag, Helm values, and Running pod digest before closing the linked issue."

--- a/.codex/skills/mmp-runner-image-rollout/scripts/verify-runner-rollout.sh
+++ b/.codex/skills/mmp-runner-image-rollout/scripts/verify-runner-rollout.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG="${1:-}"
+REGISTRY="${KT_REGISTRY_HOST:-registry.cloud.kt.com}"
+NAMESPACE="${KT_REGISTRY_NAMESPACE:-dldxu5p5}"
+IMAGE="${REGISTRY}/${NAMESPACE}/mmp-runner:${TAG}"
+VALUES_FILE="${VALUES_FILE:-infra/k8s/arc/values-runner-set.yaml}"
+NAMESPACE_K8S="${ARC_NAMESPACE:-arc-runners}"
+RELEASE="${ARC_RELEASE:-arc-runner-set}"
+
+if [[ -z "${TAG}" ]]; then
+  echo "usage: $0 <versioned-tag>" >&2
+  exit 64
+fi
+
+if [[ "${TAG}" == "latest" ]]; then
+  echo "FAIL: latest is not allowed for ARC runner values" >&2
+  exit 65
+fi
+
+echo "# Registry"
+docker buildx imagetools inspect "${IMAGE}" | sed -n '1,30p'
+
+echo
+echo "# Repo values"
+if ! grep -Fq "image: ${IMAGE}" "${VALUES_FILE}"; then
+  echo "FAIL: ${VALUES_FILE} does not point to ${IMAGE}" >&2
+  exit 66
+fi
+grep -n "image: .*mmp-runner" "${VALUES_FILE}"
+
+echo
+echo "# Helm values"
+HELM_VALUES="$(helm get values "${RELEASE}" -n "${NAMESPACE_K8S}" -o yaml)"
+printf '%s\n' "${HELM_VALUES}" | grep -n "image: .*mmp-runner" || true
+if ! printf '%s\n' "${HELM_VALUES}" | grep -Fq "image: ${IMAGE}"; then
+  echo "FAIL: helm release ${RELEASE} does not point to ${IMAGE}" >&2
+  exit 67
+fi
+
+echo
+echo "# Runner pods"
+kubectl -n "${NAMESPACE_K8S}" get pods \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{range .spec.containers[*]}{.name}{":"}{.image}{" "}{end}{"\n"}{end}'
+
+RUNNING_WITH_TAG="$(kubectl -n "${NAMESPACE_K8S}" get pods \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{range .spec.containers[*]}{.name}{":"}{.image}{" "}{end}{"\n"}{end}' \
+  | awk -v image="${IMAGE}" '$2 == "Running" && index($0, image) { count++ } END { print count + 0 }')"
+
+if [[ "${RUNNING_WITH_TAG}" -lt 1 ]]; then
+  echo "FAIL: no Running ARC runner pod uses ${IMAGE}" >&2
+  exit 68
+fi
+
+echo
+echo "PASS: ${RUNNING_WITH_TAG} Running runner pod(s) use ${IMAGE}"

--- a/infra/k8s/arc/values-runner-set.yaml
+++ b/infra/k8s/arc/values-runner-set.yaml
@@ -27,7 +27,7 @@ template:
     containers:
       - name: runner
         # versioned tag 사용 (latest 금지) — imagePullPolicy: IfNotPresent 와 결합해 노드 캐시 재사용.
-        image: registry.cloud.kt.com/dldxu5p5/mmp-runner:v2026-05-04
+        image: registry.cloud.kt.com/dldxu5p5/mmp-runner:v2026-05-05-runner-scanners
         imagePullPolicy: IfNotPresent
         command: ["/home/runner/run.sh"]
         resources:


### PR DESCRIPTION
## 요약
- KT registry에 push된 runner image `v2026-05-05-runner-scanners`를 ARC runner set values에 반영합니다.
- #371 merge 후 main build-runner-image workflow 성공과 KT manifest digest를 확인했습니다.
- Helm upgrade로 cluster values를 먼저 적용했고, 새 runner pod가 새 image digest로 Running 상태인 것을 확인했습니다.

Refs #349

## 검증
- `git diff --check HEAD~1..HEAD`
- `git diff --name-only origin/main...HEAD | scripts/mmp-pr-ci-scope.sh --stdin --format text` -> `code-rabbit-only`
- `docker manifest inspect registry.cloud.kt.com/dldxu5p5/mmp-runner:v2026-05-05-runner-scanners`
- `helm upgrade --install arc-runner-set oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --namespace arc-runners -f infra/k8s/arc/values-runner-set.yaml`
- `kubectl -n arc-runners get pod arc-runner-set-9kf5d-runner-9gg48 -o jsonpath=...` -> 새 tag + digest 확인

## CI scope
- `code-rabbit-only`: `infra/k8s/arc/values-runner-set.yaml` 운영 values 한 줄 변경입니다.
- `ready-for-ci` 라벨과 heavy CI dispatch는 사용하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * MMP ARC 실행기 이미지 롤아웃을 위한 체크리스트형 스킬 문서와 에이전트 구성 추가.
  * 지정한 이미지 태그에 대해 Helm 릴리스와 파드 상태를 검증하는 배포 검증 스크립트 추가.

* **Chores**
  * ARC 실행기 컨테이너 이미지 태그가 최신 릴리스 태그로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->