### PR TITLE
feat(editor): 스토리 맵을 에디터 기본 화면으로 전환

### DIFF
--- a/apps/web/src/features/editor/__tests__/routeSegments.test.ts
+++ b/apps/web/src/features/editor/__tests__/routeSegments.test.ts
@@ -21,7 +21,7 @@ describe('editor route segment matrix', () => {
   );
 
   it('알 수 없는 segment는 제작 흐름의 안전한 기본 화면으로 되돌린다', () => {
-    expect(readEditorTabFromRouteSegment('unknown')).toBe('overview');
+    expect(readEditorTabFromRouteSegment('unknown')).toBe('storyMap');
     expect(readDesignSubTabFromRouteSegment('unknown')).toBe('modules');
   });
 });

--- a/apps/web/src/features/editor/components/EditorTabNav.tsx
+++ b/apps/web/src/features/editor/components/EditorTabNav.tsx
@@ -35,10 +35,10 @@ export function EditorTabNav({
     [activeModules, forcedVisibleTab],
   );
 
-  // If active tab is now hidden, fallback to overview
+  // If active tab is now hidden, fallback to the creator's main story workspace.
   useEffect(() => {
     if (!visibleTabs.some((t) => t.key === activeTab)) {
-      setActiveTab("overview");
+      setActiveTab("storyMap");
     }
   }, [visibleTabs, activeTab, setActiveTab]);
 

--- a/apps/web/src/features/editor/components/TabContent.tsx
+++ b/apps/web/src/features/editor/components/TabContent.tsx
@@ -9,6 +9,9 @@ import type { EditorThemeResponse } from "@/features/editor/api";
 const OverviewTab = lazy(() =>
   import("./OverviewTab").then((m) => ({ default: m.OverviewTab })),
 );
+const StoryMapWorkspace = lazy(() =>
+  import("./story-map/StoryMapWorkspace").then((m) => ({ default: m.StoryMapWorkspace })),
+);
 const StoryTab = lazy(() =>
   import("./StoryTab").then((m) => ({ default: m.StoryTab })),
 );
@@ -44,6 +47,8 @@ interface TabContentProps {
 
 export function TabContent({ tab, theme, themeId, routeSegment }: TabContentProps) {
   switch (tab) {
+    case "storyMap":
+      return <StoryMapWorkspace themeId={themeId} />;
     case "overview":
       return <OverviewTab theme={theme} themeId={themeId} />;
     case "story":

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -6,7 +6,7 @@ import { render, screen, cleanup } from "@testing-library/react";
 // ---------------------------------------------------------------------------
 
 const mockSetActiveTab = vi.fn();
-const mockActiveTab = { current: "overview" };
+const mockActiveTab = { current: "storyMap" };
 
 vi.mock("../../stores/editorUIStore", () => ({
   useEditorUI: () => ({
@@ -24,7 +24,7 @@ import { EditorTabNav } from "../EditorTabNav";
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
-  mockActiveTab.current = "overview";
+  mockActiveTab.current = "storyMap";
 });
 
 // ---------------------------------------------------------------------------
@@ -34,6 +34,7 @@ afterEach(() => {
 describe("EditorTabNav dynamic tabs", () => {
   it("모듈 미지정 시 always=true 탭만 표시된다", () => {
     render(<EditorTabNav />);
+    expect(screen.getByText("스토리 진행")).toBeDefined();
     expect(screen.getByText("기본정보")).toBeDefined();
     expect(screen.getByText("게임설계")).toBeDefined();
     expect(screen.queryByText("미디어")).toBeNull();
@@ -54,12 +55,12 @@ describe("EditorTabNav dynamic tabs", () => {
     render(<EditorTabNav activeModules={[]} forcedVisibleTab="media" />);
 
     expect(screen.getByText("미디어")).toBeDefined();
-    expect(mockSetActiveTab).not.toHaveBeenCalledWith("overview");
+    expect(mockSetActiveTab).not.toHaveBeenCalledWith("storyMap");
   });
 
-  it("현재 탭이 숨겨지면 overview로 전환된다", () => {
+  it("현재 탭이 숨겨지면 기본 제작 흐름으로 전환된다", () => {
     mockActiveTab.current = "media";
     render(<EditorTabNav activeModules={[]} />);
-    expect(mockSetActiveTab).toHaveBeenCalledWith("overview");
+    expect(mockSetActiveTab).toHaveBeenCalledWith("storyMap");
   });
 });

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -7,7 +7,7 @@ import {
   type OnSelectionChangeParams,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useFlowData } from "../../hooks/useFlowData";
 import { FlowToolbar } from "./FlowToolbar";
 import { StartNode } from "./StartNode";
@@ -66,6 +66,21 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
     updateEdgeCondition,
     applyPreset,
   } = useFlowData(themeId);
+
+  const renderedNodes = useMemo(
+    () =>
+      nodes.map((node) =>
+        node.id === highlightId
+          ? {
+              ...node,
+              className: [node.className, "!ring-2 !ring-amber-400"]
+                .filter(Boolean)
+                .join(" "),
+            }
+          : node,
+      ),
+    [highlightId, nodes],
+  );
 
   // Add node at canvas center
   const handleAddNode = useCallback(
@@ -140,7 +155,7 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
           onDrop={handleDrop}
         >
           <ReactFlow
-            nodes={nodes}
+            nodes={renderedNodes}
             edges={edges}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
@@ -151,7 +166,6 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
             deleteKeyCode="Delete"
             edgesFocusable={true}
             edgesReconnectable={true}
-            nodeClassName={(node) => node.id === highlightId ? "!ring-2 !ring-amber-400" : ""}
             fitView
             colorMode="dark"
           >

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -18,18 +18,16 @@ vi.mock('@xyflow/react', () => ({
   ReactFlow: ({
     children,
     nodes = [],
-    nodeClassName,
   }: {
     children?: React.ReactNode;
-    nodes?: Array<{ id: string }>;
-    nodeClassName?: (node: { id: string }) => string;
+    nodes?: Array<{ id: string; className?: string }>;
   }) => (
     <div data-testid="react-flow">
       {nodes.map((node) => (
         <div
           key={node.id}
           data-testid={`rf-node-${node.id}`}
-          className={nodeClassName?.(node) ?? ""}
+          className={node.className ?? ""}
         />
       ))}
       {children}

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -1,0 +1,126 @@
+import {
+  BookOpen,
+  Clapperboard,
+  KeyRound,
+  Library,
+  MapPin,
+  MessageSquare,
+  Search,
+  Users,
+} from "lucide-react";
+import { FlowCanvas } from "../design/FlowCanvas";
+
+interface StoryMapWorkspaceProps {
+  themeId: string;
+}
+
+const LIBRARY_GROUPS = [
+  { label: "스토리", icon: BookOpen, items: ["장면", "분기", "엔딩"] },
+  { label: "인물", icon: Users, items: ["PC 캐릭터", "NPC 캐릭터", "역할지"] },
+  { label: "조사", icon: Search, items: ["단서", "장소", "조사권"] },
+  { label: "진행", icon: MessageSquare, items: ["토론방", "조건", "트리거"] },
+  { label: "연출", icon: Clapperboard, items: ["미디어", "공개 타이밍", "화면 전환"] },
+] as const;
+
+const INSPECTOR_GROUPS = [
+  { label: "장면 내용", value: "스토리 본문과 공개 정보를 확인합니다." },
+  { label: "연결 항목", value: "등장인물, 단서, 장소를 장면 흐름에 맞춰 연결합니다." },
+  { label: "진행 조건", value: "조사권, 토론방, 트리거를 장면 전환 기준으로 정리합니다." },
+] as const;
+
+export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
+  return (
+    <section
+      aria-label="스토리 진행 제작"
+      className="flex min-h-[calc(100vh-9.5rem)] flex-col bg-slate-950 text-slate-100"
+    >
+      <div className="border-b border-slate-800 px-4 py-4 sm:px-6">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-400">
+              Story Flow
+            </p>
+            <h2 className="mt-1 text-xl font-semibold text-slate-50">스토리 진행 제작</h2>
+          </div>
+          <div className="grid grid-cols-2 gap-2 text-xs text-slate-300 sm:flex">
+            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+              장면 흐름
+            </span>
+            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+              단서 연결
+            </span>
+            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+              진행 조건
+            </span>
+            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+              연출 점검
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[17rem_minmax(0,1fr)_20rem]">
+        <aside className="border-b border-slate-800 bg-slate-950 lg:border-b-0 lg:border-r">
+          <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
+            <Library className="h-4 w-4 text-amber-400" />
+            <h3 className="text-sm font-semibold text-slate-100">제작 라이브러리</h3>
+          </div>
+          <div className="space-y-3 p-4">
+            {LIBRARY_GROUPS.map((group) => (
+              <div
+                key={group.label}
+                className="rounded-md border border-slate-800 bg-slate-900/70 p-3"
+              >
+                <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
+                  <group.icon className="h-4 w-4 text-amber-400" />
+                  {group.label}
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {group.items.map((item) => (
+                    <span
+                      key={item}
+                      className="rounded-sm border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-300"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        <main className="min-h-[620px] min-w-0 border-b border-slate-800 lg:border-b-0">
+          <FlowCanvas themeId={themeId} />
+        </main>
+
+        <aside className="bg-slate-950">
+          <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
+            <MapPin className="h-4 w-4 text-amber-400" />
+            <h3 className="text-sm font-semibold text-slate-100">장면 속성</h3>
+          </div>
+          <div className="space-y-3 p-4">
+            <div className="rounded-md border border-slate-800 bg-slate-900/70 p-4">
+              <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
+                <KeyRound className="h-4 w-4 text-amber-400" />
+                선택한 장면
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-400">
+                장면을 선택하면 이곳에서 공개 정보, 연결된 단서, 진행 조건을 한 번에 확인합니다.
+              </p>
+            </div>
+            {INSPECTOR_GROUPS.map((group) => (
+              <div
+                key={group.label}
+                className="rounded-md border border-slate-800 bg-slate-900/70 p-3"
+              >
+                <h4 className="text-sm font-medium text-slate-200">{group.label}</h4>
+                <p className="mt-2 text-xs leading-5 text-slate-400">{group.value}</p>
+              </div>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../design/FlowCanvas", () => ({
+  FlowCanvas: ({ themeId }: { themeId: string }) => (
+    <div data-testid="flow-canvas">flow canvas {themeId}</div>
+  ),
+}));
+
+import { StoryMapWorkspace } from "../StoryMapWorkspace";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("StoryMapWorkspace", () => {
+  it("스토리 진행 중심 제작 화면과 플로우 캔버스를 함께 렌더링한다", () => {
+    render(<StoryMapWorkspace themeId="theme-1" />);
+
+    expect(screen.getByRole("heading", { name: "스토리 진행 제작" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "제작 라이브러리" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "장면 속성" })).toBeDefined();
+    expect(screen.getByTestId("flow-canvas").textContent).toContain("theme-1");
+  });
+
+  it("작성자가 장면 흐름에 연결할 엔티티 묶음을 볼 수 있다", () => {
+    render(<StoryMapWorkspace themeId="theme-1" />);
+
+    expect(screen.getByText("PC 캐릭터")).toBeDefined();
+    expect(screen.getByText("단서")).toBeDefined();
+    expect(screen.getByText("장소")).toBeDefined();
+    expect(screen.getByText("토론방")).toBeDefined();
+    expect(screen.getByText("조사권")).toBeDefined();
+    expect(screen.getByText("연출")).toBeDefined();
+  });
+});

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -1,4 +1,14 @@
-import { FileText, BookOpen, Users, Settings, Music, Code, LayoutTemplate, Search } from "lucide-react";
+import {
+  FileText,
+  BookOpen,
+  Users,
+  Settings,
+  Music,
+  Code,
+  LayoutTemplate,
+  Search,
+  GitBranch,
+} from "lucide-react";
 import type { ThemeStatus } from "./api";
 
 // ---------------------------------------------------------------------------
@@ -6,6 +16,7 @@ import type { ThemeStatus } from "./api";
 // ---------------------------------------------------------------------------
 
 export const EDITOR_TABS = [
+  { key: "storyMap" as const, label: "스토리 진행", icon: GitBranch, always: true },
   { key: "overview" as const, label: "기본정보", icon: FileText, always: true },
   { key: "story" as const, label: "스토리", icon: BookOpen, always: true },
   { key: "characters" as const, label: "등장인물", icon: Users, always: true },

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -11,14 +11,19 @@ export interface EditorRouteMatrixEntry {
 }
 
 const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
+  'story-map': 'storyMap',
   overview: 'overview',
   design: 'design',
-  story: 'story',
+  story: 'storyMap',
   characters: 'characters',
   clues: 'clues',
   relations: 'clues',
   modules: 'design',
-  flow: 'design',
+  flow: 'storyMap',
+  'design/modules': 'design',
+  'design/flow': 'design',
+  'design/locations': 'design',
+  'design/endings': 'design',
   locations: 'design',
   endings: 'design',
   media: 'media',
@@ -29,39 +34,43 @@ const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
 
 const DESIGN_ROUTE_SUBTAB_MAP: Record<string, DesignSubTab> = {
   design: 'modules',
+  'design/modules': 'modules',
   modules: 'modules',
+  'design/flow': 'flow',
   flow: 'flow',
+  'design/locations': 'locations',
   locations: 'locations',
+  'design/endings': 'endings',
   endings: 'endings',
 };
 
 export const EDITOR_ROUTE_MATRIX = [
-  { path: '/editor/:id', editorTab: 'overview' },
-  { path: '/editor/:id/story', routeSegment: 'story', editorTab: 'story' },
+  { path: '/editor/:id', editorTab: 'storyMap' },
+  { path: '/editor/:id/story', routeSegment: 'story', editorTab: 'storyMap' },
   { path: '/editor/:id/characters', routeSegment: 'characters', editorTab: 'characters' },
   { path: '/editor/:id/clues', routeSegment: 'clues', editorTab: 'clues' },
   { path: '/editor/:id/relations', routeSegment: 'relations', editorTab: 'clues' },
   {
     path: '/editor/:id/design/modules',
-    routeSegment: 'modules',
+    routeSegment: 'design/modules',
     editorTab: 'design',
     designSubTab: 'modules',
   },
   {
     path: '/editor/:id/design/flow',
-    routeSegment: 'flow',
+    routeSegment: 'design/flow',
     editorTab: 'design',
     designSubTab: 'flow',
   },
   {
     path: '/editor/:id/design/locations',
-    routeSegment: 'locations',
+    routeSegment: 'design/locations',
     editorTab: 'design',
     designSubTab: 'locations',
   },
   {
     path: '/editor/:id/design/endings',
-    routeSegment: 'endings',
+    routeSegment: 'design/endings',
     editorTab: 'design',
     designSubTab: 'endings',
   },
@@ -76,7 +85,7 @@ export const EDITOR_ROUTE_MATRIX = [
   {
     path: '/editor/:id/flow',
     routeSegment: 'flow',
-    editorTab: 'design',
+    editorTab: 'storyMap',
     designSubTab: 'flow',
     alias: true,
   },
@@ -97,8 +106,8 @@ export const EDITOR_ROUTE_MATRIX = [
 ] as const satisfies readonly EditorRouteMatrixEntry[];
 
 export function readEditorTabFromRouteSegment(routeSegment?: string): EditorTab {
-  if (!routeSegment) return 'overview';
-  return EDITOR_ROUTE_TAB_MAP[routeSegment] ?? 'overview';
+  if (!routeSegment) return 'storyMap';
+  return EDITOR_ROUTE_TAB_MAP[routeSegment] ?? 'storyMap';
 }
 
 export function readDesignSubTabFromRouteSegment(routeSegment?: string): DesignSubTab {

--- a/apps/web/src/features/editor/stores/editorUIStore.ts
+++ b/apps/web/src/features/editor/stores/editorUIStore.ts
@@ -14,7 +14,7 @@ interface EditorUIState {
 }
 
 export const useEditorUI = create<EditorUIState>()((set) => ({
-  activeTab: "overview",
+  activeTab: "storyMap",
   setActiveTab: (tab) => set({ activeTab: tab }),
   validationErrors: {},
   setValidationErrors: (errors) => set({ validationErrors: errors }),

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -13,10 +13,12 @@ export default function EditorPage() {
   }>();
   const setActiveTab = useEditorUI((state) => state.setActiveTab);
   const routeSegment = designTab ?? tab;
+  const activeTabRouteSegment =
+    tab === "design" && designTab ? `design/${designTab}` : routeSegment;
 
   useEffect(() => {
-    setActiveTab(readEditorTabFromRouteSegment(routeSegment));
-  }, [setActiveTab, routeSegment]);
+    setActiveTab(readEditorTabFromRouteSegment(activeTabRouteSegment));
+  }, [setActiveTab, activeTabRouteSegment]);
 
   if (id) {
     return <ThemeEditor themeId={id} routeSegment={routeSegment} />;

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -27,8 +27,8 @@ vi.mock('@/features/editor/components', () => ({
 import EditorPage from '../EditorPage';
 
 const routeMatrixCases = [
-  ['직접 URL /editor/:id', { id: 'theme-1' }, 'no-segment', 'overview'],
-  ['직접 URL /editor/:id/story', { id: 'theme-1', tab: 'story' }, 'story', 'story'],
+  ['직접 URL /editor/:id', { id: 'theme-1' }, 'no-segment', 'storyMap'],
+  ['직접 URL /editor/:id/story', { id: 'theme-1', tab: 'story' }, 'story', 'storyMap'],
   [
     '직접 URL /editor/:id/characters',
     { id: 'theme-1', tab: 'characters' },
@@ -63,7 +63,7 @@ const routeMatrixCases = [
     'design',
   ],
   ['alias URL /editor/:id/modules', { id: 'theme-1', tab: 'modules' }, 'modules', 'design'],
-  ['alias URL /editor/:id/flow', { id: 'theme-1', tab: 'flow' }, 'flow', 'design'],
+  ['alias URL /editor/:id/flow', { id: 'theme-1', tab: 'flow' }, 'flow', 'storyMap'],
   ['alias URL /editor/:id/locations', { id: 'theme-1', tab: 'locations' }, 'locations', 'design'],
   ['alias URL /editor/:id/endings', { id: 'theme-1', tab: 'endings' }, 'endings', 'design'],
 ] as const;
@@ -74,13 +74,13 @@ afterEach(() => {
 });
 
 describe('EditorPage', () => {
-  it('id가 없으면 에디터 대시보드를 보여주고 overview 탭을 활성화한다', () => {
+  it('id가 없으면 에디터 대시보드를 보여주고 기본 제작 흐름 탭을 활성화한다', () => {
     paramsMock.mockReturnValue({});
 
     render(<EditorPage />);
 
     expect(screen.getByText('에디터 대시보드')).toBeDefined();
-    expect(setActiveTabMock).toHaveBeenCalledWith('overview');
+    expect(setActiveTabMock).toHaveBeenCalledWith('storyMap');
   });
 
   it('characters 라우트 segment를 characters 탭으로 매핑한다', () => {
@@ -121,12 +121,12 @@ describe('EditorPage', () => {
     expect(setActiveTabMock).toHaveBeenCalledWith('design');
   });
 
-  it('알 수 없는 segment는 overview 탭으로 되돌린다', () => {
+  it('알 수 없는 segment는 기본 제작 흐름 탭으로 되돌린다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'unknown' });
 
     render(<EditorPage />);
 
     expect(screen.getByText(/테마 에디터 theme-1 unknown/)).toBeDefined();
-    expect(setActiveTabMock).toHaveBeenCalledWith('overview');
+    expect(setActiveTabMock).toHaveBeenCalledWith('storyMap');
   });
 });


### PR DESCRIPTION
## 요약
- /editor/:id 기본 진입과 /editor/:id/story, /editor/:id/flow alias를 스토리 진행 중심 화면으로 연결했습니다.
- 기존 /editor/:id/design/flow는 디자인 하위 플로우 경로로 유지되도록 route segment 판별을 분리했습니다.
- 새 StoryMapWorkspace에 좌측 제작 라이브러리, 중앙 FlowCanvas, 우측 장면 속성 패널의 기본 제작 레이아웃을 추가했습니다.
- FlowCanvas 하이라이트 처리를 ReactFlow node className으로 옮겨 기본 화면 콘솔 경고를 제거했습니다.

## 검증
- pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/__tests__/routeSegments.test.ts src/features/editor/components/__tests__/EditorTabNav.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
- pnpm --filter @mmp/web exec tsc --noEmit
- Playwright smoke: desktop 1440x1000 /editor/1f86ab3d-b51c-4d5f-a461-1188fec15fb9 heading=true library=true inspector=true consoleErrors=0
- Playwright smoke: mobile 390x900 /editor/1f86ab3d-b51c-4d5f-a461-1188fec15fb9 heading=true library=true inspector=true consoleErrors=0

Closes #382
Refs #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 스토리 진행 탭이 에디터에 추가되었습니다.
  * 새로운 스토리 맵 작업 영역이 추가되어 왼쪽 라이브러리 사이드바, 중앙 캔버스 영역, 오른쪽 속성 패널로 구성됩니다.
  * 플로우 캔버스에서 노드 강조 표시 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->