### PR TITLE
feat(editor): 라운드 공개 미리보기 추가

### DIFF
--- a/apps/web/src/features/editor/components/story-map/RoundVisibilityPreviewPanel.tsx
+++ b/apps/web/src/features/editor/components/story-map/RoundVisibilityPreviewPanel.tsx
@@ -1,0 +1,138 @@
+import { AlertTriangle, Eye, MapPin, Search } from "lucide-react";
+
+import { useEditorClues, useEditorLocations } from "@/features/editor/api";
+import { buildRoundVisibilityPreview } from "@/features/editor/entities/validation/roundVisibilityPreview";
+
+interface RoundVisibilityPreviewPanelProps {
+  themeId: string;
+}
+
+function PreviewList({
+  title,
+  icon: Icon,
+  items,
+  emptyText,
+}: {
+  title: string;
+  icon: typeof Search;
+  items: Array<{ id: string; name: string; scheduleLabel: string }>;
+  emptyText: string;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-[11px] font-semibold text-slate-400">
+        <Icon className="h-3.5 w-3.5 text-amber-400" aria-hidden="true" />
+        {title} {items.length}
+      </div>
+      <ul className="mt-2 space-y-1">
+        {items.length === 0 ? (
+          <li className="text-xs text-slate-600">{emptyText}</li>
+        ) : (
+          items.slice(0, 3).map((item) => (
+            <li key={item.id} className="min-w-0 text-xs text-slate-300">
+              <span className="block truncate">{item.name}</span>
+              <span className="text-[10px] text-slate-500">{item.scheduleLabel}</span>
+            </li>
+          ))
+        )}
+        {items.length > 3 && (
+          <li className="text-[10px] font-medium text-slate-500">외 {items.length - 3}개</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+export function RoundVisibilityPreviewPanel({ themeId }: RoundVisibilityPreviewPanelProps) {
+  const cluesQuery = useEditorClues(themeId);
+  const locationsQuery = useEditorLocations(themeId);
+  const previews = buildRoundVisibilityPreview(cluesQuery.data, locationsQuery.data);
+  const warnings = previews.flatMap((preview) => preview.warnings);
+  const isLoading = cluesQuery.isLoading || locationsQuery.isLoading;
+  const isError = cluesQuery.isError || locationsQuery.isError;
+
+  return (
+    <section
+      aria-label="라운드 공개 미리보기"
+      className="border-b border-slate-800 bg-slate-950 px-4 py-4 sm:px-6"
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-start gap-3">
+          <span className="rounded-lg bg-amber-500/10 p-2 text-amber-300">
+            <Eye className="h-4 w-4" aria-hidden="true" />
+          </span>
+          <div>
+            <h3 className="text-sm font-semibold text-slate-100">라운드 공개 미리보기</h3>
+            <p className="mt-1 text-xs leading-5 text-slate-400">
+              플레이어가 각 라운드에서 볼 수 있는 장소와 단서를 미리 확인합니다.
+            </p>
+          </div>
+        </div>
+        <div className="text-xs text-slate-400">
+          {warnings.length > 0 ? (
+            <span className="inline-flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-amber-200">
+              <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+              확인 필요 {warnings.length}개
+            </span>
+          ) : (
+            <span className="inline-flex rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-emerald-200">
+              라운드 공개 상태 정상
+            </span>
+          )}
+        </div>
+      </div>
+
+      {isLoading && <p className="mt-3 text-xs text-slate-500">공개 상태를 불러오는 중입니다.</p>}
+      {isError && (
+        <p className="mt-3 rounded-md border border-red-900/60 bg-red-950/30 px-3 py-2 text-xs text-red-200">
+          라운드 공개 상태를 불러오지 못했습니다.
+        </p>
+      )}
+
+      {!isLoading && !isError && (
+        <div className="mt-4 flex gap-3 overflow-x-auto pb-1">
+          {previews.map((preview) => (
+            <article
+              key={preview.round}
+              className="min-w-[13.5rem] rounded-lg border border-slate-800 bg-slate-900/60 p-3"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <h4 className="text-sm font-semibold text-slate-100">{preview.label}</h4>
+                {preview.warnings.length > 0 && (
+                  <span className="rounded-sm bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-amber-200">
+                    확인 {preview.warnings.length}
+                  </span>
+                )}
+              </div>
+
+              <div className="mt-3 grid gap-3">
+                <PreviewList
+                  title="장소"
+                  icon={MapPin}
+                  items={preview.locations}
+                  emptyText="공개 장소 없음"
+                />
+                <PreviewList
+                  title="단서"
+                  icon={Search}
+                  items={preview.clues}
+                  emptyText="공개 단서 없음"
+                />
+              </div>
+
+              {preview.warnings.length > 0 && (
+                <ul className="mt-3 space-y-1 border-t border-slate-800 pt-2">
+                  {preview.warnings.slice(0, 2).map((warning) => (
+                    <li key={warning.id} className="text-[11px] leading-4 text-amber-200">
+                      {warning.message}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -6,6 +6,7 @@ import {
   EditorEntityLibrary,
   type StoryLibraryEntity,
 } from "./EditorEntityLibrary";
+import { RoundVisibilityPreviewPanel } from "./RoundVisibilityPreviewPanel";
 import { SceneInspector } from "./SceneInspector";
 
 interface StoryMapWorkspaceProps {
@@ -50,6 +51,8 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
           </div>
         </div>
       </div>
+
+      <RoundVisibilityPreviewPanel themeId={themeId} />
 
       <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[17rem_minmax(0,1fr)_20rem]">
         <EditorEntityLibrary

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -74,12 +74,15 @@ describe("StoryMapWorkspace", () => {
       isError: false,
     });
     useEditorCluesMock.mockReturnValue({
-      data: [{ id: "clue-1", name: "찢어진 초대장", location_id: null }],
+      data: [
+        { id: "clue-1", name: "찢어진 초대장", location_id: "loc-1", reveal_round: 1, hide_round: 2 },
+        { id: "clue-2", name: "봉인된 유언장", location_id: "loc-1", reveal_round: 3, hide_round: 3 },
+      ],
       isLoading: false,
       isError: false,
     });
     useEditorLocationsMock.mockReturnValue({
-      data: [{ id: "loc-1", name: "응접실", from_round: null, until_round: null }],
+      data: [{ id: "loc-1", name: "응접실", from_round: 1, until_round: 2 }],
       isLoading: false,
       isError: false,
     });
@@ -95,6 +98,7 @@ describe("StoryMapWorkspace", () => {
 
     expect(screen.getByLabelText("스토리 진행 제작").className).toContain("lg:overflow-hidden");
     expect(screen.getByRole("heading", { name: "스토리 진행 제작" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "라운드 공개 미리보기" })).toBeDefined();
     expect(screen.getByRole("heading", { name: "제작 라이브러리" })).toBeDefined();
     expect(screen.getByRole("heading", { name: "제작 라이브러리" }).closest("aside")?.className).toContain(
       "lg:overflow-y-auto",
@@ -107,13 +111,26 @@ describe("StoryMapWorkspace", () => {
     render(<StoryMapWorkspace themeId="theme-1" />);
 
     expect(screen.getByText("한서윤")).toBeDefined();
-    expect(screen.getByText("찢어진 초대장")).toBeDefined();
-    expect(screen.getByText("응접실")).toBeDefined();
+    expect(screen.getAllByText("찢어진 초대장").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("응접실").length).toBeGreaterThan(0);
     expect(screen.getByText("오프닝 음악")).toBeDefined();
     expect(screen.getByText("단서")).toBeDefined();
     expect(screen.getAllByText("장소").length).toBeGreaterThan(1);
     expect(screen.getAllByText("토론방").length).toBeGreaterThan(1);
     expect(screen.getAllByText("조사권").length).toBeGreaterThan(1);
+  });
+
+  it("라운드별 공개 장소/단서와 범위 밖 경고를 제작자 언어로 표시한다", () => {
+    render(<StoryMapWorkspace themeId="theme-1" />);
+
+    const preview = screen.getByLabelText("라운드 공개 미리보기");
+    expect(within(preview).getByRole("heading", { name: "1라운드" })).toBeDefined();
+    expect(within(preview).getByRole("heading", { name: "3라운드" })).toBeDefined();
+    expect(within(preview).getAllByText("찢어진 초대장").length).toBeGreaterThan(0);
+    expect(within(preview).getByText("봉인된 유언장")).toBeDefined();
+    expect(
+      within(preview).getByText("봉인된 유언장 단서는 공개되지만 응접실 장소는 이 라운드에 보이지 않습니다."),
+    ).toBeDefined();
   });
 
   it("라이브러리 항목을 선택하면 우측 패널에 연결 대상으로 표시한다", () => {
@@ -150,7 +167,7 @@ describe("StoryMapWorkspace", () => {
 
     rerender(<StoryMapWorkspace themeId="theme-2" />);
 
-    expect(screen.getAllByText("찢어진 초대장")).toHaveLength(1);
+    expect(within(getScenePropertiesPanel()).queryByText("찢어진 초대장")).toBeNull();
     expect(
       screen.getByText("왼쪽 라이브러리에서 항목을 선택하면 장면에 붙일 연결 대상으로 표시합니다."),
     ).toBeDefined();

--- a/apps/web/src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts
+++ b/apps/web/src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClueResponse, LocationResponse } from "@/features/editor/api";
+import { buildRoundVisibilityPreview } from "../roundVisibilityPreview";
+
+const baseLocation = {
+  id: "loc-1",
+  theme_id: "theme-1",
+  map_id: "map-1",
+  name: "응접실",
+  restricted_characters: null,
+  image_url: null,
+  sort_order: 1,
+  created_at: "2026-05-06T00:00:00Z",
+} satisfies LocationResponse;
+
+const baseClue = {
+  id: "clue-1",
+  theme_id: "theme-1",
+  location_id: "loc-1",
+  name: "찢어진 초대장",
+  description: null,
+  image_url: null,
+  is_common: false,
+  level: 1,
+  sort_order: 1,
+  created_at: "2026-05-06T00:00:00Z",
+  is_usable: false,
+  use_effect: null,
+  use_target: null,
+  use_consumed: false,
+} satisfies ClueResponse;
+
+describe("buildRoundVisibilityPreview", () => {
+  it("장소와 단서의 공개 라운드를 라운드별 미리보기로 변환한다", () => {
+    const previews = buildRoundVisibilityPreview(
+      [{ ...baseClue, reveal_round: 2, hide_round: 3 }],
+      [{ ...baseLocation, from_round: 1, until_round: 2 }],
+    );
+
+    expect(previews).toHaveLength(3);
+    expect(previews[0].label).toBe("1라운드");
+    expect(previews[0].locations.map((item) => item.name)).toEqual(["응접실"]);
+    expect(previews[0].clues).toHaveLength(0);
+    expect(previews[1].clues.map((item) => item.name)).toEqual(["찢어진 초대장"]);
+    expect(previews[2].locations).toHaveLength(0);
+  });
+
+  it("단서가 보이는 라운드에 연결 장소가 숨겨져 있으면 제작자용 경고를 만든다", () => {
+    const previews = buildRoundVisibilityPreview(
+      [{ ...baseClue, reveal_round: 3, hide_round: 3 }],
+      [{ ...baseLocation, from_round: 1, until_round: 2 }],
+    );
+
+    expect(previews[2].warnings).toEqual([
+      {
+        id: "hidden-location:clue-1:3",
+        message: "찢어진 초대장 단서는 공개되지만 응접실 장소는 이 라운드에 보이지 않습니다.",
+      },
+    ]);
+  });
+
+  it("잘못된 라운드 범위와 삭제된 장소 연결을 raw key 없이 설명한다", () => {
+    const previews = buildRoundVisibilityPreview(
+      [
+        { ...baseClue, id: "bad-clue", name: "잘못된 단서", reveal_round: 5, hide_round: 2 },
+        { ...baseClue, id: "lost-clue", name: "분실된 단서", location_id: "missing" },
+      ],
+      [{ ...baseLocation, from_round: 3, until_round: 1 }],
+      1,
+    );
+
+    const messages = previews[0].warnings.map((warning) => warning.message);
+    expect(messages).toContain("응접실 장소의 등장/퇴장 라운드가 서로 맞지 않습니다.");
+    expect(messages).toContain("잘못된 단서 단서의 공개/사라짐 라운드가 서로 맞지 않습니다.");
+    expect(messages).toContain("분실된 단서 단서가 삭제되었거나 찾을 수 없는 장소에 연결되어 있습니다.");
+  });
+});

--- a/apps/web/src/features/editor/entities/validation/roundVisibilityPreview.ts
+++ b/apps/web/src/features/editor/entities/validation/roundVisibilityPreview.ts
@@ -1,0 +1,123 @@
+import type { ClueResponse, LocationResponse } from "@/features/editor/api";
+
+export interface RoundVisibilityItem {
+  id: string;
+  name: string;
+  scheduleLabel: string;
+}
+
+export interface RoundVisibilityWarning {
+  id: string;
+  message: string;
+}
+
+export interface RoundVisibilityPreview {
+  round: number;
+  label: string;
+  clues: RoundVisibilityItem[];
+  locations: RoundVisibilityItem[];
+  warnings: RoundVisibilityWarning[];
+}
+
+function formatScheduleLabel(from: number | null | undefined, to: number | null | undefined): string {
+  if (from == null && to == null) return "항상 공개";
+  if (from != null && to != null) return from === to ? `${from}라운드만` : `${from}~${to}라운드`;
+  if (from != null) return `${from}라운드부터`;
+  return `${to}라운드까지`;
+}
+
+function hasInvalidRange(from: number | null | undefined, to: number | null | undefined): boolean {
+  return from != null && to != null && from > to;
+}
+
+function isVisibleInRound(
+  round: number,
+  from: number | null | undefined,
+  to: number | null | undefined,
+): boolean {
+  if (hasInvalidRange(from, to)) return false;
+  return (from ?? 1) <= round && round <= (to ?? Number.POSITIVE_INFINITY);
+}
+
+function maxFiniteRound(values: Array<number | null | undefined>): number {
+  return values.reduce((max, value) => (value != null && value > max ? value : max), 0);
+}
+
+export function buildRoundVisibilityPreview(
+  clues: ClueResponse[] = [],
+  locations: LocationResponse[] = [],
+  minRounds = 3,
+): RoundVisibilityPreview[] {
+  const maxRound = Math.max(
+    minRounds,
+    maxFiniteRound(clues.flatMap((clue) => [clue.reveal_round, clue.hide_round])),
+    maxFiniteRound(locations.flatMap((location) => [location.from_round, location.until_round])),
+  );
+  const locationById = new Map(locations.map((location) => [location.id, location]));
+
+  return Array.from({ length: maxRound }, (_, index) => {
+    const round = index + 1;
+    const visibleLocations = locations.filter((location) =>
+      isVisibleInRound(round, location.from_round, location.until_round),
+    );
+    const visibleLocationIds = new Set(visibleLocations.map((location) => location.id));
+    const visibleClues = clues.filter((clue) =>
+      isVisibleInRound(round, clue.reveal_round, clue.hide_round),
+    );
+    const warnings: RoundVisibilityWarning[] = [];
+
+    for (const location of locations) {
+      if (hasInvalidRange(location.from_round, location.until_round)) {
+        warnings.push({
+          id: `location-range:${location.id}`,
+          message: `${location.name} 장소의 등장/퇴장 라운드가 서로 맞지 않습니다.`,
+        });
+      }
+    }
+
+    for (const clue of clues) {
+      if (hasInvalidRange(clue.reveal_round, clue.hide_round)) {
+        warnings.push({
+          id: `clue-range:${clue.id}`,
+          message: `${clue.name} 단서의 공개/사라짐 라운드가 서로 맞지 않습니다.`,
+        });
+        continue;
+      }
+
+      if (!isVisibleInRound(round, clue.reveal_round, clue.hide_round) || !clue.location_id) {
+        continue;
+      }
+
+      const location = locationById.get(clue.location_id);
+      if (!location) {
+        warnings.push({
+          id: `missing-location:${clue.id}`,
+          message: `${clue.name} 단서가 삭제되었거나 찾을 수 없는 장소에 연결되어 있습니다.`,
+        });
+        continue;
+      }
+      if (!visibleLocationIds.has(location.id)) {
+        warnings.push({
+          id: `hidden-location:${clue.id}:${round}`,
+          message: `${clue.name} 단서는 공개되지만 ${location.name} 장소는 이 라운드에 보이지 않습니다.`,
+        });
+      }
+    }
+
+    return {
+      round,
+      label: `${round}라운드`,
+      clues: visibleClues.map((clue) => ({
+        id: clue.id,
+        name: clue.name,
+        scheduleLabel: formatScheduleLabel(clue.reveal_round, clue.hide_round),
+      })),
+      locations: visibleLocations.map((location) => ({
+        id: location.id,
+        name: location.name,
+        scheduleLabel: formatScheduleLabel(location.from_round, location.until_round),
+      })),
+      warnings,
+    };
+  });
+}


### PR DESCRIPTION
## 요약
- 스토리 진행 제작 화면에 라운드별 공개 장소/단서 미리보기 패널을 추가했습니다.
- 단서가 공개되는 라운드에 연결 장소가 숨겨지는 경우를 제작자용 경고 문구로 표시합니다.
- 기존 Advanced 검수 화면은 raw `config_json`/legacy key를 기본 화면에 노출하지 않는 테스트를 유지합니다.

Closes #422
Refs #381

## Coverage Plan
- `roundVisibilityPreview`: 단서/장소 라운드 변환, 숨겨진 장소 연결, 잘못된 라운드 범위, 삭제된 장소 연결을 단위 테스트로 검증했습니다.
- `StoryMapWorkspace`: 실제 story-map 화면에서 라운드 공개 미리보기와 경고가 보이는지 검증했습니다.
- `AdvancedTab`: raw `config_json`/legacy key가 제작자 기본 화면에 노출되지 않는 기존 검증을 함께 실행했습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/components/__tests__/AdvancedTab.test.tsx`
- `pnpm --filter @mmp/web exec eslint src/features/editor/entities/validation/roundVisibilityPreview.ts src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts src/features/editor/components/story-map/RoundVisibilityPreviewPanel.tsx src/features/editor/components/story-map/StoryMapWorkspace.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx`
- `git diff --check`

## PR 묶음 판단
- #422의 프론트 검증 UI만 묶었습니다. 플레이 runtime 필터, legacy config DB migration, 운영 데이터 cleanup은 이 PR에 섞지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 에디터 스토리맵 작업공간에 라운드 공개 미리보기 패널 추가
* 각 라운드별로 공개되는 장소와 단서를 미리 확인할 수 있는 기능 제공

## 테스트
* 라운드 공개 미리보기 기능의 단위 테스트 추가
* 스토리맵 작업공간 통합 테스트 확대 및 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->