### PR TITLE
feat(editor): 스토리 맵 엔티티 라이브러리 추가

### DIFF
--- a/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
+++ b/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
@@ -1,0 +1,289 @@
+import {
+  Clapperboard,
+  FileText,
+  KeyRound,
+  MapPin,
+  MessageSquare,
+  Search,
+  Users,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  useEditorCharacters,
+  useEditorClues,
+  useEditorLocations,
+  type ClueResponse,
+  type EditorCharacterResponse,
+  type LocationResponse,
+} from "@/features/editor/api";
+import { useMediaList, type MediaResponse } from "@/features/editor/mediaApi";
+
+export type StoryLibraryEntityKind =
+  | "character"
+  | "clue"
+  | "location"
+  | "media"
+  | "investigationToken"
+  | "discussionRoom"
+  | "trigger";
+
+export interface StoryLibraryEntity {
+  id: string;
+  kind: StoryLibraryEntityKind;
+  title: string;
+  detail: string;
+  section: string;
+  connectable: boolean;
+}
+
+interface EditorEntityLibraryProps {
+  themeId: string;
+  selectedEntity?: StoryLibraryEntity | null;
+  onSelectEntity: (entity: StoryLibraryEntity) => void;
+}
+
+interface LibrarySection {
+  key: string;
+  title: string;
+  icon: LucideIcon;
+  status: string;
+  entities: StoryLibraryEntity[];
+  isLoading?: boolean;
+  isError?: boolean;
+}
+
+function mapCharacters(characters: EditorCharacterResponse[] = []): StoryLibraryEntity[] {
+  return characters.map((character) => ({
+    id: character.id,
+    kind: "character",
+    title: character.name,
+    detail: character.is_playable ? "플레이어 캐릭터" : "NPC 캐릭터",
+    section: "등장인물",
+    connectable: true,
+  }));
+}
+
+function mapClues(clues: ClueResponse[] = []): StoryLibraryEntity[] {
+  return clues.map((clue) => ({
+    id: clue.id,
+    kind: "clue",
+    title: clue.name,
+    detail: clue.location_id ? "장소 단서" : "공통 단서",
+    section: "단서",
+    connectable: true,
+  }));
+}
+
+function mapLocations(locations: LocationResponse[] = []): StoryLibraryEntity[] {
+  return locations.map((location) => ({
+    id: location.id,
+    kind: "location",
+    title: location.name,
+    detail:
+      location.from_round || location.until_round
+        ? "공개 구간 있음"
+        : "상시 사용 가능",
+    section: "장소",
+    connectable: true,
+  }));
+}
+
+function mapMedia(mediaList: MediaResponse[] = []): StoryLibraryEntity[] {
+  return mediaList.map((media) => ({
+    id: media.id,
+    kind: "media",
+    title: media.name,
+    detail: media.type,
+    section: "미디어",
+    connectable: true,
+  }));
+}
+
+const PROGRESSION_ENTITIES: StoryLibraryEntity[] = [
+  {
+    id: "investigation-token",
+    kind: "investigationToken",
+    title: "조사권",
+    detail: "조사 횟수와 소비 기준",
+    section: "진행 자원",
+    connectable: true,
+  },
+  {
+    id: "discussion-room",
+    kind: "discussionRoom",
+    title: "토론방",
+    detail: "장면별 대화 공간",
+    section: "진행 자원",
+    connectable: true,
+  },
+  {
+    id: "trigger",
+    kind: "trigger",
+    title: "트리거",
+    detail: "조건을 만족하면 실행",
+    section: "진행 자원",
+    connectable: true,
+  },
+];
+
+function EntityButton({
+  entity,
+  icon: Icon,
+  isSelected,
+  onSelect,
+}: {
+  entity: StoryLibraryEntity;
+  icon: LucideIcon;
+  isSelected: boolean;
+  onSelect: (entity: StoryLibraryEntity) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={isSelected}
+      onClick={() => onSelect(entity)}
+      className={`w-full rounded-md border px-3 py-2 text-left transition ${
+        isSelected
+          ? "border-amber-500 bg-amber-500/10 text-amber-100"
+          : "border-slate-800 bg-slate-950 text-slate-200 hover:border-slate-700 hover:bg-slate-900"
+      }`}
+    >
+      <span className="flex items-start gap-2">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium">{entity.title}</span>
+          <span className="mt-1 block truncate text-xs text-slate-400">{entity.detail}</span>
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function LibrarySectionPanel({
+  section,
+  selectedEntity,
+  onSelectEntity,
+}: {
+  section: LibrarySection;
+  selectedEntity?: StoryLibraryEntity | null;
+  onSelectEntity: (entity: StoryLibraryEntity) => void;
+}) {
+  const Icon = section.icon;
+  return (
+    <div className="rounded-md border border-slate-800 bg-slate-900/70 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
+          <Icon className="h-4 w-4 text-amber-400" />
+          {section.title}
+        </div>
+        <span className="rounded-sm border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-400">
+          {section.status}
+        </span>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {section.isLoading && (
+          <p className="rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-xs text-slate-400">
+            목록을 불러오는 중입니다.
+          </p>
+        )}
+        {section.isError && (
+          <p className="rounded-md border border-red-900/60 bg-red-950/30 px-3 py-2 text-xs text-red-200">
+            목록을 불러오지 못했습니다.
+          </p>
+        )}
+        {!section.isLoading && !section.isError && section.entities.length === 0 && (
+          <p className="rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-xs text-slate-400">
+            아직 등록된 항목이 없습니다.
+          </p>
+        )}
+        {section.entities.map((entity) => (
+          <EntityButton
+            key={`${entity.kind}:${entity.id}`}
+            entity={entity}
+            icon={Icon}
+            isSelected={selectedEntity?.kind === entity.kind && selectedEntity.id === entity.id}
+            onSelect={onSelectEntity}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function EditorEntityLibrary({
+  themeId,
+  selectedEntity,
+  onSelectEntity,
+}: EditorEntityLibraryProps) {
+  const charactersQuery = useEditorCharacters(themeId);
+  const cluesQuery = useEditorClues(themeId);
+  const locationsQuery = useEditorLocations(themeId);
+  const mediaQuery = useMediaList(themeId);
+
+  const sections: LibrarySection[] = [
+    {
+      key: "characters",
+      title: "등장인물",
+      icon: Users,
+      status: `${charactersQuery.data?.length ?? 0}명`,
+      entities: mapCharacters(charactersQuery.data),
+      isLoading: charactersQuery.isLoading,
+      isError: charactersQuery.isError,
+    },
+    {
+      key: "clues",
+      title: "단서",
+      icon: Search,
+      status: `${cluesQuery.data?.length ?? 0}개`,
+      entities: mapClues(cluesQuery.data),
+      isLoading: cluesQuery.isLoading,
+      isError: cluesQuery.isError,
+    },
+    {
+      key: "locations",
+      title: "장소",
+      icon: MapPin,
+      status: `${locationsQuery.data?.length ?? 0}곳`,
+      entities: mapLocations(locationsQuery.data),
+      isLoading: locationsQuery.isLoading,
+      isError: locationsQuery.isError,
+    },
+    {
+      key: "media",
+      title: "미디어",
+      icon: Clapperboard,
+      status: `${mediaQuery.data?.length ?? 0}개`,
+      entities: mapMedia(mediaQuery.data),
+      isLoading: mediaQuery.isLoading,
+      isError: mediaQuery.isError,
+    },
+    {
+      key: "progression",
+      title: "진행 자원",
+      icon: Zap,
+      status: "3종",
+      entities: PROGRESSION_ENTITIES,
+    },
+  ];
+
+  return (
+    <aside className="border-b border-slate-800 bg-slate-950 lg:border-b-0 lg:border-r">
+      <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
+        <FileText className="h-4 w-4 text-amber-400" />
+        <h3 className="text-sm font-semibold text-slate-100">제작 라이브러리</h3>
+      </div>
+      <div className="space-y-3 p-4">
+        {sections.map((section) => (
+          <LibrarySectionPanel
+            key={section.key}
+            section={section}
+            selectedEntity={selectedEntity}
+            onSelectEntity={onSelectEntity}
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -2,7 +2,7 @@ import {
   KeyRound,
   MapPin,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FlowCanvas } from "../design/FlowCanvas";
 import {
   EditorEntityLibrary,
@@ -21,6 +21,10 @@ const INSPECTOR_GROUPS = [
 
 export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
   const [selectedEntity, setSelectedEntity] = useState<StoryLibraryEntity | null>(null);
+
+  useEffect(() => {
+    setSelectedEntity(null);
+  }, [themeId]);
 
   return (
     <section

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -1,26 +1,17 @@
 import {
-  BookOpen,
-  Clapperboard,
   KeyRound,
-  Library,
   MapPin,
-  MessageSquare,
-  Search,
-  Users,
 } from "lucide-react";
+import { useState } from "react";
 import { FlowCanvas } from "../design/FlowCanvas";
+import {
+  EditorEntityLibrary,
+  type StoryLibraryEntity,
+} from "./EditorEntityLibrary";
 
 interface StoryMapWorkspaceProps {
   themeId: string;
 }
-
-const LIBRARY_GROUPS = [
-  { label: "스토리", icon: BookOpen, items: ["장면", "분기", "엔딩"] },
-  { label: "인물", icon: Users, items: ["PC 캐릭터", "NPC 캐릭터", "역할지"] },
-  { label: "조사", icon: Search, items: ["단서", "장소", "조사권"] },
-  { label: "진행", icon: MessageSquare, items: ["토론방", "조건", "트리거"] },
-  { label: "연출", icon: Clapperboard, items: ["미디어", "공개 타이밍", "화면 전환"] },
-] as const;
 
 const INSPECTOR_GROUPS = [
   { label: "장면 내용", value: "스토리 본문과 공개 정보를 확인합니다." },
@@ -29,6 +20,8 @@ const INSPECTOR_GROUPS = [
 ] as const;
 
 export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
+  const [selectedEntity, setSelectedEntity] = useState<StoryLibraryEntity | null>(null);
+
   return (
     <section
       aria-label="스토리 진행 제작"
@@ -60,35 +53,11 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
       </div>
 
       <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[17rem_minmax(0,1fr)_20rem]">
-        <aside className="border-b border-slate-800 bg-slate-950 lg:border-b-0 lg:border-r">
-          <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
-            <Library className="h-4 w-4 text-amber-400" />
-            <h3 className="text-sm font-semibold text-slate-100">제작 라이브러리</h3>
-          </div>
-          <div className="space-y-3 p-4">
-            {LIBRARY_GROUPS.map((group) => (
-              <div
-                key={group.label}
-                className="rounded-md border border-slate-800 bg-slate-900/70 p-3"
-              >
-                <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
-                  <group.icon className="h-4 w-4 text-amber-400" />
-                  {group.label}
-                </div>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {group.items.map((item) => (
-                    <span
-                      key={item}
-                      className="rounded-sm border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-300"
-                    >
-                      {item}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </aside>
+        <EditorEntityLibrary
+          themeId={themeId}
+          selectedEntity={selectedEntity}
+          onSelectEntity={setSelectedEntity}
+        />
 
         <main className="min-h-[620px] min-w-0 border-b border-slate-800 lg:border-b-0">
           <FlowCanvas themeId={themeId} />
@@ -103,11 +72,20 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
             <div className="rounded-md border border-slate-800 bg-slate-900/70 p-4">
               <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
                 <KeyRound className="h-4 w-4 text-amber-400" />
-                선택한 장면
+                선택한 연결 대상
               </div>
-              <p className="mt-3 text-sm leading-6 text-slate-400">
-                장면을 선택하면 이곳에서 공개 정보, 연결된 단서, 진행 조건을 한 번에 확인합니다.
-              </p>
+              {selectedEntity ? (
+                <div className="mt-3 rounded-md border border-amber-500/50 bg-amber-500/10 p-3">
+                  <p className="text-sm font-medium text-amber-100">{selectedEntity.title}</p>
+                  <p className="mt-1 text-xs text-amber-200/80">
+                    {selectedEntity.section} · {selectedEntity.detail}
+                  </p>
+                </div>
+              ) : (
+                <p className="mt-3 text-sm leading-6 text-slate-400">
+                  왼쪽 라이브러리에서 항목을 선택하면 장면에 붙일 연결 대상으로 표시합니다.
+                </p>
+              )}
             </div>
             {INSPECTOR_GROUPS.map((group) => (
               <div

--- a/apps/web/src/features/editor/components/story-map/__tests__/EditorEntityLibrary.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/EditorEntityLibrary.test.tsx
@@ -121,4 +121,26 @@ describe("EditorEntityLibrary", () => {
 
     expect(screen.getAllByText("아직 등록된 항목이 없습니다.").length).toBe(4);
   });
+
+  it("목록을 불러오는 동안 로딩 상태를 보여준다", () => {
+    useEditorCharactersMock.mockReturnValue({ data: [], isLoading: true, isError: false });
+    useEditorCluesMock.mockReturnValue({ data: [], isLoading: true, isError: false });
+    useEditorLocationsMock.mockReturnValue({ data: [], isLoading: true, isError: false });
+    useMediaListMock.mockReturnValue({ data: [], isLoading: true, isError: false });
+
+    render(<EditorEntityLibrary themeId="theme-1" onSelectEntity={vi.fn()} />);
+
+    expect(screen.getAllByText("목록을 불러오는 중입니다.").length).toBe(4);
+  });
+
+  it("목록 조회에 실패하면 오류 상태를 보여준다", () => {
+    useEditorCharactersMock.mockReturnValue({ data: [], isLoading: false, isError: true });
+    useEditorCluesMock.mockReturnValue({ data: [], isLoading: false, isError: true });
+    useEditorLocationsMock.mockReturnValue({ data: [], isLoading: false, isError: true });
+    useMediaListMock.mockReturnValue({ data: [], isLoading: false, isError: true });
+
+    render(<EditorEntityLibrary themeId="theme-1" onSelectEntity={vi.fn()} />);
+
+    expect(screen.getAllByText("목록을 불러오지 못했습니다.").length).toBe(4);
+  });
 });

--- a/apps/web/src/features/editor/components/story-map/__tests__/EditorEntityLibrary.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/EditorEntityLibrary.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  useEditorCharactersMock,
+  useEditorCluesMock,
+  useEditorLocationsMock,
+  useMediaListMock,
+} = vi.hoisted(() => ({
+  useEditorCharactersMock: vi.fn(),
+  useEditorCluesMock: vi.fn(),
+  useEditorLocationsMock: vi.fn(),
+  useMediaListMock: vi.fn(),
+}));
+
+vi.mock("@/features/editor/api", () => ({
+  useEditorCharacters: () => useEditorCharactersMock(),
+  useEditorClues: () => useEditorCluesMock(),
+  useEditorLocations: () => useEditorLocationsMock(),
+}));
+
+vi.mock("@/features/editor/mediaApi", () => ({
+  useMediaList: () => useMediaListMock(),
+}));
+
+import { EditorEntityLibrary, type StoryLibraryEntity } from "../EditorEntityLibrary";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  useEditorCharactersMock.mockReturnValue({
+    data: [
+      { id: "char-1", name: "한서윤", is_playable: true },
+      { id: "char-2", name: "집사", is_playable: false },
+    ],
+    isLoading: false,
+    isError: false,
+  });
+  useEditorCluesMock.mockReturnValue({
+    data: [
+      { id: "clue-1", name: "찢어진 초대장", location_id: null },
+      { id: "clue-2", name: "피 묻은 장갑", location_id: "loc-1" },
+    ],
+    isLoading: false,
+    isError: false,
+  });
+  useEditorLocationsMock.mockReturnValue({
+    data: [{ id: "loc-1", name: "응접실", from_round: 1, until_round: 2 }],
+    isLoading: false,
+    isError: false,
+  });
+  useMediaListMock.mockReturnValue({
+    data: [{ id: "media-1", name: "오프닝 음악", type: "BGM" }],
+    isLoading: false,
+    isError: false,
+  });
+});
+
+describe("EditorEntityLibrary", () => {
+  it("기존 editor API 목록을 제작자용 라이브러리로 표시한다", () => {
+    render(<EditorEntityLibrary themeId="theme-1" onSelectEntity={vi.fn()} />);
+
+    expect(screen.getByText("한서윤")).toBeDefined();
+    expect(screen.getByText("집사")).toBeDefined();
+    expect(screen.getByText("찢어진 초대장")).toBeDefined();
+    expect(screen.getByText("피 묻은 장갑")).toBeDefined();
+    expect(screen.getByText("응접실")).toBeDefined();
+    expect(screen.getByText("오프닝 음악")).toBeDefined();
+    expect(screen.getByText("조사권")).toBeDefined();
+    expect(screen.getByText("토론방")).toBeDefined();
+    expect(screen.getByText("트리거")).toBeDefined();
+  });
+
+  it("항목을 누르면 연결 대상으로 선택 이벤트를 보낸다", () => {
+    const onSelectEntity = vi.fn();
+    render(<EditorEntityLibrary themeId="theme-1" onSelectEntity={onSelectEntity} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /피 묻은 장갑/ }));
+
+    expect(onSelectEntity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "clue-2",
+        kind: "clue",
+        title: "피 묻은 장갑",
+      }),
+    );
+  });
+
+  it("선택된 항목은 aria-pressed로 상태를 노출한다", () => {
+    const selectedEntity: StoryLibraryEntity = {
+      id: "clue-1",
+      kind: "clue",
+      title: "찢어진 초대장",
+      detail: "공통 단서",
+      section: "단서",
+      connectable: true,
+    };
+
+    render(
+      <EditorEntityLibrary
+        themeId="theme-1"
+        selectedEntity={selectedEntity}
+        onSelectEntity={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /찢어진 초대장/ }).getAttribute("aria-pressed"))
+      .toBe("true");
+  });
+
+  it("목록이 비어 있으면 빈 상태를 보여준다", () => {
+    useEditorCharactersMock.mockReturnValue({ data: [], isLoading: false, isError: false });
+    useEditorCluesMock.mockReturnValue({ data: [], isLoading: false, isError: false });
+    useEditorLocationsMock.mockReturnValue({ data: [], isLoading: false, isError: false });
+    useMediaListMock.mockReturnValue({ data: [], isLoading: false, isError: false });
+
+    render(<EditorEntityLibrary themeId="theme-1" onSelectEntity={vi.fn()} />);
+
+    expect(screen.getAllByText("아직 등록된 항목이 없습니다.").length).toBe(4);
+  });
+});

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -1,5 +1,17 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  useEditorCharactersMock,
+  useEditorCluesMock,
+  useEditorLocationsMock,
+  useMediaListMock,
+} = vi.hoisted(() => ({
+  useEditorCharactersMock: vi.fn(),
+  useEditorCluesMock: vi.fn(),
+  useEditorLocationsMock: vi.fn(),
+  useMediaListMock: vi.fn(),
+}));
 
 vi.mock("../../design/FlowCanvas", () => ({
   FlowCanvas: ({ themeId }: { themeId: string }) => (
@@ -7,13 +19,47 @@ vi.mock("../../design/FlowCanvas", () => ({
   ),
 }));
 
+vi.mock("@/features/editor/api", () => ({
+  useEditorCharacters: () => useEditorCharactersMock(),
+  useEditorClues: () => useEditorCluesMock(),
+  useEditorLocations: () => useEditorLocationsMock(),
+}));
+
+vi.mock("@/features/editor/mediaApi", () => ({
+  useMediaList: () => useMediaListMock(),
+}));
+
 import { StoryMapWorkspace } from "../StoryMapWorkspace";
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
 describe("StoryMapWorkspace", () => {
+  beforeEach(() => {
+    useEditorCharactersMock.mockReturnValue({
+      data: [{ id: "char-1", name: "한서윤", is_playable: true }],
+      isLoading: false,
+      isError: false,
+    });
+    useEditorCluesMock.mockReturnValue({
+      data: [{ id: "clue-1", name: "찢어진 초대장", location_id: null }],
+      isLoading: false,
+      isError: false,
+    });
+    useEditorLocationsMock.mockReturnValue({
+      data: [{ id: "loc-1", name: "응접실", from_round: null, until_round: null }],
+      isLoading: false,
+      isError: false,
+    });
+    useMediaListMock.mockReturnValue({
+      data: [{ id: "media-1", name: "오프닝 음악", type: "BGM" }],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
   it("스토리 진행 중심 제작 화면과 플로우 캔버스를 함께 렌더링한다", () => {
     render(<StoryMapWorkspace themeId="theme-1" />);
 
@@ -26,11 +72,22 @@ describe("StoryMapWorkspace", () => {
   it("작성자가 장면 흐름에 연결할 엔티티 묶음을 볼 수 있다", () => {
     render(<StoryMapWorkspace themeId="theme-1" />);
 
-    expect(screen.getByText("PC 캐릭터")).toBeDefined();
+    expect(screen.getByText("한서윤")).toBeDefined();
+    expect(screen.getByText("찢어진 초대장")).toBeDefined();
+    expect(screen.getByText("응접실")).toBeDefined();
+    expect(screen.getByText("오프닝 음악")).toBeDefined();
     expect(screen.getByText("단서")).toBeDefined();
     expect(screen.getByText("장소")).toBeDefined();
     expect(screen.getByText("토론방")).toBeDefined();
     expect(screen.getByText("조사권")).toBeDefined();
-    expect(screen.getByText("연출")).toBeDefined();
+  });
+
+  it("라이브러리 항목을 선택하면 우측 패널에 연결 대상으로 표시한다", () => {
+    render(<StoryMapWorkspace themeId="theme-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /찢어진 초대장/ }));
+
+    expect(screen.getByText("선택한 연결 대상")).toBeDefined();
+    expect(screen.getAllByText("찢어진 초대장").length).toBeGreaterThan(1);
   });
 });

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -90,4 +90,18 @@ describe("StoryMapWorkspace", () => {
     expect(screen.getByText("선택한 연결 대상")).toBeDefined();
     expect(screen.getAllByText("찢어진 초대장").length).toBeGreaterThan(1);
   });
+
+  it("테마가 바뀌면 이전 테마의 선택 항목을 초기화한다", () => {
+    const { rerender } = render(<StoryMapWorkspace themeId="theme-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /찢어진 초대장/ }));
+    expect(screen.getAllByText("찢어진 초대장").length).toBeGreaterThan(1);
+
+    rerender(<StoryMapWorkspace themeId="theme-2" />);
+
+    expect(screen.getAllByText("찢어진 초대장")).toHaveLength(1);
+    expect(
+      screen.getByText("왼쪽 라이브러리에서 항목을 선택하면 장면에 붙일 연결 대상으로 표시합니다."),
+    ).toBeDefined();
+  });
 });


### PR DESCRIPTION
## 요약
- 스토리 맵 좌측 제작 라이브러리를 실제 editor read hook 기반 컴포넌트로 분리했습니다.
- 등장인물, 단서, 장소, 미디어와 진행 자원(조사권, 토론방, 트리거)을 장면 연결 후보로 표시합니다.
- 라이브러리 항목 선택 상태를 우측 장면 속성 패널에 연결 대상처럼 노출합니다.
- 로딩, 오류, 빈 상태를 제작자 언어로 표시합니다.

## 검증
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/components/story-map/__tests__/EditorEntityLibrary.test.tsx
- pnpm --filter @mmp/web exec tsc --noEmit
- Playwright smoke: desktop 1440x1000 http://localhost:3001/editor/1f86ab3d-b51c-4d5f-a461-1188fec15fb9 library=true token=true consoleErrors=0
- Playwright smoke: mobile 390x900 http://localhost:3001/editor/1f86ab3d-b51c-4d5f-a461-1188fec15fb9 heading=true library=true token=true consoleErrors=0

Closes #383
Refs #381
Stacked on #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 스토리 맵 편집기의 왼쪽 패널에 통합 제작 라이브러리 추가 - 캐릭터, 단서, 장소를 한 곳에서 선택 가능
* 선택한 항목이 우측 검사 패널에 "선택한 연결 대상"으로 표시
* 각 섹션별 로딩 상태, 오류 처리, 빈 상태 안내 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->