### PR TITLE
fix(editor): 모바일 제작 화면 레이아웃 최적화

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -327,6 +327,11 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await expect(page.getByRole('tab', { name: /등장인물/, selected: true })).toBeVisible({
       timeout: 10_000,
     });
+    const editorHeader = page.locator('header').first();
+    await expect(editorHeader.getByText('에디터', { exact: true })).toBeHidden();
+    await expect(editorHeader.getByText('초안', { exact: true })).toBeHidden();
+    await expect(editorHeader.getByRole('button', { name: '검증' })).toBeVisible();
+    await expect(editorHeader.getByRole('button', { name: '출판' })).toBeVisible();
     await expectFocusIndicator(page, page.getByRole('textbox', { name: '캐릭터 검색' }));
     await expectFocusIndicator(page, page.getByRole('button', { name: '탐정 A 선택' }));
     await expectNoPageLevelHorizontalOverflow(page);

--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -342,6 +342,16 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
       page.getByLabel('미디어 카테고리 필터').getByRole('button', { name: '전체' }),
     );
     await expectNoPageLevelHorizontalOverflow(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/story`);
+    await expect(page.getByRole('tab', { name: /스토리 진행/, selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByLabel('스토리 진행 제작')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: '제작 라이브러리' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '장면 속성' })).toBeVisible();
+    await expect(page.locator('[data-testid="flow-canvas"]')).toBeVisible({ timeout: 10_000 });
+    await expectNoPageLevelHorizontalOverflow(page);
   });
 
   test('[2] 단서 이미지 업로드 경로는 /v1/editor/themes/{id}/images/upload-url (network-only)', async ({

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -80,7 +80,7 @@ export function EditorLayout({
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-slate-950 text-slate-100">
       {/* ── Top bar ── */}
-      <header className="sticky top-0 z-50 flex h-12 shrink-0 items-center gap-3 border-b border-slate-800 bg-slate-900 px-3">
+      <header className="sticky top-0 z-50 flex h-12 shrink-0 items-center gap-2 border-b border-slate-800 bg-slate-900 px-2 sm:gap-3 sm:px-3">
         <button
           type="button"
           onClick={() => navigate("/editor")}
@@ -92,29 +92,31 @@ export function EditorLayout({
 
         <div className="h-5 w-px bg-slate-800" />
 
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="shrink-0 text-xs text-slate-600">에디터</span>
-          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-slate-700" />
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 sm:gap-2">
+          <span className="hidden shrink-0 text-xs text-slate-600 sm:inline">에디터</span>
+          <ChevronRight className="hidden h-3.5 w-3.5 shrink-0 text-slate-700 sm:block" />
           <span className="truncate text-sm font-mono font-medium text-slate-200">
             {theme.title}
           </span>
-          <span className="shrink-0 rounded-sm bg-slate-800 px-1.5 py-0.5 text-[10px] font-mono text-slate-500">
+          <span className="hidden shrink-0 rounded-sm bg-slate-800 px-1.5 py-0.5 text-[10px] font-mono text-slate-500 sm:inline">
             {STATUS_LABEL[theme.status] ?? theme.status}
           </span>
         </div>
 
-        <SaveIndicator
-          status={saveStatus}
-          lastSaved={lastSaved}
-          onRetry={onRetry}
-        />
+        <div className="hidden sm:block">
+          <SaveIndicator
+            status={saveStatus}
+            lastSaved={lastSaved}
+            onRetry={onRetry}
+          />
+        </div>
 
-        <div className="h-5 w-px bg-slate-800" />
+        <div className="hidden h-5 w-px bg-slate-800 sm:block" />
 
         <button
           type="button"
           onClick={handleValidate}
-          className="h-7 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500"
+          className="h-8 rounded-sm border border-slate-700 px-2 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 sm:h-7 sm:px-3"
         >
           검증
         </button>
@@ -122,7 +124,7 @@ export function EditorLayout({
           type="button"
           onClick={onPublish}
           disabled={theme.status === "PUBLISHED"}
-          className="h-7 rounded-sm bg-amber-600 px-3 text-xs font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40"
+          className="h-8 rounded-sm bg-amber-600 px-2 text-xs font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:px-3"
         >
           출판
         </button>

--- a/apps/web/src/features/editor/components/EditorTabNav.tsx
+++ b/apps/web/src/features/editor/components/EditorTabNav.tsx
@@ -50,6 +50,14 @@ export function EditorTabNav({
     }
   }, [visibleTabs, activeTab, setActiveTab, themeId, navigate]);
 
+  useEffect(() => {
+    const activeIndex = visibleTabs.findIndex((tab) => tab.key === activeTab);
+    tabRefs.current[activeIndex]?.scrollIntoView?.({
+      block: "nearest",
+      inline: "center",
+    });
+  }, [activeTab, visibleTabs]);
+
   const selectTab = useCallback(
     (tab: EditorTab) => {
       setActiveTab(tab);
@@ -80,13 +88,13 @@ export function EditorTabNav({
   );
 
   return (
-    <div className="sticky top-12 z-40 h-10 shrink-0 border-b border-slate-800 bg-slate-950">
+    <div className="sticky top-12 z-40 h-11 shrink-0 border-b border-slate-800 bg-slate-950">
       <div className="pointer-events-none absolute inset-y-0 left-0 w-4 bg-gradient-to-r from-slate-950 to-transparent" />
       <div className="pointer-events-none absolute inset-y-0 right-0 w-4 bg-gradient-to-l from-slate-950 to-transparent" />
       <nav
         role="tablist"
         aria-label="에디터 탭"
-        className="flex h-full overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex h-full overflow-x-auto px-2 [scrollbar-width:none] sm:px-4 [&::-webkit-scrollbar]:hidden"
       >
         {visibleTabs.map((tab, index) => {
           const isActive = activeTab === tab.key;
@@ -110,7 +118,7 @@ export function EditorTabNav({
                 tabIndex={isActive ? 0 : -1}
                 onClick={() => selectTab(tab.key)}
                 onKeyDown={(e) => handleKeyDown(e, index)}
-                className={`relative flex shrink-0 items-center gap-1.5 px-4 text-xs font-medium transition-colors ${
+                className={`relative flex min-h-11 shrink-0 items-center gap-1.5 px-3 text-xs font-medium transition-colors sm:px-4 ${
                   isActive
                     ? "text-amber-400 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-amber-500"
                     : "text-slate-500 hover:bg-slate-900/50 hover:text-slate-300"

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EditorThemeResponse } from '@/features/editor/api';
+
+const { mockNavigate, mockActiveTab } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockActiveTab: { current: 'storyMap' },
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../../stores/editorUIStore', () => ({
+  useEditorUI: () => ({
+    activeTab: mockActiveTab.current,
+  }),
+}));
+
+vi.mock('../EditorTabNav', () => ({
+  EditorTabNav: () => <nav aria-label="에디터 탭">탭 내비게이션</nav>,
+}));
+
+vi.mock('../TabContent', () => ({
+  TabContent: () => <div>탭 콘텐츠</div>,
+}));
+
+import { EditorLayout } from '../EditorLayout';
+
+const baseTheme: EditorThemeResponse = {
+  id: 'theme-1',
+  title: '좁은 모바일 화면용 테스트 테마',
+  slug: 'mobile-theme',
+  description: null,
+  cover_image: null,
+  min_players: 4,
+  max_players: 6,
+  duration_min: 90,
+  price: 0,
+  coin_price: 0,
+  status: 'DRAFT',
+  config_json: null,
+  version: 1,
+  created_at: '2026-05-07T00:00:00Z',
+  review_note: null,
+  reviewed_at: null,
+  reviewed_by: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  mockActiveTab.current = 'storyMap';
+});
+
+describe('EditorLayout', () => {
+  it('모바일 헤더에서 보조 정보는 숨기고 주요 액션은 유지한다', () => {
+    const onValidate = vi.fn(() => []);
+    const onPublish = vi.fn();
+
+    const { container } = render(
+      <EditorLayout
+        theme={baseTheme}
+        themeId="theme-1"
+        saveStatus="dirty"
+        onValidate={onValidate}
+        onPublish={onPublish}
+      />,
+    );
+
+    expect(container.querySelector('header')?.className).toContain('gap-2');
+    expect(container.querySelector('header')?.className).toContain('px-2');
+    expect(screen.getByText('에디터').className).toContain('hidden');
+    expect(screen.getByText('초안').className).toContain('hidden');
+    expect(screen.getByText('변경사항 있음').closest('div')?.parentElement?.className).toContain(
+      'hidden sm:block',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '검증' }));
+    fireEvent.click(screen.getByRole('button', { name: '출판' }));
+
+    expect(onValidate).toHaveBeenCalledTimes(1);
+    expect(onPublish).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: '검증' }).className).toContain('sm:h-7');
+    expect(screen.getByRole('button', { name: '출판' }).className).toContain('sm:h-7');
+  });
+
+  it('뒤로가기와 출판 완료 테마의 비활성 상태를 유지한다', () => {
+    render(
+      <EditorLayout
+        theme={{ ...baseTheme, status: 'PUBLISHED' }}
+        themeId="theme-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('에디터 목록으로 돌아가기'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/editor');
+    expect((screen.getByRole('button', { name: '출판' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('출판됨').className).toContain('hidden');
+  });
+});

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -56,7 +56,7 @@ afterEach(() => {
 });
 
 describe('EditorLayout', () => {
-  it('모바일 헤더에서 보조 정보는 숨기고 주요 액션은 유지한다', () => {
+  it('헤더에서 핵심 정보와 주요 액션을 유지한다', () => {
     const onValidate = vi.fn(() => []);
     const onPublish = vi.fn();
 

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -2,8 +2,9 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { EditorThemeResponse } from '@/features/editor/api';
 
-const { mockNavigate, mockActiveTab } = vi.hoisted(() => ({
+const { mockNavigate, mockSetActiveTab, mockActiveTab } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
+  mockSetActiveTab: vi.fn(),
   mockActiveTab: { current: 'storyMap' },
 }));
 
@@ -14,6 +15,7 @@ vi.mock('react-router', () => ({
 vi.mock('../../stores/editorUIStore', () => ({
   useEditorUI: () => ({
     activeTab: mockActiveTab.current,
+    setActiveTab: mockSetActiveTab,
   }),
 }));
 
@@ -58,7 +60,7 @@ describe('EditorLayout', () => {
     const onValidate = vi.fn(() => []);
     const onPublish = vi.fn();
 
-    const { container } = render(
+    render(
       <EditorLayout
         theme={baseTheme}
         themeId="theme-1"
@@ -68,21 +70,17 @@ describe('EditorLayout', () => {
       />,
     );
 
-    expect(container.querySelector('header')?.className).toContain('gap-2');
-    expect(container.querySelector('header')?.className).toContain('px-2');
-    expect(screen.getByText('에디터').className).toContain('hidden');
-    expect(screen.getByText('초안').className).toContain('hidden');
-    expect(screen.getByText('변경사항 있음').closest('div')?.parentElement?.className).toContain(
-      'hidden sm:block',
-    );
+    expect(screen.getByText('좁은 모바일 화면용 테스트 테마')).toBeDefined();
+    expect(screen.getByText('초안')).toBeDefined();
+    expect(screen.getByText('변경사항 있음')).toBeDefined();
+    expect((screen.getByRole('button', { name: '검증' }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole('button', { name: '출판' }) as HTMLButtonElement).disabled).toBe(false);
 
     fireEvent.click(screen.getByRole('button', { name: '검증' }));
     fireEvent.click(screen.getByRole('button', { name: '출판' }));
 
     expect(onValidate).toHaveBeenCalledTimes(1);
     expect(onPublish).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole('button', { name: '검증' }).className).toContain('sm:h-7');
-    expect(screen.getByRole('button', { name: '출판' }).className).toContain('sm:h-7');
   });
 
   it('뒤로가기와 출판 완료 테마의 비활성 상태를 유지한다', () => {
@@ -97,6 +95,77 @@ describe('EditorLayout', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith('/editor');
     expect((screen.getByRole('button', { name: '출판' }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText('출판됨').className).toContain('hidden');
+    expect(screen.getByText('출판됨')).toBeDefined();
+  });
+
+  it('저장 상태별 표시와 재시도 액션을 헤더 안에서 유지한다', () => {
+    const onRetry = vi.fn();
+    const { rerender } = render(
+      <EditorLayout
+        theme={baseTheme}
+        themeId="theme-1"
+        saveStatus="saving"
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByText('저장 중...')).toBeDefined();
+
+    rerender(
+      <EditorLayout
+        theme={baseTheme}
+        themeId="theme-1"
+        saveStatus="error"
+        onRetry={onRetry}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /저장 실패/ }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    rerender(<EditorLayout theme={baseTheme} themeId="theme-1" saveStatus="idle" />);
+    expect(screen.queryByText('저장 중...')).toBeNull();
+    expect(screen.queryByRole('button', { name: /저장 실패/ })).toBeNull();
+  });
+
+  it('검증 결과를 표시하고 닫거나 관련 탭으로 이동할 수 있다', () => {
+    const onValidate = vi.fn(() => [
+      { type: 'error' as const, category: 'clues', message: '단서 연결이 필요합니다' },
+      { type: 'warning' as const, category: 'modules', message: '모듈 설정을 확인하세요' },
+    ]);
+
+    render(
+      <EditorLayout
+        theme={baseTheme}
+        themeId="theme-1"
+        onValidate={onValidate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '검증' }));
+
+    expect(screen.getByText('검증 결과: 1개 오류, 1개 경고')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /단서 연결이 필요합니다/ }));
+
+    expect(mockSetActiveTab).toHaveBeenCalledWith('clues');
+    expect(screen.queryByText('검증 결과: 1개 오류, 1개 경고')).toBeNull();
+  });
+
+  it('Ctrl+S와 Cmd+S 저장 단축키만 저장 액션을 실행한다', () => {
+    const onSave = vi.fn();
+
+    render(
+      <EditorLayout
+        theme={baseTheme}
+        themeId="theme-1"
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'a', ctrlKey: true });
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true });
+    fireEvent.keyDown(window, { key: 's', metaKey: true });
+
+    expect(onSave).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -37,6 +37,19 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("EditorTabNav dynamic tabs", () => {
+  it("선택된 탭을 모바일 가로 탭바 중앙으로 자동 스크롤한다", () => {
+    const scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    mockActiveTab.current = "media";
+
+    render(<EditorTabNav activeModules={[]} />);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      inline: "center",
+    });
+  });
+
   it("모듈 미지정 시 always=true 탭만 표시된다", () => {
     render(<EditorTabNav />);
     expect(screen.getByText("스토리 진행")).toBeDefined();

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 // ---------------------------------------------------------------------------
@@ -26,10 +26,31 @@ vi.mock("../../stores/editorUIStore", () => ({
 
 import { EditorTabNav } from "../EditorTabNav";
 
+const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+
+beforeAll(() => {
+  if (!originalScrollIntoView) {
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: () => {},
+    });
+  }
+});
+
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
   mockActiveTab.current = "storyMap";
+});
+
+afterAll(() => {
+  if (originalScrollIntoView) {
+    window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    return;
+  }
+
+  delete window.HTMLElement.prototype.scrollIntoView;
 });
 
 // ---------------------------------------------------------------------------
@@ -38,8 +59,9 @@ afterEach(() => {
 
 describe("EditorTabNav dynamic tabs", () => {
   it("선택된 탭을 모바일 가로 탭바 중앙으로 자동 스크롤한다", () => {
-    const scrollIntoView = vi.fn();
-    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    const scrollIntoView = vi
+      .spyOn(window.HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
     mockActiveTab.current = "media";
 
     render(<EditorTabNav activeModules={[]} />);

--- a/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
+++ b/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
@@ -171,7 +171,7 @@ function LibrarySectionPanel({
 }) {
   const Icon = section.icon;
   return (
-    <div className="rounded-md border border-slate-800 bg-slate-900/70 p-3">
+    <div className="min-w-[16rem] rounded-md border border-slate-800 bg-slate-900/70 p-3 sm:min-w-0">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
           <Icon className="h-4 w-4 text-amber-400" />
@@ -182,7 +182,7 @@ function LibrarySectionPanel({
         </span>
       </div>
 
-      <div className="mt-3 space-y-2">
+      <div className="mt-3 max-h-52 space-y-2 overflow-y-auto pr-1 sm:max-h-none sm:overflow-visible sm:pr-0">
         {section.isLoading && (
           <p className="rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-xs text-slate-400">
             목록을 불러오는 중입니다.
@@ -274,7 +274,7 @@ export function EditorEntityLibrary({
         <FileText className="h-4 w-4 text-amber-400" />
         <h3 className="text-sm font-semibold text-slate-100">제작 라이브러리</h3>
       </div>
-      <div className="space-y-3 p-4">
+      <div className="flex gap-3 overflow-x-auto p-4 [scrollbar-width:none] sm:grid sm:grid-cols-2 sm:overflow-visible lg:block lg:space-y-3 [&::-webkit-scrollbar]:hidden">
         {sections.map((section) => (
           <LibrarySectionPanel
             key={section.key}

--- a/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
+++ b/apps/web/src/features/editor/components/story-map/SceneInspector.tsx
@@ -188,7 +188,7 @@ export function SceneInspector({
         <MapPin className="h-4 w-4 text-amber-400" />
         <h3 className="text-sm font-semibold text-slate-100">장면 속성</h3>
       </div>
-      <div className="space-y-3 p-4">
+      <div className="grid gap-3 p-4 sm:grid-cols-2 lg:block lg:space-y-3">
         <div className="rounded-md border border-slate-800 bg-slate-900/70 p-4">
           <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
             <Link2 className="h-4 w-4 text-amber-400" />
@@ -223,7 +223,7 @@ export function SceneInspector({
           )}
         </div>
 
-        <div className="space-y-2">
+        <div className="grid gap-2 sm:col-span-2 sm:grid-cols-2 lg:block lg:space-y-2">
           {rows.map((row, index) => {
             const Icon = ROW_ICONS[index];
             return (

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -35,9 +35,9 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
   return (
     <section
       aria-label="스토리 진행 제작"
-      className="flex h-full min-h-[calc(100vh-9.5rem)] flex-col overflow-y-auto bg-slate-950 text-slate-100 lg:overflow-hidden"
+      className="flex h-full min-h-[calc(100vh-9.75rem)] flex-col overflow-y-auto bg-slate-950 text-slate-100 lg:overflow-hidden"
     >
-      <div className="border-b border-slate-800 px-4 py-4 sm:px-6">
+      <div className="border-b border-slate-800 px-4 py-3 sm:px-6 sm:py-4">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-400">
@@ -45,17 +45,17 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
             </p>
             <h2 className="mt-1 text-xl font-semibold text-slate-50">스토리 진행 제작</h2>
           </div>
-          <div className="grid grid-cols-2 gap-2 text-xs text-slate-300 sm:flex">
-            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+          <div className="flex gap-2 overflow-x-auto pb-1 text-xs text-slate-300 [scrollbar-width:none] sm:grid sm:grid-cols-4 sm:overflow-visible sm:pb-0 lg:flex [&::-webkit-scrollbar]:hidden">
+            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
               장면 흐름
             </span>
-            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
               단서 연결
             </span>
-            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
               진행 조건
             </span>
-            <span className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
+            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
               연출 점검
             </span>
           </div>
@@ -71,7 +71,7 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
           onSelectEntity={setSelectedEntity}
         />
 
-        <main className="min-h-[520px] min-w-0 flex-1 border-b border-slate-800 lg:min-h-0 lg:overflow-hidden lg:border-b-0">
+        <main className="min-h-[430px] min-w-0 flex-1 border-b border-slate-800 sm:min-h-[520px] lg:min-h-0 lg:overflow-hidden lg:border-b-0">
           <FlowCanvas themeId={themeId} onSelectedNodeChange={handleSelectedNodeChange} />
         </main>
 

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -115,7 +115,9 @@ describe("StoryMapWorkspace", () => {
     expect(screen.getByRole("heading", { name: "제작 라이브러리" }).closest("aside")?.className).toContain(
       "lg:overflow-y-auto",
     );
+    expect(screen.getByRole("heading", { name: "제작 라이브러리" }).closest("aside")?.querySelector("div[class*='overflow-x-auto']")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "장면 속성" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "장면 속성" }).closest("aside")?.querySelector("div[class*='sm:grid-cols-2']")).toBeTruthy();
     expect(screen.getByTestId("flow-canvas").textContent).toContain("theme-1");
   });
 


### PR DESCRIPTION
## 요약
- 모바일 상단 헤더와 에디터 탭을 압축하고, 선택된 탭이 가로 탭바 중앙으로 자동 스크롤되도록 했습니다.
- 스토리 진행 화면의 제작 라이브러리를 모바일에서 가로 카드형으로 줄이고, 장면 속성은 모바일/태블릿에서 읽기 쉬운 카드 그리드로 재배치했습니다.
- 모바일 smoke가 `/editor/:id/story` 스토리 진행 화면의 라이브러리, 장면 속성, Flow canvas까지 확인하도록 확장했습니다.

Closes #461
Refs #463

## Coverage Plan
- 모바일 탭 내비게이션: `EditorTabNav.test.tsx`에서 선택 탭 자동 스크롤을 검증했습니다.
- 스토리 진행 모바일 레이아웃: `StoryMapWorkspace.test.tsx`에서 라이브러리/속성 패널의 responsive container를 검증했습니다.
- 실제 모바일 smoke: `editor-golden-path.spec.ts`에서 캐릭터/미디어 컨트롤과 `/story` 스토리 진행 화면의 주요 패널 및 page-level horizontal overflow를 확인했습니다.

## 검증
- `pnpm --filter @mmp/web exec tsc --noEmit`
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/EditorTabNav.test.tsx src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx` (2 files, 16 tests)
- `pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium` (15 passed)

## 후속
- 통합 미디어 관리/선택 모달 UX는 #463에서 별도 진행합니다.

## CI 운영
- PR 생성 시 `ready-for-ci` 라벨은 붙이지 않았습니다.
- CodeRabbit 리뷰 정리 후 `scripts/mmp-pr-ci-scope.sh`로 scope를 분류하고 필요한 경우에만 full CI를 실행합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 에디터 탭 활성 시 자동으로 현재 탭을 가운데로 스크롤

* **개선 사항**
  * 헤더·탭·워크스페이스·라이브러리·인스펙터의 반응형 레이아웃·간격 개선
  * 소형 화면에서 라이브러리 목록 가로 스크롤 지원
  * 헤더 버튼·저장 표시 등 표시 조건 및 배치 조정

* **테스트**
  * E2E에 모바일 헤더 및 스토리 편집기 가시성 검증 추가
  * 탭 스크롤·레이아웃·헤더 동작 관련 단위/통합 테스트 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->