### PR TITLE
test(ws-auth): revoke context/race 회귀망 강화

### DIFF
--- a/apps/server/internal/ws/auth_protocol_test.go
+++ b/apps/server/internal/ws/auth_protocol_test.go
@@ -561,9 +561,6 @@ func TestAuthHandler_Identify_UsesClientContextCancelledOnClose(t *testing.T) {
 	if ctx.Err() != nil {
 		t.Fatalf("captured ctx prematurely cancelled: %v", ctx.Err())
 	}
-	if ctx == context.Background() {
-		t.Fatal("BLOCKER regression: handler passed context.Background() — closing client cannot abort the lookup")
-	}
 
 	c.Close()
 	select {
@@ -571,6 +568,32 @@ func TestAuthHandler_Identify_UsesClientContextCancelledOnClose(t *testing.T) {
 		// expected
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("Client.Close() did not cancel the captured revoke ctx")
+	}
+}
+
+func TestAuthHandler_Identify_RevokeContextAlreadyCancelledWhenClientClosed(t *testing.T) {
+	t.Parallel()
+	userID := uuid.New()
+	checker := &ctxObservingRevokeChecker{captured: make(chan context.Context, 1)}
+	h := newAuthHandler(t, checker, nil, true)
+	c := newTestAuthClient(userID)
+	c.Close()
+
+	h.Handle(c, identifyEnv(t, AuthIdentifyPayload{
+		Token: mintAccessToken(t, userID, testJWTSecret),
+	}))
+
+	var ctx context.Context
+	select {
+	case ctx = <-checker.captured:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("revoke checker not invoked")
+	}
+	select {
+	case <-ctx.Done():
+		// expected: the context came from the already-closed Client.
+	default:
+		t.Fatal("revoke checker ctx is not tied to the closed Client lifecycle")
 	}
 }
 

--- a/apps/server/internal/ws/hub_revoke_test.go
+++ b/apps/server/internal/ws/hub_revoke_test.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -270,7 +271,7 @@ func TestHub_RevokeUser_ConcurrentRegister(t *testing.T) {
 	h := newTestHub(nil)
 	defer h.Stop()
 
-	const iterations = 50
+	const iterations = 200
 	for i := 0; i < iterations; i++ {
 		userID := uuid.New()
 		c := newTestClient(h, userID)
@@ -279,10 +280,12 @@ func TestHub_RevokeUser_ConcurrentRegister(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
+			runtime.Gosched()
 			h.Register(c)
 		}()
 		go func() {
 			defer wg.Done()
+			runtime.Gosched()
 			_ = h.RevokeUser(context.Background(), userID,
 				auth.RevokeCodeBanned, "ban")
 		}()


### PR DESCRIPTION
## 요약
- `auth.identify` revoke lookup context 테스트에서 decorative `context.Background()` 비교를 제거하고, 이미 닫힌 Client의 context가 revoke checker까지 취소 상태로 전달되는지 검증합니다.
- `RevokeUser` concurrent register race guard를 200회 반복으로 늘리고 `runtime.Gosched()`로 interleaving 창을 넓힙니다.

## 이슈
Closes #201
Closes #202

## Coverage Plan
- `apps/server/internal/ws/auth_protocol_test.go`: Client lifecycle context가 revoke lookup에 직접 전파되는지 closed-before-handle 케이스 추가
- `apps/server/internal/ws/hub_revoke_test.go`: Register/RevokeUser 경합 반복 수와 scheduler yield로 race 회귀 감지력 강화

## 검증
- `go test ./internal/ws -run 'TestAuthHandler_Identify_(UsesClientContextCancelledOnClose|RevokeContextAlreadyCancelledWhenClientClosed)|TestHub_RevokeUser_ConcurrentRegister'`
- `go test -race ./internal/ws -run TestHub_RevokeUser_ConcurrentRegister`
- `go test ./internal/ws`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 웹소켓 인증 프로토콜의 컨텍스트 취소 처리에 대한 테스트 추가로 클라이언트 종료 시 올바른 취소 전파 검증
  * 동시성 테스트 강화 및 스케줄링 개선으로 경합 조건 감지 능력 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->