### PR TITLE
perf(auth): revoke push fan-out 상한 추가

### DIFF
--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -307,6 +307,17 @@ func main() {
 	revokePublisher := auth.NewCompositeRevokePublisher(wsHub, socialHub)
 	authSvc := auth.NewService(queries, redisCache.Client(), []byte(cfg.JWTSecret),
 		auditLog, revokeRepo, revokePublisher, logger)
+	if drainer, ok := authSvc.(interface {
+		DrainRevokePushes(context.Context) error
+	}); ok {
+		defer func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := drainer.DrainRevokePushes(ctx); err != nil {
+				logger.Warn().Err(err).Msg("auth revoke pushes did not drain before shutdown")
+			}
+		}()
+	}
 	authHandler := auth.NewHandler(authSvc)
 	wsAuthHandler := ws.NewAuthHandler([]byte(cfg.JWTSecret), revokeRepo, authSvc,
 		cfg.WSAuthProtocol, logger)

--- a/apps/server/internal/domain/auth/service.go
+++ b/apps/server/internal/domain/auth/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -71,6 +72,9 @@ type service struct {
 	audit      auditlog.Logger
 	revokeRepo RevokeRepo
 	publisher  RevokePublisher
+
+	revokePushSem chan struct{}
+	revokePushWG  sync.WaitGroup
 }
 
 // NewService creates a new auth service.
@@ -105,13 +109,14 @@ func NewService(
 		publisher = NoopRevokePublisher{}
 	}
 	return &service{
-		queries:    queries,
-		redis:      redisClient,
-		jwtSecret:  jwtSecret,
-		logger:     logger.With().Str("domain", "auth").Logger(),
-		audit:      audit,
-		revokeRepo: revokeRepo,
-		publisher:  publisher,
+		queries:       queries,
+		redis:         redisClient,
+		jwtSecret:     jwtSecret,
+		logger:        logger.With().Str("domain", "auth").Logger(),
+		audit:         audit,
+		revokeRepo:    revokeRepo,
+		publisher:     publisher,
+		revokePushSem: make(chan struct{}, revokePushConcurrency),
 	}
 }
 

--- a/apps/server/internal/domain/auth/service.go
+++ b/apps/server/internal/domain/auth/service.go
@@ -73,8 +73,10 @@ type service struct {
 	revokeRepo RevokeRepo
 	publisher  RevokePublisher
 
-	revokePushSem chan struct{}
-	revokePushWG  sync.WaitGroup
+	revokePushMu       sync.Mutex
+	revokePushSem      chan struct{}
+	revokePushWG       sync.WaitGroup
+	revokePushDraining bool
 }
 
 // NewService creates a new auth service.

--- a/apps/server/internal/domain/auth/service_revoke.go
+++ b/apps/server/internal/domain/auth/service_revoke.go
@@ -15,6 +15,8 @@ import (
 // healthy publishers always finish first.
 const revokePushTimeout = 15 * time.Second
 
+const revokePushConcurrency = 256
+
 // recordRevoke writes a persistent revoke_log row and pushes auth.revoked
 // to live WS sessions. The two side effects have different criticality:
 //
@@ -47,8 +49,31 @@ func (s *service) recordRevoke(ctx context.Context, userID uuid.UUID, code, reas
 		// trigger is silently bypassed on the very next reconnect.
 		return apperror.Internal("failed to record revocation")
 	}
-	go s.pushRevokeAsync(userID, code, reason)
+	s.scheduleRevokePush(userID, code, reason)
 	return nil
+}
+
+func (s *service) scheduleRevokePush(userID uuid.UUID, code, reason string) {
+	if s.revokePushSem == nil {
+		s.revokePushSem = make(chan struct{}, revokePushConcurrency)
+	}
+	select {
+	case s.revokePushSem <- struct{}{}:
+	default:
+		s.logger.Warn().
+			Str("user_id", userID.String()).
+			Str("code", code).
+			Int("limit", revokePushConcurrency).
+			Msg("revoke push concurrency limit reached; skipping live push, pull-fallback remains authoritative")
+		return
+	}
+
+	s.revokePushWG.Add(1)
+	go func() {
+		defer s.revokePushWG.Done()
+		defer func() { <-s.revokePushSem }()
+		s.pushRevokeAsync(userID, code, reason)
+	}()
 }
 
 // pushRevokeAsync invokes the configured RevokePublisher off the caller's
@@ -63,5 +88,23 @@ func (s *service) pushRevokeAsync(userID uuid.UUID, code, reason string) {
 			Str("user_id", userID.String()).
 			Str("code", code).
 			Msg("revoke push failed")
+	}
+}
+
+// DrainRevokePushes waits for in-flight revoke pushes to finish. Callers
+// use this during graceful shutdown so best-effort live closes can drain
+// while the persisted revoke_log row remains the source of truth.
+func (s *service) DrainRevokePushes(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		s.revokePushWG.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/apps/server/internal/domain/auth/service_revoke.go
+++ b/apps/server/internal/domain/auth/service_revoke.go
@@ -54,8 +54,18 @@ func (s *service) recordRevoke(ctx context.Context, userID uuid.UUID, code, reas
 }
 
 func (s *service) scheduleRevokePush(userID uuid.UUID, code, reason string) {
+	s.revokePushMu.Lock()
+	defer s.revokePushMu.Unlock()
+
 	if s.revokePushSem == nil {
 		s.revokePushSem = make(chan struct{}, revokePushConcurrency)
+	}
+	if s.revokePushDraining {
+		s.logger.Warn().
+			Str("user_id", userID.String()).
+			Str("code", code).
+			Msg("revoke push drain is active; skipping live push, pull-fallback remains authoritative")
+		return
 	}
 	select {
 	case s.revokePushSem <- struct{}{}:
@@ -95,6 +105,10 @@ func (s *service) pushRevokeAsync(userID uuid.UUID, code, reason string) {
 // use this during graceful shutdown so best-effort live closes can drain
 // while the persisted revoke_log row remains the source of truth.
 func (s *service) DrainRevokePushes(ctx context.Context) error {
+	s.revokePushMu.Lock()
+	s.revokePushDraining = true
+	s.revokePushMu.Unlock()
+
 	done := make(chan struct{})
 	go func() {
 		s.revokePushWG.Wait()

--- a/apps/server/internal/domain/auth/service_revoke_wire_test.go
+++ b/apps/server/internal/domain/auth/service_revoke_wire_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -58,6 +59,43 @@ type revokeUserCall struct {
 	UserID uuid.UUID
 	Code   string
 	Reason string
+}
+
+type blockingPublisher struct {
+	release chan struct{}
+	calls   atomic.Int64
+	active  atomic.Int64
+	maxSeen atomic.Int64
+}
+
+func newBlockingPublisher() *blockingPublisher {
+	return &blockingPublisher{release: make(chan struct{})}
+}
+
+func (b *blockingPublisher) RevokeUser(ctx context.Context, _ uuid.UUID, _, _ string) error {
+	b.calls.Add(1)
+	current := b.active.Add(1)
+	for {
+		maxSeen := b.maxSeen.Load()
+		if current <= maxSeen || b.maxSeen.CompareAndSwap(maxSeen, current) {
+			break
+		}
+	}
+	defer b.active.Add(-1)
+
+	select {
+	case <-b.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *blockingPublisher) RevokeSession(context.Context, uuid.UUID, string, string) error {
+	return nil
+}
+func (b *blockingPublisher) RevokeToken(context.Context, string, string, string) error {
+	return nil
 }
 
 func (c *capturingPublisher) RevokeUser(_ context.Context, userID uuid.UUID, code, reason string) error {
@@ -115,9 +153,10 @@ func newWireTestService(repo RevokeRepo, pub RevokePublisher) *service {
 		pub = NoopRevokePublisher{}
 	}
 	return &service{
-		logger:     zerolog.Nop(),
-		revokeRepo: repo,
-		publisher:  pub,
+		logger:        zerolog.Nop(),
+		revokeRepo:    repo,
+		publisher:     pub,
+		revokePushSem: make(chan struct{}, revokePushConcurrency),
 	}
 }
 
@@ -206,6 +245,75 @@ func TestRecordRevoke_PublisherFailure_DoesNotError(t *testing.T) {
 	// Drain the async push goroutine so it doesn't leak into the next
 	// test under -race.
 	pub.waitForUserCalls(t, 1)
+}
+
+func TestRecordRevoke_BoundsConcurrentPushFanout(t *testing.T) {
+	repo := &capturingRevokeRepo{}
+	pub := newBlockingPublisher()
+	svc := newWireTestService(repo, pub)
+
+	const attempts = 1000
+	var wg sync.WaitGroup
+	wg.Add(attempts)
+	for i := 0; i < attempts; i++ {
+		go func() {
+			defer wg.Done()
+			if err := svc.recordRevoke(context.Background(), uuid.New(), RevokeCodeLoggedOutElsewhere, "logout storm"); err != nil {
+				t.Errorf("recordRevoke: %v", err)
+			}
+		}()
+	}
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("recordRevoke calls did not return promptly under logout storm")
+	}
+
+	if len(repo.entries) != attempts {
+		t.Fatalf("revokeRepo.Insert calls = %d, want %d", len(repo.entries), attempts)
+	}
+	if got := pub.maxSeen.Load(); got > revokePushConcurrency {
+		t.Fatalf("max concurrent revoke pushes = %d, want <= %d", got, revokePushConcurrency)
+	}
+	if got := pub.calls.Load(); got > revokePushConcurrency {
+		t.Fatalf("publisher calls = %d, want <= %d", got, revokePushConcurrency)
+	}
+
+	close(pub.release)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := svc.DrainRevokePushes(ctx); err != nil {
+		t.Fatalf("DrainRevokePushes: %v", err)
+	}
+}
+
+func TestDrainRevokePushes_RespectsContextDeadline(t *testing.T) {
+	repo := &capturingRevokeRepo{}
+	pub := newBlockingPublisher()
+	svc := newWireTestService(repo, pub)
+
+	if err := svc.recordRevoke(context.Background(), uuid.New(), RevokeCodeLoggedOutElsewhere, "logout"); err != nil {
+		t.Fatalf("recordRevoke: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := svc.DrainRevokePushes(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("DrainRevokePushes err = %v, want context deadline exceeded", err)
+	}
+
+	close(pub.release)
+	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := svc.DrainRevokePushes(ctx); err != nil {
+		t.Fatalf("DrainRevokePushes after release: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/internal/domain/auth/service_revoke_wire_test.go
+++ b/apps/server/internal/domain/auth/service_revoke_wire_test.go
@@ -316,6 +316,59 @@ func TestDrainRevokePushes_RespectsContextDeadline(t *testing.T) {
 	}
 }
 
+func TestDrainRevokePushes_BlocksNewPushSchedules(t *testing.T) {
+	repo := &capturingRevokeRepo{}
+	pub := newBlockingPublisher()
+	svc := newWireTestService(repo, pub)
+
+	if err := svc.recordRevoke(context.Background(), uuid.New(), RevokeCodeLoggedOutElsewhere, "first logout"); err != nil {
+		t.Fatalf("recordRevoke first: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for pub.calls.Load() < 1 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := pub.calls.Load(); got != 1 {
+		t.Fatalf("publisher calls before drain = %d, want 1", got)
+	}
+
+	drained := make(chan error, 1)
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelDrain()
+	go func() {
+		drained <- svc.DrainRevokePushes(drainCtx)
+	}()
+
+	deadline = time.Now().Add(2 * time.Second)
+	for !svc.isRevokePushDrainingForTest() && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !svc.isRevokePushDrainingForTest() {
+		t.Fatal("DrainRevokePushes did not mark the service as draining")
+	}
+
+	if err := svc.recordRevoke(context.Background(), uuid.New(), RevokeCodeAdminRevoked, "during shutdown"); err != nil {
+		t.Fatalf("recordRevoke during drain: %v", err)
+	}
+	if got := len(repo.entries); got != 2 {
+		t.Fatalf("revokeRepo.Insert calls = %d, want 2", got)
+	}
+	if got := pub.calls.Load(); got != 1 {
+		t.Fatalf("publisher calls during drain = %d, want 1", got)
+	}
+
+	close(pub.release)
+	if err := <-drained; err != nil {
+		t.Fatalf("DrainRevokePushes: %v", err)
+	}
+}
+
+func (s *service) isRevokePushDrainingForTest() bool {
+	s.revokePushMu.Lock()
+	defer s.revokePushMu.Unlock()
+	return s.revokePushDraining
+}
+
 // ---------------------------------------------------------------------------
 // NewService nil fallback — the constructor must accept nil deps and
 // substitute the Noop variants so existing call sites stay buildable


### PR DESCRIPTION
## 요약
- `recordRevoke`의 live WS revoke push를 256개 동시 실행으로 제한해 logout storm에서 무제한 goroutine fan-out을 막습니다.
- 제한 초과 시 live push만 skip하고, 이미 기록된 `revoke_log` pull-fallback을 authoritative 안전망으로 유지합니다.
- auth service에 `DrainRevokePushes(ctx)`를 추가하고 서버 shutdown defer에서 in-flight revoke push를 15초 안에 drain합니다.

## 이슈
Closes #200

## Coverage Plan
- `apps/server/internal/domain/auth/service_revoke.go`: semaphore 기반 push scheduling, drain path
- `apps/server/internal/domain/auth/service_revoke_wire_test.go`: 1,000건 revoke storm에서 publisher 동시 실행 상한, drain timeout/성공 경로
- `apps/server/cmd/server/main.go`: auth service drain hook 컴파일 경로

## 검증
- `go test ./internal/domain/auth -run 'TestRecordRevoke|TestDrainRevokePushes|TestNewService_NilDeps'`
- `go test -race ./internal/domain/auth -run 'TestRecordRevoke_BoundsConcurrentPushFanout|TestDrainRevokePushes_RespectsContextDeadline'`
- `go test ./cmd/server ./internal/domain/auth`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 서버 종료 시 인증 revoke 푸시의 우아한 종료(드레인) 지원 추가
  * revoke 푸시의 동시성 상한 도입 및 스케줄링으로 푸시 발송 안정성 향상
  * 인플라이트 푸시 작업을 추적하고 대기하는 메커니즘 추가

* **테스트**
  * 동시 revoke 호출 시 동시성 한계와 드레인 동작을 검증하는 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->