### PR TITLE
feat(editor): 스토리 장면 속성 패널 재구성

### DIFF
--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -3,11 +3,12 @@ import {
   Background,
   MiniMap,
   Controls,
+  type Node,
   type NodeTypes,
   type OnSelectionChangeParams,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFlowData } from "../../hooks/useFlowData";
 import { FlowToolbar } from "./FlowToolbar";
 import { StartNode } from "./StartNode";
@@ -38,13 +39,14 @@ const edgeTypes = { ...conditionEdgeTypes };
 
 interface FlowCanvasProps {
   themeId: string;
+  onSelectedNodeChange?: (node: Node | null) => void;
 }
 
 // ---------------------------------------------------------------------------
 // FlowCanvas
 // ---------------------------------------------------------------------------
 
-export function FlowCanvas({ themeId }: FlowCanvasProps) {
+export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const [showOrderReview, setShowOrderReview] = useState(false);
   const [highlightId, setHighlightId] = useState<string | null>(null);
@@ -81,6 +83,10 @@ export function FlowCanvas({ themeId }: FlowCanvasProps) {
       ),
     [highlightId, nodes],
   );
+
+  useEffect(() => {
+    onSelectedNodeChange?.(selectedNode);
+  }, [onSelectedNodeChange, selectedNode]);
 
   // Add node at canvas center
   const handleAddNode = useCallback(

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -100,6 +100,31 @@ describe('FlowCanvas', () => {
     expect(screen.getByTestId('react-flow')).toBeDefined();
   });
 
+  it('선택 노드 변경 콜백을 현재 선택 상태로 호출한다', () => {
+    const selectedNode = {
+      id: 'scene-1',
+      type: 'start',
+      position: { x: 0, y: 0 },
+      data: { label: '오프닝' },
+    };
+    useFlowDataMock.mockReturnValue({
+      nodes: [selectedNode],
+      edges: [],
+      onNodesChange: vi.fn(),
+      onEdgesChange: vi.fn(),
+      onConnect: vi.fn(),
+      isLoading: false,
+      isSaving: false,
+      save: saveMock,
+      selectedNode,
+    });
+    const onSelectedNodeChange = vi.fn();
+
+    render(<FlowCanvas themeId="theme-1" onSelectedNodeChange={onSelectedNodeChange} />);
+
+    expect(onSelectedNodeChange).toHaveBeenCalledWith(selectedNode);
+  });
+
   it('장면 노드가 있으면 스토리 장면 요약을 렌더링한다', () => {
     useFlowDataMock.mockReturnValue({
       nodes: [

--- a/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
+++ b/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
@@ -1,0 +1,169 @@
+import {
+  Clapperboard,
+  Eye,
+  GitBranch,
+  KeyRound,
+  Link2,
+  MapPin,
+  MessageSquare,
+  Search,
+  Zap,
+} from "lucide-react";
+import type { Node } from "@xyflow/react";
+import type { FlowNodeData } from "@/features/editor/flowTypes";
+import type { StoryLibraryEntity } from "./EditorEntityLibrary";
+
+interface SceneInspectorProps {
+  selectedScene: Node<FlowNodeData> | null;
+  selectedEntity: StoryLibraryEntity | null;
+}
+
+interface InspectorRow {
+  label: string;
+  value: string;
+}
+
+const EMPTY_ROWS: InspectorRow[] = [
+  { label: "정보 공개", value: "장면을 선택하면 공개할 정보를 확인합니다." },
+  { label: "단서 배포", value: "장면을 선택하면 연결된 단서를 확인합니다." },
+  { label: "장소", value: "장면을 선택하면 열리는 장소를 확인합니다." },
+  { label: "조사권", value: "장면을 선택하면 조사권 사용 기준을 확인합니다." },
+  { label: "토론방", value: "장면을 선택하면 대화 공간 정책을 확인합니다." },
+  { label: "연출", value: "장면을 선택하면 미디어와 화면 전환을 확인합니다." },
+  { label: "조건", value: "장면을 선택하면 전환 조건을 확인합니다." },
+  { label: "액션", value: "장면을 선택하면 실행 동작을 확인합니다." },
+];
+
+const ROW_ICONS = [
+  Eye,
+  Search,
+  MapPin,
+  KeyRound,
+  MessageSquare,
+  Clapperboard,
+  GitBranch,
+  Zap,
+] as const;
+
+function describeSceneType(type?: string): string {
+  if (type === "phase") return "스토리 장면";
+  if (type === "branch") return "분기";
+  if (type === "ending") return "엔딩";
+  if (type === "start") return "시작 지점";
+  return "스토리 항목";
+}
+
+function countActions(actions?: FlowNodeData["onEnter"]): string {
+  const count = actions?.length ?? 0;
+  return count > 0 ? `${count}개 설정됨` : "설정 없음";
+}
+
+function hasAction(data: FlowNodeData, keyword: string): boolean {
+  return (data.onEnter ?? []).some((action) => action.type.includes(keyword));
+}
+
+function buildRows(scene: Node<FlowNodeData> | null): InspectorRow[] {
+  if (!scene) return EMPTY_ROWS;
+  const data = scene.data;
+  return [
+    {
+      label: "정보 공개",
+      value: data.description ? "장면 설명 있음" : "공개 설명 없음",
+    },
+    {
+      label: "단서 배포",
+      value: hasAction(data, "clue") ? "입장 시 단서 동작 있음" : "연결된 단서 동작 없음",
+    },
+    {
+      label: "장소",
+      value: hasAction(data, "location") ? "장소 동작 있음" : "장소 동작 없음",
+    },
+    {
+      label: "조사권",
+      value: hasAction(data, "investigation") ? "조사권 동작 있음" : "조사권 동작 없음",
+    },
+    {
+      label: "토론방",
+      value: data.discussionRoomPolicy?.enabled ? "사용" : "사용 안 함",
+    },
+    {
+      label: "연출",
+      value: data.icon || data.color ? "표시 설정 있음" : "기본 표시",
+    },
+    {
+      label: "조건",
+      value: data.autoAdvance ? "자동 진행" : "수동 또는 연결선 조건",
+    },
+    {
+      label: "액션",
+      value: `입장 ${countActions(data.onEnter)} · 퇴장 ${countActions(data.onExit)}`,
+    },
+  ];
+}
+
+export function SceneInspector({ selectedScene, selectedEntity }: SceneInspectorProps) {
+  const rows = buildRows(selectedScene);
+  const sceneTitle = selectedScene?.data.label ?? "선택한 장면 없음";
+
+  return (
+    <aside className="bg-slate-950">
+      <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
+        <MapPin className="h-4 w-4 text-amber-400" />
+        <h3 className="text-sm font-semibold text-slate-100">장면 속성</h3>
+      </div>
+      <div className="space-y-3 p-4">
+        <div className="rounded-md border border-slate-800 bg-slate-900/70 p-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
+            <Link2 className="h-4 w-4 text-amber-400" />
+            선택한 장면
+          </div>
+          <div className="mt-3 rounded-md border border-slate-800 bg-slate-950 p-3">
+            <p className="text-sm font-medium text-slate-100">{sceneTitle}</p>
+            <p className="mt-1 text-xs text-slate-400">
+              {selectedScene
+                ? describeSceneType(selectedScene.type)
+                : "중앙 흐름에서 장면을 선택하세요."}
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-md border border-slate-800 bg-slate-900/70 p-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
+            <KeyRound className="h-4 w-4 text-amber-400" />
+            선택한 연결 대상
+          </div>
+          {selectedEntity ? (
+            <div className="mt-3 rounded-md border border-amber-500/50 bg-amber-500/10 p-3">
+              <p className="text-sm font-medium text-amber-100">{selectedEntity.title}</p>
+              <p className="mt-1 text-xs text-amber-200/80">
+                {selectedEntity.section} · {selectedEntity.detail}
+              </p>
+            </div>
+          ) : (
+            <p className="mt-3 text-sm leading-6 text-slate-400">
+              왼쪽 라이브러리에서 항목을 선택하면 장면에 붙일 연결 대상으로 표시합니다.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {rows.map((row, index) => {
+            const Icon = ROW_ICONS[index];
+            return (
+              <div
+                key={row.label}
+                className="rounded-md border border-slate-800 bg-slate-900/70 p-3"
+              >
+                <div className="flex items-center gap-2 text-sm font-medium text-slate-200">
+                  <Icon className="h-4 w-4 text-amber-400" />
+                  {row.label}
+                </div>
+                <p className="mt-2 text-xs leading-5 text-slate-400">{row.value}</p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -1,26 +1,20 @@
-import {
-  KeyRound,
-  MapPin,
-} from "lucide-react";
+import type { Node } from "@xyflow/react";
 import { useState } from "react";
+import type { FlowNodeData } from "@/features/editor/flowTypes";
 import { FlowCanvas } from "../design/FlowCanvas";
 import {
   EditorEntityLibrary,
   type StoryLibraryEntity,
 } from "./EditorEntityLibrary";
+import { SceneInspector } from "./SceneInspector";
 
 interface StoryMapWorkspaceProps {
   themeId: string;
 }
 
-const INSPECTOR_GROUPS = [
-  { label: "장면 내용", value: "스토리 본문과 공개 정보를 확인합니다." },
-  { label: "연결 항목", value: "등장인물, 단서, 장소를 장면 흐름에 맞춰 연결합니다." },
-  { label: "진행 조건", value: "조사권, 토론방, 트리거를 장면 전환 기준으로 정리합니다." },
-] as const;
-
 export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
   const [selectedEntity, setSelectedEntity] = useState<StoryLibraryEntity | null>(null);
+  const [selectedScene, setSelectedScene] = useState<Node<FlowNodeData> | null>(null);
 
   return (
     <section
@@ -60,44 +54,10 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
         />
 
         <main className="min-h-[620px] min-w-0 border-b border-slate-800 lg:border-b-0">
-          <FlowCanvas themeId={themeId} />
+          <FlowCanvas themeId={themeId} onSelectedNodeChange={setSelectedScene} />
         </main>
 
-        <aside className="bg-slate-950">
-          <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
-            <MapPin className="h-4 w-4 text-amber-400" />
-            <h3 className="text-sm font-semibold text-slate-100">장면 속성</h3>
-          </div>
-          <div className="space-y-3 p-4">
-            <div className="rounded-md border border-slate-800 bg-slate-900/70 p-4">
-              <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
-                <KeyRound className="h-4 w-4 text-amber-400" />
-                선택한 연결 대상
-              </div>
-              {selectedEntity ? (
-                <div className="mt-3 rounded-md border border-amber-500/50 bg-amber-500/10 p-3">
-                  <p className="text-sm font-medium text-amber-100">{selectedEntity.title}</p>
-                  <p className="mt-1 text-xs text-amber-200/80">
-                    {selectedEntity.section} · {selectedEntity.detail}
-                  </p>
-                </div>
-              ) : (
-                <p className="mt-3 text-sm leading-6 text-slate-400">
-                  왼쪽 라이브러리에서 항목을 선택하면 장면에 붙일 연결 대상으로 표시합니다.
-                </p>
-              )}
-            </div>
-            {INSPECTOR_GROUPS.map((group) => (
-              <div
-                key={group.label}
-                className="rounded-md border border-slate-800 bg-slate-900/70 p-3"
-              >
-                <h4 className="text-sm font-medium text-slate-200">{group.label}</h4>
-                <p className="mt-2 text-xs leading-5 text-slate-400">{group.value}</p>
-              </div>
-            ))}
-          </div>
-        </aside>
+        <SceneInspector selectedScene={selectedScene} selectedEntity={selectedEntity} />
       </div>
     </section>
   );

--- a/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Node } from "@xyflow/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { FlowNodeData } from "@/features/editor/flowTypes";
+import { SceneInspector } from "../SceneInspector";
+import type { StoryLibraryEntity } from "../EditorEntityLibrary";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SceneInspector", () => {
+  it("장면이 없으면 제작자 언어의 빈 요약을 표시한다", () => {
+    render(<SceneInspector selectedScene={null} selectedEntity={null} />);
+
+    expect(screen.getByText("선택한 장면 없음")).toBeDefined();
+    expect(screen.getByText("장면을 선택하면 공개할 정보를 확인합니다.")).toBeDefined();
+    expect(screen.getByText("장면을 선택하면 실행 동작을 확인합니다.")).toBeDefined();
+  });
+
+  it("선택한 장면의 공개, 토론방, 조건, 액션 요약을 표시한다", () => {
+    const scene: Node<FlowNodeData> = {
+      id: "scene-1",
+      type: "phase",
+      position: { x: 0, y: 0 },
+      data: {
+        label: "오프닝",
+        description: "도입 장면",
+        autoAdvance: true,
+        onEnter: [{ type: "give_clue" }],
+        onExit: [{ type: "open_location" }],
+        discussionRoomPolicy: {
+          enabled: true,
+          mainRoomName: "전체 토론",
+          privateRoomsEnabled: false,
+          privateRoomName: "비밀 대화",
+          availability: "phase_active",
+        },
+      },
+    };
+
+    render(<SceneInspector selectedScene={scene} selectedEntity={null} />);
+
+    expect(screen.getByText("오프닝")).toBeDefined();
+    expect(screen.getByText("스토리 장면")).toBeDefined();
+    expect(screen.getByText("장면 설명 있음")).toBeDefined();
+    expect(screen.getByText("입장 시 단서 동작 있음")).toBeDefined();
+    expect(screen.getByText("사용")).toBeDefined();
+    expect(screen.getByText("자동 진행")).toBeDefined();
+    expect(screen.getByText("입장 1개 설정됨 · 퇴장 1개 설정됨")).toBeDefined();
+  });
+
+  it("선택한 라이브러리 항목을 연결 대상으로 표시한다", () => {
+    const entity: StoryLibraryEntity = {
+      id: "clue-1",
+      kind: "clue",
+      title: "찢어진 초대장",
+      detail: "공통 단서",
+      section: "단서",
+      connectable: true,
+    };
+
+    render(<SceneInspector selectedScene={null} selectedEntity={entity} />);
+
+    expect(screen.getByText("찢어진 초대장")).toBeDefined();
+    expect(screen.getByText("단서 · 공통 단서")).toBeDefined();
+  });
+});

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -14,8 +14,32 @@ const {
 }));
 
 vi.mock("../../design/FlowCanvas", () => ({
-  FlowCanvas: ({ themeId }: { themeId: string }) => (
-    <div data-testid="flow-canvas">flow canvas {themeId}</div>
+  FlowCanvas: ({
+    themeId,
+    onSelectedNodeChange,
+  }: {
+    themeId: string;
+    onSelectedNodeChange?: (node: unknown) => void;
+  }) => (
+    <div data-testid="flow-canvas">
+      flow canvas {themeId}
+      <button
+        type="button"
+        onClick={() =>
+          onSelectedNodeChange?.({
+            id: "scene-1",
+            type: "phase",
+            data: {
+              label: "오프닝",
+              description: "도입 장면",
+              discussionRoomPolicy: { enabled: true },
+            },
+          })
+        }
+      >
+        장면 선택
+      </button>
+    </div>
   ),
 }));
 
@@ -77,9 +101,9 @@ describe("StoryMapWorkspace", () => {
     expect(screen.getByText("응접실")).toBeDefined();
     expect(screen.getByText("오프닝 음악")).toBeDefined();
     expect(screen.getByText("단서")).toBeDefined();
-    expect(screen.getByText("장소")).toBeDefined();
-    expect(screen.getByText("토론방")).toBeDefined();
-    expect(screen.getByText("조사권")).toBeDefined();
+    expect(screen.getAllByText("장소").length).toBeGreaterThan(1);
+    expect(screen.getAllByText("토론방").length).toBeGreaterThan(1);
+    expect(screen.getAllByText("조사권").length).toBeGreaterThan(1);
   });
 
   it("라이브러리 항목을 선택하면 우측 패널에 연결 대상으로 표시한다", () => {
@@ -89,5 +113,16 @@ describe("StoryMapWorkspace", () => {
 
     expect(screen.getByText("선택한 연결 대상")).toBeDefined();
     expect(screen.getAllByText("찢어진 초대장").length).toBeGreaterThan(1);
+  });
+
+  it("중앙 흐름에서 장면이 선택되면 우측 패널에 장면 요약을 표시한다", () => {
+    render(<StoryMapWorkspace themeId="theme-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "장면 선택" }));
+
+    expect(screen.getByText("오프닝")).toBeDefined();
+    expect(screen.getByText("스토리 장면")).toBeDefined();
+    expect(screen.getByText("장면 설명 있음")).toBeDefined();
+    expect(screen.getByText("사용")).toBeDefined();
   });
 });


### PR DESCRIPTION
## 요약
- FlowCanvas의 선택 노드를 스토리 맵 우측 패널로 전달하도록 얇은 콜백을 추가했습니다.
- SceneInspector를 추가해 선택한 장면 기준으로 정보 공개, 단서 배포, 장소, 조사권, 토론방, 연출, 조건, 액션 요약을 제작자 언어로 표시합니다.
- 선택한 라이브러리 항목도 우측 패널에서 연결 대상으로 함께 표시합니다.
- 새 저장 계약이나 backend runtime 판정은 추가하지 않았습니다.

## 검증
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
- pnpm --filter @mmp/web exec tsc --noEmit
- Playwright smoke: desktop 1440x1000 http://localhost:3002/editor/1f86ab3d-b51c-4d5f-a461-1188fec15fb9 inspector=true sceneEmpty=true action=true consoleErrors=0
- Playwright smoke: mobile 390x900 http://localhost:3002/editor/1f86ab3d-b51c-4d5f-a461-1188fec15fb9 heading=true inspector=true action=true consoleErrors=0

Closes #384
Refs #381
Stacked on #388