### PR TITLE
feat(editor): 장면 읽기 대사와 정보 공개 분리

### DIFF
--- a/apps/web/src/features/editor/components/design/InformationDeliveryOptionList.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryOptionList.tsx
@@ -1,0 +1,114 @@
+import { Search, UserRound } from "lucide-react";
+
+export interface OptionItem {
+  id: string;
+  name: string;
+  summary?: string;
+  groupLabel?: string;
+}
+
+interface SearchFieldProps {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}
+
+export function SearchField({ label, value, placeholder, onChange }: SearchFieldProps) {
+  return (
+    <label className="flex flex-col gap-1 text-[11px] text-slate-400">
+      {label}
+      <span className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-2 py-1.5 focus-within:border-amber-500 focus-within:ring-2 focus-within:ring-amber-500/40">
+        <Search className="h-3.5 w-3.5 text-slate-400" />
+        <input
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="min-w-0 flex-1 bg-transparent text-xs text-slate-200 placeholder-slate-600 focus:outline-none"
+        />
+      </span>
+    </label>
+  );
+}
+
+interface OptionListProps<T extends OptionItem> {
+  title: string;
+  emptyText: string;
+  items: T[];
+  allItems?: T[];
+  selectedIds: string[];
+  single?: boolean;
+  getMeta: (item: T) => string | undefined;
+  onToggle: (id: string) => void;
+}
+
+export function OptionList<T extends OptionItem>({
+  title,
+  emptyText,
+  items,
+  allItems,
+  selectedIds,
+  single = false,
+  getMeta,
+  onToggle,
+}: OptionListProps<T>) {
+  const selectedItems = (allItems ?? items).filter((item) => selectedIds.includes(item.id));
+
+  return (
+    <div className="rounded border border-slate-800 bg-slate-950/70 p-2">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[11px] font-medium text-slate-400">{title}</span>
+        {selectedItems.length > 0 && (
+          <span className="text-[10px] text-amber-300">{selectedItems.length}개 선택</span>
+        )}
+      </div>
+      {selectedItems.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {selectedItems.map((item) => (
+            <span
+              key={item.id}
+              className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-[10px] text-amber-100"
+            >
+              {single ? <UserRound className="h-3 w-3" /> : null}
+              {item.name}
+            </span>
+          ))}
+        </div>
+      )}
+      {items.length === 0 ? (
+        <p className="px-2 py-3 text-center text-xs text-slate-400">{emptyText}</p>
+      ) : (
+        <div className="grid max-h-44 gap-1 overflow-y-auto pr-1">
+          {items.map((item) => {
+            const selected = selectedIds.includes(item.id);
+            const meta = getMeta(item);
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onToggle(item.id)}
+                aria-pressed={selected}
+                className={`flex min-h-10 items-center justify-between gap-2 rounded px-2 py-2 text-left text-xs transition-colors ${
+                  selected
+                    ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40"
+                    : "bg-slate-900 text-slate-300 hover:bg-slate-800"
+                }`}
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate">{item.name}</span>
+                  {item.summary && (
+                    <span className="mt-0.5 block truncate text-[10px] text-slate-400">
+                      {item.summary}
+                    </span>
+                  )}
+                </span>
+                {meta && <span className="shrink-0 text-[10px] text-slate-400">{meta}</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
 import { useEditorCharacters } from "../../api";
 import { useReadingSections } from "../../readingApi";
+import { useStoryInfos, type StoryInfoResponse } from "../../storyInfoApi";
 import {
   filterReadingSectionOptions,
   toReadingSectionPickerOptions,
 } from "../../entities/story/readingSectionAdapter";
-import { InformationDeliveryContent, InformationDeliveryHeader } from "./InformationDeliveryPanelViews";
+import {
+  InformationDeliveryContent,
+  InformationDeliveryHeader,
+  type StoryInfoOption,
+} from "./InformationDeliveryPanelViews";
 import type { FlowNodeData } from "../../flowTypes";
 import {
   flowNodeToInformationDeliveries,
@@ -38,8 +43,15 @@ export function InformationDeliveryPanel({
     isError: sectionsError,
     refetch: refetchSections,
   } = useReadingSections(themeId);
+  const {
+    data: storyInfos = [],
+    isLoading: storyInfosLoading,
+    isError: storyInfosError,
+    refetch: refetchStoryInfos,
+  } = useStoryInfos(themeId);
   const [characterQuery, setCharacterQuery] = useState("");
   const [sectionQuery, setSectionQuery] = useState("");
+  const [infoQuery, setInfoQuery] = useState("");
   const savedDeliveries = useMemo(
     () => flowNodeToInformationDeliveries(phaseData),
     [phaseData],
@@ -63,10 +75,15 @@ export function InformationDeliveryPanel({
   }, [characters, characterQuery]);
 
   const sectionOptions = useMemo(() => toReadingSectionPickerOptions(sections), [sections]);
+  const storyInfoOptions = useMemo(() => toStoryInfoOptions(storyInfos), [storyInfos]);
 
   const filteredSections = useMemo(
     () => filterReadingSectionOptions(sectionOptions, sectionQuery),
     [sectionOptions, sectionQuery],
+  );
+  const filteredStoryInfos = useMemo(
+    () => filterStoryInfoOptions(storyInfoOptions, infoQuery),
+    [storyInfoOptions, infoQuery],
   );
 
   const updateDeliveries = (next: InformationDeliveryViewModel[]) => {
@@ -102,14 +119,23 @@ export function InformationDeliveryPanel({
         : [...delivery.readingSectionIds, sectionId],
     });
   };
+  const toggleStoryInfo = (delivery: InformationDeliveryViewModel, storyInfoId: string) => {
+    const hasStoryInfo = delivery.storyInfoIds.includes(storyInfoId);
+    updateDelivery(delivery.id, {
+      storyInfoIds: hasStoryInfo
+        ? delivery.storyInfoIds.filter((id) => id !== storyInfoId)
+        : [...delivery.storyInfoIds, storyInfoId],
+    });
+  };
 
-  const loading = charactersLoading || sectionsLoading;
-  const hasLoadError = charactersError || sectionsError;
+  const loading = charactersLoading || sectionsLoading || storyInfosLoading;
+  const hasLoadError = charactersError || sectionsError || storyInfosError;
   const canAddCharacterDelivery = characters.length > 0;
 
   const retryLoad = () => {
     if (charactersError) void refetchCharacters();
     if (sectionsError) void refetchSections();
+    if (storyInfosError) void refetchStoryInfos();
   };
 
   return (
@@ -125,20 +151,51 @@ export function InformationDeliveryPanel({
         hasLoadError={hasLoadError}
         hasCharacters={characters.length > 0}
         hasSections={sections.length > 0}
+        hasStoryInfos={storyInfos.length > 0}
         characterQuery={characterQuery}
         sectionQuery={sectionQuery}
+        infoQuery={infoQuery}
         deliveries={draftDeliveries}
         characters={filteredCharacters}
         allCharacters={characters}
         sections={filteredSections}
         allSections={sectionOptions}
+        storyInfos={filteredStoryInfos}
+        allStoryInfos={storyInfoOptions}
         onRetryLoad={retryLoad}
         onCharacterQueryChange={setCharacterQuery}
         onSectionQueryChange={setSectionQuery}
+        onInfoQueryChange={setInfoQuery}
         onSelectCharacter={(deliveryId, characterId) => updateDelivery(deliveryId, { characterId })}
         onToggleSection={toggleSection}
+        onToggleStoryInfo={toggleStoryInfo}
         onRemoveDelivery={removeDelivery}
       />
     </section>
   );
+}
+
+function toStoryInfoOptions(infos: StoryInfoResponse[]): StoryInfoOption[] {
+  return infos.map((info) => ({
+    id: info.id,
+    name: info.title,
+    summary: summarizeInfo(info.body),
+    metaLabel: info.imageMediaId ? "이미지 포함" : undefined,
+  }));
+}
+
+function filterStoryInfoOptions(options: StoryInfoOption[], query: string): StoryInfoOption[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return options;
+  return options.filter(
+    (option) =>
+      option.name.toLowerCase().includes(normalized) ||
+      (option.summary?.toLowerCase().includes(normalized) ?? false),
+  );
+}
+
+function summarizeInfo(body: string): string | undefined {
+  const trimmed = body.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > 48 ? `${trimmed.slice(0, 48)}...` : trimmed;
 }

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
@@ -1,6 +1,7 @@
-import { Plus, Search, Trash2, Users, UserRound } from "lucide-react";
+import { Plus, Trash2, Users } from "lucide-react";
 import type { InformationDeliveryViewModel } from "../../entities/shared/informationDeliveryAdapter";
 import type { ReadingSectionPickerOption } from "../../entities/story/readingSectionAdapter";
+import { OptionList, SearchField } from "./InformationDeliveryOptionList";
 
 interface InformationDeliveryHeaderProps {
   canAddCharacterDelivery: boolean;
@@ -16,9 +17,9 @@ export function InformationDeliveryHeader({
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div>
-        <h4 className="text-sm font-semibold text-slate-100">읽기 대사 전달</h4>
+        <h4 className="text-sm font-semibold text-slate-100">읽기 대사 배치와 정보 공개</h4>
         <p className="mt-1 text-xs leading-5 text-slate-400">
-          이 페이즈가 시작될 때 전체 또는 캐릭터별로 보여줄 읽기 대사를 선택합니다.
+          이 장면에서 보여줄 읽기 대사와 공개할 정보 카드를 대상별로 연결합니다.
         </p>
       </div>
       <div className="flex flex-wrap gap-2">
@@ -28,7 +29,7 @@ export function InformationDeliveryHeader({
           className="inline-flex items-center justify-center gap-1 rounded border border-amber-500/40 px-2.5 py-1.5 text-xs text-amber-200 hover:bg-amber-500/10"
         >
           <Users className="h-3.5 w-3.5" />
-          전체 전달
+          전체 대상 추가
         </button>
         <button
           type="button"
@@ -41,7 +42,7 @@ export function InformationDeliveryHeader({
           }`}
         >
           <Plus className="h-3.5 w-3.5" />
-          캐릭터별 추가
+          캐릭터별 대상 추가
         </button>
       </div>
     </div>
@@ -53,19 +54,32 @@ interface InformationDeliveryContentProps {
   hasLoadError: boolean;
   hasCharacters: boolean;
   hasSections: boolean;
+  hasStoryInfos: boolean;
   characterQuery: string;
   sectionQuery: string;
+  infoQuery: string;
   deliveries: InformationDeliveryViewModel[];
   characters: { id: string; name: string }[];
   allCharacters: { id: string; name: string }[];
   sections: ReadingSectionPickerOption[];
   allSections: ReadingSectionPickerOption[];
+  storyInfos: StoryInfoOption[];
+  allStoryInfos: StoryInfoOption[];
   onRetryLoad: () => void;
   onCharacterQueryChange: (value: string) => void;
   onSectionQueryChange: (value: string) => void;
+  onInfoQueryChange: (value: string) => void;
   onSelectCharacter: (deliveryId: string, characterId: string) => void;
   onToggleSection: (delivery: InformationDeliveryViewModel, sectionId: string) => void;
+  onToggleStoryInfo: (delivery: InformationDeliveryViewModel, storyInfoId: string) => void;
   onRemoveDelivery: (deliveryId: string) => void;
+}
+
+export interface StoryInfoOption {
+  id: string;
+  name: string;
+  summary?: string;
+  metaLabel?: string;
 }
 
 export function InformationDeliveryContent({
@@ -73,24 +87,30 @@ export function InformationDeliveryContent({
   hasLoadError,
   hasCharacters,
   hasSections,
+  hasStoryInfos,
   characterQuery,
   sectionQuery,
+  infoQuery,
   deliveries,
   characters,
   allCharacters,
   sections,
   allSections,
+  storyInfos,
+  allStoryInfos,
   onRetryLoad,
   onCharacterQueryChange,
   onSectionQueryChange,
+  onInfoQueryChange,
   onSelectCharacter,
   onToggleSection,
+  onToggleStoryInfo,
   onRemoveDelivery,
 }: InformationDeliveryContentProps) {
   if (loading) {
     return (
       <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-400">
-        캐릭터와 읽기 대사를 불러오는 중입니다.
+        캐릭터, 읽기 대사, 정보를 불러오는 중입니다.
       </p>
     );
   }
@@ -98,7 +118,7 @@ export function InformationDeliveryContent({
   if (hasLoadError) {
     return (
       <div className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-3 text-xs text-red-100">
-        <p>읽기 대사 전달에 필요한 캐릭터와 대사 목록을 불러오지 못했습니다.</p>
+        <p>장면 연결에 필요한 캐릭터, 읽기 대사, 정보 목록을 불러오지 못했습니다.</p>
         <button
           type="button"
           onClick={onRetryLoad}
@@ -110,17 +130,17 @@ export function InformationDeliveryContent({
     );
   }
 
-  if (!hasSections) {
+  if (!hasSections && !hasStoryInfos) {
     return (
       <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-400">
-        전달할 읽기 대사가 없습니다. 먼저 읽기 대사 탭에서 플레이어에게 보여줄 대사를 만들어 주세요.
+        배치할 읽기 대사와 공개할 정보가 없습니다. 먼저 읽기 대사 또는 정보 관리에서 장면에 연결할 항목을 만들어 주세요.
       </p>
     );
   }
 
   return (
     <>
-      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
         <SearchField
           label="캐릭터 검색"
           value={characterQuery}
@@ -132,6 +152,12 @@ export function InformationDeliveryContent({
           value={sectionQuery}
           onChange={onSectionQueryChange}
           placeholder="대사 이름으로 찾기"
+        />
+        <SearchField
+          label="정보 검색"
+          value={infoQuery}
+          onChange={onInfoQueryChange}
+          placeholder="정보 제목으로 찾기"
         />
       </div>
 
@@ -150,8 +176,11 @@ export function InformationDeliveryContent({
               allCharacters={allCharacters}
               sections={sections}
               allSections={allSections}
+              storyInfos={storyInfos}
+              allStoryInfos={allStoryInfos}
               onSelectCharacter={(characterId) => onSelectCharacter(delivery.id, characterId)}
               onToggleSection={(sectionId) => onToggleSection(delivery, sectionId)}
+              onToggleStoryInfo={(storyInfoId) => onToggleStoryInfo(delivery, storyInfoId)}
               onRemove={() => onRemoveDelivery(delivery.id)}
             />
           ))}
@@ -164,34 +193,9 @@ export function InformationDeliveryContent({
 
 function getEmptyDeliveryMessage(hasCharacters: boolean): string {
   if (!hasCharacters) {
-    return "아직 전달 설정이 없습니다. 전체 전달을 눌러 모든 플레이어에게 줄 공통 대사를 설정해 주세요.";
+    return "아직 장면 연결이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 대사나 정보를 연결해 주세요.";
   }
-  return "아직 전달 설정이 없습니다. 전체 전달 또는 캐릭터별 추가를 눌러 전달 대상을 정해 주세요.";
-}
-
-interface SearchFieldProps {
-  label: string;
-  value: string;
-  placeholder: string;
-  onChange: (value: string) => void;
-}
-
-function SearchField({ label, value, placeholder, onChange }: SearchFieldProps) {
-  return (
-    <label className="flex flex-col gap-1 text-[11px] text-slate-400">
-      {label}
-      <span className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-2 py-1.5 focus-within:border-amber-500 focus-within:ring-2 focus-within:ring-amber-500/40">
-        <Search className="h-3.5 w-3.5 text-slate-400" />
-        <input
-          type="search"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          className="min-w-0 flex-1 bg-transparent text-xs text-slate-200 placeholder-slate-600 focus:outline-none"
-        />
-      </span>
-    </label>
-  );
+  return "아직 장면 연결이 없습니다. 전체 대상 추가 또는 캐릭터별 대상 추가를 눌러 대상을 정해 주세요.";
 }
 
 interface DeliveryCardProps {
@@ -201,8 +205,11 @@ interface DeliveryCardProps {
   allCharacters: { id: string; name: string }[];
   sections: ReadingSectionPickerOption[];
   allSections: ReadingSectionPickerOption[];
+  storyInfos: StoryInfoOption[];
+  allStoryInfos: StoryInfoOption[];
   onSelectCharacter: (characterId: string) => void;
   onToggleSection: (sectionId: string) => void;
+  onToggleStoryInfo: (storyInfoId: string) => void;
   onRemove: () => void;
 }
 
@@ -213,8 +220,11 @@ function DeliveryCard({
   allCharacters,
   sections,
   allSections,
+  storyInfos,
+  allStoryInfos,
   onSelectCharacter,
   onToggleSection,
+  onToggleStoryInfo,
   onRemove,
 }: DeliveryCardProps) {
   const selectedCharacterName =
@@ -226,15 +236,15 @@ function DeliveryCard({
     <article className="rounded-lg border border-slate-800 bg-slate-900/80 p-3">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold text-slate-200">전달 설정 {index + 1}</p>
+          <p className="text-xs font-semibold text-slate-200">장면 연결 {index + 1}</p>
           <p className="mt-1 text-[11px] text-slate-400">
-            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · {delivery.readingSectionIds.length}개 대사
+            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · 대사 {delivery.readingSectionIds.length}개 · 정보 {delivery.storyInfoIds.length}개
           </p>
         </div>
         <button
           type="button"
           onClick={onRemove}
-          aria-label={`전달 설정 ${index + 1} 삭제`}
+          aria-label={`장면 연결 ${index + 1} 삭제`}
           className="rounded p-1 text-slate-400 hover:bg-red-500/10 hover:text-red-300"
         >
           <Trash2 className="h-4 w-4" />
@@ -245,7 +255,7 @@ function DeliveryCard({
         {delivery.recipientType === "all_players" ? (
           <div className="flex items-center gap-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
             <Users className="h-4 w-4" />
-            이 페이즈의 공통 읽기 대사로 모든 플레이어에게 전달됩니다.
+            이 장면의 공통 읽기 대사와 공개 정보로 모든 플레이어에게 보여집니다.
           </div>
         ) : (
           <OptionList
@@ -260,7 +270,7 @@ function DeliveryCard({
         )}
 
         <OptionList
-          title="전달할 읽기 대사"
+          title="읽기 대사 배치"
           emptyText="검색 결과가 없습니다."
           items={sections}
           selectedIds={delivery.readingSectionIds}
@@ -268,91 +278,16 @@ function DeliveryCard({
           onToggle={onToggleSection}
           allItems={allSections}
         />
+        <OptionList
+          title="정보 공개"
+          emptyText="검색 결과가 없습니다."
+          items={storyInfos}
+          selectedIds={delivery.storyInfoIds}
+          getMeta={(info) => info.metaLabel}
+          onToggle={onToggleStoryInfo}
+          allItems={allStoryInfos}
+        />
       </div>
     </article>
-  );
-}
-
-interface OptionItem {
-  id: string;
-  name: string;
-  summary?: string;
-  groupLabel?: string;
-}
-
-interface OptionListProps<T extends OptionItem> {
-  title: string;
-  emptyText: string;
-  items: T[];
-  allItems?: T[];
-  selectedIds: string[];
-  single?: boolean;
-  getMeta: (item: T) => string | undefined;
-  onToggle: (id: string) => void;
-}
-
-function OptionList<T extends OptionItem>({
-  title,
-  emptyText,
-  items,
-  allItems,
-  selectedIds,
-  single = false,
-  getMeta,
-  onToggle,
-}: OptionListProps<T>) {
-  const selectedItems = (allItems ?? items).filter((item) => selectedIds.includes(item.id));
-
-  return (
-    <div className="rounded border border-slate-800 bg-slate-950/70 p-2">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <span className="text-[11px] font-medium text-slate-400">{title}</span>
-        {selectedItems.length > 0 && (
-          <span className="text-[10px] text-amber-300">{selectedItems.length}개 선택</span>
-        )}
-      </div>
-      {selectedItems.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-1.5">
-          {selectedItems.map((item) => (
-            <span
-              key={item.id}
-              className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-[10px] text-amber-100"
-            >
-              {single ? <UserRound className="h-3 w-3" /> : null}
-              {item.name}
-            </span>
-          ))}
-        </div>
-      )}
-      {items.length === 0 ? (
-        <p className="px-2 py-3 text-center text-xs text-slate-400">{emptyText}</p>
-      ) : (
-        <div className="grid max-h-44 gap-1 overflow-y-auto pr-1">
-          {items.map((item) => {
-            const selected = selectedIds.includes(item.id);
-            const meta = getMeta(item);
-            return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => onToggle(item.id)}
-                aria-pressed={selected}
-                className={`flex min-h-10 items-center justify-between gap-2 rounded px-2 py-2 text-left text-xs transition-colors ${
-                  selected
-                    ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40"
-                    : "bg-slate-900 text-slate-300 hover:bg-slate-800"
-                }`}
-              >
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate">{item.name}</span>
-                  {item.summary && <span className="mt-0.5 block truncate text-[10px] text-slate-400">{item.summary}</span>}
-                </span>
-                {meta && <span className="shrink-0 text-[10px] text-slate-400">{meta}</span>}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -172,7 +172,7 @@ function PhaseSummaryCard({ viewModel }: { viewModel: PhaseEditorViewModel }) {
           label="다음 이동"
           value={`${viewModel.defaultTransitionLabel} · 조건 이동 ${viewModel.conditionalTransitionCount}개`}
         />
-        <SummaryRow label="정보 전달" value={`${viewModel.informationDeliveryCount}개 설정`} />
+        <SummaryRow label="정보 공개" value={`${viewModel.informationDeliveryCount}개 설정`} />
         <SummaryRow label="토론방" value={formatDiscussionRoomSummary(viewModel.discussionRoomPolicy)} />
         <SummaryRow label="시작 트리거" value={enterActions} />
         <SummaryRow label="종료 트리거" value={exitActions} />

--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -4,9 +4,10 @@ import type { FlowNodeData } from "../../../flowTypes";
 import { InformationDeliveryPanel } from "../InformationDeliveryPanel";
 import { DELIVER_INFORMATION_ACTION } from "../phaseEditorAdapter";
 
-const { useEditorCharactersMock, useReadingSectionsMock } = vi.hoisted(() => ({
+const { useEditorCharactersMock, useReadingSectionsMock, useStoryInfosMock } = vi.hoisted(() => ({
   useEditorCharactersMock: vi.fn(),
   useReadingSectionsMock: vi.fn(),
+  useStoryInfosMock: vi.fn(),
 }));
 
 vi.mock("../../../api", () => ({
@@ -15,6 +16,10 @@ vi.mock("../../../api", () => ({
 
 vi.mock("../../../readingApi", () => ({
   useReadingSections: () => useReadingSectionsMock(),
+}));
+
+vi.mock("../../../storyInfoApi", () => ({
+  useStoryInfos: () => useStoryInfosMock(),
 }));
 
 vi.stubGlobal("crypto", { randomUUID: () => "delivery-new" });
@@ -27,6 +32,36 @@ const characters = [
 const sections = [
   { id: "rs-1", name: "비밀 편지", lines: [{ Text: "편지" }] },
   { id: "rs-2", name: "저택 소문", lines: [{ Text: "소문" }, { Text: "증언" }] },
+];
+const storyInfos = [
+  {
+    id: "info-1",
+    themeId: "theme-1",
+    title: "숨겨진 단서",
+    body: "모두가 확인해야 하는 공개 정보",
+    imageMediaId: null,
+    relatedCharacterIds: [],
+    relatedClueIds: [],
+    relatedLocationIds: [],
+    sortOrder: 0,
+    version: 1,
+    createdAt: "2026-05-06T00:00:00Z",
+    updatedAt: "2026-05-06T00:00:00Z",
+  },
+  {
+    id: "info-2",
+    themeId: "theme-1",
+    title: "비밀 통로",
+    body: "서재 뒤쪽에 통로가 있다",
+    imageMediaId: "media-1",
+    relatedCharacterIds: [],
+    relatedClueIds: [],
+    relatedLocationIds: [],
+    sortOrder: 1,
+    version: 1,
+    createdAt: "2026-05-06T00:00:00Z",
+    updatedAt: "2026-05-06T00:00:00Z",
+  },
 ];
 
 beforeEach(() => {
@@ -42,6 +77,12 @@ beforeEach(() => {
     isError: false,
     refetch: vi.fn(),
   });
+  useStoryInfosMock.mockReturnValue({
+    data: storyInfos,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
 });
 
 afterEach(() => {
@@ -50,17 +91,17 @@ afterEach(() => {
 });
 
 describe("InformationDeliveryPanel", () => {
-  it("모든 페이즈에서 캐릭터별 정보 전달 설정을 추가할 수 있다", () => {
+  it("모든 페이즈에서 캐릭터별 장면 연결 설정을 추가할 수 있다", () => {
     const onChange = vi.fn();
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={onChange} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "캐릭터별 추가" }));
+    fireEvent.click(screen.getByRole("button", { name: "캐릭터별 대상 추가" }));
 
-    expect(screen.getByText("받을 캐릭터를 선택하세요 · 0개 대사")).toBeDefined();
+    expect(screen.getByText("받을 캐릭터를 선택하세요 · 대사 0개 · 정보 0개")).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 
-  it("캐릭터와 전달 정보를 검색하고 여러 정보를 선택/삭제할 수 있다", () => {
+  it("캐릭터, 읽기 대사, 공개 정보를 검색하고 선택/삭제할 수 있다", () => {
     const onChange = vi.fn();
     const phaseData: FlowNodeData = {
       onEnter: [
@@ -73,6 +114,7 @@ describe("InformationDeliveryPanel", () => {
                 id: "d1",
                 target: { type: "character" },
                 reading_section_ids: ["rs-1"],
+                story_info_ids: ["info-1"],
               },
             ],
           },
@@ -98,6 +140,7 @@ describe("InformationDeliveryPanel", () => {
                 id: "d1",
                 target: { type: "character", character_id: "char-2" },
                 reading_section_ids: ["rs-1"],
+                story_info_ids: ["info-1"],
               },
             ],
           },
@@ -121,6 +164,7 @@ describe("InformationDeliveryPanel", () => {
                 id: "d1",
                 target: { type: "character", character_id: "char-2" },
                 reading_section_ids: ["rs-1", "rs-2"],
+                story_info_ids: ["info-1"],
               },
             ],
           },
@@ -128,7 +172,31 @@ describe("InformationDeliveryPanel", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "전달 설정 1 삭제" }));
+    fireEvent.change(screen.getByPlaceholderText("정보 제목으로 찾기"), {
+      target: { value: "비밀" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /비밀 통로/ }));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-2" },
+                reading_section_ids: ["rs-1", "rs-2"],
+                story_info_ids: ["info-1", "info-2"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "장면 연결 1 삭제" }));
     expect(onChange).toHaveBeenLastCalledWith({ onEnter: [] });
   });
 
@@ -136,6 +204,7 @@ describe("InformationDeliveryPanel", () => {
   it("캐릭터 또는 읽기 대사 조회 실패를 빈 상태와 구분하고 재시도할 수 있다", () => {
     const refetchCharacters = vi.fn();
     const refetchSections = vi.fn();
+    const refetchStoryInfos = vi.fn();
     useEditorCharactersMock.mockReturnValue({
       data: [],
       isLoading: false,
@@ -148,17 +217,24 @@ describe("InformationDeliveryPanel", () => {
       isError: true,
       refetch: refetchSections,
     });
+    useStoryInfosMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+      refetch: refetchStoryInfos,
+    });
 
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
-    expect(screen.getByText("읽기 대사 전달에 필요한 캐릭터와 대사 목록을 불러오지 못했습니다.")).toBeDefined();
+    expect(screen.getByText("장면 연결에 필요한 캐릭터, 읽기 대사, 정보 목록을 불러오지 못했습니다.")).toBeDefined();
     fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
 
     expect(refetchCharacters).toHaveBeenCalledTimes(1);
     expect(refetchSections).toHaveBeenCalledTimes(1);
+    expect(refetchStoryInfos).toHaveBeenCalledTimes(1);
   });
 
-  it("phaseData onEnter 변경이 들어오면 저장된 전달 설정을 다시 반영한다", () => {
+  it("phaseData onEnter 변경이 들어오면 저장된 장면 연결 설정을 다시 반영한다", () => {
     const firstPhaseData: FlowNodeData = {
       onEnter: [
         {
@@ -170,6 +246,7 @@ describe("InformationDeliveryPanel", () => {
                 id: "d1",
                 target: { type: "character", character_id: "char-1" },
                 reading_section_ids: ["rs-1"],
+                story_info_ids: ["info-1"],
               },
             ],
           },
@@ -187,6 +264,7 @@ describe("InformationDeliveryPanel", () => {
                 id: "d2",
                 target: { type: "character", character_id: "char-2" },
                 reading_section_ids: ["rs-2"],
+                story_info_ids: [],
               },
             ],
           },
@@ -197,15 +275,15 @@ describe("InformationDeliveryPanel", () => {
     const { rerender } = render(
       <InformationDeliveryPanel themeId="theme-1" phaseData={firstPhaseData} onChange={vi.fn()} />,
     );
-    expect(screen.getByText("탐정 A · 1개 대사")).toBeDefined();
+    expect(screen.getByText("탐정 A · 대사 1개 · 정보 1개")).toBeDefined();
 
     rerender(<InformationDeliveryPanel themeId="theme-1" phaseData={nextPhaseData} onChange={vi.fn()} />);
 
-    expect(screen.getByText("용의자 B · 1개 대사")).toBeDefined();
+    expect(screen.getByText("용의자 B · 대사 1개 · 정보 0개")).toBeDefined();
   });
 
 
-  it("캐릭터가 없으면 캐릭터별 추가를 비활성화하고 안내한다", () => {
+  it("캐릭터가 없으면 캐릭터별 대상 추가를 비활성화하고 안내한다", () => {
     useEditorCharactersMock.mockReturnValue({
       data: [],
       isLoading: false,
@@ -215,8 +293,8 @@ describe("InformationDeliveryPanel", () => {
 
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
-    expect((screen.getByRole("button", { name: "캐릭터별 추가" }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText("아직 전달 설정이 없습니다. 전체 전달을 눌러 모든 플레이어에게 줄 공통 대사를 설정해 주세요.")).toBeDefined();
+    expect((screen.getByRole("button", { name: "캐릭터별 대상 추가" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("아직 장면 연결이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 대사나 정보를 연결해 주세요.")).toBeDefined();
   });
 
   it("모든 페이즈에서 모든 플레이어 공통 전달을 추가할 수 있다", () => {
@@ -229,9 +307,9 @@ describe("InformationDeliveryPanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "전체 전달" }));
+    fireEvent.click(screen.getByRole("button", { name: "전체 대상 추가" }));
 
-    expect(screen.getByText("모든 플레이어 · 0개 대사")).toBeDefined();
+    expect(screen.getByText("모든 플레이어 · 대사 0개 · 정보 0개")).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
@@ -9,7 +9,7 @@ import {
 vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
 
 describe("phaseEditorAdapter", () => {
-  it("API flow node의 정보 전달 action을 제작자용 ViewModel로 변환한다", () => {
+  it("API flow node의 정보 공개 action을 제작자용 ViewModel로 변환한다", () => {
     const data: FlowNodeData = {
       onEnter: [
         { id: "a1", type: "broadcast", params: { message: "시작" } },
@@ -40,16 +40,18 @@ describe("phaseEditorAdapter", () => {
         recipientType: "character",
         characterId: "char-1",
         readingSectionIds: ["rs-1", "rs-2"],
+        storyInfoIds: [],
       },
       {
         id: "d2",
         recipientType: "all_players",
         readingSectionIds: ["rs-common"],
+        storyInfoIds: [],
       },
     ]);
   });
 
-  it("정보 전달 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다", () => {
+  it("정보 공개 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다", () => {
     const data: FlowNodeData = {
       onEnter: [
         { id: "legacy", type: "deliver_information", params: { deliveries: [] } },
@@ -62,12 +64,14 @@ describe("phaseEditorAdapter", () => {
         id: "draft",
         recipientType: "character",
         readingSectionIds: [],
+        storyInfoIds: [],
       },
       {
         id: "d1",
         recipientType: "character",
         characterId: "char-1",
         readingSectionIds: ["rs-1", "rs-2", "rs-1"],
+        storyInfoIds: ["info-1", "info-1"],
       },
     ]);
 
@@ -82,6 +86,7 @@ describe("phaseEditorAdapter", () => {
               id: "d1",
               target: { type: "character", character_id: "char-1" },
               reading_section_ids: ["rs-1", "rs-2"],
+              story_info_ids: ["info-1"],
             },
           ],
         },
@@ -89,7 +94,7 @@ describe("phaseEditorAdapter", () => {
     ]);
   });
 
-  it("마지막 전달 설정을 삭제하면 정보 전달 action만 제거하고 다른 action은 유지한다", () => {
+  it("마지막 공개 설정을 삭제하면 정보 공개 action만 제거하고 다른 action은 유지한다", () => {
     const data: FlowNodeData = {
       onEnter: [
         { id: "info", type: DELIVER_INFORMATION_ACTION, params: { deliveries: [] } },
@@ -102,20 +107,20 @@ describe("phaseEditorAdapter", () => {
     });
   });
 
-  it("미완성 전달 설정은 저장 payload에서 제외한다", () => {
+  it("미완성 공개 설정은 저장 payload에서 제외한다", () => {
     const data: FlowNodeData = { onEnter: [{ id: "chat", type: "enable_chat" }] };
 
     expect(
       informationDeliveriesToFlowNodePatch(data, [
-        { id: "empty", recipientType: "character", readingSectionIds: [] },
-        { id: "no-character", recipientType: "character", readingSectionIds: ["rs-1"] },
-        { id: "no-section", recipientType: "all_players", readingSectionIds: [] },
+        { id: "empty", recipientType: "character", readingSectionIds: [], storyInfoIds: [] },
+        { id: "no-character", recipientType: "character", readingSectionIds: ["rs-1"], storyInfoIds: [] },
+        { id: "no-section", recipientType: "all_players", readingSectionIds: [], storyInfoIds: [] },
       ]),
     ).toEqual({ onEnter: [{ id: "chat", type: "enable_chat" }] });
   });
 
 
-  it("모든 페이즈에서 all_players 전달 설정을 저장한다", () => {
+  it("모든 페이즈에서 all_players 공개 설정을 저장한다", () => {
     expect(
       informationDeliveriesToFlowNodePatch(
         { phase_type: "investigation" },
@@ -124,6 +129,7 @@ describe("phaseEditorAdapter", () => {
             id: "all",
             recipientType: "all_players",
             readingSectionIds: ["rs-common"],
+            storyInfoIds: [],
           },
         ],
       ).onEnter,
@@ -137,6 +143,7 @@ describe("phaseEditorAdapter", () => {
               id: "all",
               target: { type: "all_players" },
               reading_section_ids: ["rs-common"],
+              story_info_ids: [],
             },
           ],
         },

--- a/apps/web/src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts
@@ -11,7 +11,7 @@ import {
 vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
 
 describe("phaseEntityAdapter", () => {
-  it("API flow node의 정보 전달 action을 제작자용 ViewModel로 변환한다", () => {
+  it("API flow node의 정보 공개 action을 제작자용 ViewModel로 변환한다", () => {
     const data: FlowNodeData = {
       onEnter: [
         { id: "a1", type: "broadcast", params: { message: "시작" } },
@@ -42,16 +42,18 @@ describe("phaseEntityAdapter", () => {
         recipientType: "character",
         characterId: "char-1",
         readingSectionIds: ["rs-1", "rs-2"],
+        storyInfoIds: [],
       },
       {
         id: "d2",
         recipientType: "all_players",
         readingSectionIds: ["rs-common"],
+        storyInfoIds: [],
       },
     ]);
   });
 
-  it("정보 전달 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다", () => {
+  it("정보 공개 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다", () => {
     const data: FlowNodeData = {
       onEnter: [
         { id: "legacy", type: "deliver_information", params: { deliveries: [] } },
@@ -64,12 +66,14 @@ describe("phaseEntityAdapter", () => {
         id: "draft",
         recipientType: "character",
         readingSectionIds: [],
+        storyInfoIds: [],
       },
       {
         id: "d1",
         recipientType: "character",
         characterId: "char-1",
         readingSectionIds: ["rs-1", "rs-2", "rs-1"],
+        storyInfoIds: ["info-1", "info-1"],
       },
     ]);
 
@@ -84,6 +88,7 @@ describe("phaseEntityAdapter", () => {
               id: "d1",
               target: { type: "character", character_id: "char-1" },
               reading_section_ids: ["rs-1", "rs-2"],
+              story_info_ids: ["info-1"],
             },
           ],
         },
@@ -91,7 +96,7 @@ describe("phaseEntityAdapter", () => {
     ]);
   });
 
-  it("마지막 전달 설정을 삭제하면 정보 전달 action만 제거하고 다른 action은 유지한다", () => {
+  it("마지막 공개 설정을 삭제하면 정보 공개 action만 제거하고 다른 action은 유지한다", () => {
     const data: FlowNodeData = {
       onEnter: [
         { id: "info", type: DELIVER_INFORMATION_ACTION, params: { deliveries: [] } },
@@ -104,7 +109,7 @@ describe("phaseEntityAdapter", () => {
     });
   });
 
-  it("모든 페이즈에서 all_players 전달 설정을 저장한다", () => {
+  it("모든 페이즈에서 all_players 공개 설정을 저장한다", () => {
     expect(
       informationDeliveriesToFlowNodePatch(
         { phase_type: "investigation" },
@@ -113,6 +118,7 @@ describe("phaseEntityAdapter", () => {
             id: "all",
             recipientType: "all_players",
             readingSectionIds: ["rs-common"],
+            storyInfoIds: [],
           },
         ],
       ).onEnter,
@@ -126,6 +132,7 @@ describe("phaseEntityAdapter", () => {
               id: "all",
               target: { type: "all_players" },
               reading_section_ids: ["rs-common"],
+              story_info_ids: [],
             },
           ],
         },

--- a/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
@@ -13,7 +13,7 @@ describe("actionAdapter", () => {
     expect(getCreatorActionLabel("unknown_custom_action")).toBe("직접 설정한 실행");
   });
 
-  it("정보 전달 action의 legacy/current 타입을 동일하게 판정한다", () => {
+  it("정보 공개 action의 legacy/current 타입을 동일하게 판정한다", () => {
     expect(isInformationDeliveryAction({ type: DELIVER_INFORMATION_ACTION })).toBe(true);
     expect(isInformationDeliveryAction({ type: "deliver_information" })).toBe(true);
     expect(isInformationDeliveryAction({ type: "SET_BGM" })).toBe(false);
@@ -42,7 +42,7 @@ describe("actionAdapter", () => {
     expect(getCreatorActionLabel("set_theme_color")).toBe("화면 색상 테마 변경");
   });
 
-  it("정보 전달은 phase summary의 일반 action 목록에서 제외할 수 있다", () => {
+  it("정보 공개는 phase summary의 일반 action 목록에서 제외할 수 있다", () => {
     expect(
       toCreatorActionLabels(
         [{ type: "SET_BGM" }, { type: DELIVER_INFORMATION_ACTION }, { type: "MUTE_CHAT" }],

--- a/apps/web/src/features/editor/entities/shared/__tests__/informationDeliveryAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/informationDeliveryAdapter.test.ts
@@ -8,7 +8,7 @@ import {
 vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
 
 describe("informationDeliveryAdapter", () => {
-  it("legacy/current 정보 전달 payload를 같은 ViewModel로 정규화한다", () => {
+  it("legacy/current 정보 공개 payload를 같은 ViewModel로 정규화한다", () => {
     expect(
       flowNodeToInformationDeliveries({
         onEnter: [
@@ -21,6 +21,7 @@ describe("informationDeliveryAdapter", () => {
                   recipient_type: "character",
                   character_id: "char-1",
                   readingSectionIds: ["rs-1", "rs-1"],
+                  storyInfoIds: ["info-1", "info-1"],
                 },
               ],
             },
@@ -33,17 +34,28 @@ describe("informationDeliveryAdapter", () => {
         recipientType: "character",
         characterId: "char-1",
         readingSectionIds: ["rs-1"],
+        storyInfoIds: ["info-1"],
       },
     ]);
   });
 
-  it("완성된 전달 설정을 모든 페이즈에서 current payload로 저장한다", () => {
+  it("완성된 공개 설정을 모든 페이즈에서 current payload로 저장한다", () => {
     expect(
       informationDeliveriesToFlowNodePatch(
         { phase_type: "investigation" },
         [
-          { id: "empty", recipientType: "character", readingSectionIds: [] },
-          { id: "all", recipientType: "all_players", readingSectionIds: ["rs-1"] },
+          {
+            id: "empty",
+            recipientType: "character",
+            readingSectionIds: [],
+            storyInfoIds: [],
+          },
+          {
+            id: "all",
+            recipientType: "all_players",
+            readingSectionIds: ["rs-1"],
+            storyInfoIds: ["info-1"],
+          },
         ],
       ),
     ).toEqual({
@@ -57,6 +69,41 @@ describe("informationDeliveryAdapter", () => {
                 id: "all",
                 target: { type: "all_players" },
                 reading_section_ids: ["rs-1"],
+                story_info_ids: ["info-1"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("정보 카드만 연결한 공개 설정도 완성된 payload로 저장한다", () => {
+    expect(
+      informationDeliveriesToFlowNodePatch(
+        { phase_type: "story_progression" },
+        [
+          {
+            id: "info-only",
+            recipientType: "character",
+            characterId: "char-1",
+            readingSectionIds: [],
+            storyInfoIds: ["info-1", "info-1"],
+          },
+        ],
+      ),
+    ).toEqual({
+      onEnter: [
+        {
+          id: "generated-id",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "info-only",
+                target: { type: "character", character_id: "char-1" },
+                reading_section_ids: [],
+                story_info_ids: ["info-1"],
               },
             ],
           },

--- a/apps/web/src/features/editor/entities/shared/actionAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/actionAdapter.ts
@@ -23,8 +23,8 @@ export const CREATOR_ACTION_OPTIONS: CreatorActionOption[] = [
 
 const ACTION_LABELS = new Map<string, string>([
   ...CREATOR_ACTION_OPTIONS.map((option) => [option.value, option.label] as const),
-  [DELIVER_INFORMATION_ACTION, "정보 전달"],
-  [LEGACY_DELIVER_INFORMATION_ACTION, "정보 전달"],
+  [DELIVER_INFORMATION_ACTION, "정보 공개"],
+  [LEGACY_DELIVER_INFORMATION_ACTION, "정보 공개"],
   ["OPEN_GROUP_CHAT", "토론방 열기"],
   ["CLOSE_GROUP_CHAT", "토론방 닫기"],
   ["broadcast", "공지 전달"],

--- a/apps/web/src/features/editor/entities/shared/informationDeliveryAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/informationDeliveryAdapter.ts
@@ -12,6 +12,7 @@ export interface InformationDeliveryViewModel {
   recipientType: InformationRecipientType;
   characterId?: string;
   readingSectionIds: string[];
+  storyInfoIds: string[];
 }
 
 interface StoredInformationDelivery {
@@ -24,6 +25,8 @@ interface StoredInformationDelivery {
   character_id?: unknown;
   reading_section_ids?: unknown;
   readingSectionIds?: unknown;
+  story_info_ids?: unknown;
+  storyInfoIds?: unknown;
 }
 
 interface DeliverInformationParams {
@@ -74,11 +77,12 @@ export function makeEmptyInformationDelivery(
     id: makeId(),
     recipientType,
     readingSectionIds: [],
+    storyInfoIds: [],
   };
 }
 
 export function isCompleteInformationDelivery(delivery: InformationDeliveryViewModel): boolean {
-  if (delivery.readingSectionIds.length === 0) return false;
+  if (delivery.readingSectionIds.length === 0 && delivery.storyInfoIds.length === 0) return false;
   return delivery.recipientType === "all_players" || Boolean(delivery.characterId);
 }
 
@@ -110,6 +114,11 @@ function normalizeDelivery(
     : Array.isArray(delivery.readingSectionIds)
       ? delivery.readingSectionIds
       : [];
+  const rawStoryInfoIds = Array.isArray(delivery.story_info_ids)
+    ? delivery.story_info_ids
+    : Array.isArray(delivery.storyInfoIds)
+      ? delivery.storyInfoIds
+      : [];
 
   return normalizeViewModel({
     id: typeof delivery.id === "string" && delivery.id ? delivery.id : makeId(),
@@ -123,6 +132,9 @@ function normalizeDelivery(
     readingSectionIds: rawSectionIds.filter(
       (id): id is string => typeof id === "string" && id.length > 0,
     ),
+    storyInfoIds: rawStoryInfoIds.filter(
+      (id): id is string => typeof id === "string" && id.length > 0,
+    ),
   });
 }
 
@@ -130,11 +142,13 @@ function normalizeViewModel(
   delivery: InformationDeliveryViewModel,
 ): InformationDeliveryViewModel {
   const uniqueSectionIds = Array.from(new Set(delivery.readingSectionIds)).filter(Boolean);
+  const uniqueStoryInfoIds = Array.from(new Set(delivery.storyInfoIds)).filter(Boolean);
   if (delivery.recipientType === "all_players") {
     return {
       id: delivery.id || makeId(),
       recipientType: "all_players",
       readingSectionIds: uniqueSectionIds,
+      storyInfoIds: uniqueStoryInfoIds,
     };
   }
   return {
@@ -142,6 +156,7 @@ function normalizeViewModel(
     recipientType: "character",
     characterId: delivery.characterId,
     readingSectionIds: uniqueSectionIds,
+    storyInfoIds: uniqueStoryInfoIds,
   };
 }
 
@@ -153,6 +168,7 @@ function toStoredDelivery(delivery: InformationDeliveryViewModel) {
         ? { type: "all_players" }
         : { type: "character", character_id: delivery.characterId },
     reading_section_ids: delivery.readingSectionIds,
+    story_info_ids: delivery.storyInfoIds,
   };
 }
 


### PR DESCRIPTION
## 요약
- 스토리 진행 장면 설정에서 읽기 대사 배치와 정보 공개를 별도 선택 영역으로 분리했습니다.
- 정보 관리 엔티티를 장면에서 참조할 수 있도록 story_info_ids 저장 경로를 추가하고, 기존 reading_section_ids는 읽기 대사 호환 경로로 유지했습니다.
- 제작자 화면의 정보 전달 용어를 정보 공개/장면 연결 기준으로 정리했습니다.

Closes #405
Refs #381

## Coverage Plan
- informationDeliveryAdapter: legacy/current payload 정규화, story_info_ids 저장, 정보 카드만 연결한 공개 설정 저장을 검증했습니다.
- InformationDeliveryPanel: 캐릭터/읽기 대사/정보 검색, 선택, 삭제, 조회 실패 재시도를 검증했습니다.
- phase/story adapters: 기존 flow node round-trip과 summary label 회귀를 검증했습니다.

## 제외 / 후속
- 정보 관리 CRUD는 #404에서 처리된 범위를 사용하며, 이 PR에는 추가 CRUD를 섞지 않았습니다.
- 읽기 대사 이미지 필드와 미디어 통합 선택기는 #406 이후 범위로 남겼습니다.
- 플레이 화면 runtime 해석은 2차 백엔드/runtime/game screen 작업에서 이어갈 범위입니다.

## 검증
- git diff --check
- pnpm --filter @mmp/web exec eslint src/features/editor/components/design/InformationDeliveryPanel.tsx src/features/editor/components/design/InformationDeliveryPanelViews.tsx src/features/editor/components/design/InformationDeliveryOptionList.tsx src/features/editor/entities/shared/informationDeliveryAdapter.ts src/features/editor/entities/shared/actionAdapter.ts
- pnpm --filter @mmp/web exec tsc --noEmit
- pnpm --filter @mmp/web exec vitest run src/features/editor/entities/shared/__tests__/actionAdapter.test.ts src/features/editor/entities/shared/__tests__/informationDeliveryAdapter.test.ts src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts src/features/editor/entities/story/__tests__/storySceneAdapter.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 정보 공개(스토리 정보) 전달 기능 추가 - 캐릭터별 장면 연결 지원
  * 검색 필드와 필터링 기능을 포함한 향상된 정보 전달 UI 추가
  * 섹션 기반 전달과 스토리 정보 기반 전달을 모두 지원

* **개선사항**
  * "정보 전달"에서 "정보 공개"로 레이블 용어 통일

<!-- end of auto-generated comment: release notes by coderabbit.ai -->