### PR TITLE
feat(editor): 역할지 MDX 작성기 적용

### DIFF
--- a/apps/web/src/features/editor/components/content/MediaEmbedPicker.tsx
+++ b/apps/web/src/features/editor/components/content/MediaEmbedPicker.tsx
@@ -3,15 +3,23 @@ import { Image, Video, X } from 'lucide-react';
 import type { MediaResponse, MediaType } from '@/features/editor/mediaApi';
 import { MediaPicker } from '../media/MediaPicker';
 
-export function InfoMediaEmbedPicker({
+export function MediaEmbedPicker({
   themeId,
   pickerType,
+  imageButtonLabel = '이미지 삽입',
+  videoButtonLabel = '영상 삽입',
+  imagePickerTitle = '이미지 선택',
+  videoPickerTitle = '영상 선택',
   onOpen,
   onClose,
   onSelect,
 }: {
   themeId: string;
   pickerType: MediaType | null;
+  imageButtonLabel?: string;
+  videoButtonLabel?: string;
+  imagePickerTitle?: string;
+  videoPickerTitle?: string;
   onOpen: (type: MediaType) => void;
   onClose: () => void;
   onSelect: (media: MediaResponse) => void;
@@ -20,23 +28,26 @@ export function InfoMediaEmbedPicker({
     <div className="flex flex-wrap items-center gap-2">
       <button
         type="button"
+        data-rich-content-control="true"
         onClick={() => onOpen('IMAGE')}
         className="inline-flex items-center gap-1.5 rounded border border-slate-700 px-2.5 py-1.5 text-xs text-slate-200 hover:border-amber-400 hover:text-amber-200"
       >
         <Image className="h-3.5 w-3.5" />
-        이미지 삽입
+        {imageButtonLabel}
       </button>
       <button
         type="button"
+        data-rich-content-control="true"
         onClick={() => onOpen('VIDEO')}
         className="inline-flex items-center gap-1.5 rounded border border-slate-700 px-2.5 py-1.5 text-xs text-slate-200 hover:border-amber-400 hover:text-amber-200"
       >
         <Video className="h-3.5 w-3.5" />
-        영상 삽입
+        {videoButtonLabel}
       </button>
       {pickerType && (
         <button
           type="button"
+          data-rich-content-control="true"
           onClick={onClose}
           className="inline-flex items-center gap-1 text-xs text-slate-500 hover:text-slate-200"
         >
@@ -50,7 +61,7 @@ export function InfoMediaEmbedPicker({
         onSelect={onSelect}
         themeId={themeId}
         filterType={pickerType ?? undefined}
-        title={pickerType === 'VIDEO' ? '정보 영상 선택' : '정보 이미지 선택'}
+        title={pickerType === 'VIDEO' ? videoPickerTitle : imagePickerTitle}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -78,6 +78,7 @@ export function RichContentEditor({
   return (
     <div
       className="space-y-2"
+      role="region"
       aria-label={ariaLabel}
       onBlurCapture={(event) => onBlurCapture?.(event.relatedTarget)}
     >

--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useRef } from 'react';
+import {
+  BlockTypeSelect,
+  BoldItalicUnderlineToggles,
+  CreateLink,
+  ListsToggle,
+  MDXEditor,
+  UndoRedo,
+  headingsPlugin,
+  linkPlugin,
+  listsPlugin,
+  quotePlugin,
+  thematicBreakPlugin,
+  toolbarPlugin,
+  type MDXEditorMethods,
+} from '@mdxeditor/editor';
+
+import type { MediaResponse, MediaType } from '@/features/editor/mediaApi';
+import { MediaEmbedPicker } from './MediaEmbedPicker';
+
+export function RichContentEditor({
+  themeId,
+  markdown,
+  onChange,
+  pickerType,
+  onOpenPicker,
+  onClosePicker,
+  ariaLabel,
+  imageButtonLabel,
+  videoButtonLabel,
+  imagePickerTitle,
+  videoPickerTitle,
+  onBlurCapture,
+}: {
+  themeId: string;
+  markdown: string;
+  onChange: (markdown: string) => void;
+  pickerType: MediaType | null;
+  onOpenPicker: (type: MediaType) => void;
+  onClosePicker: () => void;
+  ariaLabel: string;
+  imageButtonLabel?: string;
+  videoButtonLabel?: string;
+  imagePickerTitle?: string;
+  videoPickerTitle?: string;
+  onBlurCapture?: (relatedTarget: EventTarget | null) => void;
+}) {
+  const editorRef = useRef<MDXEditorMethods>(null);
+  const plugins = useMemo(
+    () => [
+      headingsPlugin(),
+      listsPlugin(),
+      quotePlugin(),
+      linkPlugin(),
+      thematicBreakPlugin(),
+      toolbarPlugin({
+        toolbarContents: () => (
+          <>
+            <UndoRedo />
+            <BlockTypeSelect />
+            <BoldItalicUnderlineToggles />
+            <ListsToggle />
+            <CreateLink />
+          </>
+        ),
+      }),
+    ],
+    [],
+  );
+
+  function handleSelectMedia(media: MediaResponse) {
+    const type = media.type === 'VIDEO' ? 'video' : 'image';
+    const snippet = `\n\n<MediaEmbed mediaId="${media.id}" type="${type}" />\n`;
+    editorRef.current?.insertMarkdown(snippet);
+    onClosePicker();
+  }
+
+  return (
+    <div
+      className="space-y-2"
+      aria-label={ariaLabel}
+      onBlurCapture={(event) => onBlurCapture?.(event.relatedTarget)}
+    >
+      <MediaEmbedPicker
+        themeId={themeId}
+        pickerType={pickerType}
+        imageButtonLabel={imageButtonLabel}
+        videoButtonLabel={videoButtonLabel}
+        imagePickerTitle={imagePickerTitle}
+        videoPickerTitle={videoPickerTitle}
+        onOpen={onOpenPicker}
+        onClose={onClosePicker}
+        onSelect={handleSelectMedia}
+      />
+      <MDXEditor
+        ref={editorRef}
+        markdown={markdown}
+        onChange={onChange}
+        plugins={plugins}
+        className="mmp-mdx-editor"
+        contentEditableClassName="text-sm leading-6 text-slate-100"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/content/RichContentPreview.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentPreview.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
 
@@ -23,16 +24,19 @@ export function RichContentPreview({
   emptyMessage: string;
 }) {
   const { data: media = [] } = useMediaList(themeId);
-  const markdownWithMedia = markdown.replace(
-    mediaEmbedPattern,
-    (_, mediaId: string, type: string) => {
-      const item = media.find((candidate) => candidate.id === mediaId);
-      const label = item?.name ?? '삭제되었거나 접근할 수 없는 미디어';
-      const kind = type === 'video' ? '영상' : '이미지';
-      return `\n\n> ${kind}: ${label}\n\n`;
-    },
-  );
-  const html = DOMPurify.sanitize(marked.parse(markdownWithMedia, { async: false }) as string);
+  const html = useMemo(() => {
+    const markdownWithMedia = markdown.replace(
+      mediaEmbedPattern,
+      (_, mediaId: string, type: string) => {
+        const item = media.find((candidate) => candidate.id === mediaId);
+        const label = item?.name ?? '삭제되었거나 접근할 수 없는 미디어';
+        const kind = type === 'video' ? '영상' : '이미지';
+        return `\n\n> ${kind}: ${label}\n\n`;
+      },
+    );
+
+    return DOMPurify.sanitize(marked.parse(markdownWithMedia, { async: false }) as string);
+  }, [markdown, media]);
 
   return (
     <section

--- a/apps/web/src/features/editor/components/content/RichContentPreview.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentPreview.tsx
@@ -1,0 +1,58 @@
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+import { useMediaList } from '@/features/editor/mediaApi';
+
+const mediaEmbedPattern = /<MediaEmbed\s+mediaId=["']([^"']+)["']\s+type=["']([^"']+)["']\s*\/>/g;
+
+export function RichContentPreview({
+  themeId,
+  title,
+  titleFallback,
+  markdown,
+  ariaLabel,
+  eyebrow = 'Preview',
+  emptyMessage,
+}: {
+  themeId: string;
+  title: string;
+  titleFallback: string;
+  markdown: string;
+  ariaLabel: string;
+  eyebrow?: string;
+  emptyMessage: string;
+}) {
+  const { data: media = [] } = useMediaList(themeId);
+  const markdownWithMedia = markdown.replace(
+    mediaEmbedPattern,
+    (_, mediaId: string, type: string) => {
+      const item = media.find((candidate) => candidate.id === mediaId);
+      const label = item?.name ?? '삭제되었거나 접근할 수 없는 미디어';
+      const kind = type === 'video' ? '영상' : '이미지';
+      return `\n\n> ${kind}: ${label}\n\n`;
+    },
+  );
+  const html = DOMPurify.sanitize(marked.parse(markdownWithMedia, { async: false }) as string);
+
+  return (
+    <section
+      className="rounded border border-slate-800 bg-slate-950 p-4"
+      aria-label={ariaLabel}
+    >
+      <div className="mb-3 border-b border-slate-800 pb-3">
+        <p className="text-xs uppercase tracking-wide text-amber-300">{eyebrow}</p>
+        <h3 className="mt-1 text-base font-semibold text-slate-100">
+          {title.trim() || titleFallback}
+        </h3>
+      </div>
+      {markdown.trim() ? (
+        <div
+          className="prose prose-invert max-w-none text-sm leading-6 text-slate-200"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      ) : (
+        <p className="text-sm text-slate-500">{emptyMessage}</p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import { ChevronLeft, ChevronRight, FileText, FileUp, Save } from 'lucide-react';
 import { Button } from '@/shared/components/ui/Button';
 import { Spinner } from '@/shared/components/ui/Spinner';
-import { useMediaDownloadUrl, type MediaResponse } from '@/features/editor/mediaApi';
+import { useMediaDownloadUrl, type MediaResponse, type MediaType } from '@/features/editor/mediaApi';
 import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
+import { RichContentEditor } from '@/features/editor/components/content/RichContentEditor';
+import { RichContentPreview } from '@/features/editor/components/content/RichContentPreview';
 import { ImageRoleSheetPanel } from './ImageRoleSheetPanel';
 import { useRoleSheetEditorState } from './useRoleSheetEditorState';
 
@@ -98,6 +100,7 @@ export function CharacterRoleSheetSection({
         />
       ) : (
         <MarkdownRoleSheetEditor
+          themeId={themeId}
           characterName={characterName}
           draft={state.draft}
           saveStatus={state.saveStatus}
@@ -152,7 +155,10 @@ function UnsupportedRoleSheetFormatNotice({ characterName }: { characterName: st
 }
 
 function isSaveButtonTarget(target: EventTarget | null) {
-  return target instanceof HTMLElement && target.closest('[data-role-sheet-save="true"]') !== null;
+  return (
+    target instanceof HTMLElement &&
+    target.closest('[data-role-sheet-save="true"], [data-rich-content-control="true"]') !== null
+  );
 }
 
 function RoleSheetFormatSelector({
@@ -215,6 +221,7 @@ function FormatButton({
 }
 
 function MarkdownRoleSheetEditor({
+  themeId,
   characterName,
   draft,
   saveStatus,
@@ -227,6 +234,7 @@ function MarkdownRoleSheetEditor({
   onSave,
   onSaveBlur,
 }: {
+  themeId: string;
   characterName: string;
   draft: string;
   saveStatus: 'idle' | 'saved' | 'failed';
@@ -239,16 +247,35 @@ function MarkdownRoleSheetEditor({
   onSave: () => void;
   onSaveBlur: () => void;
 }) {
+  const [pickerType, setPickerType] = useState<MediaType | null>(null);
+
   return (
     <div className="space-y-3">
-      <textarea
-        aria-label="역할지 Markdown"
-        value={draft}
-        onChange={(event) => onDraftChange(event.target.value)}
-        onBlur={(event) => onBlur(event.relatedTarget)}
-        placeholder={`## ${characterName}의 정체\n\n## 비밀\n\n## 동기\n\n## 알리바이`}
-        className="min-h-64 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-xs leading-5 text-slate-200 placeholder:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-      />
+      <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <RichContentEditor
+          themeId={themeId}
+          markdown={draft}
+          onChange={onDraftChange}
+          pickerType={pickerType}
+          onOpenPicker={setPickerType}
+          onClosePicker={() => setPickerType(null)}
+          ariaLabel="역할지 Markdown"
+          imageButtonLabel="역할지 이미지 삽입"
+          videoButtonLabel="역할지 영상 삽입"
+          imagePickerTitle="역할지 이미지 선택"
+          videoPickerTitle="역할지 영상 선택"
+          onBlurCapture={onBlur}
+        />
+        <RichContentPreview
+          themeId={themeId}
+          title={`${characterName} 역할지`}
+          titleFallback="역할지 프리뷰"
+          markdown={draft}
+          ariaLabel="역할지 프리뷰"
+          eyebrow="Player Preview"
+          emptyMessage="본문을 작성하면 플레이어에게 보일 역할지가 표시됩니다."
+        />
+      </div>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p

--- a/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
@@ -251,7 +251,7 @@ function MarkdownRoleSheetEditor({
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_22rem]">
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_22rem]">
         <RichContentEditor
           themeId={themeId}
           markdown={draft}

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, act, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { forwardRef, useImperativeHandle } from 'react';
 import { ApiHttpError } from '@/lib/api-error';
@@ -75,7 +75,7 @@ vi.mock('@mdxeditor/editor', () => ({
     }));
     return (
       <textarea
-        aria-label="역할지 Markdown"
+        aria-label="editable markdown"
         value={markdown}
         onChange={(event) => onChange(event.currentTarget.value)}
       />
@@ -257,6 +257,12 @@ function readStartingClues(config: Record<string, unknown>) {
 
 const endcardSectionName = /^결과 카드 (?:작성됨|비어 있음)$/;
 const roleSheetSectionName = /^역할지 Markdown 또는 PDF$/;
+
+function getRoleSheetEditor() {
+  return within(screen.getByRole('region', { name: '역할지 Markdown' })).getByRole('textbox', {
+    name: 'editable markdown',
+  });
+}
 const startingClueSectionName = /^시작 단서 \d+\/\d+개 배정$/;
 const hiddenMissionSectionName = /^히든 미션 \d+개$/;
 
@@ -327,7 +333,7 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByRole('button', { name: roleSheetSectionName }).getAttribute('aria-expanded')).toBe('false');
     expect(screen.getByRole('button', { name: startingClueSectionName }).getAttribute('aria-expanded')).toBe('false');
     expect(screen.getByRole('button', { name: hiddenMissionSectionName }).getAttribute('aria-expanded')).toBe('false');
-    expect(screen.queryByRole('textbox', { name: '역할지 Markdown' })).toBeNull();
+    expect(screen.queryByRole('region', { name: '역할지 Markdown' })).toBeNull();
   });
 
   it('범인 캐릭터에 "범인" 라벨이 표시된다', () => {
@@ -582,7 +588,7 @@ describe('CharacterAssignPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
 
-    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' });
+    const roleSheet = getRoleSheetEditor();
     fireEvent.change(roleSheet, { target: { value: '## 비밀\n범인은 아직 모른다.' } });
     fireEvent.click(screen.getByRole('button', { name: '역할지 저장' }));
 
@@ -598,7 +604,7 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByText('filter:IMAGE')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: '캐릭터 이미지 선택' }));
 
-    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' }) as HTMLTextAreaElement;
+    const roleSheet = getRoleSheetEditor() as HTMLTextAreaElement;
     expect(roleSheet.value).toContain('<MediaEmbed mediaId="image-1" type="image" />');
     expect(screen.getByText('이미지: 캐릭터 이미지')).toBeDefined();
   });
@@ -612,7 +618,7 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByText('filter:VIDEO')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: '역할지 영상 선택' }));
 
-    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' }) as HTMLTextAreaElement;
+    const roleSheet = getRoleSheetEditor() as HTMLTextAreaElement;
     expect(roleSheet.value).toContain('<MediaEmbed mediaId="video-1" type="video" />');
     expect(screen.getByText('영상: 역할지 영상')).toBeDefined();
   });
@@ -636,7 +642,7 @@ describe('CharacterAssignPanel', () => {
     openRoleSheetSection();
 
     expect(screen.getByText('아직 저장된 역할지가 없습니다.')).toBeDefined();
-    expect((screen.getByRole('textbox', { name: '역할지 Markdown' }) as HTMLTextAreaElement).value).toBe('');
+    expect((getRoleSheetEditor() as HTMLTextAreaElement).value).toBe('');
   });
 
   it('역할지 로드 실패 시 재시도 버튼을 표시한다', () => {
@@ -680,7 +686,7 @@ describe('CharacterAssignPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
 
-    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' });
+    const roleSheet = getRoleSheetEditor();
     const saveButton = screen.getByRole('button', { name: '역할지 저장' });
     fireEvent.change(roleSheet, { target: { value: '수정된 역할지' } });
     fireEvent.mouseDown(saveButton);
@@ -714,7 +720,7 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByTitle('홍길동 PDF 역할지 1페이지').getAttribute('src')).toBe(
       'https://cdn.example/role.pdf#page=1&toolbar=0&navpanes=0&view=FitH',
     );
-    expect(screen.queryByRole('textbox', { name: '역할지 Markdown' })).toBeNull();
+    expect(screen.queryByRole('region', { name: '역할지 Markdown' })).toBeNull();
   });
 
   it('PDF 역할지를 미디어 관리 문서 picker로 연결한다', () => {
@@ -775,7 +781,7 @@ describe('CharacterAssignPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '다음 이미지 페이지' }));
     expect(screen.getByText('2 / 2페이지')).toBeDefined();
     expect(screen.getByAltText('홍길동 이미지 롤지 2페이지').getAttribute('src')).toBe('https://cdn.example/role-2.webp');
-    expect(screen.queryByRole('textbox', { name: '역할지 Markdown' })).toBeNull();
+    expect(screen.queryByRole('region', { name: '역할지 Markdown' })).toBeNull();
   });
 
   it('이미지 URL을 추가하고 이미지 롤지를 저장한다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { forwardRef, useImperativeHandle } from 'react';
 import { ApiHttpError } from '@/lib/api-error';
 
 // ---------------------------------------------------------------------------
@@ -64,6 +65,35 @@ vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: () => useMediaListMock(),
 }));
 
+vi.mock('@mdxeditor/editor', () => ({
+  MDXEditor: forwardRef<
+    { insertMarkdown: (snippet: string) => void },
+    { markdown: string; onChange: (markdown: string) => void }
+  >(({ markdown, onChange }, ref) => {
+    useImperativeHandle(ref, () => ({
+      insertMarkdown: (snippet: string) => onChange(`${markdown}${snippet}`),
+    }));
+    return (
+      <textarea
+        aria-label="역할지 Markdown"
+        value={markdown}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+    );
+  }),
+  headingsPlugin: vi.fn(() => ({})),
+  listsPlugin: vi.fn(() => ({})),
+  quotePlugin: vi.fn(() => ({})),
+  linkPlugin: vi.fn(() => ({})),
+  thematicBreakPlugin: vi.fn(() => ({})),
+  toolbarPlugin: vi.fn(() => ({})),
+  UndoRedo: () => null,
+  BlockTypeSelect: () => null,
+  BoldItalicUnderlineToggles: () => null,
+  ListsToggle: () => null,
+  CreateLink: () => null,
+}));
+
 vi.mock('@/features/editor/components/media/MediaPicker', () => ({
   MediaPicker: ({
     open,
@@ -95,6 +125,21 @@ vi.mock('@/features/editor/components/media/MediaPicker', () => ({
             onClick={() => onSelect({ id: 'document-2', name: 'DOCX 역할지', type: 'DOCUMENT', mime_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })}
           >
             DOCX 역할지 선택
+          </button>
+        </div>
+      );
+    }
+
+    if (filterType === 'VIDEO') {
+      return (
+        <div>
+          <span>filter:{filterType}</span>
+          <span>selected:{selectedId ?? 'none'}</span>
+          <button
+            type="button"
+            onClick={() => onSelect({ id: 'video-1', name: '역할지 영상', type: 'VIDEO' })}
+          >
+            역할지 영상 선택
           </button>
         </div>
       );
@@ -257,7 +302,10 @@ describe('CharacterAssignPanel', () => {
     useUpsertCharacterRoleSheetMock.mockReturnValue({ mutate: upsertRoleSheetMutateMock, isPending: false });
     useMediaDownloadUrlMock.mockReturnValue({ data: undefined, isLoading: false, isError: false, refetch: vi.fn() });
     useMediaListMock.mockReturnValue({
-      data: [{ id: 'image-1', name: '캐릭터 이미지', type: 'IMAGE' }],
+      data: [
+        { id: 'image-1', name: '캐릭터 이미지', type: 'IMAGE' },
+        { id: 'video-1', name: '역할지 영상', type: 'VIDEO' },
+      ],
       isLoading: false,
     });
     updateCharacterPendingMock.value = false;
@@ -541,6 +589,34 @@ describe('CharacterAssignPanel', () => {
     expect(screen.getByText('저장되었습니다.')).toBeDefined();
   });
 
+  it('역할지 작성기는 미디어 관리 이미지를 mediaId embed로 삽입하고 프리뷰한다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
+
+    fireEvent.click(screen.getByRole('button', { name: '역할지 이미지 삽입' }));
+    expect(screen.getByText('filter:IMAGE')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: '캐릭터 이미지 선택' }));
+
+    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' }) as HTMLTextAreaElement;
+    expect(roleSheet.value).toContain('<MediaEmbed mediaId="image-1" type="image" />');
+    expect(screen.getByText('이미지: 캐릭터 이미지')).toBeDefined();
+  });
+
+  it('역할지 작성기는 지원 영상 미디어를 mediaId embed로 삽입한다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
+
+    fireEvent.click(screen.getByRole('button', { name: '역할지 영상 삽입' }));
+    expect(screen.getByText('filter:VIDEO')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: '역할지 영상 선택' }));
+
+    const roleSheet = screen.getByRole('textbox', { name: '역할지 Markdown' }) as HTMLTextAreaElement;
+    expect(roleSheet.value).toContain('<MediaEmbed mediaId="video-1" type="video" />');
+    expect(screen.getByText('영상: 역할지 영상')).toBeDefined();
+  });
+
   it('저장된 역할지가 없으면 빈 Markdown 초안으로 시작한다', () => {
     useCharacterRoleSheetMock.mockReturnValue({
       data: undefined,
@@ -710,7 +786,7 @@ describe('CharacterAssignPanel', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
-    fireEvent.click(screen.getAllByRole('button', { name: /이미지/ }).at(-1)!);
+    fireEvent.click(screen.getByRole('button', { name: '이미지 여러 장을 순서대로 보기' }));
     fireEvent.change(screen.getByRole('textbox', { name: '이미지 페이지 URL' }), {
       target: { value: 'https://cdn.example/role-1.webp' },
     });
@@ -738,7 +814,7 @@ describe('CharacterAssignPanel', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
-    fireEvent.click(screen.getAllByRole('button', { name: /이미지/ }).at(-1)!);
+    fireEvent.click(screen.getByRole('button', { name: '이미지 여러 장을 순서대로 보기' }));
     fireEvent.click(screen.getByRole('button', { name: '미디어 라이브러리에서 추가' }));
     fireEvent.click(screen.getByRole('button', { name: '캐릭터 이미지 선택' }));
     fireEvent.click(screen.getByRole('button', { name: '이미지 롤지 저장' }));

--- a/apps/web/src/features/editor/components/info/InfoMarkdownEditor.tsx
+++ b/apps/web/src/features/editor/components/info/InfoMarkdownEditor.tsx
@@ -1,22 +1,5 @@
-import { useMemo, useRef } from 'react';
-import {
-  BlockTypeSelect,
-  BoldItalicUnderlineToggles,
-  CreateLink,
-  ListsToggle,
-  MDXEditor,
-  UndoRedo,
-  headingsPlugin,
-  linkPlugin,
-  listsPlugin,
-  quotePlugin,
-  thematicBreakPlugin,
-  toolbarPlugin,
-  type MDXEditorMethods,
-} from '@mdxeditor/editor';
-
-import type { MediaResponse, MediaType } from '@/features/editor/mediaApi';
-import { InfoMediaEmbedPicker } from './InfoMediaEmbedPicker';
+import type { MediaType } from '@/features/editor/mediaApi';
+import { RichContentEditor } from '@/features/editor/components/content/RichContentEditor';
 
 export function InfoMarkdownEditor({
   themeId,
@@ -33,53 +16,17 @@ export function InfoMarkdownEditor({
   onOpenPicker: (type: MediaType) => void;
   onClosePicker: () => void;
 }) {
-  const editorRef = useRef<MDXEditorMethods>(null);
-  const plugins = useMemo(
-    () => [
-      headingsPlugin(),
-      listsPlugin(),
-      quotePlugin(),
-      linkPlugin(),
-      thematicBreakPlugin(),
-      toolbarPlugin({
-        toolbarContents: () => (
-          <>
-            <UndoRedo />
-            <BlockTypeSelect />
-            <BoldItalicUnderlineToggles />
-            <ListsToggle />
-            <CreateLink />
-          </>
-        ),
-      }),
-    ],
-    []
-  );
-
-  function handleSelectMedia(media: MediaResponse) {
-    const type = media.type === 'VIDEO' ? 'video' : 'image';
-    const snippet = `\n\n<MediaEmbed mediaId="${media.id}" type="${type}" />\n`;
-    editorRef.current?.insertMarkdown(snippet);
-    onClosePicker();
-  }
-
   return (
-    <div className="space-y-2" aria-label="정보 본문 작성기">
-      <InfoMediaEmbedPicker
-        themeId={themeId}
-        pickerType={pickerType}
-        onOpen={onOpenPicker}
-        onClose={onClosePicker}
-        onSelect={handleSelectMedia}
-      />
-      <MDXEditor
-        ref={editorRef}
-        markdown={markdown}
-        onChange={onChange}
-        plugins={plugins}
-        className="mmp-mdx-editor"
-        contentEditableClassName="text-sm leading-6 text-slate-100"
-      />
-    </div>
+    <RichContentEditor
+      themeId={themeId}
+      markdown={markdown}
+      onChange={onChange}
+      pickerType={pickerType}
+      onOpenPicker={onOpenPicker}
+      onClosePicker={onClosePicker}
+      ariaLabel="정보 본문 작성기"
+      imagePickerTitle="정보 이미지 선택"
+      videoPickerTitle="정보 영상 선택"
+    />
   );
 }

--- a/apps/web/src/features/editor/components/info/InfoPreview.tsx
+++ b/apps/web/src/features/editor/components/info/InfoPreview.tsx
@@ -1,9 +1,4 @@
-import DOMPurify from 'dompurify';
-import { marked } from 'marked';
-
-import { useMediaList } from '@/features/editor/mediaApi';
-
-const mediaEmbedPattern = /<MediaEmbed\s+mediaId=["']([^"']+)["']\s+type=["']([^"']+)["']\s*\/>/g;
+import { RichContentPreview } from '@/features/editor/components/content/RichContentPreview';
 
 export function InfoPreview({
   themeId,
@@ -14,39 +9,14 @@ export function InfoPreview({
   title: string;
   markdown: string;
 }) {
-  const { data: media = [] } = useMediaList(themeId);
-  const markdownWithMedia = markdown.replace(
-    mediaEmbedPattern,
-    (_, mediaId: string, type: string) => {
-      const item = media.find((candidate) => candidate.id === mediaId);
-      const label = item?.name ?? '삭제되었거나 접근할 수 없는 미디어';
-      const kind = type === 'video' ? '영상' : '이미지';
-      return `\n\n> ${kind}: ${label}\n\n`;
-    }
-  );
-  const html = DOMPurify.sanitize(marked.parse(markdownWithMedia, { async: false }) as string);
-
   return (
-    <section
-      className="rounded border border-slate-800 bg-slate-950 p-4"
-      aria-label="정보 카드 프리뷰"
-    >
-      <div className="mb-3 border-b border-slate-800 pb-3">
-        <p className="text-xs uppercase tracking-wide text-amber-300">Preview</p>
-        <h3 className="mt-1 text-base font-semibold text-slate-100">
-          {title.trim() || '제목 없는 정보'}
-        </h3>
-      </div>
-      {markdown.trim() ? (
-        <div
-          className="prose prose-invert max-w-none text-sm leading-6 text-slate-200"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      ) : (
-        <p className="text-sm text-slate-500">
-          본문을 작성하면 플레이어에게 보일 카드가 표시됩니다.
-        </p>
-      )}
-    </section>
+    <RichContentPreview
+      themeId={themeId}
+      title={title}
+      titleFallback="제목 없는 정보"
+      markdown={markdown}
+      ariaLabel="정보 카드 프리뷰"
+      emptyMessage="본문을 작성하면 플레이어에게 보일 카드가 표시됩니다."
+    />
   );
 }

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { forwardRef, useImperativeHandle } from 'react';
 
 const {
@@ -51,7 +51,7 @@ vi.mock('@mdxeditor/editor', () => ({
     }));
     return (
       <textarea
-        aria-label="정보 본문"
+        aria-label="editable markdown"
         value={markdown}
         onChange={(event) => onChange(event.target.value)}
       />
@@ -116,6 +116,12 @@ const baseInfo = {
   createdAt: '2026-05-06T00:00:00Z',
   updatedAt: '2026-05-06T00:00:00Z',
 };
+
+function getInfoBodyEditor() {
+  return within(screen.getByRole('region', { name: '정보 본문 작성기' })).getByRole('textbox', {
+    name: 'editable markdown',
+  });
+}
 
 let createMutate: ReturnType<typeof vi.fn>;
 let updateMutate: ReturnType<typeof vi.fn>;
@@ -247,7 +253,7 @@ describe('InfoTab', () => {
     expect(screen.getByText('filter:VIDEO')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'CCTV 선택' }));
 
-    expect(screen.getByLabelText('정보 본문')).toHaveProperty(
+    expect(getInfoBodyEditor()).toHaveProperty(
       'value',
       expect.stringContaining('<MediaEmbed mediaId="video-1" type="video" />')
     );


### PR DESCRIPTION
## 요약
- 정보 관리용 Markdown 작성기/미리보기를 `RichContentEditor`와 `RichContentPreview` 공유 컴포넌트로 분리했습니다.
- 역할지 Markdown 입력에 MDXEditor 기반 작성기, 이미지/영상 삽입, 즉시 미리보기를 적용했습니다.
- 역할지 저장 blur guard가 새 rich content toolbar 클릭을 저장 트리거로 오인하지 않도록 보강했습니다.

## Coverage Plan
- `RichContentEditor` / `MediaEmbedPicker`: `InfoTab`과 `CharacterAssignPanel` 테스트로 MDX 작성기 입력, 이미지/영상 삽입 계약을 검증합니다.
- `RichContentPreview`: 정보 미리보기와 역할지 미리보기에서 Markdown 텍스트와 미디어 라벨 렌더링을 검증합니다.
- `CharacterRoleSheetSection`: 역할지 저장, 이미지/PDF 기존 흐름, Markdown 미디어 삽입을 `CharacterAssignPanel` focused test로 검증합니다.
- E2E는 추가하지 않았습니다. 이번 변경은 에디터 내부 컴포넌트/미리보기/저장 payload 경로이며, unit + quick local CI로 주요 분기를 덮었습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/api/roleSheets.test.ts` 통과 (3 files, 47 tests)
- `pnpm --filter @mmp/web typecheck` 통과
- `scripts/mmp-local-ci.sh quick` 통과
  - mode: quick
  - status: success
  - head: `5e6247481f3231918db39541b194320159e42309`
  - started_at: `2026-05-07T13:48:26Z`
  - finished_at: `2026-05-07T14:17:00Z`
  - web tests: quick pipeline passed after conflict resolution

Refs #470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지·비디오 삽입 UI의 라벨과 피커 제목을 사용자 지정 가능하도록 확장
  * 리치 콘텐츠 편집기와 미리보기 컴포넌트 추가로 풍부한 미디어 편집·미리보기 제공

* **리팩토링**
  * 편집기·미리보기 구조 통합: 기존 컴포넌트들이 리치 에디터·프리뷰로 대체되어 일관성·유지보수성 개선
  * 역할지 편집에 테마 연동 및 미디어 피커 흐름 통합

* **테스트**
  * 미디어 삽입 관련 유닛테스트 보강 및 접근성 기반 쿼리로 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->