### PR TITLE
feat(editor): 커버와 지도 이미지를 미디어 참조로 연결

### DIFF
--- a/apps/server/db/migrations/00039_theme_cover_map_media_ids.sql
+++ b/apps/server/db/migrations/00039_theme_cover_map_media_ids.sql
@@ -1,9 +1,20 @@
 -- +goose Up
+ALTER TABLE theme_media
+  ADD CONSTRAINT theme_media_theme_id_id_unique UNIQUE (theme_id, id);
+
 ALTER TABLE themes
-  ADD COLUMN cover_image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL;
+  ADD COLUMN cover_image_media_id UUID,
+  ADD CONSTRAINT themes_cover_image_media_same_theme_fk
+    FOREIGN KEY (id, cover_image_media_id)
+    REFERENCES theme_media(theme_id, id)
+    ON DELETE SET NULL;
 
 ALTER TABLE theme_maps
-  ADD COLUMN image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL;
+  ADD COLUMN image_media_id UUID,
+  ADD CONSTRAINT theme_maps_image_media_same_theme_fk
+    FOREIGN KEY (theme_id, image_media_id)
+    REFERENCES theme_media(theme_id, id)
+    ON DELETE SET NULL;
 
 CREATE INDEX idx_themes_cover_image_media
   ON themes(cover_image_media_id)
@@ -18,7 +29,12 @@ DROP INDEX IF EXISTS idx_theme_maps_image_media;
 DROP INDEX IF EXISTS idx_themes_cover_image_media;
 
 ALTER TABLE theme_maps
+  DROP CONSTRAINT IF EXISTS theme_maps_image_media_same_theme_fk,
   DROP COLUMN IF EXISTS image_media_id;
 
 ALTER TABLE themes
+  DROP CONSTRAINT IF EXISTS themes_cover_image_media_same_theme_fk,
   DROP COLUMN IF EXISTS cover_image_media_id;
+
+ALTER TABLE theme_media
+  DROP CONSTRAINT IF EXISTS theme_media_theme_id_id_unique;

--- a/apps/server/db/migrations/00039_theme_cover_map_media_ids.sql
+++ b/apps/server/db/migrations/00039_theme_cover_map_media_ids.sql
@@ -7,14 +7,14 @@ ALTER TABLE themes
   ADD CONSTRAINT themes_cover_image_media_same_theme_fk
     FOREIGN KEY (id, cover_image_media_id)
     REFERENCES theme_media(theme_id, id)
-    ON DELETE SET NULL;
+    ON DELETE SET NULL (cover_image_media_id);
 
 ALTER TABLE theme_maps
   ADD COLUMN image_media_id UUID,
   ADD CONSTRAINT theme_maps_image_media_same_theme_fk
     FOREIGN KEY (theme_id, image_media_id)
     REFERENCES theme_media(theme_id, id)
-    ON DELETE SET NULL;
+    ON DELETE SET NULL (image_media_id);
 
 CREATE INDEX idx_themes_cover_image_media
   ON themes(cover_image_media_id)

--- a/apps/server/db/migrations/00039_theme_cover_map_media_ids.sql
+++ b/apps/server/db/migrations/00039_theme_cover_map_media_ids.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+ALTER TABLE themes
+  ADD COLUMN cover_image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL;
+
+ALTER TABLE theme_maps
+  ADD COLUMN image_media_id UUID REFERENCES theme_media(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_themes_cover_image_media
+  ON themes(cover_image_media_id)
+  WHERE cover_image_media_id IS NOT NULL;
+
+CREATE INDEX idx_theme_maps_image_media
+  ON theme_maps(image_media_id)
+  WHERE image_media_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_theme_maps_image_media;
+DROP INDEX IF EXISTS idx_themes_cover_image_media;
+
+ALTER TABLE theme_maps
+  DROP COLUMN IF EXISTS image_media_id;
+
+ALTER TABLE themes
+  DROP COLUMN IF EXISTS cover_image_media_id;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -9,12 +9,12 @@ SELECT * FROM theme_maps WHERE theme_id = $1 ORDER BY sort_order;
 SELECT * FROM theme_maps WHERE id = $1;
 
 -- name: CreateMap :one
-INSERT INTO theme_maps (theme_id, name, image_url, sort_order)
-VALUES ($1, $2, $3, $4)
+INSERT INTO theme_maps (theme_id, name, image_url, image_media_id, sort_order)
+VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: UpdateMap :one
-UPDATE theme_maps SET name = $2, image_url = $3, sort_order = $4
+UPDATE theme_maps SET name = $2, image_url = $3, image_media_id = $4, sort_order = $5
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/db/queries/media.sql
+++ b/apps/server/db/queries/media.sql
@@ -62,6 +62,18 @@ WHERE theme_id = $1
   AND key ~ '^role_sheet:'
   AND body ~ $2;
 
+-- name: FindThemeCoverReferencesForMedia :many
+SELECT id, title
+FROM themes
+WHERE id = sqlc.arg('theme_id')
+  AND cover_image_media_id = sqlc.arg('media_id');
+
+-- name: FindMapReferencesForMedia :many
+SELECT id, name
+FROM theme_maps
+WHERE theme_id = sqlc.arg('theme_id')
+  AND image_media_id = sqlc.arg('media_id');
+
 -- ============================================================
 -- Media (Batch)
 -- ============================================================

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -34,10 +34,10 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 RETURNING *;
 
 -- name: UpdateTheme :one
-UPDATE themes SET title = $2, slug = $3, description = $4, cover_image = $5,
-  min_players = $6, max_players = $7, duration_min = $8, price = $9, coin_price = $10,
+UPDATE themes SET title = $2, slug = $3, description = $4, cover_image = $5, cover_image_media_id = $6,
+  min_players = $7, max_players = $8, duration_min = $9, price = $10, coin_price = $11,
   version = version + 1, updated_at = NOW()
-WHERE id = $1 AND version = $11
+WHERE id = $1 AND version = $12
 RETURNING *;
 
 -- name: DeleteTheme :exec
@@ -85,4 +85,4 @@ SELECT * FROM themes ORDER BY created_at DESC LIMIT $1 OFFSET $2;
 SELECT * FROM rooms ORDER BY created_at DESC LIMIT $1 OFFSET $2;
 
 -- name: UpdateThemeCoverImage :exec
-UPDATE themes SET cover_image = $2, updated_at = NOW() WHERE id = $1;
+UPDATE themes SET cover_image = $2, cover_image_media_id = NULL, updated_at = NOW() WHERE id = $1;

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -158,16 +158,17 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 }
 
 const createMap = `-- name: CreateMap :one
-INSERT INTO theme_maps (theme_id, name, image_url, sort_order)
-VALUES ($1, $2, $3, $4)
-RETURNING id, theme_id, name, image_url, sort_order, created_at
+INSERT INTO theme_maps (theme_id, name, image_url, image_media_id, sort_order)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, theme_id, name, image_url, sort_order, created_at, image_media_id
 `
 
 type CreateMapParams struct {
-	ThemeID   uuid.UUID   `json:"theme_id"`
-	Name      string      `json:"name"`
-	ImageUrl  pgtype.Text `json:"image_url"`
-	SortOrder int32       `json:"sort_order"`
+	ThemeID      uuid.UUID   `json:"theme_id"`
+	Name         string      `json:"name"`
+	ImageUrl     pgtype.Text `json:"image_url"`
+	ImageMediaID pgtype.UUID `json:"image_media_id"`
+	SortOrder    int32       `json:"sort_order"`
 }
 
 func (q *Queries) CreateMap(ctx context.Context, arg CreateMapParams) (ThemeMap, error) {
@@ -175,6 +176,7 @@ func (q *Queries) CreateMap(ctx context.Context, arg CreateMapParams) (ThemeMap,
 		arg.ThemeID,
 		arg.Name,
 		arg.ImageUrl,
+		arg.ImageMediaID,
 		arg.SortOrder,
 	)
 	var i ThemeMap
@@ -185,6 +187,7 @@ func (q *Queries) CreateMap(ctx context.Context, arg CreateMapParams) (ThemeMap,
 		&i.ImageUrl,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
@@ -429,7 +432,7 @@ func (q *Queries) GetLocationWithOwner(ctx context.Context, arg GetLocationWithO
 }
 
 const getMap = `-- name: GetMap :one
-SELECT id, theme_id, name, image_url, sort_order, created_at FROM theme_maps WHERE id = $1
+SELECT id, theme_id, name, image_url, sort_order, created_at, image_media_id FROM theme_maps WHERE id = $1
 `
 
 func (q *Queries) GetMap(ctx context.Context, id uuid.UUID) (ThemeMap, error) {
@@ -442,13 +445,14 @@ func (q *Queries) GetMap(ctx context.Context, id uuid.UUID) (ThemeMap, error) {
 		&i.ImageUrl,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
 
 const getMapWithOwner = `-- name: GetMapWithOwner :one
 
-SELECT m.id, m.theme_id, m.name, m.image_url, m.sort_order, m.created_at FROM theme_maps m
+SELECT m.id, m.theme_id, m.name, m.image_url, m.sort_order, m.created_at, m.image_media_id FROM theme_maps m
 JOIN themes t ON m.theme_id = t.id
 WHERE m.id = $1 AND t.creator_id = $2
 `
@@ -471,6 +475,7 @@ func (q *Queries) GetMapWithOwner(ctx context.Context, arg GetMapWithOwnerParams
 		&i.ImageUrl,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.ImageMediaID,
 	)
 	return i, err
 }
@@ -671,7 +676,7 @@ func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) (
 
 const listMapsByTheme = `-- name: ListMapsByTheme :many
 
-SELECT id, theme_id, name, image_url, sort_order, created_at FROM theme_maps WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, name, image_url, sort_order, created_at, image_media_id FROM theme_maps WHERE theme_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -693,6 +698,7 @@ func (q *Queries) ListMapsByTheme(ctx context.Context, themeID uuid.UUID) ([]The
 			&i.ImageUrl,
 			&i.SortOrder,
 			&i.CreatedAt,
+			&i.ImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -817,16 +823,17 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 }
 
 const updateMap = `-- name: UpdateMap :one
-UPDATE theme_maps SET name = $2, image_url = $3, sort_order = $4
+UPDATE theme_maps SET name = $2, image_url = $3, image_media_id = $4, sort_order = $5
 WHERE id = $1
-RETURNING id, theme_id, name, image_url, sort_order, created_at
+RETURNING id, theme_id, name, image_url, sort_order, created_at, image_media_id
 `
 
 type UpdateMapParams struct {
-	ID        uuid.UUID   `json:"id"`
-	Name      string      `json:"name"`
-	ImageUrl  pgtype.Text `json:"image_url"`
-	SortOrder int32       `json:"sort_order"`
+	ID           uuid.UUID   `json:"id"`
+	Name         string      `json:"name"`
+	ImageUrl     pgtype.Text `json:"image_url"`
+	ImageMediaID pgtype.UUID `json:"image_media_id"`
+	SortOrder    int32       `json:"sort_order"`
 }
 
 func (q *Queries) UpdateMap(ctx context.Context, arg UpdateMapParams) (ThemeMap, error) {
@@ -834,6 +841,7 @@ func (q *Queries) UpdateMap(ctx context.Context, arg UpdateMapParams) (ThemeMap,
 		arg.ID,
 		arg.Name,
 		arg.ImageUrl,
+		arg.ImageMediaID,
 		arg.SortOrder,
 	)
 	var i ThemeMap
@@ -844,6 +852,7 @@ func (q *Queries) UpdateMap(ctx context.Context, arg UpdateMapParams) (ThemeMap,
 		&i.ImageUrl,
 		&i.SortOrder,
 		&i.CreatedAt,
+		&i.ImageMediaID,
 	)
 	return i, err
 }

--- a/apps/server/internal/db/media.sql.go
+++ b/apps/server/internal/db/media.sql.go
@@ -104,6 +104,43 @@ func (q *Queries) DeleteMediaWithOwner(ctx context.Context, arg DeleteMediaWithO
 	return result.RowsAffected(), nil
 }
 
+const findMapReferencesForMedia = `-- name: FindMapReferencesForMedia :many
+SELECT id, name
+FROM theme_maps
+WHERE theme_id = $1
+  AND image_media_id = $2
+`
+
+type FindMapReferencesForMediaParams struct {
+	ThemeID uuid.UUID   `json:"theme_id"`
+	MediaID pgtype.UUID `json:"media_id"`
+}
+
+type FindMapReferencesForMediaRow struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+func (q *Queries) FindMapReferencesForMedia(ctx context.Context, arg FindMapReferencesForMediaParams) ([]FindMapReferencesForMediaRow, error) {
+	rows, err := q.db.Query(ctx, findMapReferencesForMedia, arg.ThemeID, arg.MediaID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindMapReferencesForMediaRow{}
+	for rows.Next() {
+		var i FindMapReferencesForMediaRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findRoleSheetReferencesForMedia = `-- name: FindRoleSheetReferencesForMedia :many
 SELECT id, key
 FROM theme_contents
@@ -132,6 +169,43 @@ func (q *Queries) FindRoleSheetReferencesForMedia(ctx context.Context, arg FindR
 	for rows.Next() {
 		var i FindRoleSheetReferencesForMediaRow
 		if err := rows.Scan(&i.ID, &i.Key); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findThemeCoverReferencesForMedia = `-- name: FindThemeCoverReferencesForMedia :many
+SELECT id, title
+FROM themes
+WHERE id = $1
+  AND cover_image_media_id = $2
+`
+
+type FindThemeCoverReferencesForMediaParams struct {
+	ThemeID uuid.UUID   `json:"theme_id"`
+	MediaID pgtype.UUID `json:"media_id"`
+}
+
+type FindThemeCoverReferencesForMediaRow struct {
+	ID    uuid.UUID `json:"id"`
+	Title string    `json:"title"`
+}
+
+func (q *Queries) FindThemeCoverReferencesForMedia(ctx context.Context, arg FindThemeCoverReferencesForMediaParams) ([]FindThemeCoverReferencesForMediaRow, error) {
+	rows, err := q.db.Query(ctx, findThemeCoverReferencesForMedia, arg.ThemeID, arg.MediaID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindThemeCoverReferencesForMediaRow{}
+	for rows.Next() {
+		var i FindThemeCoverReferencesForMediaRow
+		if err := rows.Scan(&i.ID, &i.Title); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -268,26 +268,27 @@ type StoryInfo struct {
 }
 
 type Theme struct {
-	ID          uuid.UUID          `json:"id"`
-	CreatorID   uuid.UUID          `json:"creator_id"`
-	Title       string             `json:"title"`
-	Slug        string             `json:"slug"`
-	Description pgtype.Text        `json:"description"`
-	CoverImage  pgtype.Text        `json:"cover_image"`
-	MinPlayers  int32              `json:"min_players"`
-	MaxPlayers  int32              `json:"max_players"`
-	DurationMin int32              `json:"duration_min"`
-	Price       int32              `json:"price"`
-	Status      string             `json:"status"`
-	ConfigJson  json.RawMessage    `json:"config_json"`
-	Version     int32              `json:"version"`
-	PublishedAt pgtype.Timestamptz `json:"published_at"`
-	CreatedAt   time.Time          `json:"created_at"`
-	UpdatedAt   time.Time          `json:"updated_at"`
-	CoinPrice   int32              `json:"coin_price"`
-	ReviewNote  pgtype.Text        `json:"review_note"`
-	ReviewedAt  pgtype.Timestamptz `json:"reviewed_at"`
-	ReviewedBy  pgtype.UUID        `json:"reviewed_by"`
+	ID                uuid.UUID          `json:"id"`
+	CreatorID         uuid.UUID          `json:"creator_id"`
+	Title             string             `json:"title"`
+	Slug              string             `json:"slug"`
+	Description       pgtype.Text        `json:"description"`
+	CoverImage        pgtype.Text        `json:"cover_image"`
+	MinPlayers        int32              `json:"min_players"`
+	MaxPlayers        int32              `json:"max_players"`
+	DurationMin       int32              `json:"duration_min"`
+	Price             int32              `json:"price"`
+	Status            string             `json:"status"`
+	ConfigJson        json.RawMessage    `json:"config_json"`
+	Version           int32              `json:"version"`
+	PublishedAt       pgtype.Timestamptz `json:"published_at"`
+	CreatedAt         time.Time          `json:"created_at"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+	CoinPrice         int32              `json:"coin_price"`
+	ReviewNote        pgtype.Text        `json:"review_note"`
+	ReviewedAt        pgtype.Timestamptz `json:"reviewed_at"`
+	ReviewedBy        pgtype.UUID        `json:"reviewed_by"`
+	CoverImageMediaID pgtype.UUID        `json:"cover_image_media_id"`
 }
 
 type ThemeCharacter struct {
@@ -354,12 +355,13 @@ type ThemeLocation struct {
 }
 
 type ThemeMap struct {
-	ID        uuid.UUID   `json:"id"`
-	ThemeID   uuid.UUID   `json:"theme_id"`
-	Name      string      `json:"name"`
-	ImageUrl  pgtype.Text `json:"image_url"`
-	SortOrder int32       `json:"sort_order"`
-	CreatedAt time.Time   `json:"created_at"`
+	ID           uuid.UUID   `json:"id"`
+	ThemeID      uuid.UUID   `json:"theme_id"`
+	Name         string      `json:"name"`
+	ImageUrl     pgtype.Text `json:"image_url"`
+	SortOrder    int32       `json:"sort_order"`
+	CreatedAt    time.Time   `json:"created_at"`
+	ImageMediaID pgtype.UUID `json:"image_media_id"`
 }
 
 type ThemeMedium struct {

--- a/apps/server/internal/db/review.sql.go
+++ b/apps/server/internal/db/review.sql.go
@@ -24,7 +24,7 @@ SET status       = 'PUBLISHED',
     updated_at   = NOW()
 WHERE id = $1
   AND status = 'PENDING_REVIEW'
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type ApproveThemeParams struct {
@@ -57,6 +57,7 @@ func (q *Queries) ApproveTheme(ctx context.Context, arg ApproveThemeParams) (The
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
@@ -73,7 +74,7 @@ func (q *Queries) GetUserTrustedCreator(ctx context.Context, id uuid.UUID) (bool
 }
 
 const listPendingReviewThemes = `-- name: ListPendingReviewThemes :many
-SELECT t.id, t.creator_id, t.title, t.slug, t.description, t.cover_image, t.min_players, t.max_players, t.duration_min, t.price, t.status, t.config_json, t.version, t.published_at, t.created_at, t.updated_at, t.coin_price, t.review_note, t.reviewed_at, t.reviewed_by, u.nickname AS creator_name
+SELECT t.id, t.creator_id, t.title, t.slug, t.description, t.cover_image, t.min_players, t.max_players, t.duration_min, t.price, t.status, t.config_json, t.version, t.published_at, t.created_at, t.updated_at, t.coin_price, t.review_note, t.reviewed_at, t.reviewed_by, t.cover_image_media_id, u.nickname AS creator_name
 FROM themes t
 JOIN users u ON t.creator_id = u.id
 WHERE t.status = 'PENDING_REVIEW'
@@ -81,27 +82,28 @@ ORDER BY t.updated_at ASC
 `
 
 type ListPendingReviewThemesRow struct {
-	ID          uuid.UUID          `json:"id"`
-	CreatorID   uuid.UUID          `json:"creator_id"`
-	Title       string             `json:"title"`
-	Slug        string             `json:"slug"`
-	Description pgtype.Text        `json:"description"`
-	CoverImage  pgtype.Text        `json:"cover_image"`
-	MinPlayers  int32              `json:"min_players"`
-	MaxPlayers  int32              `json:"max_players"`
-	DurationMin int32              `json:"duration_min"`
-	Price       int32              `json:"price"`
-	Status      string             `json:"status"`
-	ConfigJson  json.RawMessage    `json:"config_json"`
-	Version     int32              `json:"version"`
-	PublishedAt pgtype.Timestamptz `json:"published_at"`
-	CreatedAt   time.Time          `json:"created_at"`
-	UpdatedAt   time.Time          `json:"updated_at"`
-	CoinPrice   int32              `json:"coin_price"`
-	ReviewNote  pgtype.Text        `json:"review_note"`
-	ReviewedAt  pgtype.Timestamptz `json:"reviewed_at"`
-	ReviewedBy  pgtype.UUID        `json:"reviewed_by"`
-	CreatorName string             `json:"creator_name"`
+	ID                uuid.UUID          `json:"id"`
+	CreatorID         uuid.UUID          `json:"creator_id"`
+	Title             string             `json:"title"`
+	Slug              string             `json:"slug"`
+	Description       pgtype.Text        `json:"description"`
+	CoverImage        pgtype.Text        `json:"cover_image"`
+	MinPlayers        int32              `json:"min_players"`
+	MaxPlayers        int32              `json:"max_players"`
+	DurationMin       int32              `json:"duration_min"`
+	Price             int32              `json:"price"`
+	Status            string             `json:"status"`
+	ConfigJson        json.RawMessage    `json:"config_json"`
+	Version           int32              `json:"version"`
+	PublishedAt       pgtype.Timestamptz `json:"published_at"`
+	CreatedAt         time.Time          `json:"created_at"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+	CoinPrice         int32              `json:"coin_price"`
+	ReviewNote        pgtype.Text        `json:"review_note"`
+	ReviewedAt        pgtype.Timestamptz `json:"reviewed_at"`
+	ReviewedBy        pgtype.UUID        `json:"reviewed_by"`
+	CoverImageMediaID pgtype.UUID        `json:"cover_image_media_id"`
+	CreatorName       string             `json:"creator_name"`
 }
 
 func (q *Queries) ListPendingReviewThemes(ctx context.Context) ([]ListPendingReviewThemesRow, error) {
@@ -134,6 +136,7 @@ func (q *Queries) ListPendingReviewThemes(ctx context.Context) ([]ListPendingRev
 			&i.ReviewNote,
 			&i.ReviewedAt,
 			&i.ReviewedBy,
+			&i.CoverImageMediaID,
 			&i.CreatorName,
 		); err != nil {
 			return nil, err
@@ -155,7 +158,7 @@ SET status      = 'REJECTED',
     updated_at  = NOW()
 WHERE id = $1
   AND status = 'PENDING_REVIEW'
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type RejectThemeParams struct {
@@ -188,6 +191,7 @@ func (q *Queries) RejectTheme(ctx context.Context, arg RejectThemeParams) (Theme
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
@@ -214,7 +218,7 @@ SET status      = 'PENDING_REVIEW',
     reviewed_by = NULL,
     updated_at  = NOW()
 WHERE id = $1
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 func (q *Queries) SubmitThemeForReview(ctx context.Context, id uuid.UUID) (Theme, error) {
@@ -241,6 +245,7 @@ func (q *Queries) SubmitThemeForReview(ctx context.Context, id uuid.UUID) (Theme
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
@@ -254,7 +259,7 @@ SET status      = 'SUSPENDED',
     updated_at  = NOW()
 WHERE id = $1
   AND status IN ('PUBLISHED', 'PENDING_REVIEW')
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type SuspendThemeParams struct {
@@ -287,6 +292,7 @@ func (q *Queries) SuspendTheme(ctx context.Context, arg SuspendThemeParams) (The
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
@@ -296,7 +302,7 @@ UPDATE themes
 SET status     = 'UNPUBLISHED',
     updated_at = NOW()
 WHERE id = $1
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 func (q *Queries) UnpublishTheme(ctx context.Context, id uuid.UUID) (Theme, error) {
@@ -323,6 +329,7 @@ func (q *Queries) UnpublishTheme(ctx context.Context, id uuid.UUID) (Theme, erro
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -28,7 +28,7 @@ func (q *Queries) CountThemeCharacters(ctx context.Context, themeID uuid.UUID) (
 const createTheme = `-- name: CreateTheme :one
 INSERT INTO themes (creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, config_json)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type CreateThemeParams struct {
@@ -81,6 +81,7 @@ func (q *Queries) CreateTheme(ctx context.Context, arg CreateThemeParams) (Theme
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
@@ -178,7 +179,7 @@ func (q *Queries) DeleteThemeCharacter(ctx context.Context, id uuid.UUID) error 
 }
 
 const getTheme = `-- name: GetTheme :one
-SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by FROM themes WHERE id = $1
+SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id FROM themes WHERE id = $1
 `
 
 func (q *Queries) GetTheme(ctx context.Context, id uuid.UUID) (Theme, error) {
@@ -205,12 +206,13 @@ func (q *Queries) GetTheme(ctx context.Context, id uuid.UUID) (Theme, error) {
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
 
 const getThemeBySlug = `-- name: GetThemeBySlug :one
-SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by FROM themes WHERE slug = $1
+SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id FROM themes WHERE slug = $1
 `
 
 func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error) {
@@ -237,6 +239,7 @@ func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
@@ -354,7 +357,7 @@ func (q *Queries) ListAllRooms(ctx context.Context, arg ListAllRoomsParams) ([]R
 }
 
 const listAllThemes = `-- name: ListAllThemes :many
-SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by FROM themes ORDER BY created_at DESC LIMIT $1 OFFSET $2
+SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id FROM themes ORDER BY created_at DESC LIMIT $1 OFFSET $2
 `
 
 type ListAllThemesParams struct {
@@ -392,6 +395,7 @@ func (q *Queries) ListAllThemes(ctx context.Context, arg ListAllThemesParams) ([
 			&i.ReviewNote,
 			&i.ReviewedAt,
 			&i.ReviewedBy,
+			&i.CoverImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -404,7 +408,7 @@ func (q *Queries) ListAllThemes(ctx context.Context, arg ListAllThemesParams) ([
 }
 
 const listPublishedThemes = `-- name: ListPublishedThemes :many
-SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by FROM themes WHERE status = 'PUBLISHED' ORDER BY published_at DESC LIMIT $1 OFFSET $2
+SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id FROM themes WHERE status = 'PUBLISHED' ORDER BY published_at DESC LIMIT $1 OFFSET $2
 `
 
 type ListPublishedThemesParams struct {
@@ -442,6 +446,7 @@ func (q *Queries) ListPublishedThemes(ctx context.Context, arg ListPublishedThem
 			&i.ReviewNote,
 			&i.ReviewedAt,
 			&i.ReviewedBy,
+			&i.CoverImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -499,25 +504,26 @@ func (q *Queries) ListThemesByCreator(ctx context.Context, creatorID uuid.UUID) 
 }
 
 const updateTheme = `-- name: UpdateTheme :one
-UPDATE themes SET title = $2, slug = $3, description = $4, cover_image = $5,
-  min_players = $6, max_players = $7, duration_min = $8, price = $9, coin_price = $10,
+UPDATE themes SET title = $2, slug = $3, description = $4, cover_image = $5, cover_image_media_id = $6,
+  min_players = $7, max_players = $8, duration_min = $9, price = $10, coin_price = $11,
   version = version + 1, updated_at = NOW()
-WHERE id = $1 AND version = $11
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+WHERE id = $1 AND version = $12
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type UpdateThemeParams struct {
-	ID          uuid.UUID   `json:"id"`
-	Title       string      `json:"title"`
-	Slug        string      `json:"slug"`
-	Description pgtype.Text `json:"description"`
-	CoverImage  pgtype.Text `json:"cover_image"`
-	MinPlayers  int32       `json:"min_players"`
-	MaxPlayers  int32       `json:"max_players"`
-	DurationMin int32       `json:"duration_min"`
-	Price       int32       `json:"price"`
-	CoinPrice   int32       `json:"coin_price"`
-	Version     int32       `json:"version"`
+	ID                uuid.UUID   `json:"id"`
+	Title             string      `json:"title"`
+	Slug              string      `json:"slug"`
+	Description       pgtype.Text `json:"description"`
+	CoverImage        pgtype.Text `json:"cover_image"`
+	CoverImageMediaID pgtype.UUID `json:"cover_image_media_id"`
+	MinPlayers        int32       `json:"min_players"`
+	MaxPlayers        int32       `json:"max_players"`
+	DurationMin       int32       `json:"duration_min"`
+	Price             int32       `json:"price"`
+	CoinPrice         int32       `json:"coin_price"`
+	Version           int32       `json:"version"`
 }
 
 func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme, error) {
@@ -527,6 +533,7 @@ func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme
 		arg.Slug,
 		arg.Description,
 		arg.CoverImage,
+		arg.CoverImageMediaID,
 		arg.MinPlayers,
 		arg.MaxPlayers,
 		arg.DurationMin,
@@ -556,6 +563,7 @@ func (q *Queries) UpdateTheme(ctx context.Context, arg UpdateThemeParams) (Theme
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
@@ -649,7 +657,7 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 const updateThemeConfigJson = `-- name: UpdateThemeConfigJson :one
 UPDATE themes SET config_json = $2, version = version + 1, updated_at = NOW()
 WHERE id = $1 AND version = $3
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type UpdateThemeConfigJsonParams struct {
@@ -682,12 +690,13 @@ func (q *Queries) UpdateThemeConfigJson(ctx context.Context, arg UpdateThemeConf
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }
 
 const updateThemeCoverImage = `-- name: UpdateThemeCoverImage :exec
-UPDATE themes SET cover_image = $2, updated_at = NOW() WHERE id = $1
+UPDATE themes SET cover_image = $2, cover_image_media_id = NULL, updated_at = NOW() WHERE id = $1
 `
 
 type UpdateThemeCoverImageParams struct {
@@ -703,7 +712,7 @@ func (q *Queries) UpdateThemeCoverImage(ctx context.Context, arg UpdateThemeCove
 const updateThemeStatus = `-- name: UpdateThemeStatus :one
 UPDATE themes SET status = $2, published_at = CASE WHEN $2 = 'PUBLISHED' THEN NOW() ELSE published_at END, updated_at = NOW()
 WHERE id = $1
-RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by
+RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type UpdateThemeStatusParams struct {
@@ -735,6 +744,7 @@ func (q *Queries) UpdateThemeStatus(ctx context.Context, arg UpdateThemeStatusPa
 		&i.ReviewNote,
 		&i.ReviewedAt,
 		&i.ReviewedBy,
+		&i.CoverImageMediaID,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/helpers.go
+++ b/apps/server/internal/domain/editor/helpers.go
@@ -91,19 +91,20 @@ func isUniqueViolation(err error) bool {
 
 func toThemeResponse(t db.Theme) *ThemeResponse {
 	resp := &ThemeResponse{
-		ID:          t.ID,
-		Title:       t.Title,
-		Slug:        t.Slug,
-		Description: textToPtr(t.Description),
-		CoverImage:  textToPtr(t.CoverImage),
-		MinPlayers:  t.MinPlayers,
-		MaxPlayers:  t.MaxPlayers,
-		DurationMin: t.DurationMin,
-		Price:       t.Price,
-		CoinPrice:   t.CoinPrice,
-		Status:      t.Status,
-		Version:     t.Version,
-		CreatedAt:   t.CreatedAt,
+		ID:                t.ID,
+		Title:             t.Title,
+		Slug:              t.Slug,
+		Description:       textToPtr(t.Description),
+		CoverImage:        textToPtr(t.CoverImage),
+		CoverImageMediaID: pgtypeUUIDToPtr(t.CoverImageMediaID),
+		MinPlayers:        t.MinPlayers,
+		MaxPlayers:        t.MaxPlayers,
+		DurationMin:       t.DurationMin,
+		Price:             t.Price,
+		CoinPrice:         t.CoinPrice,
+		Status:            t.Status,
+		Version:           t.Version,
+		CreatedAt:         t.CreatedAt,
 	}
 	if len(t.ConfigJson) > 0 && string(t.ConfigJson) != "null" {
 		resp.ConfigJson = t.ConfigJson

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -52,6 +52,8 @@ type mediaQueries interface {
 	UpdateMedia(ctx context.Context, arg db.UpdateMediaParams) (db.ThemeMedium, error)
 	DeleteMedia(ctx context.Context, id uuid.UUID) error
 	DeleteMediaWithOwner(ctx context.Context, arg db.DeleteMediaWithOwnerParams) (int64, error)
+	FindThemeCoverReferencesForMedia(ctx context.Context, arg db.FindThemeCoverReferencesForMediaParams) ([]db.FindThemeCoverReferencesForMediaRow, error)
+	FindMapReferencesForMedia(ctx context.Context, arg db.FindMapReferencesForMediaParams) ([]db.FindMapReferencesForMediaRow, error)
 	FindMediaReferencesInReadingSections(ctx context.Context, arg db.FindMediaReferencesInReadingSectionsParams) ([]db.FindMediaReferencesInReadingSectionsRow, error)
 	FindRoleSheetReferencesForMedia(ctx context.Context, arg db.FindRoleSheetReferencesForMediaParams) ([]db.FindRoleSheetReferencesForMediaRow, error)
 }
@@ -454,6 +456,38 @@ func (s *mediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.
 				Name: r.Name,
 			})
 		}
+	}
+
+	themeCoverRefs, err := s.q.FindThemeCoverReferencesForMedia(ctx, db.FindThemeCoverReferencesForMediaParams{
+		ThemeID: media.ThemeID,
+		MediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to check theme cover media references")
+		return apperror.Internal("failed to check media references")
+	}
+	for _, r := range themeCoverRefs {
+		refList = append(refList, mediaReferenceInfo{
+			Type: "theme_cover",
+			ID:   r.ID.String(),
+			Name: r.Title,
+		})
+	}
+
+	mapRefs, err := s.q.FindMapReferencesForMedia(ctx, db.FindMapReferencesForMediaParams{
+		ThemeID: media.ThemeID,
+		MediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to check map media references")
+		return apperror.Internal("failed to check media references")
+	}
+	for _, r := range mapRefs {
+		refList = append(refList, mediaReferenceInfo{
+			Type: "map",
+			ID:   r.ID.String(),
+			Name: r.Name,
+		})
 	}
 
 	roleSheetRefs, err := s.q.FindRoleSheetReferencesForMedia(ctx, db.FindRoleSheetReferencesForMediaParams{

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -25,6 +25,7 @@ import (
 type fakeMediaQueries struct {
 	themes        map[uuid.UUID]db.Theme
 	media         map[uuid.UUID]db.ThemeMedium
+	maps          map[uuid.UUID]db.ThemeMap
 	sessions      map[uuid.UUID]db.GameSession
 	sections      map[uuid.UUID]db.ReadingSection
 	roleSheetRefs map[uuid.UUID][]db.FindRoleSheetReferencesForMediaRow
@@ -34,6 +35,7 @@ func newFakeMediaQueries() *fakeMediaQueries {
 	return &fakeMediaQueries{
 		themes:        make(map[uuid.UUID]db.Theme),
 		media:         make(map[uuid.UUID]db.ThemeMedium),
+		maps:          make(map[uuid.UUID]db.ThemeMap),
 		sessions:      make(map[uuid.UUID]db.GameSession),
 		sections:      make(map[uuid.UUID]db.ReadingSection),
 		roleSheetRefs: make(map[uuid.UUID][]db.FindRoleSheetReferencesForMediaRow),
@@ -184,6 +186,30 @@ func (f *fakeMediaQueries) DeleteMediaWithOwner(_ context.Context, arg db.Delete
 	}
 	delete(f.media, arg.ID)
 	return 1, nil
+}
+
+func (f *fakeMediaQueries) FindThemeCoverReferencesForMedia(_ context.Context, arg db.FindThemeCoverReferencesForMediaParams) ([]db.FindThemeCoverReferencesForMediaRow, error) {
+	if !arg.MediaID.Valid {
+		return []db.FindThemeCoverReferencesForMediaRow{}, nil
+	}
+	theme, ok := f.themes[arg.ThemeID]
+	if !ok || !theme.CoverImageMediaID.Valid || theme.CoverImageMediaID.Bytes != arg.MediaID.Bytes {
+		return []db.FindThemeCoverReferencesForMediaRow{}, nil
+	}
+	return []db.FindThemeCoverReferencesForMediaRow{{ID: theme.ID, Title: theme.Title}}, nil
+}
+
+func (f *fakeMediaQueries) FindMapReferencesForMedia(_ context.Context, arg db.FindMapReferencesForMediaParams) ([]db.FindMapReferencesForMediaRow, error) {
+	out := []db.FindMapReferencesForMediaRow{}
+	if !arg.MediaID.Valid {
+		return out, nil
+	}
+	for _, m := range f.maps {
+		if m.ThemeID == arg.ThemeID && m.ImageMediaID.Valid && m.ImageMediaID.Bytes == arg.MediaID.Bytes {
+			out = append(out, db.FindMapReferencesForMediaRow{ID: m.ID, Name: m.Name})
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeMediaQueries) FindMediaReferencesInReadingSections(_ context.Context, arg db.FindMediaReferencesInReadingSectionsParams) ([]db.FindMediaReferencesInReadingSectionsRow, error) {
@@ -548,6 +574,47 @@ func TestMediaService_Delete_Success_NoReferences(t *testing.T) {
 	}
 	if _, ok := q.media[mediaID]; ok {
 		t.Fatalf("media should have been deleted")
+	}
+}
+
+func TestMediaService_Delete_BlockedByThemeCoverReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeImage)
+	theme := q.themes[themeID]
+	theme.Title = "저택 살인사건"
+	theme.CoverImageMediaID = pgtype.UUID{Bytes: mediaID, Valid: true}
+	q.themes[themeID] = theme
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+
+	var appErr *apperror.AppError
+	_ = errors.As(err, &appErr)
+	refs := appErr.Params["references"].([]map[string]string)
+	if len(refs) != 1 || refs[0]["type"] != "theme_cover" || refs[0]["id"] != themeID.String() || refs[0]["name"] != "저택 살인사건" {
+		t.Fatalf("unexpected theme cover references: %#v", refs)
+	}
+}
+
+func TestMediaService_Delete_BlockedByMapImageReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeImage)
+	mapID := uuid.New()
+	q.maps[mapID] = db.ThemeMap{
+		ID:           mapID,
+		ThemeID:      themeID,
+		Name:         "1층 지도",
+		ImageMediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	}
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+
+	var appErr *apperror.AppError
+	_ = errors.As(err, &appErr)
+	refs := appErr.Params["references"].([]map[string]string)
+	if len(refs) != 1 || refs[0]["type"] != "map" || refs[0]["id"] != mapID.String() || refs[0]["name"] != "1층 지도" {
+		t.Fatalf("unexpected map references: %#v", refs)
 	}
 }
 

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -49,34 +49,36 @@ type CreateThemeRequest struct {
 }
 
 type UpdateThemeRequest struct {
-	Title       string  `json:"title" validate:"required,min=2,max=100"`
-	Description *string `json:"description" validate:"omitempty,max=2000"`
-	CoverImage  *string `json:"cover_image" validate:"omitempty,url"`
-	MinPlayers  int32   `json:"min_players" validate:"required,min=2,max=20"`
-	MaxPlayers  int32   `json:"max_players" validate:"required,min=2,max=20"`
-	DurationMin int32   `json:"duration_min" validate:"required,min=10,max=300"`
-	Price       int32   `json:"price" validate:"min=0"`
-	CoinPrice   int32   `json:"coin_price" validate:"min=0,max=100000"`
+	Title             string       `json:"title" validate:"required,min=2,max=100"`
+	Description       *string      `json:"description" validate:"omitempty,max=2000"`
+	CoverImage        *string      `json:"cover_image" validate:"omitempty,url"`
+	CoverImageMediaID OptionalUUID `json:"cover_image_media_id"`
+	MinPlayers        int32        `json:"min_players" validate:"required,min=2,max=20"`
+	MaxPlayers        int32        `json:"max_players" validate:"required,min=2,max=20"`
+	DurationMin       int32        `json:"duration_min" validate:"required,min=10,max=300"`
+	Price             int32        `json:"price" validate:"min=0"`
+	CoinPrice         int32        `json:"coin_price" validate:"min=0,max=100000"`
 }
 
 type ThemeResponse struct {
-	ID          uuid.UUID       `json:"id"`
-	Title       string          `json:"title"`
-	Slug        string          `json:"slug"`
-	Description *string         `json:"description,omitempty"`
-	CoverImage  *string         `json:"cover_image,omitempty"`
-	MinPlayers  int32           `json:"min_players"`
-	MaxPlayers  int32           `json:"max_players"`
-	DurationMin int32           `json:"duration_min"`
-	Price       int32           `json:"price"`
-	CoinPrice   int32           `json:"coin_price"`
-	Status      string          `json:"status"`
-	ConfigJson  json.RawMessage `json:"config_json,omitempty"`
-	Version     int32           `json:"version"`
-	CreatedAt   time.Time       `json:"created_at"`
-	ReviewNote  *string         `json:"review_note,omitempty"`
-	ReviewedAt  *time.Time      `json:"reviewed_at,omitempty"`
-	ReviewedBy  *uuid.UUID      `json:"reviewed_by,omitempty"`
+	ID                uuid.UUID       `json:"id"`
+	Title             string          `json:"title"`
+	Slug              string          `json:"slug"`
+	Description       *string         `json:"description,omitempty"`
+	CoverImage        *string         `json:"cover_image,omitempty"`
+	CoverImageMediaID *uuid.UUID      `json:"cover_image_media_id,omitempty"`
+	MinPlayers        int32           `json:"min_players"`
+	MaxPlayers        int32           `json:"max_players"`
+	DurationMin       int32           `json:"duration_min"`
+	Price             int32           `json:"price"`
+	CoinPrice         int32           `json:"coin_price"`
+	Status            string          `json:"status"`
+	ConfigJson        json.RawMessage `json:"config_json,omitempty"`
+	Version           int32           `json:"version"`
+	CreatedAt         time.Time       `json:"created_at"`
+	ReviewNote        *string         `json:"review_note,omitempty"`
+	ReviewedAt        *time.Time      `json:"reviewed_at,omitempty"`
+	ReviewedBy        *uuid.UUID      `json:"reviewed_by,omitempty"`
 }
 
 type ThemeSummary struct {

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -44,11 +44,20 @@ func (s *service) CreateMap(ctx context.Context, creatorID, themeID uuid.UUID, r
 	if count >= MaxMapsPerTheme {
 		return nil, apperror.BadRequest(fmt.Sprintf("theme cannot have more than %d maps", MaxMapsPerTheme))
 	}
+	imageMediaID, err := s.resolveThemeImageMedia(ctx, themeID, req.ImageMediaID, "map image")
+	if err != nil {
+		return nil, err
+	}
+	imageURL := ptrToText(req.ImageURL)
+	if imageMediaID.Valid {
+		imageURL = pgtype.Text{}
+	}
 	m, err := s.q.CreateMap(ctx, db.CreateMapParams{
-		ThemeID:   themeID,
-		Name:      req.Name,
-		ImageUrl:  ptrToText(req.ImageURL),
-		SortOrder: req.SortOrder,
+		ThemeID:      themeID,
+		Name:         req.Name,
+		ImageUrl:     imageURL,
+		ImageMediaID: imageMediaID,
+		SortOrder:    req.SortOrder,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create map")
@@ -67,11 +76,28 @@ func (s *service) UpdateMap(ctx context.Context, creatorID, mapID uuid.UUID, req
 		s.logger.Error().Err(err).Msg("failed to get map")
 		return nil, apperror.Internal("failed to get map")
 	}
+	imageURL := m.ImageUrl
+	if req.ImageURL != nil {
+		imageURL = ptrToText(req.ImageURL)
+	}
+	imageMediaID := m.ImageMediaID
+	if req.ImageMediaID.Set {
+		if req.ImageMediaID.Value == nil {
+			imageMediaID = pgtype.UUID{}
+		} else {
+			imageMediaID, err = s.resolveThemeImageMedia(ctx, m.ThemeID, req.ImageMediaID.Value, "map image")
+			imageURL = pgtype.Text{}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 	updated, err := s.q.UpdateMap(ctx, db.UpdateMapParams{
-		ID:        m.ID,
-		Name:      req.Name,
-		ImageUrl:  ptrToText(req.ImageURL),
-		SortOrder: req.SortOrder,
+		ID:           m.ID,
+		Name:         req.Name,
+		ImageUrl:     imageURL,
+		ImageMediaID: imageMediaID,
+		SortOrder:    req.SortOrder,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update map")
@@ -182,6 +208,7 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 			imageMediaID = pgtype.UUID{}
 		} else {
 			imageMediaID, err = s.resolveThemeImageMedia(ctx, l.ThemeID, req.ImageMediaID.Value, "location image")
+			imageURL = pgtype.Text{}
 		}
 		if err != nil {
 			return nil, err
@@ -325,12 +352,13 @@ func (s *service) DeleteLocation(ctx context.Context, creatorID, locID uuid.UUID
 
 func toMapResponse(m db.ThemeMap) MapResponse {
 	return MapResponse{
-		ID:        m.ID,
-		ThemeID:   m.ThemeID,
-		Name:      m.Name,
-		ImageURL:  textToPtr(m.ImageUrl),
-		SortOrder: m.SortOrder,
-		CreatedAt: m.CreatedAt,
+		ID:           m.ID,
+		ThemeID:      m.ThemeID,
+		Name:         m.Name,
+		ImageURL:     textToPtr(m.ImageUrl),
+		ImageMediaID: pgtypeUUIDToPtr(m.ImageMediaID),
+		SortOrder:    m.SortOrder,
+		CreatedAt:    m.CreatedAt,
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -246,6 +246,56 @@ func TestService_LocationImageMediaReference(t *testing.T) {
 	}
 }
 
+func TestService_MapImageMediaReference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	media := createLocationMedia(t, f.q, themeID, "지도 이미지", MediaTypeImage)
+	otherThemeMedia := createLocationMedia(t, f.q, otherThemeID, "다른 테마 이미지", MediaTypeImage)
+	voiceMedia := createLocationMedia(t, f.q, themeID, "효과음", MediaTypeVoice)
+
+	created, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{
+		Name:         "1층 지도",
+		ImageMediaID: uuidPtr(media.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateMap with image media: %v", err)
+	}
+	if created.ImageMediaID == nil || *created.ImageMediaID != media.ID {
+		t.Fatalf("ImageMediaID = %v, want %s", created.ImageMediaID, media.ID)
+	}
+
+	if _, err := f.svc.UpdateMap(ctx, creatorID, created.ID, UpdateMapRequest{
+		Name:         created.Name,
+		ImageMediaID: OptionalUUID{Set: true, Value: uuidPtr(otherThemeMedia.ID)},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateMap with other theme image error = %T %v, want media not in theme", err, err)
+	}
+	if _, err := f.svc.UpdateMap(ctx, creatorID, created.ID, UpdateMapRequest{
+		Name:         created.Name,
+		ImageMediaID: OptionalUUID{Set: true, Value: uuidPtr(voiceMedia.ID)},
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateMap with non-image media error = %T %v, want media not in theme", err, err)
+	}
+
+	updated, err := f.svc.UpdateMap(ctx, creatorID, created.ID, UpdateMapRequest{
+		Name:         created.Name,
+		SortOrder:    created.SortOrder,
+		ImageMediaID: OptionalUUID{Set: true},
+	})
+	if err != nil {
+		t.Fatalf("UpdateMap clear image media: %v", err)
+	}
+	if updated.ImageMediaID != nil {
+		t.Fatalf("ImageMediaID after clear = %v, want nil", updated.ImageMediaID)
+	}
+}
+
 func isBadRequest(err error) bool {
 	var appErr *apperror.AppError
 	return errors.As(err, &appErr) && appErr.Code == apperror.ErrBadRequest

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -269,6 +269,9 @@ func TestService_MapImageMediaReference(t *testing.T) {
 	if created.ImageMediaID == nil || *created.ImageMediaID != media.ID {
 		t.Fatalf("ImageMediaID = %v, want %s", created.ImageMediaID, media.ID)
 	}
+	if created.ImageURL != nil {
+		t.Fatalf("ImageURL = %q, want nil when ImageMediaID is set", *created.ImageURL)
+	}
 
 	if _, err := f.svc.UpdateMap(ctx, creatorID, created.ID, UpdateMapRequest{
 		Name:         created.Name,

--- a/apps/server/internal/domain/editor/service_themes_test.go
+++ b/apps/server/internal/domain/editor/service_themes_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -122,6 +124,72 @@ func TestService_UpdateTheme(t *testing.T) {
 	if resp.MinPlayers != 3 {
 		t.Errorf("min_players not updated: got %d", resp.MinPlayers)
 	}
+}
+
+func TestService_UpdateTheme_CoverImageMediaReference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	media := createLocationMedia(t, f.q, themeID, "커버 이미지", MediaTypeImage)
+	otherThemeMedia := createLocationMedia(t, f.q, otherThemeID, "다른 테마 이미지", MediaTypeImage)
+	voiceMedia := createLocationMedia(t, f.q, themeID, "음성", MediaTypeVoice)
+
+	updated, err := f.svc.UpdateTheme(ctx, creatorID, themeID, UpdateThemeRequest{
+		Title:             "커버 참조 테마",
+		CoverImageMediaID: OptionalUUID{Set: true, Value: uuidPtr(media.ID)},
+		MinPlayers:        2,
+		MaxPlayers:        6,
+		DurationMin:       90,
+	})
+	if err != nil {
+		t.Fatalf("UpdateTheme with cover image media: %v", err)
+	}
+	if updated.CoverImageMediaID == nil || *updated.CoverImageMediaID != media.ID {
+		t.Fatalf("CoverImageMediaID = %v, want %s", updated.CoverImageMediaID, media.ID)
+	}
+
+	if _, err := f.svc.UpdateTheme(ctx, creatorID, updated.ID, UpdateThemeRequest{
+		Title:             updated.Title,
+		CoverImageMediaID: OptionalUUID{Set: true, Value: uuidPtr(otherThemeMedia.ID)},
+		MinPlayers:        updated.MinPlayers,
+		MaxPlayers:        updated.MaxPlayers,
+		DurationMin:       updated.DurationMin,
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateTheme with other theme media error = %T %v, want media not in theme", err, err)
+	}
+
+	if _, err := f.svc.UpdateTheme(ctx, creatorID, updated.ID, UpdateThemeRequest{
+		Title:             updated.Title,
+		CoverImageMediaID: OptionalUUID{Set: true, Value: uuidPtr(voiceMedia.ID)},
+		MinPlayers:        updated.MinPlayers,
+		MaxPlayers:        updated.MaxPlayers,
+		DurationMin:       updated.DurationMin,
+	}); !isMediaNotInTheme(err) {
+		t.Fatalf("UpdateTheme with non-image media error = %T %v, want media not in theme", err, err)
+	}
+
+	cleared, err := f.svc.UpdateTheme(ctx, creatorID, updated.ID, UpdateThemeRequest{
+		Title:             updated.Title,
+		CoverImageMediaID: OptionalUUID{Set: true},
+		MinPlayers:        updated.MinPlayers,
+		MaxPlayers:        updated.MaxPlayers,
+		DurationMin:       updated.DurationMin,
+	})
+	if err != nil {
+		t.Fatalf("UpdateTheme clear cover image media: %v", err)
+	}
+	if cleared.CoverImageMediaID != nil {
+		t.Fatalf("CoverImageMediaID after clear = %v, want nil", cleared.CoverImageMediaID)
+	}
+}
+
+func uuidPtr(id uuid.UUID) *uuid.UUID {
+	return &id
 }
 
 func TestService_UpdateTheme_ForbiddenForNonOwner(t *testing.T) {

--- a/apps/server/internal/domain/editor/themes.go
+++ b/apps/server/internal/domain/editor/themes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
@@ -54,22 +55,39 @@ func (s *service) UpdateTheme(ctx context.Context, creatorID, themeID uuid.UUID,
 	if err != nil {
 		return nil, err
 	}
+	coverImage := theme.CoverImage
+	if req.CoverImage != nil {
+		coverImage = ptrToText(req.CoverImage)
+	}
+	coverImageMediaID := theme.CoverImageMediaID
+	if req.CoverImageMediaID.Set {
+		if req.CoverImageMediaID.Value == nil {
+			coverImageMediaID = pgtype.UUID{}
+		} else {
+			coverImageMediaID, err = s.resolveThemeImageMedia(ctx, theme.ID, req.CoverImageMediaID.Value, "theme cover image")
+			coverImage = pgtype.Text{}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	var updated db.Theme
 	for attempt := 0; attempt < 3; attempt++ {
 		slug := generateSlug(req.Title)
 		updated, err = s.q.UpdateTheme(ctx, db.UpdateThemeParams{
-			ID:          theme.ID,
-			Title:       req.Title,
-			Slug:        slug,
-			Description: ptrToText(req.Description),
-			CoverImage:  ptrToText(req.CoverImage),
-			MinPlayers:  req.MinPlayers,
-			MaxPlayers:  req.MaxPlayers,
-			DurationMin: req.DurationMin,
-			Price:       req.Price,
-			CoinPrice:   req.CoinPrice,
-			Version:     theme.Version,
+			ID:                theme.ID,
+			Title:             req.Title,
+			Slug:              slug,
+			Description:       ptrToText(req.Description),
+			CoverImage:        coverImage,
+			CoverImageMediaID: coverImageMediaID,
+			MinPlayers:        req.MinPlayers,
+			MaxPlayers:        req.MaxPlayers,
+			DurationMin:       req.DurationMin,
+			Price:             req.Price,
+			CoinPrice:         req.CoinPrice,
+			Version:           theme.Version,
 		})
 		if err == nil {
 			return toThemeResponse(updated), nil

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -33,24 +33,27 @@ func (o *OptionalUUID) UnmarshalJSON(data []byte) error {
 // --- Map types ---
 
 type CreateMapRequest struct {
-	Name      string  `json:"name" validate:"required,min=1,max=100"`
-	ImageURL  *string `json:"image_url" validate:"omitempty,url"`
-	SortOrder int32   `json:"sort_order" validate:"min=0"`
+	Name         string     `json:"name" validate:"required,min=1,max=100"`
+	ImageURL     *string    `json:"image_url" validate:"omitempty,url"`
+	ImageMediaID *uuid.UUID `json:"image_media_id"`
+	SortOrder    int32      `json:"sort_order" validate:"min=0"`
 }
 
 type UpdateMapRequest struct {
-	Name      string  `json:"name" validate:"required,min=1,max=100"`
-	ImageURL  *string `json:"image_url" validate:"omitempty,url"`
-	SortOrder int32   `json:"sort_order" validate:"min=0"`
+	Name         string       `json:"name" validate:"required,min=1,max=100"`
+	ImageURL     *string      `json:"image_url" validate:"omitempty,url"`
+	ImageMediaID OptionalUUID `json:"image_media_id"`
+	SortOrder    int32        `json:"sort_order" validate:"min=0"`
 }
 
 type MapResponse struct {
-	ID        uuid.UUID `json:"id"`
-	ThemeID   uuid.UUID `json:"theme_id"`
-	Name      string    `json:"name"`
-	ImageURL  *string   `json:"image_url,omitempty"`
-	SortOrder int32     `json:"sort_order"`
-	CreatedAt time.Time `json:"created_at"`
+	ID           uuid.UUID  `json:"id"`
+	ThemeID      uuid.UUID  `json:"theme_id"`
+	Name         string     `json:"name"`
+	ImageURL     *string    `json:"image_url,omitempty"`
+	ImageMediaID *uuid.UUID `json:"image_media_id,omitempty"`
+	SortOrder    int32      `json:"sort_order"`
+	CreatedAt    time.Time  `json:"created_at"`
 }
 
 // --- Location types ---

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -27,6 +27,7 @@ export interface EditorThemeResponse {
   slug: string;
   description: string | null;
   cover_image: string | null;
+  cover_image_media_id?: string | null;
   min_players: number;
   max_players: number;
   duration_min: number;
@@ -88,6 +89,7 @@ export interface UpdateThemeRequest {
   title: string;
   description?: string;
   cover_image?: string;
+  cover_image_media_id?: string | null;
   min_players: number;
   max_players: number;
   duration_min: number;
@@ -176,6 +178,7 @@ export interface MapResponse {
   theme_id: string;
   name: string;
   image_url: string | null;
+  image_media_id?: string | null;
   sort_order: number;
   created_at: string;
 }
@@ -183,6 +186,7 @@ export interface MapResponse {
 export interface CreateMapRequest {
   name: string;
   image_url?: string;
+  image_media_id?: string | null;
   sort_order?: number;
 }
 

--- a/apps/web/src/features/editor/components/OverviewTab.tsx
+++ b/apps/web/src/features/editor/components/OverviewTab.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/features/editor/api';
 import { SectionDivider } from './SectionDivider';
 import { CoverImageCropUpload } from './CoverImageCropUpload';
+import { LocationImageMediaField } from './design/LocationImageMediaField';
 
 // ---------------------------------------------------------------------------
 // SpecField — inline number input with label + unit
@@ -94,6 +95,9 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
   const [title, setTitle] = useState(theme.title);
   const [description, setDescription] = useState(theme.description ?? '');
   const [coverImage, setCoverImage] = useState<string | null>(theme.cover_image || null);
+  const [coverImageMediaId, setCoverImageMediaId] = useState<string | null>(
+    theme.cover_image_media_id ?? null
+  );
   const [minPlayers, setMinPlayers] = useState(theme.min_players);
   const [maxPlayers, setMaxPlayers] = useState(theme.max_players);
   const [durationMin, setDurationMin] = useState(theme.duration_min);
@@ -107,6 +111,7 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
     setTitle(theme.title);
     setDescription(theme.description ?? '');
     setCoverImage(theme.cover_image || null);
+    setCoverImageMediaId(theme.cover_image_media_id ?? null);
     setMinPlayers(theme.min_players);
     setMaxPlayers(theme.max_players);
     setDurationMin(theme.duration_min);
@@ -124,9 +129,11 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
     if (minPlayers < 2 || minPlayers > 20) next.minPlayers = '최소 인원은 2~20 사이여야 합니다';
     if (maxPlayers < 2 || maxPlayers > 20) next.maxPlayers = '최대 인원은 2~20 사이여야 합니다';
     else if (maxPlayers < minPlayers) next.maxPlayers = '최대 인원은 최소 인원 이상이어야 합니다';
-    if (durationMin < 10 || durationMin > 300) next.durationMin = '진행 시간은 10~300분 사이여야 합니다';
+    if (durationMin < 10 || durationMin > 300)
+      next.durationMin = '진행 시간은 10~300분 사이여야 합니다';
     if (price < 0) next.price = '가격은 0 이상이어야 합니다';
-    if (coinPrice < 0 || coinPrice > 100000) next.coinPrice = '코인 가격은 0~100,000 사이여야 합니다';
+    if (coinPrice < 0 || coinPrice > 100000)
+      next.coinPrice = '코인 가격은 0~100,000 사이여야 합니다';
     return next;
   }
 
@@ -140,6 +147,7 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
       title: title.trim(),
       description: description || undefined,
       cover_image: coverImage || undefined,
+      cover_image_media_id: coverImageMediaId,
       min_players: minPlayers,
       max_players: maxPlayers,
       duration_min: durationMin,
@@ -163,7 +171,10 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
         <CoverImageCropUpload
           themeId={themeId}
           currentImageUrl={coverImage}
-          onUploaded={(url) => setCoverImage(url || null)}
+          onUploaded={(url) => {
+            setCoverImage(url || null);
+            setCoverImageMediaId(null);
+          }}
           className="w-full"
         />
 
@@ -198,9 +209,28 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
               rows={3}
               className="w-full rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-700 focus:border-amber-500/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900 transition-colors resize-none"
             />
-            {errors.description && <p className="mt-1 text-xs text-red-400">{errors.description}</p>}
+            {errors.description && (
+              <p className="mt-1 text-xs text-red-400">{errors.description}</p>
+            )}
           </div>
         </div>
+      </div>
+
+      <div className="mt-4">
+        <LocationImageMediaField
+          themeId={themeId}
+          label="테마 커버 이미지"
+          pickerTitle="테마 커버 이미지 선택"
+          emptyLabel="미디어에서 커버 선택"
+          legacyMessage="기존 커버 업로드 이미지가 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다."
+          imageMediaId={coverImageMediaId}
+          legacyImageUrl={coverImage}
+          onSelect={(media) => {
+            setCoverImageMediaId(media.id);
+            setCoverImage(null);
+          }}
+          onClear={() => setCoverImageMediaId(null)}
+        />
       </div>
 
       {/* ── 게임 스펙 ── */}

--- a/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
@@ -19,6 +19,7 @@ const {
   useEditorCharactersMock,
   useDeleteCharacterMock,
   useUpdateConfigJsonMock,
+  useMediaListMock,
 } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   toastSuccess: vi.fn(),
@@ -33,6 +34,7 @@ const {
   useEditorCharactersMock: vi.fn(),
   useDeleteCharacterMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
+  useMediaListMock: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -56,6 +58,35 @@ vi.mock("@/features/editor/components/SchemaDrivenForm", () => ({
   SchemaDrivenForm: () => null,
 }));
 
+vi.mock("@/features/editor/mediaApi", () => ({
+  useMediaList: () => useMediaListMock(),
+}));
+
+vi.mock("@/features/editor/components/media/MediaPicker", () => ({
+  MediaPicker: ({
+    open,
+    filterType,
+    selectedId,
+    onSelect,
+  }: {
+    open: boolean;
+    filterType?: string;
+    selectedId?: string | null;
+    onSelect: (media: { id: string; name: string; type: string }) => void;
+  }) =>
+    open ? (
+      <div>
+        <span>filter:{filterType}</span>
+        <span>selected:{selectedId ?? "none"}</span>
+        <button
+          type="button"
+          onClick={() => onSelect({ id: "image-1", name: "커버 이미지", type: "IMAGE" })}
+        >
+          커버 이미지 선택
+        </button>
+      </div>
+    ) : null,
+}));
 
 // ---------------------------------------------------------------------------
 // Mock: @/features/editor/api
@@ -383,6 +414,10 @@ describe("PublishBar", () => {
 describe("OverviewTab", () => {
   beforeEach(() => {
     useUpdateThemeMock.mockReturnValue(defaultMutationReturn());
+    useMediaListMock.mockReturnValue({
+      data: [{ id: "image-1", name: "커버 이미지", type: "IMAGE" }],
+      isLoading: false,
+    });
   });
 
   it("테마 데이터가 폼에 미리 채워져 렌더링된다", () => {
@@ -431,6 +466,20 @@ describe("OverviewTab", () => {
     expect(body).toHaveProperty("min_players", 4);
     expect(body).toHaveProperty("max_players", 6);
     expect(body).toHaveProperty("duration_min", 90);
+  });
+
+  it("미디어 관리 IMAGE를 커버 이미지 참조로 저장한다", () => {
+    render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
+
+    fireEvent.click(screen.getByText("미디어에서 커버 선택"));
+    expect(screen.getByText("filter:IMAGE")).toBeDefined();
+    fireEvent.click(screen.getByText("커버 이미지 선택"));
+    fireEvent.click(screen.getByText("저장"));
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    const [body] = mutateMock.mock.calls[0];
+    expect(body).toHaveProperty("cover_image_media_id", "image-1");
+    expect(body.cover_image).toBeUndefined();
   });
 });
 

--- a/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
+++ b/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
@@ -6,6 +6,10 @@ import { useMediaList, type MediaResponse } from '@/features/editor/mediaApi';
 
 interface LocationImageMediaFieldProps {
   themeId: string;
+  label?: string;
+  pickerTitle?: string;
+  emptyLabel?: string;
+  legacyMessage?: string;
   imageMediaId?: string | null;
   legacyImageUrl?: string | null;
   onSelect: (media: MediaResponse) => void;
@@ -14,6 +18,10 @@ interface LocationImageMediaFieldProps {
 
 export function LocationImageMediaField({
   themeId,
+  label = '장소 이미지',
+  pickerTitle = '장소 이미지 선택',
+  emptyLabel = '미디어 이미지 선택',
+  legacyMessage = '기존 직접 업로드 이미지가 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다.',
   imageMediaId,
   legacyImageUrl,
   onSelect,
@@ -28,7 +36,7 @@ export function LocationImageMediaField({
       <div className="mb-2 flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-300">
           <Image className="h-3.5 w-3.5 text-amber-400" />
-          장소 이미지
+          {label}
         </div>
         {imageMediaId ? (
           <button
@@ -57,14 +65,12 @@ export function LocationImageMediaField({
           onClick={() => setPickerOpen(true)}
           className="flex aspect-[16/10] w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200"
         >
-          미디어 이미지 선택
+          {emptyLabel}
         </button>
       )}
 
       {!imageMediaId && legacyImageUrl ? (
-        <p className="mt-2 text-xs leading-5 text-slate-500">
-          기존 직접 업로드 이미지가 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다.
-        </p>
+        <p className="mt-2 text-xs leading-5 text-slate-500">{legacyMessage}</p>
       ) : null}
 
       <MediaPicker
@@ -74,7 +80,7 @@ export function LocationImageMediaField({
         themeId={themeId}
         filterType="IMAGE"
         selectedId={imageMediaId}
-        title="장소 이미지 선택"
+        title={pickerTitle}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -7,12 +7,14 @@ import {
   useEditorMaps,
   useCreateMap,
   useDeleteMap,
+  useUpdateMap,
   useEditorLocations,
   useCreateLocation,
   useDeleteLocation,
 } from '@/features/editor/api';
 import { AddNameInput } from './AddNameInput';
 import { LocationDetailPanel } from './LocationDetailPanel';
+import { LocationImageMediaField } from './LocationImageMediaField';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -32,6 +34,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   const { data: locations, isLoading: locsLoading } = useEditorLocations(themeId);
   const createMap = useCreateMap(themeId);
   const deleteMap = useDeleteMap(themeId);
+  const updateMap = useUpdateMap(themeId);
   const createLocation = useCreateLocation(themeId);
   const deleteLocation = useDeleteLocation(themeId);
 
@@ -168,7 +171,11 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
                 <button
                   type="button"
                   onClick={(e) => {
-                    if (window.confirm(`${map.name} 맵을 삭제할까요? 하위 장소 편집 흐름도 함께 영향을 받습니다.`)) {
+                    if (
+                      window.confirm(
+                        `${map.name} 맵을 삭제할까요? 하위 장소 편집 흐름도 함께 영향을 받습니다.`
+                      )
+                    ) {
                       handleDeleteMap(map.id);
                     }
                   }}
@@ -185,6 +192,52 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
 
       {/* ── Location detail ── */}
       <div className="min-h-0 flex-1 px-5 py-5 md:overflow-y-auto">
+        {selectedMap ? (
+          <div className="mb-4 rounded-lg border border-slate-800 bg-slate-950/70 p-4">
+            <div className="mb-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-amber-300/80">
+                토론방 배경
+              </p>
+              <h3 className="mt-1 text-base font-semibold text-slate-100">{selectedMap.name}</h3>
+            </div>
+            <LocationImageMediaField
+              themeId={themeId}
+              label="지도 이미지"
+              pickerTitle="지도 이미지 선택"
+              emptyLabel="미디어에서 지도 선택"
+              legacyMessage="기존 지도 이미지 URL이 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다."
+              imageMediaId={selectedMap.image_media_id}
+              legacyImageUrl={selectedMap.image_url}
+              onSelect={(media) =>
+                updateMap.mutate(
+                  {
+                    mapId: selectedMap.id,
+                    body: {
+                      name: selectedMap.name,
+                      image_url: null,
+                      image_media_id: media.id,
+                      sort_order: selectedMap.sort_order,
+                    },
+                  },
+                  { onError: () => toast.error('지도 이미지 저장에 실패했습니다') }
+                )
+              }
+              onClear={() =>
+                updateMap.mutate(
+                  {
+                    mapId: selectedMap.id,
+                    body: {
+                      name: selectedMap.name,
+                      image_media_id: null,
+                      sort_order: selectedMap.sort_order,
+                    },
+                  },
+                  { onError: () => toast.error('지도 이미지 저장에 실패했습니다') }
+                )
+              }
+            />
+          </div>
+        ) : null}
         <LocationDetailPanel
           themeId={themeId}
           theme={theme}

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -15,6 +15,7 @@ const {
   useEditorMapsMock,
   useCreateMapMock,
   useDeleteMapMock,
+  useUpdateMapMock,
   useEditorLocationsMock,
   useCreateLocationMock,
   useDeleteLocationMock,
@@ -32,6 +33,7 @@ const {
   useEditorMapsMock: vi.fn(),
   useCreateMapMock: vi.fn(),
   useDeleteMapMock: vi.fn(),
+  useUpdateMapMock: vi.fn(),
   useEditorLocationsMock: vi.fn(),
   useCreateLocationMock: vi.fn(),
   useDeleteLocationMock: vi.fn(),
@@ -58,6 +60,7 @@ vi.mock('@/features/editor/api', () => ({
   useEditorMaps: () => useEditorMapsMock(),
   useCreateMap: () => useCreateMapMock(),
   useDeleteMap: () => useDeleteMapMock(),
+  useUpdateMap: () => useUpdateMapMock(),
   useEditorLocations: () => useEditorLocationsMock(),
   useCreateLocation: () => useCreateLocationMock(),
   useDeleteLocation: () => useDeleteLocationMock(),
@@ -152,6 +155,7 @@ function setupDefaultMocks() {
   useEditorLocationsMock.mockReturnValue({ data: mockLocations, isLoading: false });
   useCreateMapMock.mockReturnValue(defaultMutation());
   useDeleteMapMock.mockReturnValue(defaultMutation());
+  useUpdateMapMock.mockReturnValue(defaultMutation());
   useCreateLocationMock.mockReturnValue(defaultMutation());
   useDeleteLocationMock.mockReturnValue(defaultMutation());
   useUpdateLocationMock.mockReturnValue({
@@ -434,6 +438,42 @@ describe('LocationsSubTab', () => {
 
   describe('장소 이미지 미디어 참조', () => {
     beforeEach(setupDefaultMocks);
+
+    it('IMAGE 미디어를 지도 이미지 참조로 저장한다', () => {
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+
+      fireEvent.click(screen.getByText('미디어에서 지도 선택'));
+      expect(screen.getByText('filter:IMAGE')).toBeDefined();
+      fireEvent.click(screen.getByText('저택 사진 선택'));
+
+      expect(mutateMock).toHaveBeenCalledOnce();
+      const [payload] = mutateMock.mock.calls[0] as [
+        { mapId: string; body: Record<string, unknown> },
+      ];
+      expect(payload.mapId).toBe('map-1');
+      expect(payload.body.image_media_id).toBe('image-1');
+      expect(payload.body.image_url).toBeNull();
+      expect(payload.body.name).toBe('저택 1층');
+    });
+
+    it('선택된 지도 이미지 참조를 제거할 수 있다', () => {
+      useEditorMapsMock.mockReturnValue({
+        data: [{ ...mockMaps[0], image_media_id: 'image-1' }, ...mockMaps.slice(1)],
+        isLoading: false,
+      });
+
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+
+      expect(screen.getByText('저택 사진')).toBeDefined();
+      fireEvent.click(screen.getAllByText('제거')[0]);
+
+      expect(mutateMock).toHaveBeenCalledOnce();
+      const [payload] = mutateMock.mock.calls[0] as [
+        { mapId: string; body: Record<string, unknown> },
+      ];
+      expect(payload.mapId).toBe('map-1');
+      expect(payload.body.image_media_id).toBeNull();
+    });
 
     it('IMAGE 미디어만 선택해 장소 이미지 참조로 저장한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);

--- a/apps/web/src/features/editor/editorMapApi.ts
+++ b/apps/web/src/features/editor/editorMapApi.ts
@@ -10,7 +10,9 @@ import type { MapResponse, LocationResponse } from './api';
 
 export interface UpdateMapRequest {
   name?: string;
-  image_url?: string;
+  image_url?: string | null;
+  image_media_id?: string | null;
+  sort_order?: number;
 }
 
 export interface CreateLocationRequest {
@@ -51,7 +53,16 @@ export function useEditorMaps(themeId: string) {
 // ---------------------------------------------------------------------------
 
 export function useCreateMap(themeId: string) {
-  return useMutation<MapResponse, Error, { name: string; image_url?: string }>({
+  return useMutation<
+    MapResponse,
+    Error,
+    {
+      name: string;
+      image_url?: string | null;
+      image_media_id?: string | null;
+      sort_order?: number;
+    }
+  >({
     mutationFn: (body) => api.post<MapResponse>(`/v1/editor/themes/${themeId}/maps`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: editorKeys.maps(themeId) });


### PR DESCRIPTION
## 요약

- 테마 커버와 지도 이미지에 미디어 관리 IMAGE 참조 필드를 추가했습니다.
- 기존 URL 기반 커버/지도 이미지는 fallback으로 유지하고, 미디어 선택 시 URL을 비워 단일 출처로 관리되게 했습니다.
- 사용 중인 커버/지도 IMAGE media 삭제를 차단하도록 reference check를 확장했습니다.

Closes #436
Refs #381

## Coverage Plan

- DB/API 계약: `themes.cover_image_media_id`, `theme_maps.image_media_id` migration, sqlc query/generated code, same-theme IMAGE validation
- Backend 삭제 보호: 커버/지도에서 사용 중인 IMAGE media 삭제 차단
- Frontend: `OverviewTab` 커버 media picker, `LocationsSubTab` 지도 media picker payload
- TypeScript 계약: editor API type 확장

## 검증

- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/Editor.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx`
- `go test ./internal/domain/editor -run 'TestService_(UpdateTheme_CoverImageMediaReference|MapImageMediaReference|LocationImageMediaReference)|TestOptionalUUIDUnmarshal|TestMediaService_Delete_(Success_NoReferences|BlockedByThemeCoverReference|BlockedByMapImageReference|BlockedByRoleSheetReference)'`\n- `go test ./internal/domain/editor ./internal/domain/theme ./internal/domain/creator`\n- `git diff --check`\n\n## 제외\n\n- 기존 URL 데이터 일괄 migration은 수행하지 않았습니다.\n- 플레이 런타임 CDN/서명 URL 최종 해석은 이번 에디터 계약 PR 범위 밖입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 테마에 미디어 라이브러리에서 커버 이미지를 선택·저장하는 기능 추가 (편집 화면에 미디어 선택기 연동)
  * 맵에 미디어 라이브러리에서 이미지를 선택·저장 및 삭제하는 기능 추가 (맵 상세 패널에서 이미지 선택/해제 가능)
  * API 및 프론트엔드 응답에 이미지 미디어 ID 필드(image_media_id / cover_image_media_id) 노출

* **Tests**
  * 커버 이미지·맵 이미지 참조 관련 삭제 차단 및 저장 동작을 검증하는 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->