### PR TITLE
feat(editor): 장소 이미지를 미디어 참조로 전환

### DIFF
--- a/apps/server/db/migrations/00037_location_image_media_id.sql
+++ b/apps/server/db/migrations/00037_location_image_media_id.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+
+ALTER TABLE theme_locations
+  ADD COLUMN image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_theme_locations_image_media
+  ON theme_locations(image_media_id)
+  WHERE image_media_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_theme_locations_image_media;
+
+ALTER TABLE theme_locations
+  DROP COLUMN IF EXISTS image_media_id;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -38,13 +38,13 @@ SELECT * FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
 SELECT * FROM theme_locations WHERE id = $1;
 
 -- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING *;
 
 -- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -108,9 +108,9 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 }
 
 const createLocation = `-- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id
 `
 
 type CreateLocationParams struct {
@@ -122,6 +122,7 @@ type CreateLocationParams struct {
 	FromRound            pgtype.Int4 `json:"from_round"`
 	UntilRound           pgtype.Int4 `json:"until_round"`
 	ImageUrl             pgtype.Text `json:"image_url"`
+	ImageMediaID         pgtype.UUID `json:"image_media_id"`
 }
 
 func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) (ThemeLocation, error) {
@@ -134,6 +135,7 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		arg.FromRound,
 		arg.UntilRound,
 		arg.ImageUrl,
+		arg.ImageMediaID,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -147,6 +149,7 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		&i.FromRound,
 		&i.UntilRound,
 		&i.ImageUrl,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
@@ -368,7 +371,7 @@ func (q *Queries) GetContent(ctx context.Context, arg GetContentParams) (ThemeCo
 }
 
 const getLocation = `-- name: GetLocation :one
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url FROM theme_locations WHERE id = $1
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id FROM theme_locations WHERE id = $1
 `
 
 func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation, error) {
@@ -385,12 +388,13 @@ func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation,
 		&i.FromRound,
 		&i.UntilRound,
 		&i.ImageUrl,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
 
 const getLocationWithOwner = `-- name: GetLocationWithOwner :one
-SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round, l.image_url FROM theme_locations l
+SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round, l.image_url, l.image_media_id FROM theme_locations l
 JOIN themes t ON l.theme_id = t.id
 WHERE l.id = $1 AND t.creator_id = $2
 `
@@ -414,6 +418,7 @@ func (q *Queries) GetLocationWithOwner(ctx context.Context, arg GetLocationWithO
 		&i.FromRound,
 		&i.UntilRound,
 		&i.ImageUrl,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
@@ -583,7 +588,7 @@ func (q *Queries) ListContentsByTheme(ctx context.Context, themeID uuid.UUID) ([
 
 const listLocationsByMap = `-- name: ListLocationsByMap :many
 
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -609,6 +614,7 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 			&i.FromRound,
 			&i.UntilRound,
 			&i.ImageUrl,
+			&i.ImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -621,7 +627,7 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 }
 
 const listLocationsByTheme = `-- name: ListLocationsByTheme :many
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeLocation, error) {
@@ -644,6 +650,7 @@ func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) (
 			&i.FromRound,
 			&i.UntilRound,
 			&i.ImageUrl,
+			&i.ImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -755,9 +762,9 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 
 const updateLocation = `-- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8
 WHERE id = $1
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id
 `
 
 type UpdateLocationParams struct {
@@ -768,6 +775,7 @@ type UpdateLocationParams struct {
 	FromRound            pgtype.Int4 `json:"from_round"`
 	UntilRound           pgtype.Int4 `json:"until_round"`
 	ImageUrl             pgtype.Text `json:"image_url"`
+	ImageMediaID         pgtype.UUID `json:"image_media_id"`
 }
 
 func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) (ThemeLocation, error) {
@@ -779,6 +787,7 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		arg.FromRound,
 		arg.UntilRound,
 		arg.ImageUrl,
+		arg.ImageMediaID,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -792,6 +801,7 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		&i.FromRound,
 		&i.UntilRound,
 		&i.ImageUrl,
+		&i.ImageMediaID,
 	)
 	return i, err
 }

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -347,6 +347,7 @@ type ThemeLocation struct {
 	FromRound            pgtype.Int4 `json:"from_round"`
 	UntilRound           pgtype.Int4 `json:"until_round"`
 	ImageUrl             pgtype.Text `json:"image_url"`
+	ImageMediaID         pgtype.UUID `json:"image_media_id"`
 }
 
 type ThemeMap struct {

--- a/apps/server/internal/domain/editor/image_service.go
+++ b/apps/server/internal/domain/editor/image_service.go
@@ -301,6 +301,7 @@ func (s *ImageService) ConfirmImageUpload(
 			FromRound:            loc.FromRound,
 			UntilRound:           loc.UntilRound,
 			ImageUrl:             pgtype.Text{String: downloadURL, Valid: true},
+			ImageMediaID:         loc.ImageMediaID,
 		})
 		if err != nil {
 			s.logger.Error().Err(err).Str("location_id", targetID.String()).Msg("failed to update location image_url")

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
@@ -135,6 +136,10 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if count >= MaxLocationsPerMap {
 		return nil, apperror.BadRequest(fmt.Sprintf("map cannot have more than %d locations", MaxLocationsPerMap))
 	}
+	imageMediaID, err := s.resolveLocationImage(ctx, themeID, req.ImageMediaID)
+	if err != nil {
+		return nil, err
+	}
 	loc, err := s.q.CreateLocation(ctx, db.CreateLocationParams{
 		ThemeID:              themeID,
 		MapID:                mapID,
@@ -144,6 +149,7 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 		FromRound:            int32PtrToPgtype(accessPolicy.FromRound),
 		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
 		ImageUrl:             ptrToText(req.ImageURL),
+		ImageMediaID:         imageMediaID,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create location")
@@ -170,6 +176,17 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 	if req.ImageURL != nil {
 		imageURL = ptrToText(req.ImageURL)
 	}
+	imageMediaID := l.ImageMediaID
+	if req.ImageMediaID.Set {
+		if req.ImageMediaID.Value == nil {
+			imageMediaID = pgtype.UUID{}
+		} else {
+			imageMediaID, err = s.resolveLocationImage(ctx, l.ThemeID, req.ImageMediaID.Value)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 	updated, err := s.q.UpdateLocation(ctx, db.UpdateLocationParams{
 		ID:                   l.ID,
 		Name:                 req.Name,
@@ -178,6 +195,7 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		FromRound:            int32PtrToPgtype(accessPolicy.FromRound),
 		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
 		ImageUrl:             imageURL,
+		ImageMediaID:         imageMediaID,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update location")
@@ -215,6 +233,24 @@ func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID
 		}
 	}
 	return accessPolicy, nil
+}
+
+func (s *service) resolveLocationImage(ctx context.Context, themeID uuid.UUID, mediaID *uuid.UUID) (pgtype.UUID, error) {
+	if mediaID == nil {
+		return pgtype.UUID{}, nil
+	}
+	media, err := s.q.GetMedia(ctx, *mediaID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return pgtype.UUID{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "media not found")
+		}
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to verify location image")
+		return pgtype.UUID{}, apperror.Internal("failed to verify media reference")
+	}
+	if media.ThemeID != themeID || media.Type != MediaTypeImage {
+		return pgtype.UUID{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "media has wrong type for location image")
+	}
+	return pgtype.UUID{Bytes: *mediaID, Valid: true}, nil
 }
 
 // validateLocationRoundOrder enforces from_round <= until_round when both set.
@@ -306,6 +342,7 @@ func toLocationResponse(l db.ThemeLocation) LocationResponse {
 		Name:                 l.Name,
 		RestrictedCharacters: textToPtr(l.RestrictedCharacters),
 		ImageURL:             textToPtr(l.ImageUrl),
+		ImageMediaID:         pgtypeUUIDToPtr(l.ImageMediaID),
 		SortOrder:            l.SortOrder,
 		CreatedAt:            l.CreatedAt,
 		FromRound:            pgtypeInt4ToPtr(l.FromRound),

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -2,10 +2,15 @@ package editor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/db"
 )
 
 func int32Value(value int32) *int32 { return &value }
@@ -86,6 +91,38 @@ func TestBuildLocationAccessPolicy(t *testing.T) {
 	})
 }
 
+func TestOptionalUUIDUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	type patch struct {
+		ImageMediaID OptionalUUID `json:"image_media_id"`
+	}
+	var omitted patch
+	if err := json.Unmarshal([]byte(`{}`), &omitted); err != nil {
+		t.Fatalf("unmarshal omitted: %v", err)
+	}
+	if omitted.ImageMediaID.Set {
+		t.Fatal("omitted image_media_id should not be marked as set")
+	}
+
+	var cleared patch
+	if err := json.Unmarshal([]byte(`{"image_media_id":null}`), &cleared); err != nil {
+		t.Fatalf("unmarshal null: %v", err)
+	}
+	if !cleared.ImageMediaID.Set || cleared.ImageMediaID.Value != nil {
+		t.Fatalf("null image_media_id = %+v, want set with nil value", cleared.ImageMediaID)
+	}
+
+	rawID := uuid.New()
+	var selected patch
+	if err := json.Unmarshal([]byte(`{"image_media_id":"`+rawID.String()+`"}`), &selected); err != nil {
+		t.Fatalf("unmarshal uuid: %v", err)
+	}
+	if !selected.ImageMediaID.Set || selected.ImageMediaID.Value == nil || *selected.ImageMediaID.Value != rawID {
+		t.Fatalf("uuid image_media_id = %+v, want %s", selected.ImageMediaID, rawID)
+	}
+}
+
 func stringSlicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -150,7 +187,89 @@ func TestService_LocationRestrictedCharactersMustBelongToTheme(t *testing.T) {
 	}
 }
 
+func TestService_LocationImageMediaReference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
+	if err != nil {
+		t.Fatalf("CreateMap: %v", err)
+	}
+	media := createLocationMedia(t, f.q, themeID, "장소 이미지", MediaTypeImage)
+	otherThemeMedia := createLocationMedia(t, f.q, otherThemeID, "다른 테마 이미지", MediaTypeImage)
+	voiceMedia := createLocationMedia(t, f.q, themeID, "효과음", MediaTypeVoice)
+
+	imageID := media.ID
+	created, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{
+		Name:         "서재",
+		ImageMediaID: &imageID,
+	})
+	if err != nil {
+		t.Fatalf("CreateLocation with image media: %v", err)
+	}
+	if created.ImageMediaID == nil || *created.ImageMediaID != media.ID {
+		t.Fatalf("ImageMediaID = %v, want %s", created.ImageMediaID, media.ID)
+	}
+
+	otherThemeImageID := otherThemeMedia.ID
+	otherThemeImageRef := &otherThemeImageID
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, created.ID, UpdateLocationRequest{
+		Name:         created.Name,
+		ImageMediaID: OptionalUUID{Set: true, Value: otherThemeImageRef},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateLocation with other theme image error = %T %v, want media not in theme", err, err)
+	}
+	voiceID := voiceMedia.ID
+	voiceRef := &voiceID
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, created.ID, UpdateLocationRequest{
+		Name:         created.Name,
+		ImageMediaID: OptionalUUID{Set: true, Value: voiceRef},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateLocation with non-image media error = %T %v, want media not in theme", err, err)
+	}
+
+	updated, err := f.svc.UpdateLocation(ctx, creatorID, created.ID, UpdateLocationRequest{
+		Name:         created.Name,
+		SortOrder:    created.SortOrder,
+		ImageMediaID: OptionalUUID{Set: true},
+	})
+	if err != nil {
+		t.Fatalf("UpdateLocation clear image media: %v", err)
+	}
+	if updated.ImageMediaID != nil {
+		t.Fatalf("ImageMediaID after clear = %v, want nil", updated.ImageMediaID)
+	}
+}
+
 func isBadRequest(err error) bool {
 	var appErr *apperror.AppError
 	return errors.As(err, &appErr) && appErr.Code == apperror.ErrBadRequest
+}
+
+func isMediaNotInTheme(err error) bool {
+	var appErr *apperror.AppError
+	return errors.As(err, &appErr) && appErr.Code == apperror.ErrMediaNotInTheme
+}
+
+func createLocationMedia(t *testing.T, q *db.Queries, themeID uuid.UUID, name string, mediaType string) db.ThemeMedium {
+	t.Helper()
+	media, err := q.CreateMedia(context.Background(), db.CreateMediaParams{
+		ThemeID:    themeID,
+		Name:       name,
+		Type:       mediaType,
+		SourceType: SourceTypeFile,
+		StorageKey: pgtype.Text{String: "themes/test/" + uuid.New().String(), Valid: true},
+		FileSize:   pgtype.Int8{Int64: 1024, Valid: true},
+		MimeType:   pgtype.Text{String: "image/png", Valid: true},
+		Tags:       []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateMedia(%s): %v", name, err)
+	}
+	return media
 }

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -1,10 +1,34 @@
 package editor
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+type OptionalUUID struct {
+	Set   bool
+	Value *uuid.UUID
+}
+
+func (o *OptionalUUID) UnmarshalJSON(data []byte) error {
+	o.Set = true
+	if string(data) == "null" {
+		o.Value = nil
+		return nil
+	}
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return err
+	}
+	o.Value = &id
+	return nil
+}
 
 // --- Map types ---
 
@@ -32,34 +56,37 @@ type MapResponse struct {
 // --- Location types ---
 
 type CreateLocationRequest struct {
-	Name                 string  `json:"name" validate:"required,min=1,max=100"`
-	RestrictedCharacters *string `json:"restricted_characters"`
-	ImageURL             *string `json:"image_url" validate:"omitempty,url"`
-	SortOrder            int32   `json:"sort_order" validate:"min=0"`
-	FromRound            *int32  `json:"from_round" validate:"omitempty,min=1"`
-	UntilRound           *int32  `json:"until_round" validate:"omitempty,min=1"`
+	Name                 string     `json:"name" validate:"required,min=1,max=100"`
+	RestrictedCharacters *string    `json:"restricted_characters"`
+	ImageURL             *string    `json:"image_url" validate:"omitempty,url"`
+	ImageMediaID         *uuid.UUID `json:"image_media_id"`
+	SortOrder            int32      `json:"sort_order" validate:"min=0"`
+	FromRound            *int32     `json:"from_round" validate:"omitempty,min=1"`
+	UntilRound           *int32     `json:"until_round" validate:"omitempty,min=1"`
 }
 
 type UpdateLocationRequest struct {
-	Name                 string  `json:"name" validate:"required,min=1,max=100"`
-	RestrictedCharacters *string `json:"restricted_characters"`
-	ImageURL             *string `json:"image_url" validate:"omitempty,url"`
-	SortOrder            int32   `json:"sort_order" validate:"min=0"`
-	FromRound            *int32  `json:"from_round" validate:"omitempty,min=1"`
-	UntilRound           *int32  `json:"until_round" validate:"omitempty,min=1"`
+	Name                 string       `json:"name" validate:"required,min=1,max=100"`
+	RestrictedCharacters *string      `json:"restricted_characters"`
+	ImageURL             *string      `json:"image_url" validate:"omitempty,url"`
+	ImageMediaID         OptionalUUID `json:"image_media_id"`
+	SortOrder            int32        `json:"sort_order" validate:"min=0"`
+	FromRound            *int32       `json:"from_round" validate:"omitempty,min=1"`
+	UntilRound           *int32       `json:"until_round" validate:"omitempty,min=1"`
 }
 
 type LocationResponse struct {
-	ID                   uuid.UUID `json:"id"`
-	ThemeID              uuid.UUID `json:"theme_id"`
-	MapID                uuid.UUID `json:"map_id"`
-	Name                 string    `json:"name"`
-	RestrictedCharacters *string   `json:"restricted_characters,omitempty"`
-	ImageURL             *string   `json:"image_url,omitempty"`
-	SortOrder            int32     `json:"sort_order"`
-	CreatedAt            time.Time `json:"created_at"`
-	FromRound            *int32    `json:"from_round,omitempty"`
-	UntilRound           *int32    `json:"until_round,omitempty"`
+	ID                   uuid.UUID  `json:"id"`
+	ThemeID              uuid.UUID  `json:"theme_id"`
+	MapID                uuid.UUID  `json:"map_id"`
+	Name                 string     `json:"name"`
+	RestrictedCharacters *string    `json:"restricted_characters,omitempty"`
+	ImageURL             *string    `json:"image_url,omitempty"`
+	ImageMediaID         *uuid.UUID `json:"image_media_id,omitempty"`
+	SortOrder            int32      `json:"sort_order"`
+	CreatedAt            time.Time  `json:"created_at"`
+	FromRound            *int32     `json:"from_round,omitempty"`
+	UntilRound           *int32     `json:"until_round,omitempty"`
 }
 
 // --- Clue types ---

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -185,6 +185,7 @@ export interface LocationResponse {
   name: string;
   restricted_characters: string | null;
   image_url: string | null;
+  image_media_id?: string | null;
   sort_order: number;
   created_at: string;
   from_round?: number | null;

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Image, Info, MapPin, Trash2 } from 'lucide-react';
+import { Info, MapPin, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import type { EditorThemeResponse, MapResponse, LocationResponse } from '@/features/editor/api';
 import { useUpdateConfigJson, useUpdateLocation } from '@/features/editor/api';
-import { ImageUpload } from '@/features/editor/components/ImageUpload';
 import { EntityTriggerPlacementCard } from '@/features/editor/components/triggers/EntityTriggerPlacementCard';
 import { readLocationClueIds } from '@/features/editor/editorTypes';
 import type { EditorConfig } from '@/features/editor/utils/configShape';
@@ -12,6 +11,7 @@ import { AddNameInput } from './AddNameInput';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import { LocationAccessPolicyPanel } from './LocationAccessPolicyPanel';
 import { LocationClueAssignPanel } from './LocationClueAssignPanel';
+import { LocationImageMediaField } from './LocationImageMediaField';
 
 interface LocationDetailPanelProps {
   themeId: string;
@@ -173,17 +173,20 @@ function SelectedLocationDetail({
     const nextImageUrl = Object.prototype.hasOwnProperty.call(patch, 'image_url')
       ? (patch.image_url ?? null)
       : location.image_url;
+    const hasImageMediaPatch = Object.prototype.hasOwnProperty.call(patch, 'image_media_id');
+    const body = {
+      name: patch.name ?? location.name,
+      restricted_characters: patch.restricted_characters ?? location.restricted_characters,
+      image_url: nextImageUrl,
+      sort_order: patch.sort_order ?? location.sort_order,
+      from_round: nextFrom,
+      until_round: nextUntil,
+      ...(hasImageMediaPatch ? { image_media_id: patch.image_media_id ?? null } : {}),
+    };
     updateLocation.mutate(
       {
         locationId: location.id,
-        body: {
-          name: patch.name ?? location.name,
-          restricted_characters: patch.restricted_characters ?? location.restricted_characters,
-          image_url: nextImageUrl,
-          sort_order: patch.sort_order ?? location.sort_order,
-          from_round: nextFrom,
-          until_round: nextUntil,
-        },
+        body,
       },
       { onError: () => toast.error('장소 저장에 실패했습니다') }
     );
@@ -213,20 +216,13 @@ function SelectedLocationDetail({
           </div>
         </div>
         <div className="grid gap-4 lg:grid-cols-[minmax(12rem,0.42fr)_minmax(0,1fr)]">
-          <div>
-            <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-slate-300">
-              <Image className="h-3.5 w-3.5 text-amber-400" />
-              장소 이미지
-            </div>
-            <ImageUpload
-              themeId={themeId}
-              target="location"
-              targetId={location.id}
-              currentImageUrl={viewModel.imageUrl}
-              aspectRatio="16 / 10"
-              onUploaded={(url) => saveLocation({ image_url: url || null })}
-            />
-          </div>
+          <LocationImageMediaField
+            themeId={themeId}
+            imageMediaId={location.image_media_id}
+            legacyImageUrl={viewModel.imageUrl}
+            onSelect={(media) => saveLocation({ image_media_id: media.id, image_url: null })}
+            onClear={() => saveLocation({ image_media_id: null })}
+          />
           <div className="space-y-3">
             <RoundFields
               location={location}

--- a/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
+++ b/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Image, X } from 'lucide-react';
+
+import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
+import { useMediaList, type MediaResponse } from '@/features/editor/mediaApi';
+
+interface LocationImageMediaFieldProps {
+  themeId: string;
+  imageMediaId?: string | null;
+  legacyImageUrl?: string | null;
+  onSelect: (media: MediaResponse) => void;
+  onClear: () => void;
+}
+
+export function LocationImageMediaField({
+  themeId,
+  imageMediaId,
+  legacyImageUrl,
+  onSelect,
+  onClear,
+}: LocationImageMediaFieldProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { data: images = [] } = useMediaList(themeId, 'IMAGE');
+  const selectedImage = images.find((media) => media.id === imageMediaId) ?? null;
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-300">
+          <Image className="h-3.5 w-3.5 text-amber-400" />
+          장소 이미지
+        </div>
+        {imageMediaId ? (
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+          >
+            <X className="h-3 w-3" />
+            제거
+          </button>
+        ) : null}
+      </div>
+
+      {imageMediaId ? (
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="flex w-full items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-left text-sm text-amber-100 hover:bg-amber-500/15"
+        >
+          <span className="truncate">{selectedImage?.name ?? '선택된 이미지'}</span>
+          <span className="shrink-0 text-xs text-amber-200/70">교체</span>
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="flex aspect-[16/10] w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200"
+        >
+          미디어 이미지 선택
+        </button>
+      )}
+
+      {!imageMediaId && legacyImageUrl ? (
+        <p className="mt-2 text-xs leading-5 text-slate-500">
+          기존 직접 업로드 이미지가 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다.
+        </p>
+      ) : null}
+
+      <MediaPicker
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={onSelect}
+        themeId={themeId}
+        filterType="IMAGE"
+        selectedId={imageMediaId}
+        title="장소 이미지 선택"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -21,6 +21,7 @@ const {
   useUpdateLocationMock,
   useEditorCluesMock,
   useUpdateConfigJsonMock,
+  useMediaListMock,
 } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
@@ -37,6 +38,7 @@ const {
   useUpdateLocationMock: vi.fn(),
   useEditorCluesMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
+  useMediaListMock: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -65,6 +67,36 @@ vi.mock('@/features/editor/api', () => ({
   editorKeys: {
     theme: (id: string) => ['editor', 'themes', id] as const,
   },
+}));
+
+vi.mock('@/features/editor/mediaApi', () => ({
+  useMediaList: () => useMediaListMock(),
+}));
+
+vi.mock('@/features/editor/components/media/MediaPicker', () => ({
+  MediaPicker: ({
+    open,
+    filterType,
+    selectedId,
+    onSelect,
+  }: {
+    open: boolean;
+    filterType?: string;
+    selectedId?: string | null;
+    onSelect: (media: { id: string; name: string; type: string }) => void;
+  }) =>
+    open ? (
+      <div>
+        <span>filter:{filterType}</span>
+        <span>selected:{selectedId ?? 'none'}</span>
+        <button
+          type="button"
+          onClick={() => onSelect({ id: 'image-1', name: '저택 사진', type: 'IMAGE' })}
+        >
+          저택 사진 선택
+        </button>
+      </div>
+    ) : null,
 }));
 
 // LocationClueAssignPanel (via LocationsSubTab) now calls `useQueryClient`; stub
@@ -120,6 +152,10 @@ function setupDefaultMocks() {
     mutate: updateConfigMutateMock,
     isPending: false,
   });
+  useMediaListMock.mockReturnValue({
+    data: [{ id: 'image-1', name: '저택 사진', type: 'IMAGE' }],
+    isLoading: false,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +190,7 @@ describe('LocationsSubTab', () => {
         mutate: updateConfigMutateMock,
         isPending: false,
       });
+      useMediaListMock.mockReturnValue({ data: [], isLoading: false });
 
       const { container } = render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
       const spinner = container.querySelector('[role="status"]');
@@ -381,6 +418,44 @@ describe('LocationsSubTab', () => {
       ];
       expect(payload.body.from_round).toBeNull();
       expect(payload.body.until_round).toBe(5);
+    });
+  });
+
+  describe('장소 이미지 미디어 참조', () => {
+    beforeEach(setupDefaultMocks);
+
+    it('IMAGE 미디어만 선택해 장소 이미지 참조로 저장한다', () => {
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+
+      fireEvent.click(screen.getByText('미디어 이미지 선택'));
+      expect(screen.getByText('filter:IMAGE')).toBeDefined();
+      fireEvent.click(screen.getByText('저택 사진 선택'));
+
+      expect(updateLocationMutateMock).toHaveBeenCalledOnce();
+      const [payload] = updateLocationMutateMock.mock.calls[0] as [
+        { locationId: string; body: Record<string, unknown> },
+      ];
+      expect(payload.locationId).toBe('loc-1');
+      expect(payload.body.image_media_id).toBe('image-1');
+      expect(payload.body.image_url).toBeNull();
+    });
+
+    it('선택된 장소 이미지 참조를 제거할 수 있다', () => {
+      useEditorLocationsMock.mockReturnValue({
+        data: [{ ...mockLocations[0], image_media_id: 'image-1' }, ...mockLocations.slice(1)],
+        isLoading: false,
+      });
+
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+
+      expect(screen.getByText('저택 사진')).toBeDefined();
+      fireEvent.click(screen.getByText('제거'));
+
+      expect(updateLocationMutateMock).toHaveBeenCalledOnce();
+      const [payload] = updateLocationMutateMock.mock.calls[0] as [
+        { body: Record<string, unknown> },
+      ];
+      expect(payload.body.image_media_id).toBeNull();
     });
   });
 });

--- a/apps/web/src/features/editor/editorMapApi.ts
+++ b/apps/web/src/features/editor/editorMapApi.ts
@@ -18,6 +18,7 @@ export interface CreateLocationRequest {
   description?: string;
   restricted_characters?: string | null;
   image_url?: string | null;
+  image_media_id?: string | null;
   from_round?: number | null;
   until_round?: number | null;
 }
@@ -27,6 +28,7 @@ export interface UpdateLocationRequest {
   description?: string;
   restricted_characters?: string | null;
   image_url?: string | null;
+  image_media_id?: string | null;
   sort_order?: number;
   from_round?: number | null;
   until_round?: number | null;

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -5,6 +5,7 @@ export interface LocationEditorViewModel {
   id: string;
   name: string;
   imageUrl: string | null;
+  imageMediaId: string | null;
   roundLabel: string;
   accessLabel: string;
   clueCountLabel: string;
@@ -21,6 +22,7 @@ export function toLocationEditorViewModel(
     id: location.id,
     name: location.name,
     imageUrl: location.image_url ?? null,
+    imageMediaId: location.image_media_id ?? null,
     roundLabel: formatLocationRoundLabel(location),
     accessLabel: formatLocationAccessLabel(
       location.restricted_characters,
@@ -88,6 +90,6 @@ export function buildLocationBadges(
       ? '접근 제한 있음'
       : '전체 접근',
     clueCount > 0 ? `단서 ${clueCount}` : '단서 없음',
-    location.image_url ? '이미지 있음' : null,
+    location.image_media_id || location.image_url ? '이미지 있음' : null,
   ].filter((badge): badge is string => Boolean(badge));
 }


### PR DESCRIPTION
## 요약
- 장소 이미지에 `image_media_id` 저장 계약을 추가하고 sqlc를 갱신했습니다.
- 장소 상세 화면의 직접 이미지 업로드 UI를 미디어 관리 IMAGE picker 참조 흐름으로 대체했습니다.
- 기존 `image_url`은 legacy fallback으로 유지하고, 남은 캐릭터/단서/커버/맵 슬롯은 #427로 분리했습니다.

## Coverage Plan
- Backend: location media reference create/update/clear, same-theme IMAGE 검증, 다른 theme/non-IMAGE 거부, JSON null clear 구분
- Frontend: 장소 이미지 picker가 IMAGE만 표시하고 `image_media_id` 저장/제거 payload를 보내는지 검증
- Regression: 기존 위치 adapter badge와 이미지 업로드 서비스의 location update 필드 보존 확인

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec eslint src/features/editor/components/design/LocationDetailPanel.tsx src/features/editor/components/design/LocationImageMediaField.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/entities/location/locationEntityAdapter.ts src/features/editor/api/types.ts src/features/editor/editorMapApi.ts`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts`
- `go test ./internal/domain/editor -run 'TestOptionalUUIDUnmarshal|TestService_LocationImageMediaReference|TestService_LocationRestrictedCharactersMustBelongToTheme|TestParseUploadKey_Location|TestApplyUploadedImage_LocationPreservesFields'`

Closes #406
Refs #381
Refs #427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 위치에 이미지 미디어 선택 및 관리 기능 추가
  * 위치 상세 패널에 새로운 이미지 선택 UI 제공
  * 위치 이미지를 미디어 시스템과 통합하여 개별 선택 및 제거 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->