### PR TITLE
feat(editor): 기존 에디터 페이지를 보조 관리로 정리

### DIFF
--- a/apps/web/src/features/editor/components/EditorTabNav.tsx
+++ b/apps/web/src/features/editor/components/EditorTabNav.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useMemo, useEffect } from "react";
+import { Fragment, useRef, useCallback, useMemo, useEffect } from "react";
 import { EDITOR_TABS, type EditorTab } from "@/features/editor/constants";
 import { useEditorUI } from "@/features/editor/stores/editorUIStore";
 
@@ -72,28 +72,36 @@ export function EditorTabNav({
       >
         {visibleTabs.map((tab, index) => {
           const isActive = activeTab === tab.key;
+          const startsNewGroup = index > 0 && visibleTabs[index - 1]?.group !== tab.group;
           return (
-            <button
-              key={tab.key}
-              ref={(el) => {
-                tabRefs.current[index] = el;
-              }}
-              role="tab"
-              aria-selected={isActive}
-              aria-controls={`tabpanel-${tab.key}`}
-              id={`tab-${tab.key}`}
-              tabIndex={isActive ? 0 : -1}
-              onClick={() => setActiveTab(tab.key)}
-              onKeyDown={(e) => handleKeyDown(e, index)}
-              className={`relative flex shrink-0 items-center gap-1.5 px-4 text-xs font-medium transition-colors ${
-                isActive
-                  ? "text-amber-400 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-amber-500"
-                  : "text-slate-500 hover:bg-slate-900/50 hover:text-slate-300"
-              }`}
-            >
-              <tab.icon className="h-3.5 w-3.5" />
-              {tab.label}
-            </button>
+            <Fragment key={tab.key}>
+              {startsNewGroup && (
+                <div
+                  aria-hidden="true"
+                  className="my-2 mr-2 w-px bg-slate-800"
+                />
+              )}
+              <button
+                ref={(el) => {
+                  tabRefs.current[index] = el;
+                }}
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`tabpanel-${tab.key}`}
+                id={`tab-${tab.key}`}
+                tabIndex={isActive ? 0 : -1}
+                onClick={() => setActiveTab(tab.key)}
+                onKeyDown={(e) => handleKeyDown(e, index)}
+                className={`relative flex shrink-0 items-center gap-1.5 px-4 text-xs font-medium transition-colors ${
+                  isActive
+                    ? "text-amber-400 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-amber-500"
+                    : "text-slate-500 hover:bg-slate-900/50 hover:text-slate-300"
+                }`}
+              >
+                <tab.icon className="h-3.5 w-3.5" />
+                {tab.label}
+              </button>
+            </Fragment>
           );
         })}
       </nav>

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -35,26 +35,29 @@ describe("EditorTabNav dynamic tabs", () => {
   it("모듈 미지정 시 always=true 탭만 표시된다", () => {
     render(<EditorTabNav />);
     expect(screen.getByText("스토리 진행")).toBeDefined();
-    expect(screen.getByText("기본정보")).toBeDefined();
-    expect(screen.getByText("게임설계")).toBeDefined();
-    expect(screen.queryByText("미디어")).toBeNull();
+    expect(screen.getByText("등장인물 관리")).toBeDefined();
+    expect(screen.getByText("단서 관리")).toBeDefined();
+    expect(screen.getByText("게임 설계")).toBeDefined();
+    expect(screen.getByText("기본 설정")).toBeDefined();
+    expect(screen.getByText("고급 설정")).toBeDefined();
+    expect(screen.queryByText("미디어 관리")).toBeNull();
   });
 
   it("voice_chat 모듈 활성 시 미디어 탭이 표시된다", () => {
     render(<EditorTabNav activeModules={["voice_chat"]} />);
-    expect(screen.getByText("미디어")).toBeDefined();
+    expect(screen.getByText("미디어 관리")).toBeDefined();
   });
 
   it("모듈 비활성 시 미디어 탭이 숨겨진다", () => {
     render(<EditorTabNav activeModules={["text_chat"]} />);
-    expect(screen.queryByText("미디어")).toBeNull();
+    expect(screen.queryByText("미디어 관리")).toBeNull();
   });
 
   it("직접 URL로 열린 탭은 모듈이 비활성이어도 숨기지 않는다", () => {
     mockActiveTab.current = "media";
     render(<EditorTabNav activeModules={[]} forcedVisibleTab="media" />);
 
-    expect(screen.getByText("미디어")).toBeDefined();
+    expect(screen.getByText("미디어 관리")).toBeDefined();
     expect(mockSetActiveTab).not.toHaveBeenCalledWith("storyMap");
   });
 
@@ -62,5 +65,22 @@ describe("EditorTabNav dynamic tabs", () => {
     mockActiveTab.current = "media";
     render(<EditorTabNav activeModules={[]} />);
     expect(mockSetActiveTab).toHaveBeenCalledWith("storyMap");
+  });
+
+  it("스토리 진행, 보조 관리, 설정 순서로 탭 우선순위를 유지한다", () => {
+    render(<EditorTabNav activeModules={["voice_chat"]} />);
+
+    const tabLabels = screen.getAllByRole("tab").map((tab) => tab.textContent);
+    expect(tabLabels).toEqual([
+      "스토리 진행",
+      "스토리",
+      "등장인물 관리",
+      "단서 관리",
+      "게임 설계",
+      "미디어 관리",
+      "기본 설정",
+      "템플릿",
+      "고급 설정",
+    ]);
   });
 });

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -16,15 +16,15 @@ import type { ThemeStatus } from "./api";
 // ---------------------------------------------------------------------------
 
 export const EDITOR_TABS = [
-  { key: "storyMap" as const, label: "스토리 진행", icon: GitBranch, always: true },
-  { key: "overview" as const, label: "기본정보", icon: FileText, always: true },
-  { key: "story" as const, label: "스토리", icon: BookOpen, always: true },
-  { key: "characters" as const, label: "등장인물", icon: Users, always: true },
-  { key: "clues" as const, label: "단서", icon: Search, always: true },
-  { key: "design" as const, label: "게임설계", icon: Settings, always: true },
-  { key: "media" as const, label: "미디어", icon: Music, always: false, requiredModule: "voice_chat" },
-  { key: "advanced" as const, label: "고급", icon: Code, always: true },
-  { key: "template" as const, label: "템플릿", icon: LayoutTemplate, always: true },
+  { key: "storyMap" as const, label: "스토리 진행", icon: GitBranch, always: true, group: "primary" },
+  { key: "story" as const, label: "스토리", icon: BookOpen, always: true, group: "manage" },
+  { key: "characters" as const, label: "등장인물 관리", icon: Users, always: true, group: "manage" },
+  { key: "clues" as const, label: "단서 관리", icon: Search, always: true, group: "manage" },
+  { key: "design" as const, label: "게임 설계", icon: Settings, always: true, group: "manage" },
+  { key: "media" as const, label: "미디어 관리", icon: Music, always: false, requiredModule: "voice_chat", group: "manage" },
+  { key: "overview" as const, label: "기본 설정", icon: FileText, always: true, group: "settings" },
+  { key: "template" as const, label: "템플릿", icon: LayoutTemplate, always: true, group: "settings" },
+  { key: "advanced" as const, label: "고급 설정", icon: Code, always: true, group: "settings" },
 ] as const;
 
 export type EditorTab = (typeof EDITOR_TABS)[number]["key"];


### PR DESCRIPTION
## 요약
- 에디터 탭 순서를 스토리 진행 중심으로 재배치했습니다.
- 기존 등장인물, 단서, 게임 설계, 미디어 페이지는 직접 URL을 유지하면서 보조 관리 화면임이 드러나도록 라벨을 정리했습니다.
- 기본정보, 템플릿, 고급은 설정 영역으로 뒤쪽에 배치했습니다.
- 탭 그룹 경계와 회귀 테스트로 primary/manage/settings 우선순위를 고정했습니다.

## 검증
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/EditorTabNav.test.tsx src/pages/__tests__/EditorPage.test.tsx src/features/editor/__tests__/routeSegments.test.ts
- pnpm --filter @mmp/web exec tsc --noEmit
- Playwright smoke 시도: dev server 렌더는 정상, 현재 로컬 인증 세션이 유지되지 않아 /editor 진입은 /login으로 redirect됨

Closes #385
Refs #381
Stacked on #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 편집기 탭을 그룹별로 시각적 구분선으로 나눠 표시

* **개선 사항**
  * 탭 레이블을 더 명확한 한국어 표기로 업데이트
  * 탭의 렌더링 순서 및 우선순위 정리
  * 특정 탭은 관련 기능 활성화 시에만 표시되도록 동작 개선

* **테스트**
  * 한국어 전체 탭 라벨 및 탭 순서/가시성에 대한 테스트 확장 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->