### PR TITLE
feat(error): #283 에디터/세션 WS 에러 계약 적용

### DIFF
--- a/apps/server/internal/ws/auth_protocol.go
+++ b/apps/server/internal/ws/auth_protocol.go
@@ -321,7 +321,7 @@ func (h *AuthHandler) userRevokedAndStop(c *Client, userID uuid.UUID, since time
 // ---------------------------------------------------------------------------
 
 func (h *AuthHandler) unauthorize(c *Client, reason string) {
-	c.SendMessage(NewErrorEnvelope(ErrCodeUnauthorized, reason))
+	c.SendMessage(NewFatalErrorEnvelope(ErrCodeUnauthorized, reason))
 	c.Close()
 }
 

--- a/apps/server/internal/ws/envelope_catalog_system.go
+++ b/apps/server/internal/ws/envelope_catalog_system.go
@@ -18,7 +18,7 @@ func init() {
 		EventDef{Type: TypePing, Direction: DirBidi, Category: "system"},
 		EventDef{Type: TypePong, Direction: DirBidi, Category: "system"},
 		EventDef{Type: TypeError, Direction: DirS2C, Category: "system",
-			Note: "wire payload is ErrorPayload { code, message }"},
+			Note: "wire payload is ErrorPayload with ProblemDetail-lite recovery metadata"},
 		EventDef{Type: TypeConnected, Direction: DirS2C, Category: "system",
 			Note: "first server frame on upgrade; payload is ConnectedPayload"},
 		EventDef{Type: TypeReconnect, Direction: DirS2C, Category: "system",

--- a/apps/server/internal/ws/hub_broadcast.go
+++ b/apps/server/internal/ws/hub_broadcast.go
@@ -126,9 +126,11 @@ func (h *Hub) Whisper(fromID, toID uuid.UUID, env *Envelope) {
 //
 // Routing priority:
 //  1. Registry validation — rejects unknown types with WS error 4000.
-//  2. Session forwarding — if the client is in a game session AND a
+//  2. Router-first system/auth messages — recovery frames must not be swallowed
+//     by the session actor when a player is already in a game session.
+//  3. Session forwarding — if the client is in a game session AND a
 //     SessionSender is wired, the message is delivered to the session actor.
-//  3. Router fallback — all other messages (lobby, system) go to the Router.
+//  4. Router fallback — all other messages (lobby, system) go to the Router.
 func (h *Hub) Route(sender *Client, env *Envelope) {
 	// 1. Registry validation (when a registry is configured).
 	if h.registry != nil && !isSystemType(env.Type) {
@@ -142,7 +144,13 @@ func (h *Hub) Route(sender *Client, env *Envelope) {
 		}
 	}
 
-	// 2. Session forwarding for in-session clients.
+	// 2. Router-first recovery/system messages for in-session clients.
+	if routesBeforeSession(env.Type) {
+		h.routeViaRouter(sender, env)
+		return
+	}
+
+	// 3. Session forwarding for in-session clients.
 	if sender.SessionID != uuid.Nil && h.sessionSender != nil {
 		// Bound the message context so a stuck handler can't occupy the actor
 		// indefinitely (M-1 fix). The inbox is non-blocking, so we can't defer
@@ -168,7 +176,11 @@ func (h *Hub) Route(sender *Client, env *Envelope) {
 		return
 	}
 
-	// 3. Router fallback (lobby messages, system messages, etc.).
+	// 4. Router fallback (lobby messages, system messages, etc.).
+	h.routeViaRouter(sender, env)
+}
+
+func (h *Hub) routeViaRouter(sender *Client, env *Envelope) {
 	if h.router == nil {
 		h.logger.Error().Msg("router not set, dropping message")
 		sender.SendMessage(NewErrorEnvelope(ErrCodeInternalError, "server misconfigured"))
@@ -185,6 +197,13 @@ func isSystemType(t string) bool {
 		return true
 	}
 	return false
+}
+
+func routesBeforeSession(t string) bool {
+	if isSystemType(t) {
+		return true
+	}
+	return t == TypeAuthIdentify || t == TypeAuthResume || t == TypeAuthRefresh
 }
 
 // SessionClients returns all clients in a given session.

--- a/apps/server/internal/ws/hub_test.go
+++ b/apps/server/internal/ws/hub_test.go
@@ -389,6 +389,54 @@ func TestHub_Route_WithRouter(t *testing.T) {
 	}
 }
 
+func TestHub_Route_AuthBypassesSessionForwarding(t *testing.T) {
+	router := NewRouter(zerolog.Nop())
+	var routed bool
+	router.Handle("auth", func(c *Client, env *Envelope) {
+		routed = true
+	})
+
+	h := newTestHub(router)
+	defer h.Stop()
+
+	sender := &stubSessionSender{}
+	h.SetSessionSender(sender)
+
+	c := newTestClient(h, uuid.New())
+	c.SessionID = uuid.New()
+
+	h.Route(c, MustEnvelope(TypeAuthResume, map[string]string{"token": "t"}))
+
+	if !routed {
+		t.Fatal("auth recovery message was not routed through router")
+	}
+	if len(sender.received) != 0 {
+		t.Fatalf("auth recovery message forwarded to session actor: got %d", len(sender.received))
+	}
+}
+
+func TestHub_Route_PingBypassesSessionForwarding(t *testing.T) {
+	router := NewRouter(zerolog.Nop())
+	h := newTestHub(router)
+	defer h.Stop()
+
+	sender := &stubSessionSender{}
+	h.SetSessionSender(sender)
+
+	c := newTestClient(h, uuid.New())
+	c.SessionID = uuid.New()
+
+	h.Route(c, MustEnvelope(TypePing, nil))
+
+	got := readEnvelope(c, 200*time.Millisecond)
+	if got == nil || got.Type != TypePong {
+		t.Fatalf("expected pong via router, got %#v", got)
+	}
+	if len(sender.received) != 0 {
+		t.Fatalf("ping forwarded to session actor: got %d", len(sender.received))
+	}
+}
+
 func TestHub_Route_NilRouter(t *testing.T) {
 	h := NewHub(nil, NoopPubSub{}, zerolog.Nop())
 	defer h.Stop()
@@ -451,6 +499,25 @@ func TestRouter_Handle_MultipleNamespaces(t *testing.T) {
 	}
 	if !chatHit {
 		t.Error("chat handler was not called")
+	}
+}
+
+func TestRouter_Handle_DotNamespace(t *testing.T) {
+	r := NewRouter(zerolog.Nop())
+
+	var receivedType string
+	r.Handle("auth", func(c *Client, env *Envelope) {
+		receivedType = env.Type
+	})
+
+	h := newTestHub(r)
+	defer h.Stop()
+
+	c := newTestClient(h, uuid.New())
+	r.Route(c, MustEnvelope(TypeAuthIdentify, nil))
+
+	if receivedType != TypeAuthIdentify {
+		t.Errorf("handler received type %q, want %q", receivedType, TypeAuthIdentify)
 	}
 }
 

--- a/apps/server/internal/ws/message.go
+++ b/apps/server/internal/ws/message.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/mmp-platform/server/internal/apperror"
 )
 
 // Envelope is the wire format for all WebSocket messages.
@@ -62,13 +64,86 @@ const (
 //
 // wsgen:payload
 type ErrorPayload struct {
-	Code    ErrorCode `json:"code"`
-	Message string    `json:"message"`
+	Code          ErrorCode `json:"code"`
+	AppCode       string    `json:"app_code,omitempty"`
+	Message       string    `json:"message"`
+	Severity      string    `json:"severity,omitempty"`
+	Retryable     bool      `json:"retryable"`
+	UserAction    string    `json:"user_action,omitempty"`
+	RequestID     string    `json:"request_id,omitempty"`
+	CorrelationID string    `json:"correlation_id,omitempty"`
+	Fatal         bool      `json:"fatal"`
 }
 
 // NewErrorEnvelope creates an error envelope.
 func NewErrorEnvelope(code ErrorCode, msg string) *Envelope {
-	return MustEnvelope("error", ErrorPayload{Code: code, Message: msg})
+	return MustEnvelope(TypeError, NewErrorPayload(code, msg))
+}
+
+// NewFatalErrorEnvelope creates an error envelope for terminal failures where
+// the server will close or invalidate the socket.
+func NewFatalErrorEnvelope(code ErrorCode, msg string) *Envelope {
+	payload := NewErrorPayload(code, msg)
+	payload.Fatal = true
+	payload.Retryable = false
+	return MustEnvelope(TypeError, payload)
+}
+
+// NewAppErrorEnvelope converts an application error into the WebSocket
+// ProblemDetail-lite shape. The public message comes from the error registry,
+// not AppError.Detail, so game internals are not leaked to other players.
+func NewAppErrorEnvelope(appErr *apperror.AppError, fatal bool) *Envelope {
+	code := appErrorToWSCode(appErr)
+	payload := NewErrorPayload(code, appErr.Detail)
+	payload.AppCode = appErr.Code
+	payload.Fatal = fatal
+
+	if defn, ok := apperror.LookupDefinition(appErr.Code); ok {
+		payload.Message = defn.DefaultKR
+		payload.Severity = string(defn.Severity)
+		payload.Retryable = defn.Retryable
+		payload.UserAction = defn.UserAction
+	} else {
+		payload.Message = "요청을 처리하지 못했습니다."
+	}
+
+	return MustEnvelope(TypeError, payload)
+}
+
+// NewErrorPayload is the default WS error contract for transport-level errors.
+func NewErrorPayload(code ErrorCode, msg string) ErrorPayload {
+	appCode, severity, retryable, userAction := wsErrorMetadata(code)
+	correlationID := uuid.NewString()
+	return ErrorPayload{
+		Code:          code,
+		AppCode:       appCode,
+		Message:       msg,
+		Severity:      severity,
+		Retryable:     retryable,
+		UserAction:    userAction,
+		RequestID:     correlationID,
+		CorrelationID: correlationID,
+		Fatal:         false,
+	}
+}
+
+func wsErrorMetadata(code ErrorCode) (appCode, severity string, retryable bool, userAction string) {
+	switch code {
+	case ErrCodeBadMessage:
+		return apperror.ErrBadRequest, string(apperror.SeverityMedium), false, "fix_input"
+	case ErrCodeUnauthorized:
+		return apperror.ErrUnauthorized, string(apperror.SeverityHigh), false, "login"
+	case ErrCodeSessionFull:
+		return apperror.ErrGameFull, string(apperror.SeverityMedium), false, "choose_other"
+	case ErrCodeRateLimited:
+		return apperror.ErrSessionInboxFull, string(apperror.SeverityMedium), true, "retry_later"
+	case ErrCodeNotFound:
+		return apperror.ErrNotFound, string(apperror.SeverityMedium), false, "refresh"
+	case ErrCodeInternalError:
+		return apperror.ErrInternal, string(apperror.SeverityHigh), true, "retry_later"
+	default:
+		return "", string(apperror.SeverityMedium), false, "none"
+	}
 }
 
 // --- System messages ---

--- a/apps/server/internal/ws/message_test.go
+++ b/apps/server/internal/ws/message_test.go
@@ -1,0 +1,82 @@
+package ws
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mmp-platform/server/internal/apperror"
+)
+
+func TestNewErrorEnvelope_IncludesRecoveryMetadata(t *testing.T) {
+	env := NewErrorEnvelope(ErrCodeRateLimited, "too many requests")
+
+	var payload ErrorPayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal ErrorPayload: %v", err)
+	}
+
+	if payload.Code != ErrCodeRateLimited {
+		t.Fatalf("Code = %d, want %d", payload.Code, ErrCodeRateLimited)
+	}
+	if payload.AppCode != apperror.ErrSessionInboxFull {
+		t.Fatalf("AppCode = %q, want %q", payload.AppCode, apperror.ErrSessionInboxFull)
+	}
+	if payload.Severity == "" {
+		t.Fatal("Severity is empty")
+	}
+	if !payload.Retryable {
+		t.Fatal("Retryable = false, want true")
+	}
+	if payload.UserAction != "retry_later" {
+		t.Fatalf("UserAction = %q, want retry_later", payload.UserAction)
+	}
+	if payload.RequestID == "" || payload.CorrelationID == "" {
+		t.Fatalf("request/correlation id missing: %#v", payload)
+	}
+	if payload.RequestID != payload.CorrelationID {
+		t.Fatalf("RequestID %q must mirror CorrelationID %q", payload.RequestID, payload.CorrelationID)
+	}
+	if payload.Fatal {
+		t.Fatal("Fatal = true, want false")
+	}
+}
+
+func TestNewFatalErrorEnvelope_MarksTerminalFailure(t *testing.T) {
+	env := NewFatalErrorEnvelope(ErrCodeUnauthorized, "invalid session")
+
+	var payload ErrorPayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal ErrorPayload: %v", err)
+	}
+
+	if !payload.Fatal {
+		t.Fatal("Fatal = false, want true")
+	}
+	if payload.Retryable {
+		t.Fatal("Retryable = true, want false")
+	}
+}
+
+func TestNewAppErrorEnvelope_RedactsDetail(t *testing.T) {
+	appErr := apperror.New(
+		apperror.ErrReadingAdvanceForbidden,
+		403,
+		"role detective cannot advance line 4 in hidden room",
+	)
+	env := NewAppErrorEnvelope(appErr, false)
+
+	var payload ErrorPayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal ErrorPayload: %v", err)
+	}
+
+	if payload.AppCode != apperror.ErrReadingAdvanceForbidden {
+		t.Fatalf("AppCode = %q, want %q", payload.AppCode, apperror.ErrReadingAdvanceForbidden)
+	}
+	if payload.Message == appErr.Detail {
+		t.Fatal("Message leaked AppError.Detail")
+	}
+	if payload.UserAction != "wait" {
+		t.Fatalf("UserAction = %q, want wait", payload.UserAction)
+	}
+}

--- a/apps/server/internal/ws/reading_handler.go
+++ b/apps/server/internal/ws/reading_handler.go
@@ -389,12 +389,9 @@ func (h *ReadingWSHandler) ForwardEvent(sessionID uuid.UUID, eventType string, p
 func translateReadingError(err error) *Envelope {
 	var ae *apperror.AppError
 	if errors.As(err, &ae) {
-		return MustEnvelope(TypeError, ErrorPayload{
-			Code:    appErrorToWSCode(ae),
-			Message: ae.Code + ": " + ae.Detail,
-		})
+		return NewAppErrorEnvelope(ae, false)
 	}
-	return NewErrorEnvelope(ErrCodeInternalError, err.Error())
+	return NewErrorEnvelope(ErrCodeInternalError, "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
 }
 
 // appErrorToWSCode maps an apperror code to the closest WS error code.

--- a/apps/server/internal/ws/reading_handler_test.go
+++ b/apps/server/internal/ws/reading_handler_test.go
@@ -195,8 +195,8 @@ func findEnvelopeType(received []string, msgType string) bool {
 }
 
 // findErrorWithCode inspects the test client buffer for an error envelope
-// whose payload message contains the given reading error code substring.
-func findErrorWithCode(received []string, codeSubstring string) bool {
+// whose payload carries the given app code without leaking AppError.Detail.
+func findErrorWithCode(received []string, appCode string) bool {
 	for _, raw := range received {
 		var env Envelope
 		if err := json.Unmarshal([]byte(raw), &env); err != nil {
@@ -209,7 +209,7 @@ func findErrorWithCode(received []string, codeSubstring string) bool {
 		if err := json.Unmarshal(env.Payload, &pl); err != nil {
 			continue
 		}
-		if containsString(pl.Message, codeSubstring) {
+		if pl.AppCode == appCode {
 			return true
 		}
 	}

--- a/apps/server/internal/ws/router.go
+++ b/apps/server/internal/ws/router.go
@@ -54,7 +54,7 @@ func (r *Router) Route(c *Client, env *Envelope) {
 		return
 	}
 
-	namespace, _, _ := strings.Cut(env.Type, ":")
+	namespace := routeNamespace(env.Type)
 
 	r.mu.RLock()
 	fn, ok := r.handlers[namespace]
@@ -77,6 +77,18 @@ func (r *Router) Route(c *Client, env *Envelope) {
 		Msg("unhandled message type")
 
 	c.SendMessage(NewErrorEnvelope(ErrCodeBadMessage, "unknown message type: "+env.Type))
+}
+
+func routeNamespace(msgType string) string {
+	namespace, _, ok := strings.Cut(msgType, ":")
+	if ok {
+		return namespace
+	}
+	namespace, _, ok = strings.Cut(msgType, ".")
+	if ok {
+		return namespace
+	}
+	return msgType
 }
 
 // Namespaces returns a list of registered namespace names.

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -1,14 +1,18 @@
-import { useMemo, useState } from "react";
-import { Search } from "lucide-react";
-import type { EditorThemeResponse } from "@/features/editor/api";
-import { useFlowData } from "../../hooks/useFlowData";
-import type { FlowNodeData } from "../../flowTypes";
-import { EndingEntityDetail } from "./EndingEntityDetail";
-import { EndingDecisionSummaryPanel } from "./EndingDecisionSummaryPanel";
-import { EndingEmptyState } from "./EndingEmptyState";
-import { EndingEntityHeader } from "./EndingEntityHeader";
-import { EndingBranchRulesPanel } from "./EndingBranchRulesPanel";
-import { buildEndingDecisionSummary, toEndingEditorViewModel } from "../../entities/ending/endingEntityAdapter";
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import type { EditorThemeResponse } from '@/features/editor/api';
+import { useFlowData } from '../../hooks/useFlowData';
+import type { FlowNodeData } from '../../flowTypes';
+import { EndingEntityDetail } from './EndingEntityDetail';
+import { EndingDecisionSummaryPanel } from './EndingDecisionSummaryPanel';
+import { EndingEmptyState } from './EndingEmptyState';
+import { EndingEntityHeader } from './EndingEntityHeader';
+import { EndingBranchRulesPanel } from './EndingBranchRulesPanel';
+import {
+  buildEndingDecisionSummary,
+  toEndingEditorViewModel,
+} from '../../entities/ending/endingEntityAdapter';
+import { getDisplayErrorMessage } from '@/lib/display-error';
 
 interface EndingEntitySubTabProps {
   themeId: string;
@@ -16,14 +20,20 @@ interface EndingEntitySubTabProps {
 }
 
 export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const { nodes, edges = [], isLoading, isError, error, refetch, addNode, updateNodeData } = useFlowData(themeId);
+  const {
+    nodes,
+    edges = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+    addNode,
+    updateNodeData,
+  } = useFlowData(themeId);
 
-  const endingNodes = useMemo(
-    () => nodes.filter((node) => node.type === "ending"),
-    [nodes],
-  );
+  const endingNodes = useMemo(() => nodes.filter((node) => node.type === 'ending'), [nodes]);
 
   const filteredNodes = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -39,13 +49,10 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
   const selectedNode =
     filteredNodes.find((node) => node.id === selectedId) ?? filteredNodes[0] ?? null;
 
-  const decisionSummary = useMemo(
-    () => buildEndingDecisionSummary(nodes, edges),
-    [nodes, edges],
-  );
+  const decisionSummary = useMemo(() => buildEndingDecisionSummary(nodes, edges), [nodes, edges]);
 
   const handleAddEnding = () => {
-    addNode("ending", { x: 360 + endingNodes.length * 40, y: 220 });
+    addNode('ending', { x: 360 + endingNodes.length * 40, y: 220 });
   };
 
   if (isLoading) {
@@ -64,11 +71,9 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
           <p className="mt-2 text-sm leading-6 text-rose-200/80">
             네트워크나 권한 문제일 수 있습니다. 잠시 후 다시 시도해 주세요.
           </p>
-          {error instanceof Error && error.message && (
-            <p className="mt-3 rounded-xl bg-slate-950/60 p-3 text-left text-xs leading-5 text-rose-100/80">
-              {error.message}
-            </p>
-          )}
+          <p className="mt-3 rounded-xl bg-slate-950/60 p-3 text-left text-xs leading-5 text-rose-100/80">
+            {getDisplayErrorMessage(error, '결말 목록을 불러오지 못했습니다.')}
+          </p>
           <button
             type="button"
             onClick={() => void refetch()}
@@ -82,7 +87,10 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
   }
 
   return (
-    <div data-testid="ending-entity-panel" className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6">
+    <div
+      data-testid="ending-entity-panel"
+      className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6"
+    >
       <EndingEntityHeader onAddEnding={handleAddEnding} />
 
       <EndingDecisionSummaryPanel summary={decisionSummary} />
@@ -124,8 +132,8 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
                       aria-pressed={selected}
                       className={`rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-400/60 ${
                         selected
-                          ? "border-amber-500/70 bg-amber-500/10"
-                          : "border-slate-800 bg-slate-950 hover:border-slate-600"
+                          ? 'border-amber-500/70 bg-amber-500/10'
+                          : 'border-slate-800 bg-slate-950 hover:border-slate-600'
                       }`}
                     >
                       <div className="flex items-center gap-2">
@@ -137,7 +145,10 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
                       </p>
                       <div className="mt-2 flex flex-wrap gap-1">
                         {viewModel.badges.map((badge) => (
-                          <span key={badge} className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300">
+                          <span
+                            key={badge}
+                            className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300"
+                          >
                             {badge}
                           </span>
                         ))}

--- a/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
@@ -9,6 +9,7 @@ import {
   stringifyLocationRestrictedCharacterIds,
 } from '@/features/editor/entities/location/locationEntityAdapter';
 import { useEditorCharacters, useUpdateLocation } from '@/features/editor/api';
+import { getDisplayErrorMessage } from '@/lib/display-error';
 
 interface LocationAccessPolicyPanelProps {
   themeId: string;
@@ -61,7 +62,7 @@ export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessP
         </div>
       ) : isError ? (
         <div className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-4 text-center text-xs text-red-100">
-          <p>{error instanceof Error ? error.message : '캐릭터 목록을 불러오지 못했습니다.'}</p>
+          <p>{getDisplayErrorMessage(error, '캐릭터 목록을 불러오지 못했습니다.')}</p>
           <button
             type="button"
             onClick={() => refetch?.()}

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -146,7 +146,8 @@ describe("EndingEntitySubTab", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
     expect(screen.getByText("결말 목록을 불러오지 못했습니다")).toBeDefined();
-    expect(screen.getByText("권한이 없습니다")).toBeDefined();
+    expect(screen.getByText("결말 목록을 불러오지 못했습니다.")).toBeDefined();
+    expect(screen.queryByText("권한이 없습니다")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
     expect(refetchMock).toHaveBeenCalled();

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -145,7 +145,6 @@ describe("EndingEntitySubTab", () => {
 
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
-    expect(screen.getByText("결말 목록을 불러오지 못했습니다")).toBeDefined();
     expect(screen.getByText("결말 목록을 불러오지 못했습니다.")).toBeDefined();
     expect(screen.queryByText("권한이 없습니다")).toBeNull();
 

--- a/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
@@ -1,18 +1,13 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type DragEvent,
-} from "react";
-import { Upload, X } from "lucide-react";
+import { useEffect, useRef, useState, type ChangeEvent, type DragEvent } from 'react';
+import { Upload, X } from 'lucide-react';
 
 import {
   uploadMediaFile,
   useConfirmUpload,
   useRequestUploadUrl,
   type MediaType,
-} from "@/features/editor/mediaApi";
+} from '@/features/editor/mediaApi';
+import { getDisplayErrorMessage } from '@/lib/display-error';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,22 +20,18 @@ export interface MediaUploadModalProps {
 }
 
 const MAX_SIZE = 20 * 1024 * 1024;
-const AUDIO_MIME = ["audio/mpeg", "audio/wav", "audio/ogg"];
-const IMAGE_MIME = ["image/jpeg", "image/png", "image/webp"];
-const ACCEPT_ATTR = [...AUDIO_MIME, ...IMAGE_MIME].join(",");
+const AUDIO_MIME = ['audio/mpeg', 'audio/wav', 'audio/ogg'];
+const IMAGE_MIME = ['image/jpeg', 'image/png', 'image/webp'];
+const ACCEPT_ATTR = [...AUDIO_MIME, ...IMAGE_MIME].join(',');
 
 // ---------------------------------------------------------------------------
 // MediaUploadModal
 // ---------------------------------------------------------------------------
 
-export function MediaUploadModal({
-  open,
-  onClose,
-  themeId,
-}: MediaUploadModalProps) {
+export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalProps) {
   const [file, setFile] = useState<File | null>(null);
-  const [name, setName] = useState("");
-  const [type, setType] = useState<MediaType>("BGM");
+  const [name, setName] = useState('');
+  const [type, setType] = useState<MediaType>('BGM');
   const [isDragging, setIsDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -70,8 +61,8 @@ export function MediaUploadModal({
       controllerRef.current?.abort();
       controllerRef.current = null;
       setFile(null);
-      setName("");
-      setType("BGM");
+      setName('');
+      setType('BGM');
       setProgress(0);
       setError(null);
       setUploading(false);
@@ -81,18 +72,18 @@ export function MediaUploadModal({
 
   const handleFile = (f: File) => {
     if (f.size > MAX_SIZE) {
-      setError("파일 크기는 20MB 이하여야 합니다");
+      setError('파일 크기는 20MB 이하여야 합니다');
       return;
     }
     const nextType = inferUploadType(f.type);
     if (!nextType) {
-      setError("지원하지 않는 파일 형식입니다 (MP3, WAV, OGG, JPG, PNG, WEBP)");
+      setError('지원하지 않는 파일 형식입니다 (MP3, WAV, OGG, JPG, PNG, WEBP)');
       return;
     }
     setError(null);
     setFile(f);
     setType(nextType);
-    const defaultName = f.name.replace(/\.[^.]+$/, "");
+    const defaultName = f.name.replace(/\.[^.]+$/, '');
     setName((prev) => (prev ? prev : defaultName));
   };
 
@@ -137,8 +128,7 @@ export function MediaUploadModal({
       onClose();
     } catch (err) {
       if (!isMountedRef.current || controller.signal.aborted) return;
-      const message = err instanceof Error ? err.message : "업로드 실패";
-      setError(message);
+      setError(getDisplayErrorMessage(err, '업로드 실패'));
     } finally {
       if (controllerRef.current === controller) {
         controllerRef.current = null;
@@ -156,7 +146,7 @@ export function MediaUploadModal({
     // we have to clear uploading state here.
     setUploading(false);
     setProgress(0);
-    setError("업로드가 취소되었습니다");
+    setError('업로드가 취소되었습니다');
   };
 
   if (!open) return null;
@@ -185,8 +175,8 @@ export function MediaUploadModal({
         <div
           className={`cursor-pointer rounded-md border-2 border-dashed p-6 text-center transition ${
             isDragging
-              ? "border-amber-400 bg-amber-500/10"
-              : "border-slate-600 hover:border-slate-500"
+              ? 'border-amber-400 bg-amber-500/10'
+              : 'border-slate-600 hover:border-slate-500'
           }`}
           onDragEnter={(e) => {
             e.preventDefault();
@@ -195,9 +185,7 @@ export function MediaUploadModal({
           onDragOver={(e) => e.preventDefault()}
           onDragLeave={() => setIsDragging(false)}
           onDrop={handleDrop}
-          onClick={() =>
-            document.getElementById("media-upload-input")?.click()
-          }
+          onClick={() => document.getElementById('media-upload-input')?.click()}
           role="button"
           tabIndex={0}
           aria-label="파일 드롭 영역"
@@ -206,15 +194,11 @@ export function MediaUploadModal({
           {file ? (
             <>
               <p className="text-sm text-slate-200">{file.name}</p>
-              <p className="text-xs text-slate-400">
-                {(file.size / 1024 / 1024).toFixed(2)} MB
-              </p>
+              <p className="text-xs text-slate-400">{(file.size / 1024 / 1024).toFixed(2)} MB</p>
             </>
           ) : (
             <>
-              <p className="text-sm text-slate-400">
-                파일을 드래그하거나 클릭하여 선택
-              </p>
+              <p className="text-sm text-slate-400">파일을 드래그하거나 클릭하여 선택</p>
               <p className="mt-1 text-xs text-slate-500">(MP3, WAV, OGG, JPG, PNG, WEBP)</p>
             </>
           )}
@@ -231,10 +215,7 @@ export function MediaUploadModal({
         {file && (
           <div className="mt-4 space-y-3">
             <div>
-              <label
-                htmlFor="media-upload-name"
-                className="mb-1 block text-sm text-slate-300"
-              >
+              <label htmlFor="media-upload-name" className="mb-1 block text-sm text-slate-300">
                 이름
               </label>
               <input
@@ -246,10 +227,7 @@ export function MediaUploadModal({
               />
             </div>
             <div>
-              <label
-                htmlFor="media-upload-type"
-                className="mb-1 block text-sm text-slate-300"
-              >
+              <label htmlFor="media-upload-type" className="mb-1 block text-sm text-slate-300">
                 유형
               </label>
               <select
@@ -319,7 +297,7 @@ export function MediaUploadModal({
             disabled={!file || uploading || !name}
             className="rounded bg-amber-500 px-4 py-2 text-sm text-slate-900 hover:bg-amber-400 disabled:opacity-50"
           >
-            {uploading ? "업로드 중..." : "업로드"}
+            {uploading ? '업로드 중...' : '업로드'}
           </button>
         </div>
       </div>
@@ -328,7 +306,7 @@ export function MediaUploadModal({
 }
 
 function inferUploadType(mimeType: string): MediaType | null {
-  if (AUDIO_MIME.includes(mimeType)) return "BGM";
-  if (IMAGE_MIME.includes(mimeType)) return "IMAGE";
+  if (AUDIO_MIME.includes(mimeType)) return 'BGM';
+  if (IMAGE_MIME.includes(mimeType)) return 'IMAGE';
   return null;
 }

--- a/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ChangeEvent, type DragEvent } from 'react';
+import { useEffect, useRef, useState, type ChangeEvent, type DragEvent, type KeyboardEvent } from 'react';
 import { Upload, X } from 'lucide-react';
 
 import {
@@ -99,6 +99,17 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
     if (f) handleFile(f);
   };
 
+  const openFilePicker = () => {
+    document.getElementById('media-upload-input')?.click();
+  };
+
+  const handleDropzoneKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      openFilePicker();
+    }
+  };
+
   const handleUpload = async () => {
     if (!file) return;
     // Abort any pre-existing controller and create a fresh one for this attempt.
@@ -185,7 +196,8 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
           onDragOver={(e) => e.preventDefault()}
           onDragLeave={() => setIsDragging(false)}
           onDrop={handleDrop}
-          onClick={() => document.getElementById('media-upload-input')?.click()}
+          onClick={openFilePicker}
+          onKeyDown={handleDropzoneKeyDown}
           role="button"
           tabIndex={0}
           aria-label="파일 드롭 영역"

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -254,6 +254,36 @@ describe('MediaUploadModal', () => {
     });
   });
 
+  it('API upload error uses correlation_id as reference fallback', async () => {
+    mockedUpload.mockRejectedValueOnce(
+      new ApiHttpError({
+        type: 'about:blank',
+        title: 'Conflict',
+        status: 409,
+        detail: 'internal storage key collision for theme-1',
+        code: 'MEDIA_REFERENCE_IN_USE',
+        correlation_id: 'corr-1234567890',
+        timestamp: '2026-05-05T00:00:00Z',
+        severity: 'medium',
+        retryable: false,
+        user_action: 'review_references',
+      })
+    );
+    renderModal(true);
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [makeFile('a.mp3', 1024)] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain(
+        '이 미디어는 다른 곳에서 사용 중이라 삭제할 수 없습니다.'
+      );
+      expect(alert.textContent).toContain('Ref: corr-123');
+      expect(alert.textContent).not.toContain('internal storage key');
+    });
+  });
+
   it('passes an AbortSignal to uploadMediaFile', async () => {
     mockedUpload.mockResolvedValueOnce({});
     renderModal(true);

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -197,14 +197,30 @@ describe('MediaUploadModal', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it('upload error shows error message', async () => {
-    mockedUpload.mockRejectedValueOnce(new Error('서버 에러'));
+  it('upload error hides raw non-API error message', async () => {
+    mockedUpload.mockRejectedValueOnce(new Error('internal storage timeout'));
     renderModal(true);
     fireEvent.change(screen.getByTestId('media-upload-input'), {
       target: { files: [makeFile('a.mp3', 1024)] },
     });
     fireEvent.click(screen.getByRole('button', { name: '업로드' }));
-    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('서버 에러'));
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain('업로드 실패');
+      expect(alert.textContent).not.toContain('internal storage timeout');
+    });
+  });
+
+  it('dropzone opens file picker with keyboard activation', () => {
+    renderModal(true);
+    const input = screen.getByTestId('media-upload-input');
+    const clickSpy = vi.spyOn(input, 'click').mockImplementation(() => {});
+    const dropzone = screen.getByRole('button', { name: '파일 드롭 영역' });
+
+    fireEvent.keyDown(dropzone, { key: 'Enter' });
+    fireEvent.keyDown(dropzone, { key: ' ' });
+
+    expect(clickSpy).toHaveBeenCalledTimes(2);
   });
 
   it('API upload error hides raw detail and shows reference', async () => {

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -1,48 +1,42 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MediaUploadModal } from "../MediaUploadModal";
+import { MediaUploadModal } from '../MediaUploadModal';
+import { ApiHttpError } from '@/lib/api-error';
 
 // Mock the upload helper + hooks. We keep the hooks as no-op mutations and
 // drive behaviour through the uploadMediaFile mock.
-vi.mock("@/features/editor/mediaApi", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/features/editor/mediaApi")>(
-      "@/features/editor/mediaApi",
-    );
+vi.mock('@/features/editor/mediaApi', async () => {
+  const actual = await vi.importActual<typeof import('@/features/editor/mediaApi')>(
+    '@/features/editor/mediaApi'
+  );
   return {
     ...actual,
     uploadMediaFile: vi.fn(),
     useRequestUploadUrl: () => ({
       mutateAsync: vi.fn(async () => ({
-        upload_id: "u1",
-        upload_url: "https://r2/x",
-        expires_at: "",
+        upload_id: 'u1',
+        upload_url: 'https://r2/x',
+        expires_at: '',
       })),
     }),
     useConfirmUpload: () => ({
       mutateAsync: vi.fn(async () => ({
-        id: "m1",
-        theme_id: "t1",
-        name: "x",
-        type: "BGM",
-        source_type: "FILE",
+        id: 'm1',
+        theme_id: 't1',
+        name: 'x',
+        type: 'BGM',
+        source_type: 'FILE',
         tags: [],
         sort_order: 0,
-        created_at: "",
+        created_at: '',
       })),
     }),
   };
 });
 
-import { uploadMediaFile } from "@/features/editor/mediaApi";
+import { uploadMediaFile } from '@/features/editor/mediaApi';
 
 const mockedUpload = uploadMediaFile as unknown as ReturnType<typeof vi.fn>;
 
@@ -55,22 +49,18 @@ function renderModal(open = true, onClose = vi.fn()) {
     ...render(
       <QueryClientProvider client={qc}>
         <MediaUploadModal open={open} onClose={onClose} themeId="theme-1" />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     ),
   };
 }
 
-function makeFile(
-  name: string,
-  size: number,
-  type = "audio/mpeg",
-): File {
-  const file = new File(["x".repeat(Math.min(size, 1024))], name, { type });
-  Object.defineProperty(file, "size", { value: size, configurable: true });
+function makeFile(name: string, size: number, type = 'audio/mpeg'): File {
+  const file = new File(['x'.repeat(Math.min(size, 1024))], name, { type });
+  Object.defineProperty(file, 'size', { value: size, configurable: true });
   return file;
 }
 
-describe("MediaUploadModal", () => {
+describe('MediaUploadModal', () => {
   beforeEach(() => {
     mockedUpload.mockReset();
   });
@@ -80,231 +70,232 @@ describe("MediaUploadModal", () => {
     vi.clearAllMocks();
   });
 
-  it("renders nothing when closed", () => {
+  it('renders nothing when closed', () => {
     const { container } = renderModal(false);
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders upload zone when open", () => {
+  it('renders upload zone when open', () => {
     renderModal(true);
-    expect(screen.getByRole("dialog")).toBeTruthy();
-    expect(screen.getByText("파일을 드래그하거나 클릭하여 선택")).toBeTruthy();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('파일을 드래그하거나 클릭하여 선택')).toBeTruthy();
   });
 
-  it("file select populates filename and default name", () => {
+  it('file select populates filename and default name', () => {
     renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
-    const file = makeFile("song.mp3", 1024);
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('song.mp3', 1024);
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect(screen.getByText("song.mp3")).toBeTruthy();
-    const nameInput = screen.getByLabelText("이름") as HTMLInputElement;
-    expect(nameInput.value).toBe("song");
+    expect(screen.getByText('song.mp3')).toBeTruthy();
+    const nameInput = screen.getByLabelText('이름') as HTMLInputElement;
+    expect(nameInput.value).toBe('song');
   });
 
-  it("rejects oversized file with error", () => {
+  it('rejects oversized file with error', () => {
     renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
-    const file = makeFile("big.mp3", 21 * 1024 * 1024);
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('big.mp3', 21 * 1024 * 1024);
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect(screen.getByRole("alert").textContent).toContain(
-      "파일 크기는 20MB 이하여야 합니다",
-    );
+    expect(screen.getByRole('alert').textContent).toContain('파일 크기는 20MB 이하여야 합니다');
   });
 
-  it("rejects wrong MIME type", () => {
+  it('rejects wrong MIME type', () => {
     renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
-    const file = makeFile("doc.pdf", 1024, "application/pdf");
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('doc.pdf', 1024, 'application/pdf');
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect(screen.getByRole("alert").textContent).toContain(
-      "지원하지 않는 파일 형식입니다",
-    );
+    expect(screen.getByRole('alert').textContent).toContain('지원하지 않는 파일 형식입니다');
   });
 
-  it("rejects audio/mp4 (m4a) — backend does not accept it", () => {
+  it('rejects audio/mp4 (m4a) — backend does not accept it', () => {
     // Regression: FE previously accepted audio/mp4 but backend
     // AllowedAudioMIMEs rejects it, leading to confusing post-upload errors.
     renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
-    const file = makeFile("song.m4a", 1024, "audio/mp4");
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('song.m4a', 1024, 'audio/mp4');
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect(screen.getByRole("alert").textContent).toContain(
-      "지원하지 않는 파일 형식입니다",
-    );
+    expect(screen.getByRole('alert').textContent).toContain('지원하지 않는 파일 형식입니다');
   });
 
-  it("type select works", () => {
+  it('type select works', () => {
     renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
     fireEvent.change(input, {
-      target: { files: [makeFile("a.mp3", 1024)] },
+      target: { files: [makeFile('a.mp3', 1024)] },
     });
 
-    const select = screen.getByLabelText("유형") as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "SFX" } });
-    expect(select.value).toBe("SFX");
+    const select = screen.getByLabelText('유형') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'SFX' } });
+    expect(select.value).toBe('SFX');
   });
 
-  it("upload button triggers uploadMediaFile with correct params", async () => {
+  it('upload button triggers uploadMediaFile with correct params', async () => {
     mockedUpload.mockResolvedValueOnce({});
     const { onClose } = renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
-    const file = makeFile("track.mp3", 1024);
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('track.mp3', 1024);
     fireEvent.change(input, { target: { files: [file] } });
 
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
 
     await waitFor(() => expect(mockedUpload).toHaveBeenCalledTimes(1));
     const args = mockedUpload.mock.calls[0][0];
-    expect(args.themeId).toBe("theme-1");
+    expect(args.themeId).toBe('theme-1');
     expect(args.file).toBe(file);
-    expect(args.type).toBe("BGM");
-    expect(args.name).toBe("track");
-    expect(typeof args.requestUploadUrl).toBe("function");
-    expect(typeof args.confirmUpload).toBe("function");
-    expect(typeof args.onProgress).toBe("function");
+    expect(args.type).toBe('BGM');
+    expect(args.name).toBe('track');
+    expect(typeof args.requestUploadUrl).toBe('function');
+    expect(typeof args.confirmUpload).toBe('function');
+    expect(typeof args.onProgress).toBe('function');
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it("이미지 파일은 IMAGE 타입으로 자동 설정해 업로드한다", async () => {
+  it('이미지 파일은 IMAGE 타입으로 자동 설정해 업로드한다', async () => {
     mockedUpload.mockResolvedValueOnce({});
     renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
-    const file = makeFile("background.png", 1024, "image/png");
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('background.png', 1024, 'image/png');
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect((screen.getByLabelText("유형") as HTMLSelectElement).value).toBe("IMAGE");
+    expect((screen.getByLabelText('유형') as HTMLSelectElement).value).toBe('IMAGE');
 
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
 
     await waitFor(() => expect(mockedUpload).toHaveBeenCalledTimes(1));
-    expect(mockedUpload.mock.calls[0][0].type).toBe("IMAGE");
+    expect(mockedUpload.mock.calls[0][0].type).toBe('IMAGE');
   });
 
-
-  it("progress bar updates from onProgress", async () => {
+  it('progress bar updates from onProgress', async () => {
     mockedUpload.mockImplementationOnce(async (params: any) => {
       params.onProgress?.(42);
       return {};
     });
     renderModal(true);
-    const input = screen.getByTestId(
-      "media-upload-input",
-    ) as HTMLInputElement;
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
     fireEvent.change(input, {
-      target: { files: [makeFile("a.mp3", 1024)] },
+      target: { files: [makeFile('a.mp3', 1024)] },
     });
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
     await waitFor(() => expect(mockedUpload).toHaveBeenCalled());
     // Progress was reported synchronously inside the impl. Modal closes on
     // success, so we just verify the upload was invoked with onProgress.
     const args = mockedUpload.mock.calls[0][0];
-    expect(typeof args.onProgress).toBe("function");
+    expect(typeof args.onProgress).toBe('function');
   });
 
-  it("upload success calls onClose", async () => {
+  it('upload success calls onClose', async () => {
     mockedUpload.mockResolvedValueOnce({});
     const { onClose } = renderModal(true);
-    fireEvent.change(screen.getByTestId("media-upload-input"), {
-      target: { files: [makeFile("a.mp3", 1024)] },
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [makeFile('a.mp3', 1024)] },
     });
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it("upload error shows error message", async () => {
-    mockedUpload.mockRejectedValueOnce(new Error("서버 에러"));
+  it('upload error shows error message', async () => {
+    mockedUpload.mockRejectedValueOnce(new Error('서버 에러'));
     renderModal(true);
-    fireEvent.change(screen.getByTestId("media-upload-input"), {
-      target: { files: [makeFile("a.mp3", 1024)] },
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [makeFile('a.mp3', 1024)] },
     });
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
-    await waitFor(() =>
-      expect(screen.getByRole("alert").textContent).toContain("서버 에러"),
-    );
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('서버 에러'));
   });
 
-  it("passes an AbortSignal to uploadMediaFile", async () => {
+  it('API upload error hides raw detail and shows reference', async () => {
+    mockedUpload.mockRejectedValueOnce(
+      new ApiHttpError({
+        type: 'about:blank',
+        title: 'Conflict',
+        status: 409,
+        detail: 'internal storage key collision for theme-1',
+        code: 'MEDIA_REFERENCE_IN_USE',
+        request_id: 'req-1234567890',
+        correlation_id: 'req-1234567890',
+        timestamp: '2026-05-05T00:00:00Z',
+        severity: 'medium',
+        retryable: false,
+        user_action: 'review_references',
+      })
+    );
+    renderModal(true);
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [makeFile('a.mp3', 1024)] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain(
+        '이 미디어는 다른 곳에서 사용 중이라 삭제할 수 없습니다.'
+      );
+      expect(alert.textContent).toContain('Ref: req-1234');
+      expect(alert.textContent).not.toContain('internal storage key');
+    });
+  });
+
+  it('passes an AbortSignal to uploadMediaFile', async () => {
     mockedUpload.mockResolvedValueOnce({});
     renderModal(true);
-    fireEvent.change(screen.getByTestId("media-upload-input"), {
-      target: { files: [makeFile("a.mp3", 1024)] },
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [makeFile('a.mp3', 1024)] },
     });
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
     await waitFor(() => expect(mockedUpload).toHaveBeenCalled());
     const args = mockedUpload.mock.calls[0][0];
     expect(args.signal).toBeInstanceOf(AbortSignal);
     expect(args.signal.aborted).toBe(false);
   });
 
-  it("업로드 취소 button aborts the signal and clears uploading state", async () => {
+  it('업로드 취소 button aborts the signal and clears uploading state', async () => {
     let capturedSignal: AbortSignal | undefined;
     mockedUpload.mockImplementationOnce(
       (params: any) =>
         new Promise((_resolve, reject) => {
           capturedSignal = params.signal;
-          params.signal.addEventListener("abort", () =>
-            reject(new Error("aborted")),
-          );
-        }),
+          params.signal.addEventListener('abort', () => reject(new Error('aborted')));
+        })
     );
     renderModal(true);
-    fireEvent.change(screen.getByTestId("media-upload-input"), {
-      target: { files: [makeFile("a.mp3", 1024)] },
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [makeFile('a.mp3', 1024)] },
     });
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
     await waitFor(() => expect(mockedUpload).toHaveBeenCalled());
 
-    const abortBtn = screen.getByRole("button", {
-      name: "업로드 취소",
+    const abortBtn = screen.getByRole('button', {
+      name: '업로드 취소',
     }) as HTMLButtonElement;
     fireEvent.click(abortBtn);
 
     expect(capturedSignal?.aborted).toBe(true);
     await waitFor(() => {
       expect(
-        (screen.getByRole("button", { name: "업로드" }) as HTMLButtonElement)
-          .textContent,
-      ).toBe("업로드");
+        (screen.getByRole('button', { name: '업로드' }) as HTMLButtonElement).textContent
+      ).toBe('업로드');
     });
   });
 
-  it("cancel during upload is disabled", async () => {
+  it('cancel during upload is disabled', async () => {
     let resolveUpload: ((v: unknown) => void) | undefined;
-    mockedUpload.mockImplementationOnce(
-      () => new Promise((res) => (resolveUpload = res)),
-    );
+    mockedUpload.mockImplementationOnce(() => new Promise((res) => (resolveUpload = res)));
     renderModal(true);
-    fireEvent.change(screen.getByTestId("media-upload-input"), {
-      target: { files: [makeFile("a.mp3", 1024)] },
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [makeFile('a.mp3', 1024)] },
     });
-    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
 
     await waitFor(() => expect(mockedUpload).toHaveBeenCalled());
-    const cancel = screen.getByRole("button", {
-      name: "취소",
+    const cancel = screen.getByRole('button', {
+      name: '취소',
     }) as HTMLButtonElement;
     expect(cancel.disabled).toBe(true);
-    const close = screen.getByRole("button", {
-      name: "닫기",
+    const close = screen.getByRole('button', {
+      name: '닫기',
     }) as HTMLButtonElement;
     expect(close.disabled).toBe(true);
 

--- a/apps/web/src/lib/display-error.ts
+++ b/apps/web/src/lib/display-error.ts
@@ -1,0 +1,20 @@
+import { getUserMessage } from '@/lib/error-messages';
+import { getErrorReference } from '@/lib/show-error-toast';
+import { isApiHttpError } from '@/lib/api-error';
+
+export function getDisplayErrorMessage(
+  error: unknown,
+  fallback = '요청을 처리하지 못했습니다.'
+): string {
+  if (isApiHttpError(error)) {
+    const message = getUserMessage(error.apiError);
+    const ref = getErrorReference(error.apiError);
+    return ref ? `${message} (Ref: ${ref})` : message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}

--- a/apps/web/src/lib/display-error.ts
+++ b/apps/web/src/lib/display-error.ts
@@ -12,8 +12,8 @@ export function getDisplayErrorMessage(
     return ref ? `${message} (Ref: ${ref})` : message;
   }
 
-  if (error instanceof Error && error.message) {
-    return error.message;
+  if (error instanceof Error) {
+    return fallback;
   }
 
   return fallback;

--- a/apps/web/src/lib/show-error-toast.test.ts
+++ b/apps/web/src/lib/show-error-toast.test.ts
@@ -54,6 +54,12 @@ describe('getErrorReference', () => {
     expect(ref).toBe('trace-98');
   });
 
+  it('request_id와 trace_id가 없으면 correlation_id를 표시한다', () => {
+    const ref = getErrorReference(apiError({ correlation_id: 'corr-123456789' }));
+
+    expect(ref).toBe('corr-123');
+  });
+
   it('표시 가능한 추적 ID가 없으면 undefined를 반환한다', () => {
     expect(getErrorReference(apiError({}))).toBeUndefined();
   });

--- a/apps/web/src/lib/show-error-toast.ts
+++ b/apps/web/src/lib/show-error-toast.ts
@@ -35,6 +35,7 @@ export function showErrorToast(error: ApiError): void {
 export function getErrorReference(error: ApiError): string | undefined {
   const requestId = error.request_id?.trim();
   const traceId = error.trace_id?.trim();
-  const id = requestId || traceId;
+  const correlationId = error.correlation_id?.trim();
+  const id = requestId || traceId || correlationId;
   return id ? id.slice(0, 8) : undefined;
 }

--- a/apps/web/src/stores/__tests__/connectionStore.test.ts
+++ b/apps/web/src/stores/__tests__/connectionStore.test.ts
@@ -196,6 +196,25 @@ describe('connectionStore', () => {
     });
   });
 
+  describe('disconnectSocial', () => {
+    it('lastWsError를 null로 초기화한다', () => {
+      useConnectionStore.getState().connectSocial('token-abc');
+      const options = MockWsClient.mock.calls[0][0];
+      options.onServerError({
+        code: 4003,
+        app_code: 'SESSION_INBOX_FULL',
+        message: '요청이 많아 잠시 후 다시 시도해주세요.',
+        severity: 'medium',
+        retryable: true,
+        fatal: false,
+      });
+
+      useConnectionStore.getState().disconnectSocial();
+
+      expect(useConnectionStore.getState().lastWsError).toBeNull();
+    });
+  });
+
   describe('disconnectGame', () => {
     it('gameClient를 null로 설정한다', () => {
       useConnectionStore.getState().connectGame('session-1', 'token-abc');

--- a/apps/web/src/stores/__tests__/connectionStore.test.ts
+++ b/apps/web/src/stores/__tests__/connectionStore.test.ts
@@ -1,61 +1,55 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // WsClient mock — vi.hoisted로 hoisting 스코프에 선언
 // ---------------------------------------------------------------------------
 
-const {
-  mockConnect,
-  mockDisconnect,
-  mockOnStateChange,
-  mockSend,
-  MockWsClient,
-  WsClientState,
-} = vi.hoisted(() => {
-  const mockConnect = vi.fn();
-  const mockDisconnect = vi.fn();
-  const mockOnStateChange = vi.fn(() => vi.fn());
-  const mockSend = vi.fn();
+const { mockConnect, mockDisconnect, mockOnStateChange, mockSend, MockWsClient, WsClientState } =
+  vi.hoisted(() => {
+    const mockConnect = vi.fn();
+    const mockDisconnect = vi.fn();
+    const mockOnStateChange = vi.fn(() => vi.fn());
+    const mockSend = vi.fn();
 
-  const MockWsClient = vi.fn().mockImplementation(() => ({
-    connect: mockConnect,
-    disconnect: mockDisconnect,
-    onStateChange: mockOnStateChange,
-    send: mockSend,
-    connectionState: "idle",
-  }));
+    const MockWsClient = vi.fn().mockImplementation(() => ({
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      onStateChange: mockOnStateChange,
+      send: mockSend,
+      connectionState: 'idle',
+    }));
 
-  const WsClientState = {
-    IDLE: "idle" as const,
-    CONNECTING: "connecting" as const,
-    CONNECTED: "connected" as const,
-    RECONNECTING: "reconnecting" as const,
-    DISCONNECTED: "disconnected" as const,
-  };
+    const WsClientState = {
+      IDLE: 'idle' as const,
+      CONNECTING: 'connecting' as const,
+      CONNECTED: 'connected' as const,
+      RECONNECTING: 'reconnecting' as const,
+      DISCONNECTED: 'disconnected' as const,
+    };
 
-  return {
-    mockConnect,
-    mockDisconnect,
-    mockOnStateChange,
-    mockSend,
-    MockWsClient,
-    WsClientState,
-  };
-});
+    return {
+      mockConnect,
+      mockDisconnect,
+      mockOnStateChange,
+      mockSend,
+      MockWsClient,
+      WsClientState,
+    };
+  });
 
-vi.mock("@mmp/ws-client", () => ({
+vi.mock('@mmp/ws-client', () => ({
   WsClient: MockWsClient,
   WsClientState,
 }));
 
 // Import after mock setup
-import { useConnectionStore } from "../connectionStore";
+import { useConnectionStore } from '../connectionStore';
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("connectionStore", () => {
+describe('connectionStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useConnectionStore.setState({
@@ -64,131 +58,165 @@ describe("connectionStore", () => {
       gameState: WsClientState.IDLE,
       socialState: WsClientState.IDLE,
       sessionId: null,
+      authRevoked: null,
+      lastWsError: null,
     });
   });
 
-  describe("초기 상태", () => {
-    it("gameClient는 null이다", () => {
+  describe('초기 상태', () => {
+    it('gameClient는 null이다', () => {
       expect(useConnectionStore.getState().gameClient).toBeNull();
     });
 
-    it("socialClient는 null이다", () => {
+    it('socialClient는 null이다', () => {
       expect(useConnectionStore.getState().socialClient).toBeNull();
     });
 
-    it("gameState는 idle이다", () => {
+    it('gameState는 idle이다', () => {
       expect(useConnectionStore.getState().gameState).toBe(WsClientState.IDLE);
     });
 
-    it("socialState는 idle이다", () => {
+    it('socialState는 idle이다', () => {
       expect(useConnectionStore.getState().socialState).toBe(WsClientState.IDLE);
     });
 
-    it("sessionId는 null이다", () => {
+    it('sessionId는 null이다', () => {
       expect(useConnectionStore.getState().sessionId).toBeNull();
     });
   });
 
-  describe("connectGame", () => {
-    it("WsClient를 생성한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+  describe('connectGame', () => {
+    it('WsClient를 생성한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
 
       expect(MockWsClient).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: expect.stringContaining("/ws/game"),
-          token: "token-abc",
-        }),
+          url: expect.stringContaining('/ws/game'),
+          token: 'token-abc',
+        })
       );
     });
 
-    it("sessionId를 설정한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
-      expect(useConnectionStore.getState().sessionId).toBe("session-1");
+    it('sessionId를 설정한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
+      expect(useConnectionStore.getState().sessionId).toBe('session-1');
     });
 
-    it("client.connect()를 호출한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('client.connect()를 호출한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       expect(mockConnect).toHaveBeenCalled();
     });
 
-    it("gameClient를 저장한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('gameClient를 저장한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       expect(useConnectionStore.getState().gameClient).not.toBeNull();
     });
 
-    it("onStateChange 콜백을 등록한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('server error callback을 store에 연결한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
+      const options = MockWsClient.mock.calls[0][0];
+      const payload = {
+        code: 4010,
+        app_code: 'INTERNAL_ERROR',
+        message: '서버 오류가 발생했습니다.',
+        severity: 'high',
+        retryable: true,
+        fatal: false,
+      };
+
+      options.onServerError(payload);
+
+      expect(useConnectionStore.getState().lastWsError).toEqual(payload);
+    });
+
+    it('onStateChange 콜백을 등록한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       expect(mockOnStateChange).toHaveBeenCalled();
     });
 
-    it("기존 gameClient가 있으면 disconnect 후 새로 생성한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('기존 gameClient가 있으면 disconnect 후 새로 생성한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       vi.clearAllMocks();
 
-      useConnectionStore.getState().connectGame("session-2", "token-def");
+      useConnectionStore.getState().connectGame('session-2', 'token-def');
 
       expect(mockDisconnect).toHaveBeenCalledTimes(1);
       expect(MockWsClient).toHaveBeenCalledTimes(1);
-      expect(useConnectionStore.getState().sessionId).toBe("session-2");
+      expect(useConnectionStore.getState().sessionId).toBe('session-2');
     });
   });
 
-  describe("connectSocial", () => {
-    it("WsClient를 생성한다", () => {
-      useConnectionStore.getState().connectSocial("token-abc");
+  describe('connectSocial', () => {
+    it('WsClient를 생성한다', () => {
+      useConnectionStore.getState().connectSocial('token-abc');
 
       expect(MockWsClient).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: expect.stringContaining("/ws/social"),
-          token: "token-abc",
-        }),
+          url: expect.stringContaining('/ws/social'),
+          token: 'token-abc',
+        })
       );
     });
 
-    it("socialClient를 저장한다", () => {
-      useConnectionStore.getState().connectSocial("token-abc");
+    it('socialClient를 저장한다', () => {
+      useConnectionStore.getState().connectSocial('token-abc');
       expect(useConnectionStore.getState().socialClient).not.toBeNull();
     });
 
-    it("client.connect()를 호출한다", () => {
-      useConnectionStore.getState().connectSocial("token-abc");
+    it('social server error callback을 store에 연결한다', () => {
+      useConnectionStore.getState().connectSocial('token-abc');
+      const options = MockWsClient.mock.calls[0][0];
+      const payload = {
+        code: 4003,
+        app_code: 'SESSION_INBOX_FULL',
+        message: '요청이 많아 잠시 후 다시 시도해주세요.',
+        severity: 'medium',
+        retryable: true,
+        fatal: false,
+      };
+
+      options.onServerError(payload);
+
+      expect(useConnectionStore.getState().lastWsError).toEqual(payload);
+    });
+
+    it('client.connect()를 호출한다', () => {
+      useConnectionStore.getState().connectSocial('token-abc');
       expect(mockConnect).toHaveBeenCalled();
     });
 
-    it("기존 socialClient가 있으면 disconnect 후 새로 생성한다", () => {
-      useConnectionStore.getState().connectSocial("token-abc");
+    it('기존 socialClient가 있으면 disconnect 후 새로 생성한다', () => {
+      useConnectionStore.getState().connectSocial('token-abc');
       vi.clearAllMocks();
 
-      useConnectionStore.getState().connectSocial("token-def");
+      useConnectionStore.getState().connectSocial('token-def');
 
       expect(mockDisconnect).toHaveBeenCalledTimes(1);
       expect(MockWsClient).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe("disconnectGame", () => {
-    it("gameClient를 null로 설정한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+  describe('disconnectGame', () => {
+    it('gameClient를 null로 설정한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       useConnectionStore.getState().disconnectGame();
       expect(useConnectionStore.getState().gameClient).toBeNull();
     });
 
-    it("sessionId를 null로 초기화한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('sessionId를 null로 초기화한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       useConnectionStore.getState().disconnectGame();
       expect(useConnectionStore.getState().sessionId).toBeNull();
     });
 
-    it("gameState를 disconnected로 설정한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('gameState를 disconnected로 설정한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       useConnectionStore.getState().disconnectGame();
-      expect(useConnectionStore.getState().gameState).toBe(
-        WsClientState.DISCONNECTED,
-      );
+      expect(useConnectionStore.getState().gameState).toBe(WsClientState.DISCONNECTED);
     });
 
-    it("client.disconnect()를 호출한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('client.disconnect()를 호출한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       vi.clearAllMocks();
 
       useConnectionStore.getState().disconnectGame();
@@ -196,10 +224,10 @@ describe("connectionStore", () => {
     });
   });
 
-  describe("disconnectAll", () => {
-    it("모든 client를 null로 설정한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
-      useConnectionStore.getState().connectSocial("token-def");
+  describe('disconnectAll', () => {
+    it('모든 client를 null로 설정한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
+      useConnectionStore.getState().connectSocial('token-def');
 
       useConnectionStore.getState().disconnectAll();
 
@@ -208,15 +236,15 @@ describe("connectionStore", () => {
       expect(state.socialClient).toBeNull();
     });
 
-    it("sessionId를 null로 초기화한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
+    it('sessionId를 null로 초기화한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
       useConnectionStore.getState().disconnectAll();
       expect(useConnectionStore.getState().sessionId).toBeNull();
     });
 
-    it("모든 state를 disconnected로 설정한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
-      useConnectionStore.getState().connectSocial("token-def");
+    it('모든 state를 disconnected로 설정한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
+      useConnectionStore.getState().connectSocial('token-def');
 
       useConnectionStore.getState().disconnectAll();
 
@@ -225,9 +253,9 @@ describe("connectionStore", () => {
       expect(state.socialState).toBe(WsClientState.DISCONNECTED);
     });
 
-    it("모든 client의 disconnect()를 호출한다", () => {
-      useConnectionStore.getState().connectGame("session-1", "token-abc");
-      useConnectionStore.getState().connectSocial("token-def");
+    it('모든 client의 disconnect()를 호출한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
+      useConnectionStore.getState().connectSocial('token-def');
       vi.clearAllMocks();
 
       useConnectionStore.getState().disconnectAll();

--- a/apps/web/src/stores/__tests__/connectionStore.test.ts
+++ b/apps/web/src/stores/__tests__/connectionStore.test.ts
@@ -241,6 +241,23 @@ describe('connectionStore', () => {
       useConnectionStore.getState().disconnectGame();
       expect(mockDisconnect).toHaveBeenCalledTimes(1);
     });
+
+    it('lastWsError를 null로 초기화한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
+      const options = MockWsClient.mock.calls[0][0];
+      options.onServerError({
+        code: 4010,
+        app_code: 'INTERNAL_ERROR',
+        message: '서버 오류가 발생했습니다.',
+        severity: 'high',
+        retryable: true,
+        fatal: false,
+      });
+
+      useConnectionStore.getState().disconnectGame();
+
+      expect(useConnectionStore.getState().lastWsError).toBeNull();
+    });
   });
 
   describe('disconnectAll', () => {
@@ -279,6 +296,23 @@ describe('connectionStore', () => {
 
       useConnectionStore.getState().disconnectAll();
       expect(mockDisconnect).toHaveBeenCalledTimes(2);
+    });
+
+    it('lastWsError를 null로 초기화한다', () => {
+      useConnectionStore.getState().connectGame('session-1', 'token-abc');
+      const options = MockWsClient.mock.calls[0][0];
+      options.onServerError({
+        code: 4010,
+        app_code: 'INTERNAL_ERROR',
+        message: '서버 오류가 발생했습니다.',
+        severity: 'high',
+        retryable: true,
+        fatal: false,
+      });
+
+      useConnectionStore.getState().disconnectAll();
+
+      expect(useConnectionStore.getState().lastWsError).toBeNull();
     });
   });
 });

--- a/apps/web/src/stores/connectionStore.ts
+++ b/apps/web/src/stores/connectionStore.ts
@@ -155,7 +155,7 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
     if (socialClient) {
       socialClient.disconnect();
     }
-    set({ socialClient: null, socialState: WsClientState.DISCONNECTED });
+    set({ socialClient: null, socialState: WsClientState.DISCONNECTED, lastWsError: null });
   },
 
   disconnectAll: () => {

--- a/apps/web/src/stores/connectionStore.ts
+++ b/apps/web/src/stores/connectionStore.ts
@@ -1,5 +1,6 @@
-import { create } from "zustand";
-import { WsClient, WsClientState } from "@mmp/ws-client";
+import { create } from 'zustand';
+import type { ErrorPayload } from '@mmp/shared';
+import { WsClient, WsClientState } from '@mmp/ws-client';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -29,6 +30,7 @@ export interface ConnectionState {
    * explicit clearAuthRevoked.
    */
   authRevoked: AuthRevokedState | null;
+  lastWsError: ErrorPayload | null;
 }
 
 export interface ConnectionActions {
@@ -40,6 +42,7 @@ export interface ConnectionActions {
   setGameState: (state: WsClientState) => void;
   setSocialState: (state: WsClientState) => void;
   clearAuthRevoked: () => void;
+  clearLastWsError: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,7 +51,7 @@ export interface ConnectionActions {
 
 function buildWsBase(): string {
   const { protocol, host } = window.location;
-  const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
+  const wsProtocol = protocol === 'https:' ? 'wss:' : 'ws:';
   return `${wsProtocol}//${host}`;
 }
 
@@ -62,7 +65,7 @@ function authProtocolEnabled(): boolean {
   // Vite injects env vars at build time. In test/SSR contexts where
   // import.meta.env is undefined, fall back to off.
   try {
-    return import.meta.env.VITE_MMP_WS_AUTH_PROTOCOL === "true";
+    return import.meta.env.VITE_MMP_WS_AUTH_PROTOCOL === 'true';
   } catch {
     return false;
   }
@@ -72,118 +75,123 @@ function authProtocolEnabled(): boolean {
 // Store
 // ---------------------------------------------------------------------------
 
-export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
-  (set, get) => ({
-    gameClient: null,
-    socialClient: null,
-    gameState: WsClientState.IDLE,
-    socialState: WsClientState.IDLE,
-    sessionId: null,
-    authRevoked: null,
+export const useConnectionStore = create<ConnectionState & ConnectionActions>()((set, get) => ({
+  gameClient: null,
+  socialClient: null,
+  gameState: WsClientState.IDLE,
+  socialState: WsClientState.IDLE,
+  sessionId: null,
+  authRevoked: null,
+  lastWsError: null,
 
-    connectGame: (sessionId, token) => {
-      const { gameClient } = get();
-      if (gameClient) {
-        gameClient.disconnect();
-      }
+  connectGame: (sessionId, token) => {
+    const { gameClient } = get();
+    if (gameClient) {
+      gameClient.disconnect();
+    }
 
-      const wsBase = buildWsBase();
-      const enabled = authProtocolEnabled();
-      const client = new WsClient({
-        url: `${wsBase}/ws/game?token=${encodeURIComponent(token)}`,
-        token,
-        authProtocol: enabled,
-        onRevoked: (code, reason) => set({ authRevoked: { code, reason } }),
-        onUnauthorized: (reason) =>
-          set({ authRevoked: { code: "unauthorized", reason } }),
-        // onTokenRefreshed wiring (rotate token in useAuthStore) lands
-        // alongside auth.refresh_required scheduling — PR-9 ships only
-        // the manual refresh path, so nothing to forward yet.
-      });
+    const wsBase = buildWsBase();
+    const enabled = authProtocolEnabled();
+    const client = new WsClient({
+      url: `${wsBase}/ws/game?token=${encodeURIComponent(token)}`,
+      token,
+      authProtocol: enabled,
+      onRevoked: (code, reason) => set({ authRevoked: { code, reason } }),
+      onUnauthorized: (reason) => set({ authRevoked: { code: 'unauthorized', reason } }),
+      onServerError: (payload) => set({ lastWsError: payload }),
+      // onTokenRefreshed wiring (rotate token in useAuthStore) lands
+      // alongside auth.refresh_required scheduling — PR-9 ships only
+      // the manual refresh path, so nothing to forward yet.
+    });
 
-      client.onStateChange((state) => {
-        get().setGameState(state);
-      });
+    client.onStateChange((state) => {
+      get().setGameState(state);
+    });
 
-      set({ gameClient: client, sessionId, authRevoked: null });
-      client.connect();
-    },
+    set({ gameClient: client, sessionId, authRevoked: null, lastWsError: null });
+    client.connect();
+  },
 
-    connectSocial: (token) => {
-      const { socialClient } = get();
-      if (socialClient) {
-        socialClient.disconnect();
-      }
+  connectSocial: (token) => {
+    const { socialClient } = get();
+    if (socialClient) {
+      socialClient.disconnect();
+    }
 
-      const wsBase = buildWsBase();
-      const enabled = authProtocolEnabled();
-      const client = new WsClient({
-        url: `${wsBase}/ws/social?token=${encodeURIComponent(token)}`,
-        token,
-        authProtocol: enabled,
-        onRevoked: (code, reason) => set({ authRevoked: { code, reason } }),
-        onUnauthorized: (reason) =>
-          set({ authRevoked: { code: "unauthorized", reason } }),
-      });
+    const wsBase = buildWsBase();
+    const enabled = authProtocolEnabled();
+    const client = new WsClient({
+      url: `${wsBase}/ws/social?token=${encodeURIComponent(token)}`,
+      token,
+      authProtocol: enabled,
+      onRevoked: (code, reason) => set({ authRevoked: { code, reason } }),
+      onUnauthorized: (reason) => set({ authRevoked: { code: 'unauthorized', reason } }),
+      onServerError: (payload) => set({ lastWsError: payload }),
+    });
 
-      client.onStateChange((state) => {
-        get().setSocialState(state);
-      });
+    client.onStateChange((state) => {
+      get().setSocialState(state);
+    });
 
-      set({ socialClient: client, authRevoked: null });
-      client.connect();
-    },
+    set({ socialClient: client, authRevoked: null, lastWsError: null });
+    client.connect();
+  },
 
-    disconnectGame: () => {
-      const { gameClient } = get();
-      if (gameClient) {
-        gameClient.disconnect();
-      }
-      set({
-        gameClient: null,
-        sessionId: null,
-        gameState: WsClientState.DISCONNECTED,
-      });
-    },
+  disconnectGame: () => {
+    const { gameClient } = get();
+    if (gameClient) {
+      gameClient.disconnect();
+    }
+    set({
+      gameClient: null,
+      sessionId: null,
+      gameState: WsClientState.DISCONNECTED,
+      lastWsError: null,
+    });
+  },
 
-    disconnectSocial: () => {
-      const { socialClient } = get();
-      if (socialClient) {
-        socialClient.disconnect();
-      }
-      set({ socialClient: null, socialState: WsClientState.DISCONNECTED });
-    },
+  disconnectSocial: () => {
+    const { socialClient } = get();
+    if (socialClient) {
+      socialClient.disconnect();
+    }
+    set({ socialClient: null, socialState: WsClientState.DISCONNECTED });
+  },
 
-    disconnectAll: () => {
-      const { gameClient, socialClient } = get();
-      if (gameClient) {
-        gameClient.disconnect();
-      }
-      if (socialClient) {
-        socialClient.disconnect();
-      }
-      set({
-        gameClient: null,
-        socialClient: null,
-        sessionId: null,
-        gameState: WsClientState.DISCONNECTED,
-        socialState: WsClientState.DISCONNECTED,
-      });
-    },
+  disconnectAll: () => {
+    const { gameClient, socialClient } = get();
+    if (gameClient) {
+      gameClient.disconnect();
+    }
+    if (socialClient) {
+      socialClient.disconnect();
+    }
+    set({
+      gameClient: null,
+      socialClient: null,
+      sessionId: null,
+      gameState: WsClientState.DISCONNECTED,
+      socialState: WsClientState.DISCONNECTED,
+      lastWsError: null,
+    });
+  },
 
-    setGameState: (state) => {
-      set({ gameState: state });
-    },
+  setGameState: (state) => {
+    set({ gameState: state });
+  },
 
-    setSocialState: (state) => {
-      set({ socialState: state });
-    },
+  setSocialState: (state) => {
+    set({ socialState: state });
+  },
 
-    clearAuthRevoked: () => {
-      set({ authRevoked: null });
-    },
-  }),
-);
+  clearAuthRevoked: () => {
+    set({ authRevoked: null });
+  },
+
+  clearLastWsError: () => {
+    set({ lastWsError: null });
+  },
+}));
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -197,3 +205,4 @@ export const selectIsGameConnected = (s: ConnectionState) =>
 export const selectIsSocialConnected = (s: ConnectionState) =>
   s.socialState === WsClientState.CONNECTED;
 export const selectAuthRevoked = (s: ConnectionState) => s.authRevoked;
+export const selectLastWsError = (s: ConnectionState) => s.lastWsError;

--- a/packages/shared/src/ws/types.generated.ts
+++ b/packages/shared/src/ws/types.generated.ts
@@ -133,7 +133,7 @@ export const WsEventType = {
   ENDING_NEXT_REVEAL: "ending:next_reveal",
   /**
    * S2C · system
-   * wire payload is ErrorPayload { code, message }
+   * wire payload is ErrorPayload with ProblemDetail-lite recovery metadata
    */
   ERROR: "error",
   /** C2S · event */
@@ -875,6 +875,13 @@ export interface ConnectedPayload {
  */
 export interface ErrorPayload {
   code: number;
+  app_code?: string;
   message: string;
+  severity?: string;
+  retryable: boolean;
+  user_action?: string;
+  request_id?: string;
+  correlation_id?: string;
+  fatal: boolean;
 }
 

--- a/packages/ws-client/src/client.test.ts
+++ b/packages/ws-client/src/client.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WsEventType } from "@mmp/shared";
-import { WsClient } from "./client.js";
-import { WsClientState } from "./types.js";
-import { FakeWebSocket, installFakeWebSocket } from "./__tests__/fake-websocket.js";
-import type { FakeWsHandle } from "./__tests__/fake-websocket.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WsEventType } from '@mmp/shared';
+import type { ErrorPayload } from '@mmp/shared';
+import { WsClient } from './client.js';
+import { WsClientState } from './types.js';
+import { FakeWebSocket, installFakeWebSocket } from './__tests__/fake-websocket.js';
+import type { FakeWsHandle } from './__tests__/fake-websocket.js';
 
 // All tests use fake timers because WsClient runs a 30s heartbeat
 // setInterval and the reconnect schedule is a setTimeout. Disabling real
@@ -20,21 +21,25 @@ afterEach(() => {
   handle.restore();
 });
 
-function newClient(opts: {
-  authProtocol?: boolean;
-  token?: string;
-  onRevoked?: (code: string, reason: string) => void;
-  onUnauthorized?: (reason: string) => void;
-  onTokenRefreshed?: (token: string, expiresAt: number) => void;
-  reconnect?: { enabled?: boolean; baseDelay?: number; maxAttempts?: number };
-} = {}): WsClient {
+function newClient(
+  opts: {
+    authProtocol?: boolean;
+    token?: string;
+    onRevoked?: (code: string, reason: string) => void;
+    onUnauthorized?: (reason: string) => void;
+    onTokenRefreshed?: (token: string, expiresAt: number) => void;
+    onServerError?: (payload: ErrorPayload) => void;
+    reconnect?: { enabled?: boolean; baseDelay?: number; maxAttempts?: number };
+  } = {}
+): WsClient {
   return new WsClient({
-    url: "ws://test",
-    token: opts.token ?? "tok",
+    url: 'ws://test',
+    token: opts.token ?? 'tok',
     authProtocol: opts.authProtocol,
     onRevoked: opts.onRevoked,
     onUnauthorized: opts.onUnauthorized,
     onTokenRefreshed: opts.onTokenRefreshed,
+    onServerError: opts.onServerError,
     heartbeatInterval: 999_999, // park heartbeat way out of test timelines
     reconnect: { baseDelay: 10, maxAttempts: 5, ...opts.reconnect },
   });
@@ -44,8 +49,8 @@ function newClient(opts: {
 // Flag gate
 // ---------------------------------------------------------------------------
 
-describe("WsClient — authProtocol flag gate", () => {
-  it("flag off: no auth.identify is sent on open", () => {
+describe('WsClient — authProtocol flag gate', () => {
+  it('flag off: no auth.identify is sent on open', () => {
     const c = newClient({ authProtocol: false });
     c.connect();
     handle.getLast().triggerOpen();
@@ -53,14 +58,14 @@ describe("WsClient — authProtocol flag gate", () => {
     c.disconnect();
   });
 
-  it("flag on: first connect sends auth.identify with the configured token", () => {
-    const c = newClient({ authProtocol: true, token: "tok-A" });
+  it('flag on: first connect sends auth.identify with the configured token', () => {
+    const c = newClient({ authProtocol: true, token: 'tok-A' });
     c.connect();
     handle.getLast().triggerOpen();
     expect(handle.getLast().sent).toHaveLength(1);
     expect(handle.getLast().sent[0]).toMatchObject({
       type: WsEventType.AUTH_IDENTIFY,
-      payload: { token: "tok-A" },
+      payload: { token: 'tok-A' },
     });
     c.disconnect();
   });
@@ -70,8 +75,8 @@ describe("WsClient — authProtocol flag gate", () => {
 // Resume bookkeeping
 // ---------------------------------------------------------------------------
 
-describe("WsClient — resume bookkeeping", () => {
-  it("captures sessionId from the connected envelope and re-uses it on resume", () => {
+describe('WsClient — resume bookkeeping', () => {
+  it('captures sessionId from the connected envelope and re-uses it on resume', () => {
     const c = newClient({ authProtocol: true });
     c.connect();
     const ws1 = handle.getLast();
@@ -85,13 +90,13 @@ describe("WsClient — resume bookkeeping", () => {
     // so lastSeq advances past the initial 1.
     ws1.triggerMessage({
       type: WsEventType.CONNECTED,
-      payload: { playerId: "p", sessionId: "sess-1", seq: 1 },
+      payload: { playerId: 'p', sessionId: 'sess-1', seq: 1 },
       ts: 0,
       seq: 1,
     });
     ws1.triggerMessage({
-      type: "game:state" as never,
-      payload: { foo: "bar" },
+      type: 'game:state' as never,
+      payload: { foo: 'bar' },
       ts: 0,
       seq: 2,
     });
@@ -106,7 +111,7 @@ describe("WsClient — resume bookkeeping", () => {
     expect(ws2.sent).toHaveLength(1);
     expect(ws2.sent[0]).toMatchObject({
       type: WsEventType.AUTH_RESUME,
-      payload: { token: "tok", sessionId: "sess-1", lastSeq: 2 },
+      payload: { token: 'tok', sessionId: 'sess-1', lastSeq: 2 },
     });
     c.disconnect();
   });
@@ -116,10 +121,10 @@ describe("WsClient — resume bookkeeping", () => {
 // auth.token_issued
 // ---------------------------------------------------------------------------
 
-describe("WsClient — auth.token_issued", () => {
-  it("swaps the in-memory token and fires onTokenRefreshed", () => {
+describe('WsClient — auth.token_issued', () => {
+  it('swaps the in-memory token and fires onTokenRefreshed', () => {
     const onTokenRefreshed = vi.fn();
-    const c = newClient({ authProtocol: true, token: "old", onTokenRefreshed });
+    const c = newClient({ authProtocol: true, token: 'old', onTokenRefreshed });
     c.connect();
     const ws1 = handle.getLast();
     ws1.triggerOpen();
@@ -127,22 +132,22 @@ describe("WsClient — auth.token_issued", () => {
 
     ws1.triggerMessage({
       type: WsEventType.AUTH_TOKEN_ISSUED,
-      payload: { token: "new-token", expiresAt: 1234567 },
+      payload: { token: 'new-token', expiresAt: 1234567 },
       ts: 0,
       seq: 1,
     });
 
     expect(onTokenRefreshed).toHaveBeenCalledTimes(1);
-    expect(onTokenRefreshed).toHaveBeenCalledWith("new-token", 1234567);
+    expect(onTokenRefreshed).toHaveBeenCalledWith('new-token', 1234567);
     // The next reconnect URL must use the rotated token. Force a reconnect.
     ws1.triggerServerClose();
     vi.runAllTimers();
     const ws2 = handle.getLast();
-    expect(ws2.url).toContain("token=new-token");
+    expect(ws2.url).toContain('token=new-token');
     c.disconnect();
   });
 
-  it("does not bubble auth.token_issued to ordinary listeners", () => {
+  it('does not bubble auth.token_issued to ordinary listeners', () => {
     const c = newClient({ authProtocol: true });
     const handler = vi.fn();
     c.on(WsEventType.AUTH_TOKEN_ISSUED, handler);
@@ -150,7 +155,7 @@ describe("WsClient — auth.token_issued", () => {
     handle.getLast().triggerOpen();
     handle.getLast().triggerMessage({
       type: WsEventType.AUTH_TOKEN_ISSUED,
-      payload: { token: "x", expiresAt: 0 },
+      payload: { token: 'x', expiresAt: 0 },
       ts: 0,
       seq: 1,
     });
@@ -163,8 +168,8 @@ describe("WsClient — auth.token_issued", () => {
 // auth.revoked
 // ---------------------------------------------------------------------------
 
-describe("WsClient — auth.revoked", () => {
-  it("fires onRevoked and disables further reconnect attempts", () => {
+describe('WsClient — auth.revoked', () => {
+  it('fires onRevoked and disables further reconnect attempts', () => {
     const onRevoked = vi.fn();
     const c = newClient({ authProtocol: true, onRevoked });
     c.connect();
@@ -174,11 +179,11 @@ describe("WsClient — auth.revoked", () => {
 
     ws1.triggerMessage({
       type: WsEventType.AUTH_REVOKED,
-      payload: { code: "banned", reason: "admin ban" },
+      payload: { code: 'banned', reason: 'admin ban' },
       ts: 0,
       seq: 1,
     });
-    expect(onRevoked).toHaveBeenCalledWith("banned", "admin ban");
+    expect(onRevoked).toHaveBeenCalledWith('banned', 'admin ban');
 
     // Server closes the socket; the client must NOT reconnect.
     ws1.triggerServerClose();
@@ -192,8 +197,8 @@ describe("WsClient — auth.revoked", () => {
 // auth.invalid_session
 // ---------------------------------------------------------------------------
 
-describe("WsClient — auth.invalid_session", () => {
-  it("resumable=true: drops sessionId so the next reconnect identifies, not resumes", () => {
+describe('WsClient — auth.invalid_session', () => {
+  it('resumable=true: drops sessionId so the next reconnect identifies, not resumes', () => {
     const c = newClient({ authProtocol: true });
     c.connect();
     const ws1 = handle.getLast();
@@ -203,14 +208,14 @@ describe("WsClient — auth.invalid_session", () => {
     // Establish sessionId first.
     ws1.triggerMessage({
       type: WsEventType.CONNECTED,
-      payload: { playerId: "p", sessionId: "sess-1", seq: 1 },
+      payload: { playerId: 'p', sessionId: 'sess-1', seq: 1 },
       ts: 0,
       seq: 1,
     });
     // Server says "your resume target is gone, but you're still valid".
     ws1.triggerMessage({
       type: WsEventType.AUTH_INVALID_SESSION,
-      payload: { resumable: true, reason: "buffer expired" },
+      payload: { resumable: true, reason: 'buffer expired' },
       ts: 0,
       seq: 2,
     });
@@ -226,7 +231,7 @@ describe("WsClient — auth.invalid_session", () => {
     c.disconnect();
   });
 
-  it("resumable=false: fires onUnauthorized and disables reconnect", () => {
+  it('resumable=false: fires onUnauthorized and disables reconnect', () => {
     const onUnauthorized = vi.fn();
     const c = newClient({ authProtocol: true, onUnauthorized });
     c.connect();
@@ -236,11 +241,11 @@ describe("WsClient — auth.invalid_session", () => {
 
     ws1.triggerMessage({
       type: WsEventType.AUTH_INVALID_SESSION,
-      payload: { resumable: false, reason: "user fully unauthorized" },
+      payload: { resumable: false, reason: 'user fully unauthorized' },
       ts: 0,
       seq: 1,
     });
-    expect(onUnauthorized).toHaveBeenCalledWith("user fully unauthorized");
+    expect(onUnauthorized).toHaveBeenCalledWith('user fully unauthorized');
 
     ws1.triggerServerClose();
     vi.runAllTimers();
@@ -252,29 +257,29 @@ describe("WsClient — auth.invalid_session", () => {
 // refreshToken()
 // ---------------------------------------------------------------------------
 
-describe("WsClient — refreshToken()", () => {
-  it("sends auth.refresh with the supplied refresh token", () => {
+describe('WsClient — refreshToken()', () => {
+  it('sends auth.refresh with the supplied refresh token', () => {
     const c = newClient({ authProtocol: true });
     c.connect();
     const ws1 = handle.getLast();
     ws1.triggerOpen();
     ws1.sent.length = 0;
 
-    c.refreshToken("refresh-tok-xyz");
+    c.refreshToken('refresh-tok-xyz');
 
     expect(ws1.sent).toHaveLength(1);
     expect(ws1.sent[0]).toMatchObject({
       type: WsEventType.AUTH_REFRESH,
-      payload: { token: "refresh-tok-xyz" },
+      payload: { token: 'refresh-tok-xyz' },
     });
     c.disconnect();
   });
 
-  it("throws when authProtocol is false", () => {
+  it('throws when authProtocol is false', () => {
     const c = newClient({ authProtocol: false });
     c.connect();
     handle.getLast().triggerOpen();
-    expect(() => c.refreshToken("x")).toThrow(/authProtocol: true/);
+    expect(() => c.refreshToken('x')).toThrow(/authProtocol: true/);
     c.disconnect();
   });
 });
@@ -283,22 +288,85 @@ describe("WsClient — refreshToken()", () => {
 // Sanity: a non-PR-9 incoming envelope still reaches its listener
 // ---------------------------------------------------------------------------
 
-describe("WsClient — regression: ordinary events still emit", () => {
-  it("a non-auth envelope is delivered to subscribed listeners", () => {
+describe('WsClient — regression: ordinary events still emit', () => {
+  it('a non-auth envelope is delivered to subscribed listeners', () => {
     const c = newClient({ authProtocol: true });
     const handler = vi.fn();
-    c.on("game:state" as never, handler);
+    c.on('game:state' as never, handler);
     c.connect();
     handle.getLast().triggerOpen();
     handle.getLast().triggerMessage({
-      type: "game:state",
-      payload: { foo: "bar" },
+      type: 'game:state',
+      payload: { foo: 'bar' },
       ts: 0,
       seq: 1,
     });
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith({ foo: "bar" }, 1);
+    expect(handler).toHaveBeenCalledWith({ foo: 'bar' }, 1);
     c.disconnect();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generic server error frames
+// ---------------------------------------------------------------------------
+
+describe('WsClient — server error frames', () => {
+  it('routes recoverable error frames to onServerError without ordinary emit', () => {
+    const onServerError = vi.fn();
+    const handler = vi.fn();
+    const c = newClient({ authProtocol: true, onServerError });
+    c.on(WsEventType.ERROR, handler);
+    c.connect();
+    const ws1 = handle.getLast();
+    ws1.triggerOpen();
+
+    const payload = {
+      code: 4003,
+      app_code: 'SESSION_INBOX_FULL',
+      message: '요청이 많아 잠시 후 다시 시도해주세요.',
+      severity: 'medium',
+      retryable: true,
+      fatal: false,
+    };
+    ws1.triggerMessage({
+      type: WsEventType.ERROR,
+      payload,
+      ts: 0,
+      seq: 1,
+    });
+
+    expect(onServerError).toHaveBeenCalledWith(payload);
+    expect(handler).not.toHaveBeenCalled();
+    c.disconnect();
+  });
+
+  it('fatal error frames disable reconnect', () => {
+    const onServerError = vi.fn();
+    const c = newClient({ authProtocol: true, onServerError });
+    c.connect();
+    const ws1 = handle.getLast();
+    ws1.triggerOpen();
+
+    ws1.triggerMessage({
+      type: WsEventType.ERROR,
+      payload: {
+        code: 4001,
+        app_code: 'UNAUTHORIZED',
+        message: '인증이 필요합니다.',
+        severity: 'high',
+        retryable: false,
+        fatal: true,
+      },
+      ts: 0,
+      seq: 1,
+    });
+    ws1.triggerServerClose();
+    vi.runAllTimers();
+
+    expect(onServerError).toHaveBeenCalledTimes(1);
+    expect(handle.getAll()).toHaveLength(1);
+    expect(c.connectionState).toBe(WsClientState.DISCONNECTED);
   });
 });
 

--- a/packages/ws-client/src/client.ts
+++ b/packages/ws-client/src/client.ts
@@ -9,14 +9,15 @@ import {
   type AuthTokenIssuedPayload,
   type AuthInvalidSessionPayload,
   type ConnectedPayload,
-} from "@mmp/shared";
-import { ReconnectManager } from "./reconnect.js";
+  type ErrorPayload,
+} from '@mmp/shared';
+import { ReconnectManager } from './reconnect.js';
 import {
   WsClientState,
   type WsClientOptions,
   type WsEventHandler,
   type WsStateChangeHandler,
-} from "./types.js";
+} from './types.js';
 
 /**
  * WebSocket client with heartbeat + reconnect + typed event dispatch.
@@ -42,10 +43,7 @@ export class WsClient {
   private ws: WebSocket | null = null;
   private seq = 0;
   private state: WsClientState = WsClientState.IDLE;
-  private readonly options: Required<
-    Pick<WsClientOptions, "heartbeatInterval">
-  > &
-    WsClientOptions;
+  private readonly options: Required<Pick<WsClientOptions, 'heartbeatInterval'>> & WsClientOptions;
   private readonly reconnect: ReconnectManager;
   private readonly listeners = new Map<string, Set<WsEventHandler>>();
   private readonly stateListeners = new Set<WsStateChangeHandler>();
@@ -73,10 +71,7 @@ export class WsClient {
 
   /** Connect to the WebSocket server. */
   connect(): void {
-    if (
-      this.state === WsClientState.CONNECTED ||
-      this.state === WsClientState.CONNECTING
-    ) {
+    if (this.state === WsClientState.CONNECTED || this.state === WsClientState.CONNECTING) {
       return;
     }
     this.setState(WsClientState.CONNECTING);
@@ -93,7 +88,7 @@ export class WsClient {
     this.stopHeartbeat();
     if (this.ws) {
       this.ws.onclose = null; // suppress reconnect on intentional close
-      this.ws.close(1000, "client disconnect");
+      this.ws.close(1000, 'client disconnect');
       this.ws = null;
     }
     this.setState(WsClientState.DISCONNECTED);
@@ -122,7 +117,7 @@ export class WsClient {
    */
   refreshToken(refreshToken: string): void {
     if (!this.options.authProtocol) {
-      throw new Error("refreshToken requires authProtocol: true");
+      throw new Error('refreshToken requires authProtocol: true');
     }
     const payload: AuthRefreshPayload = { token: refreshToken };
     this.send(Events.AUTH_REFRESH, payload);
@@ -206,7 +201,7 @@ export class WsClient {
    */
   private maybeSendAuthGreeting(): void {
     if (!this.options.authProtocol) return;
-    const token = this.currentToken ?? "";
+    const token = this.currentToken ?? '';
     if (this.sessionId !== undefined && this.lastSeq !== undefined) {
       const payload: AuthResumePayload = {
         token,
@@ -238,19 +233,16 @@ export class WsClient {
       message = JSON.parse(raw) as WsMessage;
     } catch (err) {
       if (this.options.onParseError) {
-        this.options.onParseError(
-          err instanceof Error ? err : new Error(String(err)),
-          raw,
-        );
+        this.options.onParseError(err instanceof Error ? err : new Error(String(err)), raw);
       } else {
-        console.warn("[WsClient] Failed to parse message:", err);
+        console.warn('[WsClient] Failed to parse message:', err);
       }
       return;
     }
 
     // Track lastSeq for the next resume attempt — every server-stamped
     // envelope carries a monotonically increasing seq.
-    if (typeof message.seq === "number") {
+    if (typeof message.seq === 'number') {
       this.lastSeq = message.seq;
     }
 
@@ -266,6 +258,15 @@ export class WsClient {
     // PR-9 auth.* dispatch — these never reach the regular emit path
     // because consumers register dedicated callbacks instead.
     if (this.handleAuthFrame(message)) {
+      return;
+    }
+
+    if (message.type === Events.ERROR) {
+      const payload = message.payload as ErrorPayload;
+      if (payload.fatal) {
+        this.reconnect.disable();
+      }
+      this.options.onServerError?.(payload);
       return;
     }
 
@@ -327,7 +328,7 @@ function buildUrl(url: string, token: string | undefined): string {
   if (!token) return url;
   try {
     const u = new URL(url);
-    if (!u.searchParams.has("token")) u.searchParams.set("token", token);
+    if (!u.searchParams.has('token')) u.searchParams.set('token', token);
     return u.toString();
   } catch {
     // Relative or otherwise non-parseable URL — fall back to raw.

--- a/packages/ws-client/src/types.ts
+++ b/packages/ws-client/src/types.ts
@@ -1,4 +1,5 @@
-import type { WsEventType } from "@mmp/shared";
+import type { WsEventType } from '@mmp/shared';
+import type { ErrorPayload } from '@mmp/shared';
 
 export interface WsClientOptions {
   /** WebSocket server URL (ws:// or wss://) */
@@ -52,6 +53,11 @@ export interface WsClientOptions {
    * and falls back to a fresh `auth.identify` on the next connection.
    */
   onUnauthorized?: (reason: string) => void;
+  /**
+   * Called when the server sends the generic `error` frame. Fatal errors
+   * disable reconnect before this callback is invoked.
+   */
+  onServerError?: (payload: ErrorPayload) => void;
 }
 
 export interface ReconnectOptions {
@@ -66,15 +72,14 @@ export interface ReconnectOptions {
 }
 
 export const WsClientState = {
-  IDLE: "idle",
-  CONNECTING: "connecting",
-  CONNECTED: "connected",
-  RECONNECTING: "reconnecting",
-  DISCONNECTED: "disconnected",
+  IDLE: 'idle',
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+  RECONNECTING: 'reconnecting',
+  DISCONNECTED: 'disconnected',
 } as const;
 
-export type WsClientState =
-  (typeof WsClientState)[keyof typeof WsClientState];
+export type WsClientState = (typeof WsClientState)[keyof typeof WsClientState];
 
 export type WsEventHandler<T = unknown> = (payload: T, seq: number) => void;
 export type WsStateChangeHandler = (state: WsClientState) => void;
@@ -85,6 +90,6 @@ export interface WsClientEvents {
 
 /** Internal listener record. */
 export interface Listener {
-  type: WsEventType | "state:change";
+  type: WsEventType | 'state:change';
   handler: WsEventHandler | WsStateChangeHandler;
 }


### PR DESCRIPTION
## 요약
- WS `error` payload를 ProblemDetail-lite 형태로 확장해 `app_code`, `severity`, `retryable`, `user_action`, `request_id/correlation_id`, `fatal`을 전달합니다.
- 세션에 참가한 클라이언트도 `auth.*`/`ping` 복구 프레임은 session actor에 삼켜지지 않고 router로 먼저 전달되도록 보장합니다.
- reading WS AppError는 내부 `detail` 대신 registry의 사용자 메시지를 보내고, 프론트 media/editor 오류 표시는 `ApiHttpError` 기반 사용자 메시지 + 짧은 Ref로 정리합니다.

## 이슈
Closes #283
Refs #271

## 검증
- `go test ./internal/ws ./internal/apperror`
- `go test ./internal/domain/editor ./internal/domain/room`
- `pnpm --filter @mmp/shared build`
- `pnpm --filter @mmp/shared exec tsc --noEmit`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/ws-client exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx src/stores/__tests__/connectionStore.test.ts`
- `pnpm --filter @mmp/web exec vitest run src/lib/show-error-toast.test.ts src/lib/error-recovery.test.ts src/lib/api-error.test.ts`
- `pnpm --filter @mmp/ws-client exec vitest run src/client.test.ts`
- `git diff --check`

## CI 운영 메모
- PR 생성 시 `ready-for-ci` 라벨은 붙이지 않습니다.
- 코드 변경이므로 CodeRabbit 확인 후 `scripts/mmp-pr-ci-scope.sh` 결과가 `full-ci`이면 guard로 `ready-for-ci`를 적용합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 오류 응답에 복구 메타데이터(앱 코드, 심각도, 재시도 가능성, 사용자 조치, 요청/상관 ID, 치명 플래그) 추가
  * 클라이언트의 onServerError 콜백 및 최신 WS 오류 상태(lastWsError) 노출/관리 추가
  * 에러 표시 유틸(getDisplayErrorMessage) 및 미디어 업로드에 키보드 접근성 추가

* **버그 수정**
  * 인증/복구 관련 메시지 라우팅 및 세션 포워딩 동작 개선
  * 인증 실패 시 치명 오류 처리로 연결 종료 동작 일관화
  * 치명적 오류 수신 시 재연결 차단 동작 정비

* **테스트**
  * 서버·클라이언트·메시지·업로드 관련 단위 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->