### PR TITLE
test(editor): 모바일 focus smoke 보강

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -68,15 +68,31 @@ async function expectNoPageLevelHorizontalOverflow(page: Page) {
   expect(metrics.pageScrollWidth).toBeLessThanOrEqual(metrics.viewportWidth + 2);
 }
 
-async function expectFocusIndicator(locator: Locator) {
+async function expectFocusIndicator(page: Page, locator: Locator) {
   const readStyle = (el: Element) => {
     const cs = window.getComputedStyle(el);
     return { outline: cs.outline, boxShadow: cs.boxShadow };
   };
 
+  await locator.scrollIntoViewIfNeeded();
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  });
   const before = await locator.evaluate(readStyle);
-  await locator.focus();
+  let reachedTarget = false;
+
+  for (let i = 0; i < 80; i += 1) {
+    await page.keyboard.press('Tab');
+    reachedTarget = await locator.evaluate((el) => el === document.activeElement);
+    if (reachedTarget) {
+      break;
+    }
+  }
+
   const after = await locator.evaluate(readStyle);
+  const isFocusVisible = await locator.evaluate((el) => el.matches(':focus-visible'));
 
   const hasOutline =
     after.outline !== before.outline &&
@@ -85,9 +101,12 @@ async function expectFocusIndicator(locator: Locator) {
     !after.outline.startsWith('rgba(0, 0, 0, 0)');
   const hasRing =
     after.boxShadow !== before.boxShadow && !!after.boxShadow && after.boxShadow !== 'none';
+  expect(reachedTarget, 'target element was not reachable through keyboard Tab navigation').toBe(
+    true,
+  );
   expect(
-    hasOutline || hasRing,
-    `focus indicator missing — before=${before.outline}/${before.boxShadow}, after=${after.outline}/${after.boxShadow}`,
+    isFocusVisible && (hasOutline || hasRing),
+    `focus indicator missing — focusVisible=${isFocusVisible}, before=${before.outline}/${before.boxShadow}, after=${after.outline}/${after.boxShadow}`,
   ).toBe(true);
 }
 
@@ -295,17 +314,17 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await expect(page.getByRole('tab', { name: '등장인물', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expectFocusIndicator(page.getByRole('textbox', { name: '캐릭터 검색' }));
-    await expectFocusIndicator(page.getByRole('button', { name: '탐정 A 선택' }));
+    await expectFocusIndicator(page, page.getByRole('textbox', { name: '캐릭터 검색' }));
+    await expectFocusIndicator(page, page.getByRole('button', { name: '탐정 A 선택' }));
     await expectNoPageLevelHorizontalOverflow(page);
 
     await page.goto(`${BASE}/editor/${THEME_ID}/media`);
     await expect(page.getByRole('tab', { name: '미디어', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expectFocusIndicator(page.getByRole('button', { name: '파일 업로드' }));
-    await expectFocusIndicator(page.getByRole('button', { name: 'YouTube' }));
-    await expectFocusIndicator(page.getByRole('button', { name: '전체' }));
+    await expectFocusIndicator(page, page.getByRole('button', { name: '파일 업로드' }));
+    await expectFocusIndicator(page, page.getByRole('button', { name: 'YouTube' }));
+    await expectFocusIndicator(page, page.getByRole('button', { name: '전체' }));
     await expectNoPageLevelHorizontalOverflow(page);
   });
 

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -21,7 +21,7 @@
  *  9. 템플릿 탭 GET /api/v1/templates (PR-1)
  */
 import AxeBuilder from '@axe-core/playwright';
-import { test, expect, type Page, type Request } from '@playwright/test';
+import { test, expect, type Locator, type Page, type Request } from '@playwright/test';
 import {
   BASE,
   THEME_ID,
@@ -66,6 +66,22 @@ async function expectNoPageLevelHorizontalOverflow(page: Page) {
   }));
 
   expect(metrics.pageScrollWidth).toBeLessThanOrEqual(metrics.viewportWidth + 2);
+}
+
+async function expectFocusIndicator(locator: Locator) {
+  await locator.focus();
+  const style = await locator.evaluate((el) => {
+    const cs = window.getComputedStyle(el);
+    return { outline: cs.outline, boxShadow: cs.boxShadow };
+  });
+
+  const hasOutline =
+    !!style.outline && style.outline !== 'none' && !style.outline.startsWith('rgba(0, 0, 0, 0)');
+  const hasRing = !!style.boxShadow && style.boxShadow !== 'none';
+  expect(
+    hasOutline || hasRing,
+    `focus indicator missing — outline=${style.outline} boxShadow=${style.boxShadow}`,
+  ).toBe(true);
 }
 
 test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', () => {
@@ -263,6 +279,25 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
         await expectNoPageLevelHorizontalOverflow(page);
       }
     }
+  });
+
+  test('[2E] 모바일 제작 화면의 주요 컨트롤은 focus 지표를 가진다', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
+    await expect(page.getByRole('tab', { name: '등장인물', selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expectFocusIndicator(page.getByRole('textbox', { name: '캐릭터 검색' }));
+    await expectFocusIndicator(page.getByRole('button', { name: '탐정 A 선택' }));
+    await expectNoPageLevelHorizontalOverflow(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/media`);
+    await expect(page.getByRole('tab', { name: '미디어', selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expectFocusIndicator(page.getByRole('button', { name: '파일 업로드' }));
+    await expectNoPageLevelHorizontalOverflow(page);
   });
 
   test('[2] 단서 이미지 업로드 경로는 /v1/editor/themes/{id}/images/upload-url (network-only)', async ({

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -69,18 +69,25 @@ async function expectNoPageLevelHorizontalOverflow(page: Page) {
 }
 
 async function expectFocusIndicator(locator: Locator) {
-  await locator.focus();
-  const style = await locator.evaluate((el) => {
+  const readStyle = (el: Element) => {
     const cs = window.getComputedStyle(el);
     return { outline: cs.outline, boxShadow: cs.boxShadow };
-  });
+  };
+
+  const before = await locator.evaluate(readStyle);
+  await locator.focus();
+  const after = await locator.evaluate(readStyle);
 
   const hasOutline =
-    !!style.outline && style.outline !== 'none' && !style.outline.startsWith('rgba(0, 0, 0, 0)');
-  const hasRing = !!style.boxShadow && style.boxShadow !== 'none';
+    after.outline !== before.outline &&
+    !!after.outline &&
+    after.outline !== 'none' &&
+    !after.outline.startsWith('rgba(0, 0, 0, 0)');
+  const hasRing =
+    after.boxShadow !== before.boxShadow && !!after.boxShadow && after.boxShadow !== 'none';
   expect(
     hasOutline || hasRing,
-    `focus indicator missing — outline=${style.outline} boxShadow=${style.boxShadow}`,
+    `focus indicator missing — before=${before.outline}/${before.boxShadow}, after=${after.outline}/${after.boxShadow}`,
   ).toBe(true);
 }
 
@@ -297,6 +304,8 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
       timeout: 10_000,
     });
     await expectFocusIndicator(page.getByRole('button', { name: '파일 업로드' }));
+    await expectFocusIndicator(page.getByRole('button', { name: 'YouTube' }));
+    await expectFocusIndicator(page.getByRole('button', { name: '전체' }));
     await expectNoPageLevelHorizontalOverflow(page);
   });
 

--- a/apps/web/src/features/editor/components/media/MediaToolbar.tsx
+++ b/apps/web/src/features/editor/components/media/MediaToolbar.tsx
@@ -50,7 +50,7 @@ export function MediaToolbar({
               type="button"
               onClick={() => onFilterChange(pill.value)}
               aria-pressed={isActive}
-              className={`h-7 rounded-sm border px-3 text-xs font-medium transition-colors ${
+              className={`h-7 rounded-sm border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 ${
                 isActive
                   ? "border-amber-500 bg-amber-500/10 text-amber-300"
                   : "border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
@@ -67,7 +67,7 @@ export function MediaToolbar({
         <button
           type="button"
           onClick={onUploadClick}
-          className="flex h-7 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100"
+          className="flex h-7 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
         >
           <Upload className="h-3.5 w-3.5" />
           파일 업로드
@@ -75,7 +75,7 @@ export function MediaToolbar({
         <button
           type="button"
           onClick={onYouTubeClick}
-          className="flex h-7 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100"
+          className="flex h-7 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
         >
           <Youtube className="h-3.5 w-3.5" />
           YouTube


### PR DESCRIPTION
## 요약
- editor golden-path E2E에 모바일 제작 화면 주요 컨트롤 focus smoke를 추가했습니다.
- 미디어 도구 모음 버튼/필터에 focus-visible ring을 추가했습니다.
- 모바일 가로 overflow와 focus indicator를 같은 mocked editor 흐름에서 확인합니다.

Refs #396

## 검증
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium --grep "[2E]"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모바일 에디터 화면의 핵심 컨트롤에 포커스 시각 지표 추가

* **개선사항**
  * 미디어 도구모음의 버튼(필터, 업로드, YouTube) 포커스 시각 강화
  * 키보드 탐색 시 포커스 가시성 향상으로 접근성 및 사용성 개선

* **테스트**
  * 모바일 에디터에서 주요 컨트롤의 포커스 표시를 검증하는 접근성 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->