### PR TITLE
feat(runtime): 정보 공개에 스토리 정보 전달

### DIFF
--- a/apps/server/internal/module/progression/information_delivery/module.go
+++ b/apps/server/internal/module/progression/information_delivery/module.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/engine"
 )
 
@@ -241,7 +243,7 @@ func (m *Module) applyDeliveries(ctx context.Context, deliveries []deliveryConfi
 		sections := uniqueStrings(delivery.ReadingSectionIDs)
 		storyInfoIDs := uniqueStrings(delivery.StoryInfoIDs)
 		if len(sections) == 0 && len(storyInfoIDs) == 0 {
-			return fmt.Errorf("information_delivery: delivery %q has empty reading_section_ids and story_info_ids", delivery.ID)
+			return invalidDeliveryError("delivery %q has empty reading_section_ids and story_info_ids", delivery.ID)
 		}
 		item := deliveredItem{DeliveryID: delivery.ID, ReadingSectionIDs: sections, StoryInfoIDs: storyInfoIDs}
 		next := preparedDelivery{delivery: delivery, item: item}
@@ -250,7 +252,7 @@ func (m *Module) applyDeliveries(ctx context.Context, deliveries []deliveryConfi
 			// valid
 		case targetCharacter:
 			if delivery.Target.CharacterID == "" {
-				return fmt.Errorf("information_delivery: delivery %q missing character_id", delivery.ID)
+				return invalidDeliveryError("delivery %q missing character_id", delivery.ID)
 			}
 			if m.deps.PlayerInfoProvider != nil {
 				if playerID, ok := m.deps.PlayerInfoProvider.ResolvePlayerID(ctx, delivery.Target.CharacterID); ok {
@@ -259,7 +261,7 @@ func (m *Module) applyDeliveries(ctx context.Context, deliveries []deliveryConfi
 				}
 			}
 		default:
-			return fmt.Errorf("information_delivery: delivery %q has unsupported target type %q", delivery.ID, delivery.Target.Type)
+			return invalidDeliveryError("delivery %q has unsupported target type %q", delivery.ID, delivery.Target.Type)
 		}
 		prepared = append(prepared, next)
 	}
@@ -285,6 +287,14 @@ func (m *Module) applyDeliveries(ctx context.Context, deliveries []deliveryConfi
 		m.appliedDeliveryIDs[next.delivery.ID] = struct{}{}
 	}
 	return nil
+}
+
+func invalidDeliveryError(format string, args ...any) *apperror.AppError {
+	return apperror.New(
+		apperror.ErrValidation,
+		http.StatusUnprocessableEntity,
+		"information_delivery: "+fmt.Sprintf(format, args...),
+	)
 }
 
 func (m *Module) applyPlayerDelivery(playerID uuid.UUID, item deliveredItem) {

--- a/apps/server/internal/module/progression/information_delivery/module.go
+++ b/apps/server/internal/module/progression/information_delivery/module.go
@@ -29,6 +29,7 @@ type deliveryConfig struct {
 	ID                string         `json:"id"`
 	Target            deliveryTarget `json:"target"`
 	ReadingSectionIDs []string       `json:"reading_section_ids"`
+	StoryInfoIDs      []string       `json:"story_info_ids"`
 }
 
 type deliverInformationParams struct {
@@ -38,10 +39,12 @@ type deliverInformationParams struct {
 type deliveredItem struct {
 	DeliveryID        string   `json:"deliveryId"`
 	ReadingSectionIDs []string `json:"readingSectionIds"`
+	StoryInfoIDs      []string `json:"storyInfoIds"`
 }
 
 type moduleState struct {
 	VisibleReadingSectionIDs []string        `json:"visibleReadingSectionIds"`
+	VisibleStoryInfoIDs      []string        `json:"visibleStoryInfoIds"`
 	Deliveries               []deliveredItem `json:"deliveries"`
 }
 
@@ -51,18 +54,21 @@ type Module struct {
 	deps engine.ModuleDeps
 
 	// all-player deliveries are visible to every viewer once delivered.
-	allPlayerSections map[string]struct{}
-	allPlayerItems    map[string]deliveredItem
+	allPlayerSections  map[string]struct{}
+	allPlayerStoryInfo map[string]struct{}
+	allPlayerItems     map[string]deliveredItem
 
 	// playerDeliveries stores player-specific deliveries after target resolution.
-	playerSections map[uuid.UUID]map[string]struct{}
-	playerItems    map[uuid.UUID]map[string]deliveredItem
+	playerSections  map[uuid.UUID]map[string]struct{}
+	playerStoryInfo map[uuid.UUID]map[string]struct{}
+	playerItems     map[uuid.UUID]map[string]deliveredItem
 
 	// targetCodeDeliveries is used when a session has no PlayerInfoProvider or a
 	// future reconnect resolves the player after delivery time. BuildStateFor can
 	// still match by PlayerRuntimeInfo.TargetCode.
-	targetCodeSections map[string]map[string]struct{}
-	targetCodeItems    map[string]map[string]deliveredItem
+	targetCodeSections  map[string]map[string]struct{}
+	targetCodeStoryInfo map[string]map[string]struct{}
+	targetCodeItems     map[string]map[string]deliveredItem
 
 	// appliedDeliveryIDs makes phase re-entry/retry idempotent.
 	appliedDeliveryIDs map[string]struct{}
@@ -79,10 +85,13 @@ func (m *Module) Init(_ context.Context, deps engine.ModuleDeps, _ json.RawMessa
 	defer m.mu.Unlock()
 	m.deps = deps
 	m.allPlayerSections = map[string]struct{}{}
+	m.allPlayerStoryInfo = map[string]struct{}{}
 	m.allPlayerItems = map[string]deliveredItem{}
 	m.playerSections = map[uuid.UUID]map[string]struct{}{}
+	m.playerStoryInfo = map[uuid.UUID]map[string]struct{}{}
 	m.playerItems = map[uuid.UUID]map[string]deliveredItem{}
 	m.targetCodeSections = map[string]map[string]struct{}{}
+	m.targetCodeStoryInfo = map[string]map[string]struct{}{}
 	m.targetCodeItems = map[string]map[string]deliveredItem{}
 	m.appliedDeliveryIDs = map[string]struct{}{}
 	return nil
@@ -93,17 +102,31 @@ func (m *Module) BuildState() (json.RawMessage, error) {
 	defer m.mu.RUnlock()
 
 	sections := map[string]struct{}{}
+	storyInfo := map[string]struct{}{}
 	for id := range m.allPlayerSections {
 		sections[id] = struct{}{}
+	}
+	for id := range m.allPlayerStoryInfo {
+		storyInfo[id] = struct{}{}
 	}
 	for _, perPlayer := range m.playerSections {
 		for id := range perPlayer {
 			sections[id] = struct{}{}
 		}
 	}
+	for _, perPlayer := range m.playerStoryInfo {
+		for id := range perPlayer {
+			storyInfo[id] = struct{}{}
+		}
+	}
 	for _, perTarget := range m.targetCodeSections {
 		for id := range perTarget {
 			sections[id] = struct{}{}
+		}
+	}
+	for _, perTarget := range m.targetCodeStoryInfo {
+		for id := range perTarget {
+			storyInfo[id] = struct{}{}
 		}
 	}
 
@@ -124,6 +147,7 @@ func (m *Module) BuildState() (json.RawMessage, error) {
 
 	return json.Marshal(moduleState{
 		VisibleReadingSectionIDs: sortedKeys(sections),
+		VisibleStoryInfoIDs:      sortedKeys(storyInfo),
 		Deliveries:               sortedItems(items),
 	})
 }
@@ -140,18 +164,23 @@ func (m *Module) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error) {
 	defer m.mu.RUnlock()
 
 	sections := map[string]struct{}{}
+	storyInfo := map[string]struct{}{}
 	items := map[string]deliveredItem{}
 	mergeSections(sections, m.allPlayerSections)
+	mergeSections(storyInfo, m.allPlayerStoryInfo)
 	mergeItems(items, m.allPlayerItems)
 	mergeSections(sections, m.playerSections[playerID])
+	mergeSections(storyInfo, m.playerStoryInfo[playerID])
 	mergeItems(items, m.playerItems[playerID])
 	if targetCode != "" {
 		mergeSections(sections, m.targetCodeSections[targetCode])
+		mergeSections(storyInfo, m.targetCodeStoryInfo[targetCode])
 		mergeItems(items, m.targetCodeItems[targetCode])
 	}
 
 	return json.Marshal(moduleState{
 		VisibleReadingSectionIDs: sortedKeys(sections),
+		VisibleStoryInfoIDs:      sortedKeys(storyInfo),
 		Deliveries:               sortedItems(items),
 	})
 }
@@ -164,10 +193,13 @@ func (m *Module) Cleanup(_ context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.allPlayerSections = nil
+	m.allPlayerStoryInfo = nil
 	m.allPlayerItems = nil
 	m.playerSections = nil
+	m.playerStoryInfo = nil
 	m.playerItems = nil
 	m.targetCodeSections = nil
+	m.targetCodeStoryInfo = nil
 	m.targetCodeItems = nil
 	m.appliedDeliveryIDs = nil
 	return nil
@@ -207,10 +239,11 @@ func (m *Module) applyDeliveries(ctx context.Context, deliveries []deliveryConfi
 	for _, delivery := range deliveries {
 		delivery.ID = normalizeDeliveryID(delivery)
 		sections := uniqueStrings(delivery.ReadingSectionIDs)
-		if len(sections) == 0 {
-			return fmt.Errorf("information_delivery: delivery %q has empty reading_section_ids", delivery.ID)
+		storyInfoIDs := uniqueStrings(delivery.StoryInfoIDs)
+		if len(sections) == 0 && len(storyInfoIDs) == 0 {
+			return fmt.Errorf("information_delivery: delivery %q has empty reading_section_ids and story_info_ids", delivery.ID)
 		}
-		item := deliveredItem{DeliveryID: delivery.ID, ReadingSectionIDs: sections}
+		item := deliveredItem{DeliveryID: delivery.ID, ReadingSectionIDs: sections, StoryInfoIDs: storyInfoIDs}
 		next := preparedDelivery{delivery: delivery, item: item}
 		switch delivery.Target.Type {
 		case targetAllPlayers:
@@ -240,6 +273,7 @@ func (m *Module) applyDeliveries(ctx context.Context, deliveries []deliveryConfi
 		switch next.delivery.Target.Type {
 		case targetAllPlayers:
 			mergeStringIDs(m.allPlayerSections, next.item.ReadingSectionIDs)
+			mergeStringIDs(m.allPlayerStoryInfo, next.item.StoryInfoIDs)
 			m.allPlayerItems[next.item.DeliveryID] = next.item
 		case targetCharacter:
 			if next.hasPlayer {
@@ -257,10 +291,14 @@ func (m *Module) applyPlayerDelivery(playerID uuid.UUID, item deliveredItem) {
 	if m.playerSections[playerID] == nil {
 		m.playerSections[playerID] = map[string]struct{}{}
 	}
+	if m.playerStoryInfo[playerID] == nil {
+		m.playerStoryInfo[playerID] = map[string]struct{}{}
+	}
 	if m.playerItems[playerID] == nil {
 		m.playerItems[playerID] = map[string]deliveredItem{}
 	}
 	mergeStringIDs(m.playerSections[playerID], item.ReadingSectionIDs)
+	mergeStringIDs(m.playerStoryInfo[playerID], item.StoryInfoIDs)
 	m.playerItems[playerID][item.DeliveryID] = item
 }
 
@@ -268,10 +306,14 @@ func (m *Module) applyTargetCodeDelivery(characterID string, item deliveredItem)
 	if m.targetCodeSections[characterID] == nil {
 		m.targetCodeSections[characterID] = map[string]struct{}{}
 	}
+	if m.targetCodeStoryInfo[characterID] == nil {
+		m.targetCodeStoryInfo[characterID] = map[string]struct{}{}
+	}
 	if m.targetCodeItems[characterID] == nil {
 		m.targetCodeItems[characterID] = map[string]deliveredItem{}
 	}
 	mergeStringIDs(m.targetCodeSections[characterID], item.ReadingSectionIDs)
+	mergeStringIDs(m.targetCodeStoryInfo[characterID], item.StoryInfoIDs)
 	m.targetCodeItems[characterID][item.DeliveryID] = item
 }
 
@@ -279,7 +321,7 @@ func normalizeDeliveryID(delivery deliveryConfig) string {
 	if delivery.ID != "" {
 		return delivery.ID
 	}
-	return delivery.Target.Type + ":" + delivery.Target.CharacterID + ":" + joinSorted(uniqueStrings(delivery.ReadingSectionIDs))
+	return delivery.Target.Type + ":" + delivery.Target.CharacterID + ":reading:" + joinSorted(uniqueStrings(delivery.ReadingSectionIDs)) + ":story:" + joinSorted(uniqueStrings(delivery.StoryInfoIDs))
 }
 
 func mergeStringIDs(dst map[string]struct{}, ids []string) {
@@ -332,6 +374,7 @@ func sortedItems(items map[string]deliveredItem) []deliveredItem {
 	out := make([]deliveredItem, 0, len(items))
 	for _, item := range items {
 		item.ReadingSectionIDs = uniqueStrings(item.ReadingSectionIDs)
+		item.StoryInfoIDs = uniqueStrings(item.StoryInfoIDs)
 		out = append(out, item)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].DeliveryID < out[j].DeliveryID })

--- a/apps/server/internal/module/progression/information_delivery/module_test.go
+++ b/apps/server/internal/module/progression/information_delivery/module_test.go
@@ -86,6 +86,75 @@ func TestModule_DeliversOnlyToTargetCharacter(t *testing.T) {
 	}
 }
 
+func TestModule_DeliversStoryInfoOnlyToTargetCharacter(t *testing.T) {
+	alice := uuid.New()
+	bob := uuid.New()
+	provider := testPlayerProvider{
+		byID: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			alice: {PlayerID: alice, TargetCode: "char-alice"},
+			bob:   {PlayerID: bob, TargetCode: "char-bob"},
+		},
+		byTarget: map[string]uuid.UUID{"char-alice": alice, "char-bob": bob},
+	}
+	m := newTestModule(t, provider)
+
+	err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionDeliverInformation,
+		Params: json.RawMessage(`{"deliveries":[{"id":"d1","target":{"type":"character","character_id":"char-alice"},"story_info_ids":["info-2","info-1","info-1"]}]}`),
+	})
+	if err != nil {
+		t.Fatalf("ReactTo: %v", err)
+	}
+
+	aliceState := decodeState(t, mustStateFor(t, m, alice))
+	bobState := decodeState(t, mustStateFor(t, m, bob))
+
+	if got := aliceState.VisibleStoryInfoIDs; len(got) != 2 || got[0] != "info-1" || got[1] != "info-2" {
+		t.Fatalf("alice visible story info = %#v", got)
+	}
+	if got := aliceState.VisibleReadingSectionIDs; len(got) != 0 {
+		t.Fatalf("story info delivery should not create reading sections, got %#v", got)
+	}
+	if got := aliceState.Deliveries[0].StoryInfoIDs; len(got) != 2 || got[0] != "info-1" || got[1] != "info-2" {
+		t.Fatalf("alice delivery story info = %#v", got)
+	}
+	if got := bobState.VisibleStoryInfoIDs; len(got) != 0 {
+		t.Fatalf("bob should not see alice story info, got %#v", got)
+	}
+}
+
+func TestModule_DeliversReadingAndStoryInfoWithoutMixing(t *testing.T) {
+	alice := uuid.New()
+	m := newTestModule(t, nil)
+	action := engine.PhaseActionPayload{
+		Action: engine.ActionDeliverInformation,
+		Params: json.RawMessage(`{"deliveries":[{"id":"mixed","target":{"type":"all_players"},"reading_section_ids":["rs-common"],"story_info_ids":["info-common"]}]}`),
+	}
+	if err := m.ReactTo(context.Background(), action); err != nil {
+		t.Fatalf("ReactTo first: %v", err)
+	}
+	if err := m.ReactTo(context.Background(), action); err != nil {
+		t.Fatalf("ReactTo second: %v", err)
+	}
+
+	state := decodeState(t, mustStateFor(t, m, alice))
+	if got := state.VisibleReadingSectionIDs; len(got) != 1 || got[0] != "rs-common" {
+		t.Fatalf("visible sections = %#v", got)
+	}
+	if got := state.VisibleStoryInfoIDs; len(got) != 1 || got[0] != "info-common" {
+		t.Fatalf("visible story info = %#v", got)
+	}
+	if len(state.Deliveries) != 1 || state.Deliveries[0].DeliveryID != "mixed" {
+		t.Fatalf("deliveries should not duplicate: %#v", state.Deliveries)
+	}
+	if got := state.Deliveries[0].ReadingSectionIDs; len(got) != 1 || got[0] != "rs-common" {
+		t.Fatalf("delivery sections = %#v", got)
+	}
+	if got := state.Deliveries[0].StoryInfoIDs; len(got) != 1 || got[0] != "info-common" {
+		t.Fatalf("delivery story info = %#v", got)
+	}
+}
+
 func TestModule_AllPlayersAndReentryAreIdempotent(t *testing.T) {
 	alice := uuid.New()
 	m := newTestModule(t, nil)
@@ -178,6 +247,50 @@ func TestEnginePhaseEnterDeliversAndReconnectStatePersists(t *testing.T) {
 	}
 }
 
+func TestEnginePhaseEnterDeliversStoryInfoAndReconnectStatePersists(t *testing.T) {
+	alice := uuid.New()
+	bob := uuid.New()
+	provider := testPlayerProvider{
+		byID: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			alice: {PlayerID: alice, TargetCode: "char-alice"},
+			bob:   {PlayerID: bob, TargetCode: "char-bob"},
+		},
+		byTarget: map[string]uuid.UUID{"char-alice": alice, "char-bob": bob},
+	}
+	bus := engine.NewEventBus(testLogger{t})
+	module := NewModule()
+	phases := []engine.PhaseDefinition{
+		{
+			ID:   "investigation",
+			Name: "Investigation",
+			OnEnter: json.RawMessage(`[
+				{"type":"DELIVER_INFORMATION","params":{"deliveries":[
+					{"id":"alice-info","target":{"type":"character","character_id":"char-alice"},"story_info_ids":["info-secret"]},
+					{"id":"common-info","target":{"type":"all_players"},"story_info_ids":["info-common"]}
+				]}}
+			]`),
+		},
+	}
+	pe := engine.NewPhaseEngine(uuid.New(), []engine.Module{module}, bus, nil, testLogger{t}, phases)
+	pe.SetPlayerInfoProvider(provider)
+	if err := pe.Start(context.Background(), map[string]json.RawMessage{module.Name(): nil}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(context.Background())
+
+	aliceState := decodeState(t, mustStateFor(t, module, alice))
+	bobState := decodeState(t, mustStateFor(t, module, bob))
+	if got := aliceState.VisibleStoryInfoIDs; len(got) != 2 || got[0] != "info-common" || got[1] != "info-secret" {
+		t.Fatalf("alice story info reconnect state = %#v", got)
+	}
+	if got := bobState.VisibleStoryInfoIDs; len(got) != 1 || got[0] != "info-common" {
+		t.Fatalf("bob story info reconnect state = %#v", got)
+	}
+	if got := aliceState.VisibleReadingSectionIDs; len(got) != 0 {
+		t.Fatalf("story info phase action should not create reading sections, got %#v", got)
+	}
+}
+
 func TestModule_TargetCodeFallbackAndBuildState(t *testing.T) {
 	m := newTestModule(t, nil)
 	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
@@ -207,6 +320,33 @@ func TestModule_TargetCodeFallbackAndBuildState(t *testing.T) {
 	}
 }
 
+func TestModule_StoryInfoTargetCodeFallbackAndBuildState(t *testing.T) {
+	m := newTestModule(t, nil)
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionDeliverInformation,
+		Params: json.RawMessage(`{"deliveries":[{"id":"fallback","target":{"type":"character","character_id":"char-late"},"story_info_ids":["info-late"]}]}`),
+	}); err != nil {
+		t.Fatalf("ReactTo: %v", err)
+	}
+
+	state := decodeState(t, mustBuildState(t, m))
+	if len(state.VisibleStoryInfoIDs) != 1 || state.VisibleStoryInfoIDs[0] != "info-late" {
+		t.Fatalf("build state story info = %#v", state.VisibleStoryInfoIDs)
+	}
+
+	latePlayer := uuid.New()
+	m.deps.PlayerInfoProvider = testPlayerProvider{
+		byID: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			latePlayer: {PlayerID: latePlayer, TargetCode: "char-late"},
+		},
+		byTarget: map[string]uuid.UUID{"char-late": latePlayer},
+	}
+	playerState := decodeState(t, mustStateFor(t, m, latePlayer))
+	if len(playerState.VisibleStoryInfoIDs) != 1 || playerState.VisibleStoryInfoIDs[0] != "info-late" {
+		t.Fatalf("late player story info = %#v", playerState.VisibleStoryInfoIDs)
+	}
+}
+
 func TestModule_CleanupAndUnknownMessage(t *testing.T) {
 	m := newTestModule(t, nil)
 	if err := m.HandleMessage(context.Background(), uuid.New(), "noop", nil); err == nil {
@@ -233,7 +373,7 @@ func TestModule_InvalidDeliverySemanticsReturnError(t *testing.T) {
 		params json.RawMessage
 	}{
 		{
-			name:   "empty sections",
+			name:   "empty sections and story info",
 			params: json.RawMessage(`{"deliveries":[{"id":"bad","target":{"type":"all_players"},"reading_section_ids":[]}]}`),
 		},
 		{

--- a/apps/server/internal/module/progression/information_delivery/module_test.go
+++ b/apps/server/internal/module/progression/information_delivery/module_test.go
@@ -3,9 +3,11 @@ package informationdelivery
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/engine"
 )
 
@@ -186,6 +188,43 @@ func TestModule_InvalidParamsReturnError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected invalid params error")
+	}
+}
+
+func TestModule_InvalidDeliveryConfigReturnsAppError(t *testing.T) {
+	tests := []struct {
+		name   string
+		params json.RawMessage
+	}{
+		{
+			name:   "empty content ids",
+			params: json.RawMessage(`{"deliveries":[{"id":"empty","target":{"type":"all_players"}}]}`),
+		},
+		{
+			name:   "missing character id",
+			params: json.RawMessage(`{"deliveries":[{"id":"missing-character","target":{"type":"character"},"story_info_ids":["info-1"]}]}`),
+		},
+		{
+			name:   "unsupported target type",
+			params: json.RawMessage(`{"deliveries":[{"id":"bad-target","target":{"type":"room"},"story_info_ids":["info-1"]}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModule(t, nil)
+			err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+				Action: engine.ActionDeliverInformation,
+				Params: tc.params,
+			})
+			var appErr *apperror.AppError
+			if !errors.As(err, &appErr) {
+				t.Fatalf("ReactTo error = %T %v, want *apperror.AppError", err, err)
+			}
+			if appErr.Code != apperror.ErrValidation {
+				t.Fatalf("AppError code = %q, want %q", appErr.Code, apperror.ErrValidation)
+			}
+		})
 	}
 }
 

--- a/apps/server/internal/module/progression/information_delivery/module_test.go
+++ b/apps/server/internal/module/progression/information_delivery/module_test.go
@@ -317,6 +317,14 @@ func TestEnginePhaseEnterDeliversStoryInfoAndReconnectStatePersists(t *testing.T
 	}
 	defer pe.Stop(context.Background())
 
+	// Re-entering the same action must not duplicate the reconnect state.
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionDeliverInformation,
+		Params: json.RawMessage(`{"deliveries":[{"id":"alice-info","target":{"type":"character","character_id":"char-alice"},"story_info_ids":["info-secret"]},{"id":"common-info","target":{"type":"all_players"},"story_info_ids":["info-common"]}]}`),
+	}); err != nil {
+		t.Fatalf("ReactTo retry: %v", err)
+	}
+
 	aliceState := decodeState(t, mustStateFor(t, module, alice))
 	bobState := decodeState(t, mustStateFor(t, module, bob))
 	if got := aliceState.VisibleStoryInfoIDs; len(got) != 2 || got[0] != "info-common" || got[1] != "info-secret" {

--- a/apps/server/internal/module/progression/information_delivery/module_test.go
+++ b/apps/server/internal/module/progression/information_delivery/module_test.go
@@ -117,6 +117,9 @@ func TestModule_DeliversStoryInfoOnlyToTargetCharacter(t *testing.T) {
 	if got := aliceState.VisibleReadingSectionIDs; len(got) != 0 {
 		t.Fatalf("story info delivery should not create reading sections, got %#v", got)
 	}
+	if len(aliceState.Deliveries) != 1 {
+		t.Fatalf("alice deliveries = %#v", aliceState.Deliveries)
+	}
 	if got := aliceState.Deliveries[0].StoryInfoIDs; len(got) != 2 || got[0] != "info-1" || got[1] != "info-2" {
 		t.Fatalf("alice delivery story info = %#v", got)
 	}
@@ -421,7 +424,7 @@ func TestModule_InvalidDeliverySemanticsReturnError(t *testing.T) {
 	}{
 		{
 			name:   "empty sections and story info",
-			params: json.RawMessage(`{"deliveries":[{"id":"bad","target":{"type":"all_players"},"reading_section_ids":[]}]}`),
+			params: json.RawMessage(`{"deliveries":[{"id":"bad","target":{"type":"all_players"},"reading_section_ids":[],"story_info_ids":[]}]}`),
 		},
 		{
 			name:   "missing character",


### PR DESCRIPTION
## 요약
- information_delivery runtime이 `story_info_ids`를 읽기 섹션과 별도 공개 상태로 보존합니다.
- 플레이어별 `BuildStateFor`와 전체 `BuildState`에 `visibleStoryInfoIds`를 추가했습니다.
- 캐릭터 대상, 전체 플레이어 대상, phase enter/reconnect, target-code fallback에서 읽기와 정보가 섞이지 않도록 테스트했습니다.

## Coverage Plan
- `apps/server/internal/module/progression/information_delivery/module.go`: `story_info_ids` parsing, validation, delivery id normalization, all-player/player/target-code state merge를 module tests로 검증.
- `apps/server/internal/module/progression/information_delivery/module_test.go`: story info 단독 공개, reading+story 동시 공개, phase enter reconnect, late target-code fallback, 빈 payload validation을 검증.
- E2E 제외 사유: frontend adapter/panel은 이미 `storyInfoIds` payload를 생성하며, 이번 PR은 backend runtime state 계약 보강만 수행합니다.

## Local validation
- `go test ./internal/module/progression/information_delivery` 통과.
- `scripts/mmp-local-ci.sh quick` 통과.
  - marker: mode `quick`, status `success`, head `d3e3eaf6b37729bca52c96525fc6b55e324c5acb`, finished_at `2026-05-07T13:26:27Z`.
  - 기존 lint warning 47건과 기존 Rollup/chunk warning만 있으며 error는 없습니다.

Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 정보 전달이 읽기 섹션뿐만 아니라 스토리 정보 항목(story info)도 추적·전달하도록 확장
  * 전달 항목의 식별자 자동 생성이 읽기·스토리 정보 조합을 반영하도록 개선

* **버그 수정**
  * 전달된 ID 목록의 중복 제거·정렬로 출력의 결정성 보장

* **테스트**
  * 스토리 정보의 전달·가시성·재진입(idempotency) 시나리오 검증 추가
  * 잘못된 전달 구성에 대한 유효성 검사 오류 처리 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->