### PR TITLE
chore(ops): Discord 사용자 호출 알림 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,25 @@ Avoid:
 - 다음 로컬 작업이 바로 막히는 critical path를 불필요하게 위임하지 않는다.
 - API DTO, frontend adapter/ViewModel mapping, migration, PR/CI 라벨 전환처럼 공유 계약을 바꾸는 작업은 최종 통합 전까지 여러 agent가 동시에 수정하지 않는다.
 
+### Discord 사용자 호출 알림
+
+When:
+- Codex가 브레인스토밍 결정, 승인, 위험 작업 확인, 장기 정지/Stop 상태처럼 사용자 응답 없이는 진행하기 어려운 지점에 도달했을 때
+
+Do:
+1. `scripts/mmp-discord-notify.sh`를 사용해 짧은 Discord 알림을 보낸다.
+2. 알림에는 전체 작업 로그를 넣지 않고, 사용자가 터미널로 돌아와야 하는 이유와 필요한 응답만 적는다.
+3. Discord webhook URL은 repo에 저장하지 않는다. 로컬에서는 `MMP_DISCORD_WEBHOOK_URL` 또는 `~/.codex/mmp-discord-webhook-url`을 사용한다.
+4. Stop hook 알림은 중복 방지를 위해 cooldown을 둔다.
+
+Done when:
+- 사용자가 Discord에서 작업 대기 상태를 알 수 있고, 민감한 URL/토큰이 git diff나 문서에 남지 않는다.
+
+Avoid:
+- Discord 응답을 자동 명령으로 실행하지 않는다.
+- webhook URL, bot token, channel secret을 repo 파일이나 PR 본문에 기록하지 않는다.
+- 모든 테스트/CI 로그를 Discord로 전송하지 않는다.
+
 ## Git 및 PR 규율
 
 - `main`을 보호한다. 병합 가능한 변경은 feature branch와 PR을 사용한다.

--- a/scripts/mmp-discord-notify.sh
+++ b/scripts/mmp-discord-notify.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+event="manual"
+title="MMP Codex 알림"
+message=""
+urgency="normal"
+cooldown_key=""
+cooldown_seconds=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --event)
+      event="${2:-manual}"
+      shift 2
+      ;;
+    --title)
+      title="${2:-MMP Codex 알림}"
+      shift 2
+      ;;
+    --message)
+      message="${2:-}"
+      shift 2
+      ;;
+    --urgency)
+      urgency="${2:-normal}"
+      shift 2
+      ;;
+    --cooldown-key)
+      cooldown_key="${2:-}"
+      shift 2
+      ;;
+    --cooldown-seconds)
+      cooldown_seconds="${2:-0}"
+      shift 2
+      ;;
+    *)
+      if [[ -z "$message" ]]; then
+        message="$1"
+      else
+        message="${message}"$'\n'"$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$message" ]]; then
+  message="Codex가 사용자 응답이 필요한 지점에 도달했습니다. 터미널로 돌아와 확인해 주세요."
+fi
+
+webhook_url="${MMP_DISCORD_WEBHOOK_URL:-}"
+webhook_file="${MMP_DISCORD_WEBHOOK_FILE:-$HOME/.codex/mmp-discord-webhook-url}"
+if [[ -z "$webhook_url" && -r "$webhook_file" ]]; then
+  webhook_url="$(tr -d '\r\n' < "$webhook_file")"
+fi
+
+if [[ -z "$webhook_url" ]]; then
+  exit 0
+fi
+
+if [[ "$webhook_url" != https://discord.com/api/webhooks/* ]]; then
+  echo "mmp-discord-notify: invalid Discord webhook URL" >&2
+  exit 0
+fi
+
+repo_dir="$(pwd)"
+branch=""
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  branch="$(git branch --show-current 2>/dev/null || true)"
+fi
+
+if [[ -z "$cooldown_key" ]]; then
+  cooldown_key="${event}:${repo_dir}:${title}"
+fi
+
+if [[ "$cooldown_seconds" =~ ^[0-9]+$ && "$cooldown_seconds" -gt 0 ]]; then
+  state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/mmp-discord-notify"
+  mkdir -p "$state_dir"
+  key_hash="$(printf '%s' "$cooldown_key" | shasum -a 256 | awk '{print $1}')"
+  stamp_file="$state_dir/$key_hash"
+  now="$(date +%s)"
+  if [[ -r "$stamp_file" ]]; then
+    last="$(cat "$stamp_file" 2>/dev/null || echo 0)"
+    if [[ "$last" =~ ^[0-9]+$ && $((now - last)) -lt "$cooldown_seconds" ]]; then
+      exit 0
+    fi
+  fi
+  printf '%s' "$now" > "$stamp_file"
+fi
+
+content="$(node - "$event" "$title" "$message" "$urgency" "$repo_dir" "$branch" <<'NODE'
+const [, , event, title, message, urgency, repoDir, branch] = process.argv;
+const lines = [
+  '🔔 **MMP Codex 알림**',
+  `**${title}**`,
+  '',
+  message,
+  '',
+  `event: \`${event}\` · urgency: \`${urgency}\``,
+  `repo: \`${repoDir}\`${branch ? ` · branch: \`${branch}\`` : ''}`,
+  '',
+  '터미널로 돌아와 응답해 주세요.',
+];
+const content = lines.join('\n').slice(0, 1900);
+process.stdout.write(JSON.stringify({
+  content,
+  allowed_mentions: { parse: [] },
+}));
+NODE
+)"
+
+curl -fsS \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data "$content" \
+  "$webhook_url" >/dev/null 2>&1 || true

--- a/scripts/mmp-discord-notify.sh
+++ b/scripts/mmp-discord-notify.sh
@@ -146,6 +146,8 @@ NODE
 )"
 
 if curl -fsS \
+  --connect-timeout 3 \
+  --max-time 8 \
   -H "Content-Type: application/json" \
   -X POST \
   --data "$content" \

--- a/scripts/mmp-discord-notify.sh
+++ b/scripts/mmp-discord-notify.sh
@@ -11,28 +11,58 @@ cooldown_seconds=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --event)
-      event="${2:-manual}"
-      shift 2
+      if [[ $# -ge 2 && "${2:-}" != --* ]]; then
+        event="$2"
+        shift 2
+      else
+        event="manual"
+        shift 1
+      fi
       ;;
     --title)
-      title="${2:-MMP Codex 알림}"
-      shift 2
+      if [[ $# -ge 2 && "${2:-}" != --* ]]; then
+        title="$2"
+        shift 2
+      else
+        title="MMP Codex 알림"
+        shift 1
+      fi
       ;;
     --message)
-      message="${2:-}"
-      shift 2
+      if [[ $# -ge 2 && "${2:-}" != --* ]]; then
+        message="$2"
+        shift 2
+      else
+        message=""
+        shift 1
+      fi
       ;;
     --urgency)
-      urgency="${2:-normal}"
-      shift 2
+      if [[ $# -ge 2 && "${2:-}" != --* ]]; then
+        urgency="$2"
+        shift 2
+      else
+        urgency="normal"
+        shift 1
+      fi
       ;;
     --cooldown-key)
-      cooldown_key="${2:-}"
-      shift 2
+      if [[ $# -ge 2 && "${2:-}" != --* ]]; then
+        cooldown_key="$2"
+        shift 2
+      else
+        cooldown_key=""
+        shift 1
+      fi
       ;;
     --cooldown-seconds)
-      cooldown_seconds="${2:-0}"
-      shift 2
+      if [[ $# -ge 2 && "${2:-}" != --* ]]; then
+        cooldown_seconds="$2"
+        shift 2
+      else
+        cooldown_seconds="0"
+        shift 1
+      fi
       ;;
     *)
       if [[ -z "$message" ]]; then
@@ -65,32 +95,37 @@ if [[ "$webhook_url" != https://discord.com/api/webhooks/* ]]; then
 fi
 
 repo_dir="$(pwd)"
+repo_name="$(basename "$repo_dir")"
 branch=""
 if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$repo_root" ]]; then
+    repo_name="$(basename "$repo_root")"
+  fi
   branch="$(git branch --show-current 2>/dev/null || true)"
 fi
 
 if [[ -z "$cooldown_key" ]]; then
-  cooldown_key="${event}:${repo_dir}:${title}"
+  cooldown_key="${event}:${repo_name}:${title}"
 fi
 
+stamp_file=""
+now="$(date +%s)"
 if [[ "$cooldown_seconds" =~ ^[0-9]+$ && "$cooldown_seconds" -gt 0 ]]; then
   state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/mmp-discord-notify"
   mkdir -p "$state_dir"
-  key_hash="$(printf '%s' "$cooldown_key" | shasum -a 256 | awk '{print $1}')"
+  key_hash="$(node -e 'const crypto=require("crypto"); process.stdout.write(crypto.createHash("sha256").update(process.argv[1]).digest("hex"))' "$cooldown_key")"
   stamp_file="$state_dir/$key_hash"
-  now="$(date +%s)"
   if [[ -r "$stamp_file" ]]; then
     last="$(cat "$stamp_file" 2>/dev/null || echo 0)"
     if [[ "$last" =~ ^[0-9]+$ && $((now - last)) -lt "$cooldown_seconds" ]]; then
       exit 0
     fi
   fi
-  printf '%s' "$now" > "$stamp_file"
 fi
 
-content="$(node - "$event" "$title" "$message" "$urgency" "$repo_dir" "$branch" <<'NODE'
-const [, , event, title, message, urgency, repoDir, branch] = process.argv;
+content="$(node - "$event" "$title" "$message" "$urgency" "$repo_name" "$branch" <<'NODE'
+const [, , event, title, message, urgency, repoName, branch] = process.argv;
 const lines = [
   '🔔 **MMP Codex 알림**',
   `**${title}**`,
@@ -98,7 +133,7 @@ const lines = [
   message,
   '',
   `event: \`${event}\` · urgency: \`${urgency}\``,
-  `repo: \`${repoDir}\`${branch ? ` · branch: \`${branch}\`` : ''}`,
+  `repo: \`${repoName}\`${branch ? ` · branch: \`${branch}\`` : ''}`,
   '',
   '터미널로 돌아와 응답해 주세요.',
 ];
@@ -110,8 +145,14 @@ process.stdout.write(JSON.stringify({
 NODE
 )"
 
-curl -fsS \
+if curl -fsS \
   -H "Content-Type: application/json" \
   -X POST \
   --data "$content" \
-  "$webhook_url" >/dev/null 2>&1 || true
+  "$webhook_url" >/dev/null 2>&1; then
+  if [[ -n "$stamp_file" ]]; then
+    tmp_stamp="${stamp_file}.$$"
+    printf '%s' "$now" > "$tmp_stamp"
+    mv "$tmp_stamp" "$stamp_file"
+  fi
+fi


### PR DESCRIPTION
## 요약

- 사용자 응답/브레인스토밍/Stop 상태에서 짧은 Discord 알림을 보낼 수 있는 `scripts/mmp-discord-notify.sh` 추가
- webhook URL은 repo에 저장하지 않고 `MMP_DISCORD_WEBHOOK_URL` 또는 `~/.codex/mmp-discord-webhook-url`에서만 읽도록 제한
- AGENTS.md에 Discord 사용자 호출 알림 운영 규칙 추가

## Coverage Plan

- `scripts/mmp-discord-notify.sh`: 인자 파싱, webhook 파일 fallback, cooldown, JSON payload 생성 경로를 shell syntax와 실제 webhook test로 확인
- `AGENTS.md`: secret 저장 금지, 자동 응답 실행 금지, 전체 로그 전송 금지 운영 규칙을 문서로 고정
- 코드 변경이 없는 ops/script PR이므로 E2E는 부적합하며, shell syntax/JSON hook 검증으로 대체

## 검증

- `bash -n scripts/mmp-discord-notify.sh`
- `git diff --check`
- `node -e 'JSON.parse(require("fs").readFileSync(process.env.HOME+"/.codex/hooks.json","utf8")); console.log("hooks json ok")'`
- Discord setup-test 알림 전송 명령 성공

## CI scope

- 예상: code-rabbit-only
- 이유: AGENTS.md + scripts 운영 보조 변경이며 app/runtime 코드를 변경하지 않음

## 연결

Refs #442


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Discord 웹후크 알림 발송 기능이 추가되어 주요 이벤트(예: Stop 등)에 대해 알림을 받을 수 있습니다.
  * 알림에 우선도(urgency)와 기본 메시지 설정이 적용되며, 저장된 상태로 쿨다운(중복 방지)을 지원합니다.
  * 알림에 리포지토리 및 브랜치 컨텍스트가 포함되고, 웹후크 구성 부재 시 조용히 종료합니다.

* **문서**
  * 알림 절차·설정·보안 지침(민감 정보 취급·로그 규칙 포함)이 문서에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->