### PR TITLE
fix(editor): 모듈 카탈로그를 실제 제작 화면과 정렬

### DIFF
--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
@@ -69,7 +69,6 @@ import {
   MODULE_CATEGORIES,
   OPTIONAL_MODULE_CATEGORIES,
   REQUIRED_MODULE_IDS,
-  isSelectableModule,
 } from '@/features/editor/constants';
 
 // ---------------------------------------------------------------------------
@@ -147,23 +146,41 @@ describe('ModulesSubTab', () => {
   });
 
   it('선택 모듈 목록에는 실제 선택 가능한 모듈만 포함된다', () => {
-    const catalogModules = OPTIONAL_MODULE_CATEGORIES.flatMap((c) => c.modules);
+    render(<ModulesSubTab themeId="theme-1" theme={baseTheme} />);
 
-    expect(catalogModules.length).toBeGreaterThan(0);
-    for (const mod of catalogModules) {
-      expect(isSelectableModule(mod)).toBe(true);
+    const expectedVisibleModuleNames = [
+      '텍스트 채팅',
+      '귓속말',
+      '그룹 채팅',
+      '투표',
+      '고발',
+      '단서 조사',
+      '단서 교환',
+    ];
+
+    for (const moduleName of expectedVisibleModuleNames) {
+      expect(screen.getByText(moduleName)).toBeDefined();
     }
   });
 
   it('미지원 계획 모듈과 기본 제작 화면 모듈은 렌더링되지 않는다', () => {
     render(<ModulesSubTab themeId="theme-1" theme={baseTheme} />);
 
-    const hiddenModules = MODULE_CATEGORIES
-      .flatMap((c) => c.modules)
-      .filter((m) => !isSelectableModule(m));
+    const expectedHiddenModuleNames = [
+      '접속 관리',
+      '스크립트 진행',
+      '하이브리드 진행',
+      '리딩',
+      '엔딩',
+      '히든 미션',
+      '층 탐색',
+      '시작 단서',
+      '라운드 단서',
+      '시간 단서',
+    ];
 
-    for (const mod of hiddenModules) {
-      expect(screen.queryByText(mod.name)).toBeNull();
+    for (const moduleName of expectedHiddenModuleNames) {
+      expect(screen.queryByText(moduleName)).toBeNull();
     }
   });
 

--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
@@ -69,6 +69,7 @@ import {
   MODULE_CATEGORIES,
   OPTIONAL_MODULE_CATEGORIES,
   REQUIRED_MODULE_IDS,
+  isSelectableModule,
 } from '@/features/editor/constants';
 
 // ---------------------------------------------------------------------------
@@ -143,6 +144,27 @@ describe('ModulesSubTab', () => {
 
     // "코어" label should not appear since all its modules are required
     expect(screen.queryByText('코어')).toBeNull();
+  });
+
+  it('선택 모듈 목록에는 실제 선택 가능한 모듈만 포함된다', () => {
+    const catalogModules = OPTIONAL_MODULE_CATEGORIES.flatMap((c) => c.modules);
+
+    expect(catalogModules.length).toBeGreaterThan(0);
+    for (const mod of catalogModules) {
+      expect(isSelectableModule(mod)).toBe(true);
+    }
+  });
+
+  it('미지원 계획 모듈과 기본 제작 화면 모듈은 렌더링되지 않는다', () => {
+    render(<ModulesSubTab themeId="theme-1" theme={baseTheme} />);
+
+    const hiddenModules = MODULE_CATEGORIES
+      .flatMap((c) => c.modules)
+      .filter((m) => !isSelectableModule(m));
+
+    for (const mod of hiddenModules) {
+      expect(screen.queryByText(mod.name)).toBeNull();
+    }
   });
 
   it('토글 버튼 클릭 시 mutate가 호출된다', () => {

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -52,8 +52,10 @@ export const STATUS_COLOR: Record<ThemeStatus, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// Module Categories (29개 모듈, 6 카테고리)
+// Module Categories
 // ---------------------------------------------------------------------------
+
+export type ModuleCatalogVisibility = "optional" | "built_in";
 
 export interface ModuleInfo {
   id: string;
@@ -61,6 +63,7 @@ export interface ModuleInfo {
   description: string;
   supported: boolean;
   required: boolean;
+  catalogVisibility?: ModuleCatalogVisibility;
 }
 
 export interface ModuleCategory {
@@ -84,14 +87,14 @@ export const MODULE_CATEGORIES: ModuleCategory[] = [
     key: "progression",
     label: "진행",
     modules: [
-      { id: "script_progression", name: "스크립트 진행", description: "순차적 페이즈 진행", supported: true, required: false },
+      { id: "script_progression", name: "스크립트 진행", description: "순차적 페이즈 진행", supported: true, required: false, catalogVisibility: "built_in" },
       { id: "hybrid_progression", name: "하이브리드 진행", description: "타이머+합의 기반 진행", supported: false, required: false },
       { id: "event_progression", name: "이벤트 진행", description: "비선형 이벤트 그래프", supported: false, required: false },
       { id: "skip_consensus", name: "스킵 합의", description: "페이즈 스킵 투표", supported: false, required: false },
       { id: "gm_control", name: "GM 제어", description: "진행자 수동 제어", supported: false, required: false },
       { id: "consensus_control", name: "합의 제어", description: "플레이어 합의 기반 제어", supported: false, required: false },
-      { id: "reading", name: "리딩", description: "대사 낭독 시스템", supported: true, required: false },
-      { id: "ending", name: "엔딩", description: "엔딩 분기/결과 처리", supported: true, required: false },
+      { id: "reading", name: "리딩", description: "대사 낭독 시스템", supported: true, required: false, catalogVisibility: "built_in" },
+      { id: "ending", name: "엔딩", description: "엔딩 분기/결과 처리", supported: true, required: false, catalogVisibility: "built_in" },
     ],
   },
   {
@@ -111,14 +114,14 @@ export const MODULE_CATEGORIES: ModuleCategory[] = [
     modules: [
       { id: "voting", name: "투표", description: "다수결 투표 시스템", supported: true, required: false },
       { id: "accusation", name: "고발", description: "범인 지목/변호", supported: true, required: false },
-      { id: "hidden_mission", name: "히든 미션", description: "비밀 임무 시스템", supported: true, required: false },
+      { id: "hidden_mission", name: "히든 미션", description: "비밀 임무 시스템", supported: true, required: false, catalogVisibility: "built_in" },
     ],
   },
   {
     key: "exploration",
     label: "탐색",
     modules: [
-      { id: "floor_exploration", name: "층 탐색", description: "건물 층별 탐색", supported: true, required: false },
+      { id: "floor_exploration", name: "층 탐색", description: "건물 층별 탐색", supported: false, required: false },
       { id: "room_exploration", name: "방 탐색", description: "방별 탐색", supported: false, required: false },
       { id: "timed_exploration", name: "시간 제한 탐색", description: "제한 시간 내 탐색", supported: false, required: false },
       { id: "location_clue", name: "장소 단서", description: "위치 기반 단서 발견", supported: false, required: false },
@@ -130,9 +133,9 @@ export const MODULE_CATEGORIES: ModuleCategory[] = [
     label: "단서 배포",
     modules: [
       { id: "conditional_clue", name: "조건부 단서", description: "조건 충족 시 단서 제공", supported: false, required: false },
-      { id: "starting_clue", name: "시작 단서", description: "게임 시작 시 배포", supported: true, required: false },
-      { id: "round_clue", name: "라운드 단서", description: "라운드별 단서 배포", supported: true, required: false },
-      { id: "timed_clue", name: "시간 단서", description: "시간 경과 시 배포", supported: true, required: false },
+      { id: "starting_clue", name: "시작 단서", description: "게임 시작 시 배포", supported: true, required: false, catalogVisibility: "built_in" },
+      { id: "round_clue", name: "라운드 단서", description: "라운드별 단서 배포", supported: false, required: false },
+      { id: "timed_clue", name: "시간 단서", description: "시간 경과 시 배포", supported: false, required: false },
       { id: "trade_clue", name: "단서 교환", description: "플레이어 간 단서 교환", supported: true, required: false },
     ],
   },
@@ -147,7 +150,11 @@ export const REQUIRED_MODULE_IDS = MODULE_CATEGORIES
   .filter((m) => m.required)
   .map((m) => m.id);
 
+export function isSelectableModule(module: ModuleInfo): boolean {
+  return module.supported && !module.required && module.catalogVisibility !== "built_in";
+}
+
 export const OPTIONAL_MODULE_CATEGORIES = MODULE_CATEGORIES.map((cat) => ({
   ...cat,
-  modules: cat.modules.filter((m) => !m.required),
+  modules: cat.modules.filter(isSelectableModule),
 })).filter((cat) => cat.modules.length > 0);


### PR DESCRIPTION
## 요약
- 모듈 탭이 실제 선택 가능한 런타임 모듈만 표시하도록 `supported`/기본 제공 상태를 반영했습니다.
- 스토리 진행, 리딩, 엔딩, 히든 미션, 시작 단서처럼 이미 기본 제작 화면에 있는 항목은 optional toggle에서 제외했습니다.
- 미지원/계획 단계 모듈이 모듈 탭에 렌더링되지 않도록 회귀 테스트를 추가했습니다.

Refs #381

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx src/features/editor/components/design/__tests__/ModulesSubTab.deckInvestigation.test.tsx
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/__tests__/Editor.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 모듈 추가: hidden_mission, starting_clue, round_clue, timed_clue, reading, ending
  * 모듈 가시성 및 선택 로직 개선: 가시성 분류 도입과 내장(built_in) 모듈 제외로 선택 가능한 모듈 필터링 강화

* **테스트**
  * 선택 가능 모듈만 표시되고 지원되지 않는/내장 모듈은 숨겨지는지 검증하는 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->