### PR TITLE
feat(editor): 엔티티 이미지 슬롯을 미디어 참조로 통합

### DIFF
--- a/apps/server/db/migrations/00038_character_clue_image_media_ids.sql
+++ b/apps/server/db/migrations/00038_character_clue_image_media_ids.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+ALTER TABLE theme_characters
+  ADD COLUMN image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL,
+  ADD COLUMN endcard_image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL;
+
+ALTER TABLE theme_clues
+  ADD COLUMN image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_theme_characters_image_media
+  ON theme_characters(image_media_id)
+  WHERE image_media_id IS NOT NULL;
+
+CREATE INDEX idx_theme_characters_endcard_image_media
+  ON theme_characters(endcard_image_media_id)
+  WHERE endcard_image_media_id IS NOT NULL;
+
+CREATE INDEX idx_theme_clues_image_media
+  ON theme_clues(image_media_id)
+  WHERE image_media_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_theme_clues_image_media;
+DROP INDEX IF EXISTS idx_theme_characters_endcard_image_media;
+DROP INDEX IF EXISTS idx_theme_characters_image_media;
+
+ALTER TABLE theme_clues
+  DROP COLUMN IF EXISTS image_media_id;
+
+ALTER TABLE theme_characters
+  DROP COLUMN IF EXISTS endcard_image_media_id,
+  DROP COLUMN IF EXISTS image_media_id;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -68,13 +68,13 @@ SELECT * FROM theme_clues WHERE location_id = $1 ORDER BY sort_order;
 SELECT * FROM theme_clues WHERE id = $1;
 
 -- name: CreateClue :one
-INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, image_media_id, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 RETURNING *;
 
 -- name: UpdateClue :one
 UPDATE theme_clues
-SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, sort_order = $8, is_usable = $9, use_effect = $10, use_target = $11, use_consumed = $12, reveal_round = $13, hide_round = $14
+SET location_id = $2, name = $3, description = $4, image_url = $5, image_media_id = $6, is_common = $7, level = $8, sort_order = $9, is_usable = $10, use_effect = $11, use_target = $12, use_consumed = $13, reveal_round = $14, hide_round = $15
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -28,9 +28,9 @@ SELECT * FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order;
 INSERT INTO theme_characters (
   theme_id, name, description, image_url, is_culprit, mystery_role, sort_order,
   is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate,
-  endcard_title, endcard_body, endcard_image_url, alias_rules
+  endcard_title, endcard_body, endcard_image_url, image_media_id, endcard_image_media_id, alias_rules
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 RETURNING *;
 
 -- name: UpdateTheme :one
@@ -66,7 +66,9 @@ UPDATE theme_characters SET
   endcard_title = $12,
   endcard_body = $13,
   endcard_image_url = $14,
-  alias_rules = $15
+  image_media_id = $15,
+  endcard_image_media_id = $16,
+  alias_rules = $17
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -46,26 +46,27 @@ func (q *Queries) CountMapsByTheme(ctx context.Context, themeID uuid.UUID) (int6
 }
 
 const createClue = `-- name: CreateClue :one
-INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round
+INSERT INTO theme_clues (theme_id, location_id, name, description, image_url, image_media_id, is_common, level, sort_order, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round, image_media_id
 `
 
 type CreateClueParams struct {
-	ThemeID     uuid.UUID   `json:"theme_id"`
-	LocationID  pgtype.UUID `json:"location_id"`
-	Name        string      `json:"name"`
-	Description pgtype.Text `json:"description"`
-	ImageUrl    pgtype.Text `json:"image_url"`
-	IsCommon    bool        `json:"is_common"`
-	Level       int32       `json:"level"`
-	SortOrder   int32       `json:"sort_order"`
-	IsUsable    bool        `json:"is_usable"`
-	UseEffect   pgtype.Text `json:"use_effect"`
-	UseTarget   pgtype.Text `json:"use_target"`
-	UseConsumed bool        `json:"use_consumed"`
-	RevealRound pgtype.Int4 `json:"reveal_round"`
-	HideRound   pgtype.Int4 `json:"hide_round"`
+	ThemeID      uuid.UUID   `json:"theme_id"`
+	LocationID   pgtype.UUID `json:"location_id"`
+	Name         string      `json:"name"`
+	Description  pgtype.Text `json:"description"`
+	ImageUrl     pgtype.Text `json:"image_url"`
+	ImageMediaID pgtype.UUID `json:"image_media_id"`
+	IsCommon     bool        `json:"is_common"`
+	Level        int32       `json:"level"`
+	SortOrder    int32       `json:"sort_order"`
+	IsUsable     bool        `json:"is_usable"`
+	UseEffect    pgtype.Text `json:"use_effect"`
+	UseTarget    pgtype.Text `json:"use_target"`
+	UseConsumed  bool        `json:"use_consumed"`
+	RevealRound  pgtype.Int4 `json:"reveal_round"`
+	HideRound    pgtype.Int4 `json:"hide_round"`
 }
 
 func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeClue, error) {
@@ -75,6 +76,7 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 		arg.Name,
 		arg.Description,
 		arg.ImageUrl,
+		arg.ImageMediaID,
 		arg.IsCommon,
 		arg.Level,
 		arg.SortOrder,
@@ -103,6 +105,7 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 		&i.UseConsumed,
 		&i.RevealRound,
 		&i.HideRound,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
@@ -282,7 +285,7 @@ func (q *Queries) DeleteMapWithOwner(ctx context.Context, arg DeleteMapWithOwner
 }
 
 const getClue = `-- name: GetClue :one
-SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round FROM theme_clues WHERE id = $1
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round, image_media_id FROM theme_clues WHERE id = $1
 `
 
 func (q *Queries) GetClue(ctx context.Context, id uuid.UUID) (ThemeClue, error) {
@@ -305,12 +308,13 @@ func (q *Queries) GetClue(ctx context.Context, id uuid.UUID) (ThemeClue, error) 
 		&i.UseConsumed,
 		&i.RevealRound,
 		&i.HideRound,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
 
 const getClueWithOwner = `-- name: GetClueWithOwner :one
-SELECT c.id, c.theme_id, c.location_id, c.name, c.description, c.image_url, c.is_common, c.level, c.sort_order, c.created_at, c.is_usable, c.use_effect, c.use_target, c.use_consumed, c.reveal_round, c.hide_round FROM theme_clues c
+SELECT c.id, c.theme_id, c.location_id, c.name, c.description, c.image_url, c.is_common, c.level, c.sort_order, c.created_at, c.is_usable, c.use_effect, c.use_target, c.use_consumed, c.reveal_round, c.hide_round, c.image_media_id FROM theme_clues c
 JOIN themes t ON c.theme_id = t.id
 WHERE c.id = $1 AND t.creator_id = $2
 `
@@ -340,6 +344,7 @@ func (q *Queries) GetClueWithOwner(ctx context.Context, arg GetClueWithOwnerPara
 		&i.UseConsumed,
 		&i.RevealRound,
 		&i.HideRound,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
@@ -471,7 +476,7 @@ func (q *Queries) GetMapWithOwner(ctx context.Context, arg GetMapWithOwnerParams
 }
 
 const listCluesByLocation = `-- name: ListCluesByLocation :many
-SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round FROM theme_clues WHERE location_id = $1 ORDER BY sort_order
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round, image_media_id FROM theme_clues WHERE location_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) ListCluesByLocation(ctx context.Context, locationID pgtype.UUID) ([]ThemeClue, error) {
@@ -500,6 +505,7 @@ func (q *Queries) ListCluesByLocation(ctx context.Context, locationID pgtype.UUI
 			&i.UseConsumed,
 			&i.RevealRound,
 			&i.HideRound,
+			&i.ImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -513,7 +519,7 @@ func (q *Queries) ListCluesByLocation(ctx context.Context, locationID pgtype.UUI
 
 const listCluesByTheme = `-- name: ListCluesByTheme :many
 
-SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round FROM theme_clues WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round, image_media_id FROM theme_clues WHERE theme_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -545,6 +551,7 @@ func (q *Queries) ListCluesByTheme(ctx context.Context, themeID uuid.UUID) ([]Th
 			&i.UseConsumed,
 			&i.RevealRound,
 			&i.HideRound,
+			&i.ImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -699,26 +706,27 @@ func (q *Queries) ListMapsByTheme(ctx context.Context, themeID uuid.UUID) ([]The
 
 const updateClue = `-- name: UpdateClue :one
 UPDATE theme_clues
-SET location_id = $2, name = $3, description = $4, image_url = $5, is_common = $6, level = $7, sort_order = $8, is_usable = $9, use_effect = $10, use_target = $11, use_consumed = $12, reveal_round = $13, hide_round = $14
+SET location_id = $2, name = $3, description = $4, image_url = $5, image_media_id = $6, is_common = $7, level = $8, sort_order = $9, is_usable = $10, use_effect = $11, use_target = $12, use_consumed = $13, reveal_round = $14, hide_round = $15
 WHERE id = $1
-RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round
+RETURNING id, theme_id, location_id, name, description, image_url, is_common, level, sort_order, created_at, is_usable, use_effect, use_target, use_consumed, reveal_round, hide_round, image_media_id
 `
 
 type UpdateClueParams struct {
-	ID          uuid.UUID   `json:"id"`
-	LocationID  pgtype.UUID `json:"location_id"`
-	Name        string      `json:"name"`
-	Description pgtype.Text `json:"description"`
-	ImageUrl    pgtype.Text `json:"image_url"`
-	IsCommon    bool        `json:"is_common"`
-	Level       int32       `json:"level"`
-	SortOrder   int32       `json:"sort_order"`
-	IsUsable    bool        `json:"is_usable"`
-	UseEffect   pgtype.Text `json:"use_effect"`
-	UseTarget   pgtype.Text `json:"use_target"`
-	UseConsumed bool        `json:"use_consumed"`
-	RevealRound pgtype.Int4 `json:"reveal_round"`
-	HideRound   pgtype.Int4 `json:"hide_round"`
+	ID           uuid.UUID   `json:"id"`
+	LocationID   pgtype.UUID `json:"location_id"`
+	Name         string      `json:"name"`
+	Description  pgtype.Text `json:"description"`
+	ImageUrl     pgtype.Text `json:"image_url"`
+	ImageMediaID pgtype.UUID `json:"image_media_id"`
+	IsCommon     bool        `json:"is_common"`
+	Level        int32       `json:"level"`
+	SortOrder    int32       `json:"sort_order"`
+	IsUsable     bool        `json:"is_usable"`
+	UseEffect    pgtype.Text `json:"use_effect"`
+	UseTarget    pgtype.Text `json:"use_target"`
+	UseConsumed  bool        `json:"use_consumed"`
+	RevealRound  pgtype.Int4 `json:"reveal_round"`
+	HideRound    pgtype.Int4 `json:"hide_round"`
 }
 
 func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeClue, error) {
@@ -728,6 +736,7 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 		arg.Name,
 		arg.Description,
 		arg.ImageUrl,
+		arg.ImageMediaID,
 		arg.IsCommon,
 		arg.Level,
 		arg.SortOrder,
@@ -756,6 +765,7 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 		&i.UseConsumed,
 		&i.RevealRound,
 		&i.HideRound,
+		&i.ImageMediaID,
 	)
 	return i, err
 }

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -291,41 +291,44 @@ type Theme struct {
 }
 
 type ThemeCharacter struct {
-	ID                uuid.UUID       `json:"id"`
-	ThemeID           uuid.UUID       `json:"theme_id"`
-	Name              string          `json:"name"`
-	Description       pgtype.Text     `json:"description"`
-	ImageUrl          pgtype.Text     `json:"image_url"`
-	IsCulprit         bool            `json:"is_culprit"`
-	SortOrder         int32           `json:"sort_order"`
-	MysteryRole       string          `json:"mystery_role"`
-	IsPlayable        bool            `json:"is_playable"`
-	ShowInIntro       bool            `json:"show_in_intro"`
-	CanSpeakInReading bool            `json:"can_speak_in_reading"`
-	IsVotingCandidate bool            `json:"is_voting_candidate"`
-	EndcardTitle      pgtype.Text     `json:"endcard_title"`
-	EndcardBody       pgtype.Text     `json:"endcard_body"`
-	EndcardImageUrl   pgtype.Text     `json:"endcard_image_url"`
-	AliasRules        json.RawMessage `json:"alias_rules"`
+	ID                  uuid.UUID       `json:"id"`
+	ThemeID             uuid.UUID       `json:"theme_id"`
+	Name                string          `json:"name"`
+	Description         pgtype.Text     `json:"description"`
+	ImageUrl            pgtype.Text     `json:"image_url"`
+	IsCulprit           bool            `json:"is_culprit"`
+	SortOrder           int32           `json:"sort_order"`
+	MysteryRole         string          `json:"mystery_role"`
+	IsPlayable          bool            `json:"is_playable"`
+	ShowInIntro         bool            `json:"show_in_intro"`
+	CanSpeakInReading   bool            `json:"can_speak_in_reading"`
+	IsVotingCandidate   bool            `json:"is_voting_candidate"`
+	EndcardTitle        pgtype.Text     `json:"endcard_title"`
+	EndcardBody         pgtype.Text     `json:"endcard_body"`
+	EndcardImageUrl     pgtype.Text     `json:"endcard_image_url"`
+	AliasRules          json.RawMessage `json:"alias_rules"`
+	ImageMediaID        pgtype.UUID     `json:"image_media_id"`
+	EndcardImageMediaID pgtype.UUID     `json:"endcard_image_media_id"`
 }
 
 type ThemeClue struct {
-	ID          uuid.UUID   `json:"id"`
-	ThemeID     uuid.UUID   `json:"theme_id"`
-	LocationID  pgtype.UUID `json:"location_id"`
-	Name        string      `json:"name"`
-	Description pgtype.Text `json:"description"`
-	ImageUrl    pgtype.Text `json:"image_url"`
-	IsCommon    bool        `json:"is_common"`
-	Level       int32       `json:"level"`
-	SortOrder   int32       `json:"sort_order"`
-	CreatedAt   time.Time   `json:"created_at"`
-	IsUsable    bool        `json:"is_usable"`
-	UseEffect   pgtype.Text `json:"use_effect"`
-	UseTarget   pgtype.Text `json:"use_target"`
-	UseConsumed bool        `json:"use_consumed"`
-	RevealRound pgtype.Int4 `json:"reveal_round"`
-	HideRound   pgtype.Int4 `json:"hide_round"`
+	ID           uuid.UUID   `json:"id"`
+	ThemeID      uuid.UUID   `json:"theme_id"`
+	LocationID   pgtype.UUID `json:"location_id"`
+	Name         string      `json:"name"`
+	Description  pgtype.Text `json:"description"`
+	ImageUrl     pgtype.Text `json:"image_url"`
+	IsCommon     bool        `json:"is_common"`
+	Level        int32       `json:"level"`
+	SortOrder    int32       `json:"sort_order"`
+	CreatedAt    time.Time   `json:"created_at"`
+	IsUsable     bool        `json:"is_usable"`
+	UseEffect    pgtype.Text `json:"use_effect"`
+	UseTarget    pgtype.Text `json:"use_target"`
+	UseConsumed  bool        `json:"use_consumed"`
+	RevealRound  pgtype.Int4 `json:"reveal_round"`
+	HideRound    pgtype.Int4 `json:"hide_round"`
+	ImageMediaID pgtype.UUID `json:"image_media_id"`
 }
 
 type ThemeContent struct {

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -89,28 +89,30 @@ const createThemeCharacter = `-- name: CreateThemeCharacter :one
 INSERT INTO theme_characters (
   theme_id, name, description, image_url, is_culprit, mystery_role, sort_order,
   is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate,
-  endcard_title, endcard_body, endcard_image_url, alias_rules
+  endcard_title, endcard_body, endcard_image_url, image_media_id, endcard_image_media_id, alias_rules
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id
 `
 
 type CreateThemeCharacterParams struct {
-	ThemeID           uuid.UUID       `json:"theme_id"`
-	Name              string          `json:"name"`
-	Description       pgtype.Text     `json:"description"`
-	ImageUrl          pgtype.Text     `json:"image_url"`
-	IsCulprit         bool            `json:"is_culprit"`
-	MysteryRole       string          `json:"mystery_role"`
-	SortOrder         int32           `json:"sort_order"`
-	IsPlayable        bool            `json:"is_playable"`
-	ShowInIntro       bool            `json:"show_in_intro"`
-	CanSpeakInReading bool            `json:"can_speak_in_reading"`
-	IsVotingCandidate bool            `json:"is_voting_candidate"`
-	EndcardTitle      pgtype.Text     `json:"endcard_title"`
-	EndcardBody       pgtype.Text     `json:"endcard_body"`
-	EndcardImageUrl   pgtype.Text     `json:"endcard_image_url"`
-	AliasRules        json.RawMessage `json:"alias_rules"`
+	ThemeID             uuid.UUID       `json:"theme_id"`
+	Name                string          `json:"name"`
+	Description         pgtype.Text     `json:"description"`
+	ImageUrl            pgtype.Text     `json:"image_url"`
+	IsCulprit           bool            `json:"is_culprit"`
+	MysteryRole         string          `json:"mystery_role"`
+	SortOrder           int32           `json:"sort_order"`
+	IsPlayable          bool            `json:"is_playable"`
+	ShowInIntro         bool            `json:"show_in_intro"`
+	CanSpeakInReading   bool            `json:"can_speak_in_reading"`
+	IsVotingCandidate   bool            `json:"is_voting_candidate"`
+	EndcardTitle        pgtype.Text     `json:"endcard_title"`
+	EndcardBody         pgtype.Text     `json:"endcard_body"`
+	EndcardImageUrl     pgtype.Text     `json:"endcard_image_url"`
+	ImageMediaID        pgtype.UUID     `json:"image_media_id"`
+	EndcardImageMediaID pgtype.UUID     `json:"endcard_image_media_id"`
+	AliasRules          json.RawMessage `json:"alias_rules"`
 }
 
 func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeCharacterParams) (ThemeCharacter, error) {
@@ -129,6 +131,8 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		arg.EndcardTitle,
 		arg.EndcardBody,
 		arg.EndcardImageUrl,
+		arg.ImageMediaID,
+		arg.EndcardImageMediaID,
 		arg.AliasRules,
 	)
 	var i ThemeCharacter
@@ -149,6 +153,8 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		&i.EndcardBody,
 		&i.EndcardImageUrl,
 		&i.AliasRules,
+		&i.ImageMediaID,
+		&i.EndcardImageMediaID,
 	)
 	return i, err
 }
@@ -236,7 +242,7 @@ func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error
 }
 
 const getThemeCharacter = `-- name: GetThemeCharacter :one
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules FROM theme_characters WHERE id = $1
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id FROM theme_characters WHERE id = $1
 `
 
 func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCharacter, error) {
@@ -259,12 +265,14 @@ func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCha
 		&i.EndcardBody,
 		&i.EndcardImageUrl,
 		&i.AliasRules,
+		&i.ImageMediaID,
+		&i.EndcardImageMediaID,
 	)
 	return i, err
 }
 
 const getThemeCharacters = `-- name: GetThemeCharacters :many
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]ThemeCharacter, error) {
@@ -293,6 +301,8 @@ func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]
 			&i.EndcardBody,
 			&i.EndcardImageUrl,
 			&i.AliasRules,
+			&i.ImageMediaID,
+			&i.EndcardImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -565,27 +575,31 @@ UPDATE theme_characters SET
   endcard_title = $12,
   endcard_body = $13,
   endcard_image_url = $14,
-  alias_rules = $15
+  image_media_id = $15,
+  endcard_image_media_id = $16,
+  alias_rules = $17
 WHERE id = $1
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id
 `
 
 type UpdateThemeCharacterParams struct {
-	ID                uuid.UUID       `json:"id"`
-	Name              string          `json:"name"`
-	Description       pgtype.Text     `json:"description"`
-	ImageUrl          pgtype.Text     `json:"image_url"`
-	IsCulprit         bool            `json:"is_culprit"`
-	MysteryRole       string          `json:"mystery_role"`
-	SortOrder         int32           `json:"sort_order"`
-	IsPlayable        bool            `json:"is_playable"`
-	ShowInIntro       bool            `json:"show_in_intro"`
-	CanSpeakInReading bool            `json:"can_speak_in_reading"`
-	IsVotingCandidate bool            `json:"is_voting_candidate"`
-	EndcardTitle      pgtype.Text     `json:"endcard_title"`
-	EndcardBody       pgtype.Text     `json:"endcard_body"`
-	EndcardImageUrl   pgtype.Text     `json:"endcard_image_url"`
-	AliasRules        json.RawMessage `json:"alias_rules"`
+	ID                  uuid.UUID       `json:"id"`
+	Name                string          `json:"name"`
+	Description         pgtype.Text     `json:"description"`
+	ImageUrl            pgtype.Text     `json:"image_url"`
+	IsCulprit           bool            `json:"is_culprit"`
+	MysteryRole         string          `json:"mystery_role"`
+	SortOrder           int32           `json:"sort_order"`
+	IsPlayable          bool            `json:"is_playable"`
+	ShowInIntro         bool            `json:"show_in_intro"`
+	CanSpeakInReading   bool            `json:"can_speak_in_reading"`
+	IsVotingCandidate   bool            `json:"is_voting_candidate"`
+	EndcardTitle        pgtype.Text     `json:"endcard_title"`
+	EndcardBody         pgtype.Text     `json:"endcard_body"`
+	EndcardImageUrl     pgtype.Text     `json:"endcard_image_url"`
+	ImageMediaID        pgtype.UUID     `json:"image_media_id"`
+	EndcardImageMediaID pgtype.UUID     `json:"endcard_image_media_id"`
+	AliasRules          json.RawMessage `json:"alias_rules"`
 }
 
 func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeCharacterParams) (ThemeCharacter, error) {
@@ -604,6 +618,8 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		arg.EndcardTitle,
 		arg.EndcardBody,
 		arg.EndcardImageUrl,
+		arg.ImageMediaID,
+		arg.EndcardImageMediaID,
 		arg.AliasRules,
 	)
 	var i ThemeCharacter
@@ -624,6 +640,8 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		&i.EndcardBody,
 		&i.EndcardImageUrl,
 		&i.AliasRules,
+		&i.ImageMediaID,
+		&i.EndcardImageMediaID,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -91,58 +91,64 @@ type ThemeSummary struct {
 }
 
 type CreateCharacterRequest struct {
-	Name              string               `json:"name" validate:"required,min=1,max=50"`
-	Description       *string              `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string              `json:"image_url" validate:"omitempty,optional_url"`
-	IsCulprit         bool                 `json:"is_culprit"`
-	MysteryRole       string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
-	SortOrder         int32                `json:"sort_order" validate:"min=0"`
-	IsPlayable        *bool                `json:"is_playable"`
-	ShowInIntro       *bool                `json:"show_in_intro"`
-	CanSpeakInReading *bool                `json:"can_speak_in_reading"`
-	IsVotingCandidate *bool                `json:"is_voting_candidate"`
-	EndcardTitle      *string              `json:"endcard_title" validate:"omitempty,max=80"`
-	EndcardBody       *string              `json:"endcard_body" validate:"omitempty,max=3000"`
-	EndcardImageURL   *string              `json:"endcard_image_url" validate:"omitempty,optional_url"`
-	AliasRules        []CharacterAliasRule `json:"alias_rules"`
+	Name                string               `json:"name" validate:"required,min=1,max=50"`
+	Description         *string              `json:"description" validate:"omitempty,max=2000"`
+	ImageURL            *string              `json:"image_url" validate:"omitempty,optional_url"`
+	ImageMediaID        *uuid.UUID           `json:"image_media_id"`
+	IsCulprit           bool                 `json:"is_culprit"`
+	MysteryRole         string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
+	SortOrder           int32                `json:"sort_order" validate:"min=0"`
+	IsPlayable          *bool                `json:"is_playable"`
+	ShowInIntro         *bool                `json:"show_in_intro"`
+	CanSpeakInReading   *bool                `json:"can_speak_in_reading"`
+	IsVotingCandidate   *bool                `json:"is_voting_candidate"`
+	EndcardTitle        *string              `json:"endcard_title" validate:"omitempty,max=80"`
+	EndcardBody         *string              `json:"endcard_body" validate:"omitempty,max=3000"`
+	EndcardImageURL     *string              `json:"endcard_image_url" validate:"omitempty,optional_url"`
+	EndcardImageMediaID *uuid.UUID           `json:"endcard_image_media_id"`
+	AliasRules          []CharacterAliasRule `json:"alias_rules"`
 }
 
 type UpdateCharacterRequest struct {
-	Name              string               `json:"name" validate:"required,min=1,max=50"`
-	Description       *string              `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string              `json:"image_url" validate:"omitempty,optional_url"`
-	IsCulprit         bool                 `json:"is_culprit"`
-	MysteryRole       string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
-	SortOrder         int32                `json:"sort_order" validate:"min=0"`
-	IsPlayable        *bool                `json:"is_playable"`
-	ShowInIntro       *bool                `json:"show_in_intro"`
-	CanSpeakInReading *bool                `json:"can_speak_in_reading"`
-	IsVotingCandidate *bool                `json:"is_voting_candidate"`
-	EndcardTitle      *string              `json:"endcard_title" validate:"omitempty,max=80"`
-	EndcardBody       *string              `json:"endcard_body" validate:"omitempty,max=3000"`
-	EndcardImageURL   *string              `json:"endcard_image_url" validate:"omitempty,optional_url"`
-	AliasRules        []CharacterAliasRule `json:"alias_rules"`
+	Name                string               `json:"name" validate:"required,min=1,max=50"`
+	Description         *string              `json:"description" validate:"omitempty,max=2000"`
+	ImageURL            *string              `json:"image_url" validate:"omitempty,optional_url"`
+	ImageMediaID        OptionalUUID         `json:"image_media_id"`
+	IsCulprit           bool                 `json:"is_culprit"`
+	MysteryRole         string               `json:"mystery_role" validate:"omitempty,oneof=suspect culprit accomplice detective"`
+	SortOrder           int32                `json:"sort_order" validate:"min=0"`
+	IsPlayable          *bool                `json:"is_playable"`
+	ShowInIntro         *bool                `json:"show_in_intro"`
+	CanSpeakInReading   *bool                `json:"can_speak_in_reading"`
+	IsVotingCandidate   *bool                `json:"is_voting_candidate"`
+	EndcardTitle        *string              `json:"endcard_title" validate:"omitempty,max=80"`
+	EndcardBody         *string              `json:"endcard_body" validate:"omitempty,max=3000"`
+	EndcardImageURL     *string              `json:"endcard_image_url" validate:"omitempty,optional_url"`
+	EndcardImageMediaID OptionalUUID         `json:"endcard_image_media_id"`
+	AliasRules          []CharacterAliasRule `json:"alias_rules"`
 }
 
 type CharacterAliasRule = engine.CharacterAliasRule
 
 type CharacterResponse struct {
-	ID                uuid.UUID            `json:"id"`
-	ThemeID           uuid.UUID            `json:"theme_id"`
-	Name              string               `json:"name"`
-	Description       *string              `json:"description,omitempty"`
-	ImageURL          *string              `json:"image_url,omitempty"`
-	IsCulprit         bool                 `json:"is_culprit"`
-	MysteryRole       string               `json:"mystery_role"`
-	SortOrder         int32                `json:"sort_order"`
-	IsPlayable        bool                 `json:"is_playable"`
-	ShowInIntro       bool                 `json:"show_in_intro"`
-	CanSpeakInReading bool                 `json:"can_speak_in_reading"`
-	IsVotingCandidate bool                 `json:"is_voting_candidate"`
-	EndcardTitle      *string              `json:"endcard_title,omitempty"`
-	EndcardBody       *string              `json:"endcard_body,omitempty"`
-	EndcardImageURL   *string              `json:"endcard_image_url,omitempty"`
-	AliasRules        []CharacterAliasRule `json:"alias_rules"`
+	ID                  uuid.UUID            `json:"id"`
+	ThemeID             uuid.UUID            `json:"theme_id"`
+	Name                string               `json:"name"`
+	Description         *string              `json:"description,omitempty"`
+	ImageURL            *string              `json:"image_url,omitempty"`
+	ImageMediaID        *uuid.UUID           `json:"image_media_id,omitempty"`
+	IsCulprit           bool                 `json:"is_culprit"`
+	MysteryRole         string               `json:"mystery_role"`
+	SortOrder           int32                `json:"sort_order"`
+	IsPlayable          bool                 `json:"is_playable"`
+	ShowInIntro         bool                 `json:"show_in_intro"`
+	CanSpeakInReading   bool                 `json:"can_speak_in_reading"`
+	IsVotingCandidate   bool                 `json:"is_voting_candidate"`
+	EndcardTitle        *string              `json:"endcard_title,omitempty"`
+	EndcardBody         *string              `json:"endcard_body,omitempty"`
+	EndcardImageURL     *string              `json:"endcard_image_url,omitempty"`
+	EndcardImageMediaID *uuid.UUID           `json:"endcard_image_media_id,omitempty"`
+	AliasRules          []CharacterAliasRule `json:"alias_rules"`
 }
 
 // --- Service interface ---

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -47,23 +47,33 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		s.logger.Error().Err(err).Msg("failed to marshal character alias rules")
 		return nil, apperror.Internal("failed to create character")
 	}
+	imageMediaID, err := s.resolveThemeImageMedia(ctx, themeID, req.ImageMediaID, "character profile image")
+	if err != nil {
+		return nil, err
+	}
+	endcardImageMediaID, err := s.resolveThemeImageMedia(ctx, themeID, req.EndcardImageMediaID, "character endcard image")
+	if err != nil {
+		return nil, err
+	}
 
 	char, err := s.q.CreateThemeCharacter(ctx, db.CreateThemeCharacterParams{
-		ThemeID:           themeID,
-		Name:              req.Name,
-		Description:       ptrToText(req.Description),
-		ImageUrl:          characterImageText(req.ImageURL),
-		IsCulprit:         rolePolicy.IsCulprit,
-		MysteryRole:       rolePolicy.MysteryRole,
-		SortOrder:         req.SortOrder,
-		IsPlayable:        visibilityPolicy.IsPlayable,
-		ShowInIntro:       visibilityPolicy.ShowInIntro,
-		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
-		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
-		EndcardTitle:      ptrToText(req.EndcardTitle),
-		EndcardBody:       ptrToText(req.EndcardBody),
-		EndcardImageUrl:   ptrToText(req.EndcardImageURL),
-		AliasRules:        aliasRulesJSON,
+		ThemeID:             themeID,
+		Name:                req.Name,
+		Description:         ptrToText(req.Description),
+		ImageUrl:            characterImageText(req.ImageURL),
+		IsCulprit:           rolePolicy.IsCulprit,
+		MysteryRole:         rolePolicy.MysteryRole,
+		SortOrder:           req.SortOrder,
+		IsPlayable:          visibilityPolicy.IsPlayable,
+		ShowInIntro:         visibilityPolicy.ShowInIntro,
+		CanSpeakInReading:   visibilityPolicy.CanSpeakInReading,
+		IsVotingCandidate:   visibilityPolicy.IsVotingCandidate,
+		EndcardTitle:        ptrToText(req.EndcardTitle),
+		EndcardBody:         ptrToText(req.EndcardBody),
+		EndcardImageUrl:     ptrToText(req.EndcardImageURL),
+		ImageMediaID:        imageMediaID,
+		EndcardImageMediaID: endcardImageMediaID,
+		AliasRules:          aliasRulesJSON,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create character")
@@ -112,23 +122,47 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 			return nil, apperror.Internal("failed to update character")
 		}
 	}
+	imageMediaID := char.ImageMediaID
+	if req.ImageMediaID.Set {
+		if req.ImageMediaID.Value == nil {
+			imageMediaID = pgtype.UUID{}
+		} else {
+			imageMediaID, err = s.resolveThemeImageMedia(ctx, char.ThemeID, req.ImageMediaID.Value, "character profile image")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	endcardImageMediaID := char.EndcardImageMediaID
+	if req.EndcardImageMediaID.Set {
+		if req.EndcardImageMediaID.Value == nil {
+			endcardImageMediaID = pgtype.UUID{}
+		} else {
+			endcardImageMediaID, err = s.resolveThemeImageMedia(ctx, char.ThemeID, req.EndcardImageMediaID.Value, "character endcard image")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	updated, err := s.q.UpdateThemeCharacter(ctx, db.UpdateThemeCharacterParams{
-		ID:                charID,
-		Name:              req.Name,
-		Description:       ptrToText(req.Description),
-		ImageUrl:          characterImageText(req.ImageURL, char.ImageUrl),
-		IsCulprit:         rolePolicy.IsCulprit,
-		MysteryRole:       rolePolicy.MysteryRole,
-		SortOrder:         req.SortOrder,
-		IsPlayable:        visibilityPolicy.IsPlayable,
-		ShowInIntro:       visibilityPolicy.ShowInIntro,
-		CanSpeakInReading: visibilityPolicy.CanSpeakInReading,
-		IsVotingCandidate: visibilityPolicy.IsVotingCandidate,
-		EndcardTitle:      characterEndcardText(req.EndcardTitle, char.EndcardTitle),
-		EndcardBody:       characterEndcardText(req.EndcardBody, char.EndcardBody),
-		EndcardImageUrl:   characterEndcardText(req.EndcardImageURL, char.EndcardImageUrl),
-		AliasRules:        aliasRulesJSON,
+		ID:                  charID,
+		Name:                req.Name,
+		Description:         ptrToText(req.Description),
+		ImageUrl:            characterImageText(req.ImageURL, char.ImageUrl),
+		IsCulprit:           rolePolicy.IsCulprit,
+		MysteryRole:         rolePolicy.MysteryRole,
+		SortOrder:           req.SortOrder,
+		IsPlayable:          visibilityPolicy.IsPlayable,
+		ShowInIntro:         visibilityPolicy.ShowInIntro,
+		CanSpeakInReading:   visibilityPolicy.CanSpeakInReading,
+		IsVotingCandidate:   visibilityPolicy.IsVotingCandidate,
+		EndcardTitle:        characterEndcardText(req.EndcardTitle, char.EndcardTitle),
+		EndcardBody:         characterEndcardText(req.EndcardBody, char.EndcardBody),
+		EndcardImageUrl:     characterEndcardText(req.EndcardImageURL, char.EndcardImageUrl),
+		ImageMediaID:        imageMediaID,
+		EndcardImageMediaID: endcardImageMediaID,
+		AliasRules:          aliasRulesJSON,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update character")
@@ -214,22 +248,24 @@ func (s *service) ListCharacters(ctx context.Context, creatorID, themeID uuid.UU
 
 func toCharacterResponse(c db.ThemeCharacter) *CharacterResponse {
 	return &CharacterResponse{
-		ID:                c.ID,
-		ThemeID:           c.ThemeID,
-		Name:              c.Name,
-		Description:       textToPtr(c.Description),
-		ImageURL:          textToPtr(c.ImageUrl),
-		IsCulprit:         c.IsCulprit,
-		MysteryRole:       c.MysteryRole,
-		SortOrder:         c.SortOrder,
-		IsPlayable:        c.IsPlayable,
-		ShowInIntro:       c.ShowInIntro,
-		CanSpeakInReading: c.CanSpeakInReading,
-		IsVotingCandidate: c.IsVotingCandidate,
-		EndcardTitle:      textToPtr(c.EndcardTitle),
-		EndcardBody:       textToPtr(c.EndcardBody),
-		EndcardImageURL:   textToPtr(c.EndcardImageUrl),
-		AliasRules:        unmarshalCharacterAliasRules(c.AliasRules),
+		ID:                  c.ID,
+		ThemeID:             c.ThemeID,
+		Name:                c.Name,
+		Description:         textToPtr(c.Description),
+		ImageURL:            textToPtr(c.ImageUrl),
+		ImageMediaID:        pgtypeUUIDToPtr(c.ImageMediaID),
+		IsCulprit:           c.IsCulprit,
+		MysteryRole:         c.MysteryRole,
+		SortOrder:           c.SortOrder,
+		IsPlayable:          c.IsPlayable,
+		ShowInIntro:         c.ShowInIntro,
+		CanSpeakInReading:   c.CanSpeakInReading,
+		IsVotingCandidate:   c.IsVotingCandidate,
+		EndcardTitle:        textToPtr(c.EndcardTitle),
+		EndcardBody:         textToPtr(c.EndcardBody),
+		EndcardImageURL:     textToPtr(c.EndcardImageUrl),
+		EndcardImageMediaID: pgtypeUUIDToPtr(c.EndcardImageMediaID),
+		AliasRules:          unmarshalCharacterAliasRules(c.AliasRules),
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -401,6 +401,75 @@ func TestService_CharacterEndcardContract(t *testing.T) {
 	}
 }
 
+func TestService_CharacterImageMediaReferences(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	profileMedia := createLocationMedia(t, f.q, themeID, "프로필 이미지", MediaTypeImage)
+	endcardMedia := createLocationMedia(t, f.q, themeID, "엔드카드 이미지", MediaTypeImage)
+	otherThemeMedia := createLocationMedia(t, f.q, otherThemeID, "다른 테마 이미지", MediaTypeImage)
+	voiceMedia := createLocationMedia(t, f.q, themeID, "목소리", MediaTypeVoice)
+
+	profileID := profileMedia.ID
+	endcardID := endcardMedia.ID
+	created, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{
+		Name:                "탐정",
+		ImageMediaID:        &profileID,
+		EndcardImageMediaID: &endcardID,
+	})
+	if err != nil {
+		t.Fatalf("CreateCharacter with media refs: %v", err)
+	}
+	if created.ImageMediaID == nil || *created.ImageMediaID != profileMedia.ID {
+		t.Fatalf("ImageMediaID = %v, want %s", created.ImageMediaID, profileMedia.ID)
+	}
+	if created.EndcardImageMediaID == nil || *created.EndcardImageMediaID != endcardMedia.ID {
+		t.Fatalf("EndcardImageMediaID = %v, want %s", created.EndcardImageMediaID, endcardMedia.ID)
+	}
+
+	otherThemeIDRef := otherThemeMedia.ID
+	if _, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:         created.Name,
+		MysteryRole:  created.MysteryRole,
+		IsCulprit:    created.IsCulprit,
+		SortOrder:    created.SortOrder,
+		ImageMediaID: OptionalUUID{Set: true, Value: &otherThemeIDRef},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateCharacter with other theme image error = %T %v, want media not in theme", err, err)
+	}
+
+	voiceID := voiceMedia.ID
+	if _, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:                created.Name,
+		MysteryRole:         created.MysteryRole,
+		IsCulprit:           created.IsCulprit,
+		SortOrder:           created.SortOrder,
+		EndcardImageMediaID: OptionalUUID{Set: true, Value: &voiceID},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateCharacter with non-image endcard media error = %T %v, want media not in theme", err, err)
+	}
+
+	cleared, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:                created.Name,
+		MysteryRole:         created.MysteryRole,
+		IsCulprit:           created.IsCulprit,
+		SortOrder:           created.SortOrder,
+		ImageMediaID:        OptionalUUID{Set: true},
+		EndcardImageMediaID: OptionalUUID{Set: true},
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter clear media refs: %v", err)
+	}
+	if cleared.ImageMediaID != nil || cleared.EndcardImageMediaID != nil {
+		t.Fatalf("cleared media refs = profile %v endcard %v, want nil", cleared.ImageMediaID, cleared.EndcardImageMediaID)
+	}
+}
+
 func TestService_CreateCharacterNPCVisibility(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -523,6 +592,63 @@ func TestService_CreateClue(t *testing.T) {
 	}
 	if resp.Level != 2 {
 		t.Errorf("level mismatch: got %d", resp.Level)
+	}
+}
+
+func TestService_ClueImageMediaReference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	imageMedia := createLocationMedia(t, f.q, themeID, "단서 이미지", MediaTypeImage)
+	otherThemeMedia := createLocationMedia(t, f.q, otherThemeID, "다른 테마 이미지", MediaTypeImage)
+	voiceMedia := createLocationMedia(t, f.q, themeID, "목소리", MediaTypeVoice)
+
+	imageID := imageMedia.ID
+	created, err := f.svc.CreateClue(ctx, creatorID, themeID, CreateClueRequest{
+		Name:         "혈흔",
+		Level:        1,
+		ImageMediaID: &imageID,
+	})
+	if err != nil {
+		t.Fatalf("CreateClue with image media: %v", err)
+	}
+	if created.ImageMediaID == nil || *created.ImageMediaID != imageMedia.ID {
+		t.Fatalf("ImageMediaID = %v, want %s", created.ImageMediaID, imageMedia.ID)
+	}
+
+	otherThemeIDRef := otherThemeMedia.ID
+	if _, err := f.svc.UpdateClue(ctx, creatorID, created.ID, UpdateClueRequest{
+		Name:         created.Name,
+		Level:        created.Level,
+		ImageMediaID: OptionalUUID{Set: true, Value: &otherThemeIDRef},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateClue with other theme image error = %T %v, want media not in theme", err, err)
+	}
+
+	voiceID := voiceMedia.ID
+	if _, err := f.svc.UpdateClue(ctx, creatorID, created.ID, UpdateClueRequest{
+		Name:         created.Name,
+		Level:        created.Level,
+		ImageMediaID: OptionalUUID{Set: true, Value: &voiceID},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateClue with non-image media error = %T %v, want media not in theme", err, err)
+	}
+
+	cleared, err := f.svc.UpdateClue(ctx, creatorID, created.ID, UpdateClueRequest{
+		Name:         created.Name,
+		Level:        created.Level,
+		ImageMediaID: OptionalUUID{Set: true},
+	})
+	if err != nil {
+		t.Fatalf("UpdateClue clear image media: %v", err)
+	}
+	if cleared.ImageMediaID != nil {
+		t.Fatalf("ImageMediaID after clear = %v, want nil", cleared.ImageMediaID)
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_clue.go
+++ b/apps/server/internal/domain/editor/service_clue.go
@@ -54,21 +54,26 @@ func (s *service) CreateClue(ctx context.Context, creatorID, themeID uuid.UUID, 
 	if count >= MaxCluesPerTheme {
 		return nil, apperror.BadRequest(fmt.Sprintf("theme cannot have more than %d clues", MaxCluesPerTheme))
 	}
+	imageMediaID, err := s.resolveThemeImageMedia(ctx, themeID, req.ImageMediaID, "clue image")
+	if err != nil {
+		return nil, err
+	}
 	clue, err := s.q.CreateClue(ctx, db.CreateClueParams{
-		ThemeID:     themeID,
-		LocationID:  uuidPtrToPgtype(req.LocationID),
-		Name:        req.Name,
-		Description: ptrToText(req.Description),
-		ImageUrl:    ptrToText(req.ImageURL),
-		IsCommon:    req.IsCommon,
-		Level:       req.Level,
-		SortOrder:   req.SortOrder,
-		IsUsable:    usePolicy.IsUsable,
-		UseEffect:   ptrToText(usePolicy.UseEffect),
-		UseTarget:   ptrToText(usePolicy.UseTarget),
-		UseConsumed: usePolicy.UseConsumed,
-		RevealRound: int32PtrToPgtype(req.RevealRound),
-		HideRound:   int32PtrToPgtype(req.HideRound),
+		ThemeID:      themeID,
+		LocationID:   uuidPtrToPgtype(req.LocationID),
+		Name:         req.Name,
+		Description:  ptrToText(req.Description),
+		ImageUrl:     ptrToText(req.ImageURL),
+		ImageMediaID: imageMediaID,
+		IsCommon:     req.IsCommon,
+		Level:        req.Level,
+		SortOrder:    req.SortOrder,
+		IsUsable:     usePolicy.IsUsable,
+		UseEffect:    ptrToText(usePolicy.UseEffect),
+		UseTarget:    ptrToText(usePolicy.UseTarget),
+		UseConsumed:  usePolicy.UseConsumed,
+		RevealRound:  int32PtrToPgtype(req.RevealRound),
+		HideRound:    int32PtrToPgtype(req.HideRound),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create clue")
@@ -94,21 +99,33 @@ func (s *service) UpdateClue(ctx context.Context, creatorID, clueID uuid.UUID, r
 		s.logger.Error().Err(err).Msg("failed to get clue")
 		return nil, apperror.Internal("failed to get clue")
 	}
+	imageMediaID := c.ImageMediaID
+	if req.ImageMediaID.Set {
+		if req.ImageMediaID.Value == nil {
+			imageMediaID = pgtype.UUID{}
+		} else {
+			imageMediaID, err = s.resolveThemeImageMedia(ctx, c.ThemeID, req.ImageMediaID.Value, "clue image")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 	updated, err := s.q.UpdateClue(ctx, db.UpdateClueParams{
-		ID:          c.ID,
-		LocationID:  uuidPtrToPgtype(req.LocationID),
-		Name:        req.Name,
-		Description: ptrToText(req.Description),
-		ImageUrl:    ptrToText(req.ImageURL),
-		IsCommon:    req.IsCommon,
-		Level:       req.Level,
-		SortOrder:   req.SortOrder,
-		IsUsable:    usePolicy.IsUsable,
-		UseEffect:   ptrToText(usePolicy.UseEffect),
-		UseTarget:   ptrToText(usePolicy.UseTarget),
-		UseConsumed: usePolicy.UseConsumed,
-		RevealRound: int32PtrToPgtype(req.RevealRound),
-		HideRound:   int32PtrToPgtype(req.HideRound),
+		ID:           c.ID,
+		LocationID:   uuidPtrToPgtype(req.LocationID),
+		Name:         req.Name,
+		Description:  ptrToText(req.Description),
+		ImageUrl:     ptrToText(req.ImageURL),
+		ImageMediaID: imageMediaID,
+		IsCommon:     req.IsCommon,
+		Level:        req.Level,
+		SortOrder:    req.SortOrder,
+		IsUsable:     usePolicy.IsUsable,
+		UseEffect:    ptrToText(usePolicy.UseEffect),
+		UseTarget:    ptrToText(usePolicy.UseTarget),
+		UseConsumed:  usePolicy.UseConsumed,
+		RevealRound:  int32PtrToPgtype(req.RevealRound),
+		HideRound:    int32PtrToPgtype(req.HideRound),
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update clue")
@@ -244,22 +261,23 @@ func (s *service) UpsertContent(ctx context.Context, creatorID, themeID uuid.UUI
 
 func toClueResponse(c db.ThemeClue) ClueResponse {
 	return ClueResponse{
-		ID:          c.ID,
-		ThemeID:     c.ThemeID,
-		LocationID:  pgtypeUUIDToPtr(c.LocationID),
-		Name:        c.Name,
-		Description: textToPtr(c.Description),
-		ImageURL:    textToPtr(c.ImageUrl),
-		IsCommon:    c.IsCommon,
-		Level:       c.Level,
-		SortOrder:   c.SortOrder,
-		CreatedAt:   c.CreatedAt,
-		IsUsable:    c.IsUsable,
-		UseEffect:   textToPtr(c.UseEffect),
-		UseTarget:   textToPtr(c.UseTarget),
-		UseConsumed: c.UseConsumed,
-		RevealRound: pgtypeInt4ToPtr(c.RevealRound),
-		HideRound:   pgtypeInt4ToPtr(c.HideRound),
+		ID:           c.ID,
+		ThemeID:      c.ThemeID,
+		LocationID:   pgtypeUUIDToPtr(c.LocationID),
+		Name:         c.Name,
+		Description:  textToPtr(c.Description),
+		ImageURL:     textToPtr(c.ImageUrl),
+		ImageMediaID: pgtypeUUIDToPtr(c.ImageMediaID),
+		IsCommon:     c.IsCommon,
+		Level:        c.Level,
+		SortOrder:    c.SortOrder,
+		CreatedAt:    c.CreatedAt,
+		IsUsable:     c.IsUsable,
+		UseEffect:    textToPtr(c.UseEffect),
+		UseTarget:    textToPtr(c.UseTarget),
+		UseConsumed:  c.UseConsumed,
+		RevealRound:  pgtypeInt4ToPtr(c.RevealRound),
+		HideRound:    pgtypeInt4ToPtr(c.HideRound),
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -136,7 +136,7 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if count >= MaxLocationsPerMap {
 		return nil, apperror.BadRequest(fmt.Sprintf("map cannot have more than %d locations", MaxLocationsPerMap))
 	}
-	imageMediaID, err := s.resolveLocationImage(ctx, themeID, req.ImageMediaID)
+	imageMediaID, err := s.resolveThemeImageMedia(ctx, themeID, req.ImageMediaID, "location image")
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		if req.ImageMediaID.Value == nil {
 			imageMediaID = pgtype.UUID{}
 		} else {
-			imageMediaID, err = s.resolveLocationImage(ctx, l.ThemeID, req.ImageMediaID.Value)
+			imageMediaID, err = s.resolveThemeImageMedia(ctx, l.ThemeID, req.ImageMediaID.Value, "location image")
 		}
 		if err != nil {
 			return nil, err
@@ -235,7 +235,7 @@ func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID
 	return accessPolicy, nil
 }
 
-func (s *service) resolveLocationImage(ctx context.Context, themeID uuid.UUID, mediaID *uuid.UUID) (pgtype.UUID, error) {
+func (s *service) resolveThemeImageMedia(ctx context.Context, themeID uuid.UUID, mediaID *uuid.UUID, purpose string) (pgtype.UUID, error) {
 	if mediaID == nil {
 		return pgtype.UUID{}, nil
 	}
@@ -244,11 +244,11 @@ func (s *service) resolveLocationImage(ctx context.Context, themeID uuid.UUID, m
 		if errors.Is(err, pgx.ErrNoRows) {
 			return pgtype.UUID{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "media not found")
 		}
-		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to verify location image")
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Str("purpose", purpose).Msg("failed to verify image media")
 		return pgtype.UUID{}, apperror.Internal("failed to verify media reference")
 	}
 	if media.ThemeID != themeID || media.Type != MediaTypeImage {
-		return pgtype.UUID{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "media has wrong type for location image")
+		return pgtype.UUID{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "media has wrong type for "+purpose)
 	}
 	return pgtype.UUID{Bytes: *mediaID, Valid: true}, nil
 }

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -92,54 +92,57 @@ type LocationResponse struct {
 // --- Clue types ---
 
 type CreateClueRequest struct {
-	LocationID  *uuid.UUID `json:"location_id"`
-	Name        string     `json:"name" validate:"required,min=1,max=200"`
-	Description *string    `json:"description" validate:"omitempty,max=2000"`
-	ImageURL    *string    `json:"image_url" validate:"omitempty,url"`
-	IsCommon    bool       `json:"is_common"`
-	Level       int32      `json:"level" validate:"min=1,max=10"`
-	SortOrder   int32      `json:"sort_order" validate:"min=0"`
-	IsUsable    bool       `json:"is_usable"`
-	UseEffect   *string    `json:"use_effect" validate:"omitempty,oneof=peek steal reveal block swap"`
-	UseTarget   *string    `json:"use_target" validate:"omitempty,oneof=player clue self"`
-	UseConsumed bool       `json:"use_consumed"`
-	RevealRound *int32     `json:"reveal_round" validate:"omitempty,min=1"`
-	HideRound   *int32     `json:"hide_round" validate:"omitempty,min=1"`
+	LocationID   *uuid.UUID `json:"location_id"`
+	Name         string     `json:"name" validate:"required,min=1,max=200"`
+	Description  *string    `json:"description" validate:"omitempty,max=2000"`
+	ImageURL     *string    `json:"image_url" validate:"omitempty,url"`
+	ImageMediaID *uuid.UUID `json:"image_media_id"`
+	IsCommon     bool       `json:"is_common"`
+	Level        int32      `json:"level" validate:"min=1,max=10"`
+	SortOrder    int32      `json:"sort_order" validate:"min=0"`
+	IsUsable     bool       `json:"is_usable"`
+	UseEffect    *string    `json:"use_effect" validate:"omitempty,oneof=peek steal reveal block swap"`
+	UseTarget    *string    `json:"use_target" validate:"omitempty,oneof=player clue self"`
+	UseConsumed  bool       `json:"use_consumed"`
+	RevealRound  *int32     `json:"reveal_round" validate:"omitempty,min=1"`
+	HideRound    *int32     `json:"hide_round" validate:"omitempty,min=1"`
 }
 
 type UpdateClueRequest struct {
-	LocationID  *uuid.UUID `json:"location_id"`
-	Name        string     `json:"name" validate:"required,min=1,max=200"`
-	Description *string    `json:"description" validate:"omitempty,max=2000"`
-	ImageURL    *string    `json:"image_url" validate:"omitempty,url"`
-	IsCommon    bool       `json:"is_common"`
-	Level       int32      `json:"level" validate:"min=1,max=10"`
-	SortOrder   int32      `json:"sort_order" validate:"min=0"`
-	IsUsable    bool       `json:"is_usable"`
-	UseEffect   *string    `json:"use_effect" validate:"omitempty,oneof=peek steal reveal block swap"`
-	UseTarget   *string    `json:"use_target" validate:"omitempty,oneof=player clue self"`
-	UseConsumed bool       `json:"use_consumed"`
-	RevealRound *int32     `json:"reveal_round" validate:"omitempty,min=1"`
-	HideRound   *int32     `json:"hide_round" validate:"omitempty,min=1"`
+	LocationID   *uuid.UUID   `json:"location_id"`
+	Name         string       `json:"name" validate:"required,min=1,max=200"`
+	Description  *string      `json:"description" validate:"omitempty,max=2000"`
+	ImageURL     *string      `json:"image_url" validate:"omitempty,url"`
+	ImageMediaID OptionalUUID `json:"image_media_id"`
+	IsCommon     bool         `json:"is_common"`
+	Level        int32        `json:"level" validate:"min=1,max=10"`
+	SortOrder    int32        `json:"sort_order" validate:"min=0"`
+	IsUsable     bool         `json:"is_usable"`
+	UseEffect    *string      `json:"use_effect" validate:"omitempty,oneof=peek steal reveal block swap"`
+	UseTarget    *string      `json:"use_target" validate:"omitempty,oneof=player clue self"`
+	UseConsumed  bool         `json:"use_consumed"`
+	RevealRound  *int32       `json:"reveal_round" validate:"omitempty,min=1"`
+	HideRound    *int32       `json:"hide_round" validate:"omitempty,min=1"`
 }
 
 type ClueResponse struct {
-	ID          uuid.UUID  `json:"id"`
-	ThemeID     uuid.UUID  `json:"theme_id"`
-	LocationID  *uuid.UUID `json:"location_id,omitempty"`
-	Name        string     `json:"name"`
-	Description *string    `json:"description,omitempty"`
-	ImageURL    *string    `json:"image_url,omitempty"`
-	IsCommon    bool       `json:"is_common"`
-	Level       int32      `json:"level"`
-	SortOrder   int32      `json:"sort_order"`
-	CreatedAt   time.Time  `json:"created_at"`
-	IsUsable    bool       `json:"is_usable"`
-	UseEffect   *string    `json:"use_effect,omitempty"`
-	UseTarget   *string    `json:"use_target,omitempty"`
-	UseConsumed bool       `json:"use_consumed"`
-	RevealRound *int32     `json:"reveal_round,omitempty"`
-	HideRound   *int32     `json:"hide_round,omitempty"`
+	ID           uuid.UUID  `json:"id"`
+	ThemeID      uuid.UUID  `json:"theme_id"`
+	LocationID   *uuid.UUID `json:"location_id,omitempty"`
+	Name         string     `json:"name"`
+	Description  *string    `json:"description,omitempty"`
+	ImageURL     *string    `json:"image_url,omitempty"`
+	ImageMediaID *uuid.UUID `json:"image_media_id,omitempty"`
+	IsCommon     bool       `json:"is_common"`
+	Level        int32      `json:"level"`
+	SortOrder    int32      `json:"sort_order"`
+	CreatedAt    time.Time  `json:"created_at"`
+	IsUsable     bool       `json:"is_usable"`
+	UseEffect    *string    `json:"use_effect,omitempty"`
+	UseTarget    *string    `json:"use_target,omitempty"`
+	UseConsumed  bool       `json:"use_consumed"`
+	RevealRound  *int32     `json:"reveal_round,omitempty"`
+	HideRound    *int32     `json:"hide_round,omitempty"`
 }
 
 // --- Clue edge (unified group) types ---

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -47,6 +47,7 @@ export interface EditorCharacterResponse {
   name: string;
   description: string | null;
   image_url: string | null;
+  image_media_id?: string | null;
   is_culprit: boolean;
   mystery_role: MysteryRole;
   sort_order: number;
@@ -57,6 +58,7 @@ export interface EditorCharacterResponse {
   endcard_title?: string | null;
   endcard_body?: string | null;
   endcard_image_url?: string | null;
+  endcard_image_media_id?: string | null;
   alias_rules: CharacterAliasRule[];
 }
 
@@ -97,6 +99,7 @@ export interface CreateCharacterRequest {
   name: string;
   description?: string;
   image_url?: string;
+  image_media_id?: string | null;
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
   sort_order?: number;
@@ -107,6 +110,7 @@ export interface CreateCharacterRequest {
   endcard_title?: string;
   endcard_body?: string;
   endcard_image_url?: string;
+  endcard_image_media_id?: string | null;
   alias_rules?: CharacterAliasRule[];
 }
 
@@ -114,6 +118,7 @@ export interface UpdateCharacterRequest {
   name?: string;
   description?: string;
   image_url?: string;
+  image_media_id?: string | null;
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
   sort_order?: number;
@@ -124,6 +129,7 @@ export interface UpdateCharacterRequest {
   endcard_title?: string;
   endcard_body?: string;
   endcard_image_url?: string;
+  endcard_image_media_id?: string | null;
   alias_rules?: CharacterAliasRule[];
 }
 
@@ -131,6 +137,7 @@ export interface CreateClueRequest {
   name: string;
   description?: string;
   image_url?: string;
+  image_media_id?: string | null;
   level?: number;
   is_common?: boolean;
   sort_order?: number;
@@ -147,6 +154,7 @@ export interface UpdateClueRequest {
   name?: string;
   description?: string;
   image_url?: string;
+  image_media_id?: string | null;
   level?: number;
   is_common?: boolean;
   sort_order?: number;
@@ -199,6 +207,7 @@ export interface ClueResponse {
   name: string;
   description: string | null;
   image_url: string | null;
+  image_media_id?: string | null;
   is_common: boolean;
   level: number;
   sort_order: number;

--- a/apps/web/src/features/editor/components/CharacterForm.tsx
+++ b/apps/web/src/features/editor/components/CharacterForm.tsx
@@ -8,7 +8,6 @@ import {
   useUpdateCharacter,
   type EditorCharacterResponse,
 } from '@/features/editor/api';
-import { ImageCropUpload } from '@/features/editor/components/ImageCropUpload';
 
 interface CharacterFormProps {
   themeId: string;
@@ -22,7 +21,6 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [imageUrl, setImageUrl] = useState('');
   const [isCulprit, setIsCulprit] = useState(false);
   const [sortOrder, setSortOrder] = useState(0);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -35,13 +33,11 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
       if (character) {
         setName(character.name);
         setDescription(character.description ?? '');
-        setImageUrl(character.image_url ?? '');
         setIsCulprit(character.is_culprit);
         setSortOrder(character.sort_order);
       } else {
         setName('');
         setDescription('');
-        setImageUrl('');
         setIsCulprit(false);
         setSortOrder(0);
       }
@@ -86,7 +82,8 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
           body: {
             name: name.trim(),
             description: description || undefined,
-            image_url: imageUrl,
+            image_url: character.image_url ?? undefined,
+            image_media_id: character.image_media_id ?? undefined,
             is_culprit: isCulprit,
             sort_order: sortOrder,
             mystery_role: nextMysteryRole,
@@ -97,6 +94,7 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
             endcard_title: character.endcard_title ?? undefined,
             endcard_body: character.endcard_body ?? undefined,
             endcard_image_url: character.endcard_image_url ?? undefined,
+            endcard_image_media_id: character.endcard_image_media_id ?? undefined,
           },
         },
         {
@@ -174,27 +172,6 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
               {errors.description && (
                 <p className="text-sm text-red-400">{errors.description}</p>
               )}
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-              <span className="text-sm font-medium text-slate-300">캐릭터 이미지</span>
-              <div className="flex items-center gap-4">
-                <ImageCropUpload
-                  themeId={themeId}
-                  targetId={character?.id ?? ''}
-                  target="character"
-                  currentImageUrl={imageUrl || null}
-                  onUploaded={(url) => setImageUrl(url)}
-                  onRemoved={imageUrl ? () => setImageUrl('') : undefined}
-                  size="lg"
-                  shape="circle"
-                />
-                <p className="text-xs text-slate-500">
-                  클릭하여 이미지를 업로드하세요
-                  <br />
-                  1:1 비율로 자동 자르기됩니다
-                </p>
-              </div>
             </div>
 
             <div className="flex items-center gap-2">

--- a/apps/web/src/features/editor/components/ClueForm.tsx
+++ b/apps/web/src/features/editor/components/ClueForm.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/shared/components/ui/Button';
 import { Input } from '@/shared/components/ui/Input';
 import { type ClueResponse } from '@/features/editor/api';
 import { useClueFormSubmit } from '@/features/editor/hooks/useClueFormSubmit';
-import { ClueFormImageSection } from './ClueFormImageSection';
+import { ImageMediaReferenceField } from '@/features/editor/components/media/ImageMediaReferenceField';
 import { buildClueUsePayload, getClueUseEffectOption } from '@/features/editor/entities/clue/clueEntityAdapter';
 import { ClueFormAdvancedFields } from './ClueFormAdvancedFields';
 
@@ -23,9 +23,9 @@ interface ClueFormProps {
 // ClueForm
 //
 // Slim shell that owns controlled form state and delegates:
-//   - image upload UI → ClueFormImageSection
+//   - image media selection → ImageMediaReferenceField
 //   - advanced/item-usage fields → ClueFormAdvancedFields
-//   - create/update + post-create image upload → useClueFormSubmit
+//   - create/update → useClueFormSubmit
 // ---------------------------------------------------------------------------
 
 export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
@@ -35,6 +35,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [imageUrl, setImageUrl] = useState('');
+  const [imageMediaId, setImageMediaId] = useState<string | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   // Advanced fields (hidden by default)
@@ -57,10 +58,6 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
   const [revealRound, setRevealRound] = useState<number | null>(null);
   const [hideRound, setHideRound] = useState<number | null>(null);
 
-  // Pending image for new clue (staged upload)
-  const [pendingImage, setPendingImage] = useState<File | null>(null);
-  const [pendingPreview, setPendingPreview] = useState<string | null>(null);
-
   const { submit, isPending } = useClueFormSubmit({
     themeId,
     clue,
@@ -74,6 +71,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
       setName(clue.name);
       setDescription(clue.description ?? '');
       setImageUrl(clue.image_url ?? '');
+      setImageMediaId(clue.image_media_id ?? null);
       setIsCommon(clue.is_common ?? false);
       setLevel(clue.level ?? 1);
       setSortOrder(clue.sort_order ?? 0);
@@ -87,6 +85,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
       setName('');
       setDescription('');
       setImageUrl('');
+      setImageMediaId(null);
       setIsCommon(false);
       setLevel(1);
       setSortOrder(0);
@@ -97,8 +96,6 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
       setRevealRound(null);
       setHideRound(null);
     }
-    setPendingImage(null);
-    setPendingPreview(null);
     setErrors({});
     setShowAdvanced(false);
   }, [isOpen, clue]);
@@ -124,18 +121,6 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
     return next;
   }
 
-  function handlePendingImageSelect(file: File) {
-    if (pendingPreview) URL.revokeObjectURL(pendingPreview);
-    setPendingImage(file);
-    setPendingPreview(URL.createObjectURL(file));
-  }
-
-  function handlePendingImageClear() {
-    if (pendingPreview) URL.revokeObjectURL(pendingPreview);
-    setPendingImage(null);
-    setPendingPreview(null);
-  }
-
   function handleUseEffectChange(effect: string) {
     setUseEffect(effect);
     const option = getClueUseEffectOption(effect);
@@ -152,7 +137,8 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
       buildClueUsePayload({
         name: name.trim(),
         description: description || undefined,
-        image_url: imageUrl || undefined,
+        image_url: imageMediaId ? '' : imageUrl || undefined,
+        image_media_id: imageMediaId,
         level,
         sort_order: sortOrder,
         is_common: isCommon,
@@ -163,7 +149,7 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
         reveal_round: revealRound,
         hide_round: hideRound,
       }),
-      pendingImage,
+      null,
     );
   }
 
@@ -184,17 +170,20 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
       }
     >
       <form id="clue-form" onSubmit={handleSubmit} className="space-y-4">
-        <ClueFormImageSection
+        <ImageMediaReferenceField
           themeId={themeId}
-          isEditMode={isEditMode}
-          clueId={clue?.id}
-          imageUrl={imageUrl}
-          onImageUrlChange={setImageUrl}
-          pendingImage={pendingImage}
-          pendingPreview={pendingPreview}
-          isUploading={isPending && !!pendingImage}
-          onPendingImageSelect={handlePendingImageSelect}
-          onPendingImageClear={handlePendingImageClear}
+          label="단서 이미지"
+          imageMediaId={imageMediaId}
+          legacyImageUrl={imageUrl || null}
+          pickerTitle="단서 이미지 선택"
+          emptyLabel="단서 이미지 선택"
+          compact
+          disabled={isPending}
+          onSelect={(media) => {
+            setImageMediaId(media.id);
+            setImageUrl('');
+          }}
+          onClear={() => setImageMediaId(null)}
         />
 
         <Input

--- a/apps/web/src/features/editor/components/ClueForm.tsx
+++ b/apps/web/src/features/editor/components/ClueForm.tsx
@@ -183,7 +183,10 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
             setImageMediaId(media.id);
             setImageUrl('');
           }}
-          onClear={() => setImageMediaId(null)}
+          onClear={() => {
+            setImageMediaId(null);
+            setImageUrl('');
+          }}
         />
 
         <Input

--- a/apps/web/src/features/editor/components/ClueForm.tsx
+++ b/apps/web/src/features/editor/components/ClueForm.tsx
@@ -133,11 +133,17 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) return;
 
+    const nextImageUrl = imageMediaId
+      ? ''
+      : clue?.image_url && imageUrl === ''
+        ? ''
+        : imageUrl || undefined;
+
     submit(
       buildClueUsePayload({
         name: name.trim(),
         description: description || undefined,
-        image_url: imageMediaId ? '' : imageUrl || undefined,
+        image_url: nextImageUrl,
         image_media_id: imageMediaId,
         level,
         sort_order: sortOrder,

--- a/apps/web/src/features/editor/components/__tests__/CharacterForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CharacterForm.test.tsx
@@ -23,10 +23,6 @@ vi.mock('@/features/editor/api', () => ({
   useUpdateCharacter: () => useUpdateCharacterMock(),
 }));
 
-vi.mock('@/features/editor/components/ImageCropUpload', () => ({
-  ImageCropUpload: () => <div data-testid="character-image-upload" />,
-}));
-
 vi.mock('@/shared/components/ui/Modal', () => ({
   Modal: ({
     isOpen,
@@ -149,12 +145,12 @@ describe('CharacterForm', () => {
     );
   });
 
-  it('수정 모달은 기존 quick edit 필드를 유지한다', () => {
+  it('수정 모달도 이미지 슬롯은 상세 기본정보에서만 관리하게 한다', () => {
     render(<CharacterForm themeId="theme-1" character={character} isOpen onClose={vi.fn()} />);
 
     expect(screen.getByRole('dialog', { name: '캐릭터 수정' })).toBeDefined();
     expect(screen.getByLabelText('설명')).toBeDefined();
-    expect(screen.getByTestId('character-image-upload')).toBeDefined();
+    expect(screen.queryByText('캐릭터 이미지')).toBeNull();
     expect(screen.getByLabelText(/범인 여부/)).toBeDefined();
     expect(screen.getByLabelText('정렬 순서')).toBeDefined();
   });

--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -249,7 +249,7 @@ describe('ClueForm', () => {
     expect(updateMutate).toHaveBeenCalledTimes(1);
     const [args] = updateMutate.mock.calls[0];
     expect(args.body.image_media_id).toBeNull();
-    expect(args.body.image_url).toBeUndefined();
+    expect(args.body.image_url).toBe('');
   });
 
   it('edit 모드에서는 useUpdateClue.mutate가 호출된다', () => {

--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -219,6 +219,39 @@ describe('ClueForm', () => {
     expect(mergeClueImageMock).not.toHaveBeenCalled();
   });
 
+  it('edit 모드에서 이미지 제거 시 media id와 legacy URL을 함께 비운다', () => {
+    const onClose = vi.fn();
+    const existing = {
+      id: 'clue-with-image',
+      theme_id: 'theme-1',
+      location_id: null,
+      name: '이미지 단서',
+      description: null,
+      image_url: 'https://cdn.example/legacy-clue.webp',
+      image_media_id: 'image-1',
+      is_common: false,
+      level: 1,
+      sort_order: 0,
+      created_at: '2026-04-15T00:00:00Z',
+      is_usable: false,
+      use_effect: null,
+      use_target: null,
+      use_consumed: false,
+    };
+
+    render(
+      <ClueForm themeId="theme-1" clue={existing} isOpen onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '제거' }));
+    fireEvent.submit(document.getElementById('clue-form')!);
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    const [args] = updateMutate.mock.calls[0];
+    expect(args.body.image_media_id).toBeNull();
+    expect(args.body.image_url).toBeUndefined();
+  });
+
   it('edit 모드에서는 useUpdateClue.mutate가 호출된다', () => {
     const onClose = vi.fn();
     const existing = {

--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -21,6 +21,7 @@ const {
   useUpdateClueMock,
   mergeClueImageMock,
   uploadImageMock,
+  useMediaListMock,
   toastSuccessMock,
   toastErrorMock,
 } = vi.hoisted(() => ({
@@ -28,6 +29,7 @@ const {
   useUpdateClueMock: vi.fn(),
   mergeClueImageMock: vi.fn(),
   uploadImageMock: vi.fn(),
+  useMediaListMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
 }));
@@ -47,6 +49,36 @@ vi.mock('@/features/editor/editorClueApi', () => ({
 
 vi.mock('@/features/editor/imageApi', () => ({
   uploadImage: uploadImageMock,
+}));
+
+vi.mock('@/features/editor/mediaApi', () => ({
+  useMediaList: () => useMediaListMock(),
+}));
+
+vi.mock('@/features/editor/components/media/MediaPicker', () => ({
+  MediaPicker: ({
+    open,
+    filterType,
+    selectedId,
+    onSelect,
+  }: {
+    open: boolean;
+    filterType?: string;
+    selectedId?: string | null;
+    onSelect: (media: { id: string; name: string; type: string }) => void;
+  }) =>
+    open ? (
+      <div>
+        <span>filter:{filterType}</span>
+        <span>selected:{selectedId ?? 'none'}</span>
+        <button
+          type="button"
+          onClick={() => onSelect({ id: 'image-1', name: '증거 사진', type: 'IMAGE' })}
+        >
+          증거 사진 선택
+        </button>
+      </div>
+    ) : null,
 }));
 
 vi.mock('@/shared/components/ui/Modal', () => ({
@@ -143,6 +175,10 @@ describe('ClueForm', () => {
     useUpdateClueMock.mockReturnValue({ mutate: updateMutate, isPending: false });
     mergeClueImageMock.mockReset();
     uploadImageMock.mockReset();
+    useMediaListMock.mockReturnValue({
+      data: [{ id: 'image-1', name: '증거 사진', type: 'IMAGE' }],
+      isLoading: false,
+    });
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
   });
@@ -162,45 +198,25 @@ describe('ClueForm', () => {
     expect(body.is_usable).toBe(false);
   });
 
-  it('create 성공 후 pendingImage가 있으면 uploadImage + mergeClueImage가 호출된다', async () => {
-    uploadImageMock.mockResolvedValueOnce('https://cdn/clue.png');
+  it('미디어 관리의 IMAGE 항목을 단서 이미지로 선택한다', () => {
     const onClose = vi.fn();
 
     render(<ClueForm themeId="theme-1" isOpen onClose={onClose} />);
 
-    // 이름 입력
     fireEvent.change(screen.getByLabelText('이름'), {
       target: { value: 'with-image' },
     });
-
-    // 파일 input에 파일 주입 (hidden input)
-    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
-    expect(fileInput).not.toBeNull();
-    const file = new File(['data'], 'test.png', { type: 'image/png' });
-    Object.defineProperty(fileInput, 'files', { value: [file] });
-    fireEvent.change(fileInput);
-
-    // 저장
+    fireEvent.click(screen.getByRole('button', { name: '단서 이미지 선택' }));
+    expect(screen.getByText('filter:IMAGE')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: '증거 사진 선택' }));
     fireEvent.submit(document.getElementById('clue-form')!);
+
     expect(createMutate).toHaveBeenCalledTimes(1);
-
-    // onSuccess 시뮬레이션
-    const [, options] = createMutate.mock.calls[0];
-    await options.onSuccess({ id: 'new-clue-id' });
-
-    expect(uploadImageMock).toHaveBeenCalledWith(
-      'theme-1',
-      'clue',
-      'new-clue-id',
-      expect.any(File),
-      'image/png',
-    );
-    expect(mergeClueImageMock).toHaveBeenCalledWith(
-      'theme-1',
-      'new-clue-id',
-      'https://cdn/clue.png',
-    );
-    expect(onClose).toHaveBeenCalled();
+    const [body] = createMutate.mock.calls[0];
+    expect(body.image_media_id).toBe('image-1');
+    expect(body.image_url).toBe('');
+    expect(uploadImageMock).not.toHaveBeenCalled();
+    expect(mergeClueImageMock).not.toHaveBeenCalled();
   });
 
   it('edit 모드에서는 useUpdateClue.mutate가 호출된다', () => {

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -12,7 +12,7 @@ import {
 import {
   buildCharacterAliasRulesUpdatePayload,
   buildCharacterVisibilityUpdatePayload,
-  buildCharacterProfileImageUpdatePayload,
+  buildCharacterProfileImageMediaUpdatePayload,
   buildCharacterRoleUpdatePayload,
   buildCharacterEndcardUpdatePayload,
   getCharacterListBadges,
@@ -155,7 +155,7 @@ export function CharacterAssignPanel({
   );
 
   const handleEndcardChangeForChar = useCallback(
-    (characterId: string, values: { title: string; body: string; imageUrl: string }) => {
+    (characterId: string, values: { title: string; body: string; imageUrl: string; imageMediaId?: string | null }) => {
       if (updateCharacter.isPending) return;
 
       const selected = characters?.find((char) => char.id === characterId);
@@ -170,7 +170,7 @@ export function CharacterAssignPanel({
   );
 
   const handleProfileImageChangeForChar = useCallback(
-    (characterId: string, imageUrl: string | null) => {
+    (characterId: string, imageMediaId: string | null) => {
       if (updateCharacter.isPending) return;
 
       const selected = characters?.find((char) => char.id === characterId);
@@ -178,7 +178,7 @@ export function CharacterAssignPanel({
 
       updateCharacter.mutate({
         characterId: selected.id,
-        body: buildCharacterProfileImageUpdatePayload(selected, imageUrl),
+        body: buildCharacterProfileImageMediaUpdatePayload(selected, imageMediaId),
       });
     },
     [characters, updateCharacter],

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -6,7 +6,7 @@ import { MissionEditor } from './MissionEditor';
 import { StartingClueAssigner } from './StartingClueAssigner';
 import { CharacterRoleSheetSection } from './CharacterRoleSheetSection';
 import { CharacterAliasRulesEditor } from './CharacterAliasRulesEditor';
-import { ImageCropUpload } from '@/features/editor/components/ImageCropUpload';
+import { ImageMediaReferenceField } from '@/features/editor/components/media/ImageMediaReferenceField';
 import {
   type CharacterVisibilityField,
   characterRoleOptions,
@@ -34,6 +34,7 @@ interface CharacterItem {
   name: string;
   description?: string | null;
   image_url?: string | null;
+  image_media_id?: string | null;
   is_culprit?: boolean;
   mystery_role?: MysteryRole;
   sort_order?: number;
@@ -44,6 +45,7 @@ interface CharacterItem {
   endcard_title?: string | null;
   endcard_body?: string | null;
   endcard_image_url?: string | null;
+  endcard_image_media_id?: string | null;
   alias_rules?: CharacterAliasRule[];
 }
 
@@ -61,8 +63,8 @@ interface CharacterDetailPanelProps {
   onMysteryRoleChange?: (role: MysteryRole) => void;
   onVisibilityChange?: (field: CharacterVisibilityField, value: boolean) => void;
   onAliasRulesSave?: (rules: CharacterAliasRule[]) => void;
-  onEndcardChange?: (values: { title: string; body: string; imageUrl: string }) => void;
-  onProfileImageChange?: (imageUrl: string | null) => void;
+  onEndcardChange?: (values: { title: string; body: string; imageUrl: string; imageMediaId?: string | null }) => void;
+  onProfileImageChange?: (imageMediaId: string | null) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +93,7 @@ export function CharacterDetailPanel({
   const [endcardTitle, setEndcardTitle] = useState('');
   const [endcardBody, setEndcardBody] = useState('');
   const [endcardImageUrl, setEndcardImageUrl] = useState('');
+  const [endcardImageMediaId, setEndcardImageMediaId] = useState<string | null>(null);
   const characterOptions = useMemo(
     () => characters.map((char) => ({ id: char.id, name: char.name })),
     [characters]
@@ -106,11 +109,13 @@ export function CharacterDetailPanel({
     setEndcardTitle(selectedChar?.endcard_title ?? '');
     setEndcardBody(selectedChar?.endcard_body ?? '');
     setEndcardImageUrl(selectedChar?.endcard_image_url ?? '');
+    setEndcardImageMediaId(selectedChar?.endcard_image_media_id ?? null);
   }, [
     selectedChar?.id,
     selectedChar?.endcard_title,
     selectedChar?.endcard_body,
     selectedChar?.endcard_image_url,
+    selectedChar?.endcard_image_media_id,
   ]);
 
   if (!selectedChar) {
@@ -128,6 +133,7 @@ export function CharacterDetailPanel({
     name: selectedChar.name,
     description: selectedChar.description ?? null,
     image_url: selectedChar.image_url ?? null,
+    image_media_id: selectedChar.image_media_id ?? null,
     is_culprit: Boolean(selectedChar.is_culprit),
     mystery_role: selectedRole,
     sort_order: selectedChar.sort_order ?? 0,
@@ -140,12 +146,14 @@ export function CharacterDetailPanel({
     endcard_title: selectedChar.endcard_title ?? null,
     endcard_body: selectedChar.endcard_body ?? null,
     endcard_image_url: selectedChar.endcard_image_url ?? null,
+    endcard_image_media_id: selectedChar.endcard_image_media_id ?? null,
     alias_rules: selectedChar.alias_rules ?? [],
   });
   const endcardDirty =
     endcardTitle !== (selectedChar.endcard_title ?? '') ||
     endcardBody !== (selectedChar.endcard_body ?? '') ||
-    endcardImageUrl !== (selectedChar.endcard_image_url ?? '');
+    endcardImageUrl !== (selectedChar.endcard_image_url ?? '') ||
+    endcardImageMediaId !== (selectedChar.endcard_image_media_id ?? null);
 
   return (
     <div className="max-w-4xl space-y-3">
@@ -177,27 +185,25 @@ export function CharacterDetailPanel({
             forceOpen: true,
             children: (
               <div className="grid gap-3 md:grid-cols-[8rem_minmax(0,1fr)]">
-                <div className="flex min-h-32 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-slate-800 bg-slate-950 p-2 text-xs text-slate-600">
+                <div className="min-w-0">
                   {onProfileImageChange ? (
-                    <>
-                      <ImageCropUpload
+                    <ImageMediaReferenceField
                         themeId={themeId}
-                        targetId={selectedChar.id}
-                        target="character"
-                        currentImageUrl={selectedChar.image_url ?? null}
-                        onUploaded={onProfileImageChange}
-                        onRemoved={
-                          selectedChar.image_url ? () => onProfileImageChange(null) : undefined
-                        }
-                        size="sm"
-                        shape="circle"
-                      />
-                      <span>{selectedChar.image_url ? '이미지 변경' : '이미지 업로드'}</span>
-                    </>
+                        label="프로필 이미지"
+                        imageMediaId={selectedChar.image_media_id ?? null}
+                        legacyImageUrl={selectedChar.image_url ?? null}
+                        pickerTitle="프로필 이미지 선택"
+                        emptyLabel="이미지 선택"
+                        compact
+                        onSelect={(media) => onProfileImageChange(media.id)}
+                        onClear={() => onProfileImageChange(null)}
+                    />
                   ) : (
-                    <span className="px-2 text-center text-[11px] leading-5 text-slate-500">
+                    <div className="rounded-lg border border-slate-800 bg-slate-950 p-3 text-center">
+                      <span className="px-2 text-[11px] leading-5 text-slate-500">
                       현재 프로필 이미지를 편집할 수 없습니다.
-                    </span>
+                      </span>
+                    </div>
                   )}
                 </div>
                 <div className="space-y-2.5">
@@ -314,19 +320,21 @@ export function CharacterDetailPanel({
                       placeholder={`${selectedChar.name}의 후일담`}
                     />
                   </label>
-                  <label className="block">
-                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
-                      이미지 URL
-                    </span>
-                    <input
-                      type="url"
-                      value={endcardImageUrl}
-                      disabled={!onEndcardChange}
-                      onChange={(event) => setEndcardImageUrl(event.currentTarget.value)}
-                      className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-200 outline-none transition focus:border-amber-500/60 disabled:opacity-70"
-                      placeholder="https://..."
-                    />
-                  </label>
+                  <ImageMediaReferenceField
+                    themeId={themeId}
+                    label="결과 카드 이미지"
+                    imageMediaId={endcardImageMediaId}
+                    legacyImageUrl={selectedChar.endcard_image_url ?? null}
+                    pickerTitle="결과 카드 이미지 선택"
+                    emptyLabel="결과 카드 이미지 선택"
+                    compact
+                    disabled={!onEndcardChange}
+                    onSelect={(media) => {
+                      setEndcardImageMediaId(media.id);
+                      setEndcardImageUrl('');
+                    }}
+                    onClear={() => setEndcardImageMediaId(null)}
+                  />
                 </div>
                 <label className="block">
                   <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
@@ -351,6 +359,7 @@ export function CharacterDetailPanel({
                         title: endcardTitle,
                         body: endcardBody,
                         imageUrl: endcardImageUrl,
+                        imageMediaId: endcardImageMediaId,
                       })
                     }
                     className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:border-slate-800 disabled:bg-slate-950 disabled:text-slate-600"

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -19,6 +19,7 @@ const {
   updateCharacterPendingMock,
   uploadMediaFileMock,
   useMediaDownloadUrlMock,
+  useMediaListMock,
 } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
   useEditorCharactersMock: vi.fn(),
@@ -31,6 +32,7 @@ const {
   updateCharacterPendingMock: { value: false },
   uploadMediaFileMock: vi.fn(),
   useMediaDownloadUrlMock: vi.fn(),
+  useMediaListMock: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -59,29 +61,33 @@ vi.mock('@/features/editor/mediaApi', () => ({
   useRequestUploadUrl: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConfirmUpload: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useMediaDownloadUrl: (mediaId?: string) => useMediaDownloadUrlMock(mediaId),
+  useMediaList: () => useMediaListMock(),
 }));
 
-vi.mock('@/features/editor/components/ImageCropUpload', () => ({
-  ImageCropUpload: ({
-    currentImageUrl,
-    onUploaded,
-    onRemoved,
+vi.mock('@/features/editor/components/media/MediaPicker', () => ({
+  MediaPicker: ({
+    open,
+    filterType,
+    selectedId,
+    onSelect,
   }: {
-    currentImageUrl?: string | null;
-    onUploaded: (url: string) => void;
-    onRemoved?: () => void;
-  }) => (
-    <div>
-      <button type="button" onClick={() => onUploaded('https://cdn.example/character.webp')}>
-        프로필 사진 업로드
-      </button>
-      {currentImageUrl && onRemoved && (
-        <button type="button" onClick={onRemoved}>
-          프로필 사진 삭제
+    open: boolean;
+    filterType?: string;
+    selectedId?: string | null;
+    onSelect: (media: { id: string; name: string; type: string }) => void;
+  }) =>
+    open ? (
+      <div>
+        <span>filter:{filterType}</span>
+        <span>selected:{selectedId ?? 'none'}</span>
+        <button
+          type="button"
+          onClick={() => onSelect({ id: 'image-1', name: '캐릭터 이미지', type: 'IMAGE' })}
+        >
+          캐릭터 이미지 선택
         </button>
-      )}
-    </div>
-  ),
+      </div>
+    ) : null,
 }));
 
 // ---------------------------------------------------------------------------
@@ -225,6 +231,10 @@ describe('CharacterAssignPanel', () => {
     useCharacterRoleSheetMock.mockReturnValue({ data: { format: 'markdown', markdown: { body: '' } }, isLoading: false });
     useUpsertCharacterRoleSheetMock.mockReturnValue({ mutate: upsertRoleSheetMutateMock, isPending: false });
     useMediaDownloadUrlMock.mockReturnValue({ data: undefined, isLoading: false, isError: false, refetch: vi.fn() });
+    useMediaListMock.mockReturnValue({
+      data: [{ id: 'image-1', name: '캐릭터 이미지', type: 'IMAGE' }],
+      isLoading: false,
+    });
     updateCharacterPendingMock.value = false;
   });
 
@@ -366,9 +376,8 @@ describe('CharacterAssignPanel', () => {
     fireEvent.change(screen.getByRole('textbox', { name: '제목' }), {
       target: { value: '범인의 후일담' },
     });
-    fireEvent.change(screen.getByRole('textbox', { name: '이미지 URL' }), {
-      target: { value: 'https://cdn.example/endcard.webp' },
-    });
+    fireEvent.click(screen.getByRole('button', { name: '결과 카드 이미지 선택' }));
+    fireEvent.click(screen.getByRole('button', { name: '캐릭터 이미지 선택' }));
     fireEvent.change(screen.getByRole('textbox', { name: '본문' }), {
       target: { value: '사건 이후의 선택을 보여준다.' },
     });
@@ -389,21 +398,25 @@ describe('CharacterAssignPanel', () => {
         is_voting_candidate: true,
         endcard_title: '범인의 후일담',
         endcard_body: '사건 이후의 선택을 보여준다.',
-        endcard_image_url: 'https://cdn.example/endcard.webp',
+        endcard_image_url: '',
+        endcard_image_media_id: 'image-1',
       },
     });
   });
 
-  it('기본 정보에서 캐릭터 이미지를 업로드한다', () => {
+  it('기본 정보에서 캐릭터 이미지를 미디어 관리 IMAGE로 선택한다', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
-    fireEvent.click(screen.getByRole('button', { name: '프로필 사진 업로드' }));
+    fireEvent.click(screen.getByRole('button', { name: '이미지 선택' }));
+    expect(screen.getByText('filter:IMAGE')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: '캐릭터 이미지 선택' }));
 
     expect(updateCharacterMutateMock).toHaveBeenCalledWith({
       characterId: 'char-1',
       body: expect.objectContaining({
         name: '홍길동',
-        image_url: 'https://cdn.example/character.webp',
+        image_url: '',
+        image_media_id: 'image-1',
         mystery_role: 'culprit',
         is_culprit: true,
       }),
@@ -412,19 +425,19 @@ describe('CharacterAssignPanel', () => {
 
   it('기본 정보에서 캐릭터 이미지를 삭제한다', () => {
     useEditorCharactersMock.mockReturnValue({
-      data: [{ ...mockCharacters[0], image_url: 'https://cdn.example/old.webp' }],
+      data: [{ ...mockCharacters[0], image_media_id: 'image-1' }],
       isLoading: false,
     });
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
-    fireEvent.click(screen.getByRole('button', { name: '프로필 사진 삭제' }));
+    fireEvent.click(screen.getByRole('button', { name: '제거' }));
 
     expect(updateCharacterMutateMock).toHaveBeenCalledWith({
       characterId: 'char-1',
       body: expect.objectContaining({
         name: '홍길동',
-        image_url: '',
+        image_media_id: null,
         mystery_role: 'culprit',
         is_culprit: true,
       }),
@@ -639,7 +652,7 @@ describe('CharacterAssignPanel', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
-    fireEvent.click(screen.getByRole('button', { name: /이미지/ }));
+    fireEvent.click(screen.getAllByRole('button', { name: /이미지/ }).at(-1)!);
     fireEvent.change(screen.getByRole('textbox', { name: '이미지 페이지 URL' }), {
       target: { value: 'https://cdn.example/role-1.webp' },
     });

--- a/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
+++ b/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { Image, X } from 'lucide-react';
+
+import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
+import { useMediaList, type MediaResponse } from '@/features/editor/mediaApi';
+
+interface ImageMediaReferenceFieldProps {
+  themeId: string;
+  label: string;
+  imageMediaId?: string | null;
+  legacyImageUrl?: string | null;
+  pickerTitle?: string;
+  emptyLabel?: string;
+  legacyHint?: string;
+  disabled?: boolean;
+  compact?: boolean;
+  onSelect: (media: MediaResponse) => void;
+  onClear: () => void;
+}
+
+export function ImageMediaReferenceField({
+  themeId,
+  label,
+  imageMediaId,
+  legacyImageUrl,
+  pickerTitle,
+  emptyLabel = '미디어 이미지 선택',
+  legacyHint = '기존 직접 업로드 이미지가 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다.',
+  disabled = false,
+  compact = false,
+  onSelect,
+  onClear,
+}: ImageMediaReferenceFieldProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { data: images = [] } = useMediaList(themeId, 'IMAGE');
+  const selectedImage = images.find((media) => media.id === imageMediaId) ?? null;
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-300">
+          <Image className="h-3.5 w-3.5 text-amber-400" />
+          {label}
+        </div>
+        {imageMediaId && !disabled ? (
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+          >
+            <X className="h-3 w-3" />
+            제거
+          </button>
+        ) : null}
+      </div>
+
+      {imageMediaId ? (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => setPickerOpen(true)}
+          className="flex w-full items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-left text-sm text-amber-100 hover:bg-amber-500/15 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          <span className="truncate">{selectedImage?.name ?? '선택된 이미지'}</span>
+          <span className="shrink-0 text-xs text-amber-200/70">교체</span>
+        </button>
+      ) : (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => setPickerOpen(true)}
+          className={`flex w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200 disabled:cursor-not-allowed disabled:opacity-70 ${
+            compact ? 'min-h-16' : 'aspect-[16/10]'
+          }`}
+        >
+          {emptyLabel}
+        </button>
+      )}
+
+      {!imageMediaId && legacyImageUrl ? (
+        <p className="mt-2 text-xs leading-5 text-slate-500">{legacyHint}</p>
+      ) : null}
+
+      <MediaPicker
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={onSelect}
+        themeId={themeId}
+        filterType="IMAGE"
+        selectedId={imageMediaId}
+        title={pickerTitle ?? `${label} 선택`}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -4,7 +4,7 @@ import {
   buildCharacterVisibilityUpdatePayload,
   buildCharacterAliasRulesUpdatePayload,
   buildCharacterEndcardUpdatePayload,
-  buildCharacterProfileImageUpdatePayload,
+  buildCharacterProfileImageMediaUpdatePayload,
   getCharacterListBadges,
   buildCharacterRoleUpdatePayload,
   getCharacterRoleBadge,
@@ -244,7 +244,8 @@ describe('characterEditorAdapter', () => {
     const payload = buildCharacterEndcardUpdatePayload(character({ is_playable: false }), {
       title: '  새 결말  ',
       body: '  공개되는 후일담  ',
-      imageUrl: '  https://cdn.example/new.webp  ',
+      imageUrl: '',
+      imageMediaId: 'image-1',
     });
 
     expect(payload).toMatchObject({
@@ -253,7 +254,8 @@ describe('characterEditorAdapter', () => {
       is_playable: false,
       endcard_title: '새 결말',
       endcard_body: '공개되는 후일담',
-      endcard_image_url: 'https://cdn.example/new.webp',
+      endcard_image_url: '',
+      endcard_image_media_id: 'image-1',
     });
   });
 
@@ -271,15 +273,16 @@ describe('characterEditorAdapter', () => {
     });
   });
 
-  it('프로필 이미지 삭제 payload는 빈 문자열로 backend clear 계약을 사용한다', () => {
-    const payload = buildCharacterProfileImageUpdatePayload(
+  it('프로필 이미지 선택 payload는 미디어 참조를 사용하고 URL을 비운다', () => {
+    const payload = buildCharacterProfileImageMediaUpdatePayload(
       character({ image_url: 'https://cdn.example/old.webp' }),
-      null,
+      'image-1',
     );
 
     expect(payload).toMatchObject({
       name: '홍길동',
       image_url: '',
+      image_media_id: 'image-1',
       mystery_role: 'suspect',
     });
   });

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -18,6 +18,7 @@ export interface CharacterEditorViewModel {
   name: string;
   description: string;
   imageUrl: string | null;
+  imageMediaId: string | null;
   sortOrder: number;
   role: MysteryRole;
   roleLabel: string;
@@ -35,6 +36,7 @@ export interface CharacterEditorViewModel {
   endcardTitle: string;
   endcardBody: string;
   endcardImageUrl: string | null;
+  endcardImageMediaId: string | null;
   hasEndcard: boolean;
   aliasRules: CharacterAliasRule[];
   hasAliasRules: boolean;
@@ -169,6 +171,7 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     name: character.name,
     description: character.description?.trim() ?? '',
     imageUrl: character.image_url,
+    imageMediaId: character.image_media_id ?? null,
     sortOrder: character.sort_order,
     role,
     roleLabel: option.label,
@@ -176,7 +179,7 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     roleBadge: option.label,
     isSpoilerRole: option.spoiler,
     isDefaultVotingCandidate: option.defaultVotingCandidate,
-    hasPublicIntro: Boolean(character.description?.trim() || character.image_url),
+    hasPublicIntro: Boolean(character.description?.trim() || character.image_media_id || character.image_url),
     isPlayable: visibility.isPlayable,
     characterTypeLabel: visibility.isPlayable ? 'PC' : 'NPC',
     showInIntro: visibility.showInIntro,
@@ -186,7 +189,13 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     endcardTitle: character.endcard_title?.trim() ?? '',
     endcardBody: character.endcard_body?.trim() ?? '',
     endcardImageUrl: character.endcard_image_url,
-    hasEndcard: Boolean(character.endcard_title?.trim() || character.endcard_body?.trim() || character.endcard_image_url),
+    endcardImageMediaId: character.endcard_image_media_id ?? null,
+    hasEndcard: Boolean(
+      character.endcard_title?.trim() ||
+      character.endcard_body?.trim() ||
+      character.endcard_image_media_id ||
+      character.endcard_image_url,
+    ),
     aliasRules,
     hasAliasRules: aliasRules.length > 0,
   };
@@ -233,13 +242,14 @@ export function buildCharacterVisibilityUpdatePayload(
 
 export function buildCharacterEndcardUpdatePayload(
   character: EditorCharacterResponse,
-  values: { title: string; body: string; imageUrl: string },
+  values: { title: string; body: string; imageUrl: string; imageMediaId?: string | null },
 ): UpdateCharacterRequest {
   const role = normalizeCharacterEditorRole(character);
   const visibility = getCharacterVisibility(character, role);
   const title = values.title.trim();
   const body = values.body.trim();
   const imageUrl = values.imageUrl.trim();
+  const imageMediaId = values.imageMediaId ?? null;
 
   return {
     name: character.name,
@@ -254,17 +264,19 @@ export function buildCharacterEndcardUpdatePayload(
     is_voting_candidate: visibility.isVotingCandidate,
     endcard_title: title,
     endcard_body: body,
-    endcard_image_url: imageUrl,
+    endcard_image_url: imageMediaId ? '' : imageUrl,
+    endcard_image_media_id: imageMediaId,
   };
 }
 
-export function buildCharacterProfileImageUpdatePayload(
+export function buildCharacterProfileImageMediaUpdatePayload(
   character: EditorCharacterResponse,
-  imageUrl: string | null,
+  imageMediaId: string | null,
 ): UpdateCharacterRequest {
   return {
     ...buildCharacterBaseUpdatePayload(character),
-    image_url: imageUrl ?? '',
+    image_url: imageMediaId ? '' : character.image_url ?? undefined,
+    image_media_id: imageMediaId,
   };
 }
 

--- a/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
@@ -17,6 +17,7 @@ export interface ClueEditorViewModel {
   name: string;
   description: string;
   imageUrl: string | null;
+  imageMediaId: string | null;
   publicScopeLabel: string;
   roundLabel: string;
   useEffectLabel: string;
@@ -79,6 +80,7 @@ export function toClueEditorViewModel(clue: ClueResponse, referenceCount = 0): C
     name: clue.name,
     description: clue.description?.trim() || '플레이어에게 보일 단서 설명을 입력하세요.',
     imageUrl: clue.image_url ?? null,
+    imageMediaId: clue.image_media_id ?? null,
     publicScopeLabel: clue.is_common ? '모든 플레이어가 공유' : '지정된 캐릭터나 장소에서만 획득',
     roundLabel: formatRoundRange(clue.reveal_round, clue.hide_round) || '처음부터 끝까지',
     useEffectLabel: effect?.label ?? '사용 효과 없음',

--- a/apps/web/src/features/editor/hooks/useClueFormSubmit.ts
+++ b/apps/web/src/features/editor/hooks/useClueFormSubmit.ts
@@ -23,6 +23,7 @@ export interface ClueSubmitBody {
   name: string;
   description?: string;
   image_url?: string;
+  image_media_id?: string | null;
   level: number;
   sort_order: number;
   is_common: boolean;


### PR DESCRIPTION
## 요약

- 캐릭터 프로필, 캐릭터 결과 카드, 단서 이미지에 `image_media_id` 기반 저장 계약을 추가했습니다.
- 에디터 UI에서 해당 이미지 슬롯을 직접 업로드/URL 입력이 아니라 미디어 관리의 IMAGE 항목 선택으로 연결했습니다.
- 기존 `image_url` / `endcard_image_url`은 호환 필드로 유지하고, 미디어 선택 시 URL을 비워 새 참조가 우선되게 했습니다.
- 커버/맵 이미지는 crop/파생 이미지 정책이 필요해 후속 #436으로 분리했습니다.

Closes #427
Refs #381
Refs #436

## 검증

- `go test ./internal/domain/editor`
- `go test ./internal/domain/editor -run 'CharacterImageMedia|ClueImageMedia|LocationImageMedia|OptionalUUID'`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/CharacterForm.test.tsx src/features/editor/components/__tests__/ClueForm.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx`
- `pnpm --filter @mmp/web exec eslint src/features/editor/components/media/ImageMediaReferenceField.tsx src/features/editor/components/design/CharacterAssignPanel.tsx src/features/editor/components/design/CharacterDetailPanel.tsx src/features/editor/components/CharacterForm.tsx src/features/editor/components/ClueForm.tsx src/features/editor/hooks/useClueFormSubmit.ts src/features/editor/entities/character/characterEditorAdapter.ts src/features/editor/entities/clue/clueEntityAdapter.ts src/features/editor/components/__tests__/CharacterForm.test.tsx src/features/editor/components/__tests__/ClueForm.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캐릭터·단서에 미디어 라이브러리 이미지를 연결(프로필·엔드카드 포함)하고 에디터에서 선택·교체·해제할 수 있음. 업로드 대신 미디어 참조 기반 워크플로로 전환.
  * 생성/수정 API와 프론트엔드 타입에 이미지 미디어 참조 필드가 추가되어 미디어 ID로 저장·전달 가능.

* **테스트**
  * 미디어 선택, 테마 내 미디어 검증, 참조 업데이트/삭제를 검증하는 통합 및 컴포넌트 테스트 추가.

* **데이터베이스**
  * 캐릭터·단서 테이블에 이미지 미디어 참조 컬럼과 부분 인덱스가 추가되어 미디어 연결을 저장·조회 성능 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->