### PR TITLE
feat(editor): 정보 본문 미디어 참조 저장

### DIFF
--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -192,7 +192,7 @@ func main() {
 	imageHandler := editor.NewImageHandler(imageSvc)
 	readingSvc := editor.NewReadingService(queries, logger)
 	readingHandler := editor.NewReadingHandler(readingSvc)
-	storyInfoSvc := editor.NewStoryInfoService(queries, logger)
+	storyInfoSvc := editor.NewStoryInfoService(queries, pool, logger)
 	storyInfoHandler := editor.NewStoryInfoHandler(storyInfoSvc, auditLog, logger)
 	adminSvc := admin.NewService(queries, logger)
 	friendSvc := social.NewFriendService(queries, logger)

--- a/apps/server/db/migrations/00042_story_info_media_refs.sql
+++ b/apps/server/db/migrations/00042_story_info_media_refs.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+
+ALTER TABLE story_infos
+ADD COLUMN content_format VARCHAR(32) NOT NULL DEFAULT 'mdx_v1'
+    CHECK (content_format IN ('mdx_v1'));
+
+CREATE TABLE story_info_media_refs (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    story_info_id UUID NOT NULL REFERENCES story_infos(id) ON DELETE CASCADE,
+    media_id      UUID NOT NULL REFERENCES theme_media(id) ON DELETE RESTRICT,
+    usage         VARCHAR(32) NOT NULL CHECK (usage IN ('cover', 'embedded_image', 'embedded_video')),
+    sort_order    INT NOT NULL DEFAULT 0,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_story_info_media_refs_story_info ON story_info_media_refs(story_info_id, sort_order);
+CREATE INDEX idx_story_info_media_refs_media ON story_info_media_refs(media_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS story_info_media_refs;
+
+ALTER TABLE story_infos
+DROP COLUMN IF EXISTS content_format;

--- a/apps/server/db/queries/story_infos.sql
+++ b/apps/server/db/queries/story_infos.sql
@@ -18,36 +18,51 @@ INSERT INTO story_infos (
   theme_id,
   title,
   body,
+  content_format,
   image_media_id,
   related_character_ids,
   related_clue_ids,
   related_location_ids,
   sort_order
 )
-SELECT $1, $2, $3, $4, $5, $6, $7, $8
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
 FROM themes t
-WHERE t.id = $1 AND t.creator_id = $9
+WHERE t.id = $1 AND t.creator_id = $10
 RETURNING *;
 
 -- name: UpdateStoryInfo :one
 UPDATE story_infos
 SET title = $2,
     body = $3,
-    image_media_id = $4,
-    related_character_ids = $5,
-    related_clue_ids = $6,
-    related_location_ids = $7,
-    sort_order = $8,
+    content_format = $4,
+    image_media_id = $5,
+    related_character_ids = $6,
+    related_clue_ids = $7,
+    related_location_ids = $8,
+    sort_order = $9,
     version = version + 1,
     updated_at = NOW()
 FROM themes t
 WHERE story_infos.id = $1
   AND story_infos.theme_id = t.id
-  AND t.creator_id = $10
-  AND story_infos.version = $9
+  AND t.creator_id = $11
+  AND story_infos.version = $10
 RETURNING story_infos.*;
 
 -- name: DeleteStoryInfoWithOwner :one
 DELETE FROM story_infos si USING themes t
 WHERE si.id = $1 AND si.theme_id = t.id AND t.creator_id = $2
 RETURNING si.theme_id;
+
+-- name: DeleteStoryInfoMediaRefs :exec
+DELETE FROM story_info_media_refs
+WHERE story_info_id = $1;
+
+-- name: CreateStoryInfoMediaRef :exec
+INSERT INTO story_info_media_refs (
+  story_info_id,
+  media_id,
+  usage,
+  sort_order
+)
+VALUES ($1, $2, $3, $4);

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -265,6 +265,16 @@ type StoryInfo struct {
 	Version             int32           `json:"version"`
 	CreatedAt           time.Time       `json:"created_at"`
 	UpdatedAt           time.Time       `json:"updated_at"`
+	ContentFormat       string          `json:"content_format"`
+}
+
+type StoryInfoMediaRef struct {
+	ID          uuid.UUID `json:"id"`
+	StoryInfoID uuid.UUID `json:"story_info_id"`
+	MediaID     uuid.UUID `json:"media_id"`
+	Usage       string    `json:"usage"`
+	SortOrder   int32     `json:"sort_order"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 type Theme struct {

--- a/apps/server/internal/db/story_infos.sql.go
+++ b/apps/server/internal/db/story_infos.sql.go
@@ -18,22 +18,24 @@ INSERT INTO story_infos (
   theme_id,
   title,
   body,
+  content_format,
   image_media_id,
   related_character_ids,
   related_clue_ids,
   related_location_ids,
   sort_order
 )
-SELECT $1, $2, $3, $4, $5, $6, $7, $8
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
 FROM themes t
-WHERE t.id = $1 AND t.creator_id = $9
-RETURNING id, theme_id, title, body, image_media_id, related_character_ids, related_clue_ids, related_location_ids, sort_order, version, created_at, updated_at
+WHERE t.id = $1 AND t.creator_id = $10
+RETURNING id, theme_id, title, body, image_media_id, related_character_ids, related_clue_ids, related_location_ids, sort_order, version, created_at, updated_at, content_format
 `
 
 type CreateStoryInfoParams struct {
 	ThemeID             uuid.UUID       `json:"theme_id"`
 	Title               string          `json:"title"`
 	Body                string          `json:"body"`
+	ContentFormat       string          `json:"content_format"`
 	ImageMediaID        pgtype.UUID     `json:"image_media_id"`
 	RelatedCharacterIds json.RawMessage `json:"related_character_ids"`
 	RelatedClueIds      json.RawMessage `json:"related_clue_ids"`
@@ -47,6 +49,7 @@ func (q *Queries) CreateStoryInfo(ctx context.Context, arg CreateStoryInfoParams
 		arg.ThemeID,
 		arg.Title,
 		arg.Body,
+		arg.ContentFormat,
 		arg.ImageMediaID,
 		arg.RelatedCharacterIds,
 		arg.RelatedClueIds,
@@ -68,8 +71,46 @@ func (q *Queries) CreateStoryInfo(ctx context.Context, arg CreateStoryInfoParams
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ContentFormat,
 	)
 	return i, err
+}
+
+const createStoryInfoMediaRef = `-- name: CreateStoryInfoMediaRef :exec
+INSERT INTO story_info_media_refs (
+  story_info_id,
+  media_id,
+  usage,
+  sort_order
+)
+VALUES ($1, $2, $3, $4)
+`
+
+type CreateStoryInfoMediaRefParams struct {
+	StoryInfoID uuid.UUID `json:"story_info_id"`
+	MediaID     uuid.UUID `json:"media_id"`
+	Usage       string    `json:"usage"`
+	SortOrder   int32     `json:"sort_order"`
+}
+
+func (q *Queries) CreateStoryInfoMediaRef(ctx context.Context, arg CreateStoryInfoMediaRefParams) error {
+	_, err := q.db.Exec(ctx, createStoryInfoMediaRef,
+		arg.StoryInfoID,
+		arg.MediaID,
+		arg.Usage,
+		arg.SortOrder,
+	)
+	return err
+}
+
+const deleteStoryInfoMediaRefs = `-- name: DeleteStoryInfoMediaRefs :exec
+DELETE FROM story_info_media_refs
+WHERE story_info_id = $1
+`
+
+func (q *Queries) DeleteStoryInfoMediaRefs(ctx context.Context, storyInfoID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteStoryInfoMediaRefs, storyInfoID)
+	return err
 }
 
 const deleteStoryInfoWithOwner = `-- name: DeleteStoryInfoWithOwner :one
@@ -91,7 +132,7 @@ func (q *Queries) DeleteStoryInfoWithOwner(ctx context.Context, arg DeleteStoryI
 }
 
 const getStoryInfoWithOwner = `-- name: GetStoryInfoWithOwner :one
-SELECT si.id, si.theme_id, si.title, si.body, si.image_media_id, si.related_character_ids, si.related_clue_ids, si.related_location_ids, si.sort_order, si.version, si.created_at, si.updated_at FROM story_infos si
+SELECT si.id, si.theme_id, si.title, si.body, si.image_media_id, si.related_character_ids, si.related_clue_ids, si.related_location_ids, si.sort_order, si.version, si.created_at, si.updated_at, si.content_format FROM story_infos si
 JOIN themes t ON si.theme_id = t.id
 WHERE si.id = $1 AND t.creator_id = $2
 `
@@ -117,13 +158,14 @@ func (q *Queries) GetStoryInfoWithOwner(ctx context.Context, arg GetStoryInfoWit
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ContentFormat,
 	)
 	return i, err
 }
 
 const listStoryInfosByTheme = `-- name: ListStoryInfosByTheme :many
 
-SELECT si.id, si.theme_id, si.title, si.body, si.image_media_id, si.related_character_ids, si.related_clue_ids, si.related_location_ids, si.sort_order, si.version, si.created_at, si.updated_at FROM story_infos si
+SELECT si.id, si.theme_id, si.title, si.body, si.image_media_id, si.related_character_ids, si.related_clue_ids, si.related_location_ids, si.sort_order, si.version, si.created_at, si.updated_at, si.content_format FROM story_infos si
 JOIN themes t ON si.theme_id = t.id
 WHERE si.theme_id = $1 AND t.creator_id = $2
 ORDER BY si.sort_order, si.created_at
@@ -159,6 +201,7 @@ func (q *Queries) ListStoryInfosByTheme(ctx context.Context, arg ListStoryInfosB
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.ContentFormat,
 		); err != nil {
 			return nil, err
 		}
@@ -174,25 +217,27 @@ const updateStoryInfo = `-- name: UpdateStoryInfo :one
 UPDATE story_infos
 SET title = $2,
     body = $3,
-    image_media_id = $4,
-    related_character_ids = $5,
-    related_clue_ids = $6,
-    related_location_ids = $7,
-    sort_order = $8,
+    content_format = $4,
+    image_media_id = $5,
+    related_character_ids = $6,
+    related_clue_ids = $7,
+    related_location_ids = $8,
+    sort_order = $9,
     version = version + 1,
     updated_at = NOW()
 FROM themes t
 WHERE story_infos.id = $1
   AND story_infos.theme_id = t.id
-  AND t.creator_id = $10
-  AND story_infos.version = $9
-RETURNING story_infos.id, story_infos.theme_id, story_infos.title, story_infos.body, story_infos.image_media_id, story_infos.related_character_ids, story_infos.related_clue_ids, story_infos.related_location_ids, story_infos.sort_order, story_infos.version, story_infos.created_at, story_infos.updated_at
+  AND t.creator_id = $11
+  AND story_infos.version = $10
+RETURNING story_infos.id, story_infos.theme_id, story_infos.title, story_infos.body, story_infos.image_media_id, story_infos.related_character_ids, story_infos.related_clue_ids, story_infos.related_location_ids, story_infos.sort_order, story_infos.version, story_infos.created_at, story_infos.updated_at, story_infos.content_format
 `
 
 type UpdateStoryInfoParams struct {
 	ID                  uuid.UUID       `json:"id"`
 	Title               string          `json:"title"`
 	Body                string          `json:"body"`
+	ContentFormat       string          `json:"content_format"`
 	ImageMediaID        pgtype.UUID     `json:"image_media_id"`
 	RelatedCharacterIds json.RawMessage `json:"related_character_ids"`
 	RelatedClueIds      json.RawMessage `json:"related_clue_ids"`
@@ -207,6 +252,7 @@ func (q *Queries) UpdateStoryInfo(ctx context.Context, arg UpdateStoryInfoParams
 		arg.ID,
 		arg.Title,
 		arg.Body,
+		arg.ContentFormat,
 		arg.ImageMediaID,
 		arg.RelatedCharacterIds,
 		arg.RelatedClueIds,
@@ -229,6 +275,7 @@ func (q *Queries) UpdateStoryInfo(ctx context.Context, arg UpdateStoryInfoParams
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ContentFormat,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/mock_story_info_service_test.go
+++ b/apps/server/internal/domain/editor/mock_story_info_service_test.go
@@ -57,6 +57,34 @@ func (mr *MockstoryInfoQueriesMockRecorder) CreateStoryInfo(ctx, arg any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStoryInfo", reflect.TypeOf((*MockstoryInfoQueries)(nil).CreateStoryInfo), ctx, arg)
 }
 
+// CreateStoryInfoMediaRef mocks base method.
+func (m *MockstoryInfoQueries) CreateStoryInfoMediaRef(ctx context.Context, arg db.CreateStoryInfoMediaRefParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateStoryInfoMediaRef", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateStoryInfoMediaRef indicates an expected call of CreateStoryInfoMediaRef.
+func (mr *MockstoryInfoQueriesMockRecorder) CreateStoryInfoMediaRef(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStoryInfoMediaRef", reflect.TypeOf((*MockstoryInfoQueries)(nil).CreateStoryInfoMediaRef), ctx, arg)
+}
+
+// DeleteStoryInfoMediaRefs mocks base method.
+func (m *MockstoryInfoQueries) DeleteStoryInfoMediaRefs(ctx context.Context, storyInfoID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteStoryInfoMediaRefs", ctx, storyInfoID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteStoryInfoMediaRefs indicates an expected call of DeleteStoryInfoMediaRefs.
+func (mr *MockstoryInfoQueriesMockRecorder) DeleteStoryInfoMediaRefs(ctx, storyInfoID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStoryInfoMediaRefs", reflect.TypeOf((*MockstoryInfoQueries)(nil).DeleteStoryInfoMediaRefs), ctx, storyInfoID)
+}
+
 // DeleteStoryInfoWithOwner mocks base method.
 func (m *MockstoryInfoQueries) DeleteStoryInfoWithOwner(ctx context.Context, arg db.DeleteStoryInfoWithOwnerParams) (uuid.UUID, error) {
 	m.ctrl.T.Helper()

--- a/apps/server/internal/domain/editor/story_info_media_refs.go
+++ b/apps/server/internal/domain/editor/story_info_media_refs.go
@@ -1,0 +1,181 @@
+package editor
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/db"
+)
+
+type storyInfoMediaRef struct {
+	mediaID   uuid.UUID
+	usage     string
+	sortOrder int32
+}
+
+type storyInfoMediaEmbed struct {
+	mediaID uuid.UUID
+	rawType string
+}
+
+var (
+	storyInfoMediaEmbedRe = regexp.MustCompile(`(?s)<MediaEmbed\b([^>]*)/?>`)
+	storyInfoAttrRe       = regexp.MustCompile(`\b(mediaId|type)\s*=\s*"([^"]*)"`)
+)
+
+func (s *storyInfoService) createStoryInfoWithRefs(ctx context.Context, arg db.CreateStoryInfoParams, refs []storyInfoMediaRef) (db.StoryInfo, error) {
+	var row db.StoryInfo
+	if s.pool != nil && s.withTx != nil {
+		err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			var txErr error
+			row, txErr = s.createStoryInfoWithRefsUsing(ctx, s.withTx(tx), arg, refs)
+			return txErr
+		})
+		return row, err
+	}
+	return s.createStoryInfoWithRefsUsing(ctx, s.q, arg, refs)
+}
+
+func (s *storyInfoService) createStoryInfoWithRefsUsing(ctx context.Context, q storyInfoQueries, arg db.CreateStoryInfoParams, refs []storyInfoMediaRef) (db.StoryInfo, error) {
+	row, err := q.CreateStoryInfo(ctx, arg)
+	if err != nil {
+		return db.StoryInfo{}, err
+	}
+	if err := s.replaceStoryInfoMediaRefs(ctx, q, row.ID, refs); err != nil {
+		return db.StoryInfo{}, err
+	}
+	return row, nil
+}
+
+func (s *storyInfoService) updateStoryInfoWithRefs(ctx context.Context, arg db.UpdateStoryInfoParams, refs []storyInfoMediaRef) (db.StoryInfo, error) {
+	var row db.StoryInfo
+	if s.pool != nil && s.withTx != nil {
+		err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			var txErr error
+			row, txErr = s.updateStoryInfoWithRefsUsing(ctx, s.withTx(tx), arg, refs)
+			return txErr
+		})
+		return row, err
+	}
+	return s.updateStoryInfoWithRefsUsing(ctx, s.q, arg, refs)
+}
+
+func (s *storyInfoService) updateStoryInfoWithRefsUsing(ctx context.Context, q storyInfoQueries, arg db.UpdateStoryInfoParams, refs []storyInfoMediaRef) (db.StoryInfo, error) {
+	row, err := q.UpdateStoryInfo(ctx, arg)
+	if err != nil {
+		return db.StoryInfo{}, err
+	}
+	if err := s.replaceStoryInfoMediaRefs(ctx, q, row.ID, refs); err != nil {
+		return db.StoryInfo{}, err
+	}
+	return row, nil
+}
+
+func (s *storyInfoService) replaceStoryInfoMediaRefs(ctx context.Context, q storyInfoQueries, infoID uuid.UUID, refs []storyInfoMediaRef) error {
+	if err := q.DeleteStoryInfoMediaRefs(ctx, infoID); err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		if err := q.CreateStoryInfoMediaRef(ctx, db.CreateStoryInfoMediaRefParams{
+			StoryInfoID: infoID,
+			MediaID:     ref.mediaID,
+			Usage:       ref.usage,
+			SortOrder:   ref.sortOrder,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *storyInfoService) resolveStoryInfoMediaRefs(ctx context.Context, themeID uuid.UUID, imageMediaID pgtype.UUID, body string) ([]storyInfoMediaRef, error) {
+	refs := []storyInfoMediaRef{}
+	sortOrder := int32(0)
+	if imageMediaID.Valid {
+		refs = append(refs, storyInfoMediaRef{
+			mediaID:   uuid.UUID(imageMediaID.Bytes),
+			usage:     "cover",
+			sortOrder: sortOrder,
+		})
+		sortOrder++
+	}
+	for _, embed := range extractStoryInfoMediaEmbeds(body) {
+		media, err := s.resolveStoryInfoEmbeddedMedia(ctx, themeID, embed)
+		if err != nil {
+			return nil, err
+		}
+		usage := "embedded_image"
+		if media.Type == MediaTypeVideo {
+			usage = "embedded_video"
+		}
+		refs = append(refs, storyInfoMediaRef{
+			mediaID:   embed.mediaID,
+			usage:     usage,
+			sortOrder: sortOrder,
+		})
+		sortOrder++
+	}
+	return refs, nil
+}
+
+func extractStoryInfoMediaEmbeds(body string) []storyInfoMediaEmbed {
+	matches := storyInfoMediaEmbedRe.FindAllStringSubmatch(body, -1)
+	out := make([]storyInfoMediaEmbed, 0, len(matches))
+	for _, match := range matches {
+		attrs := map[string]string{}
+		for _, attr := range storyInfoAttrRe.FindAllStringSubmatch(match[1], -1) {
+			attrs[attr[1]] = attr[2]
+		}
+		id, err := uuid.Parse(strings.TrimSpace(attrs["mediaId"]))
+		if err != nil {
+			out = append(out, storyInfoMediaEmbed{})
+			continue
+		}
+		out = append(out, storyInfoMediaEmbed{
+			mediaID: id,
+			rawType: strings.ToLower(strings.TrimSpace(attrs["type"])),
+		})
+	}
+	return out
+}
+
+func (s *storyInfoService) resolveStoryInfoEmbeddedMedia(ctx context.Context, themeID uuid.UUID, embed storyInfoMediaEmbed) (db.ThemeMedium, error) {
+	if embed.mediaID == uuid.Nil {
+		return db.ThemeMedium{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "invalid MediaEmbed mediaId")
+	}
+	media, err := s.q.GetMedia(ctx, embed.mediaID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.ThemeMedium{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "embedded media not found")
+		}
+		s.logger.Error().Err(err).Str("media_id", embed.mediaID.String()).Msg("failed to verify story info embedded media")
+		return db.ThemeMedium{}, apperror.Internal("failed to verify embedded media reference")
+	}
+	if media.ThemeID != themeID || (media.Type != MediaTypeImage && media.Type != MediaTypeVideo) {
+		return db.ThemeMedium{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "embedded media has wrong type or theme")
+	}
+	if media.Type == MediaTypeVideo && media.SourceType != SourceTypeYouTube {
+		return db.ThemeMedium{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "MediaEmbed video must reference a YouTube media item")
+	}
+	switch embed.rawType {
+	case "":
+	case "image":
+		if media.Type != MediaTypeImage {
+			return db.ThemeMedium{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "MediaEmbed type does not match media")
+		}
+	case "video":
+		if media.Type != MediaTypeVideo {
+			return db.ThemeMedium{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "MediaEmbed type does not match media")
+		}
+	default:
+		return db.ThemeMedium{}, apperror.New(apperror.ErrValidation, 422, "unsupported MediaEmbed type")
+	}
+	return media, nil
+}

--- a/apps/server/internal/domain/editor/story_info_service.go
+++ b/apps/server/internal/domain/editor/story_info_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
@@ -26,6 +27,8 @@ type storyInfoQueries interface {
 	CreateStoryInfo(ctx context.Context, arg db.CreateStoryInfoParams) (db.StoryInfo, error)
 	UpdateStoryInfo(ctx context.Context, arg db.UpdateStoryInfoParams) (db.StoryInfo, error)
 	DeleteStoryInfoWithOwner(ctx context.Context, arg db.DeleteStoryInfoWithOwnerParams) (uuid.UUID, error)
+	DeleteStoryInfoMediaRefs(ctx context.Context, storyInfoID uuid.UUID) error
+	CreateStoryInfoMediaRef(ctx context.Context, arg db.CreateStoryInfoMediaRefParams) error
 }
 
 type StoryInfoService interface {
@@ -37,11 +40,30 @@ type StoryInfoService interface {
 
 type storyInfoService struct {
 	q      storyInfoQueries
+	pool   *pgxpool.Pool
+	withTx func(pgx.Tx) storyInfoQueries
 	logger zerolog.Logger
 }
 
-func NewStoryInfoService(q *db.Queries, logger zerolog.Logger) StoryInfoService {
-	return newStoryInfoServiceWith(q, logger)
+type storyInfoUpdatePayload struct {
+	title             string
+	body              string
+	contentFormat     string
+	sortOrder         int32
+	currentImageParam pgtype.UUID
+	imageMediaID      **string
+	characterIDs      []string
+	clueIDs           []string
+	locationIDs       []string
+}
+
+func NewStoryInfoService(q *db.Queries, pool *pgxpool.Pool, logger zerolog.Logger) StoryInfoService {
+	svc := newStoryInfoServiceWith(q, logger)
+	svc.pool = pool
+	svc.withTx = func(tx pgx.Tx) storyInfoQueries {
+		return q.WithTx(tx)
+	}
+	return svc
 }
 
 func newStoryInfoServiceWith(q storyInfoQueries, logger zerolog.Logger) *storyInfoService {
@@ -80,7 +102,15 @@ func (s *storyInfoService) Create(ctx context.Context, creatorID, themeID uuid.U
 	if err != nil {
 		return nil, err
 	}
+	contentFormat, err := resolveStoryInfoContentFormat(req.ContentFormat)
+	if err != nil {
+		return nil, err
+	}
 	imageParam, err := s.resolveStoryInfoImage(ctx, themeID, req.ImageMediaID)
+	if err != nil {
+		return nil, err
+	}
+	mediaRefs, err := s.resolveStoryInfoMediaRefs(ctx, themeID, imageParam, body)
 	if err != nil {
 		return nil, err
 	}
@@ -88,17 +118,18 @@ func (s *storyInfoService) Create(ctx context.Context, creatorID, themeID uuid.U
 	if err != nil {
 		return nil, err
 	}
-	row, err := s.q.CreateStoryInfo(ctx, db.CreateStoryInfoParams{
+	row, err := s.createStoryInfoWithRefs(ctx, db.CreateStoryInfoParams{
 		ThemeID:             themeID,
 		Title:               title,
 		Body:                body,
+		ContentFormat:       contentFormat,
 		ImageMediaID:        imageParam,
 		RelatedCharacterIds: charRefs,
 		RelatedClueIds:      clueRefs,
 		RelatedLocationIds:  locationRefs,
 		SortOrder:           req.SortOrder,
 		CreatorID:           creatorID,
-	})
+	}, mediaRefs)
 	if err != nil {
 		s.logger.Error().Err(err).Str("theme_id", themeID.String()).Msg("failed to create story info")
 		return nil, apperror.Internal("failed to create story info")
@@ -111,65 +142,31 @@ func (s *storyInfoService) Update(ctx context.Context, creatorID, infoID uuid.UU
 	if err != nil {
 		return nil, err
 	}
-	resp, err := toStoryInfoResponse(current)
-	if err != nil {
-		return nil, apperror.Internal("corrupted story info data")
-	}
-	title := resp.Title
-	if req.Title != nil {
-		title = *req.Title
-	}
-	body := resp.Body
-	if req.Body != nil {
-		body = *req.Body
-	}
-	title, body, err = validateStoryInfoText(title, body)
+	payload, err := s.mergeUpdateRequest(current, req)
 	if err != nil {
 		return nil, err
 	}
-	sortOrder := current.SortOrder
-	if req.SortOrder != nil {
-		sortOrder = *req.SortOrder
-	}
-	imageParam := current.ImageMediaID
-	switch {
-	case req.ImageMediaID == nil:
-	case *req.ImageMediaID == nil:
-		imageParam = pgtype.UUID{}
-	default:
-		imageParam, err = s.resolveStoryInfoImage(ctx, current.ThemeID, *req.ImageMediaID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	charIDs := resp.RelatedCharacterIDs
-	if req.RelatedCharacterIDs != nil {
-		charIDs = *req.RelatedCharacterIDs
-	}
-	clueIDs := resp.RelatedClueIDs
-	if req.RelatedClueIDs != nil {
-		clueIDs = *req.RelatedClueIDs
-	}
-	locationIDs := resp.RelatedLocationIDs
-	if req.RelatedLocationIDs != nil {
-		locationIDs = *req.RelatedLocationIDs
-	}
-	charRefs, clueRefs, locationRefs, err := s.resolveStoryInfoRefs(ctx, current.ThemeID, charIDs, clueIDs, locationIDs)
+	imageParam, mediaRefs, err := s.resolveUpdateMedia(ctx, current.ThemeID, payload)
 	if err != nil {
 		return nil, err
 	}
-	row, err := s.q.UpdateStoryInfo(ctx, db.UpdateStoryInfoParams{
+	charRefs, clueRefs, locationRefs, err := s.resolveUpdateRefs(ctx, current.ThemeID, payload)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.updateStoryInfoWithRefs(ctx, db.UpdateStoryInfoParams{
 		ID:                  infoID,
-		Title:               title,
-		Body:                body,
+		Title:               payload.title,
+		Body:                payload.body,
+		ContentFormat:       payload.contentFormat,
 		ImageMediaID:        imageParam,
 		RelatedCharacterIds: charRefs,
 		RelatedClueIds:      clueRefs,
 		RelatedLocationIds:  locationRefs,
-		SortOrder:           sortOrder,
+		SortOrder:           payload.sortOrder,
 		Version:             req.Version,
 		CreatorID:           creatorID,
-	})
+	}, mediaRefs)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, apperror.New(apperror.ErrConflict, 409, "version mismatch")
@@ -178,6 +175,73 @@ func (s *storyInfoService) Update(ctx context.Context, creatorID, infoID uuid.UU
 		return nil, apperror.Internal("failed to update story info")
 	}
 	return toStoryInfoResponse(row)
+}
+
+func (s *storyInfoService) mergeUpdateRequest(current db.StoryInfo, req UpdateStoryInfoRequest) (*storyInfoUpdatePayload, error) {
+	resp, err := toStoryInfoResponse(current)
+	if err != nil {
+		return nil, apperror.Internal("corrupted story info data")
+	}
+	payload := &storyInfoUpdatePayload{
+		title:             resp.Title,
+		body:              resp.Body,
+		contentFormat:     resp.ContentFormat,
+		sortOrder:         current.SortOrder,
+		currentImageParam: current.ImageMediaID,
+		imageMediaID:      req.ImageMediaID,
+		characterIDs:      resp.RelatedCharacterIDs,
+		clueIDs:           resp.RelatedClueIDs,
+		locationIDs:       resp.RelatedLocationIDs,
+	}
+	if req.Title != nil {
+		payload.title = *req.Title
+	}
+	if req.Body != nil {
+		payload.body = *req.Body
+	}
+	if req.ContentFormat != nil {
+		payload.contentFormat, err = resolveStoryInfoContentFormat(req.ContentFormat)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if payload.title, payload.body, err = validateStoryInfoText(payload.title, payload.body); err != nil {
+		return nil, err
+	}
+	if req.SortOrder != nil {
+		payload.sortOrder = *req.SortOrder
+	}
+	if req.RelatedCharacterIDs != nil {
+		payload.characterIDs = *req.RelatedCharacterIDs
+	}
+	if req.RelatedClueIDs != nil {
+		payload.clueIDs = *req.RelatedClueIDs
+	}
+	if req.RelatedLocationIDs != nil {
+		payload.locationIDs = *req.RelatedLocationIDs
+	}
+	return payload, nil
+}
+
+func (s *storyInfoService) resolveUpdateMedia(ctx context.Context, themeID uuid.UUID, payload *storyInfoUpdatePayload) (pgtype.UUID, []storyInfoMediaRef, error) {
+	imageParam := payload.currentImageParam
+	switch {
+	case payload.imageMediaID == nil:
+	case *payload.imageMediaID == nil:
+		imageParam = pgtype.UUID{}
+	default:
+		resolved, err := s.resolveStoryInfoImage(ctx, themeID, *payload.imageMediaID)
+		if err != nil {
+			return pgtype.UUID{}, nil, err
+		}
+		imageParam = resolved
+	}
+	mediaRefs, err := s.resolveStoryInfoMediaRefs(ctx, themeID, imageParam, payload.body)
+	return imageParam, mediaRefs, err
+}
+
+func (s *storyInfoService) resolveUpdateRefs(ctx context.Context, themeID uuid.UUID, payload *storyInfoUpdatePayload) (json.RawMessage, json.RawMessage, json.RawMessage, error) {
+	return s.resolveStoryInfoRefs(ctx, themeID, payload.characterIDs, payload.clueIDs, payload.locationIDs)
 }
 
 func (s *storyInfoService) Delete(ctx context.Context, creatorID, infoID uuid.UUID) (uuid.UUID, error) {
@@ -234,6 +298,16 @@ func validateStoryInfoText(title string, body string) (string, string, error) {
 		return "", "", apperror.New(apperror.ErrValidation, 422, "story info body is too long")
 	}
 	return title, body, nil
+}
+
+func resolveStoryInfoContentFormat(raw *string) (string, error) {
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		return StoryInfoContentFormatMDXV1, nil
+	}
+	if strings.TrimSpace(*raw) != StoryInfoContentFormatMDXV1 {
+		return "", apperror.New(apperror.ErrValidation, 422, "unsupported story info content format")
+	}
+	return StoryInfoContentFormatMDXV1, nil
 }
 
 func (s *storyInfoService) resolveStoryInfoImage(ctx context.Context, themeID uuid.UUID, raw *string) (pgtype.UUID, error) {
@@ -360,6 +434,7 @@ func toStoryInfoResponse(row db.StoryInfo) (*StoryInfoResponse, error) {
 		ThemeID:             row.ThemeID,
 		Title:               row.Title,
 		Body:                row.Body,
+		ContentFormat:       storyInfoContentFormatOrDefault(row.ContentFormat),
 		RelatedCharacterIDs: charIDs,
 		RelatedClueIDs:      clueIDs,
 		RelatedLocationIDs:  locationIDs,
@@ -384,4 +459,11 @@ func decodeStoryInfoRefs(raw json.RawMessage) ([]string, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func storyInfoContentFormatOrDefault(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return StoryInfoContentFormatMDXV1
+	}
+	return raw
 }

--- a/apps/server/internal/domain/editor/story_info_service_test.go
+++ b/apps/server/internal/domain/editor/story_info_service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/apperror"
@@ -16,28 +17,32 @@ import (
 )
 
 type fakeStoryInfoQueries struct {
-	themes      map[uuid.UUID]db.Theme
-	media       map[uuid.UUID]db.ThemeMedium
-	characters  map[uuid.UUID]db.ThemeCharacter
-	clues       map[uuid.UUID]db.ThemeClue
-	locations   map[uuid.UUID]db.ThemeLocation
-	infos       map[uuid.UUID]db.StoryInfo
-	themeErr    error
-	mediaErr    error
-	charErr     error
-	clueErr     error
-	locationErr error
-	listErr     error
-	getInfoErr  error
-	createErr   error
-	updateErr   error
-	deleteErr   error
+	themes       map[uuid.UUID]db.Theme
+	media        map[uuid.UUID]db.ThemeMedium
+	mediaRefs    map[uuid.UUID][]db.CreateStoryInfoMediaRefParams
+	characters   map[uuid.UUID]db.ThemeCharacter
+	clues        map[uuid.UUID]db.ThemeClue
+	locations    map[uuid.UUID]db.ThemeLocation
+	infos        map[uuid.UUID]db.StoryInfo
+	themeErr     error
+	mediaErr     error
+	charErr      error
+	clueErr      error
+	locationErr  error
+	listErr      error
+	getInfoErr   error
+	createErr    error
+	updateErr    error
+	deleteErr    error
+	refDeleteErr error
+	refCreateErr error
 }
 
 func newFakeStoryInfoQueries() *fakeStoryInfoQueries {
 	return &fakeStoryInfoQueries{
 		themes:     map[uuid.UUID]db.Theme{},
 		media:      map[uuid.UUID]db.ThemeMedium{},
+		mediaRefs:  map[uuid.UUID][]db.CreateStoryInfoMediaRefParams{},
 		characters: map[uuid.UUID]db.ThemeCharacter{},
 		clues:      map[uuid.UUID]db.ThemeClue{},
 		locations:  map[uuid.UUID]db.ThemeLocation{},
@@ -142,6 +147,7 @@ func (f *fakeStoryInfoQueries) CreateStoryInfo(_ context.Context, arg db.CreateS
 		ThemeID:             arg.ThemeID,
 		Title:               arg.Title,
 		Body:                arg.Body,
+		ContentFormat:       arg.ContentFormat,
 		ImageMediaID:        arg.ImageMediaID,
 		RelatedCharacterIds: arg.RelatedCharacterIds,
 		RelatedClueIds:      arg.RelatedClueIds,
@@ -169,6 +175,7 @@ func (f *fakeStoryInfoQueries) UpdateStoryInfo(_ context.Context, arg db.UpdateS
 	}
 	info.Title = arg.Title
 	info.Body = arg.Body
+	info.ContentFormat = arg.ContentFormat
 	info.ImageMediaID = arg.ImageMediaID
 	info.RelatedCharacterIds = arg.RelatedCharacterIds
 	info.RelatedClueIds = arg.RelatedClueIds
@@ -196,12 +203,29 @@ func (f *fakeStoryInfoQueries) DeleteStoryInfoWithOwner(_ context.Context, arg d
 	return info.ThemeID, nil
 }
 
+func (f *fakeStoryInfoQueries) DeleteStoryInfoMediaRefs(_ context.Context, storyInfoID uuid.UUID) error {
+	if f.refDeleteErr != nil {
+		return f.refDeleteErr
+	}
+	delete(f.mediaRefs, storyInfoID)
+	return nil
+}
+
+func (f *fakeStoryInfoQueries) CreateStoryInfoMediaRef(_ context.Context, arg db.CreateStoryInfoMediaRefParams) error {
+	if f.refCreateErr != nil {
+		return f.refCreateErr
+	}
+	f.mediaRefs[arg.StoryInfoID] = append(f.mediaRefs[arg.StoryInfoID], arg)
+	return nil
+}
+
 type storyInfoFixture struct {
 	q           *fakeStoryInfoQueries
 	svc         *storyInfoService
 	creatorID   uuid.UUID
 	themeID     uuid.UUID
 	imageID     uuid.UUID
+	videoID     uuid.UUID
 	bgmID       uuid.UUID
 	characterID uuid.UUID
 	clueID      uuid.UUID
@@ -219,8 +243,10 @@ func newStoryInfoFixture(t *testing.T) *storyInfoFixture {
 	q.themes[otherThemeID] = db.Theme{ID: otherThemeID, CreatorID: creatorID}
 
 	imageID := uuid.New()
+	videoID := uuid.New()
 	bgmID := uuid.New()
 	q.media[imageID] = db.ThemeMedium{ID: imageID, ThemeID: themeID, Type: MediaTypeImage}
+	q.media[videoID] = db.ThemeMedium{ID: videoID, ThemeID: themeID, Type: MediaTypeVideo, SourceType: SourceTypeYouTube}
 	q.media[bgmID] = db.ThemeMedium{ID: bgmID, ThemeID: themeID, Type: MediaTypeBGM}
 
 	characterID := uuid.New()
@@ -238,6 +264,7 @@ func newStoryInfoFixture(t *testing.T) *storyInfoFixture {
 		creatorID:   creatorID,
 		themeID:     themeID,
 		imageID:     imageID,
+		videoID:     videoID,
 		bgmID:       bgmID,
 		characterID: characterID,
 		clueID:      clueID,
@@ -265,6 +292,9 @@ func TestStoryInfoService_Create_SuccessWithImageAndRefs(t *testing.T) {
 	if resp.ImageMediaID == nil || *resp.ImageMediaID != image {
 		t.Fatalf("image reference not persisted: %+v", resp.ImageMediaID)
 	}
+	if resp.ContentFormat != StoryInfoContentFormatMDXV1 {
+		t.Fatalf("content format default not applied: %q", resp.ContentFormat)
+	}
 	if len(resp.RelatedCharacterIDs) != 1 || resp.RelatedCharacterIDs[0] != f.characterID.String() {
 		t.Fatalf("character refs not normalized: %+v", resp.RelatedCharacterIDs)
 	}
@@ -273,8 +303,103 @@ func TestStoryInfoService_Create_SuccessWithImageAndRefs(t *testing.T) {
 	}
 }
 
+func TestStoryInfoService_Create_StoresCoverAndEmbeddedMediaRefs(t *testing.T) {
+	f := newStoryInfoFixture(t)
+	image := f.imageID.String()
+	body := "현장 사진\n\n<MediaEmbed type=\"image\" mediaId=\"" + f.imageID.String() + "\" />\n\n<MediaEmbed mediaId=\"" + f.videoID.String() + "\" type=\"video\" />"
+
+	resp, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title:        "미디어 정보",
+		Body:         body,
+		ImageMediaID: &image,
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	refs := f.q.mediaRefs[resp.ID]
+	if len(refs) != 3 {
+		t.Fatalf("expected cover + 2 embeds, got %#v", refs)
+	}
+	if refs[0].MediaID != f.imageID || refs[0].Usage != "cover" || refs[0].SortOrder != 0 {
+		t.Fatalf("unexpected cover ref: %#v", refs[0])
+	}
+	if refs[1].MediaID != f.imageID || refs[1].Usage != "embedded_image" || refs[1].SortOrder != 1 {
+		t.Fatalf("unexpected image ref: %#v", refs[1])
+	}
+	if refs[2].MediaID != f.videoID || refs[2].Usage != "embedded_video" || refs[2].SortOrder != 2 {
+		t.Fatalf("unexpected video ref: %#v", refs[2])
+	}
+}
+
+func TestStoryInfoService_Create_ReturnsInternalAndKeepsRefsEmptyWhenRefDeleteFails(t *testing.T) {
+	f := newStoryInfoFixture(t)
+	f.q.refDeleteErr = context.DeadlineExceeded
+	image := f.imageID.String()
+
+	resp, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title:        "ref delete 실패",
+		Body:         `<MediaEmbed mediaId="` + f.videoID.String() + `" type="video" />`,
+		ImageMediaID: &image,
+	})
+	if resp != nil {
+		t.Fatalf("expected nil response, got %+v", resp)
+	}
+	assertAppCode(t, err, apperror.ErrInternal)
+	if len(f.q.mediaRefs) != 0 {
+		t.Fatalf("expected no media refs after delete failure, got %#v", f.q.mediaRefs)
+	}
+}
+
+func TestStoryInfoService_Create_ReturnsInternalAndKeepsRefsEmptyWhenRefCreateFails(t *testing.T) {
+	f := newStoryInfoFixture(t)
+	f.q.refCreateErr = context.DeadlineExceeded
+	image := f.imageID.String()
+
+	resp, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title:        "ref create 실패",
+		Body:         `<MediaEmbed mediaId="` + f.videoID.String() + `" type="video" />`,
+		ImageMediaID: &image,
+	})
+	if resp != nil {
+		t.Fatalf("expected nil response, got %+v", resp)
+	}
+	assertAppCode(t, err, apperror.ErrInternal)
+	if len(f.q.mediaRefs) != 0 {
+		t.Fatalf("expected no partial media refs after create failure, got %#v", f.q.mediaRefs)
+	}
+}
+
+func TestStoryInfoService_Create_RejectsInvalidEmbeddedMediaRefs(t *testing.T) {
+	f := newStoryInfoFixture(t)
+	_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title: "잘못된 embed",
+		Body:  `<MediaEmbed mediaId="not-a-uuid" type="image" />`,
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+
+	_, err = f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title: "타입 불일치 embed",
+		Body:  `<MediaEmbed mediaId="` + f.imageID.String() + `" type="video" />`,
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+
+	_, err = f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title: "지원하지 않는 embed",
+		Body:  `<MediaEmbed mediaId="` + f.imageID.String() + `" type="audio" />`,
+	})
+	assertAppCode(t, err, apperror.ErrValidation)
+
+	fileVideoID := uuid.New()
+	f.q.media[fileVideoID] = db.ThemeMedium{ID: fileVideoID, ThemeID: f.themeID, Type: MediaTypeVideo, SourceType: SourceTypeFile}
+	_, err = f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title: "YouTube가 아닌 영상 embed",
+		Body:  `<MediaEmbed mediaId="` + fileVideoID.String() + `" />`,
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+}
+
 func TestStoryInfoService_NewConstructsConcreteService(t *testing.T) {
-	if svc := NewStoryInfoService(nil, zerolog.Nop()); svc == nil {
+	if svc := NewStoryInfoService(nil, nil, zerolog.Nop()); svc == nil {
 		t.Fatal("expected service")
 	}
 }
@@ -439,6 +564,33 @@ func TestStoryInfoService_Create_ReturnsInternalForInsertFailure(t *testing.T) {
 	assertAppCode(t, err, apperror.ErrInternal)
 }
 
+func TestStoryInfoService_Create_RollsBackStoryRowWhenMediaRefInsertFails(t *testing.T) {
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	svc := NewStoryInfoService(f.q, f.pool, zerolog.Nop()).(*storyInfoService)
+
+	_, err := svc.createStoryInfoWithRefs(ctx, db.CreateStoryInfoParams{
+		ThemeID:             themeID,
+		Title:               "tx create rollback",
+		Body:                "본문",
+		ContentFormat:       StoryInfoContentFormatMDXV1,
+		RelatedCharacterIds: json.RawMessage(`[]`),
+		RelatedClueIds:      json.RawMessage(`[]`),
+		RelatedLocationIds:  json.RawMessage(`[]`),
+		CreatorID:           creatorID,
+	}, []storyInfoMediaRef{{
+		mediaID:   uuid.New(),
+		usage:     "embedded_image",
+		sortOrder: 0,
+	}})
+	if err == nil {
+		t.Fatal("expected media ref insert failure")
+	}
+	assertStoryInfoTitleCount(t, f.pool, themeID, "tx create rollback", 0)
+}
+
 func TestStoryInfoService_List_ScopesRowsToCreatorTheme(t *testing.T) {
 	f := newStoryInfoFixture(t)
 	otherCreator := uuid.New()
@@ -545,6 +697,98 @@ func TestStoryInfoService_Update_ChangesRefsSortAndImage(t *testing.T) {
 	}
 }
 
+func TestStoryInfoService_Update_ReplacesStoryInfoMediaRefs(t *testing.T) {
+	f := newStoryInfoFixture(t)
+	image := f.imageID.String()
+	created, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title:        "수정 전",
+		Body:         `<MediaEmbed mediaId="` + f.imageID.String() + `" type="image" />`,
+		ImageMediaID: &image,
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if len(f.q.mediaRefs[created.ID]) != 2 {
+		t.Fatalf("expected initial refs, got %#v", f.q.mediaRefs[created.ID])
+	}
+
+	body := `<MediaEmbed mediaId="` + f.videoID.String() + `" type="video" />`
+	clearImage := (*string)(nil)
+	updated, err := f.svc.Update(context.Background(), f.creatorID, created.ID, UpdateStoryInfoRequest{
+		Body:         &body,
+		ImageMediaID: &clearImage,
+		Version:      created.Version,
+	})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	refs := f.q.mediaRefs[updated.ID]
+	if len(refs) != 1 || refs[0].MediaID != f.videoID || refs[0].Usage != "embedded_video" || refs[0].SortOrder != 0 {
+		t.Fatalf("expected replaced video ref only, got %#v", refs)
+	}
+}
+
+func TestStoryInfoService_Update_ReturnsInternalAndKeepsExistingRefsWhenRefDeleteFails(t *testing.T) {
+	f := newStoryInfoFixture(t)
+	image := f.imageID.String()
+	created, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title:        "수정 전",
+		Body:         `<MediaEmbed mediaId="` + f.imageID.String() + `" type="image" />`,
+		ImageMediaID: &image,
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	before := append([]db.CreateStoryInfoMediaRefParams(nil), f.q.mediaRefs[created.ID]...)
+	body := `<MediaEmbed mediaId="` + f.videoID.String() + `" type="video" />`
+	f.q.refDeleteErr = context.DeadlineExceeded
+
+	resp, err := f.svc.Update(context.Background(), f.creatorID, created.ID, UpdateStoryInfoRequest{
+		Body:    &body,
+		Version: created.Version,
+	})
+	if resp != nil {
+		t.Fatalf("expected nil response, got %+v", resp)
+	}
+	assertAppCode(t, err, apperror.ErrInternal)
+	after := f.q.mediaRefs[created.ID]
+	if len(after) != len(before) {
+		t.Fatalf("expected existing refs to remain after delete failure, before=%#v after=%#v", before, after)
+	}
+	for i := range before {
+		if after[i] != before[i] {
+			t.Fatalf("expected existing refs to remain after delete failure, before=%#v after=%#v", before, after)
+		}
+	}
+}
+
+func TestStoryInfoService_Update_ReturnsInternalAndKeepsNoPartialRefsWhenRefCreateFails(t *testing.T) {
+	f := newStoryInfoFixture(t)
+	image := f.imageID.String()
+	created, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateStoryInfoRequest{
+		Title:        "수정 전",
+		Body:         `<MediaEmbed mediaId="` + f.imageID.String() + `" type="image" />`,
+		ImageMediaID: &image,
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	body := `<MediaEmbed mediaId="` + f.videoID.String() + `" type="video" />`
+	f.q.refCreateErr = context.DeadlineExceeded
+
+	resp, err := f.svc.Update(context.Background(), f.creatorID, created.ID, UpdateStoryInfoRequest{
+		Body:    &body,
+		Version: created.Version,
+	})
+	if resp != nil {
+		t.Fatalf("expected nil response, got %+v", resp)
+	}
+	assertAppCode(t, err, apperror.ErrInternal)
+	if refs := f.q.mediaRefs[created.ID]; len(refs) != 0 {
+		t.Fatalf("expected no partial media refs after create failure, got %#v", refs)
+	}
+}
+
 func TestStoryInfoService_Update_ReturnsInternalForReadAndWriteFailures(t *testing.T) {
 	f := newStoryInfoFixture(t)
 	f.q.getInfoErr = context.DeadlineExceeded
@@ -559,6 +803,54 @@ func TestStoryInfoService_Update_ReturnsInternalForReadAndWriteFailures(t *testi
 	f.q.updateErr = context.DeadlineExceeded
 	_, err = f.svc.Update(context.Background(), f.creatorID, created.ID, UpdateStoryInfoRequest{Version: created.Version})
 	assertAppCode(t, err, apperror.ErrInternal)
+}
+
+func TestStoryInfoService_Update_RollsBackStoryRowAndRefsWhenMediaRefInsertFails(t *testing.T) {
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	image := createLocationMedia(t, f.q, themeID, "tx-image", MediaTypeImage)
+	svc := NewStoryInfoService(f.q, f.pool, zerolog.Nop()).(*storyInfoService)
+
+	created, err := svc.createStoryInfoWithRefs(ctx, db.CreateStoryInfoParams{
+		ThemeID:             themeID,
+		Title:               "tx update before",
+		Body:                "본문",
+		ContentFormat:       StoryInfoContentFormatMDXV1,
+		RelatedCharacterIds: json.RawMessage(`[]`),
+		RelatedClueIds:      json.RawMessage(`[]`),
+		RelatedLocationIds:  json.RawMessage(`[]`),
+		CreatorID:           creatorID,
+	}, []storyInfoMediaRef{{
+		mediaID:   image.ID,
+		usage:     "embedded_image",
+		sortOrder: 0,
+	}})
+	if err != nil {
+		t.Fatalf("createStoryInfoWithRefs: %v", err)
+	}
+
+	_, err = svc.updateStoryInfoWithRefs(ctx, db.UpdateStoryInfoParams{
+		ID:                  created.ID,
+		Title:               "tx update after",
+		Body:                "변경 본문",
+		ContentFormat:       StoryInfoContentFormatMDXV1,
+		RelatedCharacterIds: json.RawMessage(`[]`),
+		RelatedClueIds:      json.RawMessage(`[]`),
+		RelatedLocationIds:  json.RawMessage(`[]`),
+		Version:             created.Version,
+		CreatorID:           creatorID,
+	}, []storyInfoMediaRef{{
+		mediaID:   uuid.New(),
+		usage:     "embedded_image",
+		sortOrder: 0,
+	}})
+	if err == nil {
+		t.Fatal("expected media ref insert failure")
+	}
+	assertStoryInfoRow(t, f.pool, created.ID, "tx update before", created.Version)
+	assertStoryInfoMediaRefCount(t, f.pool, created.ID, 1)
 }
 
 func TestStoryInfoService_Delete_ReturnsThemeIDAndRemovesRow(t *testing.T) {
@@ -597,6 +889,55 @@ func TestStoryInfoService_Delete_ReturnsInternalForDeleteFailure(t *testing.T) {
 
 	_, err := f.svc.Delete(context.Background(), f.creatorID, uuid.New())
 	assertAppCode(t, err, apperror.ErrInternal)
+}
+
+func assertStoryInfoTitleCount(t *testing.T, pool *pgxpool.Pool, themeID uuid.UUID, title string, want int) {
+	t.Helper()
+	var got int
+	err := pool.QueryRow(context.Background(), `
+		SELECT count(*)
+		FROM story_infos
+		WHERE theme_id = $1 AND title = $2
+	`, themeID, title).Scan(&got)
+	if err != nil {
+		t.Fatalf("count story_infos: %v", err)
+	}
+	if got != want {
+		t.Fatalf("story info count = %d, want %d", got, want)
+	}
+}
+
+func assertStoryInfoRow(t *testing.T, pool *pgxpool.Pool, infoID uuid.UUID, wantTitle string, wantVersion int32) {
+	t.Helper()
+	var title string
+	var version int32
+	err := pool.QueryRow(context.Background(), `
+		SELECT title, version
+		FROM story_infos
+		WHERE id = $1
+	`, infoID).Scan(&title, &version)
+	if err != nil {
+		t.Fatalf("select story_info: %v", err)
+	}
+	if title != wantTitle || version != wantVersion {
+		t.Fatalf("story info row = title %q version %d, want title %q version %d", title, version, wantTitle, wantVersion)
+	}
+}
+
+func assertStoryInfoMediaRefCount(t *testing.T, pool *pgxpool.Pool, infoID uuid.UUID, want int) {
+	t.Helper()
+	var got int
+	err := pool.QueryRow(context.Background(), `
+		SELECT count(*)
+		FROM story_info_media_refs
+		WHERE story_info_id = $1
+	`, infoID).Scan(&got)
+	if err != nil {
+		t.Fatalf("count story_info_media_refs: %v", err)
+	}
+	if got != want {
+		t.Fatalf("story info media ref count = %d, want %d", got, want)
+	}
 }
 
 func TestToStoryInfoResponse_DecodesStoredReferences(t *testing.T) {

--- a/apps/server/internal/domain/editor/story_info_types.go
+++ b/apps/server/internal/domain/editor/story_info_types.go
@@ -10,11 +10,14 @@ const (
 	MaxStoryInfoTitleLength = 200
 	MaxStoryInfoBodyLength  = 20000
 	MaxStoryInfoRefs        = 100
+
+	StoryInfoContentFormatMDXV1 = "mdx_v1"
 )
 
 type CreateStoryInfoRequest struct {
 	Title               string   `json:"title"`
 	Body                string   `json:"body"`
+	ContentFormat       *string  `json:"contentFormat,omitempty"`
 	ImageMediaID        *string  `json:"imageMediaId,omitempty"`
 	RelatedCharacterIDs []string `json:"relatedCharacterIds"`
 	RelatedClueIDs      []string `json:"relatedClueIds"`
@@ -25,6 +28,7 @@ type CreateStoryInfoRequest struct {
 type UpdateStoryInfoRequest struct {
 	Title               *string   `json:"title,omitempty"`
 	Body                *string   `json:"body,omitempty"`
+	ContentFormat       *string   `json:"contentFormat,omitempty"`
 	ImageMediaID        **string  `json:"imageMediaId,omitempty"`
 	RelatedCharacterIDs *[]string `json:"relatedCharacterIds,omitempty"`
 	RelatedClueIDs      *[]string `json:"relatedClueIds,omitempty"`
@@ -38,6 +42,7 @@ type StoryInfoResponse struct {
 	ThemeID             uuid.UUID `json:"themeId"`
 	Title               string    `json:"title"`
 	Body                string    `json:"body"`
+	ContentFormat       string    `json:"contentFormat"`
 	ImageMediaID        *string   `json:"imageMediaId,omitempty"`
 	RelatedCharacterIDs []string  `json:"relatedCharacterIds"`
 	RelatedClueIDs      []string  `json:"relatedClueIds"`

--- a/apps/web/src/features/editor/storyInfoApi.test.ts
+++ b/apps/web/src/features/editor/storyInfoApi.test.ts
@@ -37,6 +37,7 @@ const mockInfo: StoryInfoResponse = {
   themeId: THEME_ID,
   title: "피해자의 비밀",
   body: "모두에게 공개할 정보",
+  contentFormat: "mdx_v1",
   imageMediaId: "image-1",
   relatedCharacterIds: ["char-1"],
   relatedClueIds: ["clue-1"],

--- a/apps/web/src/features/editor/storyInfoApi.ts
+++ b/apps/web/src/features/editor/storyInfoApi.ts
@@ -9,6 +9,7 @@ export interface StoryInfoResponse {
   themeId: string;
   title: string;
   body: string;
+  contentFormat: "mdx_v1";
   imageMediaId?: string | null;
   relatedCharacterIds: string[];
   relatedClueIds: string[];
@@ -22,6 +23,7 @@ export interface StoryInfoResponse {
 export interface CreateStoryInfoRequest {
   title: string;
   body: string;
+  contentFormat?: "mdx_v1";
   imageMediaId?: string | null;
   relatedCharacterIds: string[];
   relatedClueIds: string[];
@@ -32,6 +34,7 @@ export interface CreateStoryInfoRequest {
 export interface UpdateStoryInfoRequest {
   title?: string;
   body?: string;
+  contentFormat?: "mdx_v1";
   imageMediaId?: string | null;
   relatedCharacterIds?: string[];
   relatedClueIds?: string[];


### PR DESCRIPTION
## 요약
- `story_infos`에 `content_format`을 추가하고 기본 저장 포맷을 `mdx_v1`로 고정했습니다.
- `story_info_media_refs` 테이블을 추가해 대표 이미지와 본문 `MediaEmbed` 이미지/영상 참조를 저장합니다.
- 정보 생성/수정 시 backend가 본문 mediaId를 파싱해 같은 테마의 IMAGE/YouTube VIDEO인지 검증하고, 참조 테이블을 transaction 안에서 재생성합니다.
- frontend `StoryInfoResponse`/request 타입에 `contentFormat`을 반영했습니다.

## Issue
- Refs #469
- #469의 PR-2 범위입니다. 미디어 삭제 차단/참조 제거 cleanup과 runtime `story_info_ids` delivery는 같은 이슈의 후속 PR에서 계속 진행합니다.

## Coverage Plan
- DB/migration: `00042_story_info_media_refs.sql`, `story_infos.sql`, sqlc generated models/queries는 `go test ./...`와 `scripts/mmp-local-ci.sh quick`의 generate/migrate-preview로 검증했습니다.
- `story_info_service`: create/update의 cover/embedded image/embedded video refs 저장, invalid mediaId, media type mismatch, unsupported embed type, refs replacement를 `story_info_service_test.go`로 검증했습니다.
- transaction wiring: production constructor가 `pgxpool.Pool`을 받아 `Create/Update + ref replace`를 같은 transaction 경계에서 수행하도록 `cmd/server` compile과 editor tests로 검증했습니다.
- frontend API contract: `storyInfoApi.ts` 타입과 `storyInfoApi.test.ts` mutation/query 테스트로 `contentFormat` contract를 검증했습니다.
- E2E 미작성 사유: 이번 PR은 저장 schema/API contract와 backend validation 중심이며 PR-1에서 UI 작성 흐름을 검증했습니다. 브라우저 사용자 흐름 확장은 #469 PR-3/PR-4에서 삭제 UX/runtime delivery 연결 시 다룹니다.

## Local validation
- `go test ./internal/domain/editor -run 'TestStoryInfoService|TestToStoryInfoResponse|TestDecodeStoryInfoRefs'` ✅
- `go test ./internal/domain/editor` ✅
- `go test ./cmd/server ./internal/domain/editor ./internal/db` ✅
- `go test ./...` ✅
- `pnpm --filter @mmp/web test -- src/features/editor/storyInfoApi.test.ts` ✅ 6 tests
- `pnpm --filter @mmp/web typecheck` ✅
- `scripts/mmp-local-ci.sh quick` ✅ success at `0b3154233886b8c20c7445749138d972483ceab8`
- build note: existing Rollup circular chunk warnings and existing MDXEditor `InfoTab` chunk-size warning remain; build exits successfully.

## Deferred / Follow-up
- PR-3: media delete reference scan에 `story_info_media_refs` 사용처 포함, 409 references 표시, 명시적 `참조 제거 후 삭제` cleanup.
- PR-4: runtime `information_delivery`가 `story_info_ids`를 player state로 전달.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 스토리에 미디어 참조 관리 추가: 커버 및 본문 임베드 미디어를 연결하고 정렬 순서로 유지합니다.
  * 콘텐츠 형식 지정 지원: 생성/수정 시 contentFormat을 설정 가능하며 응답에 항상 포함됩니다 (기본 mdx_v1).
  * 임베드 검증 강화: 임베드된 미디어의 유형·출처 일치 여부를 엄격히 검사해 부적합 참조를 거부하고 저장 과정의 원자성을 보장합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->