### PR TITLE
feat(editor): 등장인물 결과 카드 편집 책임 분리

### DIFF
--- a/apps/web/src/features/editor/components/CharacterForm.tsx
+++ b/apps/web/src/features/editor/components/CharacterForm.tsx
@@ -91,10 +91,6 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
             show_in_intro: character.show_in_intro,
             can_speak_in_reading: character.can_speak_in_reading,
             is_voting_candidate: character.is_voting_candidate,
-            endcard_title: character.endcard_title ?? undefined,
-            endcard_body: character.endcard_body ?? undefined,
-            endcard_image_url: character.endcard_image_url ?? undefined,
-            endcard_image_media_id: character.endcard_image_media_id ?? undefined,
           },
         },
         {

--- a/apps/web/src/features/editor/components/__tests__/CharacterForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CharacterForm.test.tsx
@@ -154,4 +154,34 @@ describe('CharacterForm', () => {
     expect(screen.getByLabelText(/범인 여부/)).toBeDefined();
     expect(screen.getByLabelText('정렬 순서')).toBeDefined();
   });
+
+  it('수정 요청은 기존 결과 카드 값을 등장인물 payload에 보존하지 않는다', () => {
+    render(
+      <CharacterForm
+        themeId="theme-1"
+        character={{
+          ...character,
+          endcard_title: '홍길동의 후일담',
+          endcard_body: '사건 이후의 선택',
+          endcard_image_url: 'https://cdn.example/endcard.webp',
+        }}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.objectContaining({
+          endcard_title: expect.anything(),
+          endcard_body: expect.anything(),
+          endcard_image_url: expect.anything(),
+          endcard_image_media_id: expect.anything(),
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
 });

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -14,7 +14,6 @@ import {
   buildCharacterVisibilityUpdatePayload,
   buildCharacterProfileImageMediaUpdatePayload,
   buildCharacterRoleUpdatePayload,
-  buildCharacterEndcardUpdatePayload,
   getCharacterListBadges,
   type CharacterVisibilityField,
 } from "@/features/editor/entities/character/characterEditorAdapter";
@@ -154,21 +153,6 @@ export function CharacterAssignPanel({
     [characters, updateCharacter],
   );
 
-  const handleEndcardChangeForChar = useCallback(
-    (characterId: string, values: { title: string; body: string; imageUrl: string; imageMediaId?: string | null }) => {
-      if (updateCharacter.isPending) return;
-
-      const selected = characters?.find((char) => char.id === characterId);
-      if (!selected) return;
-
-      updateCharacter.mutate({
-        characterId: selected.id,
-        body: buildCharacterEndcardUpdatePayload(selected, values),
-      });
-    },
-    [characters, updateCharacter],
-  );
-
   const handleProfileImageChangeForChar = useCallback(
     (characterId: string, imageMediaId: string | null) => {
       if (updateCharacter.isPending) return;
@@ -274,11 +258,6 @@ export function CharacterAssignPanel({
               updateCharacter.isPending
                 ? undefined
                 : (rules) => handleAliasRulesSaveForChar(char.id, rules)
-            }
-            onEndcardChange={
-              updateCharacter.isPending
-                ? undefined
-                : (values) => handleEndcardChangeForChar(char.id, values)
             }
             onProfileImageChange={
               updateCharacter.isPending

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -42,10 +42,6 @@ interface CharacterItem {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
-  endcard_title?: string | null;
-  endcard_body?: string | null;
-  endcard_image_url?: string | null;
-  endcard_image_media_id?: string | null;
   alias_rules?: CharacterAliasRule[];
 }
 
@@ -63,7 +59,6 @@ interface CharacterDetailPanelProps {
   onMysteryRoleChange?: (role: MysteryRole) => void;
   onVisibilityChange?: (field: CharacterVisibilityField, value: boolean) => void;
   onAliasRulesSave?: (rules: CharacterAliasRule[]) => void;
-  onEndcardChange?: (values: { title: string; body: string; imageUrl: string; imageMediaId?: string | null }) => void;
   onProfileImageChange?: (imageMediaId: string | null) => void;
 }
 
@@ -85,15 +80,10 @@ export function CharacterDetailPanel({
   onMysteryRoleChange,
   onVisibilityChange,
   onAliasRulesSave,
-  onEndcardChange,
   onProfileImageChange,
 }: CharacterDetailPanelProps) {
   const [aliasDrafts, setAliasDrafts] = useState<CharacterAliasRule[]>([]);
   const aliasDraftCharacterIdRef = useRef<string | null>(null);
-  const [endcardTitle, setEndcardTitle] = useState('');
-  const [endcardBody, setEndcardBody] = useState('');
-  const [endcardImageUrl, setEndcardImageUrl] = useState('');
-  const [endcardImageMediaId, setEndcardImageMediaId] = useState<string | null>(null);
   const characterOptions = useMemo(
     () => characters.map((char) => ({ id: char.id, name: char.name })),
     [characters]
@@ -104,19 +94,6 @@ export function CharacterDetailPanel({
     aliasDraftCharacterIdRef.current = selectedChar?.id ?? null;
     setAliasDrafts(normalizeCharacterAliasRules(selectedChar?.alias_rules));
   }, [selectedChar]);
-
-  useEffect(() => {
-    setEndcardTitle(selectedChar?.endcard_title ?? '');
-    setEndcardBody(selectedChar?.endcard_body ?? '');
-    setEndcardImageUrl(selectedChar?.endcard_image_url ?? '');
-    setEndcardImageMediaId(selectedChar?.endcard_image_media_id ?? null);
-  }, [
-    selectedChar?.id,
-    selectedChar?.endcard_title,
-    selectedChar?.endcard_body,
-    selectedChar?.endcard_image_url,
-    selectedChar?.endcard_image_media_id,
-  ]);
 
   if (!selectedChar) {
     return (
@@ -143,17 +120,8 @@ export function CharacterDetailPanel({
     is_voting_candidate:
       selectedChar.is_voting_candidate ??
       getCharacterRoleOption(selectedRole).defaultVotingCandidate,
-    endcard_title: selectedChar.endcard_title ?? null,
-    endcard_body: selectedChar.endcard_body ?? null,
-    endcard_image_url: selectedChar.endcard_image_url ?? null,
-    endcard_image_media_id: selectedChar.endcard_image_media_id ?? null,
     alias_rules: selectedChar.alias_rules ?? [],
   });
-  const endcardDirty =
-    endcardTitle !== (selectedChar.endcard_title ?? '') ||
-    endcardBody !== (selectedChar.endcard_body ?? '') ||
-    endcardImageUrl !== (selectedChar.endcard_image_url ?? '') ||
-    endcardImageMediaId !== (selectedChar.endcard_image_media_id ?? null);
 
   return (
     <div className="w-full space-y-3">
@@ -184,28 +152,7 @@ export function CharacterDetailPanel({
             defaultOpen: true,
             forceOpen: true,
             children: (
-              <div className="grid gap-3 md:grid-cols-[8rem_minmax(0,1fr)]">
-                <div className="min-w-0">
-                  {onProfileImageChange ? (
-                    <ImageMediaReferenceField
-                        themeId={themeId}
-                        label="프로필 이미지"
-                        imageMediaId={selectedChar.image_media_id ?? null}
-                        legacyImageUrl={selectedChar.image_url ?? null}
-                        pickerTitle="프로필 이미지 선택"
-                        emptyLabel="이미지 선택"
-                        compact
-                        onSelect={(media) => onProfileImageChange(media.id)}
-                        onClear={() => onProfileImageChange(null)}
-                    />
-                  ) : (
-                    <div className="rounded-lg border border-slate-800 bg-slate-950 p-3 text-center">
-                      <span className="px-2 text-[11px] leading-5 text-slate-500">
-                      현재 프로필 이미지를 편집할 수 없습니다.
-                      </span>
-                    </div>
-                  )}
-                </div>
+              <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_14rem]">
                 <div className="space-y-2.5">
                   <div className="grid gap-3 sm:grid-cols-2">
                     <div>
@@ -297,76 +244,26 @@ export function CharacterDetailPanel({
                     }}
                   />
                 </div>
-              </div>
-            ),
-          },
-          {
-            id: 'endcard',
-            title: '결과 카드',
-            subtitle: selectedView.hasEndcard ? '작성됨' : '비어 있음',
-            children: (
-              <div className="space-y-3">
-                <div className="grid gap-3 md:grid-cols-2">
-                  <label className="block">
-                    <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
-                      제목
-                    </span>
-                    <input
-                      type="text"
-                      value={endcardTitle}
-                      maxLength={80}
-                      disabled={!onEndcardChange}
-                      onChange={(event) => setEndcardTitle(event.currentTarget.value)}
-                      className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-200 outline-none transition focus:border-amber-500/60 disabled:opacity-70"
-                      placeholder={`${selectedChar.name}의 후일담`}
+                <div className="min-w-0 xl:order-last">
+                  {onProfileImageChange ? (
+                    <ImageMediaReferenceField
+                      themeId={themeId}
+                      label="프로필 이미지"
+                      imageMediaId={selectedChar.image_media_id ?? null}
+                      legacyImageUrl={selectedChar.image_url ?? null}
+                      pickerTitle="프로필 이미지 선택"
+                      emptyLabel="이미지 선택"
+                      compact
+                      onSelect={(media) => onProfileImageChange(media.id)}
+                      onClear={() => onProfileImageChange(null)}
                     />
-                  </label>
-                  <ImageMediaReferenceField
-                    themeId={themeId}
-                    label="결과 카드 이미지"
-                    imageMediaId={endcardImageMediaId}
-                    legacyImageUrl={selectedChar.endcard_image_url ?? null}
-                    pickerTitle="결과 카드 이미지 선택"
-                    emptyLabel="결과 카드 이미지 선택"
-                    compact
-                    disabled={!onEndcardChange}
-                    onSelect={(media) => {
-                      setEndcardImageMediaId(media.id);
-                      setEndcardImageUrl('');
-                    }}
-                    onClear={() => setEndcardImageMediaId(null)}
-                  />
-                </div>
-                <label className="block">
-                  <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
-                    본문
-                  </span>
-                  <textarea
-                    value={endcardBody}
-                    maxLength={3000}
-                    rows={5}
-                    disabled={!onEndcardChange}
-                    onChange={(event) => setEndcardBody(event.currentTarget.value)}
-                    className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm leading-5 text-slate-200 outline-none transition focus:border-amber-500/60 disabled:opacity-70"
-                    placeholder="게임 종료 후 이 인물에게 보여줄 내용을 작성하세요."
-                  />
-                </label>
-                <div className="flex justify-end">
-                  <button
-                    type="button"
-                    disabled={!onEndcardChange || !endcardDirty}
-                    onClick={() =>
-                      onEndcardChange?.({
-                        title: endcardTitle,
-                        body: endcardBody,
-                        imageUrl: endcardImageUrl,
-                        imageMediaId: endcardImageMediaId,
-                      })
-                    }
-                    className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:border-slate-800 disabled:bg-slate-950 disabled:text-slate-600"
-                  >
-                    결과 카드 저장
-                  </button>
+                  ) : (
+                    <div className="rounded-lg border border-slate-800 bg-slate-950 p-3 text-center">
+                      <span className="px-2 text-[11px] leading-5 text-slate-500">
+                        현재 프로필 이미지를 편집할 수 없습니다.
+                      </span>
+                    </div>
+                  )}
                 </div>
               </div>
             ),

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -219,7 +219,7 @@ export function EndingEntityDetail({
           <div>
             <h4 className="text-sm font-semibold text-slate-100">캐릭터별 결과 카드 작성 현황</h4>
             <p className="mt-1 text-xs leading-5 text-slate-400">
-              상세 문구는 등장인물 관리의 결과 카드에서 작성합니다. 이곳에서는 누락된 캐릭터를 확인합니다.
+              캐릭터별 결과 문구는 엔딩 관리 책임으로 이동합니다. 이곳에서는 기존 작성 현황과 누락된 캐릭터를 확인합니다.
             </p>
           </div>
           <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-amber-100">

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -210,7 +210,6 @@ function readStartingClues(config: Record<string, unknown>) {
   return modules?.starting_clue?.config?.startingClues ?? {};
 }
 
-const endcardSectionName = /^결과 카드 (?:작성됨|비어 있음)$/;
 const roleSheetSectionName = /^역할지 Markdown 또는 PDF$/;
 const startingClueSectionName = /^시작 단서 \d+\/\d+개 배정$/;
 const hiddenMissionSectionName = /^히든 미션 \d+개$/;
@@ -220,10 +219,6 @@ function openCharacterSection(name: RegExp) {
   if (button.getAttribute('aria-expanded') === 'false') {
     fireEvent.click(button);
   }
-}
-
-function openEndcardSection() {
-  openCharacterSection(endcardSectionName);
 }
 
 function openRoleSheetSection() {
@@ -275,10 +270,11 @@ describe('CharacterAssignPanel', () => {
     renderPanel();
 
     expect(screen.getByRole('button', { name: /기본 정보/ }).getAttribute('aria-expanded')).toBe('true');
-    expect(screen.getByRole('button', { name: endcardSectionName }).getAttribute('aria-expanded')).toBe('false');
     expect(screen.getByRole('button', { name: roleSheetSectionName }).getAttribute('aria-expanded')).toBe('false');
     expect(screen.getByRole('button', { name: startingClueSectionName }).getAttribute('aria-expanded')).toBe('false');
     expect(screen.getByRole('button', { name: hiddenMissionSectionName }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('button', { name: /결과 카드/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: '결과 카드 저장' })).toBeNull();
     expect(screen.queryByRole('textbox', { name: '역할지 Markdown' })).toBeNull();
   });
 
@@ -393,39 +389,30 @@ describe('CharacterAssignPanel', () => {
     expect(updateCharacterMutateMock).not.toHaveBeenCalled();
   });
 
-  it('결과 카드 내용을 캐릭터 저장 계약으로 보낸다', () => {
+  it('기존 결과 카드 값이 있어도 등장인물 화면 저장 payload에 포함하지 않는다', () => {
+    useEditorCharactersMock.mockReturnValue({
+      data: [{
+        ...mockCharacters[0],
+        endcard_title: '범인의 후일담',
+        endcard_body: '사건 이후의 선택',
+        endcard_image_media_id: 'image-1',
+      }],
+      isLoading: false,
+    });
+
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
-    openEndcardSection();
+    fireEvent.click(screen.getByRole('button', { name: /공범/ }));
 
-    fireEvent.change(screen.getByRole('textbox', { name: '제목' }), {
-      target: { value: '범인의 후일담' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: '결과 카드 이미지 선택' }));
-    fireEvent.click(screen.getByRole('button', { name: '캐릭터 이미지 선택' }));
-    fireEvent.change(screen.getByRole('textbox', { name: '본문' }), {
-      target: { value: '사건 이후의 선택을 보여준다.' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: '결과 카드 저장' }));
-
+    expect(screen.queryByRole('button', { name: /결과 카드/ })).toBeNull();
     expect(updateCharacterMutateMock).toHaveBeenCalledWith({
       characterId: 'char-1',
-      body: {
-        name: '홍길동',
-        description: undefined,
-        image_url: undefined,
-        is_culprit: true,
-        mystery_role: 'culprit',
-        sort_order: 0,
-        is_playable: true,
-        show_in_intro: true,
-        can_speak_in_reading: true,
-        is_voting_candidate: true,
-        endcard_title: '범인의 후일담',
-        endcard_body: '사건 이후의 선택을 보여준다.',
-        endcard_image_url: '',
-        endcard_image_media_id: 'image-1',
-      },
+      body: expect.not.objectContaining({
+        endcard_title: expect.anything(),
+        endcard_body: expect.anything(),
+        endcard_image_url: expect.anything(),
+        endcard_image_media_id: expect.anything(),
+      }),
     });
   });
 

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -3,7 +3,6 @@ import type { EditorCharacterResponse } from '@/features/editor/api/types';
 import {
   buildCharacterVisibilityUpdatePayload,
   buildCharacterAliasRulesUpdatePayload,
-  buildCharacterEndcardUpdatePayload,
   buildCharacterProfileImageMediaUpdatePayload,
   getCharacterListBadges,
   buildCharacterRoleUpdatePayload,
@@ -103,21 +102,6 @@ describe('characterEditorAdapter', () => {
     }]);
   });
 
-  it('결과 카드 필드를 제작자용 ViewModel로 변환한다', () => {
-    const vm = toCharacterEditorViewModel(character({
-      endcard_title: '홍길동의 후일담',
-      endcard_body: '사건 이후에도 단서를 정리한다.',
-      endcard_image_url: 'https://cdn.example/endcard.webp',
-    }));
-
-    expect(vm).toMatchObject({
-      endcardTitle: '홍길동의 후일담',
-      endcardBody: '사건 이후에도 단서를 정리한다.',
-      endcardImageUrl: 'https://cdn.example/endcard.webp',
-      hasEndcard: true,
-    });
-  });
-
   it('NPC 표시 정책을 제작자용 ViewModel 배지로 변환한다', () => {
     const vm = toCharacterEditorViewModel(character({
       is_playable: false,
@@ -165,19 +149,18 @@ describe('characterEditorAdapter', () => {
     expect(buildCharacterRoleUpdatePayload(character(), 'detective').is_culprit).toBe(false);
   });
 
-  it('역할 변경 저장 payload에서 기존 결과 카드 내용을 보존한다', () => {
+  it('역할 변경 저장 payload에서 기존 결과 카드 내용을 보내지 않는다', () => {
     const payload = buildCharacterRoleUpdatePayload(character({
       endcard_title: '결과 제목',
       endcard_body: '결과 본문',
       endcard_image_url: 'https://cdn.example/result.webp',
     }), 'detective');
 
-    expect(payload).toMatchObject({
-      mystery_role: 'detective',
-      endcard_title: '결과 제목',
-      endcard_body: '결과 본문',
-      endcard_image_url: 'https://cdn.example/result.webp',
-    });
+    expect(payload).toMatchObject({ mystery_role: 'detective' });
+    expect(payload).not.toHaveProperty('endcard_title');
+    expect(payload).not.toHaveProperty('endcard_body');
+    expect(payload).not.toHaveProperty('endcard_image_url');
+    expect(payload).not.toHaveProperty('endcard_image_media_id');
   });
 
   it('NPC로 전환할 때 투표 후보를 함께 끈다', () => {
@@ -227,50 +210,15 @@ describe('characterEditorAdapter', () => {
     });
   });
 
-  it('등장인물 유형 변경 저장 payload에서 기존 결과 카드 내용을 보존한다', () => {
+  it('등장인물 유형 변경 저장 payload에서 기존 결과 카드 내용을 보내지 않는다', () => {
     const payload = buildCharacterVisibilityUpdatePayload(character({
       endcard_title: '결과 제목',
       endcard_body: '결과 본문',
     }), 'show_in_intro', false);
 
-    expect(payload).toMatchObject({
-      show_in_intro: false,
-      endcard_title: '결과 제목',
-      endcard_body: '결과 본문',
-    });
-  });
-
-  it('결과 카드 저장 payload를 만든다', () => {
-    const payload = buildCharacterEndcardUpdatePayload(character({ is_playable: false }), {
-      title: '  새 결말  ',
-      body: '  공개되는 후일담  ',
-      imageUrl: '',
-      imageMediaId: 'image-1',
-    });
-
-    expect(payload).toMatchObject({
-      name: '홍길동',
-      mystery_role: 'suspect',
-      is_playable: false,
-      endcard_title: '새 결말',
-      endcard_body: '공개되는 후일담',
-      endcard_image_url: '',
-      endcard_image_media_id: 'image-1',
-    });
-  });
-
-  it('빈 결과 카드 저장 payload는 빈 문자열을 유지해 backend clear 계약을 사용한다', () => {
-    const payload = buildCharacterEndcardUpdatePayload(character(), {
-      title: ' ',
-      body: ' ',
-      imageUrl: ' ',
-    });
-
-    expect(payload).toMatchObject({
-      endcard_title: '',
-      endcard_body: '',
-      endcard_image_url: '',
-    });
+    expect(payload).toMatchObject({ show_in_intro: false });
+    expect(payload).not.toHaveProperty('endcard_title');
+    expect(payload).not.toHaveProperty('endcard_body');
   });
 
   it('프로필 이미지 선택 payload는 미디어 참조를 사용하고 URL을 비운다', () => {

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -214,11 +214,15 @@ describe('characterEditorAdapter', () => {
     const payload = buildCharacterVisibilityUpdatePayload(character({
       endcard_title: '결과 제목',
       endcard_body: '결과 본문',
+      endcard_image_url: 'https://cdn.example/result.webp',
+      endcard_image_media_id: 'image-1',
     }), 'show_in_intro', false);
 
     expect(payload).toMatchObject({ show_in_intro: false });
     expect(payload).not.toHaveProperty('endcard_title');
     expect(payload).not.toHaveProperty('endcard_body');
+    expect(payload).not.toHaveProperty('endcard_image_url');
+    expect(payload).not.toHaveProperty('endcard_image_media_id');
   });
 
   it('프로필 이미지 선택 payload는 미디어 참조를 사용하고 URL을 비운다', () => {

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -33,11 +33,6 @@ export interface CharacterEditorViewModel {
   canSpeakInReading: boolean;
   isVotingCandidate: boolean;
   visibilityBadges: string[];
-  endcardTitle: string;
-  endcardBody: string;
-  endcardImageUrl: string | null;
-  endcardImageMediaId: string | null;
-  hasEndcard: boolean;
   aliasRules: CharacterAliasRule[];
   hasAliasRules: boolean;
 }
@@ -132,17 +127,6 @@ export function normalizeCharacterAliasRules(rules: CharacterAliasRule[] | null 
     .filter((rule) => Boolean(rule.id && (rule.display_name || rule.display_icon_url || rule.display_icon_media_id)));
 }
 
-function getExistingEndcardPayload(character: EditorCharacterResponse): Pick<
-  UpdateCharacterRequest,
-  'endcard_title' | 'endcard_body' | 'endcard_image_url'
-> {
-  return {
-    ...(character.endcard_title ? { endcard_title: character.endcard_title } : {}),
-    ...(character.endcard_body ? { endcard_body: character.endcard_body } : {}),
-    ...(character.endcard_image_url ? { endcard_image_url: character.endcard_image_url } : {}),
-  };
-}
-
 function buildCharacterBaseUpdatePayload(character: EditorCharacterResponse, role = normalizeCharacterEditorRole(character)) {
   const visibility = getCharacterVisibility(character, role);
   return {
@@ -156,7 +140,6 @@ function buildCharacterBaseUpdatePayload(character: EditorCharacterResponse, rol
     show_in_intro: visibility.showInIntro,
     can_speak_in_reading: visibility.canSpeakInReading,
     is_voting_candidate: visibility.isVotingCandidate,
-    ...getExistingEndcardPayload(character),
     alias_rules: normalizeCharacterAliasRules(character.alias_rules),
   };
 }
@@ -187,16 +170,6 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     canSpeakInReading: visibility.canSpeakInReading,
     isVotingCandidate: visibility.isVotingCandidate,
     visibilityBadges: getVisibilityBadges(visibility),
-    endcardTitle: character.endcard_title?.trim() ?? '',
-    endcardBody: character.endcard_body?.trim() ?? '',
-    endcardImageUrl: character.endcard_image_url,
-    endcardImageMediaId: character.endcard_image_media_id ?? null,
-    hasEndcard: Boolean(
-      character.endcard_title?.trim() ||
-      character.endcard_body?.trim() ||
-      character.endcard_image_media_id ||
-      character.endcard_image_url,
-    ),
     aliasRules,
     hasAliasRules: aliasRules.length > 0,
   };
@@ -237,36 +210,6 @@ export function buildCharacterVisibilityUpdatePayload(
   return {
     ...buildCharacterBaseUpdatePayload(character, role),
     ...next,
-    ...getExistingEndcardPayload(character),
-  };
-}
-
-export function buildCharacterEndcardUpdatePayload(
-  character: EditorCharacterResponse,
-  values: { title: string; body: string; imageUrl: string; imageMediaId?: string | null },
-): UpdateCharacterRequest {
-  const role = normalizeCharacterEditorRole(character);
-  const visibility = getCharacterVisibility(character, role);
-  const title = values.title.trim();
-  const body = values.body.trim();
-  const imageUrl = values.imageUrl.trim();
-  const imageMediaId = values.imageMediaId ?? null;
-
-  return {
-    name: character.name,
-    description: character.description ?? undefined,
-    image_url: character.image_url ?? undefined,
-    is_culprit: role === 'culprit',
-    mystery_role: role,
-    sort_order: character.sort_order,
-    is_playable: visibility.isPlayable,
-    show_in_intro: visibility.showInIntro,
-    can_speak_in_reading: visibility.canSpeakInReading,
-    is_voting_candidate: visibility.isVotingCandidate,
-    endcard_title: title,
-    endcard_body: body,
-    endcard_image_url: imageMediaId ? '' : imageUrl,
-    endcard_image_media_id: imageMediaId,
   };
 }
 


### PR DESCRIPTION
## 요약
- 등장인물 상세 패널에서 결과 카드 Accordion과 저장 핸들러를 제거했습니다.
- 기본 정보 레이아웃을 텍스트/설정 우선 + 우측 프로필 이미지 구조로 정리했습니다.
- 기존 결과 카드 값이 있어도 등장인물 저장 payload에 endcard_* 필드가 포함되지 않도록 adapter와 구형 CharacterForm 경로를 정리했습니다.
- 엔딩 상세 화면 안내 문구를 결과 카드 책임 이동에 맞게 수정했습니다.

## Coverage Plan
- apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx: 결과 카드 UI 제거와 기본 정보 레이아웃 변경을 CharacterAssignPanel 렌더 테스트로 확인합니다.
- apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx: 역할/표시/프로필 이미지 저장 payload가 endcard_* 필드를 보내지 않는지 확인합니다.
- apps/web/src/features/editor/entities/character/characterEditorAdapter.ts: role/visibility/profile/alias payload builder가 기존 endcard 값을 보존하지 않는지 adapter unit test로 확인합니다.
- apps/web/src/features/editor/components/CharacterForm.tsx: 구형 캐릭터 수정 모달도 endcard_* 필드를 저장 payload에 넣지 않는지 unit test로 확인합니다.
- apps/web/src/features/editor/components/design/EndingEntityDetail.tsx: 결과 카드 작성 현황은 엔딩 관리 책임이라는 안내만 바뀌며, EndingEntitySubTab 테스트로 기존 현황 표시 흐름을 유지 확인합니다.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts src/features/editor/components/__tests__/CharacterForm.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx: PASS (57 tests)
- scripts/mmp-local-ci.sh quick: PASS
  - marker head: 241c056914c8cc11da026c8f494aeb1753029a7e
  - marker finished_at: 2026-05-07T13:41:28Z
  - web tests: 173 files / 1579 tests passed

## E2E
- 별도 브라우저 E2E는 추가하지 않았습니다. 이번 변경은 등장인물 편집 화면의 결과 카드 저장 surface 제거와 payload 계약 정리이며, 관련 렌더링/저장 payload 분기를 focused unit test와 quick 검증으로 덮었습니다.

Refs #470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 변경**
  * 캐릭터 관리 화면에서 결과 카드(엔드카드) 편집 UI가 제거되었습니다.
  * 결과 카드 작성/편집은 엔딩 관리 영역에서만 이루어집니다.
  * 기존 캐릭터를 저장할 때 결과 카드 관련 값은 업데이트 요청에 포함되지 않습니다(신규 생성 동작은 변경 없음).
* **테스트**
  * 관련 동작을 검증하는 테스트들이 추가·수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->