### PR TITLE
feat(editor): 미디어 라이브러리와 선택 모달 UX 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -31,6 +31,9 @@ vi.mock("../../../mediaApi", () => ({
     ],
     isLoading: false,
   }),
+  useMediaCategories: () => ({ data: [] }),
+  useRequestUploadUrl: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useConfirmUpload: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/editor/components/media/MediaCard.tsx
+++ b/apps/web/src/features/editor/components/media/MediaCard.tsx
@@ -76,6 +76,8 @@ export function MediaCard({
   const youtubeId = isYouTube && media.url ? extractYouTubeVideoId(media.url) : null;
   const thumbnailUrl = youtubeId
     ? `https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg`
+    : media.type === "IMAGE" && media.url
+      ? media.url
     : null;
   const duration = formatDuration(media.duration);
   const badgeClass = TYPE_BADGE[media.type] ?? "bg-slate-700 text-slate-300";
@@ -101,7 +103,7 @@ export function MediaCard({
       }`}
     >
       {/* Thumbnail */}
-      <div className="relative flex h-24 items-center justify-center bg-slate-950/60">
+      <div className="relative flex aspect-[4/3] min-h-28 items-center justify-center bg-slate-950/60">
         {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
@@ -153,7 +155,12 @@ export function MediaCard({
             <span className="text-[10px] font-mono text-slate-500">{duration}</span>
           )}
         </div>
-        <p className="truncate text-xs font-medium text-slate-200">{media.name}</p>
+        <p className="line-clamp-2 min-h-[2rem] text-xs font-medium leading-4 text-slate-200">
+          {media.name}
+        </p>
+        {media.tags.length > 0 && (
+          <p className="truncate text-[10px] text-slate-500">{media.tags.slice(0, 3).join(", ")}</p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, X, Trash2, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useDeleteMedia,
+  useMediaCategories,
   useUpdateMedia,
   type MediaReferenceInfo,
   type MediaResponse,
@@ -28,6 +29,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const [name, setName] = useState(media.name);
   const [tagsText, setTagsText] = useState((media.tags ?? []).join(', '));
   const [sortOrder, setSortOrder] = useState<number>(media.sort_order);
+  const [categoryId, setCategoryId] = useState<string>(media.category_id ?? '');
   const [duration, setDuration] = useState<string>(
     media.duration != null ? String(media.duration) : ''
   );
@@ -38,12 +40,14 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
     setName(media.name);
     setTagsText((media.tags ?? []).join(', '));
     setSortOrder(media.sort_order);
+    setCategoryId(media.category_id ?? '');
     setDuration(media.duration != null ? String(media.duration) : '');
     setReferenceWarning(null);
-  }, [media.id, media.name, media.tags, media.sort_order, media.duration]);
+  }, [media.id, media.name, media.tags, media.sort_order, media.category_id, media.duration]);
 
   const updateMutation = useUpdateMedia(themeId);
   const deleteMutation = useDeleteMedia(themeId);
+  const { data: categories = [] } = useMediaCategories(themeId);
 
   const handleSave = () => {
     const trimmedName = name.trim();
@@ -65,6 +69,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
       type: media.type,
       sort_order: sortOrder,
       tags,
+      category_id: categoryId || undefined,
       ...(durationNum != null ? { duration: durationNum } : {}),
     };
     updateMutation.mutate(
@@ -141,14 +146,20 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
         <div className="grid grid-cols-2 gap-3">
           <label className="flex flex-col gap-1">
             <span className="text-[10px] font-mono uppercase tracking-widest text-slate-600">
-              정렬 순서
+              카테고리
             </span>
-            <input
-              type="number"
-              value={sortOrder}
-              onChange={(e) => setSortOrder(Number(e.target.value))}
+            <select
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
               className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-            />
+            >
+              <option value="">전체</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
           </label>
           <label className="flex flex-col gap-1">
             <span className="text-[10px] font-mono uppercase tracking-widest text-slate-600">

--- a/apps/web/src/features/editor/components/media/MediaPicker.tsx
+++ b/apps/web/src/features/editor/components/media/MediaPicker.tsx
@@ -1,13 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { ResourcePicker } from "./ResourcePicker";
+import { MediaUploadModal } from "./MediaUploadModal";
+import { extractYouTubeVideoId } from "@/features/audio/YouTubePlayer";
 import {
   filterMediaResourceViewModels,
+  getAllowedMediaTypesForUseCase,
   getMediaResourceTypeLabel,
   toMediaResourceViewModels,
   type MediaResourceUseCase,
 } from "@/features/editor/entities/mediaResource/mediaResourceAdapter";
 import {
+  useMediaCategories,
   useMediaList,
   type MediaResponse,
   type MediaType,
@@ -38,20 +42,47 @@ export function MediaPicker({
   selectedId,
   title,
 }: MediaPickerProps) {
-  const { data: media = [], isLoading } = useMediaList(themeId, filterType);
   const [searchQuery, setSearchQuery] = useState("");
+  const [categoryId, setCategoryId] = useState<string | null>(null);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const allowedTypes = useMemo(
+    () => (useCase ? getAllowedMediaTypesForUseCase(useCase) : []),
+    [useCase],
+  );
+  const queryType = filterType ?? (allowedTypes.length === 1 ? allowedTypes[0] : undefined);
+  const { data: media = [], isLoading } = useMediaList(
+    themeId,
+    queryType,
+    categoryId ?? undefined,
+  );
+  const { data: categories = [] } = useMediaCategories(themeId);
 
   useEffect(() => {
-    if (!open) setSearchQuery("");
+    if (!open) {
+      setSearchQuery("");
+      setCategoryId(null);
+      setUploadOpen(false);
+    }
   }, [open]);
 
   const resourceViewModels = useMemo(
     () => toMediaResourceViewModels(media, { useCase }),
     [media, useCase],
   );
+  const selectableResources = useMemo(
+    () => (useCase ? resourceViewModels.filter((resource) => resource.isSelectable) : resourceViewModels),
+    [resourceViewModels, useCase],
+  );
   const filteredResources = useMemo(
-    () => filterMediaResourceViewModels(resourceViewModels, searchQuery),
-    [resourceViewModels, searchQuery],
+    () =>
+      filterMediaResourceViewModels(selectableResources, searchQuery).map((resource) => {
+        const source = media.find((item) => item.id === resource.id);
+        return {
+          ...resource,
+          thumbnailUrl: source ? getPickerThumbnailUrl(source) : null,
+        };
+      }),
+    [media, selectableResources, searchQuery],
   );
 
   if (!open) return null;
@@ -65,21 +96,48 @@ export function MediaPicker({
 
   const filterHint = filterType
     ? `${getMediaResourceTypeLabel(filterType)} 유형만 표시됩니다`
-    : null;
+    : allowedTypes.length > 0
+      ? `${allowedTypes.map(getMediaResourceTypeLabel).join(", ")} 유형만 표시됩니다`
+      : null;
+  const uploadTypes = filterType ? [filterType] : allowedTypes.length > 0 ? allowedTypes : undefined;
+  const canUploadFromPicker =
+    !uploadTypes || uploadTypes.some((type) => type !== "VIDEO");
 
   return (
-    <ResourcePicker
-      title={title || "미디어 선택"}
-      resources={filteredResources}
-      searchQuery={searchQuery}
-      onSearchQueryChange={setSearchQuery}
-      onClose={onClose}
-      onSelect={handleSelect}
-      selectedId={selectedId}
-      isLoading={isLoading}
-      emptyLabel="미디어가 없습니다"
-      searchEmptyLabel="검색 결과가 없습니다"
-      filterHint={filterHint}
-    />
+    <>
+      <ResourcePicker
+        title={title || "미디어 선택"}
+        resources={filteredResources}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+        onClose={onClose}
+        onSelect={handleSelect}
+        categories={categories}
+        categoryId={categoryId}
+        onCategoryChange={setCategoryId}
+        onUploadClick={canUploadFromPicker ? () => setUploadOpen(true) : undefined}
+        selectedId={selectedId}
+        isLoading={isLoading}
+        emptyLabel="미디어가 없습니다"
+        searchEmptyLabel="검색 결과가 없습니다"
+        filterHint={filterHint}
+      />
+      <MediaUploadModal
+        open={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+        themeId={themeId}
+        categoryId={categoryId}
+        allowedTypes={uploadTypes}
+      />
+    </>
   );
+}
+
+function getPickerThumbnailUrl(media: MediaResponse): string | null {
+  if (media.type === "IMAGE" && media.url) return media.url;
+  if (media.source_type === "YOUTUBE" && media.url) {
+    const youtubeId = extractYouTubeVideoId(media.url);
+    return youtubeId ? `https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg` : null;
+  }
+  return null;
 }

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from "react";
 import { Spinner } from "@/shared/components/ui";
 import {
+  useCreateMediaCategory,
+  useDeleteMediaCategory,
+  useMediaCategories,
   useMediaList,
   type MediaResponse,
   type MediaType,
@@ -26,6 +29,8 @@ export interface MediaTabProps {
 
 export function MediaTab({ themeId }: MediaTabProps) {
   const [filter, setFilter] = useState<MediaFilter>("all");
+  const [categoryId, setCategoryId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   // Modal state.
   const [uploadOpen, setUploadOpen] = useState(false);
@@ -34,8 +39,25 @@ export function MediaTab({ themeId }: MediaTabProps) {
   const queryType: MediaType | undefined =
     filter === "all" ? undefined : filter;
 
-  const { data: mediaList, isLoading, isError } = useMediaList(themeId, queryType);
-  const media: MediaResponse[] = useMemo(() => mediaList ?? [], [mediaList]);
+  const { data: categories = [] } = useMediaCategories(themeId);
+  const createCategoryMutation = useCreateMediaCategory(themeId);
+  const deleteCategoryMutation = useDeleteMediaCategory(themeId);
+  const { data: mediaList, isLoading, isError } = useMediaList(
+    themeId,
+    queryType,
+    categoryId ?? undefined,
+  );
+  const media: MediaResponse[] = useMemo(() => {
+    const list = mediaList ?? [];
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    if (!normalizedQuery) return list;
+    return list.filter((item) =>
+      [item.name, item.type, item.source_type, ...item.tags]
+        .join(" ")
+        .toLowerCase()
+        .includes(normalizedQuery),
+    );
+  }, [mediaList, searchQuery]);
   const selected = media.find((m) => m.id === selectedId) ?? null;
 
   const { playingId, toggle: togglePreview, stop: stopPreview } = usePreviewPlayer();
@@ -44,6 +66,43 @@ export function MediaTab({ themeId }: MediaTabProps) {
     setFilter(next);
     setSelectedId(null);
     stopPreview();
+  };
+
+  const handleCategoryChange = (nextCategoryId: string | null) => {
+    setCategoryId(nextCategoryId);
+    setSelectedId(null);
+    stopPreview();
+  };
+
+  const handleSearchChange = (query: string) => {
+    setSearchQuery(query);
+    setSelectedId(null);
+    stopPreview();
+  };
+
+  const handleCreateCategory = () => {
+    const name = window.prompt("새 미디어 카테고리 이름을 입력하세요")?.trim();
+    if (!name) return;
+    createCategoryMutation.mutate({
+      name,
+      sort_order: categories.length + 1,
+    });
+  };
+
+  const handleDeleteCategory = () => {
+    if (!categoryId) return;
+    const category = categories.find((item) => item.id === categoryId);
+    const ok = window.confirm(
+      `"${category?.name ?? "선택한 카테고리"}" 카테고리를 삭제하시겠습니까? 연결된 미디어는 전체 카테고리로 이동합니다.`,
+    );
+    if (!ok) return;
+    deleteCategoryMutation.mutate(categoryId, {
+      onSuccess: () => {
+        setCategoryId(null);
+        setSelectedId(null);
+        stopPreview();
+      },
+    });
   };
 
   const handleClose = () => {
@@ -55,6 +114,13 @@ export function MediaTab({ themeId }: MediaTabProps) {
       <MediaToolbar
         filter={filter}
         onFilterChange={handleFilterChange}
+        categories={categories}
+        categoryId={categoryId}
+        onCategoryChange={handleCategoryChange}
+        searchQuery={searchQuery}
+        onSearchQueryChange={handleSearchChange}
+        onCreateCategory={handleCreateCategory}
+        onDeleteCategory={handleDeleteCategory}
         onUploadClick={() => setUploadOpen(true)}
         onYouTubeClick={() => setYoutubeOpen(true)}
       />
@@ -76,13 +142,18 @@ export function MediaTab({ themeId }: MediaTabProps) {
             </div>
           ) : media.length === 0 ? (
             <div className="flex h-full items-center justify-center">
-              <p className="text-xs font-mono uppercase tracking-widest text-slate-700">
-                미디어 없음
-              </p>
+              <div className="text-center">
+                <p className="text-xs font-mono uppercase tracking-widest text-slate-700">
+                  미디어 없음
+                </p>
+                {searchQuery.trim() && (
+                  <p className="mt-2 text-xs text-slate-500">검색어나 필터를 조정해 보세요</p>
+                )}
+              </div>
             </div>
           ) : (
             <div
-              className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-4"
+              className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
               role="list"
               aria-label="미디어 목록"
             >
@@ -115,6 +186,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
         open={uploadOpen}
         onClose={() => setUploadOpen(false)}
         themeId={themeId}
+        categoryId={categoryId}
       />
       <YouTubeAddModal
         open={youtubeOpen}

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -83,9 +83,11 @@ export function MediaTab({ themeId }: MediaTabProps) {
   const handleCreateCategory = () => {
     const name = window.prompt("새 미디어 카테고리 이름을 입력하세요")?.trim();
     if (!name) return;
+    const nextSortOrder =
+      categories.reduce((max, category) => Math.max(max, category.sort_order), 0) + 1;
     createCategoryMutation.mutate({
       name,
-      sort_order: categories.length + 1,
+      sort_order: nextSortOrder,
     });
   };
 

--- a/apps/web/src/features/editor/components/media/MediaToolbar.tsx
+++ b/apps/web/src/features/editor/components/media/MediaToolbar.tsx
@@ -1,5 +1,5 @@
-import { Upload, Youtube } from "lucide-react";
-import type { MediaType } from "@/features/editor/mediaApi";
+import { Plus, Search, Trash2, Upload, Youtube } from "lucide-react";
+import type { MediaCategoryResponse, MediaType } from "@/features/editor/mediaApi";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -10,6 +10,13 @@ export type MediaFilter = MediaType | "all";
 export interface MediaToolbarProps {
   filter: MediaFilter;
   onFilterChange: (f: MediaFilter) => void;
+  categories: MediaCategoryResponse[];
+  categoryId: string | null;
+  onCategoryChange: (categoryId: string | null) => void;
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+  onCreateCategory: () => void;
+  onDeleteCategory: () => void;
   onUploadClick: () => void;
   onYouTubeClick: () => void;
 }
@@ -31,17 +38,118 @@ const PILLS: Array<{ value: MediaFilter; label: string }> = [
 export function MediaToolbar({
   filter,
   onFilterChange,
+  categories,
+  categoryId,
+  onCategoryChange,
+  searchQuery,
+  onSearchQueryChange,
+  onCreateCategory,
+  onDeleteCategory,
   onUploadClick,
   onYouTubeClick,
 }: MediaToolbarProps) {
   return (
     <div
-      className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-slate-800 bg-slate-950 px-4"
+      className="flex shrink-0 flex-col gap-3 border-b border-slate-800 bg-slate-950 px-4 py-3"
       role="toolbar"
       aria-label="미디어 도구 모음"
     >
-      {/* Filter pills */}
-      <div className="flex items-center gap-1.5" role="group" aria-label="미디어 타입 필터">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div
+            className="flex gap-1.5 overflow-x-auto pb-1"
+            role="group"
+            aria-label="미디어 카테고리 필터"
+          >
+            <button
+              type="button"
+              onClick={() => onCategoryChange(null)}
+              aria-pressed={categoryId == null}
+              className={`h-7 rounded-sm border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 ${
+                categoryId == null
+                  ? "border-amber-500 bg-amber-500/10 text-amber-300"
+                  : "border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
+              }`}
+            >
+              전체
+            </button>
+            {categories.map((category) => {
+              const isActive = categoryId === category.id;
+              return (
+                <button
+                  key={category.id}
+                  type="button"
+                  onClick={() => onCategoryChange(category.id)}
+                  aria-pressed={isActive}
+                  className={`h-7 shrink-0 rounded-sm border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 ${
+                    isActive
+                      ? "border-amber-500 bg-amber-500/10 text-amber-300"
+                      : "border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
+                  }`}
+                >
+                  {category.name}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              onClick={onCreateCategory}
+              className="flex h-7 shrink-0 items-center gap-1 rounded-sm border border-slate-700 px-2.5 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              카테고리
+            </button>
+            {categoryId && (
+              <button
+                type="button"
+                onClick={onDeleteCategory}
+                className="flex h-7 shrink-0 items-center gap-1 rounded-sm border border-rose-900/80 px-2.5 text-xs font-medium text-rose-300 transition-colors hover:border-rose-500 hover:text-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500/60"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                카테고리 삭제
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <label className="relative min-w-0 sm:w-64">
+            <Search className="pointer-events-none absolute left-2.5 top-2 h-3.5 w-3.5 text-slate-500" />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(event) => onSearchQueryChange(event.target.value)}
+              placeholder="이름, 태그로 검색"
+              aria-label="미디어 검색"
+              className="h-8 w-full rounded-sm border border-slate-700 bg-slate-950 pl-8 pr-2 text-xs text-slate-200 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            />
+          </label>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onUploadClick}
+              className="flex h-8 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            >
+              <Upload className="h-3.5 w-3.5" />
+              파일 업로드
+            </button>
+            <button
+              type="button"
+              onClick={onYouTubeClick}
+              className="flex h-8 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            >
+              <Youtube className="h-3.5 w-3.5" />
+              YouTube
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="flex gap-1.5 overflow-x-auto pb-1"
+        role="group"
+        aria-label="미디어 타입 필터"
+      >
         {PILLS.map((pill) => {
           const isActive = filter === pill.value;
           return (
@@ -50,7 +158,7 @@ export function MediaToolbar({
               type="button"
               onClick={() => onFilterChange(pill.value)}
               aria-pressed={isActive}
-              className={`h-7 rounded-sm border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 ${
+              className={`h-7 shrink-0 rounded-sm border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 ${
                 isActive
                   ? "border-amber-500 bg-amber-500/10 text-amber-300"
                   : "border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
@@ -60,26 +168,6 @@ export function MediaToolbar({
             </button>
           );
         })}
-      </div>
-
-      {/* Action buttons */}
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onUploadClick}
-          className="flex h-7 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-        >
-          <Upload className="h-3.5 w-3.5" />
-          파일 업로드
-        </button>
-        <button
-          type="button"
-          onClick={onYouTubeClick}
-          className="flex h-7 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-        >
-          <Youtube className="h-3.5 w-3.5" />
-          YouTube
-        </button>
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
@@ -1,10 +1,19 @@
-import { useEffect, useRef, useState, type ChangeEvent, type DragEvent, type KeyboardEvent } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type KeyboardEvent,
+} from 'react';
 import { Upload, X } from 'lucide-react';
 
 import {
   uploadMediaFile,
   useConfirmUpload,
   useRequestUploadUrl,
+  type MediaResponse,
   type MediaType,
 } from '@/features/editor/mediaApi';
 import { getDisplayErrorMessage } from '@/lib/display-error';
@@ -17,18 +26,43 @@ export interface MediaUploadModalProps {
   open: boolean;
   onClose: () => void;
   themeId: string;
+  categoryId?: string | null;
+  allowedTypes?: MediaType[];
+  onUploaded?: (media: MediaResponse) => void;
 }
 
 const MAX_SIZE = 20 * 1024 * 1024;
 const AUDIO_MIME = ['audio/mpeg', 'audio/wav', 'audio/ogg'];
 const IMAGE_MIME = ['image/jpeg', 'image/png', 'image/webp'];
-const ACCEPT_ATTR = [...AUDIO_MIME, ...IMAGE_MIME].join(',');
+const DOCUMENT_MIME = ['application/pdf'];
+const MIME_BY_TYPE: Record<MediaType, string[]> = {
+  BGM: AUDIO_MIME,
+  SFX: AUDIO_MIME,
+  VOICE: AUDIO_MIME,
+  IMAGE: IMAGE_MIME,
+  DOCUMENT: DOCUMENT_MIME,
+  VIDEO: [],
+};
+const TYPE_OPTIONS: Array<{ value: MediaType; label: string }> = [
+  { value: 'BGM', label: '배경음악' },
+  { value: 'SFX', label: '효과음' },
+  { value: 'VOICE', label: '음성' },
+  { value: 'IMAGE', label: '이미지' },
+  { value: 'DOCUMENT', label: '문서' },
+];
 
 // ---------------------------------------------------------------------------
 // MediaUploadModal
 // ---------------------------------------------------------------------------
 
-export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalProps) {
+export function MediaUploadModal({
+  open,
+  onClose,
+  themeId,
+  categoryId,
+  allowedTypes,
+  onUploaded,
+}: MediaUploadModalProps) {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState('');
   const [type, setType] = useState<MediaType>('BGM');
@@ -39,6 +73,21 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
 
   const requestUrlMutation = useRequestUploadUrl(themeId);
   const confirmMutation = useConfirmUpload(themeId);
+  const uploadableTypes = useMemo(
+    () =>
+      TYPE_OPTIONS.filter((option) =>
+        allowedTypes?.length ? allowedTypes.includes(option.value) : true,
+      ).filter((option) => MIME_BY_TYPE[option.value].length > 0),
+    [allowedTypes],
+  );
+  const acceptedMimeTypes = useMemo(
+    () => Array.from(new Set(uploadableTypes.flatMap((option) => MIME_BY_TYPE[option.value]))),
+    [uploadableTypes],
+  );
+  const acceptAttr = acceptedMimeTypes.join(',');
+  const typeOptionsForFile = file
+    ? uploadableTypes.filter((option) => MIME_BY_TYPE[option.value].includes(file.type))
+    : uploadableTypes;
 
   // Abort controller for the in-flight upload. Re-created per upload attempt.
   const controllerRef = useRef<AbortController | null>(null);
@@ -62,22 +111,25 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
       controllerRef.current = null;
       setFile(null);
       setName('');
-      setType('BGM');
+      setType(uploadableTypes[0]?.value ?? 'BGM');
       setProgress(0);
       setError(null);
       setUploading(false);
       setIsDragging(false);
     }
-  }, [open]);
+  }, [open, uploadableTypes]);
 
   const handleFile = (f: File) => {
     if (f.size > MAX_SIZE) {
       setError('파일 크기는 20MB 이하여야 합니다');
       return;
     }
-    const nextType = inferUploadType(f.type);
+    const nextType = inferUploadType(
+      f.type,
+      uploadableTypes.map((option) => option.value),
+    );
     if (!nextType) {
-      setError('지원하지 않는 파일 형식입니다 (MP3, WAV, OGG, JPG, PNG, WEBP)');
+      setError(`지원하지 않는 파일 형식입니다 (${acceptedMimeTypesLabel(acceptedMimeTypes)})`);
       return;
     }
     setError(null);
@@ -121,11 +173,12 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
     setError(null);
     setProgress(0);
     try {
-      await uploadMediaFile({
+      const uploaded = await uploadMediaFile({
         themeId,
         file,
         type,
         name: name || file.name,
+        categoryId: categoryId ?? undefined,
         requestUploadUrl: requestUrlMutation.mutateAsync,
         confirmUpload: confirmMutation.mutateAsync,
         onProgress: (p) => {
@@ -136,6 +189,7 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
         signal: controller.signal,
       });
       if (!isMountedRef.current || controller.signal.aborted) return;
+      onUploaded?.(uploaded);
       onClose();
     } catch (err) {
       if (!isMountedRef.current || controller.signal.aborted) return;
@@ -211,7 +265,7 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
           ) : (
             <>
               <p className="text-sm text-slate-400">파일을 드래그하거나 클릭하여 선택</p>
-              <p className="mt-1 text-xs text-slate-500">(MP3, WAV, OGG, JPG, PNG, WEBP)</p>
+              <p className="mt-1 text-xs text-slate-500">({acceptedMimeTypesLabel(acceptedMimeTypes)})</p>
             </>
           )}
         </div>
@@ -220,7 +274,7 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
           data-testid="media-upload-input"
           type="file"
           className="hidden"
-          accept={ACCEPT_ATTR}
+          accept={acceptAttr}
           onChange={handleInputChange}
         />
 
@@ -249,10 +303,11 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
                 onChange={(e) => setType(e.target.value as MediaType)}
                 disabled={uploading}
               >
-                <option value="BGM">배경음악</option>
-                <option value="SFX">효과음</option>
-                <option value="VOICE">음성</option>
-                <option value="IMAGE">이미지</option>
+                {typeOptionsForFile.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
             </div>
           </div>
@@ -317,8 +372,38 @@ export function MediaUploadModal({ open, onClose, themeId }: MediaUploadModalPro
   );
 }
 
-function inferUploadType(mimeType: string): MediaType | null {
-  if (AUDIO_MIME.includes(mimeType)) return 'BGM';
-  if (IMAGE_MIME.includes(mimeType)) return 'IMAGE';
+function inferUploadType(mimeType: string, allowedTypes: MediaType[]): MediaType | null {
+  if (AUDIO_MIME.includes(mimeType)) {
+    return allowedTypes.find((type) => ['BGM', 'SFX', 'VOICE'].includes(type)) ?? null;
+  }
+  if (IMAGE_MIME.includes(mimeType)) return allowedTypes.includes('IMAGE') ? 'IMAGE' : null;
+  if (DOCUMENT_MIME.includes(mimeType)) {
+    return allowedTypes.includes('DOCUMENT') ? 'DOCUMENT' : null;
+  }
   return null;
+}
+
+function acceptedMimeTypesLabel(mimeTypes: string[]): string {
+  return mimeTypes
+    .map((mime) => {
+      switch (mime) {
+        case 'audio/mpeg':
+          return 'MP3';
+        case 'audio/wav':
+          return 'WAV';
+        case 'audio/ogg':
+          return 'OGG';
+        case 'image/jpeg':
+          return 'JPG';
+        case 'image/png':
+          return 'PNG';
+        case 'image/webp':
+          return 'WEBP';
+        case 'application/pdf':
+          return 'PDF';
+        default:
+          return mime;
+      }
+    })
+    .join(', ');
 }

--- a/apps/web/src/features/editor/components/media/ResourcePicker.tsx
+++ b/apps/web/src/features/editor/components/media/ResourcePicker.tsx
@@ -14,15 +14,23 @@ import {
 import type {
   MediaResourceViewModel,
 } from "@/features/editor/entities/mediaResource/mediaResourceAdapter";
-import type { MediaType } from "@/features/editor/mediaApi";
+import type { MediaCategoryResponse, MediaType } from "@/features/editor/mediaApi";
+
+export interface PickerMediaResource extends MediaResourceViewModel {
+  thumbnailUrl?: string | null;
+}
 
 export interface ResourcePickerProps {
   title: string;
-  resources: MediaResourceViewModel[];
+  resources: PickerMediaResource[];
   searchQuery: string;
   onSearchQueryChange: (query: string) => void;
   onClose: () => void;
   onSelect: (resourceId: string) => void;
+  categories?: MediaCategoryResponse[];
+  categoryId?: string | null;
+  onCategoryChange?: (categoryId: string | null) => void;
+  onUploadClick?: () => void;
   selectedId?: string | null;
   isLoading?: boolean;
   emptyLabel?: string;
@@ -56,6 +64,10 @@ export function ResourcePicker({
   onSearchQueryChange,
   onClose,
   onSelect,
+  categories = [],
+  categoryId = null,
+  onCategoryChange,
+  onUploadClick,
   selectedId,
   isLoading = false,
   emptyLabel = "리소스가 없습니다",
@@ -71,7 +83,7 @@ export function ResourcePicker({
       aria-modal="true"
       aria-label={title}
     >
-      <div className="flex max-h-[84vh] w-full max-w-2xl flex-col rounded-xl border border-slate-700 bg-slate-900 p-4 shadow-2xl shadow-black/40 sm:p-6">
+      <div className="flex max-h-[88vh] w-full max-w-5xl flex-col rounded-lg border border-slate-700 bg-slate-900 p-4 shadow-2xl shadow-black/40 sm:p-6">
         <div className="mb-4 flex items-start justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
@@ -89,16 +101,64 @@ export function ResourcePicker({
           </button>
         </div>
 
-        <div className="relative mb-3">
-          <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
-          <input
-            type="text"
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
-            placeholder="이름, 태그, 종류로 검색"
-            value={searchQuery}
-            onChange={(event) => onSearchQueryChange(event.target.value)}
-            aria-label="미디어 이름 검색"
-          />
+        <div className="mb-3 flex flex-col gap-2">
+          {onCategoryChange ? (
+            <div
+              className="flex gap-1.5 overflow-x-auto pb-1"
+              role="group"
+              aria-label="미디어 카테고리 필터"
+            >
+              <button
+                type="button"
+                onClick={() => onCategoryChange(null)}
+                aria-pressed={categoryId == null}
+                className={`h-7 shrink-0 rounded-sm border px-3 text-xs font-medium ${
+                  categoryId == null
+                    ? "border-amber-500 bg-amber-500/10 text-amber-300"
+                    : "border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
+                }`}
+              >
+                전체
+              </button>
+              {categories.map((category) => (
+                <button
+                  key={category.id}
+                  type="button"
+                  onClick={() => onCategoryChange(category.id)}
+                  aria-pressed={categoryId === category.id}
+                  className={`h-7 shrink-0 rounded-sm border px-3 text-xs font-medium ${
+                    categoryId === category.id
+                      ? "border-amber-500 bg-amber-500/10 text-amber-300"
+                      : "border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
+                  }`}
+                >
+                  {category.name}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <label className="relative min-w-0 flex-1">
+              <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
+              <input
+                type="text"
+                className="w-full rounded-sm border border-slate-700 bg-slate-950 py-2 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
+                placeholder="이름, 태그, 종류로 검색"
+                value={searchQuery}
+                onChange={(event) => onSearchQueryChange(event.target.value)}
+                aria-label="미디어 이름 검색"
+              />
+            </label>
+            {onUploadClick ? (
+              <button
+                type="button"
+                onClick={onUploadClick}
+                className="h-10 shrink-0 rounded-sm border border-slate-700 px-3 text-sm font-medium text-slate-200 transition-colors hover:border-slate-500 hover:text-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+              >
+                바로 업로드
+              </button>
+            ) : null}
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto pr-1">
@@ -114,11 +174,12 @@ export function ResourcePicker({
               {hasQuery ? searchEmptyLabel : emptyLabel}
             </div>
           ) : (
-            <ul className="space-y-2">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" role="list">
               {resources.map((resource) => {
                 const isSelected = selectedId === resource.id;
+                const thumbnailUrl = resource.thumbnailUrl;
                 return (
-                  <li key={resource.id}>
+                  <div key={resource.id} role="listitem">
                     <button
                       type="button"
                       onClick={() => {
@@ -126,37 +187,45 @@ export function ResourcePicker({
                       }}
                       disabled={!resource.isSelectable}
                       aria-pressed={isSelected}
-                      className={`flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                      className={`flex h-full w-full flex-col overflow-hidden rounded-sm border text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
                         isSelected
                           ? "border-amber-500/50 bg-amber-500/15"
                           : "border-slate-800 bg-slate-950 hover:border-slate-700 hover:bg-slate-800"
                       }`}
                     >
-                      <MediaTypeIcon type={resource.type} />
-                      <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <p className="truncate text-sm font-medium text-slate-100">
-                            {resource.name}
-                          </p>
-                          <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300">
-                            {resource.typeLabel}
+                      <div className="relative flex aspect-[4/3] w-full items-center justify-center bg-slate-950/80">
+                        {thumbnailUrl ? (
+                          <img
+                            src={thumbnailUrl}
+                            alt=""
+                            className="h-full w-full object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <MediaTypeIcon type={resource.type} />
+                        )}
+                        {resource.isExternal ? (
+                          <span className="absolute left-2 top-2 rounded-sm bg-black/70 px-1.5 py-0.5 text-[10px] font-medium text-white">
+                            YouTube
                           </span>
+                        ) : null}
+                      </div>
+                      <div className="min-w-0 px-3 py-2">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <p className="truncate text-sm font-medium text-slate-100">{resource.name}</p>
+                          {resource.isExternal ? (
+                            <Youtube className="h-4 w-4 shrink-0 text-rose-500" aria-label="YouTube" />
+                          ) : null}
                         </div>
-                        <p className="mt-1 text-xs text-slate-400">
+                        <p className="mt-1 line-clamp-2 text-xs text-slate-400">
                           {resource.unselectableReason ?? resource.metaLabel}
                         </p>
                       </div>
-                      {resource.isExternal ? (
-                        <Youtube
-                          className="h-4 w-4 shrink-0 text-rose-500"
-                          aria-label="YouTube"
-                        />
-                      ) : null}
                     </button>
-                  </li>
+                  </div>
                 );
               })}
-            </ul>
+            </div>
           )}
         </div>
 

--- a/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
@@ -5,12 +5,26 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { useMediaListMock } = vi.hoisted(() => ({
+const {
+  useMediaListMock,
+  useMediaCategoriesMock,
+  useRequestUploadUrlMock,
+  useConfirmUploadMock,
+  uploadMediaFileMock,
+} = vi.hoisted(() => ({
   useMediaListMock: vi.fn(),
+  useMediaCategoriesMock: vi.fn(),
+  useRequestUploadUrlMock: vi.fn(),
+  useConfirmUploadMock: vi.fn(),
+  uploadMediaFileMock: vi.fn(),
 }));
 
 vi.mock("@/features/editor/mediaApi", () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
+  useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
+  useRequestUploadUrl: () => useRequestUploadUrlMock(),
+  useConfirmUpload: () => useConfirmUploadMock(),
+  uploadMediaFile: (...args: unknown[]) => uploadMediaFileMock(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -75,6 +89,19 @@ beforeEach(() => {
     data: mockMedia,
     isLoading: false,
   });
+  useMediaCategoriesMock.mockReturnValue({
+    data: [
+      {
+        id: "category-screen",
+        theme_id: "theme-1",
+        name: "스크린",
+        sort_order: 1,
+        created_at: "2026-04-05T00:00:00Z",
+      },
+    ],
+  });
+  useRequestUploadUrlMock.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+  useConfirmUploadMock.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
 });
 
 afterEach(() => {
@@ -123,7 +150,7 @@ describe("MediaPicker", () => {
         filterType="BGM"
       />,
     );
-    expect(useMediaListMock).toHaveBeenCalledWith("theme-1", "BGM");
+    expect(useMediaListMock).toHaveBeenCalledWith("theme-1", "BGM", undefined);
     // Footer hint 표시
     expect(screen.getByText(/배경음악 유형만 표시됩니다/)).toBeDefined();
   });
@@ -142,7 +169,7 @@ describe("MediaPicker", () => {
       />,
     );
 
-    expect(useMediaListMock).toHaveBeenCalledWith("theme-1", filterType);
+    expect(useMediaListMock).toHaveBeenCalledWith("theme-1", filterType, undefined);
     expect(screen.getByText(hint)).toBeDefined();
   });
 
@@ -246,7 +273,7 @@ describe("MediaPicker", () => {
     expect(otherBtn.getAttribute("aria-pressed")).toBe("false");
   });
 
-  it("useCase가 맞지 않는 항목은 선택하지 못하게 한다", () => {
+  it("useCase가 맞지 않는 항목은 목록에서 제외한다", () => {
     const onSelect = vi.fn();
     const onClose = vi.fn();
     render(
@@ -259,12 +286,25 @@ describe("MediaPicker", () => {
       />,
     );
 
-    const bgmItem = screen.getByText("오프닝 BGM").closest("button") as HTMLElement;
-    fireEvent.click(bgmItem);
-
+    expect(screen.queryByText("오프닝 BGM")).toBeNull();
     expect(onSelect).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
-    expect(screen.getAllByText(/문서 리소스만 선택/).length).toBeGreaterThan(0);
+    expect(screen.getByText("미디어가 없습니다")).toBeDefined();
+  });
+
+  it("카테고리 탭 선택 시 해당 카테고리로 목록을 다시 조회한다", () => {
+    render(
+      <MediaPicker
+        open={true}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        themeId="theme-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "스크린", pressed: false }));
+
+    expect(useMediaListMock).toHaveBeenLastCalledWith("theme-1", undefined, "category-screen");
   });
 
   it("로딩 상태를 표시한다", () => {

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -258,6 +258,52 @@ describe('MediaTab', () => {
     }
   });
 
+  it('새 카테고리는 기존 sort_order 최댓값 다음 순서로 생성한다', () => {
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+    useMediaCategoriesMock.mockReturnValue({
+      data: [
+        {
+          id: 'category-screen',
+          theme_id: 'theme-1',
+          name: '스크린',
+          sort_order: 1,
+          created_at: '2026-04-05T00:00:00Z',
+        },
+        {
+          id: 'category-clue',
+          theme_id: 'theme-1',
+          name: '단서',
+          sort_order: 7,
+          created_at: '2026-04-05T00:00:00Z',
+        },
+      ],
+    });
+    const mutate = vi.fn();
+    useCreateMediaCategoryMock.mockReturnValue({
+      mutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('증거 사진');
+
+    try {
+      render(<MediaTab themeId="theme-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: '카테고리' }));
+
+      expect(mutate).toHaveBeenCalledWith({
+        name: '증거 사진',
+        sort_order: 8,
+      });
+    } finally {
+      promptSpy.mockRestore();
+    }
+  });
+
   it('카드 클릭 시 상세 패널이 열린다', () => {
     useMediaListMock.mockReturnValue({
       data: mockMedia,

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -7,6 +7,9 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
 const {
   useMediaListMock,
+  useMediaCategoriesMock,
+  useCreateMediaCategoryMock,
+  useDeleteMediaCategoryMock,
   useUpdateMediaMock,
   useDeleteMediaMock,
   useRequestUploadUrlMock,
@@ -16,6 +19,9 @@ const {
   toastError,
 } = vi.hoisted(() => ({
   useMediaListMock: vi.fn(),
+  useMediaCategoriesMock: vi.fn(),
+  useCreateMediaCategoryMock: vi.fn(),
+  useDeleteMediaCategoryMock: vi.fn(),
   useUpdateMediaMock: vi.fn(),
   useDeleteMediaMock: vi.fn(),
   useRequestUploadUrlMock: vi.fn(),
@@ -27,6 +33,9 @@ const {
 
 vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
+  useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
+  useCreateMediaCategory: () => useCreateMediaCategoryMock(),
+  useDeleteMediaCategory: () => useDeleteMediaCategoryMock(),
   useUpdateMedia: () => useUpdateMediaMock(),
   useDeleteMedia: () => useDeleteMediaMock(),
   useRequestUploadUrl: () => useRequestUploadUrlMock(),
@@ -113,6 +122,19 @@ function mutationStub() {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  useMediaCategoriesMock.mockReturnValue({
+    data: [
+      {
+        id: 'category-screen',
+        theme_id: 'theme-1',
+        name: '스크린',
+        sort_order: 1,
+        created_at: '2026-04-05T00:00:00Z',
+      },
+    ],
+  });
+  useCreateMediaCategoryMock.mockReturnValue(mutationStub());
+  useDeleteMediaCategoryMock.mockReturnValue(mutationStub());
   useUpdateMediaMock.mockReturnValue(mutationStub());
   useDeleteMediaMock.mockReturnValue(mutationStub());
   useRequestUploadUrlMock.mockReturnValue(mutationStub());
@@ -180,13 +202,60 @@ describe('MediaTab', () => {
     render(<MediaTab themeId="theme-1" />);
 
     // 초기에는 'all' → undefined
-    expect(useMediaListMock).toHaveBeenLastCalledWith('theme-1', undefined);
+    expect(useMediaListMock).toHaveBeenLastCalledWith('theme-1', undefined, undefined);
 
     // BGM 필터 클릭 — pill button (효과음/음성과 분리되도록 BGM 정확 매칭)
     const bgmPill = screen.getByRole('button', { name: 'BGM', pressed: false });
     fireEvent.click(bgmPill);
 
-    expect(useMediaListMock).toHaveBeenLastCalledWith('theme-1', 'BGM');
+    expect(useMediaListMock).toHaveBeenLastCalledWith('theme-1', 'BGM', undefined);
+  });
+
+  it('카테고리와 검색 필터를 함께 적용한다', () => {
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<MediaTab themeId="theme-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '스크린', pressed: false }));
+    expect(useMediaListMock).toHaveBeenLastCalledWith('theme-1', undefined, 'category-screen');
+
+    fireEvent.change(screen.getByLabelText('미디어 검색'), { target: { value: '문 닫는' } });
+    expect(screen.queryByText('오프닝 BGM')).toBeNull();
+    expect(screen.getByText('문 닫는 소리')).toBeDefined();
+  });
+
+  it('선택한 카테고리를 삭제하면 전체 카테고리로 돌아간다', () => {
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+    const mutate = vi.fn((_id: string, options?: { onSuccess?: () => void }) => {
+      options?.onSuccess?.();
+    });
+    useDeleteMediaCategoryMock.mockReturnValue({
+      mutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    try {
+      render(<MediaTab themeId="theme-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: '스크린', pressed: false }));
+      fireEvent.click(screen.getByRole('button', { name: /카테고리 삭제/ }));
+
+      expect(mutate).toHaveBeenCalledWith('category-screen', expect.any(Object));
+      const categoryGroup = screen.getByRole('group', { name: '미디어 카테고리 필터' });
+      expect(within(categoryGroup).getByRole('button', { name: '전체', pressed: true })).toBeDefined();
+    } finally {
+      confirmSpy.mockRestore();
+    }
   });
 
   it('카드 클릭 시 상세 패널이 열린다', () => {

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -40,7 +40,11 @@ import { uploadMediaFile } from '@/features/editor/mediaApi';
 
 const mockedUpload = uploadMediaFile as unknown as ReturnType<typeof vi.fn>;
 
-function renderModal(open = true, onClose = vi.fn()) {
+function renderModal(
+  open = true,
+  onClose = vi.fn(),
+  props: Partial<React.ComponentProps<typeof MediaUploadModal>> = {},
+) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -48,7 +52,7 @@ function renderModal(open = true, onClose = vi.fn()) {
     onClose,
     ...render(
       <QueryClientProvider client={qc}>
-        <MediaUploadModal open={open} onClose={onClose} themeId="theme-1" />
+        <MediaUploadModal open={open} onClose={onClose} themeId="theme-1" {...props} />
       </QueryClientProvider>
     ),
   };
@@ -104,7 +108,7 @@ describe('MediaUploadModal', () => {
   it('rejects wrong MIME type', () => {
     renderModal(true);
     const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
-    const file = makeFile('doc.pdf', 1024, 'application/pdf');
+    const file = makeFile('notes.txt', 1024, 'text/plain');
     fireEvent.change(input, { target: { files: [file] } });
 
     expect(screen.getByRole('alert').textContent).toContain('지원하지 않는 파일 형식입니다');
@@ -135,7 +139,7 @@ describe('MediaUploadModal', () => {
 
   it('upload button triggers uploadMediaFile with correct params', async () => {
     mockedUpload.mockResolvedValueOnce({});
-    const { onClose } = renderModal(true);
+    const { onClose } = renderModal(true, vi.fn(), { categoryId: 'category-screen' });
     const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
     const file = makeFile('track.mp3', 1024);
     fireEvent.change(input, { target: { files: [file] } });
@@ -148,6 +152,7 @@ describe('MediaUploadModal', () => {
     expect(args.file).toBe(file);
     expect(args.type).toBe('BGM');
     expect(args.name).toBe('track');
+    expect(args.categoryId).toBe('category-screen');
     expect(typeof args.requestUploadUrl).toBe('function');
     expect(typeof args.confirmUpload).toBe('function');
     expect(typeof args.onProgress).toBe('function');
@@ -167,6 +172,30 @@ describe('MediaUploadModal', () => {
 
     await waitFor(() => expect(mockedUpload).toHaveBeenCalledTimes(1));
     expect(mockedUpload.mock.calls[0][0].type).toBe('IMAGE');
+  });
+
+  it('문서 파일은 DOCUMENT 타입으로 자동 설정해 업로드한다', async () => {
+    mockedUpload.mockResolvedValueOnce({});
+    renderModal(true);
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('role-sheet.pdf', 1024, 'application/pdf');
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect((screen.getByLabelText('유형') as HTMLSelectElement).value).toBe('DOCUMENT');
+
+    fireEvent.click(screen.getByRole('button', { name: '업로드' }));
+
+    await waitFor(() => expect(mockedUpload).toHaveBeenCalledTimes(1));
+    expect(mockedUpload.mock.calls[0][0].type).toBe('DOCUMENT');
+  });
+
+  it('allowedTypes가 있으면 해당 유형 파일만 받는다', () => {
+    renderModal(true, vi.fn(), { allowedTypes: ['IMAGE'] });
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('song.mp3', 1024, 'audio/mpeg');
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(screen.getByRole('alert').textContent).toContain('지원하지 않는 파일 형식입니다');
   });
 
   it('progress bar updates from onProgress', async () => {

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -10,12 +10,18 @@ const {
   useUpdateReadingSectionMock,
   useDeleteReadingSectionMock,
   useMediaListMock,
+  useMediaCategoriesMock,
+  useRequestUploadUrlMock,
+  useConfirmUploadMock,
   invalidateQueriesMock,
   writeTextMock,
 } = vi.hoisted(() => ({
   useUpdateReadingSectionMock: vi.fn(),
   useDeleteReadingSectionMock: vi.fn(),
   useMediaListMock: vi.fn(),
+  useMediaCategoriesMock: vi.fn(),
+  useRequestUploadUrlMock: vi.fn(),
+  useConfirmUploadMock: vi.fn(),
   invalidateQueriesMock: vi.fn(),
   writeTextMock: vi.fn(),
 }));
@@ -34,6 +40,9 @@ vi.mock("@/features/editor/readingApi", async () => {
 
 vi.mock("@/features/editor/mediaApi", () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
+  useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
+  useRequestUploadUrl: (...args: unknown[]) => useRequestUploadUrlMock(...args),
+  useConfirmUpload: (...args: unknown[]) => useConfirmUploadMock(...args),
 }));
 
 vi.mock("@/services/queryClient", () => ({
@@ -118,6 +127,15 @@ beforeEach(() => {
     isPending: false,
   });
   useMediaListMock.mockReturnValue({ data: [], isLoading: false });
+  useMediaCategoriesMock.mockReturnValue({ data: [] });
+  useRequestUploadUrlMock.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  });
+  useConfirmUploadMock.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
## 요약
- 미디어 관리 탭을 카테고리 탭 + 타입 필터 + 검색이 함께 동작하는 gallery-first 화면으로 정리했습니다.
- `MediaPicker`를 리스트형 선택기에서 갤러리 선택 모달로 바꾸고, 카테고리 필터와 바로 업로드 CTA를 추가했습니다.
- 업로드 모달이 선택 컨텍스트의 카테고리/허용 타입을 반영하고, PDF 문서 업로드까지 지원하도록 확장했습니다.
- 이미지/YouTube 썸네일과 문서/오디오 fallback 표시를 개선하되, adapter ViewModel에는 raw storage URL을 넣지 않도록 유지했습니다.

## 이슈
Refs #444
Refs #450

#444는 미디어 라이브러리/선택 모달 UX를 다룹니다. #450은 참조 차단과 부분 성공 처리가 필요한 다중 선택 삭제 후속 이슈입니다.

## Coverage Plan
- `MediaTab.tsx`: 카테고리 조회/생성/삭제, 카테고리+검색 필터, 상세 패널, 참조 차단 삭제 경고를 `MediaTab.test.tsx`로 검증했습니다.
- `MediaPicker.tsx` / `ResourcePicker.tsx`: gallery picker 렌더링, 타입/useCase 필터, 카테고리 필터, 검색, 선택/닫기, raw URL 미노출을 `MediaPicker.test.tsx`와 adapter 테스트로 검증했습니다.
- `MediaUploadModal.tsx`: allowedTypes, categoryId 전달, 이미지/PDF 자동 타입 추론, MIME 거부, 업로드 취소/에러를 `MediaUploadModal.test.tsx`로 검증했습니다.
- E2E는 이번 PR에서 제외했습니다. route/field 연결이 아니라 media component UX 단위 변경이고, 핵심 분기는 focused Vitest로 직접 검증했습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/mediaResource/__tests__/mediaResourceAdapter.test.ts src/features/editor/components/media/__tests__/MediaTab.test.tsx src/features/editor/components/media/__tests__/MediaPicker.test.tsx src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx`
- `git diff --check`

## 제외
- 기존 에디터 필드를 새 picker로 교체하는 작업은 #445에서 처리합니다.
- 참조 차단을 고려한 다중 선택 삭제는 #450에서 처리합니다.
- backend media contract 변경은 포함하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 미디어 카테고리 관리 및 필터링(생성/삭제, 드롭다운 선택, 카테고리별 조회)
  * 이미지 및 YouTube 썸네일 지원, 반응형 가로세로비 썸네일 레이아웃
  * 미디어 카드: 제목 2줄 클램프 및 최대 3개 태그 표시
  * 검색·카테고리 기반 미디어 선택기, 그리드형 썸네일 뷰 및 업로드 모달 통합
  * 업로드: 카테고리 전달, 허용 타입 및 동적 MIME 처리, 업로드 콜백 지원

* **테스트**
  * 카테고리·업로드 관련 단위 테스트 확장 및 시나리오 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->