### PR TITLE
feat(editor): 장면별 토론방 정책 편집 UI 확장

### DIFF
--- a/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx
@@ -1,4 +1,10 @@
-import type { DiscussionRoomAvailability, DiscussionRoomPolicy } from "../../flowTypes";
+import type {
+  DiscussionParticipantMode,
+  DiscussionRoomAvailability,
+  DiscussionRoomCloseBehavior,
+  DiscussionRoomKind,
+  DiscussionRoomPolicy,
+} from "../../flowTypes";
 import {
   normalizeDiscussionRoomPolicy,
   patchDiscussionRoomPolicy,
@@ -39,6 +45,19 @@ export function DiscussionRoomPolicyPanel({ policy, onChange }: DiscussionRoomPo
 
         {normalized.enabled && (
           <div className="grid gap-3">
+            <label className="grid gap-1 text-xs text-slate-400">
+              <span className="font-medium text-slate-300">토론 유형</span>
+              <select
+                className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                value={normalized.roomKind}
+                onChange={(event) => update({ roomKind: event.target.value as DiscussionRoomKind })}
+              >
+                <option value="all">전체 토론</option>
+                <option value="small_group">소그룹 토론</option>
+                <option value="private">비공개 토론</option>
+              </select>
+            </label>
+
             <LabeledTextInput
               label="메인 토론방"
               value={normalized.mainRoomName}
@@ -70,6 +89,36 @@ export function DiscussionRoomPolicyPanel({ policy, onChange }: DiscussionRoomPo
               />
             )}
 
+            <div className="grid gap-2 rounded border border-slate-800 bg-slate-900/40 px-3 py-2">
+              <label className="grid gap-1 text-xs text-slate-400">
+                <span className="font-medium text-slate-300">참여 대상</span>
+                <select
+                  className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                  value={normalized.participantMode}
+                  onChange={(event) =>
+                    update({ participantMode: event.target.value as DiscussionParticipantMode })
+                  }
+                >
+                  <option value="all">전원 참여</option>
+                  <option value="characters">특정 캐릭터</option>
+                  <option value="condition">조건 그룹</option>
+                </select>
+              </label>
+
+              {normalized.participantMode !== "all" && (
+                <LabeledTextInput
+                  label={normalized.participantMode === "characters" ? "참여 캐릭터 메모" : "참여 조건 메모"}
+                  value={normalized.participantSummary ?? ""}
+                  placeholder={
+                    normalized.participantMode === "characters"
+                      ? "예: 탐정, 피해자 가족"
+                      : "예: 단서 A 보유자만"
+                  }
+                  onChange={(participantSummary) => update({ participantSummary })}
+                />
+              )}
+            </div>
+
             <label className="grid gap-1 text-xs text-slate-400">
               <span className="font-medium text-slate-300">이용 가능 시점</span>
               <select
@@ -92,6 +141,20 @@ export function DiscussionRoomPolicyPanel({ policy, onChange }: DiscussionRoomPo
                 onChange={(conditionalRoomName) => update({ conditionalRoomName })}
               />
             )}
+
+            <label className="grid gap-1 text-xs text-slate-400">
+              <span className="font-medium text-slate-300">장면 종료 시 처리</span>
+              <select
+                className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                value={normalized.closeBehavior}
+                onChange={(event) =>
+                  update({ closeBehavior: event.target.value as DiscussionRoomCloseBehavior })
+                }
+              >
+                <option value="close_on_exit">장면 종료 시 닫기</option>
+                <option value="keep_until_next_scene">다음 장면까지 유지</option>
+              </select>
+            </label>
           </div>
         )}
       </div>

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactElement } from "react";
 
@@ -127,11 +127,15 @@ describe("PhaseNodePanel extended fields", () => {
     expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
       discussionRoomPolicy: {
         enabled: true,
+        roomKind: "all",
         mainRoomName: "추리 회의",
         privateRoomsEnabled: false,
         privateRoomName: "밀담방",
+        participantMode: "all",
+        participantSummary: "",
         availability: "phase_active",
         conditionalRoomName: "",
+        closeBehavior: "close_on_exit",
       },
     });
   });
@@ -161,12 +165,140 @@ describe("PhaseNodePanel extended fields", () => {
     expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
       discussionRoomPolicy: {
         enabled: true,
+        roomKind: "all",
         mainRoomName: "전체 토론",
         privateRoomsEnabled: false,
         privateRoomName: "밀담방",
+        participantMode: "all",
+        participantSummary: "",
         availability: "condition",
         conditionalRoomName: "비밀 토론",
+        closeBehavior: "close_on_exit",
       },
+    });
+  });
+
+  it("토론방 사용 여부와 밀담방 허용 상태를 장면 데이터로 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({
+          discussionRoomPolicy: {
+            enabled: true,
+            roomKind: "all",
+            mainRoomName: "전체 토론",
+            privateRoomsEnabled: false,
+            privateRoomName: "밀담방",
+            participantMode: "all",
+            participantSummary: "",
+            availability: "phase_active",
+            conditionalRoomName: "",
+            closeBehavior: "close_on_exit",
+          },
+        })}
+        themeId="t1"
+        onUpdate={onUpdate}
+      />,
+    );
+
+    const discussionPanel = screen.getByTestId("discussion-room-policy-panel");
+    fireEvent.click(within(discussionPanel).getByRole("checkbox", { name: /토론방/ }));
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: expect.objectContaining({
+        enabled: false,
+      }),
+    });
+
+    fireEvent.click(within(discussionPanel).getByRole("checkbox", { name: /밀담방 허용/ }));
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: expect.objectContaining({
+        enabled: true,
+        privateRoomsEnabled: true,
+      }),
+    });
+  });
+
+  it("토론 유형, 참여 대상, 종료 정책을 장면 데이터로 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({
+          discussionRoomPolicy: {
+            enabled: true,
+            mainRoomName: "전체 토론",
+            privateRoomsEnabled: false,
+            privateRoomName: "밀담방",
+            availability: "phase_active",
+          },
+        })}
+        themeId="t1"
+        onUpdate={onUpdate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("토론 유형"), {
+      target: { value: "small_group" },
+    });
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: expect.objectContaining({
+        enabled: true,
+        roomKind: "small_group",
+      }),
+    });
+
+    fireEvent.change(screen.getByLabelText("참여 대상"), {
+      target: { value: "characters" },
+    });
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: expect.objectContaining({
+        enabled: true,
+        participantMode: "characters",
+      }),
+    });
+
+    fireEvent.change(screen.getByLabelText("장면 종료 시 처리"), {
+      target: { value: "keep_until_next_scene" },
+    });
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: expect.objectContaining({
+        enabled: true,
+        closeBehavior: "keep_until_next_scene",
+      }),
+    });
+  });
+
+  it("특정 참여 대상 메모를 장면 데이터로 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({
+          discussionRoomPolicy: {
+            enabled: true,
+            roomKind: "small_group",
+            mainRoomName: "전체 토론",
+            privateRoomsEnabled: false,
+            privateRoomName: "밀담방",
+            participantMode: "characters",
+            participantSummary: "",
+            availability: "phase_active",
+            closeBehavior: "close_on_exit",
+          },
+        })}
+        themeId="t1"
+        onUpdate={onUpdate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("참여 캐릭터 메모"), {
+      target: { value: "탐정, 목격자" },
+    });
+
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      discussionRoomPolicy: expect.objectContaining({
+        enabled: true,
+        participantMode: "characters",
+        participantSummary: "탐정, 목격자",
+      }),
     });
   });
 });

--- a/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
+++ b/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
@@ -12,6 +12,7 @@ import {
 import type { Node } from "@xyflow/react";
 import type { FlowNodeData } from "@/features/editor/flowTypes";
 import type { StoryLibraryEntity } from "./EditorEntityLibrary";
+import { formatDiscussionRoomSummary } from "@/features/editor/entities/phase/discussionRoomPolicyAdapter";
 
 interface SceneInspectorProps {
   selectedScene: Node<FlowNodeData> | null;
@@ -84,7 +85,7 @@ function buildRows(scene: Node<FlowNodeData> | null): InspectorRow[] {
     },
     {
       label: "토론방",
-      value: data.discussionRoomPolicy?.enabled ? "사용" : "사용 안 함",
+      value: formatDiscussionRoomSummary(data.discussionRoomPolicy),
     },
     {
       label: "연출",

--- a/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
@@ -28,10 +28,13 @@ describe("SceneInspector", () => {
         description: "도입 장면",
         discussionRoomPolicy: {
           enabled: true,
+          roomKind: "all",
           mainRoomName: "전체 토론",
           privateRoomsEnabled: false,
           privateRoomName: "비밀 대화",
+          participantMode: "all",
           availability: "phase_active",
+          closeBehavior: "close_on_exit",
         },
         onEnter: [{ type: "give_clue", params: {} }],
       },
@@ -55,6 +58,8 @@ describe("SceneInspector", () => {
     expect(screen.getByText("찢어진 초대장")).toBeDefined();
     expect(screen.getByText("장면 설명 있음")).toBeDefined();
     expect(screen.getByText("입장 시 단서 동작 있음")).toBeDefined();
-    expect(screen.getByText("사용")).toBeDefined();
+    expect(
+      screen.getByText("장면 시작 시 · 전원 참여 · 장면 종료 시 닫기 · 전체 토론: 전체 토론"),
+    ).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -32,7 +32,16 @@ vi.mock("../../design/FlowCanvas", () => ({
             data: {
               label: "오프닝",
               description: "도입 장면",
-              discussionRoomPolicy: { enabled: true },
+              discussionRoomPolicy: {
+                enabled: true,
+                roomKind: "all",
+                mainRoomName: "전체 토론",
+                privateRoomsEnabled: false,
+                privateRoomName: "밀담방",
+                participantMode: "all",
+                availability: "phase_active",
+                closeBehavior: "close_on_exit",
+              },
             },
           })
         }
@@ -165,6 +174,6 @@ describe("StoryMapWorkspace", () => {
     expect(screen.getByText("오프닝")).toBeDefined();
     expect(screen.getByText("스토리 장면")).toBeDefined();
     expect(screen.getByText("장면 설명 있음")).toBeDefined();
-    expect(screen.getByText("사용")).toBeDefined();
+    expect(screen.getByText("장면 시작 시 · 전원 참여 · 장면 종료 시 닫기 · 전체 토론: 전체 토론")).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -103,9 +103,9 @@ export const MODULE_CATEGORIES: ModuleCategory[] = [
     key: "communication",
     label: "소통",
     modules: [
-      { id: "text_chat", name: "텍스트 채팅", description: "전체/그룹 채팅", supported: true, required: false },
-      { id: "whisper", name: "귓속말", description: "1:1 비밀 메시지", supported: true, required: false },
-      { id: "group_chat", name: "그룹 채팅", description: "소그룹 채팅방", supported: true, required: false },
+      { id: "text_chat", name: "텍스트 채팅", description: "전역 채팅 기능 활성화", supported: true, required: false },
+      { id: "whisper", name: "귓속말", description: "전역 1:1 비밀 메시지 기능", supported: true, required: false },
+      { id: "group_chat", name: "그룹 채팅", description: "전역 소그룹 채팅 기능", supported: true, required: false },
       { id: "voice_chat", name: "음성 채팅", description: "실시간 음성 통화", supported: false, required: false },
       { id: "spatial_voice", name: "공간 음성", description: "위치 기반 음성", supported: false, required: false },
     ],

--- a/apps/web/src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts
@@ -9,11 +9,15 @@ describe("discussionRoomPolicyAdapter", () => {
   it("빈 정책을 제작자 기본값으로 정규화한다", () => {
     expect(normalizeDiscussionRoomPolicy(undefined)).toEqual({
       enabled: false,
+      roomKind: "all",
       mainRoomName: "전체 토론",
       privateRoomsEnabled: false,
       privateRoomName: "밀담방",
+      participantMode: "all",
+      participantSummary: "",
       availability: "phase_active",
       conditionalRoomName: "",
+      closeBehavior: "close_on_exit",
     });
   });
 
@@ -30,11 +34,33 @@ describe("discussionRoomPolicyAdapter", () => {
       ),
     ).toEqual({
       enabled: true,
+      roomKind: "all",
       mainRoomName: "전체 토론",
       privateRoomsEnabled: true,
       privateRoomName: "비밀 회의",
+      participantMode: "all",
+      participantSummary: "",
       availability: "condition",
       conditionalRoomName: "단서 공개 후",
+      closeBehavior: "close_on_exit",
+    });
+  });
+
+  it("토론 유형, 참여 대상, 종료 정책을 저장 가능한 정책으로 병합한다", () => {
+    expect(
+      patchDiscussionRoomPolicy(undefined, {
+        enabled: true,
+        roomKind: "small_group",
+        participantMode: "characters",
+        participantSummary: "탐정, 목격자",
+        closeBehavior: "keep_until_next_scene",
+      }),
+    ).toMatchObject({
+      enabled: true,
+      roomKind: "small_group",
+      participantMode: "characters",
+      participantSummary: "탐정, 목격자",
+      closeBehavior: "keep_until_next_scene",
     });
   });
 
@@ -43,21 +69,30 @@ describe("discussionRoomPolicyAdapter", () => {
     expect(
       formatDiscussionRoomSummary({
         enabled: true,
+        roomKind: "all",
         mainRoomName: "추리 회의",
         privateRoomsEnabled: true,
         privateRoomName: "밀담",
+        participantMode: "all",
         availability: "phase_active",
+        closeBehavior: "close_on_exit",
       }),
-    ).toBe("장면 시작 시 · 추리 회의, 밀담");
+    ).toBe("장면 시작 시 · 전원 참여 · 장면 종료 시 닫기 · 전체 토론: 추리 회의, 밀담");
     expect(
       formatDiscussionRoomSummary({
         enabled: true,
+        roomKind: "private",
         mainRoomName: "추리 회의",
         privateRoomsEnabled: false,
         privateRoomName: "밀담",
+        participantMode: "condition",
+        participantSummary: "단서 A 보유자",
         availability: "condition",
         conditionalRoomName: "비밀 토론",
+        closeBehavior: "keep_until_next_scene",
       }),
-    ).toBe("트리거가 열 때까지 대기 · 추리 회의, 비밀 토론");
+    ).toBe(
+      "트리거가 열 때까지 대기 · 조건: 단서 A 보유자 · 다음 장면까지 유지 · 비공개 토론: 추리 회의, 비밀 토론",
+    );
   });
 });

--- a/apps/web/src/features/editor/entities/phase/discussionRoomPolicyAdapter.ts
+++ b/apps/web/src/features/editor/entities/phase/discussionRoomPolicyAdapter.ts
@@ -2,11 +2,15 @@ import type { DiscussionRoomPolicy } from "../../flowTypes";
 
 export const DEFAULT_DISCUSSION_ROOM_POLICY: DiscussionRoomPolicy = {
   enabled: false,
+  roomKind: "all",
   mainRoomName: "전체 토론",
   privateRoomsEnabled: false,
   privateRoomName: "밀담방",
+  participantMode: "all",
+  participantSummary: "",
   availability: "phase_active",
   conditionalRoomName: "",
+  closeBehavior: "close_on_exit",
 };
 
 export function normalizeDiscussionRoomPolicy(
@@ -15,10 +19,16 @@ export function normalizeDiscussionRoomPolicy(
   return {
     ...DEFAULT_DISCUSSION_ROOM_POLICY,
     ...policy,
+    roomKind: normalizeRoomKind(policy?.roomKind),
     mainRoomName: cleanName(policy?.mainRoomName, DEFAULT_DISCUSSION_ROOM_POLICY.mainRoomName),
     privateRoomName: cleanName(policy?.privateRoomName, DEFAULT_DISCUSSION_ROOM_POLICY.privateRoomName),
+    participantMode: normalizeParticipantMode(policy?.participantMode),
+    participantSummary: policy?.participantSummary?.trim() ?? "",
     availability: policy?.availability === "condition" ? "condition" : "phase_active",
     conditionalRoomName: policy?.conditionalRoomName?.trim() ?? "",
+    closeBehavior: policy?.closeBehavior === "keep_until_next_scene"
+      ? "keep_until_next_scene"
+      : "close_on_exit",
   };
 }
 
@@ -32,16 +42,47 @@ export function patchDiscussionRoomPolicy(
 export function formatDiscussionRoomSummary(policy: DiscussionRoomPolicy | null | undefined): string {
   const normalized = normalizeDiscussionRoomPolicy(policy);
   if (!normalized.enabled) return "토론방 사용 안 함";
-  const rooms = [normalized.mainRoomName];
+  const rooms = [`${roomKindLabel(normalized.roomKind)}: ${normalized.mainRoomName}`];
   if (normalized.privateRoomsEnabled) rooms.push(normalized.privateRoomName);
   if (normalized.availability === "condition" && normalized.conditionalRoomName) {
     rooms.push(normalized.conditionalRoomName);
   }
   const availability = normalized.availability === "condition" ? "트리거가 열 때까지 대기" : "장면 시작 시";
-  return `${availability} · ${rooms.join(", ")}`;
+  return [
+    availability,
+    participantLabel(normalized),
+    normalized.closeBehavior === "keep_until_next_scene" ? "다음 장면까지 유지" : "장면 종료 시 닫기",
+    rooms.join(", "),
+  ].join(" · ");
 }
 
 function cleanName(value: string | undefined, fallback: string): string {
   const trimmed = value?.trim();
   return trimmed ? trimmed : fallback;
+}
+
+function normalizeRoomKind(value: unknown): DiscussionRoomPolicy["roomKind"] {
+  if (value === "small_group" || value === "private") return value;
+  return "all";
+}
+
+function normalizeParticipantMode(value: unknown): DiscussionRoomPolicy["participantMode"] {
+  if (value === "characters" || value === "condition") return value;
+  return "all";
+}
+
+function roomKindLabel(kind: DiscussionRoomPolicy["roomKind"]): string {
+  if (kind === "small_group") return "소그룹 토론";
+  if (kind === "private") return "비공개 토론";
+  return "전체 토론";
+}
+
+function participantLabel(policy: DiscussionRoomPolicy): string {
+  if (policy.participantMode === "characters") {
+    return policy.participantSummary ? `참여자: ${policy.participantSummary}` : "특정 캐릭터 참여";
+  }
+  if (policy.participantMode === "condition") {
+    return policy.participantSummary ? `조건: ${policy.participantSummary}` : "조건 만족 시 참여";
+  }
+  return "전원 참여";
 }

--- a/apps/web/src/features/editor/flowTypes.ts
+++ b/apps/web/src/features/editor/flowTypes.ts
@@ -11,14 +11,21 @@ export interface PhaseAction {
 }
 
 export type DiscussionRoomAvailability = "phase_active" | "condition";
+export type DiscussionRoomKind = "all" | "small_group" | "private";
+export type DiscussionParticipantMode = "all" | "characters" | "condition";
+export type DiscussionRoomCloseBehavior = "close_on_exit" | "keep_until_next_scene";
 
 export interface DiscussionRoomPolicy {
   enabled: boolean;
+  roomKind: DiscussionRoomKind;
   mainRoomName: string;
   privateRoomsEnabled: boolean;
   privateRoomName: string;
+  participantMode: DiscussionParticipantMode;
+  participantSummary?: string;
   availability: DiscussionRoomAvailability;
   conditionalRoomName?: string;
+  closeBehavior: DiscussionRoomCloseBehavior;
 }
 
 export interface FlowNodeData {


### PR DESCRIPTION
## 요약

- 장면 속성 패널 토론방 정책에 전체/소그룹/비공개 유형, 참여 대상, 장면 종료 시 처리 옵션을 추가했습니다.
- 토론방 정책 정규화/요약 어댑터를 확장해 story-map 우측 장면 요약에서 제작자가 바로 읽을 수 있게 했습니다.
- 모듈 탭의 소통 모듈 설명을 전역 기능으로 명확히 해 장면별 정책 UI와 역할을 분리했습니다.

## 이슈

Closes #419
Refs #381

## Coverage Plan

- `discussionRoomPolicyAdapter`: 기본값, 타입/참여 대상/종료 정책 정규화, 제작자 요약 문자열을 unit test로 고정했습니다.
- `DiscussionRoomPolicyPanel` via `PhaseNodePanelExtended`: 사용 여부, 밀담방 허용, 유형, 참여 대상, 참여 메모, 종료 정책 저장 payload를 Vitest로 검증했습니다.
- `SceneInspector` / `StoryMapWorkspace`: 선택 장면 요약에서 새 토론방 정책 문구가 노출되는지 component test로 검증했습니다.
- 플레이어 토론방 runtime, 채팅/음성/backend 권한 처리는 #419 제외 범위라 이번 PR에 포함하지 않았습니다.

## 검증

- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec eslint src/features/editor/flowTypes.ts src/features/editor/entities/phase/discussionRoomPolicyAdapter.ts src/features/editor/components/design/DiscussionRoomPolicyPanel.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx src/features/editor/components/story-map/SceneInspector.tsx src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/constants.ts`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/entities/phase/__tests__/discussionRoomPolicyAdapter.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 토론방 정책 설정 강화: 토론 유형(전체/소그룹/비공개), 참여 대상(전체/캐릭터/조건부), 장면 종료 시 처리 옵션이 추가되었습니다.
  * 토론방 설정이 더 상세하게 표시됩니다.

* **Documentation**
  * 채팅 모듈 설명 업데이트: 전역 채팅, 비밀 메시지, 소그룹 채팅 기능 설명이 명확하게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->