### PR TITLE
feat(editor): 조사권 비용을 장소 단서 조사에 연결

### DIFF
--- a/apps/web/src/features/editor/components/design/InvestigationCostSelector.tsx
+++ b/apps/web/src/features/editor/components/design/InvestigationCostSelector.tsx
@@ -1,0 +1,112 @@
+import { Coins } from 'lucide-react';
+import type {
+  InvestigationCostDraft,
+  InvestigationTokenDraft,
+} from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
+import { formatInvestigationCostLabel } from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
+
+interface InvestigationCostSelectorProps {
+  clueName: string;
+  cost: InvestigationCostDraft;
+  tokens: InvestigationTokenDraft[];
+  disabled: boolean;
+  manageHref: string;
+  onChange: (cost: InvestigationCostDraft) => void;
+}
+
+function normalizeCost(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 1;
+  return Math.max(1, Math.floor(parsed));
+}
+
+export function InvestigationCostSelector({
+  clueName,
+  cost,
+  tokens,
+  disabled,
+  manageHref,
+  onChange,
+}: InvestigationCostSelectorProps) {
+  const fallbackTokenId = tokens[0]?.id ?? 'investigation-token';
+  const selectedTokenId = cost.mode === 'token' ? cost.tokenId : fallbackTokenId;
+  const selectedCost = cost.mode === 'token' ? cost.tokenCost : 1;
+
+  return (
+    <div className="mt-2 rounded-md border border-slate-800 bg-slate-950/80 p-2">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+          <Coins className="h-3 w-3 text-amber-400/70" />
+          조사 비용
+        </p>
+        <span className="rounded-full border border-slate-800 px-2 py-0.5 text-[10px] text-slate-500">
+          {formatInvestigationCostLabel(cost, tokens)}
+        </span>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(8rem,0.8fr)_5rem]">
+        <button
+          type="button"
+          disabled={disabled}
+          aria-pressed={cost.mode === 'free'}
+          aria-label={`${clueName} 무료 조사로 설정`}
+          onClick={() => onChange({ mode: 'free' })}
+          className={`rounded-md border px-2 py-1.5 text-xs transition disabled:opacity-50 ${
+            cost.mode === 'free'
+              ? 'border-emerald-400/50 bg-emerald-500/10 text-emerald-200'
+              : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-300'
+          }`}
+        >
+          무료
+        </button>
+
+        <label className="min-w-0">
+          <span className="sr-only">{clueName} 조사권 종류</span>
+          <select
+            value={selectedTokenId}
+            disabled={disabled}
+            aria-label={`${clueName} 조사권 종류`}
+            onChange={(event) =>
+              onChange({ mode: 'token', tokenId: event.target.value, tokenCost: selectedCost })
+            }
+            className="w-full rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 disabled:opacity-50"
+          >
+            {tokens.map((token) => (
+              <option key={token.id} value={token.id}>
+                {token.iconLabel} {token.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          <span className="sr-only">{clueName} 조사권 소비량</span>
+          <input
+            type="number"
+            min={1}
+            value={selectedCost}
+            disabled={disabled}
+            aria-label={`${clueName} 조사권 소비량`}
+            onChange={(event) =>
+              onChange({
+                mode: 'token',
+                tokenId: selectedTokenId,
+                tokenCost: normalizeCost(event.target.value),
+              })
+            }
+            className="w-full rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 disabled:opacity-50"
+          />
+        </label>
+      </div>
+      <div className="mt-1.5 flex flex-wrap items-center justify-between gap-2 text-[10px] text-slate-600">
+        <span>조사권 이름과 시작 수량은 모듈 탭의 조사권 설정에서 관리합니다.</span>
+        <a
+          href={manageHref}
+          className="rounded border border-slate-800 px-2 py-1 text-slate-400 hover:border-amber-500/50 hover:text-amber-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+        >
+          조사권 관리
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { Check, MapPin, Package, Plus, Search, X } from 'lucide-react';
+import { Check, MapPin, Package, Plus, Search } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import type { EditorThemeResponse, LocationResponse, ClueResponse } from '@/features/editor/api';
@@ -10,6 +10,18 @@ import {
   writeLocationDiscoveries,
   type LocationDiscoveryConfig,
 } from '@/features/editor/editorTypes';
+import {
+  readDeckInvestigationConfig,
+  writeDeckInvestigationConfig,
+} from '@/features/editor/entities/deckInvestigation/deckInvestigationAdapter';
+import {
+  readLocationClueInvestigationCost,
+  removeLocationClueInvestigationCost,
+  syncLocationClueInvestigationRequirements,
+  writeLocationClueInvestigationCost,
+  type InvestigationCostDraft,
+} from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
+import { LocationSelectedClueItem } from './LocationSelectedClueItem';
 
 interface LocationClueAssignPanelProps {
   themeId: string;
@@ -46,6 +58,10 @@ export function LocationClueAssignPanel({
     () => readLocationDiscoveries(theme.config_json, location.id),
     [theme.config_json, location.id]
   );
+  const investigationDraft = useMemo(
+    () => readDeckInvestigationConfig(theme.config_json),
+    [theme.config_json]
+  );
   const assignedIds = useMemo(
     () => discoveries.map((discovery) => discovery.clueId),
     [discoveries]
@@ -65,8 +81,11 @@ export function LocationClueAssignPanel({
     );
   }, [clues, query]);
 
-  function commit(next: LocationDiscoveryConfig[]) {
-    const nextConfig = writeLocationDiscoveries(theme.config_json, location.id, next);
+  function commit(next: LocationDiscoveryConfig[], deckDraft?: typeof investigationDraft) {
+    const locationConfig = writeLocationDiscoveries(theme.config_json, location.id, next);
+    const nextConfig = deckDraft
+      ? writeDeckInvestigationConfig(locationConfig, deckDraft)
+      : locationConfig;
     const nextIds = next.map((discovery) => discovery.clueId);
     const cacheKey = editorKeys.theme(themeId);
     const previous = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
@@ -96,21 +115,54 @@ export function LocationClueAssignPanel({
   }
 
   function removeClue(clueId: string) {
-    commit(discoveries.filter((discovery) => discovery.clueId !== clueId));
+    const cost = readLocationClueInvestigationCost(investigationDraft, location.id, clueId);
+    commit(
+      discoveries.filter((discovery) => discovery.clueId !== clueId),
+      cost.mode === 'token'
+        ? removeLocationClueInvestigationCost(investigationDraft, location.id, clueId)
+        : undefined
+    );
   }
 
   function toggleRequiredClue(clueId: string, requiredClueId: string) {
+    let nextRequiredIds: string[] = [];
+    const nextDiscoveries = discoveries.map((discovery) => {
+      if (discovery.clueId !== clueId) return discovery;
+      const requiredSet = new Set(discovery.requiredClueIds);
+      if (requiredSet.has(requiredClueId)) requiredSet.delete(requiredClueId);
+      else requiredSet.add(requiredClueId);
+      nextRequiredIds = Array.from(requiredSet).filter((id) => id !== clueId);
+      return {
+        ...discovery,
+        requiredClueIds: nextRequiredIds,
+        oncePerPlayer: true,
+      };
+    });
     commit(
-      discoveries.map((discovery) => {
-        if (discovery.clueId !== clueId) return discovery;
-        const requiredSet = new Set(discovery.requiredClueIds);
-        if (requiredSet.has(requiredClueId)) requiredSet.delete(requiredClueId);
-        else requiredSet.add(requiredClueId);
-        return {
-          ...discovery,
-          requiredClueIds: Array.from(requiredSet).filter((id) => id !== clueId),
-          oncePerPlayer: true,
-        };
+      nextDiscoveries,
+      readLocationClueInvestigationCost(investigationDraft, location.id, clueId).mode === 'token'
+        ? syncLocationClueInvestigationRequirements(
+            investigationDraft,
+            location.id,
+            clueId,
+            nextRequiredIds
+          )
+        : undefined
+    );
+  }
+
+  function updateInvestigationCost(clue: ClueResponse, cost: InvestigationCostDraft) {
+    const discovery = discoveries.find((item) => item.clueId === clue.id);
+    if (!discovery) return;
+    commit(
+      discoveries,
+      writeLocationClueInvestigationCost(investigationDraft, {
+        locationId: location.id,
+        locationName: location.name,
+        clueId: clue.id,
+        clueName: clue.name,
+        requiredClueIds: discovery.requiredClueIds,
+        cost,
       })
     );
   }
@@ -212,15 +264,23 @@ export function LocationClueAssignPanel({
             ) : (
               <div className="space-y-2">
                 {selectedClues.map((clue) => (
-                  <SelectedClue
+                  <LocationSelectedClueItem
                     key={clue.id}
                     clue={clue}
                     discovery={discoveries.find((item) => item.clueId === clue.id)}
                     availableClues={clues.filter((candidate) => candidate.id !== clue.id)}
                     clueById={clueById}
+                    tokens={investigationDraft.tokens}
+                    cost={readLocationClueInvestigationCost(
+                      investigationDraft,
+                      location.id,
+                      clue.id
+                    )}
                     disabled={updateConfig.isPending}
+                    manageHref={`/editor/${themeId}/design/modules`}
                     onRemove={removeClue}
                     onToggleRequired={toggleRequiredClue}
+                    onCostChange={updateInvestigationCost}
                   />
                 ))}
               </div>
@@ -262,91 +322,6 @@ function ClueOption({
         {selected ? <Check className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
       </span>
     </button>
-  );
-}
-
-function SelectedClue({
-  clue,
-  discovery,
-  availableClues,
-  clueById,
-  disabled,
-  onRemove,
-  onToggleRequired,
-}: {
-  clue: ClueResponse;
-  discovery?: LocationDiscoveryConfig;
-  availableClues: ClueResponse[];
-  clueById: Map<string, ClueResponse>;
-  disabled: boolean;
-  onRemove: (id: string) => void;
-  onToggleRequired: (clueId: string, requiredClueId: string) => void;
-}) {
-  const requiredIds = discovery?.requiredClueIds ?? [];
-  const requiredSet = new Set(requiredIds);
-  const selectedRequiredNames = requiredIds
-    .map((id) => clueById.get(id)?.name)
-    .filter(Boolean)
-    .join(', ');
-
-  return (
-    <div className="rounded-lg border border-amber-500/20 bg-slate-950/80 px-2.5 py-2">
-      <div className="flex items-center gap-2">
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-amber-500/10 text-[9px] font-semibold text-amber-300">
-          {roundLabel(clue)}
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-xs font-medium text-slate-200">{clue.name}</span>
-          <span className="block truncate text-[10px] text-slate-600">{clueMeta(clue)}</span>
-        </span>
-        <span className="shrink-0 rounded-full border border-slate-800 px-2 py-0.5 text-[10px] text-slate-500">
-          1회 발견
-        </span>
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={() => onRemove(clue.id)}
-          aria-label={`${clue.name} 제거`}
-          className="rounded-full p-1 text-slate-600 hover:bg-red-950/40 hover:text-red-300 disabled:opacity-50"
-        >
-          <X className="h-3 w-3" />
-        </button>
-      </div>
-      <div className="mt-2 rounded-md border border-slate-800 bg-slate-950/80 p-2">
-        <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-          필요 단서
-        </p>
-        {availableClues.length === 0 ? (
-          <p className="text-[10px] text-slate-600">조건으로 사용할 다른 단서가 없습니다.</p>
-        ) : (
-          <div className="flex flex-wrap gap-1.5">
-            {availableClues.map((candidate) => {
-              const selected = requiredSet.has(candidate.id);
-              return (
-                <button
-                  key={candidate.id}
-                  type="button"
-                  disabled={disabled}
-                  onClick={() => onToggleRequired(clue.id, candidate.id)}
-                  aria-pressed={selected}
-                  aria-label={`${clue.name} 발견 조건 ${candidate.name} ${selected ? '해제' : '필요'}`}
-                  className={`rounded-full border px-2 py-1 text-[10px] transition disabled:opacity-50 ${
-                    selected
-                      ? 'border-amber-400/50 bg-amber-500/10 text-amber-200'
-                      : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-300'
-                  }`}
-                >
-                  {candidate.name}
-                </button>
-              );
-            })}
-          </div>
-        )}
-        <p className="mt-1.5 text-[10px] text-slate-600">
-          {selectedRequiredNames ? `${selectedRequiredNames} 보유 시 발견` : '조건 없음'}
-        </p>
-      </div>
-    </div>
   );
 }
 

--- a/apps/web/src/features/editor/components/design/LocationSelectedClueItem.tsx
+++ b/apps/web/src/features/editor/components/design/LocationSelectedClueItem.tsx
@@ -1,0 +1,121 @@
+import { X } from 'lucide-react';
+import type { ClueResponse } from '@/features/editor/api';
+import type { LocationDiscoveryConfig } from '@/features/editor/editorTypes';
+import type {
+  InvestigationCostDraft,
+  InvestigationTokenDraft,
+} from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
+import { InvestigationCostSelector } from './InvestigationCostSelector';
+
+interface LocationSelectedClueItemProps {
+  clue: ClueResponse;
+  discovery?: LocationDiscoveryConfig;
+  availableClues: ClueResponse[];
+  clueById: Map<string, ClueResponse>;
+  tokens: InvestigationTokenDraft[];
+  cost: InvestigationCostDraft;
+  disabled: boolean;
+  manageHref: string;
+  onRemove: (id: string) => void;
+  onToggleRequired: (clueId: string, requiredClueId: string) => void;
+  onCostChange: (clue: ClueResponse, cost: InvestigationCostDraft) => void;
+}
+
+function clueMeta(clue: ClueResponse) {
+  return [clue.location_id ? '장소 단서' : '미배치', clue.is_common ? '공용' : null]
+    .filter(Boolean)
+    .join(' · ');
+}
+
+function roundLabel(clue: ClueResponse) {
+  return typeof clue.reveal_round === 'number' ? `R${clue.reveal_round}` : 'CL';
+}
+
+export function LocationSelectedClueItem({
+  clue,
+  discovery,
+  availableClues,
+  clueById,
+  tokens,
+  cost,
+  disabled,
+  manageHref,
+  onRemove,
+  onToggleRequired,
+  onCostChange,
+}: LocationSelectedClueItemProps) {
+  const requiredIds = discovery?.requiredClueIds ?? [];
+  const requiredSet = new Set(requiredIds);
+  const selectedRequiredNames = requiredIds
+    .map((id) => clueById.get(id)?.name)
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <div className="rounded-lg border border-amber-500/20 bg-slate-950/80 px-2.5 py-2">
+      <div className="flex items-center gap-2">
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-amber-500/10 text-[9px] font-semibold text-amber-300">
+          {roundLabel(clue)}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-xs font-medium text-slate-200">{clue.name}</span>
+          <span className="block truncate text-[10px] text-slate-600">{clueMeta(clue)}</span>
+        </span>
+        <span className="shrink-0 rounded-full border border-slate-800 px-2 py-0.5 text-[10px] text-slate-500">
+          1회 발견
+        </span>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onRemove(clue.id)}
+          aria-label={`${clue.name} 제거`}
+          className="rounded-full p-1 text-slate-600 hover:bg-red-950/40 hover:text-red-300 disabled:opacity-50"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+      <div className="mt-2 rounded-md border border-slate-800 bg-slate-950/80 p-2">
+        <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+          필요 단서
+        </p>
+        {availableClues.length === 0 ? (
+          <p className="text-[10px] text-slate-600">조건으로 사용할 다른 단서가 없습니다.</p>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {availableClues.map((candidate) => {
+              const selected = requiredSet.has(candidate.id);
+              return (
+                <button
+                  key={candidate.id}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onToggleRequired(clue.id, candidate.id)}
+                  aria-pressed={selected}
+                  aria-label={`${clue.name} 발견 조건 ${candidate.name} ${selected ? '해제' : '필요'}`}
+                  className={`rounded-full border px-2 py-1 text-[10px] transition disabled:opacity-50 ${
+                    selected
+                      ? 'border-amber-400/50 bg-amber-500/10 text-amber-200'
+                      : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-300'
+                  }`}
+                >
+                  {candidate.name}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        <p className="mt-1.5 text-[10px] text-slate-600">
+          {selectedRequiredNames ? `${selectedRequiredNames} 보유 시 발견` : '조건 없음'}
+        </p>
+      </div>
+      <InvestigationCostSelector
+        clueName={clue.name}
+        cost={cost}
+        tokens={tokens}
+        disabled={disabled}
+        manageHref={manageHref}
+        onChange={(nextCost) => onCostChange(clue, nextCost)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -273,6 +273,107 @@ describe('LocationClueAssignPanel', () => {
     ]);
   });
 
+  it('장소 단서 조사 비용을 deck_investigation 단일 단서 deck으로 저장한다', () => {
+    const theme: EditorThemeResponse = {
+      ...baseTheme,
+      config_json: {
+        locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+        modules: {
+          deck_investigation: {
+            enabled: true,
+            config: {
+              tokens: [
+                { id: 'basic-token', name: '기본 조사권', iconLabel: '권', defaultAmount: 1 },
+              ],
+              decks: [],
+            },
+          },
+        },
+      },
+    };
+    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
+
+    expect(screen.getByText('무료 조사')).toBeDefined();
+    expect(screen.getByRole('link', { name: '조사권 관리' }).getAttribute('href')).toBe(
+      '/editor/theme-1/design/modules'
+    );
+    fireEvent.change(screen.getByLabelText('단검 조사권 소비량'), { target: { value: '2' } });
+
+    expect(mutateMock).toHaveBeenCalledOnce();
+    const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
+    const modules = config.modules as {
+      deck_investigation: {
+        config: {
+          tokens: Array<{ id: string }>;
+          decks: Array<{
+            id: string;
+            title: string;
+            tokenId: string;
+            tokenCost: number;
+            access: { locationIds: string[]; requiredClueIds: string[] };
+            cards: Array<{ clueId: string; delivery: string }>;
+          }>;
+        };
+      };
+    };
+    expect(modules.deck_investigation.config.decks[0]).toMatchObject({
+      id: 'location-clue-loc-1-clue-1',
+      title: '서재 - 단검 조사',
+      tokenId: 'basic-token',
+      tokenCost: 2,
+      access: { locationIds: ['loc-1'], requiredClueIds: [] },
+      cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+    });
+  });
+
+  it('장소 단서 조사 비용을 무료로 바꾸면 연결된 비용 deck을 제거한다', () => {
+    const theme: EditorThemeResponse = {
+      ...baseTheme,
+      config_json: {
+        locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+        modules: {
+          deck_investigation: {
+            enabled: true,
+            config: {
+              tokens: [
+                { id: 'basic-token', name: '기본 조사권', iconLabel: '권', defaultAmount: 1 },
+              ],
+              decks: [
+                {
+                  id: 'location-clue-loc-1-clue-1',
+                  title: '서재 - 단검 조사',
+                  description: '',
+                  tokenId: 'basic-token',
+                  tokenCost: 2,
+                  drawOrder: 'sequential',
+                  emptyMessage: '더 이상 얻을 단서가 없습니다.',
+                  access: {
+                    phaseIds: [],
+                    locationIds: ['loc-1'],
+                    blockedCharacterIds: [],
+                    requiredClueIds: [],
+                  },
+                  cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
+
+    expect(screen.getByText('권 기본 조사권 2개 필요')).toBeDefined();
+    fireEvent.click(screen.getByLabelText('단검 무료 조사로 설정'));
+
+    expect(mutateMock).toHaveBeenCalledOnce();
+    const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
+    const modules = config.modules as {
+      deck_investigation: { config: { decks: unknown[] } };
+    };
+    expect(modules.deck_investigation.config.decks).toEqual([]);
+  });
+
   it('이미 선택된 필요 단서를 다시 클릭하면 requiredClueIds에서 해제된다', () => {
     const theme: EditorThemeResponse = {
       ...baseTheme,

--- a/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
@@ -8,6 +8,13 @@ import {
   toDeckInvestigationViewModel,
   writeDeckInvestigationConfig,
 } from '../deckInvestigationAdapter';
+import {
+  formatInvestigationCostLabel,
+  readLocationClueInvestigationCost,
+  removeLocationClueInvestigationCost,
+  syncLocationClueInvestigationRequirements,
+  writeLocationClueInvestigationCost,
+} from '../locationClueInvestigationCost';
 
 const clue = (id: string, name = id): ClueResponse => ({
   id,
@@ -243,5 +250,70 @@ describe('deckInvestigationAdapter', () => {
         emptyMessage: '더 이상 얻을 단서가 없습니다.',
       }],
     });
+  });
+
+  it('장소 단서별 조사 비용을 단일 단서 deck으로 읽고 쓴다', () => {
+    const draft = {
+      tokens: [{ id: 'coin', name: '동전', iconLabel: '코', defaultAmount: 2 }],
+      decks: [],
+    };
+
+    const paid = writeLocationClueInvestigationCost(draft, {
+      locationId: 'loc-1',
+      locationName: '서재',
+      clueId: 'clue-1',
+      clueName: '단검',
+      requiredClueIds: ['clue-2', 'clue-1'],
+      cost: { mode: 'token', tokenId: 'coin', tokenCost: 3 },
+    });
+
+    expect(readLocationClueInvestigationCost(paid, 'loc-1', 'clue-1')).toEqual({
+      mode: 'token',
+      tokenId: 'coin',
+      tokenCost: 3,
+    });
+    expect(paid.decks[0]).toMatchObject({
+      id: 'location-clue-loc-1-clue-1',
+      title: '서재 - 단검 조사',
+      tokenId: 'coin',
+      tokenCost: 3,
+      access: { locationIds: ['loc-1'], requiredClueIds: ['clue-2'] },
+      cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+    });
+    expect(formatInvestigationCostLabel({ mode: 'token', tokenId: 'coin', tokenCost: 3 }, paid.tokens))
+      .toBe('코 동전 3개 필요');
+  });
+
+  it('장소 단서 비용을 무료로 바꾸면 자동 생성 deck만 제거한다', () => {
+    const paid = writeLocationClueInvestigationCost(createDeckInvestigationDraft(), {
+      locationId: 'loc-1',
+      locationName: '서재',
+      clueId: 'clue-1',
+      clueName: '단검',
+      requiredClueIds: [],
+      cost: { mode: 'token', tokenId: 'investigation-token', tokenCost: 1 },
+    });
+
+    expect(removeLocationClueInvestigationCost(paid, 'loc-1', 'clue-1').decks).toEqual([]);
+    expect(readLocationClueInvestigationCost(paid, 'loc-1', 'missing')).toEqual({ mode: 'free' });
+    expect(formatInvestigationCostLabel({ mode: 'free' }, paid.tokens)).toBe('무료 조사');
+  });
+
+  it('필요 단서 조건 변경 시 비용 deck의 실행 조건도 동기화한다', () => {
+    const paid = writeLocationClueInvestigationCost(createDeckInvestigationDraft(), {
+      locationId: 'loc-1',
+      locationName: '서재',
+      clueId: 'clue-1',
+      clueName: '단검',
+      requiredClueIds: [],
+      cost: { mode: 'token', tokenId: 'investigation-token', tokenCost: 1 },
+    });
+
+    const synced = syncLocationClueInvestigationRequirements(paid, 'loc-1', 'clue-1', [
+      'clue-2',
+      'clue-1',
+    ]);
+
+    expect(synced.decks[0].access.requiredClueIds).toEqual(['clue-2']);
   });
 });

--- a/apps/web/src/features/editor/entities/deckInvestigation/locationClueInvestigationCost.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/locationClueInvestigationCost.ts
@@ -1,0 +1,131 @@
+import {
+  createInvestigationDeckDraft,
+  type DeckInvestigationConfigDraft,
+  type InvestigationDeckDraft,
+  type InvestigationTokenDraft,
+} from './deckInvestigationAdapter';
+
+export type InvestigationCostDraft =
+  | { mode: 'free' }
+  | { mode: 'token'; tokenId: string; tokenCost: number };
+
+const DEFAULT_TOKEN_ID = 'investigation-token';
+const LOCATION_CLUE_DECK_PREFIX = 'location-clue';
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+export function readLocationClueInvestigationCost(
+  draft: DeckInvestigationConfigDraft,
+  locationId: string,
+  clueId: string,
+): InvestigationCostDraft {
+  const deck = draft.decks.find((item) => item.id === buildLocationClueDeckId(locationId, clueId));
+  if (!deck || deck.tokenCost <= 0) return { mode: 'free' };
+  return { mode: 'token', tokenId: deck.tokenId, tokenCost: deck.tokenCost };
+}
+
+export function writeLocationClueInvestigationCost(
+  draft: DeckInvestigationConfigDraft,
+  params: {
+    locationId: string;
+    locationName: string;
+    clueId: string;
+    clueName: string;
+    requiredClueIds: string[];
+    cost: InvestigationCostDraft;
+  },
+): DeckInvestigationConfigDraft {
+  const deckId = buildLocationClueDeckId(params.locationId, params.clueId);
+  if (params.cost.mode === 'free') {
+    return { ...draft, decks: draft.decks.filter((deck) => deck.id !== deckId) };
+  }
+
+  const fallbackTokenId = draft.tokens[0]?.id ?? DEFAULT_TOKEN_ID;
+  const tokenId = params.cost.tokenId || fallbackTokenId;
+  const tokenCost = Math.max(1, Math.floor(params.cost.tokenCost));
+  const existingDeck = draft.decks.find((deck) => deck.id === deckId);
+  const nextDeck = {
+    ...createInvestigationDeckDraft(draft.decks.length, tokenId),
+    ...(existingDeck ?? {}),
+    id: deckId,
+    title: `${params.locationName} - ${params.clueName} 조사`,
+    tokenId,
+    tokenCost,
+    drawOrder: 'sequential',
+    access: {
+      phaseIds: [],
+      locationIds: [params.locationId],
+      blockedCharacterIds: [],
+      requiredClueIds: stringList(params.requiredClueIds).filter((id) => id !== params.clueId),
+    },
+    cards: [{ clueId: params.clueId, delivery: 'private_ownership' }],
+  } satisfies InvestigationDeckDraft;
+
+  return {
+    ...draft,
+    decks: existingDeck
+      ? draft.decks.map((deck) => (deck.id === deckId ? nextDeck : deck))
+      : [...draft.decks, nextDeck],
+  };
+}
+
+export function removeLocationClueInvestigationCost(
+  draft: DeckInvestigationConfigDraft,
+  locationId: string,
+  clueId: string,
+): DeckInvestigationConfigDraft {
+  const deckId = buildLocationClueDeckId(locationId, clueId);
+  return { ...draft, decks: draft.decks.filter((deck) => deck.id !== deckId) };
+}
+
+export function syncLocationClueInvestigationRequirements(
+  draft: DeckInvestigationConfigDraft,
+  locationId: string,
+  clueId: string,
+  requiredClueIds: string[],
+): DeckInvestigationConfigDraft {
+  const deckId = buildLocationClueDeckId(locationId, clueId);
+  return {
+    ...draft,
+    decks: draft.decks.map((deck) =>
+      deck.id === deckId
+        ? {
+            ...deck,
+            access: {
+              ...deck.access,
+              requiredClueIds: stringList(requiredClueIds).filter((id) => id !== clueId),
+            },
+          }
+        : deck,
+    ),
+  };
+}
+
+export function formatInvestigationCostLabel(
+  cost: InvestigationCostDraft,
+  tokens: InvestigationTokenDraft[],
+): string {
+  if (cost.mode === 'free') return '무료 조사';
+  const token = tokens.find((item) => item.id === cost.tokenId);
+  const tokenName = token ? `${token.iconLabel} ${token.name}` : '조사권 미선택';
+  return `${tokenName} ${Math.max(1, Math.floor(cost.tokenCost))}개 필요`;
+}
+
+function buildLocationClueDeckId(locationId: string, clueId: string): string {
+  return `${LOCATION_CLUE_DECK_PREFIX}-${safeIdPart(locationId)}-${safeIdPart(clueId)}`;
+}
+
+function safeIdPart(value: string): string {
+  const clean = value.trim().replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return clean || 'item';
+}


### PR DESCRIPTION
## 요약
- 장소 단서 조사 카드에서 무료/조사권 소비 비용을 바로 설정할 수 있게 했습니다.
- 비용 저장은 새 계약을 만들지 않고 기존 `deck_investigation.config.decks`의 단일 단서 deck으로 변환합니다.
- 조사권 이름/초기 수량 관리로 바로 이동할 수 있는 `조사권 관리` 링크를 추가했습니다.

## Uzu 참고점
- Uzu의 덱/토큰 조사는 토큰을 소비해 덱에서 단서를 획득하는 구조입니다.
- MMP는 이를 그대로 복제하지 않고, 제작자가 장소 단서 조사 화면에서 비용만 정하면 내부적으로 deck investigation 계약으로 저장되도록 좁혔습니다.

## Coverage Plan
- `locationClueInvestigationCost`: 무료/유료 비용 읽기, 단일 단서 deck 저장, 무료 전환 제거, 필요 단서 조건 동기화.
- `LocationClueAssignPanel`: 장소 단서 조사 비용 selector, 관리 링크, 저장 payload를 Vitest로 고정.
- 주변 회귀: deck investigation 모듈 설정, 장소 탭, 단서 workspace, condition rule focused tests.
- E2E 대체 사유: 이번 PR은 기존 route/page 추가가 아니라 editor config 저장 UI와 adapter payload 변경이므로 focused component/adapter tests로 검증했습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec eslint src/features/editor/components/design/LocationClueAssignPanel.tsx src/features/editor/components/design/LocationSelectedClueItem.tsx src/features/editor/components/design/InvestigationCostSelector.tsx src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts src/features/editor/entities/deckInvestigation/locationClueInvestigationCost.ts src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts src/features/editor/components/design/__tests__/ModulesSubTab.deckInvestigation.test.tsx src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/components/design/condition/__tests__/ConditionRule.test.tsx` (6 files, 69 tests)

Closes #418
Refs #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 위치 단서 할당 시 조사 비용 설정 기능 추가
  * 무료 또는 토큰 기반 비용 모드 선택 가능
  * 필수 단서 의존성 관리 기능 추가
  * 조사 비용 설정 및 편집 UI 개선

* **테스트**
  * 위치 단서 조사 비용 워크플로우 테스트 추가
  * 조사 비용 관리 기능에 대한 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->