### PR TITLE
feat(editor): #375 제작자 안전 고급/미디어 UI 정리

### DIFF
--- a/apps/web/src/features/editor/components/AdvancedTab.tsx
+++ b/apps/web/src/features/editor/components/AdvancedTab.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
-import { CheckCircle2, XCircle, AlertTriangle, RefreshCw } from 'lucide-react';
-import { Button, Badge } from '@/shared/components/ui';
+import { CheckCircle2, XCircle, AlertTriangle, RefreshCw, ShieldCheck } from 'lucide-react';
+import { Button } from '@/shared/components/ui';
 import type { EditorThemeResponse } from '@/features/editor/api';
-import { useUpdateConfigJson, useValidateTheme } from '@/features/editor/api';
+import { useValidateTheme } from '@/features/editor/api';
 import { useEditorUI } from '@/features/editor/stores/editorUIStore';
 import type { EditorTab } from '@/features/editor/constants';
 import { validateGameDesign } from '@/features/editor/validation';
@@ -24,14 +24,6 @@ interface ValidationItem {
   severity: ValidationSeverity;
   message: string;
   tab?: EditorTab;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function serialize(value: Record<string, unknown> | null): string {
-  return JSON.stringify(value ?? {}, null, 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -77,42 +69,10 @@ function ValidationRow({ item, onNavigate }: ValidationRowProps) {
 // ---------------------------------------------------------------------------
 
 export function AdvancedTab({ themeId, theme }: AdvancedTabProps) {
-  const serverText = serialize(theme.config_json);
-  const [text, setText] = useState(serverText);
-  const [parseError, setParseError] = useState<string | null>(null);
   const [validationItems, setValidationItems] = useState<ValidationItem[] | null>(null);
 
-  const updateConfig = useUpdateConfigJson(themeId);
   const validateTheme = useValidateTheme(themeId);
   const { setActiveTab } = useEditorUI();
-
-  useEffect(() => {
-    setText(serverText);
-    setParseError(null);
-  }, [serverText]);
-
-  const isDirty = text !== serverText;
-  const lines = text.split('\n');
-
-  const handleSave = () => {
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(text) as Record<string, unknown>;
-    } catch {
-      setParseError('유효하지 않은 JSON 형식입니다');
-      return;
-    }
-    setParseError(null);
-    updateConfig.mutate(parsed, {
-      onSuccess: () => toast.success('설정이 저장되었습니다'),
-      onError: () => toast.error('설정 저장에 실패했습니다'),
-    });
-  };
-
-  const handleReset = () => {
-    setText(serverText);
-    setParseError(null);
-  };
 
   const handleValidate = () => {
     validateTheme.mutate(undefined, {
@@ -152,73 +112,48 @@ export function AdvancedTab({ themeId, theme }: AdvancedTabProps) {
   };
 
   return (
-    <div className="flex h-full flex-col lg:flex-row">
-      {/* ── JSON Editor ── */}
-      <div className="flex flex-1 flex-col overflow-hidden border-b border-slate-800 lg:border-b-0 lg:border-r">
-        {/* Editor header */}
-        <div className="flex items-center justify-between border-b border-slate-800 bg-slate-900 px-4 py-2">
-          <div className="flex items-center gap-3">
-            <span className="text-xs font-mono font-medium text-slate-400">config_json</span>
-            {isDirty && <Badge variant="warning">변경사항 있음</Badge>}
+    <div className="grid min-h-full gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_18rem]">
+      <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+        <div className="flex items-start gap-3">
+          <div className="rounded-lg bg-emerald-500/10 p-2 text-emerald-300">
+            <ShieldCheck className="h-5 w-5" />
           </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleReset}
-              disabled={!isDirty || updateConfig.isPending}
-            >
-              초기화
-            </Button>
-            <Button
-              size="sm"
-              onClick={handleSave}
-              isLoading={updateConfig.isPending}
-              disabled={!isDirty}
-            >
-              저장
-            </Button>
+          <div className="min-w-0">
+            <h2 className="text-base font-semibold text-slate-100">제작 검수</h2>
+            <p className="mt-1 text-sm leading-6 text-slate-400">
+              현재 제작 흐름에서 누락된 단서, 등장인물, 장면 연결을 확인합니다.
+              내부 저장 구조는 기본 제작 화면에서 직접 편집하지 않습니다.
+            </p>
           </div>
         </div>
 
-        {/* Editor with line numbers */}
-        <div className="relative flex flex-1 overflow-auto font-mono">
-          {/* Line numbers */}
-          <div className="sticky left-0 z-10 w-10 shrink-0 select-none overflow-hidden border-r border-slate-800 bg-slate-950 py-3">
-            {lines.map((_, i) => (
-              <div
-                key={i}
-                className="text-right pr-2 text-[11px] leading-5 text-slate-700"
-              >
-                {i + 1}
-              </div>
-            ))}
-          </div>
-
-          {/* Textarea */}
-          <textarea
-            value={text}
-            onChange={(e) => {
-              setText(e.target.value);
-              if (parseError) setParseError(null);
-            }}
-            spellCheck={false}
-            className="flex-1 bg-slate-950 py-3 pl-3 pr-4 font-mono text-sm leading-5 text-slate-300 caret-amber-500 selection:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-inset resize-none min-h-[400px]"
-          />
+        <div className="mt-4 rounded-lg border border-slate-800 bg-slate-900/50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-widest text-slate-500">
+            검수 기준
+          </p>
+          <ul className="mt-3 space-y-2 text-sm text-slate-300">
+            <li className="flex gap-2">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+              단서와 등장인물이 서로 참조 가능한 상태인지 확인합니다.
+            </li>
+            <li className="flex gap-2">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+              장면 흐름과 조건 분기가 끊기지 않았는지 확인합니다.
+            </li>
+            <li className="flex gap-2">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+              저장된 제작 규칙을 사용자에게 필요한 말로 요약합니다.
+            </li>
+          </ul>
         </div>
-
-        {/* Parse error */}
-        {parseError && (
-          <div className="border-t border-slate-800 bg-red-500/5 px-4 py-2">
-            <p className="text-xs text-red-400">{parseError}</p>
-          </div>
-        )}
       </div>
 
       {/* ── Validation Panel ── */}
-      <div className="w-full lg:w-72 shrink-0 flex flex-col bg-slate-950">
-        <div className="border-b border-slate-800 bg-slate-900 px-4 py-2">
-          <span className="text-xs font-mono font-medium text-slate-400">검증 결과</span>
+      <div className="flex min-h-[18rem] flex-col rounded-lg border border-slate-800 bg-slate-950">
+        <div className="border-b border-slate-800 bg-slate-900 px-4 py-3">
+          <span className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+            검증 결과
+          </span>
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 py-3">
@@ -233,8 +168,8 @@ export function AdvancedTab({ themeId, theme }: AdvancedTabProps) {
               ))}
             </div>
           ) : (
-            <p className="text-xs text-slate-700 font-mono">
-              검증 버튼을 클릭하세요
+            <p className="text-sm leading-6 text-slate-500">
+              아직 검증을 실행하지 않았습니다. 아래 버튼으로 현재 제작 상태를 확인하세요.
             </p>
           )}
         </div>

--- a/apps/web/src/features/editor/components/__tests__/AdvancedTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/AdvancedTab.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mutateMock, setActiveTabMock } = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  setActiveTabMock: vi.fn(),
+}));
+
+vi.mock('@/features/editor/api', () => ({
+  useValidateTheme: () => ({
+    mutate: mutateMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/features/editor/stores/editorUIStore', () => ({
+  useEditorUI: () => ({
+    setActiveTab: setActiveTabMock,
+  }),
+}));
+
+vi.mock('@/features/editor/validation', () => ({
+  validateGameDesign: () => [
+    { type: 'warning', category: '단서', message: '사용되지 않은 단서가 있습니다.' },
+  ],
+}));
+
+import { AdvancedTab } from '../AdvancedTab';
+import type { EditorThemeResponse } from '@/features/editor/api';
+
+const theme = {
+  id: 'theme-1',
+  title: '테스트 테마',
+  slug: 'test-theme',
+  description: '',
+  cover_image: null,
+  min_players: 4,
+  max_players: 6,
+  duration_min: 90,
+  price: 0,
+  status: 'DRAFT',
+  config_json: { modules: ['deck_investigation'], secretInternalKey: 'hidden' },
+  version: 1,
+  created_at: '2026-05-05T00:00:00Z',
+} satisfies EditorThemeResponse;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('AdvancedTab', () => {
+  it('제작자 기본 화면에서 raw config_json 편집기를 노출하지 않는다', () => {
+    render(<AdvancedTab themeId="theme-1" theme={theme} />);
+
+    expect(screen.getByText('제작 검수')).toBeDefined();
+    expect(screen.queryByText('config_json')).toBeNull();
+    expect(screen.queryByDisplayValue(/secretInternalKey/)).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('button', { name: '저장' })).toBeNull();
+  });
+
+  it('검증 결과를 제작자용 문구로 표시한다', () => {
+    mutateMock.mockImplementation((_vars, options) => {
+      options.onSuccess({
+        errors: ['등장인물을 1명 이상 추가하세요.'],
+        stats: { clues: 0, characters: 0 },
+      });
+    });
+
+    render(<AdvancedTab themeId="theme-1" theme={theme} />);
+    fireEvent.click(screen.getByRole('button', { name: '지금 검증' }));
+
+    expect(screen.getByText('등장인물을 1명 이상 추가하세요.')).toBeDefined();
+    expect(screen.getByText('[단서] 사용되지 않은 단서가 있습니다.')).toBeDefined();
+  });
+});

--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -165,13 +165,14 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
           </label>
         </div>
 
-        {/* Read-only metadata */}
-        <div className="rounded-sm border border-slate-800 bg-slate-950/50 px-3 py-2 text-[10px] font-mono text-slate-500">
-          <div>type: {media.type}</div>
-          <div>source: {media.source_type}</div>
-          {media.mime_type && <div>mime: {media.mime_type}</div>}
-          {media.file_size != null && <div>size: {media.file_size} B</div>}
-        </div>
+        <dl className="grid gap-2 rounded-sm border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs">
+          <MediaInfoRow label="분류" value={mediaTypeLabel(media.type)} />
+          <MediaInfoRow label="출처" value={mediaSourceLabel(media.source_type)} />
+          {media.mime_type && <MediaInfoRow label="파일 형식" value={mimeTypeLabel(media.mime_type)} />}
+          {media.file_size != null && (
+            <MediaInfoRow label="파일 크기" value={formatFileSize(media.file_size)} />
+          )}
+        </dl>
 
         {referenceWarning && (
           <div
@@ -224,6 +225,66 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
       </div>
     </div>
   );
+}
+
+function MediaInfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="text-right text-slate-300">{value}</dd>
+    </div>
+  );
+}
+
+function mediaTypeLabel(type: MediaResponse['type']): string {
+  switch (type) {
+    case 'BGM':
+      return '배경음악';
+    case 'SFX':
+      return '효과음';
+    case 'VOICE':
+      return '음성';
+    case 'IMAGE':
+      return '이미지';
+    case 'VIDEO':
+      return '영상';
+    case 'DOCUMENT':
+      return '문서';
+    default:
+      return '미디어';
+  }
+}
+
+function mediaSourceLabel(source: MediaResponse['source_type']): string {
+  switch (source) {
+    case 'FILE':
+      return '직접 업로드';
+    case 'YOUTUBE':
+      return 'YouTube';
+    default:
+      return '등록된 리소스';
+  }
+}
+
+function mimeTypeLabel(mimeType: string): string {
+  const labels: Record<string, string> = {
+    'audio/mpeg': 'MP3',
+    'audio/wav': 'WAV',
+    'audio/ogg': 'OGG',
+    'image/jpeg': 'JPEG',
+    'image/png': 'PNG',
+    'image/webp': 'WEBP',
+    'video/mp4': 'MP4',
+    'video/webm': 'WEBM',
+  };
+  return labels[mimeType.toLowerCase()] ?? '지원 파일';
+}
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '알 수 없음';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 function mediaReferenceTypeLabel(type: string): string {

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -210,6 +210,18 @@ describe('MediaTab', () => {
     expect(screen.getByText('미디어 상세')).toBeDefined();
     // Editable name input pre-filled
     expect(screen.getByDisplayValue('오프닝 BGM')).toBeDefined();
+    expect(screen.getByText('분류')).toBeDefined();
+    expect(screen.getByText('배경음악')).toBeDefined();
+    expect(screen.getByText('출처')).toBeDefined();
+    expect(screen.getByText('직접 업로드')).toBeDefined();
+    expect(screen.getByText('파일 형식')).toBeDefined();
+    expect(screen.getByText('MP3')).toBeDefined();
+    expect(screen.getByText('파일 크기')).toBeDefined();
+    expect(screen.getByText('1.2 MB')).toBeDefined();
+    expect(screen.queryByText('type: BGM')).toBeNull();
+    expect(screen.queryByText('source: FILE')).toBeNull();
+    expect(screen.queryByText('mime: audio/mpeg')).toBeNull();
+    expect(screen.queryByText('size: 1234567 B')).toBeNull();
   });
 
   it('상세 닫기 버튼이 선택을 해제한다', () => {


### PR DESCRIPTION
## 요약
- 고급 탭의 기본 제작 화면에서 raw `config_json` 편집기를 제거하고 제작 검수 중심 UI로 정리했습니다.
- 미디어 상세 패널의 `type/source/mime/size` raw 값을 제작자용 한국어 라벨과 파일 크기 표현으로 바꿨습니다.
- 고급 탭과 미디어 상세 패널의 raw 값 비노출 회귀 테스트를 추가했습니다.

## 검증
- `pnpm install --frozen-lockfile` (worktree 의존성 링크, reused 704/downloaded 0)
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/AdvancedTab.test.tsx src/features/editor/components/media/__tests__/MediaTab.test.tsx`
- `git diff --check`

Closes #375
Refs #334
Refs #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 고급 탭의 검증 인터페이스가 간소화되었습니다.
  * 미디어 상세 정보 표시가 개선되었습니다. 파일 크기가 바이트 단위가 아닌 읽기 쉬운 형식(MB 등)으로 표시되며, 메타데이터 레이블이 지역화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->