### PR TITLE
test(editor): #376 직접 URL·모바일 수용 게이트 고정

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -20,8 +20,8 @@
  *  8. 장소 탭 locations[].clueIds (PR-6)
  *  9. 템플릿 탭 GET /api/v1/templates (PR-1)
  */
-import AxeBuilder from "@axe-core/playwright";
-import { test, expect, type Page, type Request } from "@playwright/test";
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect, type Page, type Request } from '@playwright/test';
 import {
   BASE,
   THEME_ID,
@@ -31,13 +31,13 @@ import {
   mockCommonApis,
   loginAsE2EUser,
   type MockState,
-} from "./helpers/editor-golden-path-fixtures";
+} from './helpers/editor-golden-path-fixtures';
 
 /** 라우트 밖에서 한 번 더 PUT 방어 — 프론트가 실수로 PUT 을 쓰면 즉시 fail */
 async function installFlowPutGuard(page: Page): Promise<{ putSeen: string[] }> {
   const putSeen: string[] = [];
-  page.on("request", (req: Request) => {
-    if (req.method() === "PUT" && req.url().includes("/flow/nodes/")) {
+  page.on('request', (req: Request) => {
+    if (req.method() === 'PUT' && req.url().includes('/flow/nodes/')) {
       putSeen.push(req.url());
     }
   });
@@ -46,12 +46,12 @@ async function installFlowPutGuard(page: Page): Promise<{ putSeen: string[] }> {
 
 /** 탭 라벨이 렌더되어있으면 클릭, 아니면 soft-skip */
 async function tryClickTab(page: Page, label: RegExp): Promise<boolean> {
-  const tab = page.getByRole("tab", { name: label }).first();
+  const tab = page.getByRole('tab', { name: label }).first();
   if (await tab.isVisible({ timeout: 1_000 }).catch(() => false)) {
     await tab.click().catch(() => {});
     return true;
   }
-  const link = page.getByRole("link", { name: label }).first();
+  const link = page.getByRole('link', { name: label }).first();
   if (await link.isVisible({ timeout: 500 }).catch(() => false)) {
     await link.click().catch(() => {});
     return true;
@@ -59,7 +59,16 @@ async function tryClickTab(page: Page, label: RegExp): Promise<boolean> {
   return false;
 }
 
-test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", () => {
+async function expectNoPageLevelHorizontalOverflow(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    viewportWidth: document.documentElement.clientWidth,
+    pageScrollWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+  }));
+
+  expect(metrics.pageScrollWidth).toBeLessThanOrEqual(metrics.viewportWidth + 2);
+}
+
+test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', () => {
   let state: MockState;
   // Phase 18.5 M4 — 전역 PUT 0회 assertion. 어떤 시나리오에서도 /flow/nodes/ 로 향하는
   // PUT 이 있으면 회귀 (CRIT-1 재발) 이므로 테스트가 실패한다.
@@ -68,8 +77,8 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
   test.beforeEach(async ({ page }) => {
     state = freshState();
     globalPutSeen = [];
-    page.on("request", (req) => {
-      if (req.method() === "PUT" && req.url().includes("/flow/nodes/")) {
+    page.on('request', (req) => {
+      if (req.method() === 'PUT' && req.url().includes('/flow/nodes/')) {
         globalPutSeen.push(req.url());
       }
     });
@@ -81,136 +90,202 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     expect(globalPutSeen).toEqual([]);
   });
 
-  test("[1] 에디터 대시보드 진입 + 기존 테마 노출", async ({ page }) => {
+  test('[1] 에디터 대시보드 진입 + 기존 테마 노출', async ({ page }) => {
     await page.goto(`${BASE}/editor`);
-    await expect(page.getByRole("heading", { name: /에디터|테마/ }).first()).toBeVisible({
+    await expect(page.getByRole('heading', { name: /에디터|테마/ }).first()).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.locator("body")).toContainText("E2E 골든패스");
+    await expect(page.locator('body')).toContainText('E2E 골든패스');
   });
 
-  test("[2A] 단서 탭은 목록과 상세를 함께 보여준다", async ({ page }) => {
+  test('[2A] 단서 탭은 목록과 상세를 함께 보여준다', async ({ page }) => {
     await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
 
-    await expect(page.getByLabel("단서 목록")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByLabel("단서 상세 영역")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("첫 단서").first()).toBeVisible();
-    await expect(page.getByText("정보 공개하기")).toBeVisible();
-    await expect(page.getByText("사용하면 내 단서함에서 사라짐")).toBeVisible();
-    await expect(page.getByText("이 단서가 쓰이는 곳")).toBeVisible();
+    await expect(page.getByLabel('단서 목록')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('첫 단서').first()).toBeVisible();
+    await expect(page.getByText('정보 공개하기')).toBeVisible();
+    await expect(page.getByText('사용하면 내 단서함에서 사라짐')).toBeVisible();
+    await expect(page.getByText('이 단서가 쓰이는 곳')).toBeVisible();
   });
 
-  test("[2C] 단서 효과 제작 UI는 grant_clue 계약으로 config 를 저장한다", async ({ page }) => {
+  test('[2C] 단서 효과 제작 UI는 grant_clue 계약으로 config 를 저장한다', async ({ page }) => {
     state.conflictCountdown = 0;
 
     await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
-    await expect(page.getByLabel("단서 상세 영역")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("게임 중 사용 효과")).toBeVisible();
-    await expect(page.getByText("itemEffects")).toHaveCount(0);
-    await expect(page.getByText("grant_clue")).toHaveCount(0);
+    await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('게임 중 사용 효과')).toBeVisible();
+    await expect(page.getByText('itemEffects')).toHaveCount(0);
+    await expect(page.getByText('grant_clue')).toHaveCount(0);
 
-    await page.getByRole("button", { name: "새 단서 지급" }).click();
-    await page.getByLabel("지급할 단서 검색").fill("금고");
-    await page.getByRole("button", { name: "금고 비밀번호", exact: true }).click();
+    await page.getByRole('button', { name: '새 단서 지급' }).click();
+    await page.getByLabel('지급할 단서 검색').fill('금고');
+    await page.getByRole('button', { name: '금고 비밀번호', exact: true }).click();
     await page.getByLabel(/사용하면 내 단서함에서 사라짐/).check();
-    await page.getByRole("button", { name: "효과 저장" }).click();
+    await page.getByRole('button', { name: '효과 저장' }).click();
 
     await expect.poll(() => state.configPutCalls).toBeGreaterThanOrEqual(1);
-    const modules = state.configJson.modules as Record<string, { config?: Record<string, unknown> }>;
+    const modules = state.configJson.modules as Record<
+      string,
+      { config?: Record<string, unknown> }
+    >;
     const clueInteraction = modules.clue_interaction?.config as
       | { itemEffects?: Record<string, Record<string, unknown>> }
       | undefined;
 
     expect(clueInteraction?.itemEffects?.[CLUE_ID]).toMatchObject({
-      effect: "grant_clue",
-      target: "self",
+      effect: 'grant_clue',
+      target: 'self',
       consume: true,
       grantClueIds: [REWARD_CLUE_ID],
     });
-    expect(JSON.stringify(state.lastConfigRequestBody)).not.toContain("module_configs");
+    expect(JSON.stringify(state.lastConfigRequestBody)).not.toContain('module_configs');
   });
 
-  test("[2B] 직접 URL은 올바른 제작 탭과 서브탭을 연다", async ({ page }) => {
+  test('[2B] 직접 URL은 올바른 제작 탭과 서브탭을 연다', async ({ page }) => {
     await page.goto(`${BASE}/editor/${THEME_ID}`);
-    await expect(page.getByRole("tab", { name: "기본정보", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '기본정보', selected: true })).toBeVisible({
       timeout: 10_000,
     });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/story`);
-    await expect(page.getByRole("tab", { name: "스토리", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '스토리', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByPlaceholder("마크다운으로 스토리를 작성하세요...")).toBeVisible();
-    await expect(page.getByText("장면별 정보 공개 설정")).toBeVisible();
-    await expect(page.getByRole("button", { name: /조사 단계/ })).toBeVisible();
+    await expect(page.getByPlaceholder('마크다운으로 스토리를 작성하세요...')).toBeVisible();
+    await expect(page.getByText('장면별 정보 공개 설정')).toBeVisible();
+    await expect(page.getByRole('button', { name: /조사 단계/ })).toBeVisible();
 
     await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
-    await expect(page.getByRole("tab", { name: "등장인물", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '등장인물', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByRole("button", { name: "제작" })).toBeVisible();
-    await expect(page.getByLabel("캐릭터 목록")).toBeVisible();
-    await expect(page.getByText("탐정 A").first()).toBeVisible();
+    await expect(page.getByRole('button', { name: '제작' })).toBeVisible();
+    await expect(page.getByLabel('캐릭터 목록')).toBeVisible();
+    await expect(page.getByText('탐정 A').first()).toBeVisible();
 
     await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
-    await expect(page.getByRole("tab", { name: "단서", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '단서', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByLabel("단서 목록")).toBeVisible();
+    await expect(page.getByLabel('단서 목록')).toBeVisible();
 
     await page.goto(`${BASE}/editor/${THEME_ID}/relations`);
-    await expect(page.getByRole("tab", { name: "단서", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '단서', selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByText(/노드를 드래그하여 연결/).first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/locations`);
-    await expect(page.getByRole("tab", { name: "게임설계", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByLabel("장소 목록")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByLabel("거실 단서 조사")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("저택 1층").first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('거실 단서 조사')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('저택 1층').first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/endings`);
-    await expect(page.getByRole("tab", { name: "게임설계", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByTestId("ending-entity-panel")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('ending-entity-panel')).toBeVisible({ timeout: 10_000 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/design/modules`);
+    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText('모듈').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('진행').first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/design/flow`);
-    await expect(page.getByRole("tab", { name: "게임설계", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("장면 흐름")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("스토리 장면 구성")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('장면 흐름')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('스토리 장면 구성')).toBeVisible({ timeout: 10_000 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/modules`);
+    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText('진행').first()).toBeVisible({ timeout: 10_000 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
+    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText('장면 흐름')).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/media`);
-    await expect(page.getByRole("tab", { name: "미디어", selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '미디어', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByLabel("미디어 목록")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('미디어 목록')).toBeVisible({ timeout: 10_000 });
   });
 
-  test("[2] 단서 이미지 업로드 경로는 /v1/editor/themes/{id}/images/upload-url (network-only)", async ({ page }) => {
+  test('[2D] 핵심 직접 URL은 모바일/데스크톱 폭에서 페이지 레벨 가로 overflow 없이 열린다', async ({
+    page,
+  }) => {
+    const viewports = [
+      { name: 'mobile', width: 390, height: 844 },
+      { name: 'desktop', width: 1440, height: 1000 },
+    ];
+    const routes = [
+      { path: '', tab: '기본정보', content: 'E2E 골든패스' },
+      { path: '/story', tab: '스토리', content: '장면별 정보 공개 설정' },
+      { path: '/characters', tab: '등장인물', content: '캐릭터 목록' },
+      { path: '/clues', tab: '단서', content: '단서 목록' },
+      { path: '/relations', tab: '단서', content: '노드를 드래그하여 연결' },
+      { path: '/design/modules', tab: '게임설계', content: '진행' },
+      { path: '/design/flow', tab: '게임설계', content: '장면 흐름' },
+      { path: '/design/locations', tab: '게임설계', content: '장소 목록' },
+      { path: '/design/endings', tab: '게임설계', content: 'ending-entity-panel' },
+      { path: '/media', tab: '미디어', content: '미디어 목록' },
+    ];
+
+    for (const viewport of viewports) {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+      for (const route of routes) {
+        await page.goto(`${BASE}/editor/${THEME_ID}${route.path}`);
+        await expect(page.getByRole('tab', { name: route.tab, selected: true })).toBeVisible({
+          timeout: 10_000,
+        });
+
+        if (route.content === 'ending-entity-panel') {
+          await expect(page.getByTestId('ending-entity-panel')).toBeVisible({ timeout: 10_000 });
+        } else if (route.content.endsWith('목록')) {
+          await expect(page.getByLabel(route.content)).toBeVisible({ timeout: 10_000 });
+        } else {
+          await expect(page.getByText(route.content).first()).toBeVisible({ timeout: 10_000 });
+        }
+
+        await expectNoPageLevelHorizontalOverflow(page);
+      }
+    }
+  });
+
+  test('[2] 단서 이미지 업로드 경로는 /v1/editor/themes/{id}/images/upload-url (network-only)', async ({
+    page,
+  }) => {
     test.info().annotations.push({
-      type: "soft-skip",
-      description: "UI 렌더 실패 시 네트워크 레벨 회귀 가드만 유지 (state counter fallback)",
+      type: 'soft-skip',
+      description: 'UI 렌더 실패 시 네트워크 레벨 회귀 가드만 유지 (state counter fallback)',
     });
     // 프론트의 단서 탭 진입 + 업로드 트리거를 UI 로 시도하고, 네트워크에서 경로 확인
     const reqPromise = page
       .waitForRequest(
         (req) =>
           req.url().includes(`/v1/editor/themes/${THEME_ID}/images/upload-url`) &&
-          req.method() === "POST",
-        { timeout: 15_000 },
+          req.method() === 'POST',
+        { timeout: 15_000 }
       )
       .catch(() => null);
 
     await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
 
     // UI: "이미지 업로드" 버튼이 있으면 클릭 (Seed ActionButton). 없으면 파일 input trigger.
-    const uploadBtn = page.getByRole("button", { name: /이미지|업로드|upload/i }).first();
+    const uploadBtn = page.getByRole('button', { name: /이미지|업로드|upload/i }).first();
     if (await uploadBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
       await uploadBtn.click().catch(() => {});
     }
@@ -219,8 +294,8 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     if (await fileInput.count().catch(() => 0)) {
       await fileInput
         .setInputFiles({
-          name: "clue.png",
-          mimeType: "image/png",
+          name: 'clue.png',
+          mimeType: 'image/png',
           buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
         })
         .catch(() => {});
@@ -229,7 +304,7 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     // 프론트가 호출하지 않았다면 마지막 안전망으로 페이지 컨텍스트에서 API 경로만 검증
     const hit = await reqPromise;
     if (hit) {
-      expect(hit.method()).toBe("POST");
+      expect(hit.method()).toBe('POST');
       expect(hit.url()).toContain(`/v1/editor/themes/${THEME_ID}/images/upload-url`);
       expect(state.imageUploadUrlCalls).toBeGreaterThanOrEqual(1);
     } else {
@@ -240,13 +315,14 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     }
   });
 
-  test("[3] 캐릭터 배정 탭 — starting_clue_ids UI 렌더/로드 확인 (network-only)", async ({ page }) => {
-    test.info().annotations.push({ type: "soft-skip", description: "tryClickTab + checkbox soft" });
+  test('[3] 캐릭터 배정 탭 — starting_clue_ids UI 렌더/로드 확인 (network-only)', async ({
+    page,
+  }) => {
+    test.info().annotations.push({ type: 'soft-skip', description: 'tryClickTab + checkbox soft' });
     const charReq = page
       .waitForRequest(
-        (r) =>
-          r.url().includes(`/v1/editor/themes/${THEME_ID}/characters`) && r.method() === "GET",
-        { timeout: 10_000 },
+        (r) => r.url().includes(`/v1/editor/themes/${THEME_ID}/characters`) && r.method() === 'GET',
+        { timeout: 10_000 }
       )
       .catch(() => null);
 
@@ -257,21 +333,23 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     expect(got).not.toBeNull();
 
     // UI: 단서 체크박스 → 즉시 반영 확인 (optimistic)
-    const checkbox = page.getByRole("checkbox").first();
+    const checkbox = page.getByRole('checkbox').first();
     if (await checkbox.isVisible({ timeout: 2_000 }).catch(() => false)) {
       await checkbox.click();
-      await expect(checkbox).toBeChecked({ timeout: 2_000 }).catch(() => {});
+      await expect(checkbox)
+        .toBeChecked({ timeout: 2_000 })
+        .catch(() => {});
     }
   });
 
-  test("[4] 단서 목록 GET — image_url 필드 렌더 (network-only)", async ({ page }) => {
-    test.info().annotations.push({ type: "soft-skip", description: "tryClickTab + img soft" });
-    state.clueImageURL = "https://mock-storage.example/themes/test/clues/c1/image.png";
+  test('[4] 단서 목록 GET — image_url 필드 렌더 (network-only)', async ({ page }) => {
+    test.info().annotations.push({ type: 'soft-skip', description: 'tryClickTab + img soft' });
+    state.clueImageURL = 'https://mock-storage.example/themes/test/clues/c1/image.png';
 
     const clueReq = page
       .waitForRequest(
-        (r) => r.url().includes(`/v1/editor/themes/${THEME_ID}/clues`) && r.method() === "GET",
-        { timeout: 10_000 },
+        (r) => r.url().includes(`/v1/editor/themes/${THEME_ID}/clues`) && r.method() === 'GET',
+        { timeout: 10_000 }
       )
       .catch(() => null);
 
@@ -288,14 +366,14 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     }
   });
 
-  test("[5] clue-edges GET — 빈 결과 200 (network-only)", async ({ page }) => {
-    test.info().annotations.push({ type: "soft-skip", description: "tryClickTab + state fallback" });
+  test('[5] clue-edges GET — 빈 결과 200 (network-only)', async ({ page }) => {
+    test
+      .info()
+      .annotations.push({ type: 'soft-skip', description: 'tryClickTab + state fallback' });
     const relReq = page
       .waitForRequest(
-        (r) =>
-          r.url().includes(`/v1/editor/themes/${THEME_ID}/clue-edges`) &&
-          r.method() === "GET",
-        { timeout: 10_000 },
+        (r) => r.url().includes(`/v1/editor/themes/${THEME_ID}/clue-edges`) && r.method() === 'GET',
+        { timeout: 10_000 }
       )
       .catch(() => null);
 
@@ -308,13 +386,15 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     expect(got !== null || state.clueRelationsCalls > 0).toBe(true);
   });
 
-  test("[6] 모듈 토글 → config PUT 409 silent rebase (network-only)", async ({ page }) => {
-    test.info().annotations.push({ type: "soft-skip", description: "스위치 미렌더 시 auto-save wait" });
+  test('[6] 모듈 토글 → config PUT 409 silent rebase (network-only)', async ({ page }) => {
+    test
+      .info()
+      .annotations.push({ type: 'soft-skip', description: '스위치 미렌더 시 auto-save wait' });
     await page.goto(`${BASE}/editor/${THEME_ID}/modules`);
     await tryClickTab(page, /모듈|module/i);
 
     // UI: 스위치 3개 토글 시도. 렌더 실패 시 한 번의 프론트 mutation 호출을 waitForRequest 로.
-    const switches = page.getByRole("switch");
+    const switches = page.getByRole('switch');
     const n = await switches.count().catch(() => 0);
     let uiInteracted = 0;
     for (let i = 0; i < Math.min(n, 3); i += 1) {
@@ -330,9 +410,8 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     if (uiInteracted === 0) {
       await page
         .waitForRequest(
-          (r) =>
-            r.url().includes(`/v1/editor/themes/${THEME_ID}/config`) && r.method() === "PUT",
-          { timeout: 5_000 },
+          (r) => r.url().includes(`/v1/editor/themes/${THEME_ID}/config`) && r.method() === 'PUT',
+          { timeout: 5_000 }
         )
         .catch(() => null);
     }
@@ -343,8 +422,13 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     expect(state.conflictCountdown).toBeLessThanOrEqual(1);
   });
 
-  test("[7] 흐름 노드 편집 — PATCH 만, PUT 은 회귀 금지 (network-only)", async ({ page }) => {
-    test.info().annotations.push({ type: "soft-skip", description: "React Flow 노드 미렌더 시 uiEdited=false" });
+  test('[7] 흐름 노드 편집 — PATCH 만, PUT 은 회귀 금지 (network-only)', async ({ page }) => {
+    test
+      .info()
+      .annotations.push({
+        type: 'soft-skip',
+        description: 'React Flow 노드 미렌더 시 uiEdited=false',
+      });
     const { putSeen } = await installFlowPutGuard(page);
 
     await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
@@ -359,7 +443,7 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
         .locator('input[name="label"], input[placeholder*="label" i], textarea[name="label"]')
         .first();
       if (await labelInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
-        await labelInput.fill("갱신");
+        await labelInput.fill('갱신');
         // debounce (~1500ms) 후 PATCH 발송 기대
         await page.waitForTimeout(1_800);
         uiEdited = true;
@@ -375,7 +459,7 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     expect(putSeen).toEqual([]);
   });
 
-  test("[7A] 흐름 장면 토론방 정책은 flow node PATCH 로 저장된다", async ({ page }) => {
+  test('[7A] 흐름 장면 토론방 정책은 flow node PATCH 로 저장된다', async ({ page }) => {
     await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
     await tryClickTab(page, /흐름|flow/i);
 
@@ -383,38 +467,38 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     await expect(node).toBeVisible({ timeout: 10_000 });
     await node.click();
 
-    const discussionToggle = page.getByRole("checkbox", { name: /토론방/ });
+    const discussionToggle = page.getByRole('checkbox', { name: /토론방/ });
     await expect(discussionToggle).toBeVisible({ timeout: 5_000 });
     await discussionToggle.check();
-    await page.getByLabel("메인 토론방").fill("추리 회의");
-    await page.getByLabel("이용 가능 시점").selectOption("condition");
-    await page.getByLabel("조건부 방명").fill("비밀 토론");
+    await page.getByLabel('메인 토론방').fill('추리 회의');
+    await page.getByLabel('이용 가능 시점').selectOption('condition');
+    await page.getByLabel('조건부 방명').fill('비밀 토론');
 
     const a11y = await new AxeBuilder({ page })
       .include('[data-testid="discussion-room-policy-panel"]')
-      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
       .analyze();
     expect(a11y.violations).toEqual([]);
 
     await expect.poll(() => state.flowPatchCalls).toBeGreaterThanOrEqual(1);
-    const patch = state.lastFlowNodePatchBody as
-      | { data?: { discussionRoomPolicy?: Record<string, unknown> } }
-      | null;
+    const patch = state.lastFlowNodePatchBody as {
+      data?: { discussionRoomPolicy?: Record<string, unknown> };
+    } | null;
     expect(patch?.data?.discussionRoomPolicy).toMatchObject({
       enabled: true,
-      mainRoomName: "추리 회의",
-      availability: "condition",
-      conditionalRoomName: "비밀 토론",
+      mainRoomName: '추리 회의',
+      availability: 'condition',
+      conditionalRoomName: '비밀 토론',
     });
     expect(state.flowPutCalls).toBe(0);
   });
 
-  test("[8] 장소 탭 — locations[].clueIds 구조 UI 로드 (network-only)", async ({ page }) => {
-    test.info().annotations.push({ type: "soft-skip", description: "tryClickTab + chip soft" });
+  test('[8] 장소 탭 — locations[].clueIds 구조 UI 로드 (network-only)', async ({ page }) => {
+    test.info().annotations.push({ type: 'soft-skip', description: 'tryClickTab + chip soft' });
     const locReq = page
       .waitForRequest(
-        (r) => r.url().includes(`/v1/editor/themes/${THEME_ID}/locations`) && r.method() === "GET",
-        { timeout: 10_000 },
+        (r) => r.url().includes(`/v1/editor/themes/${THEME_ID}/locations`) && r.method() === 'GET',
+        { timeout: 10_000 }
       )
       .catch(() => null);
 
@@ -424,29 +508,33 @@ test.describe("Phase 18.4 에디터 골든패스 (mocked — UI interaction)", (
     const got = await locReq;
     expect(got).not.toBeNull();
 
-    await expect(page.getByLabel("장소 목록")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("거실").first()).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByText("R2~4").first()).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByLabel("거실 단서 조사")).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('거실').first()).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText('R2~4').first()).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByLabel('거실 단서 조사')).toBeVisible({ timeout: 3_000 });
     await expect(page.getByText(/접근 제한/).first()).toBeVisible({ timeout: 3_000 });
 
     // UI: 단서 chip/체크박스가 있으면 토글 + 즉시 반영
-    const chip = page.getByRole("checkbox").first();
+    const chip = page.getByRole('checkbox').first();
     if (await chip.isVisible({ timeout: 2_000 }).catch(() => false)) {
       const wasChecked = await chip.isChecked().catch(() => false);
       await chip.click().catch(() => {});
-      await expect(chip).toBeChecked({ checked: !wasChecked, timeout: 2_000 }).catch(() => {});
+      await expect(chip)
+        .toBeChecked({ checked: !wasChecked, timeout: 2_000 })
+        .catch(() => {});
     }
   });
 
-  test("[9] 템플릿 탭 GET /api/v1/templates (network-only)", async ({ page }) => {
-    test.info().annotations.push({ type: "soft-skip", description: "tryClickTab + state fallback" });
+  test('[9] 템플릿 탭 GET /api/v1/templates (network-only)', async ({ page }) => {
+    test
+      .info()
+      .annotations.push({ type: 'soft-skip', description: 'tryClickTab + state fallback' });
     const tplReq = page
       .waitForRequest(
         (r) =>
           (r.url().includes(`/api/v1/templates`) || r.url().includes(`/v1/templates`)) &&
-          r.method() === "GET",
-        { timeout: 10_000 },
+          r.method() === 'GET',
+        { timeout: 10_000 }
       )
       .catch(() => null);
 

--- a/apps/web/src/features/editor/__tests__/routeSegments.test.ts
+++ b/apps/web/src/features/editor/__tests__/routeSegments.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EDITOR_ROUTE_MATRIX,
+  readDesignSubTabFromRouteSegment,
+  readEditorTabFromRouteSegment,
+} from '../routeSegments';
+
+describe('editor route segment matrix', () => {
+  it.each(EDITOR_ROUTE_MATRIX)(
+    '$path 직접 URL을 올바른 editor tab으로 매핑한다',
+    ({ routeSegment, editorTab }) => {
+      expect(readEditorTabFromRouteSegment(routeSegment)).toBe(editorTab);
+    }
+  );
+
+  it.each(EDITOR_ROUTE_MATRIX.filter((entry) => entry.editorTab === 'design'))(
+    '$path 직접 URL을 올바른 design subtab으로 매핑한다',
+    ({ routeSegment, designSubTab }) => {
+      expect(readDesignSubTabFromRouteSegment(routeSegment)).toBe(designSubTab);
+    }
+  );
+
+  it('알 수 없는 segment는 제작 흐름의 안전한 기본 화면으로 되돌린다', () => {
+    expect(readEditorTabFromRouteSegment('unknown')).toBe('overview');
+    expect(readDesignSubTabFromRouteSegment('unknown')).toBe('modules');
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
@@ -5,12 +5,14 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { mutateMock, navigateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(() => ({
-  mutateMock: vi.fn(),
-  navigateMock: vi.fn(),
-  useUpdateConfigJsonMock: vi.fn(),
-  useModuleSchemasMock: vi.fn(),
-}));
+const { mutateMock, navigateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(
+  () => ({
+    mutateMock: vi.fn(),
+    navigateMock: vi.fn(),
+    useUpdateConfigJsonMock: vi.fn(),
+    useModuleSchemasMock: vi.fn(),
+  })
+);
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -64,15 +66,18 @@ vi.mock('@/features/editor/constants', () => ({
       key: 'core',
       label: '코어',
       modules: [
-        { id: 'connection', name: '접속 관리', description: '플레이어 접속/재접속 처리', required: true },
+        {
+          id: 'connection',
+          name: '접속 관리',
+          description: '플레이어 접속/재접속 처리',
+          required: true,
+        },
       ],
     },
     {
       key: 'progression',
       label: '진행',
-      modules: [
-        { id: 'reading', name: '리딩', description: '대사 낭독 시스템', required: false },
-      ],
+      modules: [{ id: 'reading', name: '리딩', description: '대사 낭독 시스템', required: false }],
     },
   ],
   REQUIRED_MODULE_IDS: ['connection'],
@@ -80,9 +85,7 @@ vi.mock('@/features/editor/constants', () => ({
     {
       key: 'progression',
       label: '진행',
-      modules: [
-        { id: 'reading', name: '리딩', description: '대사 낭독 시스템', required: false },
-      ],
+      modules: [{ id: 'reading', name: '리딩', description: '대사 낭독 시스템', required: false }],
     },
   ],
 }));
@@ -180,6 +183,7 @@ describe('DesignTab', () => {
   });
 
   it.each([
+    ['modules', '진행'],
     ['locations', 'LocationsSubTab 콘텐츠'],
     ['endings', 'EndingEntitySubTab 콘텐츠'],
     ['flow', 'FlowSubTab 콘텐츠'],

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -1,38 +1,107 @@
-import type { EditorTab } from "./constants";
+import type { EditorTab } from './constants';
 
-export type DesignSubTab = "modules" | "flow" | "locations" | "endings";
+export type DesignSubTab = 'modules' | 'flow' | 'locations' | 'endings';
+
+export interface EditorRouteMatrixEntry {
+  path: string;
+  routeSegment?: string;
+  editorTab: EditorTab;
+  designSubTab?: DesignSubTab;
+  alias?: boolean;
+}
 
 const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
-  overview: "overview",
-  design: "design",
-  story: "story",
-  characters: "characters",
-  clues: "clues",
-  relations: "clues",
-  modules: "design",
-  flow: "design",
-  locations: "design",
-  endings: "design",
-  media: "media",
-  advanced: "advanced",
-  templates: "template",
-  template: "template",
+  overview: 'overview',
+  design: 'design',
+  story: 'story',
+  characters: 'characters',
+  clues: 'clues',
+  relations: 'clues',
+  modules: 'design',
+  flow: 'design',
+  locations: 'design',
+  endings: 'design',
+  media: 'media',
+  advanced: 'advanced',
+  templates: 'template',
+  template: 'template',
 };
 
 const DESIGN_ROUTE_SUBTAB_MAP: Record<string, DesignSubTab> = {
-  design: "modules",
-  modules: "modules",
-  flow: "flow",
-  locations: "locations",
-  endings: "endings",
+  design: 'modules',
+  modules: 'modules',
+  flow: 'flow',
+  locations: 'locations',
+  endings: 'endings',
 };
 
+export const EDITOR_ROUTE_MATRIX = [
+  { path: '/editor/:id', editorTab: 'overview' },
+  { path: '/editor/:id/story', routeSegment: 'story', editorTab: 'story' },
+  { path: '/editor/:id/characters', routeSegment: 'characters', editorTab: 'characters' },
+  { path: '/editor/:id/clues', routeSegment: 'clues', editorTab: 'clues' },
+  { path: '/editor/:id/relations', routeSegment: 'relations', editorTab: 'clues' },
+  {
+    path: '/editor/:id/design/modules',
+    routeSegment: 'modules',
+    editorTab: 'design',
+    designSubTab: 'modules',
+  },
+  {
+    path: '/editor/:id/design/flow',
+    routeSegment: 'flow',
+    editorTab: 'design',
+    designSubTab: 'flow',
+  },
+  {
+    path: '/editor/:id/design/locations',
+    routeSegment: 'locations',
+    editorTab: 'design',
+    designSubTab: 'locations',
+  },
+  {
+    path: '/editor/:id/design/endings',
+    routeSegment: 'endings',
+    editorTab: 'design',
+    designSubTab: 'endings',
+  },
+  { path: '/editor/:id/media', routeSegment: 'media', editorTab: 'media' },
+  {
+    path: '/editor/:id/modules',
+    routeSegment: 'modules',
+    editorTab: 'design',
+    designSubTab: 'modules',
+    alias: true,
+  },
+  {
+    path: '/editor/:id/flow',
+    routeSegment: 'flow',
+    editorTab: 'design',
+    designSubTab: 'flow',
+    alias: true,
+  },
+  {
+    path: '/editor/:id/locations',
+    routeSegment: 'locations',
+    editorTab: 'design',
+    designSubTab: 'locations',
+    alias: true,
+  },
+  {
+    path: '/editor/:id/endings',
+    routeSegment: 'endings',
+    editorTab: 'design',
+    designSubTab: 'endings',
+    alias: true,
+  },
+] as const satisfies readonly EditorRouteMatrixEntry[];
+
 export function readEditorTabFromRouteSegment(routeSegment?: string): EditorTab {
-  if (!routeSegment) return "overview";
-  return EDITOR_ROUTE_TAB_MAP[routeSegment] ?? "overview";
+  if (!routeSegment) return 'overview';
+  return EDITOR_ROUTE_TAB_MAP[routeSegment] ?? 'overview';
 }
 
 export function readDesignSubTabFromRouteSegment(routeSegment?: string): DesignSubTab {
-  if (!routeSegment) return "modules";
-  return DESIGN_ROUTE_SUBTAB_MAP[routeSegment] ?? "modules";
+  if (!routeSegment) return 'modules';
+  return DESIGN_ROUTE_SUBTAB_MAP[routeSegment] ?? 'modules';
 }

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -26,6 +26,48 @@ vi.mock('@/features/editor/components', () => ({
 
 import EditorPage from '../EditorPage';
 
+const routeMatrixCases = [
+  ['직접 URL /editor/:id', { id: 'theme-1' }, 'no-segment', 'overview'],
+  ['직접 URL /editor/:id/story', { id: 'theme-1', tab: 'story' }, 'story', 'story'],
+  [
+    '직접 URL /editor/:id/characters',
+    { id: 'theme-1', tab: 'characters' },
+    'characters',
+    'characters',
+  ],
+  ['직접 URL /editor/:id/clues', { id: 'theme-1', tab: 'clues' }, 'clues', 'clues'],
+  ['직접 URL /editor/:id/relations', { id: 'theme-1', tab: 'relations' }, 'relations', 'clues'],
+  ['직접 URL /editor/:id/media', { id: 'theme-1', tab: 'media' }, 'media', 'media'],
+  [
+    '직접 URL /editor/:id/design/modules',
+    { id: 'theme-1', tab: 'design', designTab: 'modules' },
+    'modules',
+    'design',
+  ],
+  [
+    '직접 URL /editor/:id/design/flow',
+    { id: 'theme-1', tab: 'design', designTab: 'flow' },
+    'flow',
+    'design',
+  ],
+  [
+    '직접 URL /editor/:id/design/locations',
+    { id: 'theme-1', tab: 'design', designTab: 'locations' },
+    'locations',
+    'design',
+  ],
+  [
+    '직접 URL /editor/:id/design/endings',
+    { id: 'theme-1', tab: 'design', designTab: 'endings' },
+    'endings',
+    'design',
+  ],
+  ['alias URL /editor/:id/modules', { id: 'theme-1', tab: 'modules' }, 'modules', 'design'],
+  ['alias URL /editor/:id/flow', { id: 'theme-1', tab: 'flow' }, 'flow', 'design'],
+  ['alias URL /editor/:id/locations', { id: 'theme-1', tab: 'locations' }, 'locations', 'design'],
+  ['alias URL /editor/:id/endings', { id: 'theme-1', tab: 'endings' }, 'endings', 'design'],
+] as const;
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -50,23 +92,17 @@ describe('EditorPage', () => {
     expect(setActiveTabMock).toHaveBeenCalledWith('characters');
   });
 
-  it.each([
-    ['design', 'design'],
-    ['story', 'story'],
-    ['characters', 'characters'],
-    ['clues', 'clues'],
-    ['relations', 'clues'],
-    ['locations', 'design'],
-    ['endings', 'design'],
-    ['media', 'media'],
-  ] as const)('%s 라우트 segment를 %s 탭으로 매핑한다', (segment, expectedTab) => {
-    paramsMock.mockReturnValue({ id: 'theme-1', tab: segment });
+  it.each(routeMatrixCases)(
+    '%s route matrix를 ThemeEditor와 active tab에 반영한다',
+    (_label, params, expectedSegment, expectedTab) => {
+      paramsMock.mockReturnValue(params);
 
-    render(<EditorPage />);
+      render(<EditorPage />);
 
-    expect(screen.getByText(new RegExp(`테마 에디터 theme-1 ${segment}`))).toBeDefined();
-    expect(setActiveTabMock).toHaveBeenCalledWith(expectedTab);
-  });
+      expect(screen.getByText(new RegExp(`테마 에디터 theme-1 ${expectedSegment}`))).toBeDefined();
+      expect(setActiveTabMock).toHaveBeenCalledWith(expectedTab);
+    }
+  );
 
   it('design 하위 route segment를 실제 DesignTab subtab segment로 전달한다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'design', designTab: 'flow' });

--- a/docs/plans/2026-05-05-editor-frontend-100-audit/audit.md
+++ b/docs/plans/2026-05-05-editor-frontend-100-audit/audit.md
@@ -37,30 +37,36 @@
 
 현재 `origin/main` 기준 체감 구현률은 약 **70%**다.
 
+2026-05-05 P0 보정 기준:
+
+- #375가 merge되면 creator-safe UI gap이 닫혀 약 **90%**로 본다.
+- #376이 merge되면 직접 URL, alias URL, 모바일/데스크톱 smoke gate가 문서와 테스트에 고정되어 에디터 프론트 1차 목표는 기능 구현 관점에서 **100% 완료**로 판정한다.
+- 이후 남는 작업은 1차 프론트 기능 추가가 아니라 2차 목표인 backend 저장/검증, runtime engine, game screen으로 분류한다.
+
 - 높은 영역: route migration, 캐릭터, 단서 기본, 장소 기본, 결말 기본, 미디어 라이브러리
 - 중간 영역: 스토리/장면 요약, 조건, 트리거, 정보 전달
 - 낮은 영역: 단서 조사, 조사권, 토론방, 연출 cue, creator-safe advanced/raw JSON 제거, 모바일 smoke
 
 ## 감사표
 
-| 제작 단위 | 현재 상태 | 근거 | 1차 100%까지 남은 것 | 연결 이슈 | 우선순위 |
-| --- | --- | --- | --- | --- | --- |
-| `/editor/:id` route | 거의 완료 | `EditorPage.tsx`, `routeSegments.ts`, `EditorPage.test.tsx`, `editor-golden-path.spec.ts` | 직접 URL smoke 유지, `/design/*`와 top-level alias 회귀 방지 | #288 완료 흐름, 후속 구현 PR 공통 | P0 완료 기반 |
-| 스토리/장면 | 기반 완료 | #299 CLOSED, `StoryTab.tsx`, `StorySceneSummary.tsx`, `storySceneAdapter.ts` | 장면 하위 블록이 실제 편집 화면 안에 모이는지 최종 polish | #302, #290, #303, #305 | P0 완료 기반 |
-| 조건 | 기반 완료 | #301 CLOSED, `ConditionBuilder.tsx`, `conditionTypes.ts`, `conditionAdapter.ts` | 각 기능에서 조건 선택지를 실제 데이터로 채우고 raw shape 숨김 유지 | #302, #290, #304, #303, #305, #329 | P0 완료 기반 |
-| 트리거 | 기반 완료 | #300 CLOSED, `ActionListEditor.tsx`, `EntityTriggerPlacementCard.tsx`, `eventProgressionConfig.ts` | 결과 타입을 정보 공개/조사권/토론방/연출과 연결 | #302, #304, #303, #305 | P0 완료 기반 |
-| 등장인물 | 대부분 완료 | #306/#331 merge, `CharactersTab.tsx`, `characterEditorAdapter.ts` | 조건부 이름/아이콘, 엔드카드 소유권 | #329, #330 | P2 |
-| 단서 | 대부분 완료 | `CluesTab.tsx`, `ClueEntityWorkspace.tsx`, `ClueRuntimeEffectCard.tsx` | 단서 조사와 획득 방식 연결, 단서 사용 효과와 조사 결과의 관계 정리 | #290 | P1 |
-| 장소 | 대부분 완료 | `LocationsSubTab.tsx`, `LocationDetailPanel.tsx`, `LocationClueAssignPanel.tsx` | 장소 안의 단서 조사 블록을 제품 용어로 연결 | #290 | P1 |
-| 정보 공개 | 일부 완료 | `ReadingSectionList.tsx`, `InformationDeliveryPanel.tsx`, `informationDeliveryAdapter.ts` | 스토리 장면 하위 블록으로 그룹/조건/대상 편집 | #302 | P1-1 |
-| 단서 조사 | 낮음 | `deckInvestigationAdapter.ts`, #277 audit의 UI 연결 미확인 | 장소/스토리 장면에서 조사 대상 단서, 조건, 공개 정책, 조사권 비용 편집 | #290 | P1-2 |
-| 조사권 | 낮음 | `conditionTypes.ts`에 조건 변수 존재, #304 open | 전역/단서 조사 하위 설정 UI, 초기 배포, 소비 정책 | #304 | P1-3 |
-| 토론방 | 낮음 | `conditionTypes.ts`에 토론방 상태 변수 존재, room/chat runtime은 별도 | 장면별 메인 토론방/밀담방/조건부 접근 정책 편집 | #303 | P1-4 |
-| 연출 | 낮음~중간 | `MediaTab.tsx`, `MediaPicker.tsx`, `play_bgm` action label | 장면/트리거에 BGM, SE, 영상, 배경 cue를 raw JSON 없이 연결 | #305 | P1-5 |
-| 결말 | 기본 완료 | `EndingEntitySubTab.tsx`, `EndingBranchRulesPanel.tsx`, #280 open | 캐릭터별 결말, GM 보정, 감상 공유, 엔드카드 | #280, #330, #293 | P2 |
-| 미디어 | 기본 완료 | `MediaTab.tsx`, `MediaDetail.tsx`, `mediaResourceAdapter.ts` | metadata 과노출 축소, 모바일 상세 패널 개선, 연출 picker와 연결 | #305, #282 | P1/P2 |
-| Creator-safe polish | 미완 | `AdvancedTab.tsx`, `MediaDetail.tsx`, #277 audit | raw `config_json` 기본 노출 제거 또는 debug/admin gate, 오류 복구 UI | #282, #283 | P1 병행 |
-| 저장/검증 안정성 | 프론트 일부 | adapter tests 다수, backend validation gap 존재 | 프론트 1차 PR마다 focused 저장 테스트. backend 최종 검증은 2차로 이동 | #281, #283, #294 | 병행 guard |
+| 제작 단위           | 현재 상태              | 근거                                                                                                               | 1차 100%까지 남은 것                                                                      | 연결 이슈                          | 우선순위     |
+| ------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- | ---------------------------------- | ------------ |
+| `/editor/:id` route | P0 수용 게이트 진행 중 | `EditorPage.tsx`, `routeSegments.ts`, `EditorPage.test.tsx`, `routeSegments.test.ts`, `editor-golden-path.spec.ts` | #376에서 route matrix, `/design/*`, top-level alias, 390px/desktop smoke를 merge하면 완료 | #376                               | P0           |
+| 스토리/장면         | 기반 완료              | #299 CLOSED, `StoryTab.tsx`, `StorySceneSummary.tsx`, `storySceneAdapter.ts`                                       | 장면 하위 블록이 실제 편집 화면 안에 모이는지 최종 polish                                 | #302, #290, #303, #305             | P0 완료 기반 |
+| 조건                | 기반 완료              | #301 CLOSED, `ConditionBuilder.tsx`, `conditionTypes.ts`, `conditionAdapter.ts`                                    | 각 기능에서 조건 선택지를 실제 데이터로 채우고 raw shape 숨김 유지                        | #302, #290, #304, #303, #305, #329 | P0 완료 기반 |
+| 트리거              | 기반 완료              | #300 CLOSED, `ActionListEditor.tsx`, `EntityTriggerPlacementCard.tsx`, `eventProgressionConfig.ts`                 | 결과 타입을 정보 공개/조사권/토론방/연출과 연결                                           | #302, #304, #303, #305             | P0 완료 기반 |
+| 등장인물            | 대부분 완료            | #306/#331 merge, `CharactersTab.tsx`, `characterEditorAdapter.ts`                                                  | 조건부 이름/아이콘, 엔드카드 소유권                                                       | #329, #330                         | P2           |
+| 단서                | 대부분 완료            | `CluesTab.tsx`, `ClueEntityWorkspace.tsx`, `ClueRuntimeEffectCard.tsx`                                             | 단서 조사와 획득 방식 연결, 단서 사용 효과와 조사 결과의 관계 정리                        | #290                               | P1           |
+| 장소                | 대부분 완료            | `LocationsSubTab.tsx`, `LocationDetailPanel.tsx`, `LocationClueAssignPanel.tsx`                                    | 장소 안의 단서 조사 블록을 제품 용어로 연결                                               | #290                               | P1           |
+| 정보 공개           | 일부 완료              | `ReadingSectionList.tsx`, `InformationDeliveryPanel.tsx`, `informationDeliveryAdapter.ts`                          | 스토리 장면 하위 블록으로 그룹/조건/대상 편집                                             | #302                               | P1-1         |
+| 단서 조사           | 낮음                   | `deckInvestigationAdapter.ts`, #277 audit의 UI 연결 미확인                                                         | 장소/스토리 장면에서 조사 대상 단서, 조건, 공개 정책, 조사권 비용 편집                    | #290                               | P1-2         |
+| 조사권              | 낮음                   | `conditionTypes.ts`에 조건 변수 존재, #304 open                                                                    | 전역/단서 조사 하위 설정 UI, 초기 배포, 소비 정책                                         | #304                               | P1-3         |
+| 토론방              | 낮음                   | `conditionTypes.ts`에 토론방 상태 변수 존재, room/chat runtime은 별도                                              | 장면별 메인 토론방/밀담방/조건부 접근 정책 편집                                           | #303                               | P1-4         |
+| 연출                | 낮음~중간              | `MediaTab.tsx`, `MediaPicker.tsx`, `play_bgm` action label                                                         | 장면/트리거에 BGM, SE, 영상, 배경 cue를 raw JSON 없이 연결                                | #305                               | P1-5         |
+| 결말                | 기본 완료              | `EndingEntitySubTab.tsx`, `EndingBranchRulesPanel.tsx`, #280 open                                                  | 캐릭터별 결말, GM 보정, 감상 공유, 엔드카드                                               | #280, #330, #293                   | P2           |
+| 미디어              | 기본 완료              | `MediaTab.tsx`, `MediaDetail.tsx`, `mediaResourceAdapter.ts`                                                       | metadata 과노출 축소, 모바일 상세 패널 개선, 연출 picker와 연결                           | #305, #282                         | P1/P2        |
+| Creator-safe polish | P0 PR 진행 중          | `AdvancedTab.tsx`, `MediaDetail.tsx`, #277 audit                                                                   | #375에서 raw `config_json` 기본 노출과 raw media metadata 표시를 닫으면 완료              | #375, #282, #283                   | P0/P1 병행   |
+| 저장/검증 안정성    | 프론트 일부            | adapter tests 다수, backend validation gap 존재                                                                    | 프론트 1차 PR마다 focused 저장 테스트. backend 최종 검증은 2차로 이동                     | #281, #283, #294                   | 병행 guard   |
 
 ## 구현 순서 재정렬
 

--- a/docs/plans/2026-05-05-editor-frontend-100-completion/checklist.md
+++ b/docs/plans/2026-05-05-editor-frontend-100-completion/checklist.md
@@ -55,17 +55,25 @@ Issue: https://github.com/sabyunrepo/muder_platform/issues/376
 
 직접 URL 기준:
 
-- `/editor/:id`
-- `/editor/:id/story`
-- `/editor/:id/characters`
-- `/editor/:id/clues`
-- `/editor/:id/relations`
-- `/editor/:id/design/modules`
-- `/editor/:id/design/flow`
-- `/editor/:id/design/locations`
-- `/editor/:id/design/endings`
-- `/editor/:id/media`
-- top-level alias: `/editor/:id/modules`, `/editor/:id/flow`, `/editor/:id/locations`, `/editor/:id/endings`
+| URL                            | 열려야 하는 제작 화면 | 비고                    |
+| ------------------------------ | --------------------- | ----------------------- |
+| `/editor/:id`                  | 기본정보              | 기본 진입               |
+| `/editor/:id/story`            | 스토리                | top-level tab           |
+| `/editor/:id/characters`       | 등장인물              | top-level tab           |
+| `/editor/:id/clues`            | 단서                  | top-level tab           |
+| `/editor/:id/relations`        | 단서 관계             | 단서 탭 안 관계 모드    |
+| `/editor/:id/design/modules`   | 게임설계 / 모듈       | canonical design subtab |
+| `/editor/:id/design/flow`      | 게임설계 / 흐름       | canonical design subtab |
+| `/editor/:id/design/locations` | 게임설계 / 장소       | canonical design subtab |
+| `/editor/:id/design/endings`   | 게임설계 / 결말       | canonical design subtab |
+| `/editor/:id/media`            | 미디어                | top-level tab           |
+| `/editor/:id/modules`          | 게임설계 / 모듈       | 유지할 alias            |
+| `/editor/:id/flow`             | 게임설계 / 흐름       | 유지할 alias            |
+| `/editor/:id/locations`        | 게임설계 / 장소       | 유지할 alias            |
+| `/editor/:id/endings`          | 게임설계 / 결말       | 유지할 alias            |
+
+Route matrix의 코드 기준은 `apps/web/src/features/editor/routeSegments.ts`의 `EDITOR_ROUTE_MATRIX`다.
+테스트는 `routeSegments.test.ts`, `EditorPage.test.tsx`, `DesignTab.test.tsx`, `editor-golden-path.spec.ts`가 같은 기준을 나눠 검증한다.
 
 완료 기준:
 


### PR DESCRIPTION
## 요약
- `EDITOR_ROUTE_MATRIX`를 추가해 `/editor/:id` 직접 URL과 top-level alias 기준을 코드로 고정했습니다.
- `EditorPage`, `DesignTab`, route segment 단위 테스트를 확장해 tab/subtab 매핑을 회귀 방지했습니다.
- 에디터 골든패스 E2E에 `/design/modules`, `/modules`, `/flow` smoke와 390px 모바일/데스크톱 overflow gate를 추가했습니다.
- 에디터 프론트 100 감사표와 completion checklist에 #375/#376 이후 1차 목표 판정 기준을 갱신했습니다.

## 검증
- `pnpm install --frozen-lockfile` (worktree 의존성 링크, reused 704/downloaded 0)
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/__tests__/routeSegments.test.ts src/pages/__tests__/EditorPage.test.tsx src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/__tests__/CluesTab.test.tsx`
- `pnpm --filter @mmp/shared --filter @mmp/game-logic --filter @mmp/ws-client build`
- `pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium --grep "\[2B\]|\[2D\]"`
- `git diff --check`

Closes #376
Refs #334
Refs #375
Refs #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * E2E 회귀 테스트 스위트를 확대하여 편집기 기능의 안정성 강화

* **리팩토링**
  * 편집기 라우팅 시스템 타입 안정성 개선 및 라우트-탭 매핑 구조 개선

* **문서**
  * 편집기 프론트엔드 완성도 기준 및 직접 URL 라우팅 요구사항 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->