### PR TITLE
fix(editor): 에디터 탭 URL 동기화

### DIFF
--- a/apps/web/src/features/editor/__tests__/routeSegments.test.ts
+++ b/apps/web/src/features/editor/__tests__/routeSegments.test.ts
@@ -37,7 +37,11 @@ describe('editor route segment matrix', () => {
     ['template', '/editor/theme-1/template'],
     ['advanced', '/editor/theme-1/advanced'],
   ] as const)('%s 탭의 canonical URL을 만든다', (tab, expectedPath) => {
-    expect(buildEditorRouteForTab('theme-1', tab)).toBe(expectedPath);
+    const route = buildEditorRouteForTab('theme-1', tab);
+    const routeSegment = route.split('/').slice(3).join('/') || undefined;
+
+    expect(route).toBe(expectedPath);
+    expect(readEditorTabFromRouteSegment(routeSegment)).toBe(tab);
   });
 
   it('theme id를 URL segment로 안전하게 인코딩한다', () => {

--- a/apps/web/src/features/editor/__tests__/routeSegments.test.ts
+++ b/apps/web/src/features/editor/__tests__/routeSegments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildEditorRouteForTab,
   EDITOR_ROUTE_MATRIX,
   readDesignSubTabFromRouteSegment,
   readEditorTabFromRouteSegment,
@@ -23,5 +24,25 @@ describe('editor route segment matrix', () => {
   it('알 수 없는 segment는 제작 흐름의 안전한 기본 화면으로 되돌린다', () => {
     expect(readEditorTabFromRouteSegment('unknown')).toBe('storyMap');
     expect(readDesignSubTabFromRouteSegment('unknown')).toBe('modules');
+  });
+
+  it.each([
+    ['storyMap', '/editor/theme-1'],
+    ['story', '/editor/theme-1/story'],
+    ['characters', '/editor/theme-1/characters'],
+    ['clues', '/editor/theme-1/clues'],
+    ['design', '/editor/theme-1/design/modules'],
+    ['media', '/editor/theme-1/media'],
+    ['overview', '/editor/theme-1/overview'],
+    ['template', '/editor/theme-1/template'],
+    ['advanced', '/editor/theme-1/advanced'],
+  ] as const)('%s 탭의 canonical URL을 만든다', (tab, expectedPath) => {
+    expect(buildEditorRouteForTab('theme-1', tab)).toBe(expectedPath);
+  });
+
+  it('theme id를 URL segment로 안전하게 인코딩한다', () => {
+    expect(buildEditorRouteForTab('theme/with space', 'characters')).toBe(
+      '/editor/theme%2Fwith%20space/characters',
+    );
   });
 });

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -129,7 +129,11 @@ export function EditorLayout({
       </header>
 
       {/* ── Tab nav ── */}
-      <EditorTabNav activeModules={activeModules} forcedVisibleTab={routeTab} />
+      <EditorTabNav
+        themeId={themeId}
+        activeModules={activeModules}
+        forcedVisibleTab={routeTab}
+      />
 
       {/* ── Validation panel ── */}
       {!dismissed && (validationResult ?? externalWarnings) && (

--- a/apps/web/src/features/editor/components/EditorTabNav.tsx
+++ b/apps/web/src/features/editor/components/EditorTabNav.tsx
@@ -1,5 +1,7 @@
 import { Fragment, useRef, useCallback, useMemo, useEffect } from "react";
+import { useNavigate } from "react-router";
 import { EDITOR_TABS, type EditorTab } from "@/features/editor/constants";
+import { buildEditorRouteForTab } from "@/features/editor/routeSegments";
 import { useEditorUI } from "@/features/editor/stores/editorUIStore";
 
 // ---------------------------------------------------------------------------
@@ -9,6 +11,7 @@ import { useEditorUI } from "@/features/editor/stores/editorUIStore";
 const EMPTY_MODULES: string[] = [];
 
 interface EditorTabNavProps {
+  themeId?: string;
   activeModules?: string[];
   forcedVisibleTab?: EditorTab;
 }
@@ -18,9 +21,11 @@ interface EditorTabNavProps {
 // ---------------------------------------------------------------------------
 
 export function EditorTabNav({
+  themeId,
   activeModules = EMPTY_MODULES,
   forcedVisibleTab,
 }: EditorTabNavProps) {
+  const navigate = useNavigate();
   const { activeTab, setActiveTab } = useEditorUI();
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
@@ -39,8 +44,21 @@ export function EditorTabNav({
   useEffect(() => {
     if (!visibleTabs.some((t) => t.key === activeTab)) {
       setActiveTab("storyMap");
+      if (themeId) {
+        navigate(buildEditorRouteForTab(themeId, "storyMap"));
+      }
     }
-  }, [visibleTabs, activeTab, setActiveTab]);
+  }, [visibleTabs, activeTab, setActiveTab, themeId, navigate]);
+
+  const selectTab = useCallback(
+    (tab: EditorTab) => {
+      setActiveTab(tab);
+      if (themeId) {
+        navigate(buildEditorRouteForTab(themeId, tab));
+      }
+    },
+    [navigate, setActiveTab, themeId],
+  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, index: number) => {
@@ -54,11 +72,11 @@ export function EditorTabNav({
 
       if (next !== null) {
         e.preventDefault();
-        setActiveTab(visibleTabs[next].key);
+        selectTab(visibleTabs[next].key);
         tabRefs.current[next]?.focus();
       }
     },
-    [setActiveTab, visibleTabs],
+    [selectTab, visibleTabs],
   );
 
   return (
@@ -90,7 +108,7 @@ export function EditorTabNav({
                 aria-controls={`tabpanel-${tab.key}`}
                 id={`tab-${tab.key}`}
                 tabIndex={isActive ? 0 : -1}
-                onClick={() => setActiveTab(tab.key)}
+                onClick={() => selectTab(tab.key)}
                 onKeyDown={(e) => handleKeyDown(e, index)}
                 className={`relative flex shrink-0 items-center gap-1.5 px-4 text-xs font-medium transition-colors ${
                   isActive

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -1,12 +1,17 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
 const mockSetActiveTab = vi.fn();
+const mockNavigate = vi.fn();
 const mockActiveTab = { current: "storyMap" };
+
+vi.mock("react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
 
 vi.mock("../../stores/editorUIStore", () => ({
   useEditorUI: () => ({
@@ -82,5 +87,31 @@ describe("EditorTabNav dynamic tabs", () => {
       "템플릿",
       "고급 설정",
     ]);
+  });
+
+  it("탭 클릭 시 제작자가 다시 열 수 있는 canonical URL로 이동한다", () => {
+    render(<EditorTabNav themeId="theme-1" activeModules={["voice_chat"]} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /등장인물 관리/ }));
+
+    expect(mockSetActiveTab).toHaveBeenCalledWith("characters");
+    expect(mockNavigate).toHaveBeenCalledWith("/editor/theme-1/characters");
+  });
+
+  it("게임 설계 탭 클릭은 기본 설계 화면 URL로 이동한다", () => {
+    render(<EditorTabNav themeId="theme-1" />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /게임 설계/ }));
+
+    expect(mockSetActiveTab).toHaveBeenCalledWith("design");
+    expect(mockNavigate).toHaveBeenCalledWith("/editor/theme-1/design/modules");
+  });
+
+  it("숨겨진 현재 탭은 스토리 진행 URL로 되돌린다", () => {
+    mockActiveTab.current = "media";
+    render(<EditorTabNav themeId="theme-1" activeModules={[]} />);
+
+    expect(mockSetActiveTab).toHaveBeenCalledWith("storyMap");
+    expect(mockNavigate).toHaveBeenCalledWith("/editor/theme-1");
   });
 });

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -14,7 +14,7 @@ const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
   'story-map': 'storyMap',
   overview: 'overview',
   design: 'design',
-  story: 'storyMap',
+  story: 'story',
   characters: 'characters',
   clues: 'clues',
   relations: 'clues',
@@ -59,7 +59,7 @@ const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
 export const EDITOR_ROUTE_MATRIX = [
   { path: '/editor/:id', editorTab: 'storyMap' },
   { path: '/editor/:id/story-map', routeSegment: 'story-map', editorTab: 'storyMap', alias: true },
-  { path: '/editor/:id/story', routeSegment: 'story', editorTab: 'storyMap' },
+  { path: '/editor/:id/story', routeSegment: 'story', editorTab: 'story' },
   { path: '/editor/:id/characters', routeSegment: 'characters', editorTab: 'characters' },
   { path: '/editor/:id/clues', routeSegment: 'clues', editorTab: 'clues' },
   { path: '/editor/:id/relations', routeSegment: 'relations', editorTab: 'clues' },

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -44,6 +44,18 @@ const DESIGN_ROUTE_SUBTAB_MAP: Record<string, DesignSubTab> = {
   endings: 'endings',
 };
 
+const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
+  storyMap: undefined,
+  story: 'story',
+  characters: 'characters',
+  clues: 'clues',
+  design: 'design/modules',
+  media: 'media',
+  overview: 'overview',
+  template: 'template',
+  advanced: 'advanced',
+};
+
 export const EDITOR_ROUTE_MATRIX = [
   { path: '/editor/:id', editorTab: 'storyMap' },
   { path: '/editor/:id/story-map', routeSegment: 'story-map', editorTab: 'storyMap', alias: true },
@@ -51,6 +63,10 @@ export const EDITOR_ROUTE_MATRIX = [
   { path: '/editor/:id/characters', routeSegment: 'characters', editorTab: 'characters' },
   { path: '/editor/:id/clues', routeSegment: 'clues', editorTab: 'clues' },
   { path: '/editor/:id/relations', routeSegment: 'relations', editorTab: 'clues' },
+  { path: '/editor/:id/overview', routeSegment: 'overview', editorTab: 'overview' },
+  { path: '/editor/:id/template', routeSegment: 'template', editorTab: 'template' },
+  { path: '/editor/:id/templates', routeSegment: 'templates', editorTab: 'template', alias: true },
+  { path: '/editor/:id/advanced', routeSegment: 'advanced', editorTab: 'advanced' },
   {
     path: '/editor/:id/design/modules',
     routeSegment: 'design/modules',
@@ -114,4 +130,10 @@ export function readEditorTabFromRouteSegment(routeSegment?: string): EditorTab 
 export function readDesignSubTabFromRouteSegment(routeSegment?: string): DesignSubTab {
   if (!routeSegment) return 'modules';
   return DESIGN_ROUTE_SUBTAB_MAP[routeSegment] ?? 'modules';
+}
+
+export function buildEditorRouteForTab(themeId: string, tab: EditorTab): string {
+  const encodedThemeId = encodeURIComponent(themeId);
+  const segment = EDITOR_TAB_ROUTE_SEGMENTS[tab];
+  return segment ? `/editor/${encodedThemeId}/${segment}` : `/editor/${encodedThemeId}`;
 }

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -29,7 +29,7 @@ import EditorPage from '../EditorPage';
 const routeMatrixCases = [
   ['직접 URL /editor/:id', { id: 'theme-1' }, 'no-segment', 'storyMap'],
   ['alias URL /editor/:id/story-map', { id: 'theme-1', tab: 'story-map' }, 'story-map', 'storyMap'],
-  ['직접 URL /editor/:id/story', { id: 'theme-1', tab: 'story' }, 'story', 'storyMap'],
+  ['직접 URL /editor/:id/story', { id: 'theme-1', tab: 'story' }, 'story', 'story'],
   [
     '직접 URL /editor/:id/characters',
     { id: 'theme-1', tab: 'characters' },

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -39,6 +39,10 @@ const routeMatrixCases = [
   ['직접 URL /editor/:id/clues', { id: 'theme-1', tab: 'clues' }, 'clues', 'clues'],
   ['직접 URL /editor/:id/relations', { id: 'theme-1', tab: 'relations' }, 'relations', 'clues'],
   ['직접 URL /editor/:id/media', { id: 'theme-1', tab: 'media' }, 'media', 'media'],
+  ['직접 URL /editor/:id/overview', { id: 'theme-1', tab: 'overview' }, 'overview', 'overview'],
+  ['직접 URL /editor/:id/template', { id: 'theme-1', tab: 'template' }, 'template', 'template'],
+  ['alias URL /editor/:id/templates', { id: 'theme-1', tab: 'templates' }, 'templates', 'template'],
+  ['직접 URL /editor/:id/advanced', { id: 'theme-1', tab: 'advanced' }, 'advanced', 'advanced'],
   [
     '직접 URL /editor/:id/design/modules',
     { id: 'theme-1', tab: 'design', designTab: 'modules' },


### PR DESCRIPTION
## 요약
- 에디터 탭 클릭 시 canonical `/editor/{themeId}/...` URL로 이동하도록 연결했습니다.
- `/overview`, `/template`, `/templates`, `/advanced` 직접 URL 매핑을 route matrix에 추가했습니다.
- `/editor/{themeId}` 기본 진입은 기존처럼 스토리 진행 맵을 유지합니다.

Refs #381

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/__tests__/routeSegments.test.ts src/pages/__tests__/EditorPage.test.tsx src/features/editor/components/__tests__/EditorTabNav.test.tsx`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 에디터 탭 네비게이션에 테마 인식 경로 생성 및 라우팅이 추가되었습니다.
  * 특정 탭별로 canonical URL을 생성하는 기능이 도입되었습니다.

* **개선사항**
  * 탭 전환 시 테마 기반의 올바른 경로로 자동 네비게이션합니다.
  * 숨겨진 탭 활성화 시 대체 경로로 자동 이동하도록 개선되었습니다.
  * 테마 ID에 포함된 공백·특수문자에 대한 URL 인코딩이 개선되었습니다.

* **테스트**
  * 탭별 경로 생성, 네비게이션 동작 및 인코딩 관련 테스트가 추가/확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->