### PR TITLE
fix(editor): 스토리·미디어·장소 중첩 스크롤 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -180,7 +180,7 @@ export function LocationClueAssignPanel({
                 className="w-full rounded-lg border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
               />
             </label>
-            <div className="max-h-80 space-y-1 overflow-auto pr-1">
+            <div className="space-y-1 pr-1 lg:max-h-80 lg:overflow-y-auto">
               {visibleClues.length === 0 ? (
                 <p className="rounded-md border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
                   검색 결과가 없습니다.

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -108,9 +108,9 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   }
 
   return (
-    <div className="flex h-full flex-col md:flex-row">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
       {/* ── Map list (full-width on mobile, 240px on md+) ── */}
-      <aside className="shrink-0 overflow-y-auto border-b border-slate-800 bg-slate-950 py-2 md:w-60 md:border-b-0 md:border-r">
+      <aside className="shrink-0 border-b border-slate-800 bg-slate-950 py-2 md:min-h-0 md:w-60 md:overflow-y-auto md:border-b-0 md:border-r">
         <div className="flex items-center justify-between px-3 pb-2">
           <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
             맵
@@ -184,7 +184,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
       </aside>
 
       {/* ── Location detail ── */}
-      <div className="flex-1 overflow-y-auto px-5 py-5">
+      <div className="min-h-0 flex-1 px-5 py-5 md:overflow-y-auto">
         <LocationDetailPanel
           themeId={themeId}
           theme={theme}

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -165,7 +165,9 @@ describe('LocationsSubTab', () => {
     beforeEach(setupDefaultMocks);
 
     it('맵 이름들을 렌더링한다', () => {
-      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+      const { container } = render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+      expect(container.firstElementChild?.className).toContain('overflow-y-auto');
+      expect(container.firstElementChild?.className).toContain('md:overflow-hidden');
       expect(screen.getAllByText('저택 1층').length).toBeGreaterThan(0);
       expect(screen.getByText('저택 2층')).toBeDefined();
     });

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -51,7 +51,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <MediaToolbar
         filter={filter}
         onFilterChange={handleFilterChange}
@@ -59,9 +59,9 @@ export function MediaTab({ themeId }: MediaTabProps) {
         onYouTubeClick={() => setYoutubeOpen(true)}
       />
 
-      <div className="flex flex-1 gap-4 overflow-hidden p-4">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 lg:flex-row lg:overflow-hidden">
         {/* List */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="min-h-0 flex-1 overflow-visible lg:overflow-y-auto">
           {isLoading ? (
             <div
               className="flex h-full items-center justify-center"
@@ -105,7 +105,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
 
         {/* Detail */}
         {selected && (
-          <aside className="w-96 shrink-0 overflow-y-auto border-l border-slate-800 pl-4">
+          <aside className="min-h-0 w-full shrink-0 border-t border-slate-800 pt-4 lg:w-96 lg:overflow-y-auto lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
             <MediaDetail media={selected} themeId={themeId} onClose={handleClose} />
           </aside>
         )}

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -208,6 +208,7 @@ describe('MediaTab', () => {
 
     // Detail visible
     expect(screen.getByText('미디어 상세')).toBeDefined();
+    expect(screen.getByText('미디어 상세').closest('aside')?.className).toContain('lg:overflow-y-auto');
     // Editable name input pre-filled
     expect(screen.getByDisplayValue('오프닝 BGM')).toBeDefined();
     expect(screen.getByText('분류')).toBeDefined();

--- a/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
+++ b/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
@@ -269,7 +269,7 @@ export function EditorEntityLibrary({
   ];
 
   return (
-    <aside className="border-b border-slate-800 bg-slate-950 lg:border-b-0 lg:border-r">
+    <aside className="border-b border-slate-800 bg-slate-950 lg:min-h-0 lg:overflow-y-auto lg:border-b-0 lg:border-r">
       <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
         <FileText className="h-4 w-4 text-amber-400" />
         <h3 className="text-sm font-semibold text-slate-100">제작 라이브러리</h3>

--- a/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
+++ b/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
@@ -106,7 +106,7 @@ export function SceneInspector({ selectedScene, selectedEntity }: SceneInspector
   const sceneTitle = selectedScene?.data.label ?? "선택한 장면 없음";
 
   return (
-    <aside className="bg-slate-950">
+    <aside className="bg-slate-950 lg:min-h-0 lg:overflow-y-auto">
       <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
         <MapPin className="h-4 w-4 text-amber-400" />
         <h3 className="text-sm font-semibold text-slate-100">장면 속성</h3>

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -24,7 +24,7 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
   return (
     <section
       aria-label="스토리 진행 제작"
-      className="flex min-h-[calc(100vh-9.5rem)] flex-col bg-slate-950 text-slate-100"
+      className="flex h-full min-h-[calc(100vh-9.5rem)] flex-col overflow-y-auto bg-slate-950 text-slate-100 lg:overflow-hidden"
     >
       <div className="border-b border-slate-800 px-4 py-4 sm:px-6">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
@@ -58,7 +58,7 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
           onSelectEntity={setSelectedEntity}
         />
 
-        <main className="min-h-[620px] min-w-0 border-b border-slate-800 lg:border-b-0">
+        <main className="min-h-[520px] min-w-0 border-b border-slate-800 lg:min-h-0 lg:border-b-0">
           <FlowCanvas themeId={themeId} onSelectedNodeChange={setSelectedScene} />
         </main>
 

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -93,8 +93,12 @@ describe("StoryMapWorkspace", () => {
   it("스토리 진행 중심 제작 화면과 플로우 캔버스를 함께 렌더링한다", () => {
     render(<StoryMapWorkspace themeId="theme-1" />);
 
+    expect(screen.getByLabelText("스토리 진행 제작").className).toContain("lg:overflow-hidden");
     expect(screen.getByRole("heading", { name: "스토리 진행 제작" })).toBeDefined();
     expect(screen.getByRole("heading", { name: "제작 라이브러리" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "제작 라이브러리" }).closest("aside")?.className).toContain(
+      "lg:overflow-y-auto",
+    );
     expect(screen.getByRole("heading", { name: "장면 속성" })).toBeDefined();
     expect(screen.getByTestId("flow-canvas").textContent).toContain("theme-1");
   });


### PR DESCRIPTION
## 요약
- 미디어 탭은 모바일에서 단일 페이지 흐름을 유지하고, 데스크톱에서만 목록/상세 패널이 독립 스크롤하도록 정리했습니다.
- 장소 탭과 장소 단서 배정 목록의 모바일 중첩 스크롤을 줄였습니다.
- 스토리 진행 제작 화면의 라이브러리/속성 패널 스크롤 책임을 데스크톱 기준으로 고정했습니다.

Refs #396

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/components/media/__tests__/MediaTab.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 에디터의 반응형 레이아웃 개선: 대형 화면에서 더 나은 스크롤 동작과 최적화된 공간 활용
  * 미디어 탭의 상세 패널이 이제 반응형 두 개 열 레이아웃 지원
  * 다양한 화면 크기에서 스토리맵 작업 공간의 안정적인 오버플로우 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->