### PR TITLE
perf(db): revoke_log session_id partial index 추가

### DIFF
--- a/apps/server/db/migrations/00041_revoke_log_session_index.sql
+++ b/apps/server/db/migrations/00041_revoke_log_session_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Speed up session-targeted revoke checks used by IsSessionRevoked.
+-- Most revoke rows are user-wide or token-targeted, so keep the index partial.
+CREATE INDEX idx_revoke_log_session_id
+    ON revoke_log (session_id)
+    WHERE session_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_revoke_log_session_id;


### PR DESCRIPTION
## 요약

- `IsSessionRevoked` 조회 경로를 위해 `revoke_log(session_id)` partial index를 추가합니다.
- 기존 `00027_ws_auth_revoke_log.sql`은 불변으로 두고 새 migration `00041`에만 반영했습니다.

Closes #210

## Coverage Plan

- 변경 파일은 DB migration 1개입니다.
- 관련 revoke repository 동작은 기존 auth focused test로 회귀 확인했습니다.
- SQL 변경은 기존 generated query를 바꾸지 않으므로 sqlc 재생성은 필요 없습니다.

## 검증

- `go test ./internal/domain/auth`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 데이터베이스 성능이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->