### PR TITLE
fix(ws-auth): PR-9 후속 계약 gap 정리

### DIFF
--- a/apps/server/internal/config/config_test.go
+++ b/apps/server/internal/config/config_test.go
@@ -13,7 +13,7 @@ var envVarsToClean = []string{
 	"LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET",
 	"R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY",
 	"R2_BUCKET_NAME", "R2_PUBLIC_URL",
-	"GAME_RUNTIME_V2",
+	"GAME_RUNTIME_V2", "MMP_WS_AUTH_PROTOCOL",
 }
 
 // cleanEnv unsets all config-related env vars for the duration of the test,

--- a/apps/server/internal/domain/auth/revoke_publisher.go
+++ b/apps/server/internal/domain/auth/revoke_publisher.go
@@ -23,12 +23,14 @@ type RevokePublisher interface {
 	// changes — anything that invalidates the whole user.
 	RevokeUser(ctx context.Context, userID uuid.UUID, code, reason string) error
 
-	// RevokeSession closes a single WS session without touching the
-	// user's other devices. Used for "kick this tab" admin actions.
+	// RevokeSession closes live game sockets bound to sessionID. Social
+	// sockets do not carry the game session concept, so SocialHub treats
+	// this as a no-op.
 	RevokeSession(ctx context.Context, sessionID uuid.UUID, code, reason string) error
 
-	// RevokeToken closes any session that authenticated with the given
-	// refresh-token JTI. Used for logout-elsewhere precision.
+	// RevokeToken is a best-effort hook for future token-JTI indexed
+	// sockets. Current Hub/SocialHub implementations log and no-op; use
+	// RevokeUser for the concrete logout-elsewhere end state.
 	RevokeToken(ctx context.Context, tokenJTI, code, reason string) error
 }
 

--- a/apps/server/internal/ws/auth_payloads.go
+++ b/apps/server/internal/ws/auth_payloads.go
@@ -1,10 +1,6 @@
 package ws
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 // auth.* protocol payloads (PR-9 WS Auth Protocol).
 //
@@ -82,24 +78,26 @@ type AuthRevokedPayload struct {
 }
 
 // AuthRefreshRequiredPayload — S2C, the token is approaching expiry.
-// The client should reply with auth.refresh before ExpiresAt.
+// The client should reply with auth.refresh before ExpiresAt. ExpiresAt
+// is an epoch-ms timestamp to match the generated TypeScript contract.
 //
 // wsgen:payload
 type AuthRefreshRequiredPayload struct {
-	ExpiresAt time.Time `json:"expiresAt"`
-	Reason    string    `json:"reason,omitempty"`
+	ExpiresAt int64  `json:"expiresAt"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 // AuthTokenIssuedPayload — S2C, server's response to a successful
 // auth.refresh. Carries the rotated short-lived access token plus its
-// expiry so the client can schedule the next refresh deterministically.
+// expiry, as an epoch-ms timestamp, so the client can schedule the next
+// refresh deterministically.
 // Sent as a dedicated frame (not piggybacked on another event) per
 // videosdk 2025 / websockets.readthedocs guidance.
 //
 // wsgen:payload
 type AuthTokenIssuedPayload struct {
-	Token     string    `json:"token"`
-	ExpiresAt time.Time `json:"expiresAt"`
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expiresAt"`
 }
 
 // AuthInvalidSessionPayload — S2C, the resume target the client sent

--- a/apps/server/internal/ws/auth_protocol.go
+++ b/apps/server/internal/ws/auth_protocol.go
@@ -221,7 +221,7 @@ func (h *AuthHandler) handleRefresh(c *Client, env *Envelope) {
 	expiresAt := time.Now().Add(time.Duration(pair.ExpiresIn) * time.Second)
 	c.SendMessage(MustEnvelope(TypeAuthTokenIssued, AuthTokenIssuedPayload{
 		Token:     pair.AccessToken,
-		ExpiresAt: expiresAt,
+		ExpiresAt: expiresAt.UnixMilli(),
 	}))
 }
 

--- a/apps/server/internal/ws/auth_protocol_test.go
+++ b/apps/server/internal/ws/auth_protocol_test.go
@@ -790,10 +790,11 @@ func TestAuthHandler_Refresh_HappyPath_TokenIssued(t *testing.T) {
 	if tp.Token != pair.AccessToken {
 		t.Errorf("Token=%q, want %q", tp.Token, pair.AccessToken)
 	}
-	// ExpiresAt should be roughly before+ExpiresIn .. after+ExpiresIn.
-	earliest := before.Add(time.Duration(pair.ExpiresIn) * time.Second)
-	latest := after.Add(time.Duration(pair.ExpiresIn) * time.Second)
-	if tp.ExpiresAt.Before(earliest) || tp.ExpiresAt.After(latest) {
+	// ExpiresAt should be roughly before+ExpiresIn .. after+ExpiresIn,
+	// encoded as epoch-ms to match the generated TypeScript contract.
+	earliest := before.Add(time.Duration(pair.ExpiresIn) * time.Second).UnixMilli()
+	latest := after.Add(time.Duration(pair.ExpiresIn) * time.Second).UnixMilli()
+	if tp.ExpiresAt < earliest || tp.ExpiresAt > latest {
 		t.Errorf("ExpiresAt=%v, want within [%v, %v]", tp.ExpiresAt, earliest, latest)
 	}
 	assertChannelOpen(t, c)

--- a/apps/web/e2e/ws-auth-revoke.spec.ts
+++ b/apps/web/e2e/ws-auth-revoke.spec.ts
@@ -159,16 +159,7 @@ test.describe("PR-9 WS Auth Protocol — revoke pushes close within 30s", () => 
     ).toBe(true);
     expect(result.lapsedMs).toBeLessThan(REVOKE_DEADLINE_MS);
 
-    // receivedRevoked is informational: when the social Hub publisher
-    // wiring lands the auth.revoked frame should arrive before close.
-    // For now (game-only publisher) the close still fires because the
-    // socket is dropped, just without the in-band envelope. Soft check.
-    if (!result.receivedRevoked) {
-      console.warn(
-        "[ws-auth-revoke] auth.revoked envelope was not observed before close — " +
-          "social Hub publisher wiring is a documented PR-9 follow-up",
-      );
-    }
+    expect(result.receivedRevoked).toBe(true);
   });
 
   test("post-revoke reconnect with the same token is rejected within 30s", async ({
@@ -251,5 +242,6 @@ test.describe("PR-9 WS Auth Protocol — revoke pushes close within 30s", () => 
 
     expect(result.closed).toBe(true);
     expect(result.lapsedMs).toBeLessThan(REVOKE_DEADLINE_MS);
+    expect(result.receivedRevoked).toBe(true);
   });
 });

--- a/packages/shared/src/ws/types.generated.ts
+++ b/packages/shared/src/ws/types.generated.ts
@@ -823,7 +823,8 @@ export interface AuthRefreshPayload {
 
 /**
  * AuthRefreshRequiredPayload — S2C, the token is approaching expiry.
- * The client should reply with auth.refresh before ExpiresAt.
+ * The client should reply with auth.refresh before ExpiresAt. ExpiresAt
+ * is an epoch-ms timestamp to match the generated TypeScript contract.
  */
 export interface AuthRefreshRequiredPayload {
   expiresAt: number;
@@ -852,7 +853,8 @@ export interface AuthRevokedPayload {
 /**
  * AuthTokenIssuedPayload — S2C, server's response to a successful
  * auth.refresh. Carries the rotated short-lived access token plus its
- * expiry so the client can schedule the next refresh deterministically.
+ * expiry, as an epoch-ms timestamp, so the client can schedule the next
+ * refresh deterministically.
  * Sent as a dedicated frame (not piggybacked on another event) per
  * videosdk 2025 / websockets.readthedocs guidance.
  */

--- a/packages/ws-client/src/client.test.ts
+++ b/packages/ws-client/src/client.test.ts
@@ -28,6 +28,7 @@ function newClient(
     onRevoked?: (code: string, reason: string) => void;
     onUnauthorized?: (reason: string) => void;
     onTokenRefreshed?: (token: string, expiresAt: number) => void;
+    onRefreshRequired?: (expiresAt: number, reason?: string) => void;
     onServerError?: (payload: ErrorPayload) => void;
     reconnect?: { enabled?: boolean; baseDelay?: number; maxAttempts?: number };
   } = {}
@@ -39,6 +40,7 @@ function newClient(
     onRevoked: opts.onRevoked,
     onUnauthorized: opts.onUnauthorized,
     onTokenRefreshed: opts.onTokenRefreshed,
+    onRefreshRequired: opts.onRefreshRequired,
     onServerError: opts.onServerError,
     heartbeatInterval: 999_999, // park heartbeat way out of test timelines
     reconnect: { baseDelay: 10, maxAttempts: 5, ...opts.reconnect },
@@ -156,6 +158,47 @@ describe('WsClient — auth.token_issued', () => {
     handle.getLast().triggerMessage({
       type: WsEventType.AUTH_TOKEN_ISSUED,
       payload: { token: 'x', expiresAt: 0 },
+      ts: 0,
+      seq: 1,
+    });
+    expect(handler).not.toHaveBeenCalled();
+    c.disconnect();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auth.refresh_required
+// ---------------------------------------------------------------------------
+
+describe('WsClient — auth.refresh_required', () => {
+  it('fires onRefreshRequired with epoch-ms expiry and reason', () => {
+    const onRefreshRequired = vi.fn();
+    const c = newClient({ authProtocol: true, onRefreshRequired });
+    c.connect();
+    const ws1 = handle.getLast();
+    ws1.triggerOpen();
+
+    ws1.triggerMessage({
+      type: WsEventType.AUTH_REFRESH_REQUIRED,
+      payload: { expiresAt: 1234567, reason: 'expiring_soon' },
+      ts: 0,
+      seq: 1,
+    });
+
+    expect(onRefreshRequired).toHaveBeenCalledTimes(1);
+    expect(onRefreshRequired).toHaveBeenCalledWith(1234567, 'expiring_soon');
+    c.disconnect();
+  });
+
+  it('does not bubble auth.refresh_required to ordinary listeners', () => {
+    const c = newClient({ authProtocol: true });
+    const handler = vi.fn();
+    c.on(WsEventType.AUTH_REFRESH_REQUIRED, handler);
+    c.connect();
+    handle.getLast().triggerOpen();
+    handle.getLast().triggerMessage({
+      type: WsEventType.AUTH_REFRESH_REQUIRED,
+      payload: { expiresAt: 1234567 },
       ts: 0,
       seq: 1,
     });

--- a/packages/ws-client/src/client.ts
+++ b/packages/ws-client/src/client.ts
@@ -5,6 +5,7 @@ import {
   type AuthIdentifyPayload,
   type AuthResumePayload,
   type AuthRefreshPayload,
+  type AuthRefreshRequiredPayload,
   type AuthRevokedPayload,
   type AuthTokenIssuedPayload,
   type AuthInvalidSessionPayload,
@@ -286,6 +287,11 @@ export class WsClient {
         const payload = message.payload as AuthTokenIssuedPayload;
         this.currentToken = payload.token;
         this.options.onTokenRefreshed?.(payload.token, payload.expiresAt);
+        return true;
+      }
+      case Events.AUTH_REFRESH_REQUIRED: {
+        const payload = message.payload as AuthRefreshRequiredPayload;
+        this.options.onRefreshRequired?.(payload.expiresAt, payload.reason);
         return true;
       }
       case Events.AUTH_REVOKED: {

--- a/packages/ws-client/src/reconnect.test.ts
+++ b/packages/ws-client/src/reconnect.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReconnectManager } from "./reconnect.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("ReconnectManager.disable", () => {
   it("flips both isEnabled and canRetry to false", () => {
@@ -19,11 +23,39 @@ describe("ReconnectManager.disable", () => {
     expect(() => m.cancel()).not.toThrow();
     expect(m.canRetry).toBe(false);
   });
+
+  it("prevents a pending reconnect callback from firing", () => {
+    vi.useFakeTimers();
+    const m = new ReconnectManager({ enabled: true, baseDelay: 1000 });
+    const callback = vi.fn();
+
+    m.schedule(callback);
+    m.disable();
+    vi.runAllTimers();
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(m.canRetry).toBe(false);
+  });
 });
 
 describe("ReconnectManager.canRetry", () => {
   it("respects the enabled flag even before any attempts have happened", () => {
     const disabled = new ReconnectManager({ enabled: false, maxAttempts: 5 });
     expect(disabled.canRetry).toBe(false);
+  });
+});
+
+describe("ReconnectManager.schedule", () => {
+  it("does not schedule callbacks when reconnect is disabled", () => {
+    vi.useFakeTimers();
+    const m = new ReconnectManager({ enabled: false, baseDelay: 1000 });
+    const callback = vi.fn();
+
+    const delay = m.schedule(callback);
+    vi.runAllTimers();
+
+    expect(delay).toBe(0);
+    expect(callback).not.toHaveBeenCalled();
+    expect(m.currentAttempt).toBe(0);
   });
 });

--- a/packages/ws-client/src/reconnect.ts
+++ b/packages/ws-client/src/reconnect.ts
@@ -42,6 +42,9 @@ export class ReconnectManager {
   /** Schedule next reconnect. Returns the delay used (ms). */
   schedule(callback: () => void): number {
     this.cancel();
+    if (!this.options.enabled) {
+      return 0;
+    }
     const delay = this.getDelay();
     this.attempt++;
     this.timer = setTimeout(callback, delay);

--- a/packages/ws-client/src/types.ts
+++ b/packages/ws-client/src/types.ts
@@ -39,6 +39,12 @@ export interface WsClientOptions {
    */
   onTokenRefreshed?: (token: string, expiresAt: number) => void;
   /**
+   * Called when the server sends `auth.refresh_required`, signalling
+   * that the current access token is approaching expiry. Consumers
+   * should call refreshToken() with their refresh token before expiresAt.
+   */
+  onRefreshRequired?: (expiresAt: number, reason?: string) => void;
+  /**
    * Called when the server sends `auth.revoked` (ban / logout-elsewhere /
    * password change / admin revoke). The connection is closed and
    * reconnect is disabled — consumers typically navigate to a blocked


### PR DESCRIPTION
## 요약
- config test cleanEnv에 `MMP_WS_AUTH_PROTOCOL`을 포함해 테스트 간 환경변수 오염을 막습니다.
- WS auth `expiresAt` 서버 wire format을 generated TS 계약과 같은 epoch-ms number로 고정합니다.
- ws-client가 `auth.refresh_required`를 dedicated callback으로 처리하고, disabled reconnect schedule을 방어합니다.
- revoke E2E의 `auth.revoked` soft warning을 hard assertion으로 승격하고, revoke publisher 주석을 실제 Hub/SocialHub 구현 수준으로 맞춥니다.

## 이슈
Closes #204
Closes #205
Closes #206
Closes #207
Closes #208
Closes #209

## Coverage Plan
- `apps/server/internal/config/config_test.go`: env cleanup 회귀는 shuffle 반복 테스트로 검증
- `apps/server/internal/ws/*`: auth.refresh token_issued epoch-ms payload와 revoke publisher 관련 auth 도메인 테스트 검증
- `packages/ws-client/src/client.ts`: `auth.refresh_required` callback 및 ordinary listener 미전파 단위 테스트 검증
- `packages/ws-client/src/reconnect.ts`: disabled 상태 schedule no-op 및 pending callback cancel 단위 테스트 검증
- `apps/web/e2e/ws-auth-revoke.spec.ts`: live backend 전용 E2E assertion 강화, 로컬 이번 검증에서는 서버 미기동으로 직접 실행하지 않음

## 검증
- `go test -count=10 -shuffle=on ./internal/config`
- `go test ./internal/ws ./internal/domain/auth`
- `cd apps/server && go generate ./internal/ws`
- `pnpm install --frozen-lockfile` (worktree dependency bootstrap, lockfile unchanged)
- `pnpm --filter @mmp/ws-client test -- src/client.test.ts src/reconnect.test.ts`
- `pnpm --filter @mmp/shared build`
- `pnpm --filter @mmp/ws-client typecheck`
- `pnpm --filter @mmp/ws-client build`
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * WebSocket 인증 갱신 알림을 위한 새로운 콜백 추가: 서버가 토큰 만료를 알릴 때 `onRefreshRequired` 콜백이 만료 시간과 함께 호출됩니다.

* **버그 수정**
  * 재연결 기능 비활성화 시 불필요한 스케줄링을 방지하는 가드 로직 추가
  * 인증 취소 테스트 검증 강화

* **개선 사항**
  * 토큰 만료 시간이 밀리초 단위 Unix 타임스탬프로 표준화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->