### PR TITLE
feat(editor): 스토리맵 장면 속성 요약 보강

### DIFF
--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -3,6 +3,7 @@ import {
   Background,
   MiniMap,
   Controls,
+  type Edge,
   type Node,
   type NodeTypes,
   type OnSelectionChangeParams,
@@ -40,7 +41,10 @@ const edgeTypes = { ...conditionEdgeTypes };
 
 interface FlowCanvasProps {
   themeId: string;
-  onSelectedNodeChange?: (node: Node | null) => void;
+  onSelectedNodeChange?: (
+    node: Node | null,
+    context: { outgoingEdges: Edge[] },
+  ) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,8 +91,12 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
   );
 
   useEffect(() => {
-    onSelectedNodeChange?.(selectedNode);
-  }, [onSelectedNodeChange, selectedNode]);
+    onSelectedNodeChange?.(selectedNode, {
+      outgoingEdges: selectedNode
+        ? edges.filter((edge) => edge.source === selectedNode.id)
+        : [],
+    });
+  }, [edges, onSelectedNodeChange, selectedNode]);
 
   const selectedEdge = useMemo(
     () => edges.find((edge) => edge.id === selectedEdgeId) ?? null,

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -140,7 +140,7 @@ describe('FlowCanvas', () => {
 
     render(<FlowCanvas themeId="theme-1" onSelectedNodeChange={onSelectedNodeChange} />);
 
-    expect(onSelectedNodeChange).toHaveBeenCalledWith(selectedNode);
+    expect(onSelectedNodeChange).toHaveBeenCalledWith(selectedNode, { outgoingEdges: [] });
   });
 
   it('장면 노드가 있으면 스토리 장면 요약을 렌더링한다', () => {

--- a/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
+++ b/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
@@ -9,13 +9,23 @@ import {
   Search,
   Zap,
 } from "lucide-react";
-import type { Node } from "@xyflow/react";
-import type { FlowNodeData } from "@/features/editor/flowTypes";
+import type { Edge, Node } from "@xyflow/react";
+import type { FlowNodeData, PhaseAction } from "@/features/editor/flowTypes";
 import type { StoryLibraryEntity } from "./EditorEntityLibrary";
 import { formatDiscussionRoomSummary } from "@/features/editor/entities/phase/discussionRoomPolicyAdapter";
+import { toPhaseEditorViewModel } from "@/features/editor/entities/phase/phaseEntityAdapter";
+import {
+  flowNodeToInformationDeliveries,
+  isInformationDeliveryAction,
+} from "@/features/editor/entities/shared/informationDeliveryAdapter";
+import {
+  getCreatorActionLabel,
+  toCreatorActionLabels,
+} from "@/features/editor/entities/shared/actionAdapter";
 
 interface SceneInspectorProps {
   selectedScene: Node<FlowNodeData> | null;
+  selectedSceneEdges?: Edge[];
   selectedEntity: StoryLibraryEntity | null;
 }
 
@@ -46,6 +56,21 @@ const ROW_ICONS = [
   Zap,
 ] as const;
 
+const PRESENTATION_ACTION_TYPES = new Set([
+  "SET_BGM",
+  "PLAY_SOUND",
+  "PLAY_MEDIA",
+  "STOP_AUDIO",
+  "SET_BACKGROUND",
+  "SET_THEME_COLOR",
+  "play_bgm",
+  "play_sound",
+  "play_media",
+  "stop_bgm",
+  "set_background",
+  "set_theme_color",
+]);
+
 function describeSceneType(type?: string): string {
   if (type === "phase") return "스토리 장면";
   if (type === "branch") return "분기";
@@ -54,34 +79,81 @@ function describeSceneType(type?: string): string {
   return "스토리 항목";
 }
 
-function countActions(actions?: FlowNodeData["onEnter"]): string {
-  const count = actions?.length ?? 0;
-  return count > 0 ? `${count}개 설정됨` : "설정 없음";
+function countKeywordActions(data: FlowNodeData, keywords: string[]): number {
+  return (data.onEnter ?? []).filter((action) =>
+    keywords.some((keyword) => action.type.toLowerCase().includes(keyword)),
+  ).length;
 }
 
-function hasAction(data: FlowNodeData, keyword: string): boolean {
-  return (data.onEnter ?? []).some((action) => action.type.includes(keyword));
+function splitActions(actions: PhaseAction[]) {
+  const presentation = actions.filter((action) => PRESENTATION_ACTION_TYPES.has(action.type));
+  const trigger = actions.filter(
+    (action) =>
+      !PRESENTATION_ACTION_TYPES.has(action.type) &&
+      !isInformationDeliveryAction(action),
+  );
+  return { presentation, trigger };
 }
 
-function buildRows(scene: Node<FlowNodeData> | null): InspectorRow[] {
+function formatInformationDelivery(data: FlowNodeData): string {
+  const deliveries = flowNodeToInformationDeliveries(data);
+  if (deliveries.length === 0) return "정보 공개 설정 없음";
+  const readingCount = deliveries.reduce(
+    (sum, delivery) => sum + delivery.readingSectionIds.length,
+    0,
+  );
+  const infoCount = deliveries.reduce(
+    (sum, delivery) => sum + delivery.storyInfoIds.length,
+    0,
+  );
+  return `공개 설정 ${deliveries.length}개 · 읽기 대사 ${readingCount}개 · 스토리 정보 ${infoCount}개`;
+}
+
+function formatPresentation(data: FlowNodeData): string {
+  const { presentation } = splitActions(data.onEnter ?? []);
+  const visualLabels = [data.icon ? "아이콘" : null, data.color ? "색상" : null].filter(Boolean);
+  const actionLabels = presentation.map((action) => getCreatorActionLabel(action.type));
+  const labels = [...visualLabels, ...actionLabels];
+  return labels.length > 0 ? labels.join(", ") : "연출 설정 없음";
+}
+
+function formatTriggerActions(data: FlowNodeData): string {
+  const enter = splitActions(data.onEnter ?? []).trigger;
+  const exit = data.onExit ?? [];
+  const enterLabel = enter.length > 0
+    ? enter.map((action) => getCreatorActionLabel(action.type)).join(", ")
+    : "시작 트리거 없음";
+  const exitLabel = exit.length > 0
+    ? toCreatorActionLabels(exit).join(", ")
+    : "종료 트리거 없음";
+  return `시작: ${enterLabel} · 종료: ${exitLabel}`;
+}
+
+function buildRows(scene: Node<FlowNodeData> | null, outgoingEdges: Edge[]): InspectorRow[] {
   if (!scene) return EMPTY_ROWS;
   const data = scene.data;
+  const phaseSummary = toPhaseEditorViewModel(data, outgoingEdges);
+  const clueActionCount = countKeywordActions(data, ["clue"]);
+  const locationActionCount = countKeywordActions(data, ["location"]);
+  const investigationActionCount = countKeywordActions(data, ["investigation", "token"]);
   return [
     {
       label: "정보 공개",
-      value: data.description ? "장면 설명 있음" : "공개 설명 없음",
+      value: formatInformationDelivery(data),
     },
     {
       label: "단서 배포",
-      value: hasAction(data, "clue") ? "입장 시 단서 동작 있음" : "연결된 단서 동작 없음",
+      value: clueActionCount > 0 ? `단서 실행 ${clueActionCount}개` : "연결된 단서 실행 없음",
     },
     {
       label: "장소",
-      value: hasAction(data, "location") ? "장소 동작 있음" : "장소 동작 없음",
+      value: locationActionCount > 0 ? `장소 실행 ${locationActionCount}개` : "장소 열림/잠금 실행 없음",
     },
     {
       label: "조사권",
-      value: hasAction(data, "investigation") ? "조사권 동작 있음" : "조사권 동작 없음",
+      value: investigationActionCount > 0
+        ? `조사권 실행 ${investigationActionCount}개`
+        : "조사권 실행 없음",
     },
     {
       label: "토론방",
@@ -89,21 +161,25 @@ function buildRows(scene: Node<FlowNodeData> | null): InspectorRow[] {
     },
     {
       label: "연출",
-      value: data.icon || data.color ? "표시 설정 있음" : "기본 표시",
+      value: formatPresentation(data),
     },
     {
       label: "조건",
-      value: data.autoAdvance ? "자동 진행" : "수동 또는 연결선 조건",
+      value: `${phaseSummary.autoAdvanceLabel} · ${phaseSummary.defaultTransitionLabel} · 조건 이동 ${phaseSummary.conditionalTransitionCount}개`,
     },
     {
       label: "액션",
-      value: `입장 ${countActions(data.onEnter)} · 퇴장 ${countActions(data.onExit)}`,
+      value: formatTriggerActions(data),
     },
   ];
 }
 
-export function SceneInspector({ selectedScene, selectedEntity }: SceneInspectorProps) {
-  const rows = buildRows(selectedScene);
+export function SceneInspector({
+  selectedScene,
+  selectedSceneEdges = [],
+  selectedEntity,
+}: SceneInspectorProps) {
+  const rows = buildRows(selectedScene, selectedSceneEdges);
   const sceneTitle = selectedScene?.data.label ?? "선택한 장면 없음";
 
   return (

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -1,5 +1,5 @@
-import type { Node } from "@xyflow/react";
-import { useEffect, useState } from "react";
+import type { Edge, Node } from "@xyflow/react";
+import { useCallback, useEffect, useState } from "react";
 import type { FlowNodeData } from "@/features/editor/flowTypes";
 import { FlowCanvas } from "../design/FlowCanvas";
 import {
@@ -16,11 +16,21 @@ interface StoryMapWorkspaceProps {
 export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
   const [selectedEntity, setSelectedEntity] = useState<StoryLibraryEntity | null>(null);
   const [selectedScene, setSelectedScene] = useState<Node<FlowNodeData> | null>(null);
+  const [selectedSceneEdges, setSelectedSceneEdges] = useState<Edge[]>([]);
 
   useEffect(() => {
     setSelectedEntity(null);
     setSelectedScene(null);
+    setSelectedSceneEdges([]);
   }, [themeId]);
+
+  const handleSelectedNodeChange = useCallback(
+    (node: Node | null, context: { outgoingEdges: Edge[] }) => {
+      setSelectedScene(node as Node<FlowNodeData> | null);
+      setSelectedSceneEdges(context.outgoingEdges);
+    },
+    [],
+  );
 
   return (
     <section
@@ -62,10 +72,14 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
         />
 
         <main className="min-h-[520px] min-w-0 border-b border-slate-800 lg:min-h-0 lg:border-b-0">
-          <FlowCanvas themeId={themeId} onSelectedNodeChange={setSelectedScene} />
+          <FlowCanvas themeId={themeId} onSelectedNodeChange={handleSelectedNodeChange} />
         </main>
 
-        <SceneInspector selectedScene={selectedScene} selectedEntity={selectedEntity} />
+        <SceneInspector
+          selectedScene={selectedScene}
+          selectedSceneEdges={selectedSceneEdges}
+          selectedEntity={selectedEntity}
+        />
       </div>
     </section>
   );

--- a/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@xyflow/react";
 import type { FlowNodeData } from "@/features/editor/flowTypes";
+import { DELIVER_INFORMATION_ACTION } from "@/features/editor/entities/shared/actionAdapter";
 import { SceneInspector } from "../SceneInspector";
 
 describe("SceneInspector", () => {
@@ -36,19 +37,60 @@ describe("SceneInspector", () => {
           availability: "phase_active",
           closeBehavior: "close_on_exit",
         },
-        onEnter: [{ type: "give_clue", params: {} }],
+        onEnter: [
+          {
+            type: DELIVER_INFORMATION_ACTION,
+            params: {
+              deliveries: [
+                {
+                  id: "delivery-1",
+                  target: { type: "all_players" },
+                  reading_section_ids: ["reading-1"],
+                  story_info_ids: ["info-1", "info-2"],
+                },
+              ],
+            },
+          },
+          { type: "give_clue", params: {} },
+          { type: "SET_BGM", params: { mediaId: "media-1" } },
+        ],
+        onExit: [{ type: "MUTE_CHAT" }],
       },
     };
 
     render(
       <SceneInspector
         selectedScene={scene}
+        selectedSceneEdges={[
+          {
+            id: "edge-1",
+            source: "scene-1",
+            target: "scene-2",
+            data: {
+              condition: {
+                id: "condition-1",
+                operator: "AND",
+                rules: [
+                  {
+                    id: "rule-1",
+                    variable: "clue_held",
+                    target_character_id: "char-1",
+                    target_clue_id: "clue-1",
+                    comparator: "=",
+                    value: "true",
+                  },
+                ],
+              },
+            },
+          },
+        ]}
         selectedEntity={{
           id: "clue-1",
           kind: "clue",
           section: "단서",
           title: "찢어진 초대장",
           detail: "미배치",
+          connectable: true,
         }}
       />,
     );
@@ -56,8 +98,11 @@ describe("SceneInspector", () => {
     expect(screen.getByText("오프닝")).toBeDefined();
     expect(screen.getByText("스토리 장면")).toBeDefined();
     expect(screen.getByText("찢어진 초대장")).toBeDefined();
-    expect(screen.getByText("장면 설명 있음")).toBeDefined();
-    expect(screen.getByText("입장 시 단서 동작 있음")).toBeDefined();
+    expect(screen.getByText("공개 설정 1개 · 읽기 대사 1개 · 스토리 정보 2개")).toBeDefined();
+    expect(screen.getByText("단서 실행 1개")).toBeDefined();
+    expect(screen.getByText("BGM 재생")).toBeDefined();
+    expect(screen.getByText("자동 진행 · 기본 이동 없음 · 조건 이동 1개")).toBeDefined();
+    expect(screen.getByText("시작: 직접 설정한 실행 · 종료: 채팅 닫기")).toBeDefined();
     expect(
       screen.getByText("장면 시작 시 · 전원 참여 · 장면 종료 시 닫기 · 전체 토론: 전체 토론"),
     ).toBeDefined();

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -19,31 +19,34 @@ vi.mock("../../design/FlowCanvas", () => ({
     onSelectedNodeChange,
   }: {
     themeId: string;
-    onSelectedNodeChange?: (node: unknown) => void;
+    onSelectedNodeChange?: (node: unknown, context: { outgoingEdges: unknown[] }) => void;
   }) => (
     <div data-testid="flow-canvas">
       flow canvas {themeId}
       <button
         type="button"
         onClick={() =>
-          onSelectedNodeChange?.({
-            id: "scene-1",
-            type: "phase",
-            data: {
-              label: "오프닝",
-              description: "도입 장면",
-              discussionRoomPolicy: {
-                enabled: true,
-                roomKind: "all",
-                mainRoomName: "전체 토론",
-                privateRoomsEnabled: false,
-                privateRoomName: "밀담방",
-                participantMode: "all",
-                availability: "phase_active",
-                closeBehavior: "close_on_exit",
+          onSelectedNodeChange?.(
+            {
+              id: "scene-1",
+              type: "phase",
+              data: {
+                label: "오프닝",
+                description: "도입 장면",
+                discussionRoomPolicy: {
+                  enabled: true,
+                  roomKind: "all",
+                  mainRoomName: "전체 토론",
+                  privateRoomsEnabled: false,
+                  privateRoomName: "밀담방",
+                  participantMode: "all",
+                  availability: "phase_active",
+                  closeBehavior: "close_on_exit",
+                },
               },
             },
-          })
+            { outgoingEdges: [] },
+          )
         }
       >
         장면 선택
@@ -190,7 +193,7 @@ describe("StoryMapWorkspace", () => {
 
     expect(screen.getByText("오프닝")).toBeDefined();
     expect(screen.getByText("스토리 장면")).toBeDefined();
-    expect(screen.getByText("장면 설명 있음")).toBeDefined();
+    expect(screen.getByText("정보 공개 설정 없음")).toBeDefined();
     expect(screen.getByText("장면 시작 시 · 전원 참여 · 장면 종료 시 닫기 · 전체 토론: 전체 토론")).toBeDefined();
   });
 });


### PR DESCRIPTION
## 요약
- 스토리맵의 선택 장면 정보를 우측 속성 패널에 실제 flow node/edge 데이터 기준으로 요약합니다.
- 정보 공개, 단서/장소/조사권 실행, 토론방, 연출, 조건 이동, 시작/종료 트리거를 제작자 언어로 표시합니다.
- FlowCanvas 선택 콜백에 선택 장면의 outgoing edge context를 넘겨 조건 이동 요약이 라우트/스토리맵 화면에서 유지되게 했습니다.

## 이슈
Closes #381

## Coverage Plan
- `SceneInspector.tsx`: 선택 장면 없음, 정보 공개 payload, 조건 edge, 연출/트리거 요약 분기 -> `SceneInspector.test.tsx`
- `StoryMapWorkspace.tsx`: FlowCanvas 선택 context를 우측 패널로 전달하고 테마 변경 시 선택 상태 초기화 -> `StoryMapWorkspace.test.tsx`
- `FlowCanvas.tsx`: 선택 노드 콜백 계약 확장 -> `FlowCanvas.test.tsx`
- `/editor/:id` direct URL route matrix 유지 -> `EditorPage.test.tsx`, `routeSegments.test.ts`

## 검증
- `pnpm install --offline`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx src/pages/__tests__/EditorPage.test.tsx src/features/editor/__tests__/routeSegments.test.ts`

## 범위
- backend 저장 계약/runtime engine 구현은 #381 본문 결정대로 후속 2차 목표로 유지합니다.
- 이번 PR은 route/page migration 화면에서 장면 속성 확인성이 떨어지는 부분을 보강하는 프론트 단위 변경입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 씬 인스펙터에서 씬 정보 공개 설정, 단서 실행, BGM 재생 등 다양한 메타데이터 표시 기능 추가
  * 장면 간 연결 관계를 추적하여 더 정확한 씬 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->