### PR TITLE
test(editor): 읽기 대사 미디어 JSONB 참조 검증

### DIFF
--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -484,6 +484,7 @@ func TestFindMediaReferencesInReadingSections_JSONBIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateReadingSection: %v", err)
 	}
+	svc := NewMediaService(fixture.q, nil, zerolog.Nop())
 
 	for _, tt := range []struct {
 		name    string
@@ -502,6 +503,18 @@ func TestFindMediaReferencesInReadingSections_JSONBIntegration(t *testing.T) {
 			}
 			if len(refs) != 1 || refs[0].ID != section.ID || refs[0].Name != "JSONB refs" {
 				t.Fatalf("unexpected refs: %#v", refs)
+			}
+
+			err = svc.DeleteMedia(ctx, creatorID, tt.mediaID)
+			assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+			var appErr *apperror.AppError
+			_ = errors.As(err, &appErr)
+			references, ok := appErr.Params["references"].([]map[string]string)
+			if !ok || len(references) != 1 {
+				t.Fatalf("expected references param with 1 entry, got %#v", appErr.Params["references"])
+			}
+			if references[0]["type"] != "reading_section" || references[0]["id"] != section.ID.String() || references[0]["name"] != "JSONB refs" {
+				t.Fatalf("unexpected reference payload: %#v", references[0])
 			}
 		})
 	}

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -460,6 +460,72 @@ func TestMediaService_Delete_BlockedByReadingImageReference(t *testing.T) {
 	}
 }
 
+func TestFindMediaReferencesInReadingSections_JSONBIntegration(t *testing.T) {
+	fixture := setupFixture(t)
+	ctx := context.Background()
+	creatorID := fixture.createUser(t)
+	themeID := fixture.createThemeForUser(t, creatorID)
+
+	voice := createMediaForReferenceTest(t, fixture.q, themeID, "Narration voice", MediaTypeVoice)
+	image := createMediaForReferenceTest(t, fixture.q, themeID, "Crime scene image", MediaTypeImage)
+	linesJSON, err := json.Marshal([]map[string]any{
+		{"Index": 0, "Text": "목소리가 들린다.", "AdvanceBy": "voice", "VoiceMediaID": voice.ID.String()},
+		{"Index": 1, "Text": "현장 사진을 본다.", "AdvanceBy": "gm", "ImageMediaID": image.ID.String()},
+	})
+	if err != nil {
+		t.Fatalf("marshal lines: %v", err)
+	}
+	section, err := fixture.q.CreateReadingSection(ctx, db.CreateReadingSectionParams{
+		ThemeID:   themeID,
+		Name:      "JSONB refs",
+		Lines:     linesJSON,
+		SortOrder: 0,
+	})
+	if err != nil {
+		t.Fatalf("CreateReadingSection: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		mediaID uuid.UUID
+	}{
+		{name: "voice", mediaID: voice.ID},
+		{name: "image", mediaID: image.ID},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := fixture.q.FindMediaReferencesInReadingSections(ctx, db.FindMediaReferencesInReadingSectionsParams{
+				ThemeID: themeID,
+				MediaID: tt.mediaID,
+			})
+			if err != nil {
+				t.Fatalf("FindMediaReferencesInReadingSections: %v", err)
+			}
+			if len(refs) != 1 || refs[0].ID != section.ID || refs[0].Name != "JSONB refs" {
+				t.Fatalf("unexpected refs: %#v", refs)
+			}
+		})
+	}
+}
+
+func createMediaForReferenceTest(t *testing.T, q *db.Queries, themeID uuid.UUID, name string, mediaType string) db.ThemeMedium {
+	t.Helper()
+	media, err := q.CreateMedia(context.Background(), db.CreateMediaParams{
+		ThemeID:    themeID,
+		Name:       name,
+		Type:       mediaType,
+		SourceType: SourceTypeFile,
+		Url:        pgtype.Text{String: "https://cdn.example/" + name, Valid: true},
+		StorageKey: pgtype.Text{String: "test/" + uuid.New().String(), Valid: true},
+		MimeType:   pgtype.Text{String: "application/octet-stream", Valid: true},
+		Tags:       []string{},
+		SortOrder:  0,
+	})
+	if err != nil {
+		t.Fatalf("CreateMedia(%s): %v", name, err)
+	}
+	return media
+}
+
 func TestMediaService_Delete_Success_NoReferences(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	mediaID := seedMedia(q, themeID, MediaTypeBGM)


### PR DESCRIPTION
## 요약
- 실제 PostgreSQL JSONB 데이터에서 읽기 대사 `VoiceMediaID`와 `ImageMediaID`가 미디어 참조로 감지되는지 통합 테스트로 고정했습니다.
- production query와 migration helper를 그대로 사용해 삭제 차단 회귀를 잡습니다.

Closes #410
Refs #403
Refs #381

## 검증
- `go test ./internal/domain/editor -run 'TestFindMediaReferencesInReadingSections_JSONBIntegration'`\n- `go test ./internal/domain/editor -run 'Reading|MediaReference|MediaService_Delete_Blocked|FindMediaReferencesInReadingSections'`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 내부 개선 사항만 포함되어 있으며 **사용자에게 직접 영향을 미치는 변경 사항이 없습니다**.

* **Tests**
  * 미디어 참조 검색 로직에 대한 JSONB 기반 통합 테스트 추가 및 강화
  * 읽기 섹션 내 이미지·음성 참조 탐지 검증 및 참조된 미디어 삭제 시 적절한 오류/참조 정보 반환 확인
<!-- end of auto-generated comment: release notes by coderabbit.ai -->