### PR TITLE
fix(editor): 스토리 연결 해제와 캐릭터 이미지 UX 개선

### DIFF
--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -1199,6 +1199,7 @@ components:
         image_url:
           type: string
           format: uri
+          description: "빈 문자열을 보내면 저장된 캐릭터 이미지를 제거합니다."
         sort_order:
           type: integer
 

--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -1199,7 +1199,6 @@ components:
         image_url:
           type: string
           format: uri
-          description: "빈 문자열을 보내면 저장된 캐릭터 이미지를 제거합니다."
         sort_order:
           type: integer
 
@@ -1367,7 +1366,10 @@ components:
           maxLength: 2000
         image_url:
           type: string
-          format: uri
+          description: "캐릭터 이미지 URL입니다. 빈 문자열을 보내면 저장된 캐릭터 이미지를 제거합니다."
+          anyOf:
+            - format: uri
+            - enum: [""]
         endcard_title:
           type: string
           maxLength: 80
@@ -1412,7 +1414,10 @@ components:
           maxLength: 2000
         image_url:
           type: string
-          format: uri
+          description: "캐릭터 이미지 URL입니다. 빈 문자열을 보내면 저장된 캐릭터 이미지를 제거합니다."
+          anyOf:
+            - format: uri
+            - enum: [""]
         endcard_title:
           type: string
           maxLength: 80

--- a/apps/server/internal/domain/editor/handler_test.go
+++ b/apps/server/internal/domain/editor/handler_test.go
@@ -327,6 +327,35 @@ func TestUpdateCharacter_AllowsEmptyEndcardImageURL(t *testing.T) {
 	}
 }
 
+func TestUpdateCharacter_AllowsEmptyImageURL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockService(ctrl)
+
+	mock.EXPECT().
+		UpdateCharacter(gomock.Any(), gomock.Eq(extCreatorID), gomock.Eq(extCharID), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, _ uuid.UUID, req editor.UpdateCharacterRequest) (*editor.CharacterResponse, error) {
+			if req.ImageURL == nil || *req.ImageURL != "" {
+				t.Fatalf("expected empty image URL to reach service, got %+v", req.ImageURL)
+			}
+			return extSampleCharResponse(), nil
+		}).Times(1)
+
+	h := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
+
+	body := `{"name":"Detective Updated","is_culprit":false,"sort_order":1,"image_url":""}`
+	r := httptest.NewRequest(http.MethodPut, "/editor/characters/"+extCharID.String(), bytes.NewBufferString(body))
+	r.Header.Set("Content-Type", "application/json")
+	r = withExtAuth(r)
+	r = extChiContext(r, map[string]string{"id": extCharID.String()})
+	w := httptest.NewRecorder()
+
+	h.UpdateCharacter(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestDeleteCharacter_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := mocks.NewMockService(ctrl)

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -93,7 +93,7 @@ type ThemeSummary struct {
 type CreateCharacterRequest struct {
 	Name              string               `json:"name" validate:"required,min=1,max=50"`
 	Description       *string              `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string              `json:"image_url" validate:"omitempty,url"`
+	ImageURL          *string              `json:"image_url" validate:"omitempty,optional_url"`
 	IsCulprit         bool                 `json:"is_culprit"`
 	MysteryRole       string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
 	SortOrder         int32                `json:"sort_order" validate:"min=0"`
@@ -110,7 +110,7 @@ type CreateCharacterRequest struct {
 type UpdateCharacterRequest struct {
 	Name              string               `json:"name" validate:"required,min=1,max=50"`
 	Description       *string              `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string              `json:"image_url" validate:"omitempty,url"`
+	ImageURL          *string              `json:"image_url" validate:"omitempty,optional_url"`
 	IsCulprit         bool                 `json:"is_culprit"`
 	MysteryRole       string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
 	SortOrder         int32                `json:"sort_order" validate:"min=0"`

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -52,7 +52,7 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		ThemeID:           themeID,
 		Name:              req.Name,
 		Description:       ptrToText(req.Description),
-		ImageUrl:          ptrToText(req.ImageURL),
+		ImageUrl:          characterImageText(req.ImageURL),
 		IsCulprit:         rolePolicy.IsCulprit,
 		MysteryRole:       rolePolicy.MysteryRole,
 		SortOrder:         req.SortOrder,
@@ -117,7 +117,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		ID:                charID,
 		Name:              req.Name,
 		Description:       ptrToText(req.Description),
-		ImageUrl:          ptrToText(req.ImageURL),
+		ImageUrl:          characterImageText(req.ImageURL),
 		IsCulprit:         rolePolicy.IsCulprit,
 		MysteryRole:       rolePolicy.MysteryRole,
 		SortOrder:         req.SortOrder,
@@ -238,6 +238,13 @@ func characterEndcardText(next *string, current pgtype.Text) pgtype.Text {
 		return current
 	}
 	if *next == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *next, Valid: true}
+}
+
+func characterImageText(next *string) pgtype.Text {
+	if next == nil || *next == "" {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: *next, Valid: true}

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -117,7 +117,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		ID:                charID,
 		Name:              req.Name,
 		Description:       ptrToText(req.Description),
-		ImageUrl:          characterImageText(req.ImageURL),
+		ImageUrl:          characterImageText(req.ImageURL, char.ImageUrl),
 		IsCulprit:         rolePolicy.IsCulprit,
 		MysteryRole:       rolePolicy.MysteryRole,
 		SortOrder:         req.SortOrder,
@@ -243,8 +243,14 @@ func characterEndcardText(next *string, current pgtype.Text) pgtype.Text {
 	return pgtype.Text{String: *next, Valid: true}
 }
 
-func characterImageText(next *string) pgtype.Text {
-	if next == nil || *next == "" {
+func characterImageText(next *string, current ...pgtype.Text) pgtype.Text {
+	if next == nil {
+		if len(current) > 0 {
+			return current[0]
+		}
+		return pgtype.Text{}
+	}
+	if *next == "" {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: *next, Valid: true}

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -285,6 +285,9 @@ func TestService_UpdateCharacter(t *testing.T) {
 	if !updated.IsPlayable || !updated.ShowInIntro || !updated.CanSpeakInReading || !updated.IsVotingCandidate {
 		t.Errorf("update should preserve default playable visibility: %+v", updated)
 	}
+	if updated.ImageURL == nil || *updated.ImageURL != "https://cdn.example/original.webp" {
+		t.Fatalf("omitted image_url should preserve stored character image: %+v", updated.ImageURL)
+	}
 
 	clearedImage, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
 		Name:      "Updated",

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -262,7 +262,7 @@ func TestService_UpdateCharacter(t *testing.T) {
 	themeID := f.createThemeForUser(t, creatorID)
 
 	created, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{
-		Name: "Original", SortOrder: 0,
+		Name: "Original", SortOrder: 0, ImageURL: textPtr("https://cdn.example/original.webp"),
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -284,6 +284,19 @@ func TestService_UpdateCharacter(t *testing.T) {
 	}
 	if !updated.IsPlayable || !updated.ShowInIntro || !updated.CanSpeakInReading || !updated.IsVotingCandidate {
 		t.Errorf("update should preserve default playable visibility: %+v", updated)
+	}
+
+	clearedImage, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:      "Updated",
+		IsCulprit: true,
+		SortOrder: 0,
+		ImageURL:  textPtr(""),
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter clear image: %v", err)
+	}
+	if clearedImage.ImageURL != nil {
+		t.Fatalf("empty image_url should clear stored character image: %+v", clearedImage.ImageURL)
 	}
 }
 

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -113,7 +113,7 @@ export interface CreateCharacterRequest {
 export interface UpdateCharacterRequest {
   name?: string;
   description?: string;
-  image_url?: string | null;
+  image_url?: string;
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
   sort_order?: number;

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -113,7 +113,7 @@ export interface CreateCharacterRequest {
 export interface UpdateCharacterRequest {
   name?: string;
   description?: string;
-  image_url?: string;
+  image_url?: string | null;
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
   sort_order?: number;

--- a/apps/web/src/features/editor/components/CharacterForm.tsx
+++ b/apps/web/src/features/editor/components/CharacterForm.tsx
@@ -59,7 +59,7 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
       next.name = '이름은 50자 이하여야 합니다';
     }
 
-    if (description.length > 2000) {
+    if (isEditMode && description.length > 2000) {
       next.description = '설명은 2000자 이하여야 합니다';
     }
 
@@ -86,7 +86,7 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
           body: {
             name: name.trim(),
             description: description || undefined,
-            image_url: imageUrl || undefined,
+            image_url: imageUrl,
             is_culprit: isCulprit,
             sort_order: sortOrder,
             mystery_role: nextMysteryRole,
@@ -113,10 +113,6 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
       createCharacter.mutate(
         {
           name: name.trim(),
-          description: description || undefined,
-          image_url: imageUrl || undefined,
-          is_culprit: isCulprit,
-          sort_order: sortOrder,
         },
         {
           onSuccess: () => {
@@ -160,64 +156,69 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
           error={errors.name}
         />
 
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="character-description" className="text-sm font-medium text-slate-300">
-            설명
-          </label>
-          <textarea
-            id="character-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="캐릭터에 대한 설명"
-            maxLength={2000}
-            rows={3}
-            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
-          />
-          {errors.description && (
-            <p className="text-sm text-red-400">{errors.description}</p>
-          )}
-        </div>
+        {isEditMode && (
+          <>
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="character-description" className="text-sm font-medium text-slate-300">
+                설명
+              </label>
+              <textarea
+                id="character-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="캐릭터에 대한 설명"
+                maxLength={2000}
+                rows={3}
+                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+              />
+              {errors.description && (
+                <p className="text-sm text-red-400">{errors.description}</p>
+              )}
+            </div>
 
-        <div className="flex flex-col gap-1.5">
-          <span className="text-sm font-medium text-slate-300">캐릭터 이미지</span>
-          <div className="flex items-center gap-4">
-            <ImageCropUpload
-              themeId={themeId}
-              targetId={character?.id ?? ''}
-              target="character"
-              currentImageUrl={imageUrl || null}
-              onUploaded={(url) => setImageUrl(url)}
-              size="lg"
-              shape="circle"
+            <div className="flex flex-col gap-1.5">
+              <span className="text-sm font-medium text-slate-300">캐릭터 이미지</span>
+              <div className="flex items-center gap-4">
+                <ImageCropUpload
+                  themeId={themeId}
+                  targetId={character?.id ?? ''}
+                  target="character"
+                  currentImageUrl={imageUrl || null}
+                  onUploaded={(url) => setImageUrl(url)}
+                  onRemoved={imageUrl ? () => setImageUrl('') : undefined}
+                  size="lg"
+                  shape="circle"
+                />
+                <p className="text-xs text-slate-500">
+                  클릭하여 이미지를 업로드하세요
+                  <br />
+                  1:1 비율로 자동 자르기됩니다
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <input
+                id="character-is-culprit"
+                type="checkbox"
+                checked={isCulprit}
+                onChange={(e) => setIsCulprit(e.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+              />
+              <label htmlFor="character-is-culprit" className="text-sm font-medium text-slate-300">
+                범인 여부
+              </label>
+            </div>
+
+            <Input
+              label="정렬 순서"
+              type="number"
+              value={sortOrder}
+              onChange={(e) => setSortOrder(Number(e.target.value))}
+              min={0}
             />
-            <p className="text-xs text-slate-500">
-              클릭하여 이미지를 업로드하세요
-              <br />
-              1:1 비율로 자동 자르기됩니다
-            </p>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <input
-            id="character-is-culprit"
-            type="checkbox"
-            checked={isCulprit}
-            onChange={(e) => setIsCulprit(e.target.checked)}
-            className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
-          />
-          <label htmlFor="character-is-culprit" className="text-sm font-medium text-slate-300">
-            범인 여부
-          </label>
-        </div>
-
-        <Input
-          label="정렬 순서"
-          type="number"
-          value={sortOrder}
-          onChange={(e) => setSortOrder(Number(e.target.value))}
-          min={0}
-        />
+          </>
+        )}
       </form>
     </Modal>
   );

--- a/apps/web/src/features/editor/components/ImageCropUpload.tsx
+++ b/apps/web/src/features/editor/components/ImageCropUpload.tsx
@@ -57,7 +57,9 @@ export function ImageCropUpload({
   const previewPx = PREVIEW_SIZE[size];
   const isCircle = shape === 'circle';
 
-  function handleClick() { fileInputRef.current?.click(); }
+  function handleClick() {
+    fileInputRef.current?.click();
+  }
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -94,7 +96,10 @@ export function ImageCropUpload({
     setIsUploading(true);
     try {
       const { blob, contentType } = await getCroppedBlob(
-        imgRef.current, completedCrop, CANVAS_OUTPUT_SIZE, CANVAS_OUTPUT_SIZE,
+        imgRef.current,
+        completedCrop,
+        CANVAS_OUTPUT_SIZE,
+        CANVAS_OUTPUT_SIZE
       );
       const url = await uploadImage(themeId, target, targetId, blob, contentType);
       onUploaded(url);
@@ -108,11 +113,25 @@ export function ImageCropUpload({
     }
   }
 
-  function handleCancel() { setModalOpen(false); setSrcUrl(null); }
+  function handleCancel() {
+    setModalOpen(false);
+    setSrcUrl(null);
+  }
+
+  function handleRemoveClick() {
+    if (!window.confirm('이미지를 삭제할까요? 이 작업은 즉시 저장됩니다.')) return;
+    onRemoved?.();
+  }
 
   return (
     <>
-      <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleFileChange} />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileChange}
+      />
 
       <div className="flex flex-col items-center gap-2">
         <button
@@ -129,14 +148,18 @@ export function ImageCropUpload({
               <Camera className="h-6 w-6" />
             </span>
           )}
-          <span className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100" aria-hidden="true">
+          <span
+            className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100"
+            aria-hidden="true"
+          >
             <Camera className="h-5 w-5 text-white" />
           </span>
         </button>
         {currentImageUrl && onRemoved && (
           <button
             type="button"
-            onClick={onRemoved}
+            onClick={handleRemoveClick}
+            aria-label="이미지 삭제"
             className="inline-flex items-center gap-1 rounded-md border border-slate-800 bg-slate-950 px-2 py-1 text-[11px] font-medium text-slate-400 transition hover:border-red-500/40 hover:text-red-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/60"
           >
             <Trash2 className="h-3 w-3" />
@@ -152,9 +175,21 @@ export function ImageCropUpload({
         size="md"
         footer={
           <>
-            <Button variant="secondary" onClick={handleCancel} disabled={isUploading}>취소</Button>
-            <Button onClick={handleConfirm} disabled={isUploading || !completedCrop || !themeId || !targetId}>
-              {isUploading ? <><Loader2 className="h-4 w-4 animate-spin" />업로드 중…</> : '확인'}
+            <Button variant="secondary" onClick={handleCancel} disabled={isUploading}>
+              취소
+            </Button>
+            <Button
+              onClick={handleConfirm}
+              disabled={isUploading || !completedCrop || !themeId || !targetId}
+            >
+              {isUploading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  업로드 중…
+                </>
+              ) : (
+                '확인'
+              )}
             </Button>
           </>
         }

--- a/apps/web/src/features/editor/components/ImageCropUpload.tsx
+++ b/apps/web/src/features/editor/components/ImageCropUpload.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback } from 'react';
 import ReactCrop, { type Crop, type PixelCrop } from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
-import { Camera, Loader2 } from 'lucide-react';
+import { Camera, Loader2, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Modal } from '@/shared/components/ui/Modal';
 import { Button } from '@/shared/components/ui/Button';
@@ -18,6 +18,7 @@ export interface ImageCropUploadProps {
   target: 'character' | 'clue' | 'location';
   currentImageUrl?: string | null;
   onUploaded: (url: string) => void;
+  onRemoved?: () => void;
   size?: 'sm' | 'md' | 'lg';
   shape?: 'circle' | 'square';
 }
@@ -40,6 +41,7 @@ export function ImageCropUpload({
   target,
   currentImageUrl,
   onUploaded,
+  onRemoved,
   size = 'md',
   shape = 'circle',
 }: ImageCropUploadProps) {
@@ -112,24 +114,36 @@ export function ImageCropUpload({
     <>
       <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleFileChange} />
 
-      <button
-        type="button"
-        onClick={handleClick}
-        className="group relative flex-shrink-0 overflow-hidden border-2 border-slate-700 bg-slate-800 transition-colors hover:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
-        style={{ width: previewPx, height: previewPx, borderRadius: isCircle ? '50%' : '0.5rem' }}
-        aria-label="이미지 업로드"
-      >
-        {currentImageUrl ? (
-          <img src={currentImageUrl} alt="캐릭터 이미지" className="h-full w-full object-cover" />
-        ) : (
-          <span className="flex h-full w-full items-center justify-center text-slate-500">
-            <Camera className="h-6 w-6" />
+      <div className="flex flex-col items-center gap-2">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="group relative flex-shrink-0 overflow-hidden border-2 border-slate-700 bg-slate-800 transition-colors hover:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          style={{ width: previewPx, height: previewPx, borderRadius: isCircle ? '50%' : '0.5rem' }}
+          aria-label="이미지 업로드"
+        >
+          {currentImageUrl ? (
+            <img src={currentImageUrl} alt="캐릭터 이미지" className="h-full w-full object-cover" />
+          ) : (
+            <span className="flex h-full w-full items-center justify-center text-slate-500">
+              <Camera className="h-6 w-6" />
+            </span>
+          )}
+          <span className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100" aria-hidden="true">
+            <Camera className="h-5 w-5 text-white" />
           </span>
+        </button>
+        {currentImageUrl && onRemoved && (
+          <button
+            type="button"
+            onClick={onRemoved}
+            className="inline-flex items-center gap-1 rounded-md border border-slate-800 bg-slate-950 px-2 py-1 text-[11px] font-medium text-slate-400 transition hover:border-red-500/40 hover:text-red-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/60"
+          >
+            <Trash2 className="h-3 w-3" />
+            삭제
+          </button>
         )}
-        <span className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100" aria-hidden="true">
-          <Camera className="h-5 w-5 text-white" />
-        </span>
-      </button>
+      </div>
 
       <Modal
         isOpen={modalOpen}

--- a/apps/web/src/features/editor/components/__tests__/CharacterForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CharacterForm.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import type { EditorCharacterResponse } from '@/features/editor/api';
+
+const {
+  useCreateCharacterMock,
+  useUpdateCharacterMock,
+  createCharacterMutateMock,
+  updateCharacterMutateMock,
+} = vi.hoisted(() => ({
+  useCreateCharacterMock: vi.fn(),
+  useUpdateCharacterMock: vi.fn(),
+  createCharacterMutateMock: vi.fn(),
+  updateCharacterMutateMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/features/editor/api', () => ({
+  useCreateCharacter: () => useCreateCharacterMock(),
+  useUpdateCharacter: () => useUpdateCharacterMock(),
+}));
+
+vi.mock('@/features/editor/components/ImageCropUpload', () => ({
+  ImageCropUpload: () => <div data-testid="character-image-upload" />,
+}));
+
+vi.mock('@/shared/components/ui/Modal', () => ({
+  Modal: ({
+    isOpen,
+    children,
+    footer,
+    title,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    footer: React.ReactNode;
+    title: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/shared/components/ui/Button', () => ({
+  Button: ({
+    children,
+    onClick,
+    type,
+    form,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    type?: 'button' | 'submit';
+    form?: string;
+    disabled?: boolean;
+  }) => (
+    <button type={type ?? 'button'} form={form} onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/shared/components/ui/Input', () => ({
+  Input: ({
+    label,
+    value,
+    onChange,
+    error,
+    ...rest
+  }: {
+    label?: string;
+    value: string | number;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    error?: string;
+    [key: string]: unknown;
+  }) => (
+    <label>
+      {label}
+      <input
+        aria-label={label}
+        value={value}
+        onChange={onChange}
+        {...(rest as Record<string, unknown>)}
+      />
+      {error && <span role="alert">{error}</span>}
+    </label>
+  ),
+}));
+
+import { CharacterForm } from '../CharacterForm';
+
+const character: EditorCharacterResponse = {
+  id: 'char-1',
+  theme_id: 'theme-1',
+  name: '홍길동',
+  description: '공개 소개',
+  image_url: 'https://cdn.example/character.webp',
+  is_culprit: false,
+  mystery_role: 'suspect',
+  sort_order: 0,
+  is_playable: true,
+  show_in_intro: true,
+  can_speak_in_reading: true,
+  is_voting_candidate: true,
+  endcard_title: null,
+  endcard_body: null,
+  endcard_image_url: null,
+  alias_rules: [],
+};
+
+describe('CharacterForm', () => {
+  beforeEach(() => {
+    useCreateCharacterMock.mockReturnValue({ mutate: createCharacterMutateMock, isPending: false });
+    useUpdateCharacterMock.mockReturnValue({ mutate: updateCharacterMutateMock, isPending: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('생성 모달은 상세 기본정보와 겹치는 필드를 숨긴다', () => {
+    render(<CharacterForm themeId="theme-1" isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByRole('dialog', { name: '캐릭터 추가' })).toBeDefined();
+    expect(screen.getByLabelText('이름')).toBeDefined();
+    expect(screen.queryByLabelText('설명')).toBeNull();
+    expect(screen.queryByText('캐릭터 이미지')).toBeNull();
+    expect(screen.queryByLabelText(/범인 여부/)).toBeNull();
+    expect(screen.queryByLabelText('정렬 순서')).toBeNull();
+  });
+
+  it('생성 요청은 이름만 보낸 뒤 나머지는 기본정보에서 관리하게 한다', () => {
+    render(<CharacterForm themeId="theme-1" isOpen onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('이름'), { target: { value: '새 인물' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(createCharacterMutateMock).toHaveBeenCalledWith(
+      { name: '새 인물' },
+      expect.any(Object),
+    );
+  });
+
+  it('수정 모달은 기존 quick edit 필드를 유지한다', () => {
+    render(<CharacterForm themeId="theme-1" character={character} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByRole('dialog', { name: '캐릭터 수정' })).toBeDefined();
+    expect(screen.getByLabelText('설명')).toBeDefined();
+    expect(screen.getByTestId('character-image-upload')).toBeDefined();
+    expect(screen.getByLabelText(/범인 여부/)).toBeDefined();
+    expect(screen.getByLabelText('정렬 순서')).toBeDefined();
+  });
+});

--- a/apps/web/src/features/editor/components/__tests__/ImageCropUpload.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ImageCropUpload.test.tsx
@@ -70,6 +70,7 @@ describe('ImageCropUpload', () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 

--- a/apps/web/src/features/editor/components/__tests__/ImageCropUpload.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ImageCropUpload.test.tsx
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useEffect, useRef } from 'react';
+import { ImageCropUpload } from '../ImageCropUpload';
+
+const { getCroppedBlobMock, uploadImageMock, toastErrorMock, toastSuccessMock } = vi.hoisted(
+  () => ({
+    getCroppedBlobMock: vi.fn(),
+    uploadImageMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+  })
+);
+
+vi.mock('react-image-crop', () => ({
+  default: ({
+    children,
+    onComplete,
+  }: {
+    children: React.ReactNode;
+    onComplete: (crop: { x: number; y: number; width: number; height: number; unit: 'px' }) => void;
+  }) => {
+    const completed = useRef(false);
+    useEffect(() => {
+      if (completed.current) return;
+      completed.current = true;
+      onComplete({ x: 0, y: 0, width: 80, height: 80, unit: 'px' });
+    }, [onComplete]);
+    return <div data-testid="react-crop">{children}</div>;
+  },
+}));
+
+vi.mock('../cropUtils', () => ({
+  getCroppedBlob: getCroppedBlobMock,
+  makeInitialCrop: () => ({ unit: '%', x: 0, y: 0, width: 90, height: 90 }),
+}));
+
+vi.mock('@/features/editor/imageApi', () => ({
+  uploadImage: uploadImageMock,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+class MockFileReader {
+  result: string | ArrayBuffer | null = 'data:image/png;base64,ZmFrZQ==';
+  onload: (() => void) | null = null;
+
+  readAsDataURL() {
+    this.onload?.();
+  }
+}
+
+describe('ImageCropUpload', () => {
+  beforeEach(() => {
+    vi.stubGlobal('FileReader', MockFileReader);
+    getCroppedBlobMock.mockResolvedValue({
+      blob: new Blob(['cropped'], { type: 'image/webp' }),
+      contentType: 'image/webp',
+    });
+    uploadImageMock.mockResolvedValue('https://cdn.example/character.webp');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('이미지 삭제 전 확인하고 승인 시 onRemoved를 호출한다', () => {
+    const onRemoved = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(
+      <ImageCropUpload
+        themeId="theme-1"
+        targetId="char-1"
+        target="character"
+        currentImageUrl="https://cdn.example/old.webp"
+        onUploaded={vi.fn()}
+        onRemoved={onRemoved}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '이미지 삭제' }));
+
+    expect(window.confirm).toHaveBeenCalledWith('이미지를 삭제할까요? 이 작업은 즉시 저장됩니다.');
+    expect(onRemoved).toHaveBeenCalledOnce();
+  });
+
+  it('이미지 삭제 확인을 취소하면 onRemoved를 호출하지 않는다', () => {
+    const onRemoved = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(
+      <ImageCropUpload
+        themeId="theme-1"
+        targetId="char-1"
+        target="character"
+        currentImageUrl="https://cdn.example/old.webp"
+        onUploaded={vi.fn()}
+        onRemoved={onRemoved}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '이미지 삭제' }));
+
+    expect(onRemoved).not.toHaveBeenCalled();
+  });
+
+  it('10MB를 넘는 이미지는 업로드 모달을 열지 않고 오류를 표시한다', () => {
+    const { container } = render(
+      <ImageCropUpload
+        themeId="theme-1"
+        targetId="char-1"
+        target="character"
+        onUploaded={vi.fn()}
+      />
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const largeFile = new File(['x'], 'large.png', { type: 'image/png' });
+    Object.defineProperty(largeFile, 'size', { value: 10 * 1024 * 1024 + 1 });
+
+    fireEvent.change(input, { target: { files: [largeFile] } });
+
+    expect(toastErrorMock).toHaveBeenCalledWith('이미지 크기는 10MB 이하여야 합니다');
+    expect(screen.queryByRole('dialog', { name: '이미지 자르기' })).toBeNull();
+  });
+
+  it('자르기 확인 시 이미지를 업로드하고 URL을 전달한다', async () => {
+    const onUploaded = vi.fn();
+    const { container } = render(
+      <ImageCropUpload
+        themeId="theme-1"
+        targetId="char-1"
+        target="character"
+        onUploaded={onUploaded}
+      />
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, {
+      target: { files: [new File(['image'], 'character.png', { type: 'image/png' })] },
+    });
+    fireEvent.click(await screen.findByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(uploadImageMock).toHaveBeenCalledWith(
+        'theme-1',
+        'character',
+        'char-1',
+        expect.any(Blob),
+        'image/webp'
+      );
+    });
+    expect(onUploaded).toHaveBeenCalledWith('https://cdn.example/character.webp');
+    expect(toastSuccessMock).toHaveBeenCalledWith('이미지가 업로드되었습니다');
+  });
+});

--- a/apps/web/src/features/editor/components/__tests__/ImageCropUpload.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ImageCropUpload.test.tsx
@@ -12,14 +12,14 @@ const { getCroppedBlobMock, uploadImageMock, toastErrorMock, toastSuccessMock } 
   })
 );
 
-vi.mock('react-image-crop', () => ({
-  default: ({
+vi.mock('react-image-crop', () => {
+  function MockReactCrop({
     children,
     onComplete,
   }: {
     children: React.ReactNode;
     onComplete: (crop: { x: number; y: number; width: number; height: number; unit: 'px' }) => void;
-  }) => {
+  }) {
     const completed = useRef(false);
     useEffect(() => {
       if (completed.current) return;
@@ -27,8 +27,10 @@ vi.mock('react-image-crop', () => ({
       onComplete({ x: 0, y: 0, width: 80, height: 80, unit: 'px' });
     }, [onComplete]);
     return <div data-testid="react-crop">{children}</div>;
-  },
-}));
+  }
+
+  return { default: MockReactCrop };
+});
 
 vi.mock('../cropUtils', () => ({
   getCroppedBlob: getCroppedBlobMock,

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -12,6 +12,7 @@ import {
 import {
   buildCharacterAliasRulesUpdatePayload,
   buildCharacterVisibilityUpdatePayload,
+  buildCharacterProfileImageUpdatePayload,
   buildCharacterRoleUpdatePayload,
   buildCharacterEndcardUpdatePayload,
   getCharacterListBadges,
@@ -168,6 +169,21 @@ export function CharacterAssignPanel({
     [characters, updateCharacter],
   );
 
+  const handleProfileImageChangeForChar = useCallback(
+    (characterId: string, imageUrl: string | null) => {
+      if (updateCharacter.isPending) return;
+
+      const selected = characters?.find((char) => char.id === characterId);
+      if (!selected) return;
+
+      updateCharacter.mutate({
+        characterId: selected.id,
+        body: buildCharacterProfileImageUpdatePayload(selected, imageUrl),
+      });
+    },
+    [characters, updateCharacter],
+  );
+
   if (charsLoading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -263,6 +279,11 @@ export function CharacterAssignPanel({
               updateCharacter.isPending
                 ? undefined
                 : (values) => handleEndcardChangeForChar(char.id, values)
+            }
+            onProfileImageChange={
+              updateCharacter.isPending
+                ? undefined
+                : (imageUrl) => handleProfileImageChangeForChar(char.id, imageUrl)
             }
           />
         )}

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -6,6 +6,7 @@ import { MissionEditor } from './MissionEditor';
 import { StartingClueAssigner } from './StartingClueAssigner';
 import { CharacterRoleSheetSection } from './CharacterRoleSheetSection';
 import { CharacterAliasRulesEditor } from './CharacterAliasRulesEditor';
+import { ImageCropUpload } from '@/features/editor/components/ImageCropUpload';
 import {
   type CharacterVisibilityField,
   characterRoleOptions,
@@ -61,6 +62,7 @@ interface CharacterDetailPanelProps {
   onVisibilityChange?: (field: CharacterVisibilityField, value: boolean) => void;
   onAliasRulesSave?: (rules: CharacterAliasRule[]) => void;
   onEndcardChange?: (values: { title: string; body: string; imageUrl: string }) => void;
+  onProfileImageChange?: (imageUrl: string | null) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +84,7 @@ export function CharacterDetailPanel({
   onVisibilityChange,
   onAliasRulesSave,
   onEndcardChange,
+  onProfileImageChange,
 }: CharacterDetailPanelProps) {
   const [aliasDrafts, setAliasDrafts] = useState<CharacterAliasRule[]>([]);
   const aliasDraftCharacterIdRef = useRef<string | null>(null);
@@ -156,8 +159,22 @@ export function CharacterDetailPanel({
             forceOpen: true,
             children: (
               <div className="grid gap-3 md:grid-cols-[10rem_1fr]">
-                <div className="flex h-36 items-center justify-center rounded-lg border border-dashed border-slate-800 bg-slate-950 text-xs text-slate-600">
-                  {selectedChar.image_url ? '사진 등록됨' : '사진 없음'}
+                <div className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-slate-800 bg-slate-950 p-3 text-xs text-slate-600">
+                  <ImageCropUpload
+                    themeId={themeId}
+                    targetId={selectedChar.id}
+                    target="character"
+                    currentImageUrl={selectedChar.image_url ?? null}
+                    onUploaded={(url) => onProfileImageChange?.(url)}
+                    onRemoved={
+                      selectedChar.image_url && onProfileImageChange
+                        ? () => onProfileImageChange(null)
+                        : undefined
+                    }
+                    size="md"
+                    shape="circle"
+                  />
+                  <span>{selectedChar.image_url ? '이미지 변경' : '이미지 업로드'}</span>
                 </div>
                 <div className="space-y-3">
                   <div>

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -93,7 +93,7 @@ export function CharacterDetailPanel({
   const [endcardImageUrl, setEndcardImageUrl] = useState('');
   const characterOptions = useMemo(
     () => characters.map((char) => ({ id: char.id, name: char.name })),
-    [characters],
+    [characters]
   );
 
   useEffect(() => {
@@ -106,7 +106,12 @@ export function CharacterDetailPanel({
     setEndcardTitle(selectedChar?.endcard_title ?? '');
     setEndcardBody(selectedChar?.endcard_body ?? '');
     setEndcardImageUrl(selectedChar?.endcard_image_url ?? '');
-  }, [selectedChar?.id, selectedChar?.endcard_title, selectedChar?.endcard_body, selectedChar?.endcard_image_url]);
+  }, [
+    selectedChar?.id,
+    selectedChar?.endcard_title,
+    selectedChar?.endcard_body,
+    selectedChar?.endcard_image_url,
+  ]);
 
   if (!selectedChar) {
     return (
@@ -130,7 +135,8 @@ export function CharacterDetailPanel({
     show_in_intro: selectedChar.show_in_intro ?? true,
     can_speak_in_reading: selectedChar.can_speak_in_reading ?? true,
     is_voting_candidate:
-      selectedChar.is_voting_candidate ?? getCharacterRoleOption(selectedRole).defaultVotingCandidate,
+      selectedChar.is_voting_candidate ??
+      getCharacterRoleOption(selectedRole).defaultVotingCandidate,
     endcard_title: selectedChar.endcard_title ?? null,
     endcard_body: selectedChar.endcard_body ?? null,
     endcard_image_url: selectedChar.endcard_image_url ?? null,
@@ -145,7 +151,9 @@ export function CharacterDetailPanel({
     <div className="max-w-5xl space-y-4">
       <div>
         <h3 className="text-sm font-semibold text-slate-200">{selectedChar.name}</h3>
-        <p className="mt-1 text-xs text-slate-500">역할지, 시작 단서, 히든 미션을 한 곳에서 관리합니다.</p>
+        <p className="mt-1 text-xs text-slate-500">
+          역할지, 시작 단서, 히든 미션을 한 곳에서 관리합니다.
+        </p>
       </div>
 
       <Accordion
@@ -160,29 +168,39 @@ export function CharacterDetailPanel({
             children: (
               <div className="grid gap-3 md:grid-cols-[10rem_1fr]">
                 <div className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-slate-800 bg-slate-950 p-3 text-xs text-slate-600">
-                  <ImageCropUpload
-                    themeId={themeId}
-                    targetId={selectedChar.id}
-                    target="character"
-                    currentImageUrl={selectedChar.image_url ?? null}
-                    onUploaded={(url) => onProfileImageChange?.(url)}
-                    onRemoved={
-                      selectedChar.image_url && onProfileImageChange
-                        ? () => onProfileImageChange(null)
-                        : undefined
-                    }
-                    size="md"
-                    shape="circle"
-                  />
-                  <span>{selectedChar.image_url ? '이미지 변경' : '이미지 업로드'}</span>
+                  {onProfileImageChange ? (
+                    <>
+                      <ImageCropUpload
+                        themeId={themeId}
+                        targetId={selectedChar.id}
+                        target="character"
+                        currentImageUrl={selectedChar.image_url ?? null}
+                        onUploaded={onProfileImageChange}
+                        onRemoved={
+                          selectedChar.image_url ? () => onProfileImageChange(null) : undefined
+                        }
+                        size="md"
+                        shape="circle"
+                      />
+                      <span>{selectedChar.image_url ? '이미지 변경' : '이미지 업로드'}</span>
+                    </>
+                  ) : (
+                    <span className="px-2 text-center text-[11px] leading-5 text-slate-500">
+                      현재 프로필 이미지를 편집할 수 없습니다.
+                    </span>
+                  )}
                 </div>
                 <div className="space-y-3">
                   <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">이름</p>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                      이름
+                    </p>
                     <p className="mt-1 text-sm text-slate-200">{selectedChar.name}</p>
                   </div>
                   <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">역할</p>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                      역할
+                    </p>
                     <div className="mt-2 grid gap-2 sm:grid-cols-2">
                       {characterRoleOptions.map((option) => {
                         const active = selectedRole === option.value;
@@ -199,14 +217,18 @@ export function CharacterDetailPanel({
                             } disabled:cursor-default disabled:opacity-80`}
                           >
                             <span className="block text-xs font-semibold">{option.label}</span>
-                            <span className="mt-1 block text-[11px] leading-4 text-slate-500">{option.description}</span>
+                            <span className="mt-1 block text-[11px] leading-4 text-slate-500">
+                              {option.description}
+                            </span>
                           </button>
                         );
                       })}
                     </div>
                   </div>
                   <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">등장인물 유형</p>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                      등장인물 유형
+                    </p>
                     <div className="mt-2 grid gap-2 sm:grid-cols-2">
                       <VisibilityToggle
                         label="플레이어 캐릭터"
@@ -227,7 +249,9 @@ export function CharacterDetailPanel({
                         description="스토리 읽기 화면에서 이 인물의 대사를 사용할 수 있습니다."
                         checked={selectedView.canSpeakInReading}
                         disabled={!onVisibilityChange}
-                        onChange={(checked) => onVisibilityChange?.('can_speak_in_reading', checked)}
+                        onChange={(checked) =>
+                          onVisibilityChange?.('can_speak_in_reading', checked)
+                        }
                       />
                       <VisibilityToggle
                         label="투표 후보에 포함"
@@ -239,7 +263,9 @@ export function CharacterDetailPanel({
                     </div>
                   </div>
                   <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">공개 소개</p>
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                      공개 소개
+                    </p>
                     <p className="mt-1 whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs leading-5 text-slate-400">
                       {selectedChar.description || '공개 소개가 없습니다.'}
                     </p>
@@ -269,7 +295,9 @@ export function CharacterDetailPanel({
               <div className="space-y-3">
                 <div className="grid gap-3 md:grid-cols-2">
                   <label className="block">
-                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">제목</span>
+                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                      제목
+                    </span>
                     <input
                       type="text"
                       value={endcardTitle}
@@ -281,7 +309,9 @@ export function CharacterDetailPanel({
                     />
                   </label>
                   <label className="block">
-                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">이미지 URL</span>
+                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                      이미지 URL
+                    </span>
                     <input
                       type="url"
                       value={endcardImageUrl}
@@ -293,7 +323,9 @@ export function CharacterDetailPanel({
                   </label>
                 </div>
                 <label className="block">
-                  <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">본문</span>
+                  <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                    본문
+                  </span>
                   <textarea
                     value={endcardBody}
                     maxLength={3000}
@@ -308,11 +340,13 @@ export function CharacterDetailPanel({
                   <button
                     type="button"
                     disabled={!onEndcardChange || !endcardDirty}
-                    onClick={() => onEndcardChange?.({
-                      title: endcardTitle,
-                      body: endcardBody,
-                      imageUrl: endcardImageUrl,
-                    })}
+                    onClick={() =>
+                      onEndcardChange?.({
+                        title: endcardTitle,
+                        body: endcardBody,
+                        imageUrl: endcardImageUrl,
+                      })
+                    }
                     className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:border-slate-800 disabled:bg-slate-950 disabled:text-slate-600"
                   >
                     결과 카드 저장
@@ -378,7 +412,13 @@ interface VisibilityToggleProps {
   onChange: (checked: boolean) => void;
 }
 
-function VisibilityToggle({ label, description, checked, disabled, onChange }: VisibilityToggleProps) {
+function VisibilityToggle({
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: VisibilityToggleProps) {
   return (
     <label className="flex min-h-24 items-start gap-3 rounded-lg border border-slate-800 bg-slate-950 p-3 text-left">
       <input

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -7,19 +7,19 @@ import {
   type Edge,
   type NodeTypes,
   type OnSelectionChangeParams,
-} from "@xyflow/react";
-import "@xyflow/react/dist/style.css";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useFlowData } from "../../hooks/useFlowData";
-import { FlowToolbar } from "./FlowToolbar";
-import { StartNode } from "./StartNode";
-import { PhaseNode } from "./PhaseNode";
-import { EndingNode } from "./EndingNode";
-import { NodeDetailPanel } from "./NodeDetailPanel";
-import { FlowOrderReviewPanel } from "./FlowOrderReviewPanel";
-import { StorySceneSummary } from "./StorySceneSummary";
-import { branchNodeTypes, conditionEdgeTypes } from "./flowNodeRegistry";
-import type { FlowNodeType } from "../../flowTypes";
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useFlowData } from '../../hooks/useFlowData';
+import { FlowToolbar } from './FlowToolbar';
+import { StartNode } from './StartNode';
+import { PhaseNode } from './PhaseNode';
+import { EndingNode } from './EndingNode';
+import { NodeDetailPanel } from './NodeDetailPanel';
+import { FlowOrderReviewPanel } from './FlowOrderReviewPanel';
+import { StorySceneSummary } from './StorySceneSummary';
+import { branchNodeTypes, conditionEdgeTypes } from './flowNodeRegistry';
+import type { FlowNodeType } from '../../flowTypes';
 
 // ---------------------------------------------------------------------------
 // Node / edge type registries
@@ -51,7 +51,7 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const [showOrderReview, setShowOrderReview] = useState(false);
   const [highlightId, setHighlightId] = useState<string | null>(null);
-  const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
 
   const {
     nodes,
@@ -78,18 +78,21 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
         node.id === highlightId
           ? {
               ...node,
-              className: [node.className, "!ring-2 !ring-amber-400"]
-                .filter(Boolean)
-                .join(" "),
+              className: [node.className, '!ring-2 !ring-amber-400'].filter(Boolean).join(' '),
             }
-          : node,
+          : node
       ),
-    [highlightId, nodes],
+    [highlightId, nodes]
   );
 
   useEffect(() => {
     onSelectedNodeChange?.(selectedNode);
   }, [onSelectedNodeChange, selectedNode]);
+
+  const selectedEdge = useMemo(
+    () => edges.find((edge) => edge.id === selectedEdgeId) ?? null,
+    [edges, selectedEdgeId]
+  );
 
   // Add node at canvas center
   const handleAddNode = useCallback(
@@ -99,20 +102,20 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
       const cy = wrapper ? wrapper.clientHeight / 2 : 200;
       addNode(type as FlowNodeType, { x: cx, y: cy });
     },
-    [addNode],
+    [addNode]
   );
 
   // Drag over — allow drop
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
+    e.dataTransfer.dropEffect = 'move';
   }, []);
 
   // Drop — create node at drop position
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
-      const type = e.dataTransfer.getData("application/flow-node-type");
+      const type = e.dataTransfer.getData('application/flow-node-type');
       if (!type) return;
       const wrapper = reactFlowWrapper.current;
       if (!wrapper) return;
@@ -122,15 +125,17 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
         y: e.clientY - rect.top,
       });
     },
-    [addNode],
+    [addNode]
   );
 
   const handleSelectionChange = useCallback(
     (params: OnSelectionChangeParams) => {
       onSelectionChange({ nodes: params.nodes });
-      setSelectedEdge(params.nodes.length === 0 && params.edges.length === 1 ? params.edges[0] : null);
+      setSelectedEdgeId(
+        params.nodes.length === 0 && params.edges.length === 1 ? params.edges[0].id : null
+      );
     },
-    [onSelectionChange],
+    [onSelectionChange]
   );
 
   const selectedEdgeLabel = useMemo(() => {
@@ -163,7 +168,10 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
         isOrderReviewing={showOrderReview}
       />
       <StorySceneSummary nodes={nodes} edges={edges} />
-      <div data-testid="flow-workspace" className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
+      <div
+        data-testid="flow-workspace"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row"
+      >
         {/* Canvas */}
         <div
           ref={reactFlowWrapper}
@@ -205,8 +213,9 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
                   <button
                     type="button"
                     onClick={() => {
+                      if (!window.confirm('선 연결을 끊을까요? 이 작업은 즉시 저장됩니다.')) return;
                       deleteEdge(selectedEdge.id);
-                      setSelectedEdge(null);
+                      setSelectedEdgeId(null);
                     }}
                     className="w-full rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-200 transition hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/60"
                   >
@@ -224,7 +233,10 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
                 nodes={nodes}
                 edges={edges}
                 onHighlight={setHighlightId}
-                onClose={() => { setShowOrderReview(false); setHighlightId(null); }}
+                onClose={() => {
+                  setShowOrderReview(false);
+                  setHighlightId(null);
+                }}
               />
             </div>
           )}

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -4,7 +4,6 @@ import {
   MiniMap,
   Controls,
   type Node,
-  type Edge,
   type NodeTypes,
   type OnSelectionChangeParams,
 } from '@xyflow/react';

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -4,6 +4,7 @@ import {
   MiniMap,
   Controls,
   type Node,
+  type Edge,
   type NodeTypes,
   type OnSelectionChangeParams,
 } from "@xyflow/react";
@@ -50,6 +51,7 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const [showOrderReview, setShowOrderReview] = useState(false);
   const [highlightId, setHighlightId] = useState<string | null>(null);
+  const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
 
   const {
     nodes,
@@ -64,6 +66,7 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
     addNode,
     updateNodeData,
     deleteNode,
+    deleteEdge,
     onSelectionChange,
     updateEdgeCondition,
     applyPreset,
@@ -125,9 +128,17 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
   const handleSelectionChange = useCallback(
     (params: OnSelectionChangeParams) => {
       onSelectionChange({ nodes: params.nodes });
+      setSelectedEdge(params.nodes.length === 0 && params.edges.length === 1 ? params.edges[0] : null);
     },
     [onSelectionChange],
   );
+
+  const selectedEdgeLabel = useMemo(() => {
+    if (!selectedEdge) return null;
+    const source = nodes.find((node) => node.id === selectedEdge.source);
+    const target = nodes.find((node) => node.id === selectedEdge.target);
+    return `${String(source?.data?.label ?? selectedEdge.source)} -> ${String(target?.data?.label ?? selectedEdge.target)}`;
+  }, [nodes, selectedEdge]);
 
   if (isLoading) {
     return (
@@ -185,7 +196,26 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
         <div className="flex max-h-[55vh] w-full shrink-0 flex-col overflow-y-auto border-t border-slate-800 bg-slate-900 lg:max-h-none lg:w-72 lg:border-l lg:border-t-0">
           {!showOrderReview && !selectedNode && (
             <div className="p-4 text-sm leading-6 text-slate-400">
-              장면이나 결말을 선택하면 세부 설정을 편집할 수 있습니다.
+              {selectedEdge ? (
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-xs font-semibold text-slate-300">선 연결</p>
+                    <p className="mt-1 break-words text-xs text-slate-500">{selectedEdgeLabel}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      deleteEdge(selectedEdge.id);
+                      setSelectedEdge(null);
+                    }}
+                    className="w-full rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-200 transition hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/60"
+                  >
+                    연결 끊기
+                  </button>
+                </div>
+              ) : (
+                '장면이나 결말을 선택하면 세부 설정을 편집할 수 있습니다.'
+              )}
             </div>
           )}
           {showOrderReview && (

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -187,7 +187,7 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
             onSelectionChange={handleSelectionChange}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
-            deleteKeyCode="Delete"
+            deleteKeyCode={null}
             edgesFocusable={true}
             edgesReconnectable={true}
             fitView

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -61,6 +61,29 @@ vi.mock('@/features/editor/mediaApi', () => ({
   useMediaDownloadUrl: (mediaId?: string) => useMediaDownloadUrlMock(mediaId),
 }));
 
+vi.mock('@/features/editor/components/ImageCropUpload', () => ({
+  ImageCropUpload: ({
+    currentImageUrl,
+    onUploaded,
+    onRemoved,
+  }: {
+    currentImageUrl?: string | null;
+    onUploaded: (url: string) => void;
+    onRemoved?: () => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onUploaded('https://cdn.example/character.webp')}>
+        프로필 사진 업로드
+      </button>
+      {currentImageUrl && onRemoved && (
+        <button type="button" onClick={onRemoved}>
+          프로필 사진 삭제
+        </button>
+      )}
+    </div>
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // Import
 // ---------------------------------------------------------------------------
@@ -327,6 +350,43 @@ describe('CharacterAssignPanel', () => {
         endcard_body: '사건 이후의 선택을 보여준다.',
         endcard_image_url: 'https://cdn.example/endcard.webp',
       },
+    });
+  });
+
+  it('기본 정보에서 캐릭터 이미지를 업로드한다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    fireEvent.click(screen.getByRole('button', { name: '프로필 사진 업로드' }));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      body: expect.objectContaining({
+        name: '홍길동',
+        image_url: 'https://cdn.example/character.webp',
+        mystery_role: 'culprit',
+        is_culprit: true,
+      }),
+    });
+  });
+
+  it('기본 정보에서 캐릭터 이미지를 삭제한다', () => {
+    useEditorCharactersMock.mockReturnValue({
+      data: [{ ...mockCharacters[0], image_url: 'https://cdn.example/old.webp' }],
+      isLoading: false,
+    });
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    fireEvent.click(screen.getByRole('button', { name: '프로필 사진 삭제' }));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      body: expect.objectContaining({
+        name: '홍길동',
+        image_url: '',
+        mystery_role: 'culprit',
+        is_culprit: true,
+      }),
     });
   });
 

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -28,11 +28,7 @@ vi.mock('@xyflow/react', () => ({
   }) => (
     <div data-testid="react-flow">
       {nodes.map((node) => (
-        <div
-          key={node.id}
-          data-testid={`rf-node-${node.id}`}
-          className={node.className ?? ""}
-        />
+        <div key={node.id} data-testid={`rf-node-${node.id}`} className={node.className ?? ''} />
       ))}
       {edges.map((edge) => (
         <button
@@ -222,6 +218,7 @@ describe('FlowCanvas', () => {
 
   it('선택한 연결선을 버튼으로 끊을 수 있다', () => {
     const deleteEdge = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     useFlowDataMock.mockReturnValue({
       nodes: [
         {
@@ -259,7 +256,40 @@ describe('FlowCanvas', () => {
     expect(screen.getByText('오프닝 -> 조사')).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: '연결 끊기' }));
+    expect(window.confirm).toHaveBeenCalledWith('선 연결을 끊을까요? 이 작업은 즉시 저장됩니다.');
     expect(deleteEdge).toHaveBeenCalledWith('e-p1-p2');
+  });
+
+  it('연결선 삭제 확인을 취소하면 연결을 유지한다', () => {
+    const deleteEdge = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    useFlowDataMock.mockReturnValue({
+      nodes: [
+        { id: 'p1', type: 'phase', position: { x: 0, y: 0 }, data: { label: '오프닝' } },
+        { id: 'p2', type: 'phase', position: { x: 100, y: 0 }, data: { label: '조사' } },
+      ],
+      edges: [{ id: 'e-p1-p2', source: 'p1', target: 'p2' }],
+      onNodesChange: vi.fn(),
+      onEdgesChange: vi.fn(),
+      onConnect: vi.fn(),
+      isLoading: false,
+      isSaving: false,
+      save: saveMock,
+      selectedNode: null,
+      addNode: vi.fn(),
+      updateNodeData: vi.fn(),
+      deleteNode: vi.fn(),
+      deleteEdge,
+      onSelectionChange: vi.fn(),
+      updateEdgeCondition: vi.fn(),
+      applyPreset: vi.fn(),
+    });
+
+    render(<FlowCanvas themeId="theme-1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'e-p1-p2 선택' }));
+    fireEvent.click(screen.getByRole('button', { name: '연결 끊기' }));
+
+    expect(deleteEdge).not.toHaveBeenCalled();
   });
 });
 
@@ -269,31 +299,23 @@ describe('FlowCanvas', () => {
 
 describe('FlowToolbar', () => {
   it('저장 버튼이 렌더링된다', () => {
-    render(
-      <FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={false} />,
-    );
+    render(<FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={false} />);
     expect(screen.getByText('저장')).toBeDefined();
   });
 
   it('저장 버튼 클릭 시 onSave가 호출된다', () => {
-    render(
-      <FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={false} />,
-    );
+    render(<FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={false} />);
     fireEvent.click(screen.getByText('저장'));
     expect(saveMock).toHaveBeenCalledOnce();
   });
 
   it('isSaving=true 일 때 "저장 중..." 텍스트를 표시한다', () => {
-    render(
-      <FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={true} />,
-    );
+    render(<FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={true} />);
     expect(screen.getByText('저장 중...')).toBeDefined();
   });
 
   it('항목 추가 버튼 클릭 시 드롭다운이 열린다', () => {
-    render(
-      <FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={false} />,
-    );
+    render(<FlowToolbar onAddNode={vi.fn()} onSave={saveMock} isSaving={false} />);
     fireEvent.click(screen.getByText('항목 추가'));
     expect(screen.getByText('장면')).toBeDefined();
     expect(screen.getByText('분기')).toBeDefined();
@@ -302,9 +324,7 @@ describe('FlowToolbar', () => {
 
   it('드롭다운에서 노드 선택 시 onAddNode가 호출된다', () => {
     const onAddNode = vi.fn();
-    render(
-      <FlowToolbar onAddNode={onAddNode} onSave={vi.fn()} isSaving={false} />,
-    );
+    render(<FlowToolbar onAddNode={onAddNode} onSave={vi.fn()} isSaving={false} />);
     fireEvent.click(screen.getByText('항목 추가'));
     fireEvent.click(screen.getByText('장면'));
     expect(onAddNode).toHaveBeenCalledWith('phase');

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -18,9 +18,13 @@ vi.mock('@xyflow/react', () => ({
   ReactFlow: ({
     children,
     nodes = [],
+    edges = [],
+    onSelectionChange,
   }: {
     children?: React.ReactNode;
     nodes?: Array<{ id: string; className?: string }>;
+    edges?: Array<{ id: string; source: string; target: string }>;
+    onSelectionChange?: (params: { nodes: unknown[]; edges: unknown[] }) => void;
   }) => (
     <div data-testid="react-flow">
       {nodes.map((node) => (
@@ -29,6 +33,15 @@ vi.mock('@xyflow/react', () => ({
           data-testid={`rf-node-${node.id}`}
           className={node.className ?? ""}
         />
+      ))}
+      {edges.map((edge) => (
+        <button
+          key={edge.id}
+          type="button"
+          onClick={() => onSelectionChange?.({ nodes: [], edges: [edge] })}
+        >
+          {edge.id} 선택
+        </button>
       ))}
       {children}
     </div>
@@ -71,6 +84,14 @@ beforeEach(() => {
     isLoading: false,
     isSaving: false,
     save: saveMock,
+    selectedNode: null,
+    addNode: vi.fn(),
+    updateNodeData: vi.fn(),
+    deleteNode: vi.fn(),
+    deleteEdge: vi.fn(),
+    onSelectionChange: vi.fn(),
+    updateEdgeCondition: vi.fn(),
+    applyPreset: vi.fn(),
   });
 });
 
@@ -197,6 +218,48 @@ describe('FlowCanvas', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '순서 점검' }));
     expect(screen.getByTestId('rf-node-p2').className).not.toContain('!ring-2');
+  });
+
+  it('선택한 연결선을 버튼으로 끊을 수 있다', () => {
+    const deleteEdge = vi.fn();
+    useFlowDataMock.mockReturnValue({
+      nodes: [
+        {
+          id: 'p1',
+          type: 'phase',
+          position: { x: 0, y: 0 },
+          data: { label: '오프닝' },
+        },
+        {
+          id: 'p2',
+          type: 'phase',
+          position: { x: 100, y: 0 },
+          data: { label: '조사' },
+        },
+      ],
+      edges: [{ id: 'e-p1-p2', source: 'p1', target: 'p2' }],
+      onNodesChange: vi.fn(),
+      onEdgesChange: vi.fn(),
+      onConnect: vi.fn(),
+      isLoading: false,
+      isSaving: false,
+      save: saveMock,
+      selectedNode: null,
+      addNode: vi.fn(),
+      updateNodeData: vi.fn(),
+      deleteNode: vi.fn(),
+      deleteEdge,
+      onSelectionChange: vi.fn(),
+      updateEdgeCondition: vi.fn(),
+      applyPreset: vi.fn(),
+    });
+
+    render(<FlowCanvas themeId="theme-1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'e-p1-p2 선택' }));
+    expect(screen.getByText('오프닝 -> 조사')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: '연결 끊기' }));
+    expect(deleteEdge).toHaveBeenCalledWith('e-p1-p2');
   });
 });
 

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvasEdgeDelete.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvasEdgeDelete.test.tsx
@@ -56,8 +56,10 @@ const baseFlowData = {
   addNode: vi.fn(),
   updateNodeData: vi.fn(),
   deleteNode: vi.fn(),
+  deleteEdge: vi.fn(),
   onSelectionChange: vi.fn(),
   updateEdgeCondition: vi.fn(),
+  applyPreset: vi.fn(),
 };
 
 beforeEach(() => {
@@ -69,9 +71,9 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("FlowCanvas edge delete props", () => {
-  it("deleteKeyCode='Delete' prop이 전달된다", () => {
+  it("키보드 Delete 즉시 삭제를 비활성화한다", () => {
     render(<FlowCanvas themeId="t1" />);
-    expect(reactFlowProps.current.deleteKeyCode).toBe("Delete");
+    expect(reactFlowProps.current.deleteKeyCode).toBeNull();
   });
 
   it("edgesFocusable={true} prop이 전달된다", () => {

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -4,6 +4,7 @@ import {
   buildCharacterVisibilityUpdatePayload,
   buildCharacterAliasRulesUpdatePayload,
   buildCharacterEndcardUpdatePayload,
+  buildCharacterProfileImageUpdatePayload,
   getCharacterListBadges,
   buildCharacterRoleUpdatePayload,
   getCharacterRoleBadge,
@@ -267,6 +268,19 @@ describe('characterEditorAdapter', () => {
       endcard_title: '',
       endcard_body: '',
       endcard_image_url: '',
+    });
+  });
+
+  it('프로필 이미지 삭제 payload는 빈 문자열로 backend clear 계약을 사용한다', () => {
+    const payload = buildCharacterProfileImageUpdatePayload(
+      character({ image_url: 'https://cdn.example/old.webp' }),
+      null,
+    );
+
+    expect(payload).toMatchObject({
+      name: '홍길동',
+      image_url: '',
+      mystery_role: 'suspect',
     });
   });
 });

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -258,6 +258,16 @@ export function buildCharacterEndcardUpdatePayload(
   };
 }
 
+export function buildCharacterProfileImageUpdatePayload(
+  character: EditorCharacterResponse,
+  imageUrl: string | null,
+): UpdateCharacterRequest {
+  return {
+    ...buildCharacterBaseUpdatePayload(character),
+    image_url: imageUrl ?? '',
+  };
+}
+
 export function buildCharacterAliasRulesUpdatePayload(
   character: EditorCharacterResponse,
   aliasRules: CharacterAliasRule[],

--- a/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
@@ -1,183 +1,150 @@
-import { describe, it, expect } from "vitest";
-import type { Node, Edge } from "@xyflow/react";
-import type { FlowNodeResponse, FlowEdgeResponse } from "../../flowTypes";
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFlowData } from '../useFlowData';
 
-// ---------------------------------------------------------------------------
-// Re-export converter functions for testing via module boundary
-// We test them by importing the pure converter logic directly.
-// Since they are module-internal, we replicate the same logic here to verify
-// the shape contract between server response and ReactFlow format.
-// ---------------------------------------------------------------------------
+const { useFlowGraphMock, saveFlowMutateMock, createNodeMutateMock, deleteNodeMutateMock } =
+  vi.hoisted(() => ({
+    useFlowGraphMock: vi.fn(),
+    saveFlowMutateMock: vi.fn(),
+    createNodeMutateMock: vi.fn(),
+    deleteNodeMutateMock: vi.fn(),
+  }));
 
-function toReactFlowNode(node: FlowNodeResponse): Node {
-  return {
-    id: node.id,
-    type: node.type,
-    position: { x: node.position_x, y: node.position_y },
-    data: { ...node.data },
-  };
-}
+vi.mock('../../flowApi', () => ({
+  useFlowGraph: useFlowGraphMock,
+  useSaveFlow: () => ({ mutate: saveFlowMutateMock, isPending: false }),
+  useCreateFlowNode: () => ({ mutate: createNodeMutateMock }),
+  useDeleteFlowNode: () => ({ mutate: deleteNodeMutateMock }),
+}));
 
-function toReactFlowEdge(edge: FlowEdgeResponse): Edge {
-  return {
-    id: edge.id,
-    source: edge.source_id,
-    target: edge.target_id,
-    label: edge.label ?? undefined,
-    data: { condition: edge.condition, sort_order: edge.sort_order },
-  };
-}
-
-function toSaveRequest(nodes: Node[], edges: Edge[]) {
-  return {
-    nodes: nodes.map((n) => ({
-      id: n.id,
-      type: (n.type ?? "phase") as FlowNodeResponse["type"],
-      data: n.data as FlowNodeResponse["data"],
-      position_x: n.position.x,
-      position_y: n.position.y,
-    })),
-    edges: edges.map((e, i) => ({
-      id: e.id,
-      source_id: e.source,
-      target_id: e.target,
-      condition:
-        (e.data as { condition?: Record<string, unknown> } | undefined)
-          ?.condition ?? null,
-      label: typeof e.label === "string" ? e.label : null,
-      sort_order: i,
-    })),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Test data
-// ---------------------------------------------------------------------------
-
-const nodeResponse: FlowNodeResponse = {
-  id: "node-abc",
-  theme_id: "theme-1",
-  type: "phase",
-  data: { label: "조사 페이즈", duration: 20 },
-  position_x: 100,
-  position_y: 200,
-  created_at: "2026-04-14T00:00:00Z",
-  updated_at: "2026-04-14T00:00:00Z",
+const serverGraph = {
+  nodes: [
+    {
+      id: 'n1',
+      type: 'phase',
+      data: { label: '오프닝' },
+      position_x: 0,
+      position_y: 0,
+    },
+    {
+      id: 'n2',
+      type: 'phase',
+      data: { label: '조사' },
+      position_x: 100,
+      position_y: 0,
+    },
+  ],
+  edges: [
+    {
+      id: 'e1',
+      source_id: 'n1',
+      target_id: 'n2',
+      label: null,
+      condition: null,
+      sort_order: 0,
+    },
+  ],
 };
 
-const edgeResponse: FlowEdgeResponse = {
-  id: "edge-xyz",
-  theme_id: "theme-1",
-  source_id: "node-abc",
-  target_id: "node-def",
-  condition: null,
-  label: "성공",
-  sort_order: 0,
-  created_at: "2026-04-14T00:00:00Z",
-};
+function latestSavedGraph() {
+  const calls = saveFlowMutateMock.mock.calls;
+  return calls[calls.length - 1][0];
+}
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-describe("toReactFlowNode", () => {
-  it("id를 그대로 유지한다", () => {
-    const result = toReactFlowNode(nodeResponse);
-    expect(result.id).toBe("node-abc");
+describe('useFlowData', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useFlowGraphMock.mockReturnValue({
+      data: serverGraph,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    createNodeMutateMock.mockImplementation((_body, options) => {
+      options?.onSuccess?.({
+        id: 'n3',
+        type: 'phase',
+        data: { label: '새 장면' },
+        position_x: 200,
+        position_y: 0,
+      });
+    });
+    deleteNodeMutateMock.mockImplementation((_id, options) => {
+      options?.onSuccess?.();
+    });
   });
 
-  it("type을 그대로 유지한다", () => {
-    const result = toReactFlowNode(nodeResponse);
-    expect(result.type).toBe("phase");
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
   });
 
-  it("position_x/y를 position.x/y로 변환한다", () => {
-    const result = toReactFlowNode(nodeResponse);
-    expect(result.position.x).toBe(100);
-    expect(result.position.y).toBe(200);
+  it('edge 삭제 직후 ref를 갱신해 저장 payload에서 연결을 제거한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.deleteEdge('e1');
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(latestSavedGraph().edges).toEqual([]);
   });
 
-  it("data 필드를 복사한다", () => {
-    const result = toReactFlowNode(nodeResponse);
-    expect((result.data as { label: string }).label).toBe("조사 페이즈");
-  });
-});
+  it('연속 node 변경과 edge 삭제가 stale graph로 저장되지 않는다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
 
-describe("toReactFlowEdge", () => {
-  it("id를 그대로 유지한다", () => {
-    const result = toReactFlowEdge(edgeResponse);
-    expect(result.id).toBe("edge-xyz");
-  });
+    act(() => {
+      result.current.updateNodeData('n1', { label: '수정된 장면' });
+      result.current.deleteEdge('e1');
+      vi.runOnlyPendingTimers();
+    });
 
-  it("source_id/target_id를 source/target으로 변환한다", () => {
-    const result = toReactFlowEdge(edgeResponse);
-    expect(result.source).toBe("node-abc");
-    expect(result.target).toBe("node-def");
+    expect(latestSavedGraph().nodes[0].data).toEqual({ label: '수정된 장면' });
+    expect(latestSavedGraph().edges).toEqual([]);
   });
 
-  it("label을 그대로 유지한다", () => {
-    const result = toReactFlowEdge(edgeResponse);
-    expect(result.label).toBe("성공");
+  it('node 삭제 성공 시 연결된 edge도 ref와 저장 payload에서 제거한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.deleteNode('n1');
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(deleteNodeMutateMock).toHaveBeenCalledWith('n1', expect.any(Object));
+    expect(latestSavedGraph().nodes.map((node: { id: string }) => node.id)).toEqual(['n2']);
+    expect(latestSavedGraph().edges).toEqual([]);
   });
 
-  it("label이 null이면 undefined로 변환한다", () => {
-    const result = toReactFlowEdge({ ...edgeResponse, label: null });
-    expect(result.label).toBeUndefined();
+  it('프리셋 적용 후 edge 삭제가 최신 프리셋 edge 목록을 기준으로 동작한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.applyPreset(
+        [
+          { id: 'p1', type: 'phase', position: { x: 0, y: 0 }, data: { label: '프리셋 1' } },
+          { id: 'p2', type: 'phase', position: { x: 100, y: 0 }, data: { label: '프리셋 2' } },
+        ],
+        [{ id: 'preset-edge', source: 'p1', target: 'p2' }]
+      );
+      result.current.deleteEdge('preset-edge');
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(latestSavedGraph().nodes.map((node: { id: string }) => node.id)).toEqual(['p1', 'p2']);
+    expect(latestSavedGraph().edges).toEqual([]);
   });
 
-  it("condition과 sort_order를 data에 포함한다", () => {
-    const result = toReactFlowEdge(edgeResponse);
-    const data = result.data as { condition: unknown; sort_order: number };
-    expect(data.condition).toBeNull();
-    expect(data.sort_order).toBe(0);
-  });
-});
+  it('새 node 생성 성공 시 ref를 갱신해 다음 저장에 포함한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
 
-describe("toSaveRequest", () => {
-  const rfNode: Node = {
-    id: "node-abc",
-    type: "phase",
-    position: { x: 150, y: 250 },
-    data: { label: "조사", duration: 20 },
-  };
+    act(() => {
+      result.current.addNode('phase', { x: 200, y: 0 });
+      vi.runOnlyPendingTimers();
+    });
 
-  const rfEdge: Edge = {
-    id: "edge-xyz",
-    source: "node-abc",
-    target: "node-def",
-    label: "성공",
-    data: { condition: null, sort_order: 0 },
-  };
-
-  it("노드를 서버 형식으로 역변환한다", () => {
-    const result = toSaveRequest([rfNode], []);
-    expect(result.nodes[0].id).toBe("node-abc");
-    expect(result.nodes[0].position_x).toBe(150);
-    expect(result.nodes[0].position_y).toBe(250);
-  });
-
-  it("엣지를 서버 형식으로 역변환한다", () => {
-    const result = toSaveRequest([], [rfEdge]);
-    expect(result.edges[0].id).toBe("edge-xyz");
-    expect(result.edges[0].source_id).toBe("node-abc");
-    expect(result.edges[0].target_id).toBe("node-def");
-  });
-
-  it("엣지 sort_order는 배열 인덱스로 설정된다", () => {
-    const e2: Edge = { ...rfEdge, id: "edge-2", source: "node-def", target: "node-ghi" };
-    const result = toSaveRequest([], [rfEdge, e2]);
-    expect(result.edges[0].sort_order).toBe(0);
-    expect(result.edges[1].sort_order).toBe(1);
-  });
-
-  it("string label은 그대로 유지한다", () => {
-    const result = toSaveRequest([], [rfEdge]);
-    expect(result.edges[0].label).toBe("성공");
-  });
-
-  it("non-string label은 null로 변환한다", () => {
-    const edgeNoLabel: Edge = { ...rfEdge, label: undefined };
-    const result = toSaveRequest([], [edgeNoLabel]);
-    expect(result.edges[0].label).toBeNull();
+    expect(createNodeMutateMock).toHaveBeenCalled();
+    expect(latestSavedGraph().nodes.map((node: { id: string }) => node.id)).toContain('n3');
   });
 });

--- a/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
@@ -100,8 +100,50 @@ describe('useFlowData', () => {
       vi.runOnlyPendingTimers();
     });
 
+    expect(saveFlowMutateMock).toHaveBeenCalledTimes(1);
     expect(latestSavedGraph().nodes[0].data).toEqual({ label: '수정된 장면' });
     expect(latestSavedGraph().edges).toEqual([]);
+  });
+
+  it('onNodesChange가 position 변경을 ref와 autosave payload에 반영한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.onNodesChange([
+        { type: 'position', id: 'n1', position: { x: 50, y: 50 } },
+      ]);
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(latestSavedGraph().nodes[0]).toMatchObject({ position_x: 50, position_y: 50 });
+  });
+
+  it('onEdgesChange가 edge 삭제를 ref와 autosave payload에 반영한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.onEdgesChange([{ type: 'remove', id: 'e1' }]);
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(latestSavedGraph().edges).toEqual([]);
+  });
+
+  it('onConnect가 새 edge를 추가하고 autosave payload에 포함한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.onConnect({
+        source: 'n2',
+        target: 'n1',
+        sourceHandle: null,
+        targetHandle: null,
+      });
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(latestSavedGraph().edges).toHaveLength(2);
+    expect(latestSavedGraph().edges[1]).toMatchObject({ source_id: 'n2', target_id: 'n1' });
   });
 
   it('node 삭제 성공 시 연결된 edge도 ref와 저장 payload에서 제거한다', () => {

--- a/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
@@ -46,6 +46,10 @@ const serverGraph = {
   ],
 };
 
+function cloneServerGraph() {
+  return JSON.parse(JSON.stringify(serverGraph)) as typeof serverGraph;
+}
+
 function latestSavedGraph() {
   const calls = saveFlowMutateMock.mock.calls;
   return calls[calls.length - 1][0];
@@ -55,7 +59,7 @@ describe('useFlowData', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     useFlowGraphMock.mockReturnValue({
-      data: serverGraph,
+      data: cloneServerGraph(),
       isLoading: false,
       isError: false,
       error: null,

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -95,37 +95,28 @@ export function useFlowData(themeId: string) {
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
-      setNodes((nds) => {
-        const next = applyNodeChanges(changes, nds);
-        nodesRef.current = next;
-        autoSave(next, edgesRef.current);
-        return next;
-      });
+      const next = applyNodeChanges(changes, nodesRef.current);
+      setNodesAndRef(next);
+      autoSave(next, edgesRef.current);
     },
-    [setNodes, autoSave]
+    [setNodesAndRef, autoSave]
   );
 
   const handleEdgesChange = useCallback(
     (changes: EdgeChange[]) => {
-      setEdges((eds) => {
-        const next = applyEdgeChanges(changes, eds);
-        edgesRef.current = next;
-        autoSave(nodesRef.current, next);
-        return next;
-      });
+      const next = applyEdgeChanges(changes, edgesRef.current);
+      setEdgesAndRef(next);
+      autoSave(nodesRef.current, next);
     },
-    [setEdges, autoSave]
+    [setEdgesAndRef, autoSave]
   );
   const onConnect: OnConnect = useCallback(
     (connection) => {
-      setEdges((eds) => {
-        const next = addEdge(connection, eds);
-        edgesRef.current = next;
-        autoSave(nodesRef.current, next);
-        return next;
-      });
+      const next = addEdge(connection, edgesRef.current);
+      setEdgesAndRef(next);
+      autoSave(nodesRef.current, next);
     },
-    [setEdges, autoSave]
+    [setEdgesAndRef, autoSave]
   );
 
   const save = useCallback(() => {
@@ -143,32 +134,28 @@ export function useFlowData(themeId: string) {
         },
         {
           onSuccess: (created) => {
-            setNodes((nds) => {
-              const next = [...nds, toReactFlowNode(created)];
-              nodesRef.current = next;
-              autoSave(next, edgesRef.current);
-              return next;
-            });
+            const next = [...nodesRef.current, toReactFlowNode(created)];
+            setNodesAndRef(next);
+            autoSave(next, edgesRef.current);
           },
         }
       );
     },
-    [createNode, setNodes, autoSave]
+    [createNode, setNodesAndRef, autoSave]
   );
 
   const updateNodeData = useCallback(
     (id: string, patch: Partial<FlowNodeData>) => {
-      setNodes((nds) => {
-        const next = nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, ...patch } } : n));
-        nodesRef.current = next;
-        autoSave(next, edgesRef.current);
-        return next;
-      });
+      const next = nodesRef.current.map((n) =>
+        n.id === id ? { ...n, data: { ...n.data, ...patch } } : n
+      );
+      setNodesAndRef(next);
+      autoSave(next, edgesRef.current);
       setSelectedNode((prev) =>
         prev && prev.id === id ? { ...prev, data: { ...prev.data, ...patch } } : prev
       );
     },
-    [setNodes, autoSave]
+    [setNodesAndRef, autoSave]
   );
 
   const deleteNode = useCallback(

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -3,8 +3,12 @@ import {
   useNodesState,
   useEdgesState,
   addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
   type Node,
   type Edge,
+  type EdgeChange,
+  type NodeChange,
   type OnConnect,
   type XYPosition,
 } from "@xyflow/react";
@@ -34,9 +38,13 @@ export function useFlowData(themeId: string) {
   const initialNodes: Node[] = serverNodes.map(toReactFlowNode);
   const initialEdges: Edge[] = serverEdges.map(toReactFlowEdge);
 
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [nodes, setNodes] = useNodesState(initialNodes);
+  const [edges, setEdges] = useEdgesState(initialEdges);
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+  const edgesRef = useRef(edges);
+  edgesRef.current = edges;
 
   useEffect(() => {
     if (!data) return;
@@ -72,36 +80,36 @@ export function useFlowData(themeId: string) {
     [saveFlow],
   );
 
-  const handleNodesChange: typeof onNodesChange = useCallback(
-    (changes) => {
-      onNodesChange(changes);
+  const handleNodesChange = useCallback(
+    (changes: NodeChange[]) => {
       setNodes((nds) => {
-        autoSave(nds, edges);
-        return nds;
+        const next = applyNodeChanges(changes, nds);
+        autoSave(next, edgesRef.current);
+        return next;
       });
     },
-    [onNodesChange, setNodes, edges, autoSave],
+    [setNodes, autoSave],
   );
 
-  const handleEdgesChange: typeof onEdgesChange = useCallback(
-    (changes) => {
-      onEdgesChange(changes);
+  const handleEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
       setEdges((eds) => {
-        autoSave(nodes, eds);
-        return eds;
+        const next = applyEdgeChanges(changes, eds);
+        autoSave(nodesRef.current, next);
+        return next;
       });
     },
-    [onEdgesChange, setEdges, nodes, autoSave],
+    [setEdges, autoSave],
   );
   const onConnect: OnConnect = useCallback(
     (connection) => {
       setEdges((eds) => {
         const next = addEdge(connection, eds);
-        autoSave(nodes, next);
+        autoSave(nodesRef.current, next);
         return next;
       });
     },
-    [setEdges, nodes, autoSave],
+    [setEdges, autoSave],
   );
 
   const save = useCallback(() => {
@@ -121,14 +129,14 @@ export function useFlowData(themeId: string) {
           onSuccess: (created) => {
             setNodes((nds) => {
               const next = [...nds, toReactFlowNode(created)];
-              autoSave(next, edges);
+              autoSave(next, edgesRef.current);
               return next;
             });
           },
         },
       );
     },
-    [createNode, setNodes, edges, autoSave],
+    [createNode, setNodes, autoSave],
   );
 
   const updateNodeData = useCallback(
@@ -137,7 +145,7 @@ export function useFlowData(themeId: string) {
         const next = nds.map((n) =>
           n.id === id ? { ...n, data: { ...n.data, ...patch } } : n,
         );
-        autoSave(next, edges);
+        autoSave(next, edgesRef.current);
         return next;
       });
       setSelectedNode((prev) =>
@@ -146,30 +154,34 @@ export function useFlowData(themeId: string) {
           : prev,
       );
     },
-    [setNodes, edges, autoSave],
+    [setNodes, autoSave],
   );
 
   const deleteNode = useCallback(
     (id: string) => {
       deleteNodeMutation.mutate(id, {
         onSuccess: () => {
-          setNodes((nds) => {
-            const next = nds.filter((n) => n.id !== id);
-            autoSave(next, edges);
-            return next;
-          });
-          setEdges((eds) => {
-            const next = eds.filter(
-              (e) => e.source !== id && e.target !== id,
-            );
-            autoSave(nodes, next);
-            return next;
-          });
+          const nextNodes = nodesRef.current.filter((n) => n.id !== id);
+          const nextEdges = edgesRef.current.filter(
+            (e) => e.source !== id && e.target !== id,
+          );
+          setNodes(nextNodes);
+          setEdges(nextEdges);
+          autoSave(nextNodes, nextEdges);
           setSelectedNode((prev) => (prev?.id === id ? null : prev));
         },
       });
     },
-    [deleteNodeMutation, setNodes, setEdges, edges, nodes, autoSave],
+    [deleteNodeMutation, setNodes, setEdges, autoSave],
+  );
+
+  const deleteEdge = useCallback(
+    (id: string) => {
+      const nextEdges = edgesRef.current.filter((edge) => edge.id !== id);
+      setEdges(nextEdges);
+      autoSave(nodesRef.current, nextEdges);
+    },
+    [setEdges, autoSave],
   );
 
   const onSelectionChange = useCallback(
@@ -179,10 +191,6 @@ export function useFlowData(themeId: string) {
     [],
   );
 
-  const nodesRef = useRef(nodes);
-  nodesRef.current = nodes;
-  const edgesRef = useRef(edges);
-  edgesRef.current = edges;
   const getNodes = useCallback(() => nodesRef.current, []);
   const getEdges = useCallback(() => edgesRef.current, []);
   const { updateEdgeCondition } = useEdgeCondition(
@@ -197,7 +205,7 @@ export function useFlowData(themeId: string) {
     nodes, edges,
     onNodesChange: handleNodesChange, onEdgesChange: handleEdgesChange,
     onConnect, isLoading, isError, error, refetch, isSaving: saveFlow.isPending, save,
-    selectedNode, addNode, updateNodeData, deleteNode,
+    selectedNode, addNode, updateNodeData, deleteNode, deleteEdge,
     onSelectionChange, updateEdgeCondition, applyPreset,
   };
 }

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect, useState } from "react";
+import { useCallback, useRef, useEffect, useState } from 'react';
 import {
   useNodesState,
   useEdgesState,
@@ -11,18 +11,13 @@ import {
   type NodeChange,
   type OnConnect,
   type XYPosition,
-} from "@xyflow/react";
-import {
-  useFlowGraph,
-  useSaveFlow,
-  useCreateFlowNode,
-  useDeleteFlowNode,
-} from "../flowApi";
-import type { FlowNodeType, FlowNodeData } from "../flowTypes";
-import { toReactFlowNode, toReactFlowEdge, toSaveRequest } from "./flowConverters";
-import { createDefaultTemplate } from "./flowDefaults";
-import { useEdgeCondition } from "./useEdgeCondition";
-import { useApplyPreset } from "./useApplyPreset";
+} from '@xyflow/react';
+import { useFlowGraph, useSaveFlow, useCreateFlowNode, useDeleteFlowNode } from '../flowApi';
+import type { FlowNodeType, FlowNodeData } from '../flowTypes';
+import { toReactFlowNode, toReactFlowEdge, toSaveRequest } from './flowConverters';
+import { createDefaultTemplate } from './flowDefaults';
+import { useEdgeCondition } from './useEdgeCondition';
+import { useApplyPreset } from './useApplyPreset';
 
 export function useFlowData(themeId: string) {
   const { data, isLoading, isError, error, refetch } = useFlowGraph(themeId);
@@ -46,6 +41,22 @@ export function useFlowData(themeId: string) {
   const edgesRef = useRef(edges);
   edgesRef.current = edges;
 
+  const setNodesAndRef = useCallback(
+    (next: Node[]) => {
+      nodesRef.current = next;
+      setNodes(next);
+    },
+    [setNodes]
+  );
+
+  const setEdgesAndRef = useCallback(
+    (next: Edge[]) => {
+      edgesRef.current = next;
+      setEdges(next);
+    },
+    [setEdges]
+  );
+
   useEffect(() => {
     if (!data) return;
     const nodes_ = data.nodes ?? [];
@@ -54,13 +65,15 @@ export function useFlowData(themeId: string) {
       if (hasInitialized.current) return;
       hasInitialized.current = true;
       const tpl = createDefaultTemplate();
-      setNodes(tpl.nodes);
-      setEdges(tpl.edges);
+      setNodesAndRef(tpl.nodes);
+      setEdgesAndRef(tpl.edges);
       saveFlow.mutate(toSaveRequest(tpl.nodes, tpl.edges));
       return;
     }
-    setNodes(nodes_.map(toReactFlowNode));
-    setEdges(edges_.map(toReactFlowEdge));
+    const nextNodes = nodes_.map(toReactFlowNode);
+    const nextEdges = edges_.map(toReactFlowEdge);
+    setNodesAndRef(nextNodes);
+    setEdgesAndRef(nextEdges);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
@@ -77,39 +90,42 @@ export function useFlowData(themeId: string) {
         saveFlow.mutate(toSaveRequest(nextNodes, nextEdges));
       }, 1000);
     },
-    [saveFlow],
+    [saveFlow]
   );
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
       setNodes((nds) => {
         const next = applyNodeChanges(changes, nds);
+        nodesRef.current = next;
         autoSave(next, edgesRef.current);
         return next;
       });
     },
-    [setNodes, autoSave],
+    [setNodes, autoSave]
   );
 
   const handleEdgesChange = useCallback(
     (changes: EdgeChange[]) => {
       setEdges((eds) => {
         const next = applyEdgeChanges(changes, eds);
+        edgesRef.current = next;
         autoSave(nodesRef.current, next);
         return next;
       });
     },
-    [setEdges, autoSave],
+    [setEdges, autoSave]
   );
   const onConnect: OnConnect = useCallback(
     (connection) => {
       setEdges((eds) => {
         const next = addEdge(connection, eds);
+        edgesRef.current = next;
         autoSave(nodesRef.current, next);
         return next;
       });
     },
-    [setEdges, autoSave],
+    [setEdges, autoSave]
   );
 
   const save = useCallback(() => {
@@ -121,7 +137,7 @@ export function useFlowData(themeId: string) {
       createNode.mutate(
         {
           type,
-          data: { label: type === "phase" ? "새 장면" : undefined },
+          data: { label: type === 'phase' ? '새 장면' : undefined },
           position_x: position.x,
           position_y: position.y,
         },
@@ -129,32 +145,30 @@ export function useFlowData(themeId: string) {
           onSuccess: (created) => {
             setNodes((nds) => {
               const next = [...nds, toReactFlowNode(created)];
+              nodesRef.current = next;
               autoSave(next, edgesRef.current);
               return next;
             });
           },
-        },
+        }
       );
     },
-    [createNode, setNodes, autoSave],
+    [createNode, setNodes, autoSave]
   );
 
   const updateNodeData = useCallback(
     (id: string, patch: Partial<FlowNodeData>) => {
       setNodes((nds) => {
-        const next = nds.map((n) =>
-          n.id === id ? { ...n, data: { ...n.data, ...patch } } : n,
-        );
+        const next = nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, ...patch } } : n));
+        nodesRef.current = next;
         autoSave(next, edgesRef.current);
         return next;
       });
       setSelectedNode((prev) =>
-        prev && prev.id === id
-          ? { ...prev, data: { ...prev.data, ...patch } }
-          : prev,
+        prev && prev.id === id ? { ...prev, data: { ...prev.data, ...patch } } : prev
       );
     },
-    [setNodes, autoSave],
+    [setNodes, autoSave]
   );
 
   const deleteNode = useCallback(
@@ -162,50 +176,54 @@ export function useFlowData(themeId: string) {
       deleteNodeMutation.mutate(id, {
         onSuccess: () => {
           const nextNodes = nodesRef.current.filter((n) => n.id !== id);
-          const nextEdges = edgesRef.current.filter(
-            (e) => e.source !== id && e.target !== id,
-          );
-          setNodes(nextNodes);
-          setEdges(nextEdges);
+          const nextEdges = edgesRef.current.filter((e) => e.source !== id && e.target !== id);
+          setNodesAndRef(nextNodes);
+          setEdgesAndRef(nextEdges);
           autoSave(nextNodes, nextEdges);
           setSelectedNode((prev) => (prev?.id === id ? null : prev));
         },
       });
     },
-    [deleteNodeMutation, setNodes, setEdges, autoSave],
+    [deleteNodeMutation, setNodesAndRef, setEdgesAndRef, autoSave]
   );
 
   const deleteEdge = useCallback(
     (id: string) => {
       const nextEdges = edgesRef.current.filter((edge) => edge.id !== id);
-      setEdges(nextEdges);
+      setEdgesAndRef(nextEdges);
       autoSave(nodesRef.current, nextEdges);
     },
-    [setEdges, autoSave],
+    [setEdgesAndRef, autoSave]
   );
 
-  const onSelectionChange = useCallback(
-    ({ nodes: selected }: { nodes: Node[] }) => {
-      setSelectedNode(selected.length === 1 ? selected[0] : null);
-    },
-    [],
-  );
+  const onSelectionChange = useCallback(({ nodes: selected }: { nodes: Node[] }) => {
+    setSelectedNode(selected.length === 1 ? selected[0] : null);
+  }, []);
 
   const getNodes = useCallback(() => nodesRef.current, []);
   const getEdges = useCallback(() => edgesRef.current, []);
-  const { updateEdgeCondition } = useEdgeCondition(
-    setEdges,
-    getNodes,
-    getEdges,
-    autoSave,
-  );
-  const { applyPreset } = useApplyPreset(setNodes, setEdges, autoSave);
+  const { updateEdgeCondition } = useEdgeCondition(setEdgesAndRef, getNodes, getEdges, autoSave);
+  const { applyPreset } = useApplyPreset(setNodesAndRef, setEdgesAndRef, autoSave);
 
   return {
-    nodes, edges,
-    onNodesChange: handleNodesChange, onEdgesChange: handleEdgesChange,
-    onConnect, isLoading, isError, error, refetch, isSaving: saveFlow.isPending, save,
-    selectedNode, addNode, updateNodeData, deleteNode, deleteEdge,
-    onSelectionChange, updateEdgeCondition, applyPreset,
+    nodes,
+    edges,
+    onNodesChange: handleNodesChange,
+    onEdgesChange: handleEdgesChange,
+    onConnect,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isSaving: saveFlow.isPending,
+    save,
+    selectedNode,
+    addNode,
+    updateNodeData,
+    deleteNode,
+    deleteEdge,
+    onSelectionChange,
+    updateEdgeCondition,
+    applyPreset,
   };
 }


### PR DESCRIPTION
## 요약
- 스토리 진행 그래프에서 연결선을 선택하면 오른쪽 패널에서 `연결 끊기`를 실행할 수 있게 했습니다.
- 그래프 노드/선 변경 자동 저장이 이전 상태를 저장하던 문제를 `applyNodeChanges`/`applyEdgeChanges` 기반으로 수정했습니다.
- 캐릭터 추가 모달은 이름만 받도록 축소하고, 기본 정보 패널에서 프로필 이미지 업로드/변경/삭제를 처리하게 했습니다.
- 캐릭터 이미지 삭제를 위해 `image_url: ""`를 백엔드 clear 계약으로 허용했습니다.

## 검증
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/CharacterForm.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/FlowCanvas.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `go test ./internal/domain/editor -run 'TestUpdateCharacter_AllowsEmptyImageURL|TestService_UpdateCharacter'`\n\nRefs #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캐릭터 프로필 이미지 업로드·삭제 UI와 편집 화면 연동 추가
  * 흐름 캔버스에서 연결(Edge) 선택 후 삭제 가능

* **개선 사항**
  * 생성 폼은 최소 입력만 표시하고 상세 항목은 편집 모드에서만 노출
  * 이미지 필드에 빈 문자열을 전송해 프로필 이미지를 명시적으로 제거 가능
  * 플로우 훅에서 연결 삭제 기능 공개

* **테스트**
  * 이미지 업로드/삭제 및 플로우 관련 엔드투엔드·유닛 테스트 대폭 추가/갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->