### PR TITLE
fix(editor): story route와 장면 클릭 blocker 수정

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -186,20 +186,29 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
 
   test('[2B] 직접 URL은 올바른 제작 탭과 서브탭을 연다', async ({ page }) => {
     await page.goto(`${BASE}/editor/${THEME_ID}`);
-    await expect(page.getByRole('tab', { name: '기본정보', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '스토리 진행', selected: true })).toBeVisible({
       timeout: 10_000,
     });
+    await expect(page.getByText('스토리 진행 제작')).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/story`);
-    await expect(page.getByRole('tab', { name: '스토리', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '스토리 진행', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByPlaceholder('마크다운으로 스토리를 작성하세요...')).toBeVisible();
-    await expect(page.getByText('장면별 정보 공개 설정')).toBeVisible();
-    await expect(page.getByRole('button', { name: /조사 단계/ })).toBeVisible();
+    await expect(page.getByText('스토리 진행 제작')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('라운드 공개 미리보기')).toBeVisible({ timeout: 10_000 });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/reading`);
+    await expect(page.getByRole('tab', { name: '읽기 대사', selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText('장면에서 읽거나 들려줄 대사 묶음')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText('읽기 대사 목록')).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
-    await expect(page.getByRole('tab', { name: '등장인물', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /등장인물/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByRole('button', { name: '제작' })).toBeVisible();
@@ -207,19 +216,19 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await expect(page.getByText('탐정 A').first()).toBeVisible();
 
     await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
-    await expect(page.getByRole('tab', { name: '단서', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /단서/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByLabel('단서 목록')).toBeVisible();
 
     await page.goto(`${BASE}/editor/${THEME_ID}/relations`);
-    await expect(page.getByRole('tab', { name: '단서', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /단서/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByText(/노드를 드래그하여 연결/).first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/locations`);
-    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /게임 설계|게임설계/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
@@ -227,39 +236,39 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await expect(page.getByText('저택 1층').first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/endings`);
-    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /게임 설계|게임설계/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByTestId('ending-entity-panel')).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/design/modules`);
-    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /게임 설계|게임설계/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByText('모듈').first()).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('진행').first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/design/flow`);
-    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /게임 설계|게임설계/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByText('장면 흐름')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('스토리 장면 구성')).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/modules`);
-    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /게임 설계|게임설계/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByText('진행').first()).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
-    await expect(page.getByRole('tab', { name: '게임설계', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: '스토리 진행', selected: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText('장면 흐름')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('스토리 진행 제작')).toBeVisible({ timeout: 10_000 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/media`);
-    await expect(page.getByRole('tab', { name: '미디어', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /미디어/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByLabel('미디어 목록')).toBeVisible({ timeout: 10_000 });
@@ -273,16 +282,18 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
       { name: 'desktop', width: 1440, height: 1000 },
     ];
     const routes = [
-      { path: '', tab: '기본정보', content: 'E2E 골든패스' },
-      { path: '/story', tab: '스토리', content: '장면별 정보 공개 설정' },
-      { path: '/characters', tab: '등장인물', content: '캐릭터 목록' },
-      { path: '/clues', tab: '단서', content: '단서 목록' },
-      { path: '/relations', tab: '단서', content: '노드를 드래그하여 연결' },
-      { path: '/design/modules', tab: '게임설계', content: '진행' },
-      { path: '/design/flow', tab: '게임설계', content: '장면 흐름' },
-      { path: '/design/locations', tab: '게임설계', content: '장소 목록' },
-      { path: '/design/endings', tab: '게임설계', content: 'ending-entity-panel' },
-      { path: '/media', tab: '미디어', content: '미디어 목록' },
+      { path: '', tab: /스토리 진행/, content: '스토리 진행 제작' },
+      { path: '/story', tab: /스토리 진행/, content: '스토리 진행 제작' },
+      { path: '/reading', tab: /읽기 대사/, content: '읽기 대사 목록' },
+      { path: '/characters', tab: /등장인물/, content: '캐릭터 목록' },
+      { path: '/clues', tab: /단서/, content: '단서 목록' },
+      { path: '/relations', tab: /단서/, content: '노드를 드래그하여 연결' },
+      { path: '/design/modules', tab: /게임 설계|게임설계/, content: '진행' },
+      { path: '/design/flow', tab: /게임 설계|게임설계/, content: '장면 흐름' },
+      { path: '/design/locations', tab: /게임 설계|게임설계/, content: '장소 목록' },
+      { path: '/design/endings', tab: /게임 설계|게임설계/, content: 'ending-entity-panel' },
+      { path: '/flow', tab: /스토리 진행/, content: '스토리 진행 제작' },
+      { path: '/media', tab: /미디어/, content: '미디어 목록' },
     ];
 
     for (const viewport of viewports) {
@@ -296,6 +307,8 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
 
         if (route.content === 'ending-entity-panel') {
           await expect(page.getByTestId('ending-entity-panel')).toBeVisible({ timeout: 10_000 });
+        } else if (route.content === '읽기 대사 목록') {
+          await expect(page.getByText(route.content).first()).toBeVisible({ timeout: 10_000 });
         } else if (route.content.endsWith('목록')) {
           await expect(page.getByLabel(route.content)).toBeVisible({ timeout: 10_000 });
         } else {
@@ -311,7 +324,7 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await page.setViewportSize({ width: 390, height: 844 });
 
     await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
-    await expect(page.getByRole('tab', { name: '등장인물', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /등장인물/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expectFocusIndicator(page, page.getByRole('textbox', { name: '캐릭터 검색' }));
@@ -319,12 +332,15 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await expectNoPageLevelHorizontalOverflow(page);
 
     await page.goto(`${BASE}/editor/${THEME_ID}/media`);
-    await expect(page.getByRole('tab', { name: '미디어', selected: true })).toBeVisible({
+    await expect(page.getByRole('tab', { name: /미디어/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
     await expectFocusIndicator(page, page.getByRole('button', { name: '파일 업로드' }));
     await expectFocusIndicator(page, page.getByRole('button', { name: 'YouTube' }));
-    await expectFocusIndicator(page, page.getByRole('button', { name: '전체' }));
+    await expectFocusIndicator(
+      page,
+      page.getByLabel('미디어 카테고리 필터').getByRole('button', { name: '전체' }),
+    );
     await expectNoPageLevelHorizontalOverflow(page);
   });
 

--- a/apps/web/src/features/editor/__tests__/routeSegments.test.ts
+++ b/apps/web/src/features/editor/__tests__/routeSegments.test.ts
@@ -29,7 +29,7 @@ describe('editor route segment matrix', () => {
   it.each([
     ['storyMap', '/editor/theme-1'],
     ['info', '/editor/theme-1/info'],
-    ['story', '/editor/theme-1/story'],
+    ['story', '/editor/theme-1/reading'],
     ['characters', '/editor/theme-1/characters'],
     ['clues', '/editor/theme-1/clues'],
     ['design', '/editor/theme-1/design/modules'],

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -150,7 +150,7 @@ export function EditorLayout({
         role="tabpanel"
         id={`tabpanel-${activeTab}`}
         aria-labelledby={`tab-${activeTab}`}
-        className="flex-1 overflow-y-auto"
+        className={activeTab === "storyMap" ? "flex-1 overflow-hidden" : "flex-1 overflow-y-auto"}
       >
         <Suspense
           fallback={

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -199,8 +199,9 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
       >
         {/* Canvas */}
         <div
+          data-testid="flow-canvas"
           ref={reactFlowWrapper}
-          className="min-h-[420px] flex-1 lg:min-h-0"
+          className="relative min-h-[420px] flex-1 overflow-hidden lg:min-h-0"
           onDragOver={handleDragOver}
           onDrop={handleDrop}
         >
@@ -217,6 +218,7 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
             edgesFocusable={true}
             edgesReconnectable={true}
             fitView
+            fitViewOptions={{ padding: 0.35 }}
             colorMode="dark"
           >
             <Background />

--- a/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
@@ -55,9 +55,9 @@ export function NodeDetailPanel({
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="min-h-full">
       {/* Panel content */}
-      <div className="flex-1 overflow-y-auto">
+      <div>
         {isStart ? (
           <div className="flex h-full items-center justify-center p-4">
             <span className="text-xs text-slate-500">

--- a/apps/web/src/features/editor/components/design/StorySceneSummary.tsx
+++ b/apps/web/src/features/editor/components/design/StorySceneSummary.tsx
@@ -40,7 +40,7 @@ export function StorySceneSummary({
       </div>
 
       {previewScenes.length > 0 ? (
-        <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+        <div className="mt-3 grid gap-2 md:grid-cols-2 lg:hidden">
           {previewScenes.map((scene) => (
             <article
               key={scene.id}
@@ -64,7 +64,7 @@ export function StorySceneSummary({
           ))}
         </div>
       ) : (
-        <div className="mt-3 rounded border border-dashed border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-500">
+        <div className="mt-3 rounded border border-dashed border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-500 lg:hidden">
           장면을 추가하면 스토리 진행 구성이 여기에 표시됩니다.
         </div>
       )}

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -19,14 +19,16 @@ vi.mock('@xyflow/react', () => ({
     children,
     nodes = [],
     edges = [],
+    fitViewOptions,
     onSelectionChange,
   }: {
     children?: React.ReactNode;
     nodes?: Array<{ id: string; className?: string }>;
     edges?: Array<{ id: string; source: string; target: string }>;
+    fitViewOptions?: { padding?: number };
     onSelectionChange?: (params: { nodes: unknown[]; edges: unknown[] }) => void;
   }) => (
-    <div data-testid="react-flow">
+    <div data-testid="react-flow" data-fit-padding={String(fitViewOptions?.padding ?? '')}>
       {nodes.map((node) => (
         <div key={node.id} data-testid={`rf-node-${node.id}`} className={node.className ?? ''} />
       ))}
@@ -173,6 +175,13 @@ describe('FlowCanvas', () => {
     const workspace = screen.getByTestId('flow-workspace');
     expect(workspace.className).toContain('flex-col');
     expect(workspace.className).toContain('lg:flex-row');
+  });
+
+  it('캔버스 밖으로 튀어나온 노드가 상단 미리보기 패널 클릭을 가로막지 않게 자른다', () => {
+    render(<FlowCanvas themeId="theme-1" />);
+    const canvas = screen.getByTestId('flow-canvas');
+    expect(canvas.className).toContain('overflow-hidden');
+    expect(screen.getByTestId('react-flow').getAttribute('data-fit-padding')).toBe('0.35');
   });
 
   it('ReactFlow 보조 컴포넌트들이 렌더링된다', () => {

--- a/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
+++ b/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
@@ -269,7 +269,7 @@ export function EditorEntityLibrary({
   ];
 
   return (
-    <aside className="border-b border-slate-800 bg-slate-950 lg:min-h-0 lg:overflow-y-auto lg:border-b-0 lg:border-r">
+    <aside className="border-b border-slate-800 bg-slate-950 lg:min-h-0 lg:w-68 lg:shrink-0 lg:overflow-y-auto lg:border-b-0 lg:border-r">
       <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
         <FileText className="h-4 w-4 text-amber-400" />
         <h3 className="text-sm font-semibold text-slate-100">제작 라이브러리</h3>

--- a/apps/web/src/features/editor/components/story-map/RoundVisibilityPreviewPanel.tsx
+++ b/apps/web/src/features/editor/components/story-map/RoundVisibilityPreviewPanel.tsx
@@ -90,7 +90,7 @@ export function RoundVisibilityPreviewPanel({ themeId }: RoundVisibilityPreviewP
       )}
 
       {!isLoading && !isError && (
-        <div className="mt-4 flex gap-3 overflow-x-auto pb-1">
+        <div className="mt-4 flex gap-3 overflow-x-auto pb-1 lg:hidden">
           {previews.map((preview) => (
             <article
               key={preview.round}

--- a/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
+++ b/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
@@ -183,7 +183,7 @@ export function SceneInspector({
   const sceneTitle = selectedScene?.data.label ?? "선택한 장면 없음";
 
   return (
-    <aside className="bg-slate-950 lg:min-h-0 lg:overflow-y-auto">
+    <aside className="bg-slate-950 lg:min-h-0 lg:w-80 lg:shrink-0 lg:overflow-y-auto">
       <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-3">
         <MapPin className="h-4 w-4 text-amber-400" />
         <h3 className="text-sm font-semibold text-slate-100">장면 속성</h3>

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -64,14 +64,14 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
 
       <RoundVisibilityPreviewPanel themeId={themeId} />
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[17rem_minmax(0,1fr)_20rem]">
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row lg:overflow-hidden">
         <EditorEntityLibrary
           themeId={themeId}
           selectedEntity={selectedEntity}
           onSelectEntity={setSelectedEntity}
         />
 
-        <main className="min-h-[520px] min-w-0 border-b border-slate-800 lg:min-h-0 lg:border-b-0">
+        <main className="min-h-[520px] min-w-0 flex-1 border-b border-slate-800 lg:min-h-0 lg:overflow-hidden lg:border-b-0">
           <FlowCanvas themeId={themeId} onSelectedNodeChange={handleSelectedNodeChange} />
         </main>
 

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -12,10 +12,11 @@ export interface EditorRouteMatrixEntry {
 
 const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
   'story-map': 'storyMap',
+  story: 'storyMap',
+  reading: 'story',
   overview: 'overview',
   design: 'design',
   info: 'info',
-  story: 'story',
   characters: 'characters',
   clues: 'clues',
   relations: 'clues',
@@ -48,7 +49,7 @@ const DESIGN_ROUTE_SUBTAB_MAP: Record<string, DesignSubTab> = {
 const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
   storyMap: undefined,
   info: 'info',
-  story: 'story',
+  story: 'reading',
   characters: 'characters',
   clues: 'clues',
   design: 'design/modules',
@@ -61,8 +62,9 @@ const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
 export const EDITOR_ROUTE_MATRIX = [
   { path: '/editor/:id', editorTab: 'storyMap' },
   { path: '/editor/:id/story-map', routeSegment: 'story-map', editorTab: 'storyMap', alias: true },
+  { path: '/editor/:id/story', routeSegment: 'story', editorTab: 'storyMap' },
   { path: '/editor/:id/info', routeSegment: 'info', editorTab: 'info' },
-  { path: '/editor/:id/story', routeSegment: 'story', editorTab: 'story' },
+  { path: '/editor/:id/reading', routeSegment: 'reading', editorTab: 'story' },
   { path: '/editor/:id/characters', routeSegment: 'characters', editorTab: 'characters' },
   { path: '/editor/:id/clues', routeSegment: 'clues', editorTab: 'clues' },
   { path: '/editor/:id/relations', routeSegment: 'relations', editorTab: 'clues' },

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -1,20 +1,18 @@
 import { useEffect } from "react";
-import { useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { EditorDashboard } from "@/features/editor/components";
 import { ThemeEditor } from "@/features/editor/components";
 import { readEditorTabFromRouteSegment } from "@/features/editor/routeSegments";
 import { useEditorUI } from "@/features/editor/stores/editorUIStore";
 
 export default function EditorPage() {
-  const { id, tab, designTab } = useParams<{
+  const { id } = useParams<{
     id: string;
-    tab?: string;
-    designTab?: string;
   }>();
+  const location = useLocation();
   const setActiveTab = useEditorUI((state) => state.setActiveTab);
-  const routeSegment = designTab ?? tab;
-  const activeTabRouteSegment =
-    tab === "design" && designTab ? `design/${designTab}` : routeSegment;
+  const routeSegment = location.pathname.split("/").filter(Boolean).slice(2).join("/") || undefined;
+  const activeTabRouteSegment = routeSegment;
 
   useEffect(() => {
     setActiveTab(readEditorTabFromRouteSegment(activeTabRouteSegment));

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -1,12 +1,14 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { paramsMock, setActiveTabMock } = vi.hoisted(() => ({
+const { locationPathMock, paramsMock, setActiveTabMock } = vi.hoisted(() => ({
+  locationPathMock: vi.fn(() => '/editor'),
   paramsMock: vi.fn(),
   setActiveTabMock: vi.fn(),
 }));
 
 vi.mock('react-router', () => ({
+  useLocation: () => ({ pathname: locationPathMock() }),
   useParams: () => paramsMock(),
 }));
 
@@ -29,7 +31,8 @@ import EditorPage from '../EditorPage';
 const routeMatrixCases = [
   ['직접 URL /editor/:id', { id: 'theme-1' }, 'no-segment', 'storyMap'],
   ['alias URL /editor/:id/story-map', { id: 'theme-1', tab: 'story-map' }, 'story-map', 'storyMap'],
-  ['직접 URL /editor/:id/story', { id: 'theme-1', tab: 'story' }, 'story', 'story'],
+  ['직접 URL /editor/:id/story', { id: 'theme-1', tab: 'story' }, 'story', 'storyMap'],
+  ['직접 URL /editor/:id/reading', { id: 'theme-1', tab: 'reading' }, 'reading', 'story'],
   ['직접 URL /editor/:id/info', { id: 'theme-1', tab: 'info' }, 'info', 'info'],
   [
     '직접 URL /editor/:id/characters',
@@ -47,25 +50,25 @@ const routeMatrixCases = [
   [
     '직접 URL /editor/:id/design/modules',
     { id: 'theme-1', tab: 'design', designTab: 'modules' },
-    'modules',
+    'design/modules',
     'design',
   ],
   [
     '직접 URL /editor/:id/design/flow',
     { id: 'theme-1', tab: 'design', designTab: 'flow' },
-    'flow',
+    'design/flow',
     'design',
   ],
   [
     '직접 URL /editor/:id/design/locations',
     { id: 'theme-1', tab: 'design', designTab: 'locations' },
-    'locations',
+    'design/locations',
     'design',
   ],
   [
     '직접 URL /editor/:id/design/endings',
     { id: 'theme-1', tab: 'design', designTab: 'endings' },
-    'endings',
+    'design/endings',
     'design',
   ],
   ['alias URL /editor/:id/modules', { id: 'theme-1', tab: 'modules' }, 'modules', 'design'],
@@ -78,11 +81,13 @@ const routeMatrixCases = [
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  locationPathMock.mockReturnValue('/editor');
 });
 
 describe('EditorPage', () => {
   it('id가 없으면 에디터 대시보드를 보여주고 기본 제작 흐름 탭을 활성화한다', () => {
     paramsMock.mockReturnValue({});
+    locationPathMock.mockReturnValue('/editor');
 
     render(<EditorPage />);
 
@@ -92,6 +97,7 @@ describe('EditorPage', () => {
 
   it('characters 라우트 segment를 characters 탭으로 매핑한다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'characters' });
+    locationPathMock.mockReturnValue('/editor/theme-1/characters');
 
     render(<EditorPage />);
 
@@ -103,6 +109,11 @@ describe('EditorPage', () => {
     '%s route matrix를 ThemeEditor와 active tab에 반영한다',
     (_label, params, expectedSegment, expectedTab) => {
       paramsMock.mockReturnValue(params);
+      locationPathMock.mockReturnValue(
+        expectedSegment === 'no-segment'
+          ? `/editor/${params.id}`
+          : `/editor/${params.id}/${expectedSegment}`,
+      );
 
       render(<EditorPage />);
 
@@ -111,17 +122,19 @@ describe('EditorPage', () => {
     }
   );
 
-  it('design 하위 route segment를 실제 DesignTab subtab segment로 전달한다', () => {
+  it('design 하위 route segment를 전체 direct URL segment로 전달한다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'design', designTab: 'flow' });
+    locationPathMock.mockReturnValue('/editor/theme-1/design/flow');
 
     render(<EditorPage />);
 
-    expect(screen.getByText(/테마 에디터 theme-1 flow/)).toBeDefined();
+    expect(screen.getByText(/테마 에디터 theme-1 design\/flow/)).toBeDefined();
     expect(setActiveTabMock).toHaveBeenCalledWith('design');
   });
 
   it('modules 라우트 segment를 design 탭으로 매핑한다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'modules' });
+    locationPathMock.mockReturnValue('/editor/theme-1/modules');
 
     render(<EditorPage />);
 
@@ -130,6 +143,7 @@ describe('EditorPage', () => {
 
   it('알 수 없는 segment는 기본 제작 흐름 탭으로 되돌린다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'unknown' });
+    locationPathMock.mockReturnValue('/editor/theme-1/unknown');
 
     render(<EditorPage />);
 


### PR DESCRIPTION
## 요약
- `/editor/:id/story`를 스토리 진행 제작 화면으로 연결하고, 읽기 대사는 `/editor/:id/reading`으로 분리했습니다.
- `EditorPage`가 실제 URL path 전체를 route segment로 읽도록 바꿔 `design/flow`, `design/locations`, `design/endings` 직접 진입을 안정화했습니다.
- 스토리 진행 화면에서 라운드 미리보기/요약 패널이 Flow 노드 클릭을 가로막던 레이아웃을 정리했습니다.

Closes #460
Refs #461

## Coverage Plan
- route segment 계약: `routeSegments.test.ts`, `EditorPage.test.tsx`로 `/story`, `/reading`, `/flow`, `design/*` 직접 URL 매핑을 검증했습니다.
- Flow canvas 클릭 blocker: `FlowCanvas.test.tsx`와 Playwright golden path의 토론방 정책 클릭 흐름으로 회귀를 막았습니다.
- 모바일 후속 최적화: #461에서 별도 처리합니다. 이번 PR은 P0 route/click blocker 수정만 닫습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/pages/__tests__/EditorPage.test.tsx src/features/editor/__tests__/routeSegments.test.ts src/features/editor/components/__tests__/EditorTabNav.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx src/features/editor/components/design/__tests__/FlowCanvasEdgeDelete.test.tsx src/features/editor/components/design/__tests__/BranchWiring.test.tsx` (7 files, 107 tests)
- `pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium` (15 passed)

## CI 운영
- PR 생성 시 `ready-for-ci` 라벨은 붙이지 않았습니다.
- CodeRabbit 리뷰 정리 후 `scripts/mmp-pr-ci-scope.sh`로 scope를 분류하고 필요한 경우에만 full CI를 실행합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 스토리 맵 뷰의 반응형 레이아웃 개선으로 모바일과 데스크톱에서 더 나은 사용 경험 제공

* **버그 수정**
  * 스토리 맵 뷰 스크롤 동작 최적화
  * 플로우 캔버스 뷰 오버플로우 처리 개선

* **테스트**
  * E2E 테스트 강화로 에디터 UI 경로 및 상호작용 커버리지 확대
  * 캔버스 클리핑 동작 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->