### PR TITLE
fix(editor): 캐릭터 상세 정보 밀도 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -198,7 +198,7 @@ export function CharacterDetailPanel({
                             aria-pressed={active}
                             title={option.description}
                             onClick={() => onMysteryRoleChange?.(option.value)}
-                            className={`rounded-lg border px-3 py-2 text-center transition ${
+                            className={`min-h-11 rounded-lg border px-3 py-2 text-center transition ${
                               active
                                 ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
                                 : 'border-slate-800 bg-slate-950 text-slate-400 hover:border-slate-700'

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -139,14 +139,26 @@ export function CharacterDetailPanel({
     endcardImageUrl !== (selectedChar.endcard_image_url ?? '');
 
   return (
-    <div className="max-w-5xl space-y-4">
-      <div>
-        <h3 className="text-sm font-semibold text-slate-200">{selectedChar.name}</h3>
-        <p className="mt-1 text-xs text-slate-500">역할지, 시작 단서, 히든 미션을 한 곳에서 관리합니다.</p>
+    <div className="max-w-4xl space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-slate-200">{selectedChar.name}</h3>
+          <p className="mt-1 text-xs text-slate-500">역할지, 시작 단서, 히든 미션을 한 곳에서 관리합니다.</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5" aria-label={`${selectedChar.name} 요약`}>
+          {[selectedView.roleLabel, ...selectedView.visibilityBadges].map((badge) => (
+            <span
+              key={badge}
+              className="rounded-full border border-slate-800 bg-slate-950 px-2 py-1 text-[11px] font-medium text-slate-300"
+            >
+              {badge}
+            </span>
+          ))}
+        </div>
       </div>
 
       <Accordion
-        storageKey={`editor:character:${selectedChar.id}:sections`}
+        storageKey={`editor:character:${selectedChar.id}:sections:v2`}
         items={[
           {
             id: 'base',
@@ -155,18 +167,26 @@ export function CharacterDetailPanel({
             defaultOpen: true,
             forceOpen: true,
             children: (
-              <div className="grid gap-3 md:grid-cols-[10rem_1fr]">
-                <div className="flex h-36 items-center justify-center rounded-lg border border-dashed border-slate-800 bg-slate-950 text-xs text-slate-600">
+              <div className="grid gap-3 md:grid-cols-[8rem_minmax(0,1fr)]">
+                <div className="flex h-28 items-center justify-center rounded-lg border border-dashed border-slate-800 bg-slate-950 text-xs text-slate-600">
                   {selectedChar.image_url ? '사진 등록됨' : '사진 없음'}
                 </div>
-                <div className="space-y-3">
-                  <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">이름</p>
-                    <p className="mt-1 text-sm text-slate-200">{selectedChar.name}</p>
+                <div className="space-y-2.5">
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">이름</p>
+                      <p className="mt-1 text-sm text-slate-200">{selectedChar.name}</p>
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">공개 소개</p>
+                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-400">
+                        {selectedChar.description || '공개 소개가 없습니다.'}
+                      </p>
+                    </div>
                   </div>
                   <div>
                     <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">역할</p>
-                    <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    <div className="mt-2 grid gap-2 sm:grid-cols-4">
                       {characterRoleOptions.map((option) => {
                         const active = selectedRole === option.value;
                         return (
@@ -174,15 +194,18 @@ export function CharacterDetailPanel({
                             key={option.value}
                             type="button"
                             disabled={!onMysteryRoleChange}
+                            aria-label={option.label}
+                            aria-pressed={active}
+                            title={option.description}
                             onClick={() => onMysteryRoleChange?.(option.value)}
-                            className={`rounded-lg border px-3 py-2 text-left transition ${
+                            className={`rounded-lg border px-3 py-2 text-center transition ${
                               active
                                 ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
                                 : 'border-slate-800 bg-slate-950 text-slate-400 hover:border-slate-700'
                             } disabled:cursor-default disabled:opacity-80`}
                           >
                             <span className="block text-xs font-semibold">{option.label}</span>
-                            <span className="mt-1 block text-[11px] leading-4 text-slate-500">{option.description}</span>
+                            <span className="sr-only">{option.description}</span>
                           </button>
                         );
                       })}
@@ -221,12 +244,6 @@ export function CharacterDetailPanel({
                       />
                     </div>
                   </div>
-                  <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">공개 소개</p>
-                    <p className="mt-1 whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs leading-5 text-slate-400">
-                      {selectedChar.description || '공개 소개가 없습니다.'}
-                    </p>
-                  </div>
                   <CharacterAliasRulesEditor
                     characterName={selectedChar.name}
                     characterImageUrl={selectedChar.image_url}
@@ -247,7 +264,6 @@ export function CharacterDetailPanel({
             id: 'endcard',
             title: '결과 카드',
             subtitle: selectedView.hasEndcard ? '작성됨' : '비어 있음',
-            defaultOpen: true,
             children: (
               <div className="space-y-3">
                 <div className="grid gap-3 md:grid-cols-2">
@@ -308,7 +324,6 @@ export function CharacterDetailPanel({
             id: 'role-sheet',
             title: '역할지',
             subtitle: 'Markdown 또는 PDF',
-            defaultOpen: true,
             children: (
               <CharacterRoleSheetSection
                 themeId={themeId}
@@ -321,7 +336,6 @@ export function CharacterDetailPanel({
             id: 'starting-clue',
             title: '시작 단서',
             subtitle: `${charClueIds.length}/${clues?.length ?? 0}개 배정`,
-            defaultOpen: true,
             children: (
               <StartingClueAssigner
                 characterName={selectedChar.name}
@@ -335,7 +349,6 @@ export function CharacterDetailPanel({
             id: 'hidden-mission',
             title: '히든 미션',
             subtitle: `${charMissions.length}개`,
-            defaultOpen: true,
             children: (
               <MissionEditor
                 missions={charMissions}
@@ -363,17 +376,21 @@ interface VisibilityToggleProps {
 
 function VisibilityToggle({ label, description, checked, disabled, onChange }: VisibilityToggleProps) {
   return (
-    <label className="flex min-h-24 items-start gap-3 rounded-lg border border-slate-800 bg-slate-950 p-3 text-left">
+    <label
+      className="flex min-h-14 items-center gap-3 rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-left"
+      title={description}
+    >
       <input
         type="checkbox"
-        className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-900 text-amber-500 focus:ring-amber-500"
+        aria-label={label}
+        className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-amber-500 focus:ring-amber-500"
         checked={checked}
         disabled={disabled}
         onChange={(event) => onChange(event.currentTarget.checked)}
       />
       <span>
         <span className="block text-xs font-semibold text-slate-200">{label}</span>
-        <span className="mt-1 block text-[11px] leading-4 text-slate-500">{description}</span>
+        <span className="sr-only">{description}</span>
       </span>
     </label>
   );

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -156,7 +156,31 @@ function readStartingClues(config: Record<string, unknown>) {
   return modules?.starting_clue?.config?.startingClues ?? {};
 }
 
+function openCharacterSection(name: RegExp) {
+  const button = screen.getByRole('button', { name });
+  if (button.getAttribute('aria-expanded') === 'false') {
+    fireEvent.click(button);
+  }
+}
+
+function openEndcardSection() {
+  openCharacterSection(/결과 카드/);
+}
+
+function openRoleSheetSection() {
+  openCharacterSection(/역할지Markdown 또는 PDF/);
+}
+
+function openStartingClueSection() {
+  openCharacterSection(/시작 단서/);
+}
+
+function openHiddenMissionSection() {
+  openCharacterSection(/히든 미션/);
+}
+
 function clickFirstClue() {
+  openStartingClueSection();
   fireEvent.click(screen.getByRole('button', { name: /피 묻은 칼/ }));
 }
 
@@ -182,6 +206,17 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByRole('button', { name: '홍길동 선택' })).toBeDefined();
     expect(screen.getByRole('button', { name: '김철수 선택' })).toBeDefined();
     expect(screen.queryByText(/시스템 ID/)).toBeNull();
+  });
+
+  it('기본 정보만 처음부터 열고 세부 제작 섹션은 접어 둔다', () => {
+    renderPanel();
+
+    expect(screen.getByRole('button', { name: /기본 정보/ }).getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('button', { name: /결과 카드/ }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: /역할지Markdown 또는 PDF/ }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: /시작 단서/ }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: /히든 미션/ }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('textbox', { name: '역할지 Markdown' })).toBeNull();
   });
 
   it('범인 캐릭터에 "범인" 라벨이 표시된다', () => {
@@ -298,6 +333,7 @@ describe('CharacterAssignPanel', () => {
   it('결과 카드 내용을 캐릭터 저장 계약으로 보낸다', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openEndcardSection();
 
     fireEvent.change(screen.getByRole('textbox', { name: '제목' }), {
       target: { value: '범인의 후일담' },
@@ -346,6 +382,7 @@ describe('CharacterAssignPanel', () => {
     );
 
     expect(screen.queryByRole('button', { name: '김철수 선택' })).toBeNull();
+    openStartingClueSection();
     expect(screen.getByText('홍길동의 시작 단서')).toBeDefined();
 
     clickFirstClue();
@@ -364,6 +401,7 @@ describe('CharacterAssignPanel', () => {
       target: { value: '홍길동' },
     });
 
+    openStartingClueSection();
     expect(screen.getByText('홍길동의 시작 단서')).toBeDefined();
     clickFirstClue();
     await act(async () => { vi.advanceTimersByTime(1500); });
@@ -376,6 +414,7 @@ describe('CharacterAssignPanel', () => {
   it('캐릭터 선택 시 좌측 전체 단서와 우측 배정 영역이 표시된다', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openStartingClueSection();
     expect(screen.getByText('전체 단서 목록')).toBeDefined();
     expect(screen.getByText('홍길동의 시작 단서')).toBeDefined();
     expect(screen.getByText('피 묻은 칼')).toBeDefined();
@@ -390,6 +429,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
 
     const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' });
     fireEvent.change(roleSheet, { target: { value: '## 비밀\n범인은 아직 모른다.' } });
@@ -414,6 +454,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
 
     expect(screen.getByText('아직 저장된 역할지가 없습니다.')).toBeDefined();
     expect((screen.getByRole('textbox', { name: '역할지 Markdown' }) as HTMLTextAreaElement).value).toBe('');
@@ -436,6 +477,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
     fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
 
     expect(screen.getByText('역할지를 불러오지 못했습니다.')).toBeDefined();
@@ -447,6 +489,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
     fireEvent.click(screen.getByRole('button', { name: '역할지 저장' }));
 
     expect(upsertRoleSheetMutateMock).not.toHaveBeenCalled();
@@ -456,6 +499,7 @@ describe('CharacterAssignPanel', () => {
   it('역할지 저장 버튼 클릭 시 blur 자동 저장과 중복 호출하지 않는다', async () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
 
     const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' });
     const saveButton = screen.getByRole('button', { name: '역할지 저장' });
@@ -484,6 +528,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
 
     expect(screen.getByText('PDF 역할지')).toBeDefined();
     expect(screen.getByText('1페이지')).toBeDefined();
@@ -510,6 +555,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
 
     expect(screen.getByText('이미지 롤지')).toBeDefined();
     expect(screen.getByText('1 / 2페이지')).toBeDefined();
@@ -527,6 +573,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
     fireEvent.click(screen.getByRole('button', { name: /이미지/ }));
     fireEvent.change(screen.getByRole('textbox', { name: '이미지 페이지 URL' }), {
       target: { value: 'https://cdn.example/role-1.webp' },
@@ -547,6 +594,7 @@ describe('CharacterAssignPanel', () => {
   it('좌측 단서 목록을 장소/태그로 검색할 수 있다', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openStartingClueSection();
 
     fireEvent.change(screen.getByPlaceholderText('단서명, 장소, 태그 검색'), {
       target: { value: '부엌' },
@@ -642,6 +690,7 @@ describe('CharacterAssignPanel', () => {
   it('미션 추가 버튼이 동작한다 (1500ms debounce)', async () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openHiddenMissionSection();
     fireEvent.click(screen.getByText('추가'));
 
     await act(async () => { vi.advanceTimersByTime(1500); });
@@ -675,6 +724,7 @@ describe('CharacterAssignPanel', () => {
 
     // 3) Add a mission → character_missions must merge with existing pending
     //    starting_clue config rather than overwrite it.
+    openHiddenMissionSection();
     fireEvent.click(screen.getByText('추가'));
 
     // 4) Full debounce window from the latest edit → single mutation.

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -156,6 +156,11 @@ function readStartingClues(config: Record<string, unknown>) {
   return modules?.starting_clue?.config?.startingClues ?? {};
 }
 
+const endcardSectionName = /^결과 카드(?:작성됨|비어 있음)$/;
+const roleSheetSectionName = /^역할지Markdown 또는 PDF$/;
+const startingClueSectionName = /^시작 단서\d+\/\d+개 배정$/;
+const hiddenMissionSectionName = /^히든 미션\d+개$/;
+
 function openCharacterSection(name: RegExp) {
   const button = screen.getByRole('button', { name });
   if (button.getAttribute('aria-expanded') === 'false') {
@@ -164,19 +169,19 @@ function openCharacterSection(name: RegExp) {
 }
 
 function openEndcardSection() {
-  openCharacterSection(/결과 카드/);
+  openCharacterSection(endcardSectionName);
 }
 
 function openRoleSheetSection() {
-  openCharacterSection(/역할지Markdown 또는 PDF/);
+  openCharacterSection(roleSheetSectionName);
 }
 
 function openStartingClueSection() {
-  openCharacterSection(/시작 단서/);
+  openCharacterSection(startingClueSectionName);
 }
 
 function openHiddenMissionSection() {
-  openCharacterSection(/히든 미션/);
+  openCharacterSection(hiddenMissionSectionName);
 }
 
 function clickFirstClue() {
@@ -212,10 +217,10 @@ describe('CharacterAssignPanel', () => {
     renderPanel();
 
     expect(screen.getByRole('button', { name: /기본 정보/ }).getAttribute('aria-expanded')).toBe('true');
-    expect(screen.getByRole('button', { name: /결과 카드/ }).getAttribute('aria-expanded')).toBe('false');
-    expect(screen.getByRole('button', { name: /역할지Markdown 또는 PDF/ }).getAttribute('aria-expanded')).toBe('false');
-    expect(screen.getByRole('button', { name: /시작 단서/ }).getAttribute('aria-expanded')).toBe('false');
-    expect(screen.getByRole('button', { name: /히든 미션/ }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: endcardSectionName }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: roleSheetSectionName }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: startingClueSectionName }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: hiddenMissionSectionName }).getAttribute('aria-expanded')).toBe('false');
     expect(screen.queryByRole('textbox', { name: '역할지 Markdown' })).toBeNull();
   });
 


### PR DESCRIPTION
## 요약
- 캐릭터 상세 패널에서 기본 정보만 처음부터 열고 결과 카드/역할지/시작 단서/히든 미션은 필요할 때 열도록 정리했습니다.
- 역할 선택과 등장인물 유형 토글을 더 조밀한 컨트롤로 바꿔 첫 화면의 스크롤 부담을 줄였습니다.
- 캐릭터 탭 테스트를 사용자가 섹션을 여는 실제 흐름 기준으로 갱신했습니다.

Refs #396

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 캐릭터 상세에 새 헤더 추가—이름과 역할·공개 상태 뱃지 표시

* **개선**
  * 기본 정보 레이아웃을 2단 그리드로 재구성하고 이미지/상태 영역 추가
  * 앨리어스 규칙을 인라인 에디터로 통합하여 편집 편의성 향상
  * 공개 상태 토글의 컴팩트 레이아웃·레이블·접근성 개선
  * 엔드카드·역할지·시작 단서·히든 미션 섹션의 초기 접힘 상태로 UI 간소화

* **테스트**
  * 섹션 열기/상태 관리를 명시적으로 처리하도록 UI 테스트 안정성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->