### PR TITLE
feat(editor): 저장 충돌 복구 UI 보강

### DIFF
--- a/apps/web/src/features/editor/components/EditorSaveConflictBanner.tsx
+++ b/apps/web/src/features/editor/components/EditorSaveConflictBanner.tsx
@@ -1,0 +1,67 @@
+import { ClipboardCopy, RefreshCcw, X } from "lucide-react";
+
+interface EditorSaveConflictBannerProps {
+  scopeLabel: string;
+  onReload: () => void;
+  onPreserve: () => void;
+  onDismiss: () => void;
+}
+
+export function EditorSaveConflictBanner({
+  scopeLabel,
+  onReload,
+  onPreserve,
+  onDismiss,
+}: EditorSaveConflictBannerProps) {
+  return (
+    <section
+      role="alert"
+      aria-label={`${scopeLabel} 저장 충돌`}
+      className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-50"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-semibold">{scopeLabel} 저장 충돌이 발생했습니다</p>
+          <p className="text-xs leading-5 text-amber-100/80">
+            다른 탭이나 사용자가 더 최신 내용을 저장했습니다. 내 변경을 복사해 둔 뒤 최신 상태를
+            불러오면 덮어쓰기 위험을 줄일 수 있습니다.
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="충돌 안내 닫기"
+          onClick={onDismiss}
+          className="self-start rounded-lg p-1.5 text-amber-100/80 transition hover:bg-amber-500/20 hover:text-amber-50"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onReload}
+          className="inline-flex min-h-10 items-center gap-2 rounded-lg bg-amber-200 px-3 text-xs font-semibold text-slate-950 transition hover:bg-amber-100"
+        >
+          <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+          최신 상태 다시 불러오기
+        </button>
+        <button
+          type="button"
+          onClick={onPreserve}
+          className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-amber-300/50 px-3 text-xs font-semibold text-amber-50 transition hover:bg-amber-500/20"
+        >
+          <ClipboardCopy className="h-4 w-4" aria-hidden="true" />
+          내 변경 복사
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="inline-flex min-h-10 items-center rounded-lg border border-slate-700 px-3 text-xs font-semibold text-slate-200 transition hover:bg-slate-800"
+        >
+          취소
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/__tests__/EditorSaveConflictBanner.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorSaveConflictBanner.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditorSaveConflictBanner } from "../EditorSaveConflictBanner";
+
+describe("EditorSaveConflictBanner", () => {
+  it("저장 충돌 원인과 복구 행동을 표시하고 각 콜백을 호출한다", () => {
+    const onReload = vi.fn();
+    const onPreserve = vi.fn();
+    const onDismiss = vi.fn();
+
+    render(
+      <EditorSaveConflictBanner
+        scopeLabel="스토리 정보"
+        onReload={onReload}
+        onPreserve={onPreserve}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByRole("alert", { name: "스토리 정보 저장 충돌" })).toBeDefined();
+    expect(screen.getByText("스토리 정보 저장 충돌이 발생했습니다")).toBeDefined();
+    expect(screen.getByText(/다른 탭이나 사용자가 더 최신 내용을 저장했습니다/)).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "최신 상태 다시 불러오기" }));
+    expect(onReload).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "내 변경 복사" }));
+    expect(onPreserve).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+    fireEvent.click(screen.getByRole("button", { name: "충돌 안내 닫기" }));
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -54,7 +54,12 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
   });
 
   const mutateConfig = useCallback(
-    (nextConfig: Record<string, unknown>, successMsg: string, errorMsg: string) => {
+    (
+      nextConfig: Record<string, unknown>,
+      successMsg: string,
+      errorMsg: string,
+      onRollback?: () => void,
+    ) => {
       conflictRef.current = false;
       updateConfig.mutate(
         { ...nextConfig, version: theme.version },
@@ -69,6 +74,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
               setConflictDraft(nextConfig);
               setConflictBannerDismissed(false);
             } else {
+              onRollback?.();
               toast.error(errorMsg);
             }
           },
@@ -129,7 +135,8 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
         mutateConfig(
           writeModuleEnabled(activeConfig, moduleId, enabled),
           '모듈 설정이 저장되었습니다',
-          '모듈 설정 저장에 실패했습니다'
+          '모듈 설정 저장에 실패했습니다',
+          () => setSelectedModules(prev),
         );
 
         return next;

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -38,9 +38,14 @@ interface ModulesSubTabProps {
 export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
   const { data: moduleSchemasResp } = useModuleSchemas();
   const [conflictDraft, setConflictDraft] = useState<Record<string, unknown> | null>(null);
+  const [isConflictBannerDismissed, setConflictBannerDismissed] = useState(false);
   // conflictRef distinguishes conflict-after-retry from generic errors in
   // onError. useRef avoids re-creating the hook on every render.
   const conflictRef = useRef(false);
+  const activeConfig = useMemo(
+    () => conflictDraft ?? theme.config_json ?? {},
+    [conflictDraft, theme.config_json]
+  );
   const updateConfig = useUpdateConfigJson(themeId, {
     onConflictAfterRetry: () => {
       conflictRef.current = true;
@@ -54,50 +59,60 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
       updateConfig.mutate(
         { ...nextConfig, version: theme.version },
         {
-          onSuccess: () => toast.success(successMsg),
+          onSuccess: () => {
+            setConflictDraft(null);
+            setConflictBannerDismissed(false);
+            toast.success(successMsg);
+          },
           onError: () => {
             if (conflictRef.current) {
               setConflictDraft(nextConfig);
+              setConflictBannerDismissed(false);
             } else {
               toast.error(errorMsg);
             }
           },
-        },
+        }
       );
     },
-    [theme.version, updateConfig],
+    [theme.version, updateConfig]
   );
 
   const handleReloadAfterConflict = useCallback(() => {
     setConflictDraft(null);
+    setConflictBannerDismissed(false);
     queryClient.invalidateQueries({ queryKey: editorKeys.theme(themeId) });
   }, [themeId]);
 
-  const handleCopyConflictDraft = useCallback(() => {
+  const handleCopyConflictDraft = useCallback(async () => {
     const serialized = [
       '모듈 설정 변경 백업',
       '최신 상태를 다시 불러온 뒤 필요한 값을 참고해 다시 적용하세요.',
       '',
       JSON.stringify(conflictDraft ?? theme.config_json ?? {}, null, 2),
     ].join('\n');
-    void navigator.clipboard?.writeText(serialized);
-    toast.success('내 변경 내용을 클립보드에 복사했습니다');
+    try {
+      if (!navigator.clipboard) {
+        throw new Error('Clipboard API is not available');
+      }
+      await navigator.clipboard.writeText(serialized);
+      toast.success('내 변경 내용을 클립보드에 복사했습니다');
+    } catch {
+      toast.error('클립보드에 복사할 수 없습니다');
+    }
   }, [conflictDraft, theme.config_json]);
 
-  const serverModules = useMemo(
-    () => readEnabledModuleIds(theme.config_json),
-    [theme.config_json],
-  );
+  const serverModules = useMemo(() => readEnabledModuleIds(activeConfig), [activeConfig]);
 
   const moduleConfigs = useMemo((): Record<string, Record<string, unknown>> => {
     const result: Record<string, Record<string, unknown>> = {};
     for (const cat of OPTIONAL_MODULE_CATEGORIES) {
       for (const mod of cat.modules) {
-        result[mod.id] = readModuleConfig(theme.config_json, mod.id);
+        result[mod.id] = readModuleConfig(activeConfig, mod.id);
       }
     }
     return result;
-  }, [theme.config_json]);
+  }, [activeConfig]);
 
   const [selectedModules, setSelectedModules] = useState<string[]>(serverModules);
 
@@ -109,39 +124,37 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
     (moduleId: string) => {
       setSelectedModules((prev) => {
         const enabled = !prev.includes(moduleId);
-        const next = enabled
-          ? [...prev, moduleId]
-          : prev.filter((id) => id !== moduleId);
+        const next = enabled ? [...prev, moduleId] : prev.filter((id) => id !== moduleId);
 
         mutateConfig(
-          writeModuleEnabled(theme.config_json, moduleId, enabled),
+          writeModuleEnabled(activeConfig, moduleId, enabled),
           '모듈 설정이 저장되었습니다',
-          '모듈 설정 저장에 실패했습니다',
+          '모듈 설정 저장에 실패했습니다'
         );
 
         return next;
       });
     },
-    [theme.config_json, mutateConfig],
+    [activeConfig, mutateConfig]
   );
 
   const handleConfigChange = useCallback(
     (moduleId: string, path: string, value: unknown) => {
-      const nextConfig = writeModuleConfigPath(theme.config_json, moduleId, path, value);
+      const nextConfig = writeModuleConfigPath(activeConfig, moduleId, path, value);
       mutateConfig(nextConfig, '설정이 저장되었습니다', '설정 저장에 실패했습니다');
     },
-    [theme.config_json, mutateConfig],
+    [activeConfig, mutateConfig]
   );
 
   const handleDeckInvestigationChange = useCallback(
     (draft: DeckInvestigationConfigDraft) => {
       mutateConfig(
-        writeDeckInvestigationConfig(theme.config_json, draft),
+        writeDeckInvestigationConfig(activeConfig, draft),
         '조사권 설정이 저장되었습니다',
-        '조사권 설정 저장에 실패했습니다',
+        '조사권 설정 저장에 실패했습니다'
       );
     },
-    [theme.config_json, mutateConfig],
+    [activeConfig, mutateConfig]
   );
 
   const schemaMap = useMemo((): Record<string, TemplateSchema | null> => {
@@ -158,19 +171,17 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
 
   return (
     <div className="h-full overflow-y-auto p-4 space-y-6">
-      {conflictDraft && (
+      {conflictDraft && !isConflictBannerDismissed && (
         <EditorSaveConflictBanner
           scopeLabel="모듈 설정"
           onReload={handleReloadAfterConflict}
           onPreserve={handleCopyConflictDraft}
-          onDismiss={() => setConflictDraft(null)}
+          onDismiss={() => setConflictBannerDismissed(true)}
         />
       )}
 
       {OPTIONAL_MODULE_CATEGORIES.map((category) => {
-        const activeCount = category.modules.filter((m) =>
-          selectedModules.includes(m.id),
-        ).length;
+        const activeCount = category.modules.filter((m) => selectedModules.includes(m.id)).length;
 
         return (
           <section key={category.key}>
@@ -191,14 +202,13 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
                 const schema = schemaMap[mod.id] ?? null;
 
                 return (
-                  <div
-                    key={mod.id}
-                    className="rounded-lg border border-slate-700 bg-slate-800/50"
-                  >
+                  <div key={mod.id} className="rounded-lg border border-slate-700 bg-slate-800/50">
                     {/* Card header row */}
                     <div className="flex items-center gap-3 p-3">
                       <div className="flex-1 min-w-0">
-                        <p className={`text-xs font-medium ${isEnabled ? 'text-slate-200' : 'text-slate-500'}`}>
+                        <p
+                          className={`text-xs font-medium ${isEnabled ? 'text-slate-200' : 'text-slate-500'}`}
+                        >
                           {mod.name}
                         </p>
                         <p className="text-[10px] text-slate-600 mt-0.5 truncate">
@@ -212,6 +222,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
                         aria-checked={isEnabled}
                         aria-label={`${mod.name} ${isEnabled ? '비활성화' : '활성화'}`}
                         onClick={() => handleToggle(mod.id)}
+                        disabled={updateConfig.isPending}
                         className={`relative shrink-0 h-5 w-9 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                           isEnabled ? 'bg-amber-500' : 'bg-slate-700'
                         }`}
@@ -226,7 +237,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
 
                     {isEnabled && mod.id === DECK_INVESTIGATION_MODULE_ID && (
                       <InvestigationTokenSettingsPanel
-                        draft={readDeckInvestigationConfig(theme.config_json)}
+                        draft={readDeckInvestigationConfig(activeConfig)}
                         isSaving={updateConfig.isPending}
                         onChange={handleDeckInvestigationChange}
                       />

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -6,6 +6,7 @@ import { useUpdateConfigJson } from '@/features/editor/editorConfigApi';
 import { queryClient } from '@/services/queryClient';
 import { OPTIONAL_MODULE_CATEGORIES } from '@/features/editor/constants';
 import type { TemplateSchema } from '@/features/editor/templateApi';
+import { EditorSaveConflictBanner } from '@/features/editor/components/EditorSaveConflictBanner';
 import { SchemaDrivenForm } from '@/features/editor/components/SchemaDrivenForm';
 import {
   DECK_INVESTIGATION_MODULE_ID,
@@ -20,8 +21,6 @@ import {
   writeModuleConfigPath,
   writeModuleEnabled,
 } from '@/features/editor/utils/configShape';
-
-const CONFLICT_SNACKBAR_MSG = '동시 편집 충돌 — 최신 상태 다시 불러오기';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,6 +37,7 @@ interface ModulesSubTabProps {
 
 export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
   const { data: moduleSchemasResp } = useModuleSchemas();
+  const [conflictDraft, setConflictDraft] = useState<Record<string, unknown> | null>(null);
   // conflictRef distinguishes conflict-after-retry from generic errors in
   // onError. useRef avoids re-creating the hook on every render.
   const conflictRef = useRef(false);
@@ -57,7 +57,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
           onSuccess: () => toast.success(successMsg),
           onError: () => {
             if (conflictRef.current) {
-              toast.error(CONFLICT_SNACKBAR_MSG);
+              setConflictDraft(nextConfig);
             } else {
               toast.error(errorMsg);
             }
@@ -67,6 +67,22 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
     },
     [theme.version, updateConfig],
   );
+
+  const handleReloadAfterConflict = useCallback(() => {
+    setConflictDraft(null);
+    queryClient.invalidateQueries({ queryKey: editorKeys.theme(themeId) });
+  }, [themeId]);
+
+  const handleCopyConflictDraft = useCallback(() => {
+    const serialized = [
+      '모듈 설정 변경 백업',
+      '최신 상태를 다시 불러온 뒤 필요한 값을 참고해 다시 적용하세요.',
+      '',
+      JSON.stringify(conflictDraft ?? theme.config_json ?? {}, null, 2),
+    ].join('\n');
+    void navigator.clipboard?.writeText(serialized);
+    toast.success('내 변경 내용을 클립보드에 복사했습니다');
+  }, [conflictDraft, theme.config_json]);
 
   const serverModules = useMemo(
     () => readEnabledModuleIds(theme.config_json),
@@ -142,6 +158,15 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
 
   return (
     <div className="h-full overflow-y-auto p-4 space-y-6">
+      {conflictDraft && (
+        <EditorSaveConflictBanner
+          scopeLabel="모듈 설정"
+          onReload={handleReloadAfterConflict}
+          onPreserve={handleCopyConflictDraft}
+          onDismiss={() => setConflictDraft(null)}
+        />
+      )}
+
       {OPTIONAL_MODULE_CATEGORIES.map((category) => {
         const activeCount = category.modules.filter((m) =>
           selectedModules.includes(m.id),

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -60,6 +60,10 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
       errorMsg: string,
       onRollback?: () => void,
     ) => {
+      if (updateConfig.isPending) {
+        return;
+      }
+
       conflictRef.current = false;
       updateConfig.mutate(
         { ...nextConfig, version: theme.version },
@@ -128,6 +132,10 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
 
   const handleToggle = useCallback(
     (moduleId: string) => {
+      if (updateConfig.isPending) {
+        return;
+      }
+
       setSelectedModules((prev) => {
         const enabled = !prev.includes(moduleId);
         const next = enabled ? [...prev, moduleId] : prev.filter((id) => id !== moduleId);
@@ -142,26 +150,34 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
         return next;
       });
     },
-    [activeConfig, mutateConfig]
+    [activeConfig, mutateConfig, updateConfig.isPending]
   );
 
   const handleConfigChange = useCallback(
     (moduleId: string, path: string, value: unknown) => {
+      if (updateConfig.isPending) {
+        return;
+      }
+
       const nextConfig = writeModuleConfigPath(activeConfig, moduleId, path, value);
       mutateConfig(nextConfig, '설정이 저장되었습니다', '설정 저장에 실패했습니다');
     },
-    [activeConfig, mutateConfig]
+    [activeConfig, mutateConfig, updateConfig.isPending]
   );
 
   const handleDeckInvestigationChange = useCallback(
     (draft: DeckInvestigationConfigDraft) => {
+      if (updateConfig.isPending) {
+        return;
+      }
+
       mutateConfig(
         writeDeckInvestigationConfig(activeConfig, draft),
         '조사권 설정이 저장되었습니다',
         '조사권 설정 저장에 실패했습니다'
       );
     },
-    [activeConfig, mutateConfig]
+    [activeConfig, mutateConfig, updateConfig.isPending]
   );
 
   const schemaMap = useMemo((): Record<string, TemplateSchema | null> => {

--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
@@ -407,9 +407,11 @@ describe('ModulesSubTab', () => {
 
     // No conflict handler fired — regular failure
     const [, callbacks] = mutateMock.mock.calls[0] as [unknown, { onError: () => void }];
-    callbacks.onError();
+    act(() => callbacks.onError());
 
     expect(toast.error).toHaveBeenCalledWith('모듈 설정 저장에 실패했습니다');
+    const rolledBackToggle = screen.getByRole('switch', { name: `${optionalMod.name} 활성화` });
+    expect(rolledBackToggle.getAttribute('aria-checked')).toBe('false');
   });
 
   it('REQUIRED_MODULE_IDS의 모듈은 toggle 버튼이 없다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
@@ -1,12 +1,18 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, act, waitFor } from '@testing-library/react';
 import { toast } from 'sonner';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { mutateMock, useUpdateConfigJsonMock, useModuleSchemasMock, invalidateQueriesMock, writeTextMock } = vi.hoisted(() => ({
+const {
+  mutateMock,
+  useUpdateConfigJsonMock,
+  useModuleSchemasMock,
+  invalidateQueriesMock,
+  writeTextMock,
+} = vi.hoisted(() => ({
   mutateMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
   useModuleSchemasMock: vi.fn(),
@@ -51,10 +57,7 @@ vi.mock('@/features/editor/components/SchemaDrivenForm', () => ({
   }) => (
     <div data-testid="schema-driven-form">
       <span>{schema?.title ?? 'form'}</span>
-      <button
-        type="button"
-        onClick={() => onChange('candidatePolicy.includeDetective', true)}
-      >
+      <button type="button" onClick={() => onChange('candidatePolicy.includeDetective', true)}>
         탐정 포함 저장
       </button>
     </div>
@@ -109,6 +112,7 @@ beforeEach(() => {
       writeText: writeTextMock,
     },
   });
+  writeTextMock.mockResolvedValue(undefined);
   capturedConflictHandler = undefined;
   useUpdateConfigJsonMock.mockImplementation((opts?: { onConflictAfterRetry?: () => void }) => {
     capturedConflictHandler = opts?.onConflictAfterRetry;
@@ -307,7 +311,7 @@ describe('ModulesSubTab', () => {
     expect(config.version).toBe(42);
   });
 
-  it('conflict-after-retry 시 저장 충돌 복구 배너를 표시한다', () => {
+  it('conflict-after-retry 시 저장 충돌 복구 배너를 표시한다', async () => {
     const optionalMod = OPTIONAL_MODULE_CATEGORIES[0].modules[0];
 
     render(<ModulesSubTab themeId="theme-1" theme={baseTheme} />);
@@ -315,10 +319,7 @@ describe('ModulesSubTab', () => {
 
     // Simulate hook's conflict path: first onConflictAfterRetry, then onError
     capturedConflictHandler?.();
-    const [, callbacks] = mutateMock.mock.calls[0] as [
-      unknown,
-      { onError: () => void },
-    ];
+    const [, callbacks] = mutateMock.mock.calls[0] as [unknown, { onError: () => void }];
     act(() => callbacks.onError());
 
     expect(screen.getByRole('alert', { name: '모듈 설정 저장 충돌' })).toBeDefined();
@@ -326,13 +327,76 @@ describe('ModulesSubTab', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '내 변경 복사' }));
     expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining(optionalMod.id));
-    expect(toast.success).toHaveBeenCalledWith('내 변경 내용을 클립보드에 복사했습니다');
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith('내 변경 내용을 클립보드에 복사했습니다')
+    );
 
     fireEvent.click(screen.getByRole('button', { name: '최신 상태 다시 불러오기' }));
     expect(invalidateQueriesMock).toHaveBeenCalledWith({
       queryKey: ['editor', 'themes', 'theme-1'],
     });
     expect(screen.queryByRole('alert', { name: '모듈 설정 저장 충돌' })).toBeNull();
+  });
+
+  it('conflict draft 복사 실패 시 오류 토스트를 표시한다', async () => {
+    writeTextMock.mockRejectedValueOnce(new Error('denied'));
+    const optionalMod = OPTIONAL_MODULE_CATEGORIES[0].modules[0];
+
+    render(<ModulesSubTab themeId="theme-1" theme={baseTheme} />);
+    fireEvent.click(screen.getByRole('switch', { name: `${optionalMod.name} 활성화` }));
+
+    capturedConflictHandler?.();
+    const [, callbacks] = mutateMock.mock.calls[0] as [unknown, { onError: () => void }];
+    act(() => callbacks.onError());
+
+    fireEvent.click(screen.getByRole('button', { name: '내 변경 복사' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('클립보드에 복사할 수 없습니다'));
+    expect(toast.success).not.toHaveBeenCalledWith('내 변경 내용을 클립보드에 복사했습니다');
+  });
+
+  it('충돌 배너를 닫아도 후속 저장은 conflict draft 위에 누적된다', () => {
+    const themeWithVoting: EditorThemeResponse = {
+      ...baseTheme,
+      config_json: {
+        modules: {
+          voting: {
+            enabled: true,
+            config: { candidatePolicy: { includeSelf: false }, maxRounds: 3 },
+          },
+        },
+      },
+    };
+    useModuleSchemasMock.mockReturnValue({
+      data: {
+        schemas: {
+          voting: { type: 'object', title: '투표 설정', properties: {} },
+        },
+      },
+      isLoading: false,
+    });
+
+    render(<ModulesSubTab themeId="theme-1" theme={themeWithVoting} />);
+    fireEvent.click(screen.getByRole('button', { name: '탐정 포함 저장' }));
+
+    capturedConflictHandler?.();
+    const [, callbacks] = mutateMock.mock.calls[0] as [unknown, { onError: () => void }];
+    act(() => callbacks.onError());
+    fireEvent.click(screen.getByRole('button', { name: '취소' }));
+
+    fireEvent.click(screen.getByRole('switch', { name: '텍스트 채팅 활성화' }));
+
+    const [config] = mutateMock.mock.calls[1] as [Record<string, unknown>];
+    expect(config.modules).toMatchObject({
+      voting: {
+        enabled: true,
+        config: {
+          maxRounds: 3,
+          candidatePolicy: { includeSelf: false, includeDetective: true },
+        },
+      },
+      text_chat: { enabled: true },
+    });
   });
 
   it('일반 에러는 기본 에러 메시지를 표시한다 (충돌 아님)', () => {
@@ -342,10 +406,7 @@ describe('ModulesSubTab', () => {
     fireEvent.click(screen.getByRole('switch', { name: `${optionalMod.name} 활성화` }));
 
     // No conflict handler fired — regular failure
-    const [, callbacks] = mutateMock.mock.calls[0] as [
-      unknown,
-      { onError: () => void },
-    ];
+    const [, callbacks] = mutateMock.mock.calls[0] as [unknown, { onError: () => void }];
     callbacks.onError();
 
     expect(toast.error).toHaveBeenCalledWith('모듈 설정 저장에 실패했습니다');

--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { toast } from 'sonner';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { mutateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(() => ({
+const { mutateMock, useUpdateConfigJsonMock, useModuleSchemasMock, invalidateQueriesMock, writeTextMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
   useModuleSchemasMock: vi.fn(),
+  invalidateQueriesMock: vi.fn(),
+  writeTextMock: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -34,7 +36,7 @@ vi.mock('@/features/editor/editorConfigApi', () => ({
 }));
 
 vi.mock('@/services/queryClient', () => ({
-  queryClient: { invalidateQueries: vi.fn() },
+  queryClient: { invalidateQueries: invalidateQueriesMock },
 }));
 
 vi.mock('@/features/editor/templateApi', () => ({}));
@@ -102,6 +104,11 @@ const baseTheme: EditorThemeResponse = {
 let capturedConflictHandler: (() => void) | undefined;
 
 beforeEach(() => {
+  Object.assign(navigator, {
+    clipboard: {
+      writeText: writeTextMock,
+    },
+  });
   capturedConflictHandler = undefined;
   useUpdateConfigJsonMock.mockImplementation((opts?: { onConflictAfterRetry?: () => void }) => {
     capturedConflictHandler = opts?.onConflictAfterRetry;
@@ -300,7 +307,7 @@ describe('ModulesSubTab', () => {
     expect(config.version).toBe(42);
   });
 
-  it('conflict-after-retry 시 Snackbar 충돌 메시지를 표시한다', () => {
+  it('conflict-after-retry 시 저장 충돌 복구 배너를 표시한다', () => {
     const optionalMod = OPTIONAL_MODULE_CATEGORIES[0].modules[0];
 
     render(<ModulesSubTab themeId="theme-1" theme={baseTheme} />);
@@ -312,11 +319,20 @@ describe('ModulesSubTab', () => {
       unknown,
       { onError: () => void },
     ];
-    callbacks.onError();
+    act(() => callbacks.onError());
 
-    expect(toast.error).toHaveBeenCalledWith(
-      '동시 편집 충돌 — 최신 상태 다시 불러오기',
-    );
+    expect(screen.getByRole('alert', { name: '모듈 설정 저장 충돌' })).toBeDefined();
+    expect(screen.getByText(/다른 탭이나 사용자가 더 최신 내용을 저장했습니다/)).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: '내 변경 복사' }));
+    expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining(optionalMod.id));
+    expect(toast.success).toHaveBeenCalledWith('내 변경 내용을 클립보드에 복사했습니다');
+
+    fireEvent.click(screen.getByRole('button', { name: '최신 상태 다시 불러오기' }));
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['editor', 'themes', 'theme-1'],
+    });
+    expect(screen.queryByRole('alert', { name: '모듈 설정 저장 충돌' })).toBeNull();
   });
 
   it('일반 에러는 기본 에러 메시지를 표시한다 (충돌 아님)', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx
@@ -225,6 +225,21 @@ describe('ModulesSubTab', () => {
     expect(config.modules).toMatchObject({ [optionalMod.id]: { enabled: false } });
   });
 
+  it('저장 중에는 추가 모듈 토글 저장을 시작하지 않는다', () => {
+    const optionalMod = OPTIONAL_MODULE_CATEGORIES[0].modules[0];
+    useUpdateConfigJsonMock.mockReturnValue({ mutate: mutateMock, isPending: true });
+
+    render(<ModulesSubTab themeId="theme-1" theme={baseTheme} />);
+
+    const toggleBtn = screen.getByRole('switch', { name: `${optionalMod.name} 활성화` });
+    expect(toggleBtn).toHaveProperty('disabled', true);
+
+    fireEvent.click(toggleBtn);
+
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(toggleBtn.getAttribute('aria-checked')).toBe('false');
+  });
+
   it('활성화 + 스키마 있으면 SchemaDrivenForm이 바로 렌더링된다', () => {
     const optionalMod = OPTIONAL_MODULE_CATEGORIES[0].modules[0];
     const themeWithMod: EditorThemeResponse = {

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -219,10 +219,7 @@ export function ReadingSectionEditor({
   }
 
   function handleCopyDraft() {
-    const text = [
-      `섹션: ${draft.name}`,
-      draft.lines.map((line) => `${line.Speaker ? `${line.Speaker}: ` : ""}${line.Text}`).join("\n"),
-    ].join("\n\n");
+    const text = JSON.stringify(draft, null, 2);
     void navigator.clipboard?.writeText(text);
   }
 

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Music, Plus, Save, Trash2, X } from "lucide-react";
+import { toast } from "sonner";
 
 import { queryClient } from "@/services/queryClient";
 import { isApiHttpError } from "@/lib/api-error";
@@ -218,9 +219,17 @@ export function ReadingSectionEditor({
     queryClient.invalidateQueries({ queryKey: readingKeys.list(themeId) });
   }
 
-  function handleCopyDraft() {
+  async function handleCopyDraft() {
     const text = JSON.stringify(draft, null, 2);
-    void navigator.clipboard?.writeText(text);
+    try {
+      if (!navigator.clipboard) {
+        throw new Error("Clipboard API is not available");
+      }
+      await navigator.clipboard.writeText(text);
+      toast.success("내 변경 내용을 클립보드에 복사했습니다");
+    } catch {
+      toast.error("클립보드에 복사할 수 없습니다");
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Music, Plus, RefreshCcw, Save, Trash2, X } from "lucide-react";
+import { Music, Plus, Save, Trash2, X } from "lucide-react";
 
 import { queryClient } from "@/services/queryClient";
 import { isApiHttpError } from "@/lib/api-error";
@@ -16,6 +16,7 @@ import { MediaPicker } from "../media/MediaPicker";
 import type { MediaResponse } from "../../mediaApi";
 import { useMediaList } from "../../mediaApi";
 import { ReadingLineRow } from "./ReadingLineRow";
+import { EditorSaveConflictBanner } from "../EditorSaveConflictBanner";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -213,7 +214,16 @@ export function ReadingSectionEditor({
   }
 
   function handleRefresh() {
+    setConflict(false);
     queryClient.invalidateQueries({ queryKey: readingKeys.list(themeId) });
+  }
+
+  function handleCopyDraft() {
+    const text = [
+      `섹션: ${draft.name}`,
+      draft.lines.map((line) => `${line.Speaker ? `${line.Speaker}: ` : ""}${line.Text}`).join("\n"),
+    ].join("\n\n");
+    void navigator.clipboard?.writeText(text);
   }
 
   // -------------------------------------------------------------------------
@@ -223,17 +233,12 @@ export function ReadingSectionEditor({
   return (
     <div className="space-y-4">
       {conflict && (
-        <div className="flex items-center justify-between rounded border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
-          <span>다른 곳에서 수정되었습니다. 새로고침이 필요합니다.</span>
-          <button
-            type="button"
-            onClick={handleRefresh}
-            className="flex items-center gap-1 rounded bg-rose-500/20 px-2 py-1 text-rose-100 hover:bg-rose-500/30"
-          >
-            <RefreshCcw className="h-3 w-3" />
-            새로고침
-          </button>
-        </div>
+        <EditorSaveConflictBanner
+          scopeLabel="읽기 대사"
+          onReload={handleRefresh}
+          onPreserve={handleCopyDraft}
+          onDismiss={() => setConflict(false)}
+        />
       )}
 
       {saveError && !conflict && (

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -39,6 +40,10 @@ vi.mock("@/services/queryClient", () => ({
   queryClient: {
     invalidateQueries: invalidateQueriesMock,
   },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 // ---------------------------------------------------------------------------
@@ -100,6 +105,7 @@ beforeEach(() => {
       writeText: writeTextMock,
     },
   });
+  writeTextMock.mockResolvedValue(undefined);
   mutateAsyncUpdate = vi.fn().mockResolvedValue(sampleSection);
   mutateAsyncDelete = vi.fn().mockResolvedValue(undefined);
 
@@ -357,6 +363,9 @@ describe("ReadingSectionEditor", () => {
         2,
       ),
     );
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("내 변경 내용을 클립보드에 복사했습니다"),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "최신 상태 다시 불러오기" }));
     expect(invalidateQueriesMock).toHaveBeenCalled();
@@ -369,5 +378,25 @@ describe("ReadingSectionEditor", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "취소" }));
     expect(screen.queryByRole("alert", { name: "읽기 대사 저장 충돌" })).toBeNull();
+  });
+
+  it("copy draft reports clipboard failure", async () => {
+    writeTextMock.mockRejectedValueOnce(new Error("denied"));
+    mutateAsyncUpdate.mockRejectedValueOnce(new Error("HTTP 409 Conflict"));
+
+    renderEditor();
+    const input = screen.getByLabelText("섹션 이름") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "x" } });
+    fireEvent.click(screen.getByRole("button", { name: /저장/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert", { name: "읽기 대사 저장 충돌" })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "내 변경 복사" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("클립보드에 복사할 수 없습니다"),
+    );
+    expect(toast.success).not.toHaveBeenCalledWith("내 변경 내용을 클립보드에 복사했습니다");
   });
 });

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -10,11 +10,13 @@ const {
   useDeleteReadingSectionMock,
   useMediaListMock,
   invalidateQueriesMock,
+  writeTextMock,
 } = vi.hoisted(() => ({
   useUpdateReadingSectionMock: vi.fn(),
   useDeleteReadingSectionMock: vi.fn(),
   useMediaListMock: vi.fn(),
   invalidateQueriesMock: vi.fn(),
+  writeTextMock: vi.fn(),
 }));
 
 vi.mock("@/features/editor/readingApi", async () => {
@@ -93,6 +95,11 @@ let mutateAsyncUpdate: ReturnType<typeof vi.fn>;
 let mutateAsyncDelete: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  Object.assign(navigator, {
+    clipboard: {
+      writeText: writeTextMock,
+    },
+  });
   mutateAsyncUpdate = vi.fn().mockResolvedValue(sampleSection);
   mutateAsyncDelete = vi.fn().mockResolvedValue(undefined);
 
@@ -325,7 +332,7 @@ describe("ReadingSectionEditor", () => {
     await waitFor(() => expect(onDeleted).toHaveBeenCalled());
   });
 
-  it("409 conflict error shows refresh prompt", async () => {
+  it("409 conflict error shows reload, preserve, and cancel recovery actions", async () => {
     mutateAsyncUpdate.mockRejectedValueOnce(new Error("HTTP 409 Conflict"));
     renderEditor();
     const input = screen.getByLabelText("섹션 이름") as HTMLInputElement;
@@ -333,10 +340,23 @@ describe("ReadingSectionEditor", () => {
     fireEvent.click(screen.getByRole("button", { name: /저장/ }));
 
     await waitFor(() =>
-      expect(screen.getByText(/다른 곳에서 수정되었습니다/)).toBeTruthy(),
+      expect(screen.getByRole("alert", { name: "읽기 대사 저장 충돌" })).toBeTruthy(),
     );
+    expect(screen.getByText(/다른 탭이나 사용자가 더 최신 내용을 저장했습니다/)).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: /새로고침/ }));
+    fireEvent.click(screen.getByRole("button", { name: "내 변경 복사" }));
+    expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("섹션: x"));
+
+    fireEvent.click(screen.getByRole("button", { name: "최신 상태 다시 불러오기" }));
     expect(invalidateQueriesMock).toHaveBeenCalled();
+    expect(screen.queryByRole("alert", { name: "읽기 대사 저장 충돌" })).toBeNull();
+
+    mutateAsyncUpdate.mockRejectedValueOnce(new Error("HTTP 409 Conflict"));
+    fireEvent.click(screen.getByRole("button", { name: /저장/ }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert", { name: "읽기 대사 저장 충돌" })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+    expect(screen.queryByRole("alert", { name: "읽기 대사 저장 충돌" })).toBeNull();
   });
 });

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -345,7 +345,18 @@ describe("ReadingSectionEditor", () => {
     expect(screen.getByText(/다른 탭이나 사용자가 더 최신 내용을 저장했습니다/)).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "내 변경 복사" }));
-    expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("섹션: x"));
+    expect(writeTextMock).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          name: "x",
+          bgmMediaId: sampleSection.bgmMediaId,
+          lines: sampleSection.lines,
+          sortOrder: sampleSection.sortOrder,
+        },
+        null,
+        2,
+      ),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "최신 상태 다시 불러오기" }));
     expect(invalidateQueriesMock).toHaveBeenCalled();


### PR DESCRIPTION
## 요약
- 모듈 설정과 읽기 대사 저장 409 충돌에서 공통 복구 배너를 표시합니다.
- 제작자가 최신 상태 다시 불러오기, 내 변경 복사, 취소를 선택할 수 있게 했습니다.
- 기존 409 감지와 backend 저장 계약은 유지하고, 자동 병합/협업 편집 정책은 추가하지 않았습니다.

Closes #421
Refs #381
Refs #271

## Coverage Plan
- `EditorSaveConflictBanner`: 충돌 원인 안내와 reload/preserve/cancel/dismiss 버튼 콜백을 단위 테스트로 검증했습니다.
- `ModulesSubTab`: 409 재시도 실패와 일반 저장 실패를 분리하고, 충돌 배너의 복사/재조회 동작을 검증했습니다.
- `ReadingSectionEditor`: 읽기 대사 저장 409에서 최신 불러오기, 내 변경 복사, 취소 동작을 검증했습니다.
- `editorConfigApi`: 기존 409 `current_version` 재시도 계약 테스트를 유지했습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/EditorSaveConflictBanner.test.tsx src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/editorConfigApi.test.ts`
- `pnpm --filter @mmp/web exec eslint src/features/editor/components/EditorSaveConflictBanner.tsx src/features/editor/components/__tests__/EditorSaveConflictBanner.test.tsx src/features/editor/components/design/ModulesSubTab.tsx src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx src/features/editor/components/reading/ReadingSectionEditor.tsx src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx`
- `git diff --check`

## PR 묶음 판단
- #421 저장 충돌 UX와 테스트만 묶었습니다. 백엔드 conflict policy, 실시간 협업, 자동 merge/rebase engine은 이 PR에 섞지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 에디터 저장 충돌 배너(EditorSaveConflictBanner) 추가: 충돌 시 최신 버전 재로드, 변경사항 복사(클립보드), 취소 옵션 제공. Modules 서브탭과 읽기 섹션에 통합되고 즉시 토스트 대신 드래프트 기반 복구 흐름으로 전환. 저장 중 모듈 토글 비활성화 처리 추가.

* **테스트**
  * 배너 동작(재로드·복사·취소), 클립보드 성공/실패 경로, 충돌 복구 시나리오 및 관련 동작을 검증하는 단위/통합 테스트 추가 및 기존 테스트 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->