### PR TITLE
feat(editor): 읽기 대사 이미지 미디어 선택 지원

### DIFF
--- a/apps/server/db/queries/reading_sections.sql
+++ b/apps/server/db/queries/reading_sections.sql
@@ -35,7 +35,7 @@ WHERE rs.id = $1 AND rs.theme_id = t.id AND t.creator_id = $2;
 
 -- name: FindMediaReferencesInReadingSections :many
 -- Returns reading sections that reference the given media as bgm_media_id
--- OR inside any line's VoiceMediaID (PascalCase key — matches engine struct serialization).
+-- OR inside any line's VoiceMediaID/ImageMediaID (PascalCase keys — match engine struct serialization).
 SELECT DISTINCT rs.id, rs.name FROM reading_sections rs
 WHERE rs.theme_id = sqlc.arg('theme_id')
   AND (
@@ -43,5 +43,6 @@ WHERE rs.theme_id = sqlc.arg('theme_id')
     OR EXISTS (
       SELECT 1 FROM jsonb_array_elements(rs.lines) AS line
       WHERE line->>'VoiceMediaID' = sqlc.arg('media_id')::text
+         OR line->>'ImageMediaID' = sqlc.arg('media_id')::text
     )
   );

--- a/apps/server/internal/db/reading_sections.sql.go
+++ b/apps/server/internal/db/reading_sections.sql.go
@@ -76,6 +76,7 @@ WHERE rs.theme_id = $1
     OR EXISTS (
       SELECT 1 FROM jsonb_array_elements(rs.lines) AS line
       WHERE line->>'VoiceMediaID' = $2::text
+         OR line->>'ImageMediaID' = $2::text
     )
   )
 `
@@ -91,7 +92,7 @@ type FindMediaReferencesInReadingSectionsRow struct {
 }
 
 // Returns reading sections that reference the given media as bgm_media_id
-// OR inside any line's VoiceMediaID (PascalCase key — matches engine struct serialization).
+// OR inside any line's VoiceMediaID/ImageMediaID (PascalCase keys — match engine struct serialization).
 func (q *Queries) FindMediaReferencesInReadingSections(ctx context.Context, arg FindMediaReferencesInReadingSectionsParams) ([]FindMediaReferencesInReadingSectionsRow, error) {
 	rows, err := q.db.Query(ctx, findMediaReferencesInReadingSections, arg.ThemeID, arg.MediaID)
 	if err != nil {

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -452,8 +452,11 @@ func TestMediaService_Delete_BlockedByReadingImageReference(t *testing.T) {
 	var appErr *apperror.AppError
 	_ = errors.As(err, &appErr)
 	refs := appErr.Params["references"].([]map[string]string)
-	if len(refs) != 1 || refs[0]["id"] != sectionID.String() {
+	if len(refs) != 1 || refs[0]["id"] != sectionID.String() || refs[0]["type"] != "reading_section" || refs[0]["name"] != "Image cue" {
 		t.Fatalf("unexpected references: %#v", refs)
+	}
+	if _, ok := q.media[imageID]; !ok {
+		t.Fatalf("media should not have been deleted")
 	}
 }
 

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -197,12 +197,16 @@ func (f *fakeMediaQueries) FindMediaReferencesInReadingSections(_ context.Contex
 		if s.BgmMediaID.Valid && uuid.UUID(s.BgmMediaID.Bytes) == arg.MediaID {
 			matched = true
 		}
-		// Check voice references inside lines JSONB.
+		// Check line-level media references inside lines JSONB.
 		if !matched && len(s.Lines) > 0 {
 			var lines []map[string]any
 			if err := json.Unmarshal(s.Lines, &lines); err == nil {
 				for _, ln := range lines {
 					if v, ok := ln["VoiceMediaID"].(string); ok && v == arg.MediaID.String() {
+						matched = true
+						break
+					}
+					if v, ok := ln["ImageMediaID"].(string); ok && v == arg.MediaID.String() {
 						matched = true
 						break
 					}
@@ -417,6 +421,32 @@ func TestMediaService_Delete_BlockedByVoiceReference(t *testing.T) {
 	}
 
 	err := svc.DeleteMedia(context.Background(), creatorID, voiceID)
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+
+	var appErr *apperror.AppError
+	_ = errors.As(err, &appErr)
+	refs := appErr.Params["references"].([]map[string]string)
+	if len(refs) != 1 || refs[0]["id"] != sectionID.String() {
+		t.Fatalf("unexpected references: %#v", refs)
+	}
+}
+
+func TestMediaService_Delete_BlockedByReadingImageReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	imageID := seedMedia(q, themeID, MediaTypeImage)
+
+	linesJSON, _ := json.Marshal([]map[string]any{
+		{"Index": 0, "Text": "사진을 공개한다.", "AdvanceBy": "gm", "ImageMediaID": imageID.String()},
+	})
+	sectionID := uuid.New()
+	q.sections[sectionID] = db.ReadingSection{
+		ID:      sectionID,
+		ThemeID: themeID,
+		Name:    "Image cue",
+		Lines:   linesJSON,
+	}
+
+	err := svc.DeleteMedia(context.Background(), creatorID, imageID)
 	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
 
 	var appErr *apperror.AppError

--- a/apps/server/internal/domain/editor/reading_service.go
+++ b/apps/server/internal/domain/editor/reading_service.go
@@ -134,7 +134,21 @@ func (s *readingService) assertLineMediaInTheme(ctx context.Context, themeID uui
 	if err != nil {
 		return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": invalid "+field)
 	}
-	return s.assertMediaInTheme(ctx, themeID, mediaID, wantType)
+	if err := s.assertMediaInTheme(ctx, themeID, mediaID, wantType); err != nil {
+		return prefixLineMediaError(err, lineIndex, field)
+	}
+	return nil
+}
+
+func prefixLineMediaError(err error, lineIndex int, field string) error {
+	prefix := "line " + itoa(lineIndex) + ": " + field + ": "
+	var appErr *apperror.AppError
+	if errors.As(err, &appErr) {
+		copied := *appErr
+		copied.Detail = prefix + appErr.Detail
+		return &copied
+	}
+	return errors.New(prefix + err.Error())
 }
 
 // assertMediaInTheme verifies that mediaID exists and belongs to themeID.

--- a/apps/server/internal/domain/editor/reading_service.go
+++ b/apps/server/internal/domain/editor/reading_service.go
@@ -116,16 +116,25 @@ func (s *readingService) validateLines(ctx context.Context, themeID uuid.UUID, l
 			return apperror.New(apperror.ErrReadingVoiceRequired, 400, "line "+itoa(i)+": voice mode requires voiceMediaId")
 		}
 		if ln.VoiceMediaID != "" {
-			mediaID, err := uuid.Parse(ln.VoiceMediaID)
-			if err != nil {
-				return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(i)+": invalid voiceMediaId")
+			if err := s.assertLineMediaInTheme(ctx, themeID, ln.VoiceMediaID, MediaTypeVoice, "voiceMediaId", i); err != nil {
+				return err
 			}
-			if err := s.assertMediaInTheme(ctx, themeID, mediaID, MediaTypeVoice); err != nil {
+		}
+		if ln.ImageMediaID != "" {
+			if err := s.assertLineMediaInTheme(ctx, themeID, ln.ImageMediaID, MediaTypeImage, "imageMediaId", i); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func (s *readingService) assertLineMediaInTheme(ctx context.Context, themeID uuid.UUID, raw string, wantType string, field string, lineIndex int) error {
+	mediaID, err := uuid.Parse(raw)
+	if err != nil {
+		return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": invalid "+field)
+	}
+	return s.assertMediaInTheme(ctx, themeID, mediaID, wantType)
 }
 
 // assertMediaInTheme verifies that mediaID exists and belongs to themeID.

--- a/apps/server/internal/domain/editor/reading_service_test.go
+++ b/apps/server/internal/domain/editor/reading_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -294,6 +295,9 @@ func TestReadingService_Create_ImageMediaMustBeImageInTheme(t *testing.T) {
 		},
 	})
 	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+	if !strings.Contains(err.Error(), "line 0: imageMediaId") {
+		t.Fatalf("expected line context in error, got %v", err)
+	}
 
 	otherImage := uuid.New()
 	otherTheme := uuid.New()

--- a/apps/server/internal/domain/editor/reading_service_test.go
+++ b/apps/server/internal/domain/editor/reading_service_test.go
@@ -132,6 +132,7 @@ type readingTestFixture struct {
 	themeID   uuid.UUID
 	bgmID     uuid.UUID
 	voiceID   uuid.UUID
+	imageID   uuid.UUID
 	otherBgm  uuid.UUID // BGM in a different theme
 }
 
@@ -152,6 +153,9 @@ func newReadingFixture(t *testing.T) *readingTestFixture {
 	voiceID := uuid.New()
 	q.media[voiceID] = db.ThemeMedium{ID: voiceID, ThemeID: themeID, Type: MediaTypeVoice}
 
+	imageID := uuid.New()
+	q.media[imageID] = db.ThemeMedium{ID: imageID, ThemeID: themeID, Type: MediaTypeImage}
+
 	otherBgm := uuid.New()
 	q.media[otherBgm] = db.ThemeMedium{ID: otherBgm, ThemeID: otherThemeID, Type: MediaTypeBGM}
 
@@ -162,6 +166,7 @@ func newReadingFixture(t *testing.T) *readingTestFixture {
 		themeID:   themeID,
 		bgmID:     bgmID,
 		voiceID:   voiceID,
+		imageID:   imageID,
 		otherBgm:  otherBgm,
 	}
 }
@@ -259,6 +264,46 @@ func TestReadingService_Create_VoiceMediaNotInTheme(t *testing.T) {
 		Name: "Bad",
 		Lines: []ReadingLineDTO{
 			{Text: "x", AdvanceBy: AdvanceByVoice, VoiceMediaID: otherVoice.String()},
+		},
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+}
+
+func TestReadingService_Create_ImageMediaReference(t *testing.T) {
+	f := newReadingFixture(t)
+	resp, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name: "With image",
+		Lines: []ReadingLineDTO{
+			{Text: "사진을 확인한다.", AdvanceBy: AdvanceByGM, ImageMediaID: f.imageID.String()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if got := resp.Lines[0].ImageMediaID; got != f.imageID.String() {
+		t.Fatalf("ImageMediaID = %q, want %q", got, f.imageID.String())
+	}
+}
+
+func TestReadingService_Create_ImageMediaMustBeImageInTheme(t *testing.T) {
+	f := newReadingFixture(t)
+	_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name: "Wrong type",
+		Lines: []ReadingLineDTO{
+			{Text: "x", AdvanceBy: AdvanceByGM, ImageMediaID: f.voiceID.String()},
+		},
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+
+	otherImage := uuid.New()
+	otherTheme := uuid.New()
+	f.q.themes[otherTheme] = db.Theme{ID: otherTheme, CreatorID: f.creatorID}
+	f.q.media[otherImage] = db.ThemeMedium{ID: otherImage, ThemeID: otherTheme, Type: MediaTypeImage}
+
+	_, err = f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name: "Other theme",
+		Lines: []ReadingLineDTO{
+			{Text: "x", AdvanceBy: AdvanceByGM, ImageMediaID: otherImage.String()},
 		},
 	})
 	assertAppCode(t, err, apperror.ErrMediaNotInTheme)

--- a/apps/server/internal/domain/editor/reading_types.go
+++ b/apps/server/internal/domain/editor/reading_types.go
@@ -21,13 +21,14 @@ const (
 
 // ReadingLineDTO is the JSON shape of a single reading line as stored in
 // the reading_sections.lines JSONB column. The Go field names use PascalCase
-// (matching progression.ReadingLine) so that the encoding round-trips
-// between editor and engine without translation.
+// so engine-compatible fields and editor-only media cues round-trip without
+// translation.
 type ReadingLineDTO struct {
 	Index        int    `json:"Index"`
 	Text         string `json:"Text"`
 	Speaker      string `json:"Speaker,omitempty"`
 	VoiceMediaID string `json:"VoiceMediaID,omitempty"`
+	ImageMediaID string `json:"ImageMediaID,omitempty"`
 	AdvanceBy    string `json:"AdvanceBy,omitempty"`
 }
 

--- a/apps/web/src/features/editor/components/reading/ReadingLineRow.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingLineRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Mic, Trash2, X } from "lucide-react";
+import { Image as ImageIcon, Mic, Trash2, X } from "lucide-react";
 
 import type { ReadingLineDTO } from "../../readingApi";
 import { MediaPicker } from "../media/MediaPicker";
@@ -15,6 +15,7 @@ export interface ReadingLineRowProps {
   line: ReadingLineDTO;
   index: number;
   characters: Array<{ id: string; name: string }>;
+  selectedImage?: MediaResponse | null;
   onChange: (line: ReadingLineDTO) => void;
   onDelete: () => void;
 }
@@ -28,10 +29,12 @@ export function ReadingLineRow({
   line,
   index,
   characters,
+  selectedImage,
   onChange,
   onDelete,
 }: ReadingLineRowProps) {
-  const [pickerOpen, setPickerOpen] = useState(false);
+  const [voicePickerOpen, setVoicePickerOpen] = useState(false);
+  const [imagePickerOpen, setImagePickerOpen] = useState(false);
 
   const isNarration = line.Speaker === "나레이션";
   const advanceBy = line.AdvanceBy ?? "";
@@ -84,6 +87,14 @@ export function ReadingLineRow({
       ) as ReadingLineDTO["AdvanceBy"];
     }
     onChange(next);
+  }
+
+  function handleImageSelect(media: MediaResponse) {
+    onChange({ ...line, ImageMediaID: media.id });
+  }
+
+  function handleImageClear() {
+    onChange({ ...line, ImageMediaID: "" });
   }
 
   function handleAdvanceModeChange(val: string) {
@@ -158,10 +169,34 @@ export function ReadingLineRow({
         ) : (
           <button
             type="button"
-            onClick={() => setPickerOpen(true)}
+            onClick={() => setVoicePickerOpen(true)}
             className="text-xs text-slate-400 underline hover:text-slate-200"
           >
             음성 추가
+          </button>
+        )}
+
+        <label className="ml-4 text-xs text-slate-400">이미지:</label>
+        {line.ImageMediaID ? (
+          <span className="flex items-center gap-1 text-xs text-sky-300">
+            <ImageIcon className="h-3 w-3" />
+            {selectedImage?.name ?? "선택됨"}
+            <button
+              type="button"
+              onClick={handleImageClear}
+              aria-label="이미지 제거"
+              className="ml-0.5 text-sky-300 hover:text-sky-200"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setImagePickerOpen(true)}
+            className="text-xs text-slate-400 underline hover:text-slate-200"
+          >
+            이미지 추가
           </button>
         )}
 
@@ -194,12 +229,22 @@ export function ReadingLineRow({
       </div>
 
       <MediaPicker
-        open={pickerOpen}
-        onClose={() => setPickerOpen(false)}
+        open={voicePickerOpen}
+        onClose={() => setVoicePickerOpen(false)}
         onSelect={handleVoiceSelect}
         themeId={themeId}
         filterType="VOICE"
+        selectedId={line.VoiceMediaID}
         title="음성 선택"
+      />
+      <MediaPicker
+        open={imagePickerOpen}
+        onClose={() => setImagePickerOpen(false)}
+        onSelect={handleImageSelect}
+        themeId={themeId}
+        filterType="IMAGE"
+        selectedId={line.ImageMediaID}
+        title="이미지 선택"
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -92,6 +92,7 @@ export function ReadingSectionEditor({
   // BGM list (BGM filter only) — used to display selected BGM name without
   // an extra fetch when picker is closed.
   const { data: bgmList = [] } = useMediaList(themeId, "BGM");
+  const { data: imageList = [] } = useMediaList(themeId, "IMAGE");
   const selectedBgm = useMemo(
     () => bgmList.find((m) => m.id === draft.bgmMediaId) ?? null,
     [bgmList, draft.bgmMediaId],
@@ -110,6 +111,7 @@ export function ReadingSectionEditor({
         a.Text !== b.Text ||
         (a.Speaker ?? "") !== (b.Speaker ?? "") ||
         (a.VoiceMediaID ?? "") !== (b.VoiceMediaID ?? "") ||
+        (a.ImageMediaID ?? "") !== (b.ImageMediaID ?? "") ||
         (a.AdvanceBy ?? "") !== (b.AdvanceBy ?? "")
       ) {
         return true;
@@ -132,6 +134,7 @@ export function ReadingSectionEditor({
           Text: "",
           Speaker: "",
           VoiceMediaID: "",
+          ImageMediaID: "",
           AdvanceBy: "gm",
         },
       ],
@@ -302,6 +305,9 @@ export function ReadingSectionEditor({
               line={line}
               index={idx}
               characters={characters}
+              selectedImage={
+                imageList.find((m) => m.id === line.ImageMediaID) ?? null
+              }
               onChange={(next) => handleLineChange(idx, next)}
               onDelete={() => handleLineDelete(idx)}
             />

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -97,6 +97,10 @@ export function ReadingSectionEditor({
     () => bgmList.find((m) => m.id === draft.bgmMediaId) ?? null,
     [bgmList, draft.bgmMediaId],
   );
+  const imageById = useMemo(
+    () => new Map(imageList.map((media) => [media.id, media])),
+    [imageList],
+  );
 
   const isDirty = useMemo(() => {
     if (draft.name !== section.name) return true;
@@ -305,9 +309,7 @@ export function ReadingSectionEditor({
               line={line}
               index={idx}
               characters={characters}
-              selectedImage={
-                imageList.find((m) => m.id === line.ImageMediaID) ?? null
-              }
+              selectedImage={imageById.get(line.ImageMediaID ?? "") ?? null}
               onChange={(next) => handleLineChange(idx, next)}
               onDelete={() => handleLineDelete(idx)}
             />

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -269,6 +269,46 @@ describe("ReadingSectionEditor", () => {
     );
   });
 
+  it("line image picker serializes cleared image references", async () => {
+    useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
+      if (type === "IMAGE") {
+        return {
+          data: [
+            {
+              id: "image-1",
+              theme_id: "theme-1",
+              name: "현장 사진",
+              type: "IMAGE",
+              source_type: "FILE",
+              url: "https://example.com/image.png",
+              tags: [],
+              sort_order: 1,
+              created_at: "2026-04-05T00:00:00Z",
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: [], isLoading: false };
+    });
+
+    renderEditor({
+      section: {
+        ...sampleSection,
+        lines: [{ ...sampleSection.lines[0], ImageMediaID: "image-1" }],
+      },
+    });
+
+    expect(screen.getByText("현장 사진")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "이미지 제거" }));
+    fireEvent.click(screen.getByRole("button", { name: /저장/ }));
+
+    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines[0].ImageMediaID).toBe(
+      "",
+    );
+  });
+
   it("save button is disabled when not dirty", () => {
     renderEditor();
     const saveBtn = screen.getByRole("button", { name: /저장/ }) as HTMLButtonElement;

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -66,6 +66,7 @@ const sampleSection: ReadingSectionResponse = {
       Text: "어두운 방 안.",
       Speaker: "나레이션",
       VoiceMediaID: "",
+      ImageMediaID: "",
       AdvanceBy: "gm",
     },
     {
@@ -73,6 +74,7 @@ const sampleSection: ReadingSectionResponse = {
       Text: "누구냐?",
       Speaker: "Alice",
       VoiceMediaID: "",
+      ImageMediaID: "",
       AdvanceBy: "role:c1",
     },
   ],
@@ -226,6 +228,45 @@ describe("ReadingSectionEditor", () => {
     expect(callArg.patch.version).toBe(3);
     expect(callArg.patch.name).toBe("재명명");
     expect(Array.isArray(callArg.patch.lines)).toBe(true);
+  });
+
+  it("line image picker stores an IMAGE media reference", async () => {
+    useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
+      if (type === "IMAGE") {
+        return {
+          data: [
+            {
+              id: "image-1",
+              theme_id: "theme-1",
+              name: "현장 사진",
+              type: "IMAGE",
+              source_type: "FILE",
+              url: "https://example.com/image.png",
+              tags: [],
+              sort_order: 1,
+              created_at: "2026-04-05T00:00:00Z",
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: [], isLoading: false };
+    });
+
+    renderEditor();
+    fireEvent.click(screen.getAllByRole("button", { name: "이미지 추가" })[0]);
+
+    expect(useMediaListMock).toHaveBeenCalledWith("theme-1", "IMAGE");
+    expect(screen.getByText(/이미지 유형만 표시됩니다/)).toBeTruthy();
+    fireEvent.click(screen.getByText("현장 사진").closest("button") as HTMLElement);
+
+    expect(screen.getByText("현장 사진")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /저장/ }));
+
+    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines[0].ImageMediaID).toBe(
+      "image-1",
+    );
   });
 
   it("save button is disabled when not dirty", () => {

--- a/apps/web/src/features/editor/readingApi.ts
+++ b/apps/web/src/features/editor/readingApi.ts
@@ -10,8 +10,8 @@ import { queryClient } from "@/services/queryClient";
 //   - The OUTER wrapper (CreateReadingSectionRequest, ReadingSectionResponse,
 //     UpdateReadingSectionRequest) uses camelCase JSON tags.
 //   - The INNER ReadingLineDTO inside `lines[]` uses PascalCase JSON tags
-//     because the storage JSONB column round-trips with the engine's
-//     progression.ReadingLine struct (Go field names).
+//     because the storage JSONB column keeps the engine-compatible field
+//     names and editor-only media cues in the same line object.
 // Do not "normalize" either side — both must match the backend exactly.
 // ---------------------------------------------------------------------------
 
@@ -26,13 +26,14 @@ export type AdvanceBy = "voice" | "gm" | `role:${string}` | "";
 
 /**
  * A single reading line. Field names are PascalCase to match the JSONB
- * shape stored by the backend (which mirrors progression.ReadingLine).
+ * shape stored by the backend.
  */
 export interface ReadingLineDTO {
   Index: number;
   Text: string;
   Speaker?: string;
   VoiceMediaID?: string;
+  ImageMediaID?: string;
   AdvanceBy?: AdvanceBy;
 }
 


### PR DESCRIPTION
Closes #403
Refs #381

## 변경 사항
- 읽기 대사 줄에 `ImageMediaID`를 추가해 미디어 관리의 IMAGE 항목을 연결할 수 있게 했습니다.
- backend reading section 저장/검증에서 이미지 미디어 타입과 같은 theme 소유권을 확인합니다.
- 미디어 삭제 차단 검사에 읽기 대사 이미지 참조를 포함했습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/components/media/__tests__/MediaPicker.test.tsx src/features/editor/readingApi.test.ts`
- `go test ./internal/domain/editor -run 'Reading|MediaReference|MediaService_Delete_BlockedByReadingImageReference|MediaService_Delete_BlockedByVoiceReference'`\n- `git diff --check origin/main...HEAD`\n\n## E2E\n- backend reading API와 frontend component 단위 변경입니다. 직접 브라우저 흐름은 #404/#405에서 정보 관리 및 장면 연결 화면과 함께 확인합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리딩 섹션의 각 라인에 이미지 미디어를 첨부하고 선택/제거할 수 있습니다.
  * 에디터 UI에 이미지 선택기와 이미지 표시/제거 기능이 추가되었습니다.
  * 서버 및 검증 로직이 이미지 미디어 참조를 인식하고 테마/타입 검증을 수행합니다.

* **테스트**
  * 이미지 참조·검증 및 삭제 차단 시나리오를 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->