### PR TITLE
feat(editor): 결말 엔드카드 제작 UI 보강

### DIFF
--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -4,19 +4,36 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
 import { useUpdateFlowNode } from "../../flowApi";
-import { flowKeys, type FlowGraphResponse, type FlowNodeData } from "../../flowTypes";
+import {
+  flowKeys,
+  type EndingVisibility,
+  type FlowGraphResponse,
+  type FlowNodeData,
+} from "../../flowTypes";
+import {
+  endingVisibilityLabel,
+  normalizeEndingVisibility,
+  type EndingCharacterEndcardSummary,
+} from "../../entities/ending/endingEntityAdapter";
 
 interface EndingEntityDetailProps {
   node: Node;
   themeId: string;
+  endcardSummary: EndingCharacterEndcardSummary;
   onChange: (nodeId: string, patch: Partial<FlowNodeData>) => void;
 }
 
 const SAVE_DEBOUNCE_MS = 1000;
 
-export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDetailProps) {
+export function EndingEntityDetail({
+  node,
+  themeId,
+  endcardSummary,
+  onChange,
+}: EndingEntityDetailProps) {
   const fieldIdPrefix = useId();
   const data = node.data as FlowNodeData;
+  const visibility = normalizeEndingVisibility(data.endingVisibility);
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
 
@@ -62,6 +79,14 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
           게임이 끝났을 때 모두에게 공개할 결말 이름과 본문을 작성합니다.
           투표·질문·조건 결과는 서버가 판정하므로, 여기에는 플레이어에게 보여줄 내용만 적으면 됩니다.
         </p>
+        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+          <span className="rounded-full border border-slate-800 bg-slate-900 px-3 py-1 text-slate-300">
+            공개 범위: {endingVisibilityLabel(visibility)}
+          </span>
+          <span className="rounded-full border border-slate-800 bg-slate-900 px-3 py-1 text-slate-300">
+            캐릭터 결과 카드 {endcardSummary.readyCount}/{endcardSummary.totalCount}명 작성
+          </span>
+        </div>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
@@ -141,6 +166,80 @@ export function EndingEntityDetail({ node, themeId, onChange }: EndingEntityDeta
           Markdown 문법을 사용할 수 있습니다. 플레이어에게 보일 문장만 작성하고 내부 코드나 저장 키는 쓰지 않아도 됩니다.
         </p>
       </div>
+
+      <div className="grid gap-3 sm:grid-cols-[120px_1fr]">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-visibility`}>
+          공개 범위
+        </label>
+        <select
+          id={`${fieldIdPrefix}-visibility`}
+          value={visibility}
+          onChange={(event) => handleChange({ endingVisibility: event.target.value as EndingVisibility })}
+          onBlur={debouncer.flush}
+          className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        >
+          <option value="public">전체 공개</option>
+          <option value="players_only">참가자에게만 공개</option>
+          <option value="private_note">제작자 메모</option>
+        </select>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[120px_1fr]">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-spoiler`}>
+          스포일러 안내
+        </label>
+        <textarea
+          id={`${fieldIdPrefix}-spoiler`}
+          value={data.endingSpoilerWarning ?? ""}
+          onChange={(event) => handleChange({ endingSpoilerWarning: event.target.value })}
+          onBlur={debouncer.flush}
+          placeholder="예: 스포일러 주의: 게임 종료 후 공개되는 결말입니다."
+          rows={2}
+          className="resize-y rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[120px_1fr]">
+        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-share`}>
+          감상 공유 문구
+        </label>
+        <textarea
+          id={`${fieldIdPrefix}-share`}
+          value={data.endingShareText ?? ""}
+          onChange={(event) => handleChange({ endingShareText: event.target.value })}
+          onBlur={debouncer.flush}
+          placeholder="예: 오늘의 추리는 진실에 가까웠나요?"
+          rows={3}
+          className="resize-y rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+      </div>
+
+      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h4 className="text-sm font-semibold text-slate-100">캐릭터별 결과 카드 작성 현황</h4>
+            <p className="mt-1 text-xs leading-5 text-slate-400">
+              상세 문구는 등장인물 관리의 결과 카드에서 작성합니다. 이곳에서는 누락된 캐릭터를 확인합니다.
+            </p>
+          </div>
+          <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-amber-100">
+            {endcardSummary.readyCount}/{endcardSummary.totalCount}
+          </span>
+        </div>
+        {endcardSummary.totalCount === 0 ? (
+          <p className="mt-3 rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-400">
+            등록된 등장인물이 없습니다.
+          </p>
+        ) : endcardSummary.missingNames.length === 0 ? (
+          <p className="mt-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-100">
+            모든 캐릭터의 결과 카드가 작성되었습니다.
+          </p>
+        ) : (
+          <p className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs leading-5 text-amber-100">
+            결과 카드가 비어 있는 캐릭터: {endcardSummary.missingNames.join(", ")}
+          </p>
+        )}
+      </section>
     </section>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Search } from 'lucide-react';
-import type { EditorThemeResponse } from '@/features/editor/api';
+import { useEditorCharacters, type EditorThemeResponse } from '@/features/editor/api';
 import { useFlowData } from '../../hooks/useFlowData';
 import type { FlowNodeData } from '../../flowTypes';
 import { EndingEntityDetail } from './EndingEntityDetail';
@@ -10,6 +10,7 @@ import { EndingEntityHeader } from './EndingEntityHeader';
 import { EndingBranchRulesPanel } from './EndingBranchRulesPanel';
 import {
   buildEndingDecisionSummary,
+  buildCharacterEndcardSummary,
   toEndingEditorViewModel,
 } from '../../entities/ending/endingEntityAdapter';
 import { getDisplayErrorMessage } from '@/lib/display-error';
@@ -22,6 +23,7 @@ interface EndingEntitySubTabProps {
 export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) {
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const { data: characters = [] } = useEditorCharacters(themeId);
   const {
     nodes,
     edges = [],
@@ -50,6 +52,7 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
     filteredNodes.find((node) => node.id === selectedId) ?? filteredNodes[0] ?? null;
 
   const decisionSummary = useMemo(() => buildEndingDecisionSummary(nodes, edges), [nodes, edges]);
+  const endcardSummary = useMemo(() => buildCharacterEndcardSummary(characters), [characters]);
 
   const handleAddEnding = () => {
     addNode('ending', { x: 360 + endingNodes.length * 40, y: 220 });
@@ -161,7 +164,12 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
           </aside>
 
           {selectedNode && (
-            <EndingEntityDetail node={selectedNode} themeId={themeId} onChange={updateNodeData} />
+            <EndingEntityDetail
+              node={selectedNode}
+              themeId={themeId}
+              endcardSummary={endcardSummary}
+              onChange={updateNodeData}
+            />
           )}
         </div>
       )}

--- a/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useUpdateFlowNode } from "../../flowApi";
 import { flowKeys, type FlowGraphResponse, type FlowNodeData } from "../../flowTypes";
 import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+import { toEndingEditorViewModel } from "../../entities/ending/endingEntityAdapter";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -13,6 +14,7 @@ import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
 interface EndingNodePanelProps {
   node: Node;
   themeId: string;
+  edges?: { target: string }[];
   onUpdate: (id: string, data: Partial<FlowNodeData>) => void;
 }
 
@@ -26,6 +28,7 @@ const SAVE_DEBOUNCE_MS = 500;
 export function EndingNodePanel({
   node,
   themeId,
+  edges = [],
   onUpdate,
 }: EndingNodePanelProps) {
   const labelInputId = useId();
@@ -35,6 +38,8 @@ export function EndingNodePanel({
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
   const data = node.data as FlowNodeData;
+  const incomingCount = edges.filter((edge) => edge.target === node.id).length;
+  const viewModel = toEndingEditorViewModel(node, incomingCount);
 
   const debouncer = useDebouncedMutation<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
@@ -69,6 +74,24 @@ export function EndingNodePanel({
       <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
         엔딩 설정
       </h3>
+
+      <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-amber-300/80">
+          결말 연결 요약
+        </p>
+        <h4 className="mt-1 text-sm font-semibold text-slate-100">{viewModel.name}</h4>
+        <p className="mt-1 text-xs leading-5 text-slate-400">{viewModel.contentPreview}</p>
+        <div className="mt-2 flex flex-wrap gap-1">
+          {viewModel.badges.map((badge) => (
+            <span key={badge} className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300">
+              {badge}
+            </span>
+          ))}
+        </div>
+        <p className="mt-2 text-[11px] leading-5 text-slate-500">
+          상세 본문, 공개 범위, 캐릭터별 결과 카드는 결말 관리 탭에서 편집합니다.
+        </p>
+      </section>
 
       {/* Label */}
       <div className="flex flex-col gap-1">

--- a/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
@@ -67,7 +67,7 @@ export function NodeDetailPanel({
         ) : node.type === "phase" ? (
           <PhaseNodePanel node={node} themeId={themeId} onUpdate={onUpdate} edges={edges} />
         ) : node.type === "ending" ? (
-          <EndingNodePanel node={node} themeId={themeId} onUpdate={onUpdate} />
+          <EndingNodePanel node={node} themeId={themeId} edges={edges} onUpdate={onUpdate} />
         ) : node.type === "branch" ? (
           <BranchNodePanel
             node={node}

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -3,8 +3,9 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
-const { useFlowDataMock, addNodeMock, updateNodeDataMock, mutateMock, configMutateMock, useUpdateFlowNodeMock, refetchMock } = vi.hoisted(() => ({
+const { useFlowDataMock, useEditorCharactersMock, addNodeMock, updateNodeDataMock, mutateMock, configMutateMock, useUpdateFlowNodeMock, refetchMock } = vi.hoisted(() => ({
   useFlowDataMock: vi.fn(),
+  useEditorCharactersMock: vi.fn(),
   addNodeMock: vi.fn(),
   updateNodeDataMock: vi.fn(),
   mutateMock: vi.fn(),
@@ -20,6 +21,14 @@ vi.mock("../../../hooks/useFlowData", () => ({
 vi.mock("../../../flowApi", () => ({
   useUpdateFlowNode: () => useUpdateFlowNodeMock(),
 }));
+
+vi.mock("@/features/editor/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/editor/api")>();
+  return {
+    ...actual,
+    useEditorCharacters: () => useEditorCharactersMock(),
+  };
+});
 
 vi.mock("../../../editorConfigApi", () => ({
   useUpdateConfigJson: () => ({ mutate: configMutateMock, isPending: false }),
@@ -79,9 +88,58 @@ const makeNode = (id: string, data: Record<string, unknown> = {}, type = "ending
 
 beforeEach(() => {
   useUpdateFlowNodeMock.mockReturnValue({ mutate: mutateMock });
+  useEditorCharactersMock.mockReturnValue({
+    data: [
+      {
+        id: "char-1",
+        theme_id: "theme-1",
+        name: "하윤",
+        description: null,
+        image_url: null,
+        is_culprit: false,
+        mystery_role: "detective",
+        sort_order: 1,
+        is_playable: true,
+        show_in_intro: true,
+        can_speak_in_reading: true,
+        is_voting_candidate: true,
+        endcard_title: "하윤의 후일담",
+        endcard_body: "사건 이후의 선택",
+        endcard_image_url: null,
+        alias_rules: [],
+      },
+      {
+        id: "char-2",
+        theme_id: "theme-1",
+        name: "민재",
+        description: null,
+        image_url: null,
+        is_culprit: false,
+        mystery_role: "suspect",
+        sort_order: 2,
+        is_playable: true,
+        show_in_intro: true,
+        can_speak_in_reading: true,
+        is_voting_candidate: true,
+        endcard_title: null,
+        endcard_body: null,
+        endcard_image_url: null,
+        alias_rules: [],
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  });
   useFlowDataMock.mockReturnValue({
     nodes: [
-      makeNode("ending-1", { label: "진실", icon: "🎭", endingContent: "범인은 밝혀졌다." }),
+      makeNode("ending-1", {
+        label: "진실",
+        icon: "🎭",
+        endingContent: "범인은 밝혀졌다.",
+        endingVisibility: "players_only",
+        endingSpoilerWarning: "스포일러 주의",
+        endingShareText: "오늘의 추리는 어땠나요?",
+      }),
       makeNode("phase-1", { label: "1막" }, "phase"),
       makeNode("ending-2", { label: "오판", description: "잘못된 선택" }),
     ],
@@ -109,6 +167,9 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("결말 판정 준비")).toBeDefined();
     expect(screen.getByText("본문 작성")).toBeDefined();
+    expect(screen.getAllByText("참가자에게만 공개").length).toBeGreaterThan(0);
+    expect(screen.getByText("캐릭터 결과 카드 1/2명 작성")).toBeDefined();
+    expect(screen.getByText("결과 카드가 비어 있는 캐릭터: 민재")).toBeDefined();
     expect(screen.queryByText("1막")).toBeNull();
   });
 
@@ -185,6 +246,38 @@ describe("EndingEntitySubTab", () => {
       { nodeId: "ending-1", body: { data: expect.objectContaining({ label: "자비" }) } },
       expect.objectContaining({ onError: expect.any(Function) }),
     );
+  });
+
+  it("결말 본문, 공개 범위, 스포일러 안내, 감상 공유 문구를 저장 payload로 보낸다", () => {
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    fireEvent.change(screen.getByLabelText("결말 본문"), {
+      target: { value: "진실은 모두에게 남았다." },
+    });
+    expect(updateNodeDataMock).toHaveBeenLastCalledWith("ending-1", {
+      endingContent: "진실은 모두에게 남았다.",
+    });
+
+    fireEvent.change(screen.getByLabelText("공개 범위"), {
+      target: { value: "private_note" },
+    });
+    expect(updateNodeDataMock).toHaveBeenLastCalledWith("ending-1", {
+      endingVisibility: "private_note",
+    });
+
+    fireEvent.change(screen.getByLabelText("스포일러 안내"), {
+      target: { value: "이 결말은 플레이 후 공개됩니다." },
+    });
+    expect(updateNodeDataMock).toHaveBeenLastCalledWith("ending-1", {
+      endingSpoilerWarning: "이 결말은 플레이 후 공개됩니다.",
+    });
+
+    fireEvent.change(screen.getByLabelText("감상 공유 문구"), {
+      target: { value: "당신의 선택을 공유해 보세요." },
+    });
+    expect(updateNodeDataMock).toHaveBeenLastCalledWith("ending-1", {
+      endingShareText: "당신의 선택을 공유해 보세요.",
+    });
   });
 
   it("결말 판정 질문과 규칙을 제작자용 UI로 저장한다", () => {

--- a/apps/web/src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Edge, Node } from "@xyflow/react";
-import { buildEndingDecisionSummary, toEndingEditorViewModel } from "../endingEntityAdapter";
+import {
+  buildCharacterEndcardSummary,
+  buildEndingDecisionSummary,
+  toEndingEditorViewModel,
+} from "../endingEntityAdapter";
 
 function node(id: string, data: Record<string, unknown> = {}): Node {
   return { id, type: "ending", position: { x: 0, y: 0 }, data };
@@ -17,6 +21,9 @@ describe("endingEntityAdapter", () => {
       icon: "⚖️",
       description: "정답 결말",
       endingContent: "범인이 밝혀졌다.",
+      endingVisibility: "players_only",
+      endingSpoilerWarning: "스포일러 주의",
+      endingShareText: "감상을 공유해 주세요.",
     }), 2);
 
     expect(vm).toMatchObject({
@@ -25,9 +32,14 @@ describe("endingEntityAdapter", () => {
       icon: "⚖️",
       description: "정답 결말",
       contentPreview: "범인이 밝혀졌다.",
+      visibility: "players_only",
+      visibilityLabel: "참가자에게만 공개",
+      spoilerWarning: "스포일러 주의",
+      shareText: "감상을 공유해 주세요.",
       isReady: true,
     });
     expect(vm.badges).toContain("도달 경로 2개");
+    expect(vm.badges).toContain("참가자에게만 공개");
   });
 
   it("결말 준비 상태와 제작자용 경고를 요약한다", () => {
@@ -51,5 +63,19 @@ describe("endingEntityAdapter", () => {
 
     expect(summary.totalCount).toBe(0);
     expect(summary.warnings).toEqual(["최종 장면에서 보여줄 결말을 1개 이상 추가해 주세요."]);
+  });
+
+  it("캐릭터별 결과 카드 작성 현황을 요약한다", () => {
+    const summary = buildCharacterEndcardSummary([
+      { name: "하윤", endcard_title: "후일담", endcard_body: "", endcard_image_url: null },
+      { name: "민재", endcard_title: null, endcard_body: null, endcard_image_url: null },
+      { name: "서윤", endcard_title: "", endcard_body: "남겨진 이야기", endcard_image_url: "" },
+    ]);
+
+    expect(summary).toEqual({
+      totalCount: 3,
+      readyCount: 2,
+      missingNames: ["민재"],
+    });
   });
 });

--- a/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
@@ -1,5 +1,6 @@
 import type { Edge, Node } from "@xyflow/react";
-import type { FlowNodeData } from "../../flowTypes";
+import type { EndingVisibility, FlowNodeData } from "../../flowTypes";
+import type { EditorCharacterResponse } from "../../api";
 
 export interface EndingEditorViewModel {
   id: string;
@@ -7,8 +8,18 @@ export interface EndingEditorViewModel {
   icon: string;
   description: string;
   contentPreview: string;
+  visibility: EndingVisibility;
+  visibilityLabel: string;
+  spoilerWarning: string;
+  shareText: string;
   isReady: boolean;
   badges: string[];
+}
+
+export interface EndingCharacterEndcardSummary {
+  totalCount: number;
+  readyCount: number;
+  missingNames: string[];
 }
 
 export interface EndingDecisionSummary {
@@ -23,14 +34,19 @@ export function toEndingEditorViewModel(node: Node, incomingCount = 0): EndingEd
   const data = node.data as FlowNodeData;
   const name = data.label?.trim() || "이름 없는 결말";
   const content = data.endingContent?.trim() ?? "";
+  const visibility = normalizeEndingVisibility(data.endingVisibility);
   return {
     id: node.id,
     name,
     icon: data.icon?.trim() || "🎭",
     description: data.description?.trim() || "플레이어에게 보일 결말 설명을 작성해 주세요.",
     contentPreview: content || "결말 본문을 아직 작성하지 않았습니다.",
+    visibility,
+    visibilityLabel: endingVisibilityLabel(visibility),
+    spoilerWarning: data.endingSpoilerWarning?.trim() || "스포일러 주의: 게임 종료 후 공개되는 결말입니다.",
+    shareText: data.endingShareText?.trim() || "",
     isReady: Boolean(data.label?.trim() && content),
-    badges: buildEndingBadges(Boolean(data.label?.trim()), Boolean(content), incomingCount),
+    badges: buildEndingBadges(Boolean(data.label?.trim()), Boolean(content), incomingCount, visibility),
   };
 }
 
@@ -60,10 +76,50 @@ export function buildEndingDecisionSummary(nodes: Node[], edges: Edge[]): Ending
   };
 }
 
-function buildEndingBadges(hasName: boolean, hasContent: boolean, incomingCount: number): string[] {
+export function buildCharacterEndcardSummary(
+  characters: Pick<EditorCharacterResponse, "name" | "endcard_title" | "endcard_body" | "endcard_image_url">[],
+): EndingCharacterEndcardSummary {
+  const missingNames: string[] = [];
+  let readyCount = 0;
+
+  for (const character of characters) {
+    const hasEndcard = Boolean(
+      character.endcard_title?.trim() ||
+      character.endcard_body?.trim() ||
+      character.endcard_image_url?.trim(),
+    );
+    if (hasEndcard) readyCount += 1;
+    else missingNames.push(character.name);
+  }
+
+  return {
+    totalCount: characters.length,
+    readyCount,
+    missingNames,
+  };
+}
+
+export function normalizeEndingVisibility(value: unknown): EndingVisibility {
+  if (value === "players_only" || value === "private_note") return value;
+  return "public";
+}
+
+export function endingVisibilityLabel(value: EndingVisibility): string {
+  if (value === "players_only") return "참가자에게만 공개";
+  if (value === "private_note") return "제작자 메모";
+  return "전체 공개";
+}
+
+function buildEndingBadges(
+  hasName: boolean,
+  hasContent: boolean,
+  incomingCount: number,
+  visibility: EndingVisibility,
+): string[] {
   return [
     hasName ? "이름 있음" : "이름 필요",
     hasContent ? "본문 작성됨" : "본문 필요",
+    endingVisibilityLabel(visibility),
     incomingCount > 0 ? `도달 경로 ${incomingCount}개` : "아직 연결 없음",
   ];
 }

--- a/apps/web/src/features/editor/flowTypes.ts
+++ b/apps/web/src/features/editor/flowTypes.ts
@@ -11,6 +11,7 @@ export interface PhaseAction {
 }
 
 export type DiscussionRoomAvailability = "phase_active" | "condition";
+export type EndingVisibility = "public" | "players_only" | "private_note";
 
 export interface DiscussionRoomPolicy {
   enabled: boolean;
@@ -30,6 +31,9 @@ export interface FlowNodeData {
   icon?: string;
   color?: string;
   endingContent?: string;
+  endingVisibility?: EndingVisibility;
+  endingSpoilerWarning?: string;
+  endingShareText?: string;
   score_multiplier?: number;
   default_edge_id?: string;
   autoAdvance?: boolean;

--- a/apps/web/src/features/editor/flowTypes.ts
+++ b/apps/web/src/features/editor/flowTypes.ts
@@ -12,14 +12,21 @@ export interface PhaseAction {
 
 export type DiscussionRoomAvailability = "phase_active" | "condition";
 export type EndingVisibility = "public" | "players_only" | "private_note";
+export type DiscussionRoomKind = "all" | "small_group" | "private";
+export type DiscussionParticipantMode = "all" | "characters" | "condition";
+export type DiscussionRoomCloseBehavior = "close_on_exit" | "keep_until_next_scene";
 
 export interface DiscussionRoomPolicy {
   enabled: boolean;
+  roomKind: DiscussionRoomKind;
   mainRoomName: string;
   privateRoomsEnabled: boolean;
   privateRoomName: string;
+  participantMode: DiscussionParticipantMode;
+  participantSummary?: string;
   availability: DiscussionRoomAvailability;
   conditionalRoomName?: string;
+  closeBehavior: DiscussionRoomCloseBehavior;
 }
 
 export interface FlowNodeData {


### PR DESCRIPTION
## 요약

- 결말 상세 패널에 공개 범위, 스포일러 안내, 감상 공유 문구 편집 UI를 추가했습니다.
- 캐릭터별 결과 카드 작성 현황을 결말 관리 패널에서 확인할 수 있게 했습니다.
- 엔딩 노드 속성 패널에 결말 연결/준비 요약을 추가해 상세 편집 위치와 상태를 바로 알 수 있게 했습니다.

## 이슈

Closes #420
Refs #381

## Coverage Plan

- `endingEntityAdapter`: 공개 범위 ViewModel, 제작자용 badge, 캐릭터별 결과 카드 작성 현황 요약을 unit test로 고정했습니다.
- `EndingEntitySubTab` / `EndingEntityDetail`: 결말 본문, 공개 범위, 스포일러 안내, 감상 공유 문구 저장 payload와 엔드카드 작성 현황 표시를 Vitest로 검증했습니다.
- `EndingNodePanel`: 기존 debounce/flush 회귀 테스트를 유지하며 엔딩 노드 패널과 새 요약 카드가 함께 렌더링되는 범위를 확인했습니다.
- 플레이 결과 화면, GM override, 공유 링크 서비스, backend runtime resolve는 #420 제외 범위라 이번 PR에 포함하지 않았습니다.

## 검증

- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec eslint src/features/editor/flowTypes.ts src/features/editor/entities/ending/endingEntityAdapter.ts src/features/editor/components/design/EndingEntitySubTab.tsx src/features/editor/components/design/EndingEntityDetail.tsx src/features/editor/components/design/EndingNodePanel.tsx src/features/editor/components/design/NodeDetailPanel.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결말 공개 범위 설정 기능 추가 — 결말의 공개 대상(레이블 포함)을 편집·저장할 수 있습니다.
  * 캐릭터별 엔드카드 작성 현황 표시 — 완료/전체 및 누락된 이름을 요약해 표시합니다.
  * 결말 미리보기 패널 추가 — 에디터에서 결말 요약(이름, 미리보기, 배지)을 확인합니다.
  * 결말별 스포일러 경고 및 공유 텍스트 관리 기능 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->