### PR TITLE
fix(editor): EntityEditorShell 스크롤 레이아웃 정리

### DIFF
--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
@@ -37,12 +37,28 @@ afterEach(cleanup);
 
 describe('EntityEditorShell', () => {
   it('목록, 상세 슬롯, 검수 슬롯을 모바일 우선 흐름으로 렌더링한다', () => {
-    renderShell();
+    const { container } = renderShell();
 
     expect(screen.getByRole('region', { name: '단서 목록' })).toBeDefined();
+    expect(screen.getByRole('region', { name: '단서 상세 영역' })).toBeDefined();
     expect(screen.getByLabelText('상세 슬롯').textContent).toContain('첫 단서 상세');
     expect(screen.getByLabelText('검수 슬롯').textContent).toContain('첫 단서 검수');
     expect(screen.getByText('2개의 단서')).toBeDefined();
+    expect(container.firstElementChild?.className).toContain('min-h-0');
+    expect(container.firstElementChild?.className).toContain('lg:overflow-hidden');
+  });
+
+  it('데스크톱에서는 목록과 상세 패널이 각자 스크롤 책임을 가진다', () => {
+    renderShell();
+
+    const list = screen.getByRole('region', { name: '단서 목록' });
+    const detail = screen.getByRole('region', { name: '단서 상세 영역' });
+    const listScroller = list.querySelector('.overflow-y-auto');
+
+    expect(list.className).toContain('flex');
+    expect(list.className).toContain('min-h-0');
+    expect(listScroller?.className).toContain('lg:flex-1');
+    expect(detail.className).toContain('lg:overflow-y-auto');
   });
 
   it('검색어에 맞는 항목만 보여준다', () => {

--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
@@ -76,8 +76,11 @@ export function EntityEditorShell<TItem>({
   }
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[minmax(16rem,0.85fr)_minmax(0,1.45fr)]">
-      <section aria-label={`${title} 목록`} className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto lg:grid lg:grid-cols-[minmax(16rem,0.85fr)_minmax(0,1.45fr)] lg:overflow-hidden">
+      <section
+        aria-label={`${title} 목록`}
+        className="flex min-h-0 flex-col rounded-xl border border-slate-800 bg-slate-950/70 p-3"
+      >
         <header className="mb-3 flex items-center justify-between gap-2">
           <div>
             <h3 className="text-sm font-semibold text-slate-200">{title} 목록</h3>
@@ -106,7 +109,7 @@ export function EntityEditorShell<TItem>({
             className="w-full rounded-lg border border-slate-800 bg-slate-900 py-2.5 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
           />
         </label>
-        <div className="max-h-[34rem] space-y-2 overflow-auto pr-1">
+        <div className="max-h-80 min-h-0 space-y-2 overflow-y-auto pr-1 lg:max-h-none lg:flex-1">
           {visibleItems.length === 0 ? (
             <p className="rounded-lg border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
               검색 결과가 없습니다.
@@ -131,9 +134,14 @@ export function EntityEditorShell<TItem>({
       </section>
 
       {selected && (
-        <section className="space-y-4" aria-label={`${title} 상세 영역`}>
-          {renderDetail(selected)}
-          {renderInspector?.(selected)}
+        <section
+          className="min-h-0 overflow-y-visible lg:overflow-y-auto lg:pr-2"
+          aria-label={`${title} 상세 영역`}
+        >
+          <div className="space-y-4 pb-4">
+            {renderDetail(selected)}
+            {renderInspector?.(selected)}
+          </div>
         </section>
       )}
     </div>


### PR DESCRIPTION
## 요약
- EntityEditorShell root/list/detail 패널의 height/overflow 책임을 정리했습니다.
- 데스크톱에서는 목록과 상세가 각자 스크롤하고, 모바일은 기존 세로 흐름을 유지합니다.
- shell 레이아웃 회귀 테스트를 추가했습니다.

Refs #396

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/entities/shell/EntityEditorShell.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선**
  * 편집기 셸 레이아웃을 반응형 구조로 개선하여 모바일과 데스크톱 화면에서의 스크롤 동작 및 레이아웃 반응성 향상

* **테스트**
  * 편집기 레이아웃 테스트를 강화하여 다양한 화면 크기에서의 동작 검증 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->