### PR TITLE
feat(editor): direct URL smoke 진입 보강

### DIFF
--- a/apps/server/internal/domain/editor/handler.go
+++ b/apps/server/internal/domain/editor/handler.go
@@ -104,13 +104,22 @@ func (h *Handler) CreateTheme(w http.ResponseWriter, r *http.Request) {
 // GetTheme handles GET /editor/themes/{id}.
 func (h *Handler) GetTheme(w http.ResponseWriter, r *http.Request) {
 	creatorID := middleware.UserIDFrom(r.Context())
-	themeID, err := parseUUID(r, "id")
-	if err != nil {
-		apperror.WriteError(w, r, err)
-		return
+	locator := chi.URLParam(r, "id")
+
+	var (
+		resp *ThemeResponse
+		err  error
+	)
+	if themeID, parseErr := uuid.Parse(locator); parseErr == nil {
+		resp, err = h.svc.GetTheme(r.Context(), creatorID, themeID)
+	} else {
+		if !isValidThemeSlug(locator) {
+			apperror.WriteError(w, r, apperror.BadRequest("invalid theme id or slug format"))
+			return
+		}
+		resp, err = h.svc.GetThemeBySlug(r.Context(), creatorID, locator)
 	}
 
-	resp, err := h.svc.GetTheme(r.Context(), creatorID, themeID)
 	if err != nil {
 		apperror.WriteError(w, r, err)
 		return

--- a/apps/server/internal/domain/editor/handler_test.go
+++ b/apps/server/internal/domain/editor/handler_test.go
@@ -136,6 +136,67 @@ func TestCreateTheme_InvalidBody(t *testing.T) {
 	}
 }
 
+func TestGetTheme_ByUUID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockService(ctrl)
+
+	mock.EXPECT().
+		GetTheme(gomock.Any(), gomock.Eq(extCreatorID), gomock.Eq(extThemeID)).
+		Return(extSampleThemeResponse(), nil).Times(1)
+
+	h := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
+
+	r := httptest.NewRequest(http.MethodGet, "/editor/themes/"+extThemeID.String(), nil)
+	r = withExtAuth(r)
+	r = extChiContext(r, map[string]string{"id": extThemeID.String()})
+	w := httptest.NewRecorder()
+
+	h.GetTheme(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetTheme_BySlug(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockService(ctrl)
+
+	mock.EXPECT().
+		GetThemeBySlug(gomock.Any(), gomock.Eq(extCreatorID), gomock.Eq("e2e-test-theme")).
+		Return(extSampleThemeResponse(), nil).Times(1)
+
+	h := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
+
+	r := httptest.NewRequest(http.MethodGet, "/editor/themes/e2e-test-theme", nil)
+	r = withExtAuth(r)
+	r = extChiContext(r, map[string]string{"id": "e2e-test-theme"})
+	w := httptest.NewRecorder()
+
+	h.GetTheme(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetTheme_InvalidLocator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockService(ctrl)
+	h := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
+
+	r := httptest.NewRequest(http.MethodGet, "/editor/themes/not_a_slug", nil)
+	r = withExtAuth(r)
+	r = extChiContext(r, map[string]string{"id": "not_a_slug"})
+	w := httptest.NewRecorder()
+
+	h.GetTheme(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestUpdateTheme_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := mocks.NewMockService(ctrl)

--- a/apps/server/internal/domain/editor/helpers.go
+++ b/apps/server/internal/domain/editor/helpers.go
@@ -65,6 +65,11 @@ func pgtypeInt4ToPtr(i pgtype.Int4) *int32 {
 }
 
 var slugCleanRe = regexp.MustCompile(`[^a-z0-9-]+`)
+var themeSlugRe = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+func isValidThemeSlug(slug string) bool {
+	return themeSlugRe.MatchString(slug)
+}
 
 func generateSlug(title string) string {
 	s := strings.ToLower(strings.TrimSpace(title))

--- a/apps/server/internal/domain/editor/mock_shim_test.go
+++ b/apps/server/internal/domain/editor/mock_shim_test.go
@@ -112,6 +112,9 @@ func (m *mockService) ListCharacters(ctx context.Context, creatorID, themeID uui
 func (m *mockService) GetTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error) {
 	return nil, nil
 }
+func (m *mockService) GetThemeBySlug(ctx context.Context, creatorID uuid.UUID, slug string) (*ThemeResponse, error) {
+	return nil, nil
+}
 func (m *mockService) CreateMap(ctx context.Context, creatorID, themeID uuid.UUID, req CreateMapRequest) (*MapResponse, error) {
 	return nil, nil
 }

--- a/apps/server/internal/domain/editor/mock_shim_test.go
+++ b/apps/server/internal/domain/editor/mock_shim_test.go
@@ -36,6 +36,7 @@ type mockService struct {
 	updateThemeFn      func(ctx context.Context, creatorID, themeID uuid.UUID, req UpdateThemeRequest) (*ThemeResponse, error)
 	deleteThemeFn      func(ctx context.Context, creatorID, themeID uuid.UUID) error
 	listMyThemesFn     func(ctx context.Context, creatorID uuid.UUID) ([]ThemeSummary, error)
+	getThemeBySlugFn   func(ctx context.Context, creatorID uuid.UUID, slug string) (*ThemeResponse, error)
 	publishThemeFn     func(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error)
 	unpublishThemeFn   func(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error)
 	createCharFn       func(ctx context.Context, creatorID, themeID uuid.UUID, req CreateCharacterRequest) (*CharacterResponse, error)
@@ -113,6 +114,9 @@ func (m *mockService) GetTheme(ctx context.Context, creatorID, themeID uuid.UUID
 	return nil, nil
 }
 func (m *mockService) GetThemeBySlug(ctx context.Context, creatorID uuid.UUID, slug string) (*ThemeResponse, error) {
+	if m.getThemeBySlugFn != nil {
+		return m.getThemeBySlugFn(ctx, creatorID, slug)
+	}
 	return nil, nil
 }
 func (m *mockService) CreateMap(ctx context.Context, creatorID, themeID uuid.UUID, req CreateMapRequest) (*MapResponse, error) {

--- a/apps/server/internal/domain/editor/mocks/mock_service.go
+++ b/apps/server/internal/domain/editor/mocks/mock_service.go
@@ -263,6 +263,21 @@ func (mr *MockServiceMockRecorder) GetTheme(ctx, creatorID, themeID any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTheme", reflect.TypeOf((*MockService)(nil).GetTheme), ctx, creatorID, themeID)
 }
 
+// GetThemeBySlug mocks base method.
+func (m *MockService) GetThemeBySlug(ctx context.Context, creatorID uuid.UUID, slug string) (*editor.ThemeResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetThemeBySlug", ctx, creatorID, slug)
+	ret0, _ := ret[0].(*editor.ThemeResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetThemeBySlug indicates an expected call of GetThemeBySlug.
+func (mr *MockServiceMockRecorder) GetThemeBySlug(ctx, creatorID, slug any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThemeBySlug", reflect.TypeOf((*MockService)(nil).GetThemeBySlug), ctx, creatorID, slug)
+}
+
 // ListCharacters mocks base method.
 func (m *MockService) ListCharacters(ctx context.Context, creatorID, themeID uuid.UUID) ([]editor.CharacterResponse, error) {
 	m.ctrl.T.Helper()

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -193,6 +193,7 @@ type Service interface {
 
 	// Theme detail
 	GetTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ThemeResponse, error)
+	GetThemeBySlug(ctx context.Context, creatorID uuid.UUID, slug string) (*ThemeResponse, error)
 
 	// Validation
 	ValidateTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*ValidationResponse, error)

--- a/apps/server/internal/domain/editor/service_themes_test.go
+++ b/apps/server/internal/domain/editor/service_themes_test.go
@@ -68,6 +68,41 @@ func TestService_GetTheme_OwnershipEnforced(t *testing.T) {
 	}
 }
 
+func TestService_GetThemeBySlug_OwnershipEnforced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	otherID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	theme, err := f.q.GetTheme(ctx, themeID)
+	require.NoError(t, err)
+
+	resp, err := f.svc.GetThemeBySlug(ctx, creatorID, theme.Slug)
+	require.NoError(t, err)
+	assert.Equal(t, themeID, resp.ID)
+	assert.Equal(t, theme.Slug, resp.Slug)
+
+	_, err = f.svc.GetThemeBySlug(ctx, otherID, theme.Slug)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "you do not own this theme")
+}
+
+func TestService_GetThemeBySlug_InvalidSlug(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+
+	_, err := f.svc.GetThemeBySlug(ctx, creatorID, "not_a_slug")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid theme slug format")
+}
+
 func TestService_ListMyThemes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/apps/server/internal/domain/editor/service_themes_test.go
+++ b/apps/server/internal/domain/editor/service_themes_test.go
@@ -87,7 +87,7 @@ func TestService_GetThemeBySlug_OwnershipEnforced(t *testing.T) {
 
 	_, err = f.svc.GetThemeBySlug(ctx, otherID, theme.Slug)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "you do not own this theme")
+	assert.Contains(t, err.Error(), "theme not found")
 }
 
 func TestService_GetThemeBySlug_InvalidSlug(t *testing.T) {

--- a/apps/server/internal/domain/editor/themes.go
+++ b/apps/server/internal/domain/editor/themes.go
@@ -133,13 +133,37 @@ func (s *service) GetTheme(ctx context.Context, creatorID, themeID uuid.UUID) (*
 	if err != nil {
 		return nil, err
 	}
+	return s.themeResponseForRead(theme)
+}
+
+// GetThemeBySlug fetches a single theme by slug, enforcing creator ownership.
+// This is intentionally read-only: mutating editor endpoints remain UUID-only.
+func (s *service) GetThemeBySlug(ctx context.Context, creatorID uuid.UUID, slug string) (*ThemeResponse, error) {
+	if !isValidThemeSlug(slug) {
+		return nil, apperror.BadRequest("invalid theme slug format")
+	}
+	theme, err := s.q.GetThemeBySlug(ctx, slug)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("theme not found")
+		}
+		s.logger.Error().Err(err).Str("slug", slug).Msg("failed to get theme by slug")
+		return nil, apperror.Internal("failed to get theme")
+	}
+	if theme.CreatorID != creatorID {
+		return nil, apperror.Forbidden("you do not own this theme")
+	}
+	return s.themeResponseForRead(theme)
+}
+
+func (s *service) themeResponseForRead(theme db.Theme) (*ThemeResponse, error) {
 	legacyAxes := legacyConfigAxes(theme.ConfigJson)
 	normalized, err := NormalizeConfigJSON(theme.ConfigJson)
 	if err != nil {
-		s.logger.Error().Err(err).Str("theme_id", themeID.String()).Msg("failed to normalize config_json")
+		s.logger.Error().Err(err).Str("theme_id", theme.ID.String()).Msg("failed to normalize config_json")
 		return nil, apperror.Internal("failed to normalize config_json")
 	}
-	s.logLegacyConfigRead(themeID, legacyAxes)
+	s.logLegacyConfigRead(theme.ID, legacyAxes)
 	theme.ConfigJson = normalized
 	return toThemeResponse(theme), nil
 }

--- a/apps/server/internal/domain/editor/themes.go
+++ b/apps/server/internal/domain/editor/themes.go
@@ -151,7 +151,7 @@ func (s *service) GetThemeBySlug(ctx context.Context, creatorID uuid.UUID, slug 
 		return nil, apperror.Internal("failed to get theme")
 	}
 	if theme.CreatorID != creatorID {
-		return nil, apperror.Forbidden("you do not own this theme")
+		return nil, apperror.NotFound("theme not found")
 	}
 	return s.themeResponseForRead(theme)
 }

--- a/apps/web/src/features/editor/components/ThemeEditor.tsx
+++ b/apps/web/src/features/editor/components/ThemeEditor.tsx
@@ -18,12 +18,32 @@ function FullPageSpinner() {
   );
 }
 
-function FullPageError({ message }: { message: string }) {
+function FullPageError({ message, detail }: { message: string; detail?: string }) {
   return (
-    <div className="flex h-screen items-center justify-center bg-slate-950">
-      <p className="text-sm text-red-400">{message}</p>
+    <div className="flex h-screen items-center justify-center bg-slate-950 px-6 text-center">
+      <div className="max-w-md space-y-2">
+        <p className="text-sm font-medium text-red-300">{message}</p>
+        {detail && <p className="text-sm leading-6 text-slate-400">{detail}</p>}
+      </div>
     </div>
   );
+}
+
+const uuidLikeRe =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function buildThemeLoadError(themeId: string) {
+  if (uuidLikeRe.test(themeId)) {
+    return {
+      message: "테마를 찾을 수 없습니다",
+      detail: "삭제됐거나 현재 계정에 편집 권한이 없는 테마일 수 있습니다.",
+    };
+  }
+  return {
+    message: "샘플 또는 slug 테마를 찾을 수 없습니다",
+    detail:
+      "이 주소는 UUID가 아닌 slug로 열린 주소입니다. 로컬 샘플이라면 e2e-test-theme seed가 적용됐는지 확인하세요.",
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -37,8 +57,9 @@ interface ThemeEditorProps {
 
 export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
   const { data: theme, isLoading, isError } = useEditorTheme(themeId);
-  const { data: clues } = useEditorClues(themeId);
-  const { data: clueEdgeGroups } = useClueEdges(themeId);
+  const resolvedThemeId = theme?.id ?? "";
+  const { data: clues } = useEditorClues(resolvedThemeId);
+  const { data: clueEdgeGroups } = useClueEdges(resolvedThemeId);
 
   const handleValidate = useCallback(() => {
     if (!theme) return [];
@@ -65,12 +86,15 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
   }, [theme, clues, clueEdgeGroups]);
 
   if (isLoading) return <FullPageSpinner />;
-  if (isError || !theme) return <FullPageError message="테마를 찾을 수 없습니다" />;
+  if (isError || !theme) {
+    const errorCopy = buildThemeLoadError(themeId);
+    return <FullPageError message={errorCopy.message} detail={errorCopy.detail} />;
+  }
 
   return (
     <EditorLayout
       theme={theme}
-      themeId={themeId}
+      themeId={resolvedThemeId}
       routeSegment={routeSegment}
       onValidate={handleValidate}
     />

--- a/apps/web/src/features/editor/components/ThemeEditor.tsx
+++ b/apps/web/src/features/editor/components/ThemeEditor.tsx
@@ -4,6 +4,7 @@ import { useEditorTheme } from "@/features/editor/api";
 import { useEditorClues } from "@/features/editor/editorClueApi";
 import { validateGameDesign, validateClueGraph } from "@/features/editor/validation";
 import { useClueEdges } from "@/features/editor/clueEdgeApi";
+import { isApiHttpError } from "@/lib/api-error";
 import { EditorLayout } from "./EditorLayout";
 
 // ---------------------------------------------------------------------------
@@ -32,7 +33,27 @@ function FullPageError({ message, detail }: { message: string; detail?: string }
 const uuidLikeRe =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-function buildThemeLoadError(themeId: string) {
+function buildThemeLoadError(themeId: string, error?: unknown) {
+  if (isApiHttpError(error)) {
+    if (error.status === 400) {
+      return {
+        message: "테마 주소 형식이 올바르지 않습니다",
+        detail: "주소에는 테마 UUID 또는 영문 소문자, 숫자, 하이픈으로 된 slug만 사용할 수 있습니다.",
+      };
+    }
+    if (error.status === 403) {
+      return {
+        message: "테마 편집 권한이 없습니다",
+        detail: "현재 로그인한 계정으로는 이 테마를 편집할 수 없습니다. 다른 계정으로 로그인했는지 확인하세요.",
+      };
+    }
+    if (error.status === 404) {
+      return {
+        message: "테마를 찾을 수 없습니다",
+        detail: "삭제됐거나 현재 계정에서 접근할 수 없는 테마일 수 있습니다.",
+      };
+    }
+  }
   if (uuidLikeRe.test(themeId)) {
     return {
       message: "테마를 찾을 수 없습니다",
@@ -56,7 +77,7 @@ interface ThemeEditorProps {
 }
 
 export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
-  const { data: theme, isLoading, isError } = useEditorTheme(themeId);
+  const { data: theme, error, isLoading, isError } = useEditorTheme(themeId);
   const resolvedThemeId = theme?.id ?? "";
   const { data: clues } = useEditorClues(resolvedThemeId);
   const { data: clueEdgeGroups } = useClueEdges(resolvedThemeId);
@@ -87,7 +108,7 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
 
   if (isLoading) return <FullPageSpinner />;
   if (isError || !theme) {
-    const errorCopy = buildThemeLoadError(themeId);
+    const errorCopy = buildThemeLoadError(themeId, error);
     return <FullPageError message={errorCopy.message} detail={errorCopy.detail} />;
   }
 

--- a/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
@@ -80,17 +80,51 @@ describe('ThemeEditor', () => {
   it('테마 로드 실패 시 오류 메시지를 표시한다', () => {
     useEditorThemeMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
 
-    render(<ThemeEditor themeId="theme-1" />);
+    render(<ThemeEditor themeId="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" />);
 
     expect(screen.getByText('테마를 찾을 수 없습니다')).toBeDefined();
+    expect(screen.getByText(/편집 권한이 없는 테마/)).toBeDefined();
+  });
+
+  it('slug 주소 로드 실패 시 seed 확인 메시지를 표시한다', () => {
+    useEditorThemeMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+
+    render(<ThemeEditor themeId="e2e-test-theme" />);
+
+    expect(screen.getByText('샘플 또는 slug 테마를 찾을 수 없습니다')).toBeDefined();
+    expect(screen.getByText(/e2e-test-theme seed/)).toBeDefined();
   });
 
   it('routeSegment를 EditorLayout으로 전달하고 검증 결과를 합친다', () => {
     render(<ThemeEditor themeId="theme-1" routeSegment="modules" />);
 
     expect(screen.getByText('EditorLayout modules')).toBeDefined();
-    const props = editorLayoutMock.mock.calls[0][0] as { onValidate: () => string[]; routeSegment: string };
+    expect(useEditorThemeMock).toHaveBeenCalledWith('theme-1');
+    expect(useEditorCluesMock).toHaveBeenCalledWith('theme-1');
+    expect(useClueEdgesMock).toHaveBeenCalledWith('theme-1');
+    const props = editorLayoutMock.mock.calls[0][0] as {
+      onValidate: () => string[];
+      routeSegment: string;
+      themeId: string;
+    };
     expect(props.routeSegment).toBe('modules');
+    expect(props.themeId).toBe('theme-1');
     expect(props.onValidate()).toEqual(['game-warning', 'graph-warning']);
+  });
+
+  it('slug로 열린 뒤 하위 편집 API에는 응답의 UUID를 사용한다', () => {
+    useEditorThemeMock.mockReturnValue({
+      data: { ...theme, id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<ThemeEditor themeId="e2e-test-theme" routeSegment="flow" />);
+
+    expect(useEditorThemeMock).toHaveBeenCalledWith('e2e-test-theme');
+    expect(useEditorCluesMock).toHaveBeenCalledWith('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+    expect(useClueEdgesMock).toHaveBeenCalledWith('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+    const props = editorLayoutMock.mock.calls[0][0] as { themeId: string };
+    expect(props.themeId).toBe('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
   });
 });

--- a/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../EditorLayout', () => ({
 }));
 
 import { ThemeEditor } from '../ThemeEditor';
+import { ApiHttpError } from '@/lib/api-error';
 
 const theme = {
   id: 'theme-1',
@@ -93,6 +94,46 @@ describe('ThemeEditor', () => {
 
     expect(screen.getByText('샘플 또는 slug 테마를 찾을 수 없습니다')).toBeDefined();
     expect(screen.getByText(/e2e-test-theme seed/)).toBeDefined();
+  });
+
+  it('서버가 invalid locator를 반환하면 주소 형식 메시지를 표시한다', () => {
+    useEditorThemeMock.mockReturnValue({
+      data: undefined,
+      error: new ApiHttpError({
+        type: 'about:blank',
+        code: 'BAD_REQUEST',
+        status: 400,
+        title: 'Bad Request',
+        detail: 'invalid theme locator',
+      }),
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<ThemeEditor themeId="bad_slug!" />);
+
+    expect(screen.getByText('테마 주소 형식이 올바르지 않습니다')).toBeDefined();
+    expect(screen.getByText(/영문 소문자, 숫자, 하이픈/)).toBeDefined();
+  });
+
+  it('서버가 forbidden을 반환하면 권한 메시지를 표시한다', () => {
+    useEditorThemeMock.mockReturnValue({
+      data: undefined,
+      error: new ApiHttpError({
+        type: 'about:blank',
+        code: 'FORBIDDEN',
+        status: 403,
+        title: 'Forbidden',
+        detail: 'you do not own this theme',
+      }),
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<ThemeEditor themeId="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" />);
+
+    expect(screen.getByText('테마 편집 권한이 없습니다')).toBeDefined();
+    expect(screen.getByText(/현재 로그인한 계정/)).toBeDefined();
   });
 
   it('routeSegment를 EditorLayout으로 전달하고 검증 결과를 합친다', () => {

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -70,6 +70,7 @@ const routeMatrixCases = [
   ],
   ['alias URL /editor/:id/modules', { id: 'theme-1', tab: 'modules' }, 'modules', 'design'],
   ['alias URL /editor/:id/flow', { id: 'theme-1', tab: 'flow' }, 'flow', 'storyMap'],
+  ['sample slug URL /editor/e2e-test-theme/flow', { id: 'e2e-test-theme', tab: 'flow' }, 'flow', 'storyMap'],
   ['alias URL /editor/:id/locations', { id: 'theme-1', tab: 'locations' }, 'locations', 'design'],
   ['alias URL /editor/:id/endings', { id: 'theme-1', tab: 'endings' }, 'endings', 'design'],
 ] as const;
@@ -105,7 +106,7 @@ describe('EditorPage', () => {
 
       render(<EditorPage />);
 
-      expect(screen.getByText(new RegExp(`테마 에디터 theme-1 ${expectedSegment}`))).toBeDefined();
+      expect(screen.getByText(new RegExp(`테마 에디터 ${params.id} ${expectedSegment}`))).toBeDefined();
       expect(setActiveTabMock).toHaveBeenCalledWith(expectedTab);
     }
   );

--- a/docs/runbooks/editor-direct-url-smoke.md
+++ b/docs/runbooks/editor-direct-url-smoke.md
@@ -16,6 +16,12 @@ psql "$DATABASE_URL" -f apps/server/db/seed/e2e-themes.sql
 PGPASSWORD=mmp_dev psql -h localhost -p 25432 -U mmp -d mmf -f apps/server/db/seed/e2e-themes.sql
 ```
 
+Seed 적용 여부와 slug가 해석될 실제 UUID는 다음 명령으로 확인한다.
+
+```bash
+PGPASSWORD=mmp_dev psql -h localhost -p 25432 -U mmp -d mmf -c "SELECT slug, id AS resolved_uuid FROM themes WHERE slug = 'e2e-test-theme';"
+```
+
 ## Smoke URL
 
 아래 URL은 같은 테마 locator에 대해 기본 진입과 주요 탭이 올바르게 열리는지 확인한다. `{theme}`에는 실제 UUID 또는 `e2e-test-theme` 같은 slug를 넣을 수 있다.

--- a/docs/runbooks/editor-direct-url-smoke.md
+++ b/docs/runbooks/editor-direct-url-smoke.md
@@ -32,4 +32,18 @@ http://localhost:3000/editor/{theme}/endings
 http://localhost:3000/editor/{theme}/media
 ```
 
+로컬 샘플 slug를 바로 확인할 때는 아래 목록을 그대로 열면 된다.
+
+```text
+http://localhost:3000/editor/e2e-test-theme
+http://localhost:3000/editor/e2e-test-theme/flow
+http://localhost:3000/editor/e2e-test-theme/story
+http://localhost:3000/editor/e2e-test-theme/info
+http://localhost:3000/editor/e2e-test-theme/characters
+http://localhost:3000/editor/e2e-test-theme/clues
+http://localhost:3000/editor/e2e-test-theme/locations
+http://localhost:3000/editor/e2e-test-theme/endings
+http://localhost:3000/editor/e2e-test-theme/media
+```
+
 `/flow`는 제작 흐름의 기본 스토리 진행 화면으로 들어가는 짧은 주소다. 세부 설계 탭의 흐름 하위 화면을 직접 열려면 `/editor/{theme}/design/flow`를 사용한다.

--- a/docs/runbooks/editor-direct-url-smoke.md
+++ b/docs/runbooks/editor-direct-url-smoke.md
@@ -1,0 +1,35 @@
+# Editor Direct URL Smoke
+
+이 문서는 로컬에서 실제 제작자 에디터 URL이 열리는지 확인하는 최소 절차다.
+
+## 샘플 테마 seed
+
+`e2e-test-theme`는 UUID가 아니라 slug다. 로컬 DB에 샘플 테마가 없으면 `/editor/e2e-test-theme`는 테마 없음 화면을 보여준다.
+
+```bash
+psql "$DATABASE_URL" -f apps/server/db/seed/e2e-themes.sql
+```
+
+개발 compose 기본 DB를 직접 사용할 때는 다음처럼 접속값을 명시한다.
+
+```bash
+PGPASSWORD=mmp_dev psql -h localhost -p 25432 -U mmp -d mmf -f apps/server/db/seed/e2e-themes.sql
+```
+
+## Smoke URL
+
+아래 URL은 같은 테마 locator에 대해 기본 진입과 주요 탭이 올바르게 열리는지 확인한다. `{theme}`에는 실제 UUID 또는 `e2e-test-theme` 같은 slug를 넣을 수 있다.
+
+```text
+http://localhost:3000/editor/{theme}
+http://localhost:3000/editor/{theme}/flow
+http://localhost:3000/editor/{theme}/story
+http://localhost:3000/editor/{theme}/info
+http://localhost:3000/editor/{theme}/characters
+http://localhost:3000/editor/{theme}/clues
+http://localhost:3000/editor/{theme}/locations
+http://localhost:3000/editor/{theme}/endings
+http://localhost:3000/editor/{theme}/media
+```
+
+`/flow`는 제작 흐름의 기본 스토리 진행 화면으로 들어가는 짧은 주소다. 세부 설계 탭의 흐름 하위 화면을 직접 열려면 `/editor/{theme}/design/flow`를 사용한다.


### PR DESCRIPTION
## 요약
- editor theme GET 조회에서 UUID와 slug를 모두 허용하되, 수정/삭제/발행 API는 UUID 전용 계약을 유지했습니다.
- `/editor/e2e-test-theme`처럼 slug로 열린 화면도 응답받은 실제 UUID를 하위 편집 API에 사용하게 해 단서/관계 조회가 다시 실패하지 않게 했습니다.
- direct URL smoke runbook을 추가해 seed 적용과 확인 URL 목록을 고정했습니다.

Closes #413
Refs #381

## Coverage Plan
- Backend handler/service tests: UUID 조회, slug 조회, malformed locator, slug ownership enforcement.
- Frontend route/component tests: direct URL matrix, slug route, not-found copy, slug 입력 후 하위 API UUID 사용.
- E2E 미작성 사유: 이번 변경은 실제 route/API lookup 계약과 에러 카피 보강이며, backend seed가 필요한 브라우저 smoke는 `docs/runbooks/editor-direct-url-smoke.md`에 수동 절차로 고정했습니다.

## 검증
- `go test ./internal/domain/editor -run 'TestGetTheme_|TestService_GetTheme'`\n- `pnpm --filter @mmp/web exec tsc --noEmit`\n- `pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/__tests__/routeSegments.test.ts src/features/editor/components/__tests__/ThemeEditor.test.tsx`\n- `pnpm --filter @mmp/web exec eslint src/features/editor/components/ThemeEditor.tsx src/features/editor/components/__tests__/ThemeEditor.test.tsx src/pages/__tests__/EditorPage.test.tsx`\n- `git diff --check`\n\n## CI scope\n- `scripts/mmp-pr-ci-scope.sh --stdin --format text`: full-ci\n- PR 생성 시 `ready-for-ci` 라벨은 붙이지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 테마 조회에 UUID와 슬러그 둘 다 지원

* **개선 사항**
  * UUID/슬러그 기반 로드 실패 시 더 구체적이고 문맥화된 오류 메시지 표시
  * 로드된 테마 ID를 명확히 해 에디터 데이터 로드 흐름 안정화 및 레이아웃 전달 개선
  * 읽기 시 테마 설정 정규화 및 로그 메시지 개선

* **버그 수정**
  * 잘못된 슬러그 입력에 대해 400 응답 처리 추가

* **테스트**
  * 슬러그/UUID 조회, 권한 검증 및 오류 경로를 포함한 테스트 확장

* **문서**
  * 에디터 직접 URL 점검 가이드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->