### PR TITLE
feat(runtime): 세션 스냅샷에 캐릭터 표시값 연결

### DIFF
--- a/apps/server/internal/domain/room/mocks/mock_service.go
+++ b/apps/server/internal/domain/room/mocks/mock_service.go
@@ -169,15 +169,15 @@ func (m *MockGameStarter) EXPECT() *MockGameStarterMockRecorder {
 }
 
 // Start mocks base method.
-func (m *MockGameStarter) Start(ctx context.Context, roomID uuid.UUID, configJSON []byte) error {
+func (m *MockGameStarter) Start(ctx context.Context, roomID, themeID uuid.UUID, configJSON []byte, players []room.GameStartPlayer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", ctx, roomID, configJSON)
+	ret := m.ctrl.Call(m, "Start", ctx, roomID, themeID, configJSON, players)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockGameStarterMockRecorder) Start(ctx, roomID, configJSON any) *gomock.Call {
+func (mr *MockGameStarterMockRecorder) Start(ctx, roomID, themeID, configJSON, players any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockGameStarter)(nil).Start), ctx, roomID, configJSON)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockGameStarter)(nil).Start), ctx, roomID, themeID, configJSON, players)
 }

--- a/apps/server/internal/domain/room/service.go
+++ b/apps/server/internal/domain/room/service.go
@@ -529,6 +529,14 @@ func (s *service) buildGameStartPlayers(ctx context.Context, room db.Room) ([]Ga
 		s.logger.Error().Err(err).Stringer("theme_id", room.ThemeID).Msg("StartRoom: failed to get theme characters")
 		return nil, apperror.Internal("failed to get theme characters")
 	}
+	return mapGameStartPlayers(rows, chars, room.HostID), nil
+}
+
+func mapGameStartPlayers(
+	rows []db.GetRoomPlayersWithUserRow,
+	chars []db.ThemeCharacter,
+	hostID uuid.UUID,
+) []GameStartPlayer {
 	charByID := make(map[uuid.UUID]db.ThemeCharacter, len(chars))
 	for _, char := range chars {
 		charByID[char.ID] = char
@@ -540,7 +548,7 @@ func (s *service) buildGameStartPlayers(ctx context.Context, room db.Room) ([]Ga
 			UserID:    row.UserID,
 			Nickname:  row.Nickname,
 			AvatarURL: textToPtr(row.AvatarUrl),
-			IsHost:    row.UserID == room.HostID,
+			IsHost:    row.UserID == hostID,
 			IsReady:   row.IsReady,
 			JoinedAt:  row.JoinedAt,
 		}
@@ -556,7 +564,7 @@ func (s *service) buildGameStartPlayers(ctx context.Context, room db.Room) ([]Ga
 		}
 		players = append(players, player)
 	}
-	return players, nil
+	return players
 }
 
 func uuidToStringPtr(value pgtype.UUID) *string {

--- a/apps/server/internal/domain/room/service.go
+++ b/apps/server/internal/domain/room/service.go
@@ -3,6 +3,7 @@ package room
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -78,10 +79,26 @@ type Service interface {
 	StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
 }
 
+// GameStartPlayer is the player-facing roster input handed to the runtime
+// session when a waiting room starts.
+type GameStartPlayer struct {
+	UserID                uuid.UUID
+	CharacterID           *uuid.UUID
+	Nickname              string
+	AvatarURL             *string
+	IsHost                bool
+	IsReady               bool
+	JoinedAt              time.Time
+	CharacterName         string
+	CharacterImageURL     *string
+	CharacterImageMediaID *string
+	CharacterAliasRules   json.RawMessage
+}
+
 // GameStarter abstracts startModularGame so the room service has no direct
-// dependency on the session package. Implement with session.StartModularGameFunc.
+// dependency on the session package.
 type GameStarter interface {
-	Start(ctx context.Context, roomID uuid.UUID, configJSON []byte) error
+	Start(ctx context.Context, roomID, themeID uuid.UUID, configJSON []byte, players []GameStartPlayer) error
 }
 
 type service struct {
@@ -484,7 +501,12 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 		)
 	}
 
-	if err := s.gameStarter.Start(ctx, roomID, req.ConfigJSON); err != nil {
+	players, err := s.buildGameStartPlayers(ctx, room)
+	if err != nil {
+		return err
+	}
+
+	if err := s.gameStarter.Start(ctx, roomID, room.ThemeID, req.ConfigJSON, players); err != nil {
 		s.logger.Error().Err(err).Str("room_id", roomID.String()).Msg("StartRoom: gameStarter failed")
 		return err
 	}
@@ -494,6 +516,55 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 		Str("host_id", hostID.String()).
 		Msg("StartRoom: game started")
 	return nil
+}
+
+func (s *service) buildGameStartPlayers(ctx context.Context, room db.Room) ([]GameStartPlayer, error) {
+	rows, err := s.queries.GetRoomPlayersWithUser(ctx, room.ID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("room_id", room.ID).Msg("StartRoom: failed to get room players")
+		return nil, apperror.Internal("failed to get room players")
+	}
+	chars, err := s.queries.GetThemeCharacters(ctx, room.ThemeID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("theme_id", room.ThemeID).Msg("StartRoom: failed to get theme characters")
+		return nil, apperror.Internal("failed to get theme characters")
+	}
+	charByID := make(map[uuid.UUID]db.ThemeCharacter, len(chars))
+	for _, char := range chars {
+		charByID[char.ID] = char
+	}
+
+	players := make([]GameStartPlayer, 0, len(rows))
+	for _, row := range rows {
+		player := GameStartPlayer{
+			UserID:    row.UserID,
+			Nickname:  row.Nickname,
+			AvatarURL: textToPtr(row.AvatarUrl),
+			IsHost:    row.UserID == room.HostID,
+			IsReady:   row.IsReady,
+			JoinedAt:  row.JoinedAt,
+		}
+		if row.CharacterID.Valid {
+			charID := uuid.UUID(row.CharacterID.Bytes)
+			player.CharacterID = &charID
+			if char, ok := charByID[charID]; ok {
+				player.CharacterName = char.Name
+				player.CharacterImageURL = textToPtr(char.ImageUrl)
+				player.CharacterImageMediaID = uuidToStringPtr(char.ImageMediaID)
+				player.CharacterAliasRules = char.AliasRules
+			}
+		}
+		players = append(players, player)
+	}
+	return players, nil
+}
+
+func uuidToStringPtr(value pgtype.UUID) *string {
+	if !value.Valid {
+		return nil
+	}
+	id := uuid.UUID(value.Bytes).String()
+	return &id
 }
 
 // mapRoomResponse converts a db.Room to a RoomResponse.

--- a/apps/server/internal/domain/room/service_flag_test.go
+++ b/apps/server/internal/domain/room/service_flag_test.go
@@ -23,7 +23,7 @@ type fakeGameStarter struct {
 	returnErr error
 }
 
-func (f *fakeGameStarter) Start(_ context.Context, _ uuid.UUID, _ []byte) error {
+func (f *fakeGameStarter) Start(_ context.Context, _, _ uuid.UUID, _ []byte, _ []GameStartPlayer) error {
 	f.called = true
 	return f.returnErr
 }
@@ -108,7 +108,7 @@ func TestStartRoom_FlagOff_NoGameStarterCalled(t *testing.T) {
 					"game runtime not enabled",
 				)
 			}
-			return starter.Start(context.Background(), uuid.New(), nil)
+			return starter.Start(context.Background(), uuid.New(), uuid.New(), nil, nil)
 		},
 	}
 
@@ -136,7 +136,7 @@ func TestStartRoom_FlagOn_StarterCalled(t *testing.T) {
 
 	svc := &mockService{
 		startRoomFn: func(_ context.Context, _, _ uuid.UUID, _ StartRoomRequest) error {
-			return starter.Start(context.Background(), uuid.New(), nil)
+			return starter.Start(context.Background(), uuid.New(), uuid.New(), nil, nil)
 		},
 	}
 
@@ -154,7 +154,7 @@ func TestStartRoom_FlagOn_StarterError(t *testing.T) {
 
 	svc := &mockService{
 		startRoomFn: func(_ context.Context, _, _ uuid.UUID, _ StartRoomRequest) error {
-			return starter.Start(context.Background(), uuid.New(), nil)
+			return starter.Start(context.Background(), uuid.New(), uuid.New(), nil, nil)
 		},
 	}
 

--- a/apps/server/internal/domain/room/service_flag_test.go
+++ b/apps/server/internal/domain/room/service_flag_test.go
@@ -2,11 +2,14 @@ package room
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
@@ -210,4 +213,80 @@ func TestNewService_GameStarterNil(t *testing.T) {
 		t.Error("NewServiceWithStarter should set gameStarter")
 	}
 
+}
+
+func TestMapGameStartPlayers_UsesAssignedCharacterDisplayMetadata(t *testing.T) {
+	hostID := uuid.New()
+	guestID := uuid.New()
+	charID := uuid.New()
+	themeID := uuid.New()
+	joinedAt := time.Unix(1700, 123_000_000)
+	avatarURL := "https://cdn.example/avatar.png"
+	characterImageURL := "https://cdn.example/character.png"
+	characterImageMediaID := uuid.New()
+	aliasRules := json.RawMessage(`[{"id":"mask","display_name":"가면 쓴 탐정"}]`)
+
+	got := mapGameStartPlayers(
+		[]db.GetRoomPlayersWithUserRow{{
+			UserID: hostID,
+			CharacterID: pgtype.UUID{
+				Bytes: charID,
+				Valid: true,
+			},
+			Nickname: "계정 닉네임",
+			AvatarUrl: pgtype.Text{
+				String: avatarURL,
+				Valid:  true,
+			},
+			IsReady:  true,
+			JoinedAt: joinedAt,
+		}, {
+			UserID:   guestID,
+			Nickname: "캐릭터 미배정",
+			JoinedAt: joinedAt.Add(time.Second),
+		}},
+		[]db.ThemeCharacter{{
+			ID:       charID,
+			ThemeID:  themeID,
+			Name:     "홍길동",
+			ImageUrl: pgtype.Text{String: characterImageURL, Valid: true},
+			ImageMediaID: pgtype.UUID{
+				Bytes: characterImageMediaID,
+				Valid: true,
+			},
+			AliasRules: aliasRules,
+		}},
+		hostID,
+	)
+
+	if len(got) != 2 {
+		t.Fatalf("players len = %d, want 2", len(got))
+	}
+	host := got[0]
+	if host.UserID != hostID || host.CharacterID == nil || *host.CharacterID != charID {
+		t.Fatalf("host identity mismatch: %+v", host)
+	}
+	if host.Nickname != "계정 닉네임" || host.AvatarURL == nil || *host.AvatarURL != avatarURL {
+		t.Fatalf("host account display mismatch: %+v", host)
+	}
+	if !host.IsHost || !host.IsReady || !host.JoinedAt.Equal(joinedAt) {
+		t.Fatalf("host roster flags mismatch: %+v", host)
+	}
+	if host.CharacterName != "홍길동" {
+		t.Fatalf("CharacterName = %q, want 홍길동", host.CharacterName)
+	}
+	if host.CharacterImageURL == nil || *host.CharacterImageURL != characterImageURL {
+		t.Fatalf("CharacterImageURL = %v, want %s", host.CharacterImageURL, characterImageURL)
+	}
+	if host.CharacterImageMediaID == nil || *host.CharacterImageMediaID != characterImageMediaID.String() {
+		t.Fatalf("CharacterImageMediaID = %v, want %s", host.CharacterImageMediaID, characterImageMediaID)
+	}
+	if string(host.CharacterAliasRules) != string(aliasRules) {
+		t.Fatalf("CharacterAliasRules = %s, want %s", host.CharacterAliasRules, aliasRules)
+	}
+
+	guest := got[1]
+	if guest.UserID != guestID || guest.CharacterID != nil || guest.CharacterName != "" {
+		t.Fatalf("unassigned guest should keep account-only roster data: %+v", guest)
+	}
 }

--- a/apps/server/internal/engine/build_state_for_test.go
+++ b/apps/server/internal/engine/build_state_for_test.go
@@ -186,3 +186,85 @@ func TestPhaseEngine_BuildStateForIncludesResolvedRosterWithoutAliasRules(t *tes
 		t.Fatalf("player payload leaked targetCode: %s", raw)
 	}
 }
+
+func TestPhaseEngine_BuildStateForRosterSortsAndUsesNicknameFallback(t *testing.T) {
+	earlyID := uuid.New()
+	lateID := uuid.New()
+	displayIconURL := "https://cdn.example/icon.png"
+	pe, _ := newTestPhaseEngine(t, []Module{&stubCoreModule{name: "public_mod"}}, testPhaseDefinitions)
+	pe.SetPlayerInfoProvider(rosterProviderStub{players: []PlayerRuntimeInfo{{
+		PlayerID:       lateID,
+		Nickname:       "두 번째 참가자",
+		Role:           "",
+		IsAlive:        true,
+		ConnectedAt:    200,
+		DisplayIconURL: &displayIconURL,
+	}, {
+		PlayerID:    earlyID,
+		Nickname:    "첫 번째 참가자",
+		Role:        "detective",
+		IsAlive:     true,
+		ConnectedAt: 100,
+	}}})
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	raw, err := pe.BuildStateFor(earlyID)
+	if err != nil {
+		t.Fatalf("BuildStateFor: %v", err)
+	}
+	var body struct {
+		Players []map[string]any `json:"players"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	if len(body.Players) != 2 {
+		t.Fatalf("players len = %d, want 2: %s", len(body.Players), raw)
+	}
+	if body.Players[0]["id"] != earlyID.String() {
+		t.Fatalf("first player id = %v, want %s", body.Players[0]["id"], earlyID)
+	}
+	if body.Players[1]["displayName"] != "두 번째 참가자" {
+		t.Fatalf("displayName fallback = %v, want nickname", body.Players[1]["displayName"])
+	}
+	if body.Players[1]["role"] != nil {
+		t.Fatalf("empty role should be null, got %+v", body.Players[1]["role"])
+	}
+	if body.Players[1]["displayIconUrl"] != displayIconURL {
+		t.Fatalf("displayIconUrl = %v, want %s", body.Players[1]["displayIconUrl"], displayIconURL)
+	}
+}
+
+func TestPhaseEngine_BuildStateForIncludesEmptyRosterWhenProviderIsPresent(t *testing.T) {
+	playerID := uuid.New()
+	pe, _ := newTestPhaseEngine(t, []Module{&stubCoreModule{name: "public_mod"}}, testPhaseDefinitions)
+	pe.SetPlayerInfoProvider(rosterProviderStub{})
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	raw, err := pe.BuildStateFor(playerID)
+	if err != nil {
+		t.Fatalf("BuildStateFor: %v", err)
+	}
+	var body struct {
+		Players []map[string]any `json:"players"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	if body.Players == nil {
+		t.Fatalf("players should be an empty array when roster provider is present: %s", raw)
+	}
+	if len(body.Players) != 0 {
+		t.Fatalf("players len = %d, want 0", len(body.Players))
+	}
+}

--- a/apps/server/internal/engine/build_state_for_test.go
+++ b/apps/server/internal/engine/build_state_for_test.go
@@ -27,6 +27,32 @@ func (p *playerAwareStubModule) BuildStateFor(playerID uuid.UUID) (json.RawMessa
 	})
 }
 
+type rosterProviderStub struct {
+	players []PlayerRuntimeInfo
+}
+
+func (r rosterProviderStub) ResolvePlayerID(_ context.Context, targetCode string) (uuid.UUID, bool) {
+	for _, player := range r.players {
+		if player.PlayerID.String() == targetCode || player.TargetCode == targetCode {
+			return player.PlayerID, true
+		}
+	}
+	return uuid.Nil, false
+}
+
+func (r rosterProviderStub) PlayerRuntimeInfo(_ context.Context, playerID uuid.UUID) (PlayerRuntimeInfo, bool) {
+	for _, player := range r.players {
+		if player.PlayerID == playerID {
+			return player, true
+		}
+	}
+	return PlayerRuntimeInfo{}, false
+}
+
+func (r rosterProviderStub) PlayerRuntimeRoster(context.Context) []PlayerRuntimeInfo {
+	return r.players
+}
+
 // TestPhaseEngine_BuildStateFor_TwoPlayersDiffer verifies that player-aware
 // modules emit distinct state per player and that non-aware modules fall back
 // to BuildState (identical across players).
@@ -108,5 +134,55 @@ func TestBuildModuleStateFor_FallsBackWhenNotAware(t *testing.T) {
 	}
 	if string(got) != string(want) {
 		t.Errorf("fallback mismatch: got %s want %s", got, want)
+	}
+}
+
+func TestPhaseEngine_BuildStateForIncludesResolvedRosterWithoutAliasRules(t *testing.T) {
+	playerID := uuid.New()
+	aliasIconMediaID := uuid.New().String()
+	pe, _ := newTestPhaseEngine(t, []Module{&stubCoreModule{name: "public_mod"}}, testPhaseDefinitions)
+	pe.SetPlayerInfoProvider(rosterProviderStub{players: []PlayerRuntimeInfo{{
+		PlayerID:           playerID,
+		TargetCode:         "char_witness",
+		Nickname:           "참가자",
+		Role:               "detective",
+		IsAlive:            true,
+		IsHost:             true,
+		IsReady:            true,
+		DisplayName:        "밤의 목격자",
+		DisplayIconMediaID: &aliasIconMediaID,
+	}}})
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	raw, err := pe.BuildStateFor(playerID)
+	if err != nil {
+		t.Fatalf("BuildStateFor: %v", err)
+	}
+	var body struct {
+		Players []map[string]any `json:"players"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	if len(body.Players) != 1 {
+		t.Fatalf("players len = %d, want 1: %s", len(body.Players), raw)
+	}
+	player := body.Players[0]
+	if player["displayName"] != "밤의 목격자" || player["nickname"] != "참가자" {
+		t.Fatalf("player display mismatch: %+v", player)
+	}
+	if player["displayIconMediaId"] != aliasIconMediaID {
+		t.Fatalf("displayIconMediaId = %v, want %s", player["displayIconMediaId"], aliasIconMediaID)
+	}
+	if _, leaked := player["alias_rules"]; leaked {
+		t.Fatalf("player payload leaked alias_rules: %s", raw)
+	}
+	if _, leaked := player["targetCode"]; leaked {
+		t.Fatalf("player payload leaked targetCode: %s", raw)
 	}
 }

--- a/apps/server/internal/engine/phase_engine.go
+++ b/apps/server/internal/engine/phase_engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime/debug"
+	"sort"
 
 	"github.com/google/uuid"
 )
@@ -372,6 +373,9 @@ func (e *PhaseEngine) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error)
 		"sessionId": e.sessionID,
 		"phase":     e.CurrentPhase(),
 	}
+	if rosterProvider, ok := e.playerInfoProvider.(PlayerRuntimeRosterProvider); ok {
+		state["players"] = playerRuntimeRosterPayload(rosterProvider.PlayerRuntimeRoster(context.Background()))
+	}
 
 	moduleStates := make(map[string]json.RawMessage, len(e.modules))
 	for _, mod := range e.modules {
@@ -384,6 +388,51 @@ func (e *PhaseEngine) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error)
 	state["modules"] = moduleStates
 
 	return json.Marshal(state)
+}
+
+func playerRuntimeRosterPayload(players []PlayerRuntimeInfo) []map[string]any {
+	if len(players) == 0 {
+		return []map[string]any{}
+	}
+	players = append([]PlayerRuntimeInfo(nil), players...)
+	sort.SliceStable(players, func(i, j int) bool {
+		if players[i].ConnectedAt != players[j].ConnectedAt {
+			return players[i].ConnectedAt < players[j].ConnectedAt
+		}
+		return players[i].PlayerID.String() < players[j].PlayerID.String()
+	})
+	payload := make([]map[string]any, 0, len(players))
+	for _, player := range players {
+		name := player.DisplayName
+		if name == "" {
+			name = player.Nickname
+		}
+		row := map[string]any{
+			"id":          player.PlayerID.String(),
+			"nickname":    player.Nickname,
+			"displayName": name,
+			"role":        nullableString(player.Role),
+			"isAlive":     player.IsAlive,
+			"isHost":      player.IsHost,
+			"isReady":     player.IsReady,
+			"connectedAt": player.ConnectedAt,
+		}
+		if player.DisplayIconURL != nil {
+			row["displayIconUrl"] = *player.DisplayIconURL
+		}
+		if player.DisplayIconMediaID != nil {
+			row["displayIconMediaId"] = *player.DisplayIconMediaID
+		}
+		payload = append(payload, row)
+	}
+	return payload
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 // Stop gracefully shuts down the engine and all modules.

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -207,10 +207,17 @@ type Logger interface {
 // may need to validate player-targeted actions without owning the full session
 // roster.
 type PlayerRuntimeInfo struct {
-	PlayerID   uuid.UUID
-	TargetCode string
-	Role       string
-	IsAlive    bool
+	PlayerID           uuid.UUID
+	TargetCode         string
+	Nickname           string
+	Role               string
+	IsAlive            bool
+	IsHost             bool
+	IsReady            bool
+	ConnectedAt        int64
+	DisplayName        string
+	DisplayIconURL     *string
+	DisplayIconMediaID *string
 }
 
 // PlayerInfoProvider resolves runtime player metadata for modules that must
@@ -219,6 +226,13 @@ type PlayerRuntimeInfo struct {
 type PlayerInfoProvider interface {
 	ResolvePlayerID(ctx context.Context, targetCode string) (uuid.UUID, bool)
 	PlayerRuntimeInfo(ctx context.Context, playerID uuid.UUID) (PlayerRuntimeInfo, bool)
+}
+
+// PlayerRuntimeRosterProvider optionally exposes a player-facing roster for
+// session snapshots. Implementations must return resolved display values only;
+// raw alias rules or spoiler fields must never be included.
+type PlayerRuntimeRosterProvider interface {
+	PlayerRuntimeRoster(ctx context.Context) []PlayerRuntimeInfo
 }
 
 // ModuleDeps provides session-scoped dependencies to modules.

--- a/apps/server/internal/session/game_starter.go
+++ b/apps/server/internal/session/game_starter.go
@@ -2,8 +2,10 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/domain/room"
 	"github.com/mmp-platform/server/internal/engine"
 	"github.com/rs/zerolog"
 )
@@ -40,11 +42,11 @@ func NewGameStarter(
 // Start implements room.GameStarter. roomID is used as the sessionID (1:1
 // mapping between room and game session). configJSON is the editor-produced
 // scenario config. Returns errGameRuntimeDisabled when the feature flag is off.
-func (g *GameStarterAdapter) Start(ctx context.Context, roomID uuid.UUID, configJSON []byte) error {
+func (g *GameStarterAdapter) Start(ctx context.Context, roomID, themeID uuid.UUID, configJSON []byte, players []room.GameStartPlayer) error {
 	cfg := StartConfig{
 		SessionID:     roomID,
-		ThemeID:       uuid.Nil, // resolved from configJSON by engine
-		Players:       nil,      // players joined via WS; session actor manages roster
+		ThemeID:       themeID,
+		Players:       toSessionPlayers(players),
 		ConfigJSON:    configJSON,
 		FeatureFlag:   g.featureFlag,
 		Broadcaster:   g.broadcaster,
@@ -52,4 +54,37 @@ func (g *GameStarterAdapter) Start(ctx context.Context, roomID uuid.UUID, config
 	}
 	_, err := startModularGame(ctx, g.manager, cfg, g.logger)
 	return err
+}
+
+func toSessionPlayers(players []room.GameStartPlayer) []PlayerState {
+	if len(players) == 0 {
+		return nil
+	}
+	result := make([]PlayerState, 0, len(players))
+	for _, player := range players {
+		state := PlayerState{
+			PlayerID:    player.UserID,
+			Nickname:    player.Nickname,
+			Connected:   true,
+			IsAlive:     boolPtr(true),
+			IsHost:      player.IsHost,
+			IsReady:     player.IsReady,
+			ConnectedAt: player.JoinedAt.UnixMilli(),
+		}
+		if player.CharacterID != nil {
+			state.TargetCode = player.CharacterID.String()
+			state.DisplayBase = engine.CharacterDisplayBase{
+				Name:         player.CharacterName,
+				ImageURL:     player.CharacterImageURL,
+				ImageMediaID: player.CharacterImageMediaID,
+				AliasRules:   engine.ParseCharacterAliasRules(json.RawMessage(player.CharacterAliasRules)),
+			}
+		}
+		result = append(result, state)
+	}
+	return result
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/apps/server/internal/session/starter.go
+++ b/apps/server/internal/session/starter.go
@@ -213,10 +213,22 @@ func newStaticPlayerInfoProvider(players []PlayerState) engine.PlayerInfoProvide
 			isAlive = *player.IsAlive
 		}
 		infos[player.PlayerID] = engine.PlayerRuntimeInfo{
-			PlayerID:   player.PlayerID,
-			TargetCode: player.TargetCode,
-			Role:       player.Role,
-			IsAlive:    isAlive,
+			PlayerID:    player.PlayerID,
+			TargetCode:  player.TargetCode,
+			Nickname:    player.Nickname,
+			Role:        player.Role,
+			IsAlive:     isAlive,
+			IsHost:      player.IsHost,
+			IsReady:     player.IsReady,
+			ConnectedAt: player.ConnectedAt,
+		}
+		if player.DisplayBase.Name != "" {
+			display := engine.ResolveCharacterDisplay(player.DisplayBase, player.DisplayContext)
+			info := infos[player.PlayerID]
+			info.DisplayName = display.Name
+			info.DisplayIconURL = display.ImageURL
+			info.DisplayIconMediaID = display.ImageMediaID
+			infos[player.PlayerID] = info
 		}
 		if player.TargetCode != "" {
 			targetCodeIDs[player.TargetCode] = player.PlayerID
@@ -239,4 +251,12 @@ func (p staticPlayerInfoProvider) ResolvePlayerID(_ context.Context, targetCode 
 func (p staticPlayerInfoProvider) PlayerRuntimeInfo(_ context.Context, playerID uuid.UUID) (engine.PlayerRuntimeInfo, bool) {
 	info, ok := p.players[playerID]
 	return info, ok
+}
+
+func (p staticPlayerInfoProvider) PlayerRuntimeRoster(_ context.Context) []engine.PlayerRuntimeInfo {
+	players := make([]engine.PlayerRuntimeInfo, 0, len(p.players))
+	for _, player := range p.players {
+		players = append(players, player)
+	}
+	return players
 }

--- a/apps/server/internal/session/starter_test.go
+++ b/apps/server/internal/session/starter_test.go
@@ -422,6 +422,64 @@ func TestStaticPlayerInfoProvider_ResolvesTargetCodeAndRuntimeInfo(t *testing.T)
 	}
 }
 
+func TestStaticPlayerInfoProvider_ResolvesCharacterDisplayForRoster(t *testing.T) {
+	playerID := uuid.New()
+	iconMediaID := uuid.New().String()
+	aliasName := "밤의 목격자"
+
+	provider := newStaticPlayerInfoProvider([]PlayerState{{
+		PlayerID:   playerID,
+		TargetCode: "char_witness",
+		Nickname:   "참가자",
+		Connected:  true,
+		IsHost:     true,
+		IsReady:    true,
+		DisplayBase: engine.CharacterDisplayBase{
+			Name: "홍길동",
+			AliasRules: []engine.CharacterAliasRule{{
+				ID:                 "identity-open",
+				DisplayName:        &aliasName,
+				DisplayIconMediaID: &iconMediaID,
+				Priority:           1,
+				Condition: json.RawMessage(`{
+					"id":"group-1",
+					"operator":"AND",
+					"rules":[{
+						"id":"rule-1",
+						"variable":"custom_flag",
+						"target_flag_key":"identity_revealed",
+						"comparator":"=",
+						"value":"true"
+					}]
+				}`),
+			}},
+		},
+		DisplayContext: json.RawMessage(`{"flags":{"identity_revealed":true}}`),
+	}})
+	if provider == nil {
+		t.Fatal("expected provider")
+	}
+
+	rosterProvider, ok := provider.(engine.PlayerRuntimeRosterProvider)
+	if !ok {
+		t.Fatal("provider should expose runtime roster")
+	}
+	roster := rosterProvider.PlayerRuntimeRoster(context.Background())
+	if len(roster) != 1 {
+		t.Fatalf("roster len = %d, want 1", len(roster))
+	}
+	got := roster[0]
+	if got.DisplayName != aliasName {
+		t.Fatalf("DisplayName = %q, want %q", got.DisplayName, aliasName)
+	}
+	if got.DisplayIconMediaID == nil || *got.DisplayIconMediaID != iconMediaID {
+		t.Fatalf("DisplayIconMediaID = %v, want %s", got.DisplayIconMediaID, iconMediaID)
+	}
+	if got.Nickname != "참가자" || !got.IsHost || !got.IsReady {
+		t.Fatalf("roster metadata mismatch: %+v", got)
+	}
+}
+
 func TestStaticPlayerInfoProvider_EmptyPlayersReturnsNil(t *testing.T) {
 	if got := newStaticPlayerInfoProvider(nil); got != nil {
 		t.Fatalf("newStaticPlayerInfoProvider(nil) = %T, want nil", got)

--- a/apps/server/internal/session/starter_test.go
+++ b/apps/server/internal/session/starter_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/domain/room"
 	"github.com/mmp-platform/server/internal/engine"
 	"github.com/rs/zerolog"
 )
@@ -483,5 +484,112 @@ func TestStaticPlayerInfoProvider_ResolvesCharacterDisplayForRoster(t *testing.T
 func TestStaticPlayerInfoProvider_EmptyPlayersReturnsNil(t *testing.T) {
 	if got := newStaticPlayerInfoProvider(nil); got != nil {
 		t.Fatalf("newStaticPlayerInfoProvider(nil) = %T, want nil", got)
+	}
+}
+
+func TestToSessionPlayers_MapsRoomRosterCharacterDisplay(t *testing.T) {
+	playerID := uuid.New()
+	characterID := uuid.New()
+	joinedAt := time.Unix(1700, 456_000_000)
+	imageURL := "https://cdn.example/character.png"
+	imageMediaID := uuid.New().String()
+
+	got := toSessionPlayers([]room.GameStartPlayer{{
+		UserID:                playerID,
+		CharacterID:           &characterID,
+		Nickname:              "계정 닉네임",
+		IsHost:                true,
+		IsReady:               true,
+		JoinedAt:              joinedAt,
+		CharacterName:         "홍길동",
+		CharacterImageURL:     &imageURL,
+		CharacterImageMediaID: &imageMediaID,
+		CharacterAliasRules: json.RawMessage(`[
+			{"id":"mask","display_name":"가면 쓴 탐정","priority":1}
+		]`),
+	}})
+
+	if len(got) != 1 {
+		t.Fatalf("players len = %d, want 1", len(got))
+	}
+	player := got[0]
+	if player.PlayerID != playerID || player.TargetCode != characterID.String() {
+		t.Fatalf("identity mismatch: %+v", player)
+	}
+	if player.Nickname != "계정 닉네임" || !player.Connected || !player.IsHost || !player.IsReady {
+		t.Fatalf("account flags mismatch: %+v", player)
+	}
+	if player.IsAlive == nil || !*player.IsAlive {
+		t.Fatalf("IsAlive = %v, want true pointer", player.IsAlive)
+	}
+	if player.ConnectedAt != joinedAt.UnixMilli() {
+		t.Fatalf("ConnectedAt = %d, want %d", player.ConnectedAt, joinedAt.UnixMilli())
+	}
+	if player.DisplayBase.Name != "홍길동" {
+		t.Fatalf("DisplayBase.Name = %q, want 홍길동", player.DisplayBase.Name)
+	}
+	if player.DisplayBase.ImageURL == nil || *player.DisplayBase.ImageURL != imageURL {
+		t.Fatalf("DisplayBase.ImageURL = %v, want %s", player.DisplayBase.ImageURL, imageURL)
+	}
+	if player.DisplayBase.ImageMediaID == nil || *player.DisplayBase.ImageMediaID != imageMediaID {
+		t.Fatalf("DisplayBase.ImageMediaID = %v, want %s", player.DisplayBase.ImageMediaID, imageMediaID)
+	}
+	if len(player.DisplayBase.AliasRules) != 1 || player.DisplayBase.AliasRules[0].DisplayName == nil {
+		t.Fatalf("AliasRules not parsed: %+v", player.DisplayBase.AliasRules)
+	}
+}
+
+func TestToSessionPlayers_EmptyRosterReturnsNil(t *testing.T) {
+	if got := toSessionPlayers(nil); got != nil {
+		t.Fatalf("toSessionPlayers(nil) = %#v, want nil", got)
+	}
+	if got := toSessionPlayers([]room.GameStartPlayer{}); got != nil {
+		t.Fatalf("toSessionPlayers(empty) = %#v, want nil", got)
+	}
+}
+
+func TestGameStarterAdapter_StartRegistersSessionWithRoomRoster(t *testing.T) {
+	m := newTestManager(t)
+	bc := &mockBroadcaster{}
+	roomID := uuid.New()
+	themeID := uuid.New()
+	playerID := uuid.New()
+	characterID := uuid.New()
+	joinedAt := time.Unix(1700, 789_000_000)
+
+	starter := NewGameStarter(m, bc, true, nil, zerolog.Nop())
+	err := starter.Start(context.Background(), roomID, themeID, minimalConfigJSON(t), []room.GameStartPlayer{{
+		UserID:      playerID,
+		CharacterID: &characterID,
+		Nickname:    "계정 닉네임",
+		IsHost:      true,
+		IsReady:     true,
+		JoinedAt:    joinedAt,
+	}})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	s := m.Get(roomID)
+	if s == nil {
+		t.Fatal("session not registered")
+	}
+	defer func() {
+		if err := m.Stop(roomID); err != nil {
+			t.Fatalf("Stop failed: %v", err)
+		}
+	}()
+
+	player, ok := s.players[playerID]
+	if !ok {
+		t.Fatalf("session player %s not registered: %+v", playerID, s.players)
+	}
+	if player.PlayerID != playerID || player.TargetCode != characterID.String() {
+		t.Fatalf("roster identity mismatch: %+v", player)
+	}
+	if player.Nickname != "계정 닉네임" || !player.IsHost || !player.IsReady {
+		t.Fatalf("roster flags mismatch: %+v", player)
+	}
+	if player.ConnectedAt != joinedAt.UnixMilli() {
+		t.Fatalf("ConnectedAt = %d, want %d", player.ConnectedAt, joinedAt.UnixMilli())
 	}
 }

--- a/apps/server/internal/session/types.go
+++ b/apps/server/internal/session/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/engine"
 )
 
 // MessageKind identifies the category of a SessionMessage routed through the actor inbox.
@@ -69,11 +70,17 @@ const (
 
 // PlayerState holds per-player runtime state visible to the session actor.
 type PlayerState struct {
-	PlayerID   uuid.UUID
-	TargetCode string
-	Connected  bool
-	Role       string
-	IsAlive    *bool
+	PlayerID       uuid.UUID
+	TargetCode     string
+	Nickname       string
+	Connected      bool
+	Role           string
+	IsAlive        *bool
+	IsHost         bool
+	IsReady        bool
+	ConnectedAt    int64
+	DisplayBase    engine.CharacterDisplayBase
+	DisplayContext json.RawMessage
 }
 
 // EngineCommandPayload is the structured payload for KindEngineCommand messages.

--- a/apps/web/src/features/game/components/VoteOptionList.tsx
+++ b/apps/web/src/features/game/components/VoteOptionList.tsx
@@ -1,7 +1,8 @@
-import { User, CheckCircle } from "lucide-react";
-import type { Player } from "@mmp/shared";
+import { User, CheckCircle } from 'lucide-react';
+import type { Player } from '@mmp/shared';
+import { playerDisplayName } from '../utils/resultBreakdownAdapter';
 
-import { Button, Badge } from "@/shared/components/ui";
+import { Button, Badge } from '@/shared/components/ui';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -22,12 +23,10 @@ export function VoteOptionList({
   candidates,
   votedTargetId,
   onVote,
-  emptyMessage = "투표 가능한 플레이어가 없습니다",
+  emptyMessage = '투표 가능한 플레이어가 없습니다',
 }: VoteOptionListProps) {
   if (candidates.length === 0) {
-    return (
-      <p className="text-sm text-slate-400">{emptyMessage}</p>
-    );
+    return <p className="text-sm text-slate-400">{emptyMessage}</p>;
   }
 
   return (
@@ -39,8 +38,8 @@ export function VoteOptionList({
             key={player.id}
             className={`flex items-center justify-between rounded-lg border p-3 transition-colors ${
               isSelected
-                ? "border-amber-500 ring-2 ring-amber-500 bg-amber-500/10"
-                : "border-slate-700 bg-slate-800/50"
+                ? 'border-amber-500 ring-2 ring-amber-500 bg-amber-500/10'
+                : 'border-slate-700 bg-slate-800/50'
             }`}
           >
             <div className="flex items-center gap-3">
@@ -48,7 +47,7 @@ export function VoteOptionList({
                 <User className="h-4 w-4 text-slate-300" />
               </div>
               <span className="text-sm font-medium text-slate-200">
-                {player.nickname}
+                {playerDisplayName(player)}
               </span>
             </div>
             {isSelected ? (

--- a/apps/web/src/features/game/components/VotePanel.tsx
+++ b/apps/web/src/features/game/components/VotePanel.tsx
@@ -1,19 +1,20 @@
-import { useState } from "react";
-import { Vote, Lock, Users } from "lucide-react";
-import { WsEventType } from "@mmp/shared";
+import { useState } from 'react';
+import { Vote, Lock, Users } from 'lucide-react';
+import { WsEventType } from '@mmp/shared';
 
-import { Badge, Card } from "@/shared/components/ui";
-import { useGameSessionStore as useGameStore } from "@/stores/gameSessionStore";
-import { selectMyPlayerId, selectPlayers } from "@/stores/gameSelectors";
-import { useModuleStore } from "@/stores/moduleStoreFactory";
-import { VoteOptionList } from "./VoteOptionList";
-import { VoteResultChart } from "./VoteResultChart";
-import type { VoteResult } from "./VoteResultChart";
+import { Badge, Card } from '@/shared/components/ui';
+import { useGameSessionStore as useGameStore } from '@/stores/gameSessionStore';
+import { selectMyPlayerId, selectPlayers } from '@/stores/gameSelectors';
+import { useModuleStore } from '@/stores/moduleStoreFactory';
+import { VoteOptionList } from './VoteOptionList';
+import { VoteResultChart } from './VoteResultChart';
+import type { VoteResult } from './VoteResultChart';
 import {
   countExcludedDetectives,
   filterVotingCandidates,
   readVotingCandidatePolicy,
-} from "../utils/votingCandidates";
+} from '../utils/votingCandidates';
+import { playerDisplayNameById } from '../utils/resultBreakdownAdapter';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,18 +40,25 @@ export function VotePanel({ send, moduleId }: VotePanelProps) {
   const results = moduleData.results as VoteResult[] | null | undefined;
   const isSecret = results === null;
   const hasResults = Array.isArray(results) && results.length > 0;
+  const displayResults = hasResults
+    ? results.map((result) => ({
+        ...result,
+        nickname: playerDisplayNameById(players, result.playerId, result.nickname),
+      }))
+    : [];
 
   const candidatePolicy = readVotingCandidatePolicy(moduleData);
   const candidates = filterVotingCandidates(players, myPlayerId, candidatePolicy);
   const excludedDetectiveCount = countExcludedDetectives(players, myPlayerId, candidatePolicy);
-  const emptyMessage = excludedDetectiveCount > 0
-    ? "탐정 제외 정책 때문에 투표 가능한 플레이어가 없습니다"
-    : "투표 가능한 플레이어가 없습니다";
+  const emptyMessage =
+    excludedDetectiveCount > 0
+      ? '탐정 제외 정책 때문에 투표 가능한 플레이어가 없습니다'
+      : '투표 가능한 플레이어가 없습니다';
 
   const handleVote = (targetId: string) => {
     if (votedTargetId) return;
     setVotedTargetId(targetId);
-    send(WsEventType.GAME_ACTION, { type: "vote", targetId });
+    send(WsEventType.GAME_ACTION, { type: 'vote', targetId });
   };
 
   return (
@@ -75,7 +83,7 @@ export function VotePanel({ send, moduleId }: VotePanelProps) {
       )}
 
       {/* 투표 결과 */}
-      {hasResults && <VoteResultChart results={results!} />}
+      {hasResults && <VoteResultChart results={displayResults} />}
 
       {/* 투표 대상 목록 (결과 미수신 & 비밀 투표 아닐 때) */}
       {!hasResults && !isSecret && (

--- a/apps/web/src/features/game/components/VotingPanel.tsx
+++ b/apps/web/src/features/game/components/VotingPanel.tsx
@@ -1,18 +1,19 @@
-import { useState, useMemo } from "react";
-import { User, Vote } from "lucide-react";
-import { WsEventType } from "@mmp/shared";
-import type { Player } from "@mmp/shared";
+import { useState, useMemo } from 'react';
+import { User, Vote } from 'lucide-react';
+import { WsEventType } from '@mmp/shared';
+import type { Player } from '@mmp/shared';
 
-import { Button, Badge, Card } from "@/shared/components/ui";
-import { useGameSessionStore as useGameStore } from "@/stores/gameSessionStore";
-import { selectMyPlayerId, selectPlayers } from "@/stores/gameSelectors";
-import { useModuleStore } from "@/stores/moduleStoreFactory";
-import { useCountUp } from "../hooks/useCountUp";
+import { Button, Badge, Card } from '@/shared/components/ui';
+import { useGameSessionStore as useGameStore } from '@/stores/gameSessionStore';
+import { selectMyPlayerId, selectPlayers } from '@/stores/gameSelectors';
+import { useModuleStore } from '@/stores/moduleStoreFactory';
+import { useCountUp } from '../hooks/useCountUp';
 import {
   countExcludedDetectives,
   filterVotingCandidates,
   readVotingCandidatePolicy,
-} from "../utils/votingCandidates";
+} from '../utils/votingCandidates';
+import { playerDisplayName, playerDisplayNameById } from '../utils/resultBreakdownAdapter';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,7 +47,7 @@ function VoteBar({
 }) {
   const animatedVotes = useCountUp(result.votes);
   const widthPct = maxVotes > 0 ? (animatedVotes / maxVotes) * 100 : 0;
-  const barColor = isTop ? "bg-amber-500" : "bg-slate-600";
+  const barColor = isTop ? 'bg-amber-500' : 'bg-slate-600';
   const delay = `${staggerIndex * 100}ms`;
 
   return (
@@ -54,9 +55,9 @@ function VoteBar({
       className="motion-safe:animate-fade-slide-up space-y-1"
       style={
         {
-          "--stagger-index": staggerIndex,
+          '--stagger-index': staggerIndex,
           animationDelay: delay,
-          animationFillMode: "backwards",
+          animationFillMode: 'backwards',
         } as React.CSSProperties
       }
     >
@@ -90,30 +91,35 @@ export function VotingPanel({ send, moduleId }: VotingPanelProps) {
   const results = moduleData.results as VotingResult[] | null | undefined;
   const isSecret = results === null;
   const hasResults = Array.isArray(results) && results.length > 0;
+  const displayResults = hasResults
+    ? results.map((result) => ({
+        ...result,
+        nickname: playerDisplayNameById(players, result.playerId, result.nickname),
+      }))
+    : [];
 
   const candidatePolicy = readVotingCandidatePolicy(moduleData);
   const candidates = filterVotingCandidates(players, myPlayerId, candidatePolicy);
   const excludedDetectiveCount = countExcludedDetectives(players, myPlayerId, candidatePolicy);
-  const emptyMessage = excludedDetectiveCount > 0
-    ? "탐정 제외 정책 때문에 투표 가능한 플레이어가 없습니다"
-    : "투표 가능한 플레이어가 없습니다";
+  const emptyMessage =
+    excludedDetectiveCount > 0
+      ? '탐정 제외 정책 때문에 투표 가능한 플레이어가 없습니다'
+      : '투표 가능한 플레이어가 없습니다';
 
   // 최대 득표수 (바 너비 계산용)
-  const maxVotes = hasResults
-    ? Math.max(...results.map((r) => r.votes), 1)
-    : 1;
+  const maxVotes = hasResults ? Math.max(...displayResults.map((r) => r.votes), 1) : 1;
 
   // 낮은 득표 → 높은 득표 순 정렬 (stagger: 작은 것부터 공개)
   const sortedResults = useMemo(
-    () => (hasResults ? [...results].sort((a, b) => a.votes - b.votes) : []),
-    [hasResults, results],
+    () => (hasResults ? [...displayResults].sort((a, b) => a.votes - b.votes) : []),
+    [hasResults, displayResults]
   );
 
   /** 투표 전송 */
   const handleVote = (targetId: string) => {
     if (votedTargetId) return; // 이미 투표함
     setVotedTargetId(targetId);
-    send(WsEventType.GAME_ACTION, { type: "vote", targetId });
+    send(WsEventType.GAME_ACTION, { type: 'vote', targetId });
   };
 
   return (
@@ -121,17 +127,11 @@ export function VotingPanel({ send, moduleId }: VotingPanelProps) {
       <div className="flex items-center gap-2">
         <Vote className="h-5 w-5 text-amber-400" />
         <h3 className="text-lg font-semibold text-slate-100">투표</h3>
-        {votedTargetId && (
-          <Badge variant="success">투표 완료</Badge>
-        )}
+        {votedTargetId && <Badge variant="success">투표 완료</Badge>}
       </div>
 
       {/* 비밀 투표 안내 */}
-      {isSecret && (
-        <p className="text-sm text-slate-400">
-          비밀 투표 — 결과가 공개되지 않습니다
-        </p>
-      )}
+      {isSecret && <p className="text-sm text-slate-400">비밀 투표 — 결과가 공개되지 않습니다</p>}
 
       {/* 투표 결과 (결과 수신 시) — 낮은 득표 → 높은 득표 순 stagger */}
       {hasResults && (
@@ -167,8 +167,8 @@ export function VotingPanel({ send, moduleId }: VotingPanelProps) {
                   key={player.id}
                   className={`flex items-center justify-between rounded-lg border p-3 transition-colors ${
                     isSelected
-                      ? "border-amber-500 ring-2 ring-amber-500 bg-amber-500/10"
-                      : "border-slate-700 bg-slate-800/50"
+                      ? 'border-amber-500 ring-2 ring-amber-500 bg-amber-500/10'
+                      : 'border-slate-700 bg-slate-800/50'
                   }`}
                 >
                   <div className="flex items-center gap-3">
@@ -176,7 +176,7 @@ export function VotingPanel({ send, moduleId }: VotingPanelProps) {
                       <User className="h-4 w-4 text-slate-300" />
                     </div>
                     <span className="text-sm font-medium text-slate-200">
-                      {player.nickname}
+                      {playerDisplayName(player)}
                     </span>
                   </div>
                   {isSelected ? (

--- a/apps/web/src/features/game/components/__tests__/VotePanel.test.tsx
+++ b/apps/web/src/features/game/components/__tests__/VotePanel.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { PlayerRole, WsEventType } from "@mmp/shared";
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { PlayerRole, WsEventType } from '@mmp/shared';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -8,15 +8,24 @@ import { PlayerRole, WsEventType } from "@mmp/shared";
 
 const { mockModuleData, mockPlayers, mockMyPlayerId } = vi.hoisted(() => ({
   mockModuleData: {} as Record<string, unknown>,
-  mockPlayers: [] as Array<{ id: string; nickname: string; isAlive: boolean; isHost: boolean; isReady: boolean; role: null | string; connectedAt: number }>,
-  mockMyPlayerId: "player-1",
+  mockPlayers: [] as Array<{
+    id: string;
+    nickname: string;
+    displayName?: string;
+    isAlive: boolean;
+    isHost: boolean;
+    isReady: boolean;
+    role: null | string;
+    connectedAt: number;
+  }>,
+  mockMyPlayerId: 'player-1',
 }));
 
 // ---------------------------------------------------------------------------
 // Mock: gameStore
 // ---------------------------------------------------------------------------
 
-vi.mock("@/stores/gameSessionStore", () => ({
+vi.mock('@/stores/gameSessionStore', () => ({
   useGameSessionStore: (selector: (s: unknown) => unknown) => {
     const state = {
       players: mockPlayers,
@@ -26,7 +35,7 @@ vi.mock("@/stores/gameSessionStore", () => ({
   },
 }));
 
-vi.mock("@/stores/gameSelectors", () => ({
+vi.mock('@/stores/gameSelectors', () => ({
   selectPlayers: (s: { players: unknown[] }) => s.players,
   selectMyPlayerId: (s: { myPlayerId: string }) => s.myPlayerId,
 }));
@@ -35,10 +44,10 @@ vi.mock("@/stores/gameSelectors", () => ({
 // Mock: moduleStoreFactory
 // ---------------------------------------------------------------------------
 
-vi.mock("@/stores/moduleStoreFactory", () => ({
+vi.mock('@/stores/moduleStoreFactory', () => ({
   useModuleStore: (
     _moduleId: string,
-    selector?: (s: { data: Record<string, unknown> }) => unknown,
+    selector?: (s: { data: Record<string, unknown> }) => unknown
   ) => {
     const state = { data: mockModuleData };
     return selector ? selector(state) : state;
@@ -49,7 +58,7 @@ vi.mock("@/stores/moduleStoreFactory", () => ({
 // Mock: useCountUp (VoteResultChart 의존) — 절대 경로 사용
 // ---------------------------------------------------------------------------
 
-vi.mock("@/features/game/hooks/useCountUp", () => ({
+vi.mock('@/features/game/hooks/useCountUp', () => ({
   useCountUp: (value: number) => value,
 }));
 
@@ -57,24 +66,48 @@ vi.mock("@/features/game/hooks/useCountUp", () => ({
 // 테스트 대상
 // ---------------------------------------------------------------------------
 
-import { VotePanel } from "../VotePanel";
-import { VotingPanel } from "../VotingPanel";
+import { VotePanel } from '../VotePanel';
+import { VotingPanel } from '../VotingPanel';
 
 // ---------------------------------------------------------------------------
 // 픽스처
 // ---------------------------------------------------------------------------
 
 const PLAYERS = [
-  { id: "player-1", nickname: "나", isAlive: true, isHost: true, isReady: true, role: null, connectedAt: 0 },
-  { id: "player-2", nickname: "앨리스", isAlive: true, isHost: false, isReady: true, role: null, connectedAt: 0 },
-  { id: "player-3", nickname: "밥", isAlive: true, isHost: false, isReady: true, role: null, connectedAt: 0 },
+  {
+    id: 'player-1',
+    nickname: '나',
+    isAlive: true,
+    isHost: true,
+    isReady: true,
+    role: null,
+    connectedAt: 0,
+  },
+  {
+    id: 'player-2',
+    nickname: '앨리스',
+    isAlive: true,
+    isHost: false,
+    isReady: true,
+    role: null,
+    connectedAt: 0,
+  },
+  {
+    id: 'player-3',
+    nickname: '밥',
+    isAlive: true,
+    isHost: false,
+    isReady: true,
+    role: null,
+    connectedAt: 0,
+  },
 ];
 
 // ---------------------------------------------------------------------------
 // 테스트
 // ---------------------------------------------------------------------------
 
-describe("VotePanel", () => {
+describe('VotePanel', () => {
   const mockSend = vi.fn();
 
   beforeEach(() => {
@@ -88,31 +121,43 @@ describe("VotePanel", () => {
     cleanup();
   });
 
-  it("헤더에 투표 아이콘과 제목을 렌더링한다", () => {
+  it('헤더에 투표 아이콘과 제목을 렌더링한다', () => {
     render(<VotePanel send={mockSend} moduleId="vote" />);
-    expect(screen.getByRole("heading", { name: "투표" })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: '투표' })).toBeTruthy();
   });
 
-  it("자신을 제외한 생존 플레이어 목록을 렌더링한다", () => {
+  it('자신을 제외한 생존 플레이어 목록을 렌더링한다', () => {
     render(<VotePanel send={mockSend} moduleId="vote" />);
-    expect(screen.getByText("앨리스")).toBeTruthy();
-    expect(screen.getByText("밥")).toBeTruthy();
-    expect(screen.queryByText("나")).toBeNull();
+    expect(screen.getByText('앨리스')).toBeTruthy();
+    expect(screen.getByText('밥')).toBeTruthy();
+    expect(screen.queryByText('나')).toBeNull();
   });
 
-  it("투표 버튼 클릭 시 GAME_ACTION vote를 전송한다", () => {
+  it('backend가 준 캐릭터 표시명이 있으면 투표 후보에 표시한다', () => {
+    mockPlayers.splice(1, 1, {
+      ...PLAYERS[1],
+      displayName: '가면 쓴 증인',
+    });
+
     render(<VotePanel send={mockSend} moduleId="vote" />);
-    const btns = screen.getAllByRole("button", { name: /투표/ });
+
+    expect(screen.getByText('가면 쓴 증인')).toBeTruthy();
+    expect(screen.queryByText('앨리스')).toBeNull();
+  });
+
+  it('투표 버튼 클릭 시 GAME_ACTION vote를 전송한다', () => {
+    render(<VotePanel send={mockSend} moduleId="vote" />);
+    const btns = screen.getAllByRole('button', { name: /투표/ });
     fireEvent.click(btns[0]);
     expect(mockSend).toHaveBeenCalledWith(WsEventType.GAME_ACTION, {
-      type: "vote",
-      targetId: "player-2",
+      type: 'vote',
+      targetId: 'player-2',
     });
   });
 
-  it("투표 후 같은 버튼을 다시 클릭해도 send를 재호출하지 않는다", () => {
+  it('투표 후 같은 버튼을 다시 클릭해도 send를 재호출하지 않는다', () => {
     render(<VotePanel send={mockSend} moduleId="vote" />);
-    const btns = screen.getAllByRole("button", { name: /투표/ });
+    const btns = screen.getAllByRole('button', { name: /투표/ });
     fireEvent.click(btns[0]);
     fireEvent.click(btns[0]);
     expect(mockSend).toHaveBeenCalledOnce();
@@ -120,23 +165,36 @@ describe("VotePanel", () => {
 
   it("투표 완료 후 Badge '투표 완료'를 표시한다", () => {
     render(<VotePanel send={mockSend} moduleId="vote" />);
-    const btns = screen.getAllByRole("button", { name: /투표/ });
+    const btns = screen.getAllByRole('button', { name: /투표/ });
     fireEvent.click(btns[0]);
-    expect(screen.getByText("투표 완료")).toBeTruthy();
+    expect(screen.getByText('투표 완료')).toBeTruthy();
   });
 
-  it("results가 배열이면 투표 결과 차트를 렌더링한다", () => {
+  it('results가 배열이면 투표 결과 차트를 렌더링한다', () => {
     mockModuleData.results = [
-      { playerId: "player-2", nickname: "앨리스", votes: 3 },
-      { playerId: "player-3", nickname: "밥", votes: 1 },
+      { playerId: 'player-2', nickname: '앨리스', votes: 3 },
+      { playerId: 'player-3', nickname: '밥', votes: 1 },
     ];
     render(<VotePanel send={mockSend} moduleId="vote" />);
-    expect(screen.getByText("투표 결과")).toBeTruthy();
-    expect(screen.getByText("앨리스")).toBeTruthy();
-    expect(screen.getByText("밥")).toBeTruthy();
+    expect(screen.getByText('투표 결과')).toBeTruthy();
+    expect(screen.getByText('앨리스')).toBeTruthy();
+    expect(screen.getByText('밥')).toBeTruthy();
   });
 
-  it("results가 null이면 비밀 투표 안내를 표시한다", () => {
+  it('backend 표시명이 있으면 VotePanel 투표 결과에도 표시한다', () => {
+    mockPlayers.splice(1, 1, {
+      ...PLAYERS[1],
+      displayName: '정체를 숨긴 목격자',
+    });
+    mockModuleData.results = [{ playerId: 'player-2', nickname: '앨리스', votes: 3 }];
+
+    render(<VotePanel send={mockSend} moduleId="vote" />);
+
+    expect(screen.getByText('정체를 숨긴 목격자')).toBeTruthy();
+    expect(screen.queryByText('앨리스')).toBeNull();
+  });
+
+  it('results가 null이면 비밀 투표 안내를 표시한다', () => {
     mockModuleData.results = null;
     render(<VotePanel send={mockSend} moduleId="vote" />);
     expect(screen.getByText(/비밀 투표/)).toBeTruthy();
@@ -144,43 +202,91 @@ describe("VotePanel", () => {
 
   it("생존 플레이어가 자신뿐이면 '투표 가능한 플레이어가 없습니다'를 표시한다", () => {
     mockPlayers.length = 0;
-    mockPlayers.push({ id: "player-1", nickname: "나", isAlive: true, isHost: true, isReady: true, role: null, connectedAt: 0 });
+    mockPlayers.push({
+      id: 'player-1',
+      nickname: '나',
+      isAlive: true,
+      isHost: true,
+      isReady: true,
+      role: null,
+      connectedAt: 0,
+    });
     render(<VotePanel send={mockSend} moduleId="vote" />);
-    expect(screen.getByText("투표 가능한 플레이어가 없습니다")).toBeTruthy();
+    expect(screen.getByText('투표 가능한 플레이어가 없습니다')).toBeTruthy();
   });
 
-  it("candidatePolicy.includeDetective=false면 탐정을 후보에서 제외한다", () => {
+  it('candidatePolicy.includeDetective=false면 탐정을 후보에서 제외한다', () => {
     mockPlayers.length = 0;
     mockPlayers.push(
-      { id: "player-1", nickname: "나", isAlive: true, isHost: true, isReady: true, role: null, connectedAt: 0 },
-      { id: "player-2", nickname: "탐정", isAlive: true, isHost: false, isReady: true, role: PlayerRole.DETECTIVE, connectedAt: 0 },
-      { id: "player-3", nickname: "용의자", isAlive: true, isHost: false, isReady: true, role: PlayerRole.CIVILIAN, connectedAt: 0 },
+      {
+        id: 'player-1',
+        nickname: '나',
+        isAlive: true,
+        isHost: true,
+        isReady: true,
+        role: null,
+        connectedAt: 0,
+      },
+      {
+        id: 'player-2',
+        nickname: '탐정',
+        isAlive: true,
+        isHost: false,
+        isReady: true,
+        role: PlayerRole.DETECTIVE,
+        connectedAt: 0,
+      },
+      {
+        id: 'player-3',
+        nickname: '용의자',
+        isAlive: true,
+        isHost: false,
+        isReady: true,
+        role: PlayerRole.CIVILIAN,
+        connectedAt: 0,
+      }
     );
     mockModuleData.config = { candidatePolicy: { includeDetective: false } };
 
     render(<VotePanel send={mockSend} moduleId="vote" />);
 
-    expect(screen.queryByText("탐정")).toBeNull();
-    expect(screen.getByText("용의자")).toBeTruthy();
-    expect(screen.getByText("탐정 1명은 이번 투표 후보에서 제외됩니다.")).toBeTruthy();
+    expect(screen.queryByText('탐정')).toBeNull();
+    expect(screen.getByText('용의자')).toBeTruthy();
+    expect(screen.getByText('탐정 1명은 이번 투표 후보에서 제외됩니다.')).toBeTruthy();
   });
 
-  it("candidatePolicy.includeDetective=true면 탐정도 후보에 포함한다", () => {
+  it('candidatePolicy.includeDetective=true면 탐정도 후보에 포함한다', () => {
     mockPlayers.length = 0;
     mockPlayers.push(
-      { id: "player-1", nickname: "나", isAlive: true, isHost: true, isReady: true, role: null, connectedAt: 0 },
-      { id: "player-2", nickname: "탐정", isAlive: true, isHost: false, isReady: true, role: PlayerRole.DETECTIVE, connectedAt: 0 },
+      {
+        id: 'player-1',
+        nickname: '나',
+        isAlive: true,
+        isHost: true,
+        isReady: true,
+        role: null,
+        connectedAt: 0,
+      },
+      {
+        id: 'player-2',
+        nickname: '탐정',
+        isAlive: true,
+        isHost: false,
+        isReady: true,
+        role: PlayerRole.DETECTIVE,
+        connectedAt: 0,
+      }
     );
     mockModuleData.config = { candidatePolicy: { includeDetective: true } };
 
     render(<VotePanel send={mockSend} moduleId="vote" />);
 
-    expect(screen.getByText("탐정")).toBeTruthy();
+    expect(screen.getByText('탐정')).toBeTruthy();
     expect(screen.queryByText(/탐정 1명은/)).toBeNull();
   });
 });
 
-describe("VotingPanel", () => {
+describe('VotingPanel', () => {
   const mockSend = vi.fn();
 
   beforeEach(() => {
@@ -194,43 +300,79 @@ describe("VotingPanel", () => {
     cleanup();
   });
 
-  it("후보 클릭 시 GAME_ACTION vote를 전송하고 투표 완료 상태를 표시한다", () => {
+  it('후보 클릭 시 GAME_ACTION vote를 전송하고 투표 완료 상태를 표시한다', () => {
     render(<VotingPanel send={mockSend} moduleId="vote" />);
 
-    fireEvent.click(screen.getAllByRole("button", { name: "투표" })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: '투표' })[0]);
 
     expect(mockSend).toHaveBeenCalledWith(WsEventType.GAME_ACTION, {
-      type: "vote",
-      targetId: "player-2",
+      type: 'vote',
+      targetId: 'player-2',
     });
-    expect(screen.getByText("투표 완료")).toBeTruthy();
-    expect(screen.getByText("선택됨")).toBeTruthy();
+    expect(screen.getByText('투표 완료')).toBeTruthy();
+    expect(screen.getByText('선택됨')).toBeTruthy();
   });
 
-  it("탐정 제외 정책으로 후보가 없으면 정책 안내와 빈 상태를 표시한다", () => {
+  it('탐정 제외 정책으로 후보가 없으면 정책 안내와 빈 상태를 표시한다', () => {
     mockPlayers.length = 0;
     mockPlayers.push(
-      { id: "player-1", nickname: "나", isAlive: true, isHost: true, isReady: true, role: null, connectedAt: 0 },
-      { id: "player-2", nickname: "탐정", isAlive: true, isHost: false, isReady: true, role: PlayerRole.DETECTIVE, connectedAt: 0 },
+      {
+        id: 'player-1',
+        nickname: '나',
+        isAlive: true,
+        isHost: true,
+        isReady: true,
+        role: null,
+        connectedAt: 0,
+      },
+      {
+        id: 'player-2',
+        nickname: '탐정',
+        isAlive: true,
+        isHost: false,
+        isReady: true,
+        role: PlayerRole.DETECTIVE,
+        connectedAt: 0,
+      }
     );
     mockModuleData.config = { candidatePolicy: { includeDetective: false } };
 
     render(<VotingPanel send={mockSend} moduleId="vote" />);
 
-    expect(screen.getByText("탐정 1명은 이번 투표 후보에서 제외됩니다.")).toBeTruthy();
-    expect(screen.getByText("탐정 제외 정책 때문에 투표 가능한 플레이어가 없습니다")).toBeTruthy();
-    expect(screen.queryByText("탐정")).toBeNull();
+    expect(screen.getByText('탐정 1명은 이번 투표 후보에서 제외됩니다.')).toBeTruthy();
+    expect(screen.getByText('탐정 제외 정책 때문에 투표 가능한 플레이어가 없습니다')).toBeTruthy();
+    expect(screen.queryByText('탐정')).toBeNull();
   });
 
-  it("결과가 공개되면 낮은 득표 순으로 결과 막대를 렌더링한다", () => {
+  it('결과가 공개되면 낮은 득표 순으로 결과 막대를 렌더링한다', () => {
     mockModuleData.results = [
-      { playerId: "player-2", nickname: "앨리스", votes: 3 },
-      { playerId: "player-3", nickname: "밥", votes: 1 },
+      { playerId: 'player-2', nickname: '앨리스', votes: 3 },
+      { playerId: 'player-3', nickname: '밥', votes: 1 },
     ];
 
     render(<VotingPanel send={mockSend} moduleId="vote" />);
 
-    expect(screen.getByText("투표 결과")).toBeTruthy();
-    expect(screen.getAllByText(/\d+표/).map((el) => el.textContent)).toEqual(["1표", "3표"]);
+    expect(screen.getByText('투표 결과')).toBeTruthy();
+    expect(screen.getAllByText(/\d+표/).map((el) => el.textContent)).toEqual(['1표', '3표']);
+  });
+
+  it('backend 표시명이 있으면 VotingPanel 후보와 결과에 표시한다', () => {
+    mockPlayers.splice(1, 1, {
+      ...PLAYERS[1],
+      displayName: '가면 쓴 용의자',
+    });
+
+    render(<VotingPanel send={mockSend} moduleId="vote" />);
+
+    expect(screen.getByText('가면 쓴 용의자')).toBeTruthy();
+    expect(screen.queryByText('앨리스')).toBeNull();
+
+    cleanup();
+    mockModuleData.results = [{ playerId: 'player-2', nickname: '앨리스', votes: 3 }];
+
+    render(<VotingPanel send={mockSend} moduleId="vote" />);
+
+    expect(screen.getByText('가면 쓴 용의자')).toBeTruthy();
+    expect(screen.queryByText('앨리스')).toBeNull();
   });
 });

--- a/apps/web/src/features/game/utils/__tests__/resultBreakdownAdapter.test.ts
+++ b/apps/web/src/features/game/utils/__tests__/resultBreakdownAdapter.test.ts
@@ -3,6 +3,8 @@ import { PlayerRole, type Player } from '@mmp/shared';
 
 import {
   buildResultBreakdownViewModel,
+  playerDisplayName,
+  playerDisplayNameById,
   readEndingBranchResult,
   readVoteBreakdown,
 } from '../resultBreakdownAdapter';
@@ -105,6 +107,12 @@ describe('resultBreakdownAdapter', () => {
 
     expect(vm.voteSummary).toContain('가면 쓴 탐정');
     expect(vm.voteItems[0]).toMatchObject({ id: 'p2', label: '가면 쓴 탐정' });
+  });
+
+  it('trims display names and falls back to nicknames or caller labels', () => {
+    expect(playerDisplayName({ ...players[1], displayName: '  비밀 탐정  ' })).toBe('비밀 탐정');
+    expect(playerDisplayName({ ...players[0], displayName: '   ' })).toBe('한서윤');
+    expect(playerDisplayNameById(players, 'missing', '알 수 없음')).toBe('알 수 없음');
   });
 
   it('returns null before backend exposes a result', () => {

--- a/apps/web/src/features/game/utils/__tests__/resultBreakdownAdapter.test.ts
+++ b/apps/web/src/features/game/utils/__tests__/resultBreakdownAdapter.test.ts
@@ -1,16 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { PlayerRole, type Player } from "@mmp/shared";
+import { describe, expect, it } from 'vitest';
+import { PlayerRole, type Player } from '@mmp/shared';
 
 import {
   buildResultBreakdownViewModel,
   readEndingBranchResult,
   readVoteBreakdown,
-} from "../resultBreakdownAdapter";
+} from '../resultBreakdownAdapter';
 
 const players: Player[] = [
   {
-    id: "p1",
-    nickname: "한서윤",
+    id: 'p1',
+    nickname: '한서윤',
     role: PlayerRole.CIVILIAN,
     isAlive: true,
     isHost: false,
@@ -18,8 +18,9 @@ const players: Player[] = [
     connectedAt: 1,
   },
   {
-    id: "p2",
-    nickname: "강도윤",
+    id: 'p2',
+    nickname: '강도윤',
+    displayName: '가면 쓴 탐정',
     role: PlayerRole.DETECTIVE,
     isAlive: true,
     isHost: false,
@@ -28,13 +29,13 @@ const players: Player[] = [
   },
 ];
 
-describe("resultBreakdownAdapter", () => {
-  it("reads backend lastResult and builds creator-safe vote labels", () => {
+describe('resultBreakdownAdapter', () => {
+  it('reads backend lastResult and builds creator-safe vote labels', () => {
     const vote = readVoteBreakdown({
       lastResult: {
         results: { p1: 3, p2: 1 },
-        winner: "p1",
-        outcome: "winner",
+        winner: 'p1',
+        outcome: 'winner',
         round: 2,
         totalVotes: 4,
         eligibleVoters: 5,
@@ -42,24 +43,24 @@ describe("resultBreakdownAdapter", () => {
       },
     });
     const ending = readEndingBranchResult({
-      result: { selectedEnding: "진실의 밤", matchedPriority: 1, myScore: 3 },
+      result: { selectedEnding: '진실의 밤', matchedPriority: 1, myScore: 3 },
     });
 
     const vm = buildResultBreakdownViewModel({ players, vote, ending });
 
-    expect(vm.endingTitle).toBe("진실의 밤");
-    expect(vm.endingReason).toContain("우선순위 1번");
-    expect(vm.myScoreLabel).toBe("내 결말 점수 3점");
-    expect(vm.voteTitle).toBe("2라운드 투표 결과");
-    expect(vm.voteSummary).toContain("한서윤");
-    expect(vm.voteMeta).toEqual(["총 4표", "투표 가능 5명", "참여율 80%"]);
-    expect(vm.voteItems[0]).toMatchObject({ label: "한서윤", votes: 3, isWinner: true });
+    expect(vm.endingTitle).toBe('진실의 밤');
+    expect(vm.endingReason).toContain('우선순위 1번');
+    expect(vm.myScoreLabel).toBe('내 결말 점수 3점');
+    expect(vm.voteTitle).toBe('2라운드 투표 결과');
+    expect(vm.voteSummary).toContain('한서윤');
+    expect(vm.voteMeta).toEqual(['총 4표', '투표 가능 5명', '참여율 80%']);
+    expect(vm.voteItems[0]).toMatchObject({ label: '한서윤', votes: 3, isWinner: true });
   });
 
-  it("explains insufficient participation without exposing raw JSON", () => {
+  it('explains insufficient participation without exposing raw JSON', () => {
     const vote = readVoteBreakdown({
       results: { p1: 1 },
-      outcome: "insufficient_participation",
+      outcome: 'insufficient_participation',
       totalVotes: 1,
       eligibleVoters: 4,
       participationPct: 25,
@@ -68,28 +69,45 @@ describe("resultBreakdownAdapter", () => {
 
     const vm = buildResultBreakdownViewModel({ players, vote, ending: null });
 
-    expect(vm.endingTitle).toBe("결말 판정 대기 중");
-    expect(vm.voteSummary).toBe("투표 참여 인원이 부족해서 결과가 확정되지 않았어요.");
-    expect(vm.voteMeta).toContain("기권 1표");
+    expect(vm.endingTitle).toBe('결말 판정 대기 중');
+    expect(vm.voteSummary).toBe('투표 참여 인원이 부족해서 결과가 확정되지 않았어요.');
+    expect(vm.voteMeta).toContain('기권 1표');
   });
 
-  it("marks tie candidates and uses safe fallback label when player is unknown", () => {
+  it('marks tie candidates and uses safe fallback label when player is unknown', () => {
     const vote = readVoteBreakdown({
       results: { p1: 2, char_unknown: 2 },
-      outcome: "tie",
-      tieCandidates: ["p1", "char_unknown"],
+      outcome: 'tie',
+      tieCandidates: ['p1', 'char_unknown'],
     });
 
     const vm = buildResultBreakdownViewModel({ players, vote, ending: null });
 
-    expect(vm.voteSummary).toContain("동률");
+    expect(vm.voteSummary).toContain('동률');
     expect(vm.voteItems).toEqual([
-      expect.objectContaining({ id: "char_unknown", label: "알 수 없는 대상", isTieCandidate: true }),
-      expect.objectContaining({ id: "p1", label: "한서윤", isTieCandidate: true }),
+      expect.objectContaining({
+        id: 'char_unknown',
+        label: '알 수 없는 대상',
+        isTieCandidate: true,
+      }),
+      expect.objectContaining({ id: 'p1', label: '한서윤', isTieCandidate: true }),
     ]);
   });
 
-  it("returns null before backend exposes a result", () => {
+  it('uses backend-resolved character display names before account nicknames', () => {
+    const vote = readVoteBreakdown({
+      results: { p2: 4 },
+      winner: 'p2',
+      outcome: 'winner',
+    });
+
+    const vm = buildResultBreakdownViewModel({ players, vote, ending: null });
+
+    expect(vm.voteSummary).toContain('가면 쓴 탐정');
+    expect(vm.voteItems[0]).toMatchObject({ id: 'p2', label: '가면 쓴 탐정' });
+  });
+
+  it('returns null before backend exposes a result', () => {
     expect(readVoteBreakdown({ isOpen: true })).toBeNull();
     expect(readEndingBranchResult({ evaluated: false })).toBeNull();
   });

--- a/apps/web/src/features/game/utils/resultBreakdownAdapter.ts
+++ b/apps/web/src/features/game/utils/resultBreakdownAdapter.ts
@@ -1,10 +1,6 @@
-import type { Player } from "@mmp/shared";
+import type { Player } from '@mmp/shared';
 
-export type VoteOutcome =
-  | "winner"
-  | "tie"
-  | "no_result"
-  | "insufficient_participation";
+export type VoteOutcome = 'winner' | 'tie' | 'no_result' | 'insufficient_participation';
 
 export interface VoteBreakdownResult {
   results: Record<string, number>;
@@ -43,26 +39,39 @@ export interface ResultBreakdownViewModel {
   voteMeta: string[];
 }
 
-const UNKNOWN_ENDING = "결말 판정 대기 중";
-const UNKNOWN_VOTE_TARGET = "알 수 없는 대상";
+const UNKNOWN_ENDING = '결말 판정 대기 중';
+const UNKNOWN_VOTE_TARGET = '알 수 없는 대상';
+
+export function playerDisplayName(player: Player): string {
+  return player.displayName?.trim() || player.nickname;
+}
+
+export function playerDisplayNameById(
+  players: Player[],
+  playerId: string,
+  fallback: string
+): string {
+  const player = players.find((candidate) => candidate.id === playerId);
+  return player ? playerDisplayName(player) : fallback;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
+  return typeof value === 'string' && value.trim() ? value : undefined;
 }
 
 function readNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function readResults(value: unknown): Record<string, number> {
   if (!isRecord(value)) return {};
   const results: Record<string, number> = {};
   for (const [key, count] of Object.entries(value)) {
-    if (typeof count === "number" && Number.isFinite(count)) {
+    if (typeof count === 'number' && Number.isFinite(count)) {
       results[key] = count;
     }
   }
@@ -72,17 +81,17 @@ function readResults(value: unknown): Record<string, number> {
 export function readVoteBreakdown(moduleData: Record<string, unknown>): VoteBreakdownResult | null {
   const raw = isRecord(moduleData.lastResult) ? moduleData.lastResult : moduleData;
   const results = readResults(raw.results);
-  const hasBreakdown = Object.keys(results).length > 0 || typeof raw.outcome === "string";
+  const hasBreakdown = Object.keys(results).length > 0 || typeof raw.outcome === 'string';
   if (!hasBreakdown) return null;
 
   const tieCandidates = Array.isArray(raw.tieCandidates)
-    ? raw.tieCandidates.filter((item): item is string => typeof item === "string")
+    ? raw.tieCandidates.filter((item): item is string => typeof item === 'string')
     : undefined;
 
   return {
     results,
     winner: readString(raw.winner),
-    isTie: typeof raw.isTie === "boolean" ? raw.isTie : undefined,
+    isTie: typeof raw.isTie === 'boolean' ? raw.isTie : undefined,
     round: readNumber(raw.round),
     outcome: readString(raw.outcome) as VoteOutcome | undefined,
     totalVotes: readNumber(raw.totalVotes),
@@ -93,7 +102,9 @@ export function readVoteBreakdown(moduleData: Record<string, unknown>): VoteBrea
   };
 }
 
-export function readEndingBranchResult(moduleData: Record<string, unknown>): EndingBranchResult | null {
+export function readEndingBranchResult(
+  moduleData: Record<string, unknown>
+): EndingBranchResult | null {
   const raw = isRecord(moduleData.result) ? moduleData.result : moduleData;
   const selectedEnding = readString(raw.selectedEnding);
   if (!selectedEnding && raw.evaluated !== true) return null;
@@ -110,7 +121,7 @@ export function buildResultBreakdownViewModel(params: {
   ending: EndingBranchResult | null;
 }): ResultBreakdownViewModel {
   const { players, vote, ending } = params;
-  const playerNameById = new Map(players.map((player) => [player.id, player.nickname]));
+  const playerNameById = new Map(players.map((player) => [player.id, playerDisplayName(player)]));
   const tieCandidates = new Set(vote?.tieCandidates ?? []);
   const winner = vote?.winner;
 
@@ -122,9 +133,9 @@ export function buildResultBreakdownViewModel(params: {
       isWinner: !!winner && id === winner,
       isTieCandidate: tieCandidates.has(id),
     }))
-    .sort((a, b) => b.votes - a.votes || a.label.localeCompare(b.label, "ko"));
+    .sort((a, b) => b.votes - a.votes || a.label.localeCompare(b.label, 'ko'));
 
-  const voteTitle = vote?.round ? `${vote.round}라운드 투표 결과` : "투표 결과";
+  const voteTitle = vote?.round ? `${vote.round}라운드 투표 결과` : '투표 결과';
   const voteSummary = buildVoteSummary(vote, playerNameById);
   const voteMeta = buildVoteMeta(vote);
 
@@ -133,9 +144,9 @@ export function buildResultBreakdownViewModel(params: {
     endingReason: ending?.matchedPriority
       ? `우선순위 ${ending.matchedPriority}번 조건으로 결정됐어요.`
       : ending?.selectedEnding
-        ? "기본 결말 또는 조건 없는 결말로 결정됐어요."
-        : "아직 결말 평가가 끝나지 않았어요.",
-    myScoreLabel: typeof ending?.myScore === "number" ? `내 결말 점수 ${ending.myScore}점` : null,
+        ? '기본 결말 또는 조건 없는 결말로 결정됐어요.'
+        : '아직 결말 평가가 끝나지 않았어요.',
+    myScoreLabel: typeof ending?.myScore === 'number' ? `내 결말 점수 ${ending.myScore}점` : null,
     voteTitle,
     voteSummary,
     voteItems,
@@ -145,31 +156,31 @@ export function buildResultBreakdownViewModel(params: {
 
 function buildVoteSummary(
   vote: VoteBreakdownResult | null,
-  playerNameById: Map<string, string>,
+  playerNameById: Map<string, string>
 ): string {
-  if (!vote) return "아직 공개된 투표 결과가 없어요.";
-  if (vote.outcome === "insufficient_participation") {
-    return "투표 참여 인원이 부족해서 결과가 확정되지 않았어요.";
+  if (!vote) return '아직 공개된 투표 결과가 없어요.';
+  if (vote.outcome === 'insufficient_participation') {
+    return '투표 참여 인원이 부족해서 결과가 확정되지 않았어요.';
   }
-  if (vote.outcome === "no_result") {
-    return "동률 또는 무효 조건 때문에 확정된 투표 결과가 없어요.";
+  if (vote.outcome === 'no_result') {
+    return '동률 또는 무효 조건 때문에 확정된 투표 결과가 없어요.';
   }
-  if (vote.outcome === "tie") {
-    return "동률이어서 재투표 또는 진행자 판단이 필요해요.";
+  if (vote.outcome === 'tie') {
+    return '동률이어서 재투표 또는 진행자 판단이 필요해요.';
   }
   if (vote.winner) {
     return `${playerNameById.get(vote.winner) ?? UNKNOWN_VOTE_TARGET}에게 가장 많은 표가 모였어요.`;
   }
-  return "투표 결과를 집계했지만 최종 대상은 정해지지 않았어요.";
+  return '투표 결과를 집계했지만 최종 대상은 정해지지 않았어요.';
 }
 
 function buildVoteMeta(vote: VoteBreakdownResult | null): string[] {
   if (!vote) return [];
   const meta: string[] = [];
-  if (typeof vote.totalVotes === "number") meta.push(`총 ${vote.totalVotes}표`);
-  if (typeof vote.eligibleVoters === "number") meta.push(`투표 가능 ${vote.eligibleVoters}명`);
-  if (typeof vote.participationPct === "number") meta.push(`참여율 ${vote.participationPct}%`);
-  if (typeof vote.abstainCount === "number" && vote.abstainCount > 0) {
+  if (typeof vote.totalVotes === 'number') meta.push(`총 ${vote.totalVotes}표`);
+  if (typeof vote.eligibleVoters === 'number') meta.push(`투표 가능 ${vote.eligibleVoters}명`);
+  if (typeof vote.participationPct === 'number') meta.push(`참여율 ${vote.participationPct}%`);
+  if (typeof vote.abstainCount === 'number' && vote.abstainCount > 0) {
     meta.push(`기권 ${vote.abstainCount}표`);
   }
   return meta;

--- a/packages/shared/src/game/types.ts
+++ b/packages/shared/src/game/types.ts
@@ -25,6 +25,9 @@ export type PlayerRole = (typeof PlayerRole)[keyof typeof PlayerRole];
 export interface Player {
   id: string;
   nickname: string;
+  displayName?: string;
+  displayIconUrl?: string;
+  displayIconMediaId?: string;
   role: PlayerRole | null;
   isAlive: boolean;
   isHost: boolean;


### PR DESCRIPTION
## 요약

- room start 경로에서 room player와 theme character 배정 정보를 session runtime으로 전달합니다.
- `BuildStateFor` player-facing snapshot에 backend resolver가 계산한 `displayName`, `displayIconUrl`, `displayIconMediaId` roster를 추가합니다.
- 게임 투표 후보/결과/result breakdown은 `Player.nickname`보다 backend 표시값을 우선 사용합니다.

Refs #362

## Coverage Plan

- `apps/server/internal/domain/room/service.go`: `StartRoom`이 room player + theme character를 session start DTO로 넘기는 경로를 `internal/domain/room` focused test로 검증했습니다.
- `apps/server/internal/session/*`: room DTO -> `PlayerState` -> `PlayerRuntimeInfo` 변환과 `ResolveCharacterDisplay` 적용을 `internal/session` focused test로 검증했습니다.
- `apps/server/internal/engine/*`: `BuildStateFor` roster payload가 표시값을 포함하고 `alias_rules` 원본을 노출하지 않는 것을 `internal/engine` focused test로 검증했습니다.
- `packages/shared/src/game/types.ts`, `apps/web/src/features/game/*`: `displayName/displayIcon*` 타입 소비와 투표/결과 렌더링을 TypeScript + Vitest focused tests로 검증했습니다.

## 검증

- `go test ./internal/engine ./internal/session ./internal/domain/room`
- `pnpm --filter @mmp/web exec vitest run src/features/game/components/__tests__/VotePanel.test.tsx src/features/game/utils/__tests__/resultBreakdownAdapter.test.ts`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `git diff --check`

## 제외 / 남은 작업

- phase/round/delivered information/custom flag 등 진행 중 runtime condition context의 동적 연결은 #362에 남겼습니다. 이번 PR은 snapshot/UI가 backend 계산 표시값을 받을 수 있는 route를 먼저 고정합니다.
- 소개/읽기 화면에서 실제 캐릭터 표시를 소비하는 지점은 후속 체크에서 같은 `displayName/displayIcon*` 계약으로 연결합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경 사항

* **새로운 기능**
  * 런타임 플레이어 명단(표시명·아이콘·상태 포함) 및 게임 시작 시 플레이어 정보 전달 지원
* **개선사항**
  * 투표/결과 화면에서 백엔드 제공 표시명·아이콘을 우선 사용하도록 표시 로직 통일
  * 게임 시작 흐름과 세션에 플레이어 표시·상태 정보 통합
* **테스트**
  * 플레이어 표시·명단 및 투표 결과 관련 테스트 추가·확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->