### PR TITLE
feat(editor): 통합 미디어 교체와 참조 미리보기 연결

### DIFF
--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react';
-import { AlertTriangle, X, Trash2, Save } from 'lucide-react';
+import { AlertTriangle, Link2, RefreshCw, X, Trash2, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useDeleteMedia,
   useMediaCategories,
+  useMediaDeletePreview,
   useUpdateMedia,
   type MediaReferenceInfo,
   type MediaResponse,
   type UpdateMediaRequest,
 } from '@/features/editor/mediaApi';
 import { ApiHttpError } from '@/lib/api-error';
+import { MediaReplaceModal } from './MediaReplaceModal';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -34,6 +36,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
     media.duration != null ? String(media.duration) : ''
   );
   const [referenceWarning, setReferenceWarning] = useState<MediaReferenceInfo[] | null>(null);
+  const [replaceOpen, setReplaceOpen] = useState(false);
 
   // Reset local state when selected media changes
   useEffect(() => {
@@ -43,11 +46,15 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
     setCategoryId(media.category_id ?? '');
     setDuration(media.duration != null ? String(media.duration) : '');
     setReferenceWarning(null);
+    setReplaceOpen(false);
   }, [media.id, media.name, media.tags, media.sort_order, media.category_id, media.duration]);
 
   const updateMutation = useUpdateMedia(themeId);
   const deleteMutation = useDeleteMedia(themeId);
   const { data: categories = [] } = useMediaCategories(themeId);
+  const { data: deletePreview, isLoading: deletePreviewLoading } = useMediaDeletePreview(media.id);
+  const references = deletePreview?.references ?? [];
+  const canReplaceFile = media.source_type === 'FILE' && media.type !== 'VIDEO';
 
   const handleSave = () => {
     const trimmedName = name.trim();
@@ -185,6 +192,8 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
           )}
         </dl>
 
+        <MediaReferencesPreview references={references} loading={deletePreviewLoading} />
+
         {referenceWarning && (
           <div
             role="alert"
@@ -224,15 +233,77 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
           <Trash2 className="h-3.5 w-3.5" />
           삭제
         </button>
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={updateMutation.isPending}
-          className="flex h-8 items-center gap-1.5 rounded-sm bg-amber-600 px-3 text-xs font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          <Save className="h-3.5 w-3.5" />
-          저장
-        </button>
+        <div className="flex items-center gap-2">
+          {canReplaceFile && (
+            <button
+              type="button"
+              onClick={() => setReplaceOpen(true)}
+              className="flex h-8 items-center gap-1.5 rounded-sm border border-slate-700 px-3 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 hover:text-slate-100"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              교체
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={updateMutation.isPending}
+            className="flex h-8 items-center gap-1.5 rounded-sm bg-amber-600 px-3 text-xs font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Save className="h-3.5 w-3.5" />
+            저장
+          </button>
+        </div>
+      </div>
+      <MediaReplaceModal
+        open={replaceOpen}
+        onClose={() => setReplaceOpen(false)}
+        themeId={themeId}
+        media={media}
+        onReplaced={() => toast.success('파일을 교체했습니다')}
+      />
+    </div>
+  );
+}
+
+function MediaReferencesPreview({
+  references,
+  loading,
+}: {
+  references: MediaReferenceInfo[];
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="rounded-sm border border-slate-800 bg-slate-950/40 px-3 py-2 text-xs text-slate-500">
+        사용 위치 확인 중...
+      </div>
+    );
+  }
+  if (references.length === 0) {
+    return (
+      <div className="rounded-sm border border-slate-800 bg-slate-950/40 px-3 py-2 text-xs text-slate-500">
+        아직 연결된 제작 요소가 없습니다.
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-sm border border-amber-900/60 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">
+      <div className="flex items-start gap-2">
+        <Link2 className="mt-0.5 h-3.5 w-3.5 flex-none text-amber-400" />
+        <div className="min-w-0">
+          <p className="font-medium">사용 중인 위치 {references.length}개</p>
+          <p className="mt-1 text-[11px] text-amber-200/80">
+            삭제하면 아래 연결도 함께 해제됩니다. 교체는 연결을 유지합니다.
+          </p>
+          <ul className="mt-2 space-y-1">
+            {references.slice(0, 5).map((ref, index) => (
+              <li key={`${ref.type}-${ref.id}-${index}`} className="break-words">
+                <span className="font-medium">{mediaReferenceTypeLabel(ref.type)}</span>: {ref.name}
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/media/MediaReplaceModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaReplaceModal.tsx
@@ -1,0 +1,314 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type KeyboardEvent,
+} from "react";
+import { RefreshCw, X } from "lucide-react";
+
+import {
+  useConfirmReplacementUpload,
+  useRequestReplacementUpload,
+  type MediaResponse,
+  type MediaType,
+} from "@/features/editor/mediaApi";
+import { replaceMediaFile } from "@/features/editor/mediaReplaceUpload";
+import { getDisplayErrorMessage } from "@/lib/display-error";
+
+interface MediaReplaceModalProps {
+  open: boolean;
+  onClose: () => void;
+  themeId: string;
+  media: MediaResponse;
+  onReplaced?: (media: MediaResponse) => void;
+}
+
+const MAX_SIZE = 20 * 1024 * 1024;
+const MIME_BY_TYPE: Record<MediaType, string[]> = {
+  BGM: ["audio/mpeg", "audio/wav", "audio/ogg"],
+  SFX: ["audio/mpeg", "audio/wav", "audio/ogg"],
+  VOICE: ["audio/mpeg", "audio/wav", "audio/ogg"],
+  IMAGE: ["image/jpeg", "image/png", "image/webp"],
+  DOCUMENT: ["application/pdf"],
+  VIDEO: [],
+};
+
+export function MediaReplaceModal({
+  open,
+  onClose,
+  themeId,
+  media,
+  onReplaced,
+}: MediaReplaceModalProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const inputId = `media-replace-input-${media.id}`;
+  const controllerRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+  const requestReplacementMutation = useRequestReplacementUpload(media.id);
+  const confirmReplacementMutation = useConfirmReplacementUpload(themeId, media.id);
+  const acceptedMimeTypes = useMemo(() => MIME_BY_TYPE[media.type] ?? [], [media.type]);
+  const canReplace = media.source_type === "FILE" && acceptedMimeTypes.length > 0;
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+      setFile(null);
+      setIsDragging(false);
+      setUploading(false);
+      setProgress(0);
+      setError(null);
+    }
+  }, [open]);
+
+  const handleFile = (nextFile: File) => {
+    if (!canReplace) {
+      setError("이 미디어는 파일 교체를 지원하지 않습니다");
+      return;
+    }
+    if (nextFile.size > MAX_SIZE) {
+      setError("파일 크기는 20MB 이하여야 합니다");
+      return;
+    }
+    if (!acceptedMimeTypes.includes(nextFile.type)) {
+      setError(`현재 ${mediaTypeLabel(media.type)}와 같은 형식만 교체할 수 있습니다`);
+      return;
+    }
+    setError(null);
+    setFile(nextFile);
+  };
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextFile = event.target.files?.[0];
+    if (nextFile) handleFile(nextFile);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    const nextFile = event.dataTransfer.files?.[0];
+    if (nextFile) handleFile(nextFile);
+  };
+
+  const openFilePicker = () => {
+    document.getElementById(inputId)?.click();
+  };
+
+  const handleDropzoneKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openFilePicker();
+    }
+  };
+
+  const handleReplace = async () => {
+    if (!file) return;
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    setUploading(true);
+    setError(null);
+    setProgress(0);
+    try {
+      const replaced = await replaceMediaFile({
+        file,
+        requestReplacementUpload: requestReplacementMutation.mutateAsync,
+        confirmReplacementUpload: confirmReplacementMutation.mutateAsync,
+        onProgress: (nextProgress) => {
+          if (isMountedRef.current && !controller.signal.aborted) {
+            setProgress(nextProgress);
+          }
+        },
+        signal: controller.signal,
+      });
+      if (!isMountedRef.current || controller.signal.aborted) return;
+      onReplaced?.(replaced);
+      onClose();
+    } catch (err) {
+      if (!isMountedRef.current || controller.signal.aborted) return;
+      setError(getDisplayErrorMessage(err, "파일 교체 실패"));
+    } finally {
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+      }
+      if (isMountedRef.current) {
+        setUploading(false);
+      }
+    }
+  };
+
+  const handleAbort = () => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    setUploading(false);
+    setProgress(0);
+    setError("파일 교체가 취소되었습니다");
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-3 sm:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="미디어 파일 교체"
+    >
+      <div className="max-h-[92vh] w-full max-w-md overflow-y-auto rounded-lg border border-slate-700 bg-slate-900 p-4 shadow-2xl shadow-black/40 sm:p-6">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h2 className="flex min-w-0 items-center gap-2 text-base font-semibold text-slate-100 sm:text-lg">
+            <RefreshCw className="h-5 w-5 shrink-0 text-amber-400" />
+            <span className="truncate">파일 교체</span>
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={uploading}
+            aria-label="닫기"
+            className="rounded-sm p-1 text-slate-400 hover:bg-slate-800 hover:text-slate-200 disabled:opacity-50"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="mb-3 rounded-sm border border-slate-800 bg-slate-950/60 px-3 py-2 text-xs text-slate-300">
+          <p className="truncate font-medium text-slate-100">{media.name}</p>
+          <p className="mt-1 text-slate-500">
+            같은 {mediaTypeLabel(media.type)} 파일로 교체하면 기존 연결은 유지됩니다.
+          </p>
+        </div>
+
+        <div
+          className={`cursor-pointer rounded-md border-2 border-dashed p-5 text-center transition ${
+            isDragging
+              ? "border-amber-400 bg-amber-500/10"
+              : "border-slate-700 hover:border-slate-500"
+          } ${!canReplace ? "cursor-not-allowed opacity-50" : ""}`}
+          onDragEnter={(event) => {
+            event.preventDefault();
+            setIsDragging(true);
+          }}
+          onDragOver={(event) => event.preventDefault()}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          onClick={canReplace ? openFilePicker : undefined}
+          onKeyDown={handleDropzoneKeyDown}
+          role="button"
+          tabIndex={canReplace ? 0 : -1}
+          aria-label="교체 파일 드롭 영역"
+        >
+          <RefreshCw className="mx-auto mb-2 h-8 w-8 text-slate-500" />
+          {file ? (
+            <>
+              <p className="text-sm font-medium text-slate-100">{file.name}</p>
+              <p className="mt-1 text-xs text-slate-500">{formatFileSize(file.size)}</p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-slate-200">교체할 파일을 선택하세요</p>
+              <p className="mt-1 text-xs text-slate-500">
+                {acceptedMimeTypes.length > 0
+                  ? acceptedMimeTypesLabel(acceptedMimeTypes)
+                  : "이 유형은 파일 교체를 지원하지 않습니다"}
+              </p>
+            </>
+          )}
+          <input
+            id={inputId}
+            type="file"
+            accept={acceptedMimeTypes.join(",")}
+            className="hidden"
+            onChange={handleInputChange}
+            disabled={uploading || !canReplace}
+          />
+        </div>
+
+        {uploading && (
+          <div className="mt-4">
+            <div className="mb-1 flex justify-between text-xs text-slate-400">
+              <span>교체 중</span>
+              <span>{progress}%</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-slate-700">
+              <div
+                className="h-full bg-amber-500 transition-all"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div
+            className="mt-4 rounded border border-rose-500/40 bg-rose-500/20 p-2 text-sm text-rose-200"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={uploading ? handleAbort : onClose}
+            className="h-9 rounded-sm border border-slate-700 px-4 text-sm text-slate-300 hover:border-slate-500 hover:text-slate-100"
+          >
+            {uploading ? "취소" : "닫기"}
+          </button>
+          <button
+            type="button"
+            onClick={handleReplace}
+            disabled={!file || uploading || !canReplace}
+            className="h-9 rounded-sm bg-amber-500 px-4 text-sm font-medium text-slate-950 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {uploading ? "교체 중" : "교체"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function mediaTypeLabel(type: MediaType): string {
+  switch (type) {
+    case "BGM":
+      return "배경음악";
+    case "SFX":
+      return "효과음";
+    case "VOICE":
+      return "음성";
+    case "IMAGE":
+      return "이미지";
+    case "DOCUMENT":
+      return "문서";
+    case "VIDEO":
+      return "영상";
+  }
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function acceptedMimeTypesLabel(mimeTypes: string[]): string {
+  return mimeTypes.map((mime) => mime.split("/")[1]?.toUpperCase() ?? mime).join(", ");
+}

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -346,6 +346,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
         open={youtubeOpen}
         onClose={() => setYoutubeOpen(false)}
         themeId={themeId}
+        categoryId={categoryId}
       />
       <BulkDeleteDialog
         open={deleteDialogOpen}

--- a/apps/web/src/features/editor/components/media/YouTubeAddModal.tsx
+++ b/apps/web/src/features/editor/components/media/YouTubeAddModal.tsx
@@ -15,6 +15,7 @@ export interface YouTubeAddModalProps {
   open: boolean;
   onClose: () => void;
   themeId: string;
+  categoryId?: string | null;
 }
 
 type YouTubeMediaType = Extract<MediaType, "BGM" | "VIDEO">;
@@ -27,6 +28,7 @@ export function YouTubeAddModal({
   open,
   onClose,
   themeId,
+  categoryId,
 }: YouTubeAddModalProps) {
   const [url, setUrl] = useState("");
   const [name, setName] = useState("");
@@ -60,7 +62,12 @@ export function YouTubeAddModal({
     setCreating(true);
     setError(null);
     try {
-      await createMutation.mutateAsync({ url, name: name.trim(), type });
+      await createMutation.mutateAsync({
+        url,
+        name: name.trim(),
+        type,
+        ...(categoryId ? { category_id: categoryId } : {}),
+      });
       onClose();
     } catch (err) {
       const message =

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -10,8 +10,11 @@ const {
   useMediaCategoriesMock,
   useCreateMediaCategoryMock,
   useDeleteMediaCategoryMock,
+  useMediaDeletePreviewMock,
   useUpdateMediaMock,
   useDeleteMediaMock,
+  useRequestReplacementUploadMock,
+  useConfirmReplacementUploadMock,
   useRequestUploadUrlMock,
   useConfirmUploadMock,
   useCreateYouTubeMediaMock,
@@ -22,8 +25,11 @@ const {
   useMediaCategoriesMock: vi.fn(),
   useCreateMediaCategoryMock: vi.fn(),
   useDeleteMediaCategoryMock: vi.fn(),
+  useMediaDeletePreviewMock: vi.fn(),
   useUpdateMediaMock: vi.fn(),
   useDeleteMediaMock: vi.fn(),
+  useRequestReplacementUploadMock: vi.fn(),
+  useConfirmReplacementUploadMock: vi.fn(),
   useRequestUploadUrlMock: vi.fn(),
   useConfirmUploadMock: vi.fn(),
   useCreateYouTubeMediaMock: vi.fn(),
@@ -36,8 +42,11 @@ vi.mock('@/features/editor/mediaApi', () => ({
   useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
   useCreateMediaCategory: () => useCreateMediaCategoryMock(),
   useDeleteMediaCategory: () => useDeleteMediaCategoryMock(),
+  useMediaDeletePreview: (...args: unknown[]) => useMediaDeletePreviewMock(...args),
   useUpdateMedia: () => useUpdateMediaMock(),
   useDeleteMedia: () => useDeleteMediaMock(),
+  useRequestReplacementUpload: () => useRequestReplacementUploadMock(),
+  useConfirmReplacementUpload: () => useConfirmReplacementUploadMock(),
   useRequestUploadUrl: () => useRequestUploadUrlMock(),
   useConfirmUpload: () => useConfirmUploadMock(),
   useCreateYouTubeMedia: () => useCreateYouTubeMediaMock(),
@@ -135,8 +144,11 @@ beforeEach(() => {
   });
   useCreateMediaCategoryMock.mockReturnValue(mutationStub());
   useDeleteMediaCategoryMock.mockReturnValue(mutationStub());
+  useMediaDeletePreviewMock.mockReturnValue({ data: { references: [] }, isLoading: false });
   useUpdateMediaMock.mockReturnValue(mutationStub());
   useDeleteMediaMock.mockReturnValue(mutationStub());
+  useRequestReplacementUploadMock.mockReturnValue(mutationStub());
+  useConfirmReplacementUploadMock.mockReturnValue(mutationStub());
   useRequestUploadUrlMock.mockReturnValue(mutationStub());
   useConfirmUploadMock.mockReturnValue(mutationStub());
   useCreateYouTubeMediaMock.mockReturnValue(mutationStub());
@@ -338,6 +350,40 @@ describe('MediaTab', () => {
     expect(screen.queryByText('source: FILE')).toBeNull();
     expect(screen.queryByText('mime: audio/mpeg')).toBeNull();
     expect(screen.queryByText('size: 1234567 B')).toBeNull();
+    expect(screen.getByText('아직 연결된 제작 요소가 없습니다.')).toBeDefined();
+    expect(screen.getByRole('button', { name: '교체' })).toBeDefined();
+  });
+
+  it('상세 패널은 삭제 전 사용 위치와 파일 교체 모달을 보여준다', () => {
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+    useMediaDeletePreviewMock.mockReturnValue({
+      data: {
+        references: [
+          {
+            type: 'reading_section',
+            id: 'reading-1',
+            name: '공통 오프닝 읽기 대사',
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    render(<MediaTab themeId="theme-1" />);
+
+    const card = screen.getByText('오프닝 BGM').closest("[role='button']") as HTMLElement | null;
+    fireEvent.click(card!);
+
+    expect(screen.getByText('사용 중인 위치 1개')).toBeDefined();
+    expect(screen.getByText(/공통 오프닝 읽기 대사/)).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: '교체' }));
+    expect(screen.getByRole('dialog', { name: '미디어 파일 교체' })).toBeDefined();
+    expect(screen.getByText('같은 배경음악 파일로 교체하면 기존 연결은 유지됩니다.')).toBeDefined();
   });
 
   it('상세 닫기 버튼이 선택을 해제한다', () => {

--- a/apps/web/src/features/editor/components/media/__tests__/YouTubeAddModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/YouTubeAddModal.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ComponentProps } from "react";
 import {
   cleanup,
   fireEvent,
@@ -26,7 +27,11 @@ vi.mock("@/features/editor/mediaApi", async () => {
   };
 });
 
-function renderModal(open = true, onClose = vi.fn()) {
+function renderModal(
+  open = true,
+  onClose = vi.fn(),
+  props: Partial<ComponentProps<typeof YouTubeAddModal>> = {},
+) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -34,7 +39,7 @@ function renderModal(open = true, onClose = vi.fn()) {
     onClose,
     ...render(
       <QueryClientProvider client={qc}>
-        <YouTubeAddModal open={open} onClose={onClose} themeId="theme-1" />
+        <YouTubeAddModal open={open} onClose={onClose} themeId="theme-1" {...props} />
       </QueryClientProvider>,
     ),
   };
@@ -174,6 +179,26 @@ describe("YouTubeAddModal", () => {
         url: "https://youtu.be/dQw4w9WgXcQ",
         name: "Cutscene",
         type: "VIDEO",
+      }),
+    );
+  });
+
+  it("선택한 카테고리가 있으면 YouTube 생성 payload에 포함한다", async () => {
+    mockMutateAsync.mockResolvedValueOnce({});
+    renderModal(true, vi.fn(), { categoryId: "category-screen" });
+    fireEvent.change(screen.getByLabelText("YouTube URL"), {
+      target: { value: "https://youtu.be/dQw4w9WgXcQ" },
+    });
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "Screen Clip" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "추가" }));
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        url: "https://youtu.be/dQw4w9WgXcQ",
+        name: "Screen Clip",
+        type: "BGM",
+        category_id: "category-screen",
       }),
     );
   });

--- a/apps/web/src/features/editor/mediaReplaceUpload.test.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { replaceMediaFile } from "./mediaReplaceUpload";
+
+describe("replaceMediaFile", () => {
+  it("교체 업로드 URL 요청, PUT, confirm 순서로 media id 유지 교체를 완료한다", async () => {
+    const file = new File(["image"], "evidence.png", { type: "image/png" });
+    const requestReplacementUpload = vi.fn().mockResolvedValue({
+      upload_id: "replace-upload-1",
+      upload_url: "https://upload.example.com/replacement",
+      expires_at: "2026-05-07T00:00:00Z",
+    });
+    const putFile = vi.fn().mockResolvedValue(undefined);
+    const confirmReplacementUpload = vi.fn().mockResolvedValue({
+      id: "media-1",
+      name: "증거 사진",
+      type: "IMAGE",
+      source_type: "FILE",
+      tags: [],
+      sort_order: 1,
+      created_at: "2026-05-07T00:00:00Z",
+    });
+    const onProgress = vi.fn();
+
+    const result = await replaceMediaFile({
+      file,
+      requestReplacementUpload,
+      confirmReplacementUpload,
+      putFile,
+      onProgress,
+    });
+
+    expect(requestReplacementUpload).toHaveBeenCalledWith({
+      mime_type: "image/png",
+      file_size: file.size,
+    });
+    expect(putFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://upload.example.com/replacement",
+        file,
+        contentType: "image/png",
+        onProgress,
+      }),
+    );
+    expect(confirmReplacementUpload).toHaveBeenCalledWith({
+      upload_id: "replace-upload-1",
+    });
+    expect(result.id).toBe("media-1");
+  });
+
+  it("PUT 네트워크 실패는 지정 횟수만큼 재시도한다", async () => {
+    const file = new File(["voice"], "voice.mp3", { type: "audio/mpeg" });
+    const requestReplacementUpload = vi.fn().mockResolvedValue({
+      upload_id: "replace-upload-2",
+      upload_url: "https://upload.example.com/retry",
+      expires_at: "2026-05-07T00:00:00Z",
+    });
+    const putFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce(undefined);
+    const confirmReplacementUpload = vi.fn().mockResolvedValue({
+      id: "media-2",
+      name: "보이스",
+      type: "VOICE",
+      source_type: "FILE",
+      tags: [],
+      sort_order: 1,
+      created_at: "2026-05-07T00:00:00Z",
+    });
+
+    await replaceMediaFile({
+      file,
+      requestReplacementUpload,
+      confirmReplacementUpload,
+      putFile,
+      retryBaseDelayMs: 0,
+    });
+
+    expect(putFile).toHaveBeenCalledTimes(2);
+    expect(confirmReplacementUpload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/editor/mediaReplaceUpload.test.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.test.ts
@@ -110,4 +110,25 @@ describe("replaceMediaFile", () => {
     expect(putFile).toHaveBeenCalledTimes(1);
     expect(confirmReplacementUpload).not.toHaveBeenCalled();
   });
+
+  it("maxAttempts가 1 미만이면 업로드 URL 요청 없이 실패한다", async () => {
+    const file = new File(["image"], "evidence.png", { type: "image/png" });
+    const requestReplacementUpload = vi.fn();
+    const putFile = vi.fn();
+    const confirmReplacementUpload = vi.fn();
+
+    await expect(
+      replaceMediaFile({
+        file,
+        requestReplacementUpload,
+        confirmReplacementUpload,
+        putFile,
+        maxAttempts: 0,
+      }),
+    ).rejects.toThrow("maxAttempts는 1 이상의 정수여야 합니다");
+
+    expect(requestReplacementUpload).not.toHaveBeenCalled();
+    expect(putFile).not.toHaveBeenCalled();
+    expect(confirmReplacementUpload).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/editor/mediaReplaceUpload.test.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.test.ts
@@ -80,4 +80,34 @@ describe("replaceMediaFile", () => {
     expect(putFile).toHaveBeenCalledTimes(2);
     expect(confirmReplacementUpload).toHaveBeenCalledTimes(1);
   });
+
+  it("취소된 PUT 실패는 재시도하지 않고 confirm도 호출하지 않는다", async () => {
+    const file = new File(["voice"], "voice.mp3", { type: "audio/mpeg" });
+    const abortController = new AbortController();
+    const abortError = new DOMException("aborted", "AbortError");
+    const requestReplacementUpload = vi.fn().mockResolvedValue({
+      upload_id: "replace-upload-abort",
+      upload_url: "https://upload.example.com/abort",
+      expires_at: "2026-05-07T00:00:00Z",
+    });
+    const putFile = vi.fn().mockImplementation(() => {
+      abortController.abort();
+      return Promise.reject(abortError);
+    });
+    const confirmReplacementUpload = vi.fn();
+
+    await expect(
+      replaceMediaFile({
+        file,
+        requestReplacementUpload,
+        confirmReplacementUpload,
+        putFile,
+        signal: abortController.signal,
+        retryBaseDelayMs: 0,
+      }),
+    ).rejects.toBe(abortError);
+
+    expect(putFile).toHaveBeenCalledTimes(1);
+    expect(confirmReplacementUpload).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/editor/mediaReplaceUpload.test.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.test.ts
@@ -111,6 +111,57 @@ describe("replaceMediaFile", () => {
     expect(confirmReplacementUpload).not.toHaveBeenCalled();
   });
 
+  it("이미 취소된 상태에서는 업로드 URL 요청을 시작하지 않는다", async () => {
+    const file = new File(["image"], "evidence.png", { type: "image/png" });
+    const abortController = new AbortController();
+    abortController.abort();
+    const requestReplacementUpload = vi.fn();
+    const putFile = vi.fn();
+    const confirmReplacementUpload = vi.fn();
+
+    await expect(
+      replaceMediaFile({
+        file,
+        requestReplacementUpload,
+        confirmReplacementUpload,
+        putFile,
+        signal: abortController.signal,
+      }),
+    ).rejects.toThrow("업로드가 취소되었습니다");
+
+    expect(requestReplacementUpload).not.toHaveBeenCalled();
+    expect(putFile).not.toHaveBeenCalled();
+    expect(confirmReplacementUpload).not.toHaveBeenCalled();
+  });
+
+  it("PUT 성공 후 취소되면 confirm을 호출하지 않는다", async () => {
+    const file = new File(["image"], "evidence.png", { type: "image/png" });
+    const abortController = new AbortController();
+    const requestReplacementUpload = vi.fn().mockResolvedValue({
+      upload_id: "replace-upload-cancel-before-confirm",
+      upload_url: "https://upload.example.com/cancel-before-confirm",
+      expires_at: "2026-05-07T00:00:00Z",
+    });
+    const putFile = vi.fn().mockImplementation(() => {
+      abortController.abort();
+      return Promise.resolve();
+    });
+    const confirmReplacementUpload = vi.fn();
+
+    await expect(
+      replaceMediaFile({
+        file,
+        requestReplacementUpload,
+        confirmReplacementUpload,
+        putFile,
+        signal: abortController.signal,
+      }),
+    ).rejects.toThrow("업로드가 취소되었습니다");
+
+    expect(putFile).toHaveBeenCalledTimes(1);
+    expect(confirmReplacementUpload).not.toHaveBeenCalled();
+  });
+
   it("maxAttempts가 1 미만이면 업로드 URL 요청 없이 실패한다", async () => {
     const file = new File(["image"], "evidence.png", { type: "image/png" });
     const requestReplacementUpload = vi.fn();

--- a/apps/web/src/features/editor/mediaReplaceUpload.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.ts
@@ -26,6 +26,12 @@ export interface ReplaceMediaFileParams {
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+const throwIfAborted = (signal?: AbortSignal): void => {
+  if (signal?.aborted) {
+    throw new Error("업로드가 취소되었습니다");
+  }
+};
+
 export async function replaceMediaFile(
   params: ReplaceMediaFileParams,
 ): Promise<MediaResponse> {
@@ -47,16 +53,16 @@ export async function replaceMediaFile(
   const effectiveMimeType =
     (mimeType ?? file.type) || "application/octet-stream";
 
+  throwIfAborted(signal);
   const uploadUrl = await requestReplacementUpload({
     mime_type: effectiveMimeType,
     file_size: file.size,
   });
+  throwIfAborted(signal);
 
   let lastError: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    if (signal?.aborted) {
-      throw new Error("업로드가 취소되었습니다");
-    }
+    throwIfAborted(signal);
     try {
       await putFile({
         url: uploadUrl.upload_url,
@@ -74,6 +80,7 @@ export async function replaceMediaFile(
       }
       if (attempt < maxAttempts - 1) {
         await sleep(retryBaseDelayMs * 2 ** attempt);
+        throwIfAborted(signal);
       }
     }
   }
@@ -81,5 +88,6 @@ export async function replaceMediaFile(
     throw lastError;
   }
 
+  throwIfAborted(signal);
   return confirmReplacementUpload({ upload_id: uploadUrl.upload_id });
 }

--- a/apps/web/src/features/editor/mediaReplaceUpload.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.ts
@@ -1,0 +1,78 @@
+import {
+  defaultPutFile,
+  type ConfirmUploadRequest,
+  type MediaResponse,
+  type PutFileParams,
+  type RequestReplacementUploadRequest,
+  type UploadUrlResponse,
+} from "@/features/editor/mediaApi";
+
+export interface ReplaceMediaFileParams {
+  file: File;
+  requestReplacementUpload: (
+    req: RequestReplacementUploadRequest,
+  ) => Promise<UploadUrlResponse>;
+  confirmReplacementUpload: (
+    req: ConfirmUploadRequest,
+  ) => Promise<MediaResponse>;
+  onProgress?: (percent: number) => void;
+  signal?: AbortSignal;
+  putFile?: (params: PutFileParams) => Promise<void>;
+  mimeType?: string;
+  maxAttempts?: number;
+  retryBaseDelayMs?: number;
+}
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function replaceMediaFile(
+  params: ReplaceMediaFileParams,
+): Promise<MediaResponse> {
+  const {
+    file,
+    requestReplacementUpload,
+    confirmReplacementUpload,
+    onProgress,
+    signal,
+    putFile = defaultPutFile,
+    mimeType,
+    maxAttempts = 3,
+    retryBaseDelayMs = 200,
+  } = params;
+  const effectiveMimeType =
+    (mimeType ?? file.type) || "application/octet-stream";
+
+  const uploadUrl = await requestReplacementUpload({
+    mime_type: effectiveMimeType,
+    file_size: file.size,
+  });
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (signal?.aborted) {
+      throw new Error("업로드가 취소되었습니다");
+    }
+    try {
+      await putFile({
+        url: uploadUrl.upload_url,
+        file,
+        contentType: effectiveMimeType,
+        onProgress,
+        signal,
+      });
+      lastError = undefined;
+      break;
+    } catch (err) {
+      lastError = err;
+      if (attempt < maxAttempts - 1) {
+        await sleep(retryBaseDelayMs * 2 ** attempt);
+      }
+    }
+  }
+  if (lastError) {
+    throw lastError;
+  }
+
+  return confirmReplacementUpload({ upload_id: uploadUrl.upload_id });
+}

--- a/apps/web/src/features/editor/mediaReplaceUpload.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.ts
@@ -65,6 +65,9 @@ export async function replaceMediaFile(
       break;
     } catch (err) {
       lastError = err;
+      if (signal?.aborted) {
+        throw err;
+      }
       if (attempt < maxAttempts - 1) {
         await sleep(retryBaseDelayMs * 2 ** attempt);
       }

--- a/apps/web/src/features/editor/mediaReplaceUpload.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.ts
@@ -40,6 +40,10 @@ export async function replaceMediaFile(
     maxAttempts = 3,
     retryBaseDelayMs = 200,
   } = params;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error("maxAttempts는 1 이상의 정수여야 합니다");
+  }
+
   const effectiveMimeType =
     (mimeType ?? file.type) || "application/octet-stream";
 


### PR DESCRIPTION
## 요약
- 미디어 상세 패널에 삭제 전 사용 위치 preview를 연결했습니다.
- 파일 미디어는 같은 타입 파일로 교체할 수 있게 하고, backend replacement 계약으로 기존 media id/reference를 유지합니다.
- 선택한 미디어 카테고리가 파일 업로드뿐 아니라 YouTube 추가에도 이어지도록 연결했습니다.
- #465 backend 계약은 현재 main에 이미 구현되어 있어 검증 후 closed 처리했습니다.

Closes #463
Refs #465

## Coverage Plan
- `apps/web/src/features/editor/mediaReplaceUpload.ts`: replacement upload URL -> R2 PUT -> confirm 순서와 PUT 재시도 분기 Vitest로 검증
- `MediaDetail.tsx` / `MediaReplaceModal.tsx`: 상세 패널 사용 위치 preview, 교체 모달 진입, 연결 유지 안내를 `MediaTab.test.tsx`로 검증
- `YouTubeAddModal.tsx`: 선택 카테고리가 `category_id` payload로 전달되는지 검증
- 모바일/route smoke: 기존 `editor-golden-path.spec.ts`의 `/editor/:id/media` 및 모바일 overflow smoke 유지

## 검증
- `go test ./internal/domain/editor -run 'TestMedia(Service|Handler).*Category|TestMedia(Service|Handler).*Replacement|TestMedia(Service|Handler).*Delete|TestMediaSQLContract_CategoryReplacementAndReferenceCleanupIntegration'`\n- `pnpm --filter @mmp/web exec tsc --noEmit`\n- `pnpm --filter @mmp/web exec vitest run src/features/editor/mediaReplaceUpload.test.ts src/features/editor/mediaApi.test.ts src/features/editor/components/media/__tests__/MediaTab.test.tsx src/features/editor/components/media/__tests__/MediaPicker.test.tsx src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx src/features/editor/components/media/__tests__/YouTubeAddModal.test.tsx src/features/editor/components/media/__tests__/ResourcePicker.test.tsx`\n- `pnpm --filter @mmp/web _bootstrap:ws-client && pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium`\n\n## PR 묶음 판단\n- #463의 media management UX와 선택 모달 연결을 한 PR로 묶어 CI 반복 비용을 줄였습니다.\n- 서버 계약은 이미 main에 있어 backend 변경은 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 미디어 파일 교체: 파일 기반 미디어(동영상 제외)를 다른 파일로 교체 가능(파일 선택·드래그앤드롭, 키보드 접근성, 20MB 제한, 업로드 진행 표시·취소, 오류/성공 알림).
  - YouTube 카테고리 지정: YouTube 미디어 추가 시 카테고리 지정 가능.
  - 미디어 사용 현황 개선: 참조 기반 사용 위치를 상세히 표시하여 삭제/교체 가능 여부를 즉시 반영.

- **테스트**
  - 교체 업로드 흐름, 재시도 및 취소 시나리오를 포함한 테스트 추가/확장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->