### PR TITLE
feat(editor): 읽기 대사 블록 모델 기반 추가

### DIFF
--- a/apps/server/db/queries/media.sql
+++ b/apps/server/db/queries/media.sql
@@ -149,6 +149,7 @@ SET bgm_media_id = CASE
         line
           - CASE WHEN line->>'VoiceMediaID' = sqlc.arg('media_id')::text THEN 'VoiceMediaID' ELSE '__noop__' END
           - CASE WHEN line->>'ImageMediaID' = sqlc.arg('media_id')::text THEN 'ImageMediaID' ELSE '__noop__' END
+          - CASE WHEN line->>'MediaID' = sqlc.arg('media_id')::text THEN 'MediaID' ELSE '__noop__' END
         ORDER BY ord
       )
       FROM jsonb_array_elements(rs.lines) WITH ORDINALITY AS elem(line, ord)
@@ -165,6 +166,7 @@ WHERE rs.theme_id = t.id
       SELECT 1 FROM jsonb_array_elements(rs.lines) AS line
       WHERE line->>'VoiceMediaID' = sqlc.arg('media_id')::text
          OR line->>'ImageMediaID' = sqlc.arg('media_id')::text
+         OR line->>'MediaID' = sqlc.arg('media_id')::text
     )
   );
 

--- a/apps/server/db/queries/reading_sections.sql
+++ b/apps/server/db/queries/reading_sections.sql
@@ -44,5 +44,6 @@ WHERE rs.theme_id = sqlc.arg('theme_id')
       SELECT 1 FROM jsonb_array_elements(rs.lines) AS line
       WHERE line->>'VoiceMediaID' = sqlc.arg('media_id')::text
          OR line->>'ImageMediaID' = sqlc.arg('media_id')::text
+         OR line->>'MediaID' = sqlc.arg('media_id')::text
     )
   );

--- a/apps/server/internal/db/media.sql.go
+++ b/apps/server/internal/db/media.sql.go
@@ -78,6 +78,7 @@ SET bgm_media_id = CASE
         line
           - CASE WHEN line->>'VoiceMediaID' = $1::text THEN 'VoiceMediaID' ELSE '__noop__' END
           - CASE WHEN line->>'ImageMediaID' = $1::text THEN 'ImageMediaID' ELSE '__noop__' END
+          - CASE WHEN line->>'MediaID' = $1::text THEN 'MediaID' ELSE '__noop__' END
         ORDER BY ord
       )
       FROM jsonb_array_elements(rs.lines) WITH ORDINALITY AS elem(line, ord)
@@ -94,6 +95,7 @@ WHERE rs.theme_id = t.id
       SELECT 1 FROM jsonb_array_elements(rs.lines) AS line
       WHERE line->>'VoiceMediaID' = $1::text
          OR line->>'ImageMediaID' = $1::text
+         OR line->>'MediaID' = $1::text
     )
   )
 `

--- a/apps/server/internal/db/reading_sections.sql.go
+++ b/apps/server/internal/db/reading_sections.sql.go
@@ -77,6 +77,7 @@ WHERE rs.theme_id = $1
       SELECT 1 FROM jsonb_array_elements(rs.lines) AS line
       WHERE line->>'VoiceMediaID' = $2::text
          OR line->>'ImageMediaID' = $2::text
+         OR line->>'MediaID' = $2::text
     )
   )
 `
@@ -92,7 +93,7 @@ type FindMediaReferencesInReadingSectionsRow struct {
 }
 
 // Returns reading sections that reference the given media as bgm_media_id
-// OR inside any line's VoiceMediaID/ImageMediaID (PascalCase keys — match engine struct serialization).
+// OR inside any line's VoiceMediaID/ImageMediaID/MediaID (PascalCase keys — match engine struct serialization).
 func (q *Queries) FindMediaReferencesInReadingSections(ctx context.Context, arg FindMediaReferencesInReadingSectionsParams) ([]FindMediaReferencesInReadingSectionsRow, error) {
 	rows, err := q.db.Query(ctx, findMediaReferencesInReadingSections, arg.ThemeID, arg.MediaID)
 	if err != nil {

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -335,6 +335,10 @@ func (f *fakeMediaQueries) ClearReadingSectionMediaReferencesWithOwner(_ context
 					delete(line, "ImageMediaID")
 					changed = true
 				}
+				if line["MediaID"] == arg.MediaID.String() {
+					delete(line, "MediaID")
+					changed = true
+				}
 			}
 			if changed {
 				s.Lines, _ = json.Marshal(lines)
@@ -467,6 +471,10 @@ func (f *fakeMediaQueries) FindMediaReferencesInReadingSections(_ context.Contex
 						break
 					}
 					if v, ok := ln["ImageMediaID"].(string); ok && v == arg.MediaID.String() {
+						matched = true
+						break
+					}
+					if v, ok := ln["MediaID"].(string); ok && v == arg.MediaID.String() {
 						matched = true
 						break
 					}
@@ -757,6 +765,31 @@ func TestMediaService_PreviewDelete_ReportsReadingImageReference(t *testing.T) {
 	}
 }
 
+func TestMediaService_PreviewDelete_ReportsReadingBlockMediaReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	imageID := seedMedia(q, themeID, MediaTypeImage)
+
+	linesJSON, _ := json.Marshal([]map[string]any{
+		{"Index": 0, "Type": "image", "MediaID": imageID.String(), "AdvanceBy": "gm"},
+	})
+	sectionID := uuid.New()
+	q.sections[sectionID] = db.ReadingSection{
+		ID:      sectionID,
+		ThemeID: themeID,
+		Name:    "Image block",
+		Lines:   linesJSON,
+	}
+
+	preview, err := svc.PreviewDeleteMedia(context.Background(), creatorID, imageID)
+	if err != nil {
+		t.Fatalf("PreviewDeleteMedia: %v", err)
+	}
+	refs := preview.References
+	if len(refs) != 1 || refs[0].ID != sectionID.String() || refs[0].Type != "reading_section" || refs[0].Name != "Image block" {
+		t.Fatalf("unexpected references: %#v", refs)
+	}
+}
+
 func TestFindMediaReferencesInReadingSections_JSONBIntegration(t *testing.T) {
 	fixture := setupFixture(t)
 	ctx := context.Background()
@@ -765,9 +798,11 @@ func TestFindMediaReferencesInReadingSections_JSONBIntegration(t *testing.T) {
 
 	voice := createMediaForReferenceTest(t, fixture.q, themeID, "Narration voice", MediaTypeVoice)
 	image := createMediaForReferenceTest(t, fixture.q, themeID, "Crime scene image", MediaTypeImage)
+	blockImage := createMediaForReferenceTest(t, fixture.q, themeID, "Projected image", MediaTypeImage)
 	linesJSON, err := json.Marshal([]map[string]any{
 		{"Index": 0, "Text": "목소리가 들린다.", "AdvanceBy": "voice", "VoiceMediaID": voice.ID.String()},
 		{"Index": 1, "Text": "현장 사진을 본다.", "AdvanceBy": "gm", "ImageMediaID": image.ID.String()},
+		{"Index": 2, "Type": "image", "MediaID": blockImage.ID.String(), "AdvanceBy": "gm"},
 	})
 	if err != nil {
 		t.Fatalf("marshal lines: %v", err)
@@ -789,6 +824,7 @@ func TestFindMediaReferencesInReadingSections_JSONBIntegration(t *testing.T) {
 	}{
 		{name: "voice", mediaID: voice.ID},
 		{name: "image", mediaID: image.ID},
+		{name: "block image", mediaID: blockImage.ID},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			refs, err := fixture.q.FindMediaReferencesInReadingSections(ctx, db.FindMediaReferencesInReadingSectionsParams{

--- a/apps/server/internal/domain/editor/reading_service.go
+++ b/apps/server/internal/domain/editor/reading_service.go
@@ -176,7 +176,13 @@ func (s *readingService) validateStructuredReadingBlock(ctx context.Context, the
 		if mode != ReadingBGMModeLoop && mode != ReadingBGMModeOnce && mode != ReadingBGMModeStop {
 			return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": invalid bgm mode")
 		}
+		if err := validateBlockAdvanceBy(ln.AdvanceBy, lineIndex); err != nil {
+			return err
+		}
 		if mode == ReadingBGMModeStop {
+			if ln.MediaID != "" {
+				return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": mediaId is not allowed")
+			}
 			return nil
 		}
 		if ln.MediaID == "" {
@@ -184,7 +190,10 @@ func (s *readingService) validateStructuredReadingBlock(ctx context.Context, the
 		}
 		return s.assertLineMediaInTheme(ctx, themeID, ln.MediaID, MediaTypeBGM, "mediaId", lineIndex)
 	case ReadingBlockGMNote:
-		return nil
+		if ln.MediaID != "" {
+			return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": mediaId is not allowed")
+		}
+		return validateBlockAdvanceBy(ln.AdvanceBy, lineIndex)
 	default:
 		return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": invalid reading block type")
 	}

--- a/apps/server/internal/domain/editor/reading_service.go
+++ b/apps/server/internal/domain/editor/reading_service.go
@@ -109,6 +109,16 @@ func (s *readingService) validateLines(ctx context.Context, themeID uuid.UUID, l
 		return apperror.New(apperror.ErrValidation, 422, "too many lines in section")
 	}
 	for i, ln := range lines {
+		blockType := normalizeReadingBlockType(ln.Type)
+		if blockType == "" {
+			return apperror.New(apperror.ErrValidation, 422, "line "+itoa(i)+": invalid reading block type")
+		}
+		if blockType != ReadingBlockDialogue {
+			if err := s.validateStructuredReadingBlock(ctx, themeID, ln, blockType, i); err != nil {
+				return err
+			}
+			continue
+		}
 		if !validateAdvanceBy(ln.AdvanceBy) {
 			return apperror.New(apperror.ErrReadingInvalidAdvanceBy, 400, "line "+itoa(i)+": invalid advanceBy")
 		}
@@ -125,6 +135,67 @@ func (s *readingService) validateLines(ctx context.Context, themeID uuid.UUID, l
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+func normalizeReadingBlockType(raw string) string {
+	switch raw {
+	case "", ReadingBlockDialogue:
+		return ReadingBlockDialogue
+	case ReadingBlockImage, ReadingBlockVideo, ReadingBlockBGM, ReadingBlockGMNote:
+		return raw
+	default:
+		return ""
+	}
+}
+
+func (s *readingService) validateStructuredReadingBlock(ctx context.Context, themeID uuid.UUID, ln ReadingLineDTO, blockType string, lineIndex int) error {
+	switch blockType {
+	case ReadingBlockImage:
+		if ln.MediaID == "" {
+			return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId is required")
+		}
+		if err := s.assertLineMediaInTheme(ctx, themeID, ln.MediaID, MediaTypeImage, "mediaId", lineIndex); err != nil {
+			return err
+		}
+		return validateBlockAdvanceBy(ln.AdvanceBy, lineIndex)
+	case ReadingBlockVideo:
+		if ln.MediaID == "" {
+			return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId is required")
+		}
+		if err := s.assertLineMediaInTheme(ctx, themeID, ln.MediaID, MediaTypeVideo, "mediaId", lineIndex); err != nil {
+			return err
+		}
+		return validateBlockAdvanceBy(ln.AdvanceBy, lineIndex)
+	case ReadingBlockBGM:
+		mode := ln.BGMMode
+		if mode == "" {
+			mode = ReadingBGMModeLoop
+		}
+		if mode != ReadingBGMModeLoop && mode != ReadingBGMModeOnce && mode != ReadingBGMModeStop {
+			return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": invalid bgm mode")
+		}
+		if mode == ReadingBGMModeStop {
+			return nil
+		}
+		if ln.MediaID == "" {
+			return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId is required")
+		}
+		return s.assertLineMediaInTheme(ctx, themeID, ln.MediaID, MediaTypeBGM, "mediaId", lineIndex)
+	case ReadingBlockGMNote:
+		return nil
+	default:
+		return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": invalid reading block type")
+	}
+}
+
+func validateBlockAdvanceBy(advanceBy string, lineIndex int) error {
+	if advanceBy == AdvanceByVoice {
+		return apperror.New(apperror.ErrReadingInvalidAdvanceBy, 400, "line "+itoa(lineIndex)+": invalid advanceBy")
+	}
+	if !validateAdvanceBy(advanceBy) {
+		return apperror.New(apperror.ErrReadingInvalidAdvanceBy, 400, "line "+itoa(lineIndex)+": invalid advanceBy")
 	}
 	return nil
 }

--- a/apps/server/internal/domain/editor/reading_service_test.go
+++ b/apps/server/internal/domain/editor/reading_service_test.go
@@ -345,6 +345,34 @@ func TestReadingService_Create_BGMBlockRequiresMediaUnlessStop(t *testing.T) {
 	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
 }
 
+func TestReadingService_Create_StructuredBlocksRejectInvalidFields(t *testing.T) {
+	f := newReadingFixture(t)
+
+	t.Run("bgm stop rejects media", func(t *testing.T) {
+		_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+			Name:  "Invalid stop bgm",
+			Lines: []ReadingLineDTO{{Type: ReadingBlockBGM, BGMMode: ReadingBGMModeStop, MediaID: f.bgmID.String()}},
+		})
+		assertAppCode(t, err, apperror.ErrValidation)
+	})
+
+	t.Run("bgm stop validates advance by", func(t *testing.T) {
+		_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+			Name:  "Invalid stop advance",
+			Lines: []ReadingLineDTO{{Type: ReadingBlockBGM, BGMMode: ReadingBGMModeStop, AdvanceBy: AdvanceByVoice}},
+		})
+		assertAppCode(t, err, apperror.ErrReadingInvalidAdvanceBy)
+	})
+
+	t.Run("gm note rejects media", func(t *testing.T) {
+		_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+			Name:  "Invalid gm note",
+			Lines: []ReadingLineDTO{{Type: ReadingBlockGMNote, Text: "note", MediaID: f.imageID.String()}},
+		})
+		assertAppCode(t, err, apperror.ErrValidation)
+	})
+}
+
 func TestReadingService_Create_ImageMediaMustBeImageInTheme(t *testing.T) {
 	f := newReadingFixture(t)
 	_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{

--- a/apps/server/internal/domain/editor/reading_service_test.go
+++ b/apps/server/internal/domain/editor/reading_service_test.go
@@ -134,6 +134,7 @@ type readingTestFixture struct {
 	bgmID     uuid.UUID
 	voiceID   uuid.UUID
 	imageID   uuid.UUID
+	videoID   uuid.UUID
 	otherBgm  uuid.UUID // BGM in a different theme
 }
 
@@ -157,6 +158,9 @@ func newReadingFixture(t *testing.T) *readingTestFixture {
 	imageID := uuid.New()
 	q.media[imageID] = db.ThemeMedium{ID: imageID, ThemeID: themeID, Type: MediaTypeImage}
 
+	videoID := uuid.New()
+	q.media[videoID] = db.ThemeMedium{ID: videoID, ThemeID: themeID, Type: MediaTypeVideo}
+
 	otherBgm := uuid.New()
 	q.media[otherBgm] = db.ThemeMedium{ID: otherBgm, ThemeID: otherThemeID, Type: MediaTypeBGM}
 
@@ -168,6 +172,7 @@ func newReadingFixture(t *testing.T) *readingTestFixture {
 		bgmID:     bgmID,
 		voiceID:   voiceID,
 		imageID:   imageID,
+		videoID:   videoID,
 		otherBgm:  otherBgm,
 	}
 }
@@ -284,6 +289,60 @@ func TestReadingService_Create_ImageMediaReference(t *testing.T) {
 	if got := resp.Lines[0].ImageMediaID; got != f.imageID.String() {
 		t.Fatalf("ImageMediaID = %q, want %q", got, f.imageID.String())
 	}
+}
+
+func TestReadingService_Create_BlockMediaReferences(t *testing.T) {
+	f := newReadingFixture(t)
+	resp, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name: "With blocks",
+		Lines: []ReadingLineDTO{
+			{Type: ReadingBlockImage, MediaID: f.imageID.String(), AdvanceBy: AdvanceByGM, Position: "center", Size: "large"},
+			{Type: ReadingBlockVideo, MediaID: f.videoID.String(), AdvanceBy: AdvanceByGM, Autoplay: true, WaitUntilEnd: true},
+			{Type: ReadingBlockBGM, MediaID: f.bgmID.String(), BGMMode: ReadingBGMModeOnce},
+			{Type: ReadingBlockBGM, BGMMode: ReadingBGMModeStop},
+			{Type: ReadingBlockGMNote, Text: "GM only"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if len(resp.Lines) != 5 {
+		t.Fatalf("expected 5 blocks, got %d", len(resp.Lines))
+	}
+	if got := resp.Lines[0].MediaID; got != f.imageID.String() {
+		t.Fatalf("image MediaID = %q, want %q", got, f.imageID.String())
+	}
+	if got := resp.Lines[1].MediaID; got != f.videoID.String() {
+		t.Fatalf("video MediaID = %q, want %q", got, f.videoID.String())
+	}
+	if got := resp.Lines[2].BGMMode; got != ReadingBGMModeOnce {
+		t.Fatalf("BGMMode = %q, want %q", got, ReadingBGMModeOnce)
+	}
+}
+
+func TestReadingService_Create_BlockMediaMustMatchType(t *testing.T) {
+	f := newReadingFixture(t)
+	_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name: "Wrong block media",
+		Lines: []ReadingLineDTO{
+			{Type: ReadingBlockVideo, MediaID: f.imageID.String(), AdvanceBy: AdvanceByGM},
+		},
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+	if !strings.Contains(err.Error(), "line 0: mediaId") {
+		t.Fatalf("expected line context in error, got %v", err)
+	}
+}
+
+func TestReadingService_Create_BGMBlockRequiresMediaUnlessStop(t *testing.T) {
+	f := newReadingFixture(t)
+	_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name: "Missing bgm media",
+		Lines: []ReadingLineDTO{
+			{Type: ReadingBlockBGM, BGMMode: ReadingBGMModeLoop},
+		},
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
 }
 
 func TestReadingService_Create_ImageMediaMustBeImageInTheme(t *testing.T) {

--- a/apps/server/internal/domain/editor/reading_types.go
+++ b/apps/server/internal/domain/editor/reading_types.go
@@ -19,17 +19,44 @@ const (
 	AdvanceByRolePfx = "role:"
 )
 
+// Reading block types. An empty Type is treated as dialogue for backward
+// compatibility with sections created before the block editor.
+const (
+	ReadingBlockDialogue = "dialogue"
+	ReadingBlockImage    = "image"
+	ReadingBlockVideo    = "video"
+	ReadingBlockBGM      = "bgm"
+	ReadingBlockGMNote   = "gmNote"
+)
+
+const (
+	ReadingBGMModeLoop = "loop"
+	ReadingBGMModeOnce = "once"
+	ReadingBGMModeStop = "stop"
+)
+
 // ReadingLineDTO is the JSON shape of a single reading line as stored in
 // the reading_sections.lines JSONB column. The Go field names use PascalCase
 // so engine-compatible fields and editor-only media cues round-trip without
 // translation.
 type ReadingLineDTO struct {
 	Index        int    `json:"Index"`
-	Text         string `json:"Text"`
+	Type         string `json:"Type,omitempty"`
+	Text         string `json:"Text,omitempty"`
 	Speaker      string `json:"Speaker,omitempty"`
 	VoiceMediaID string `json:"VoiceMediaID,omitempty"`
 	ImageMediaID string `json:"ImageMediaID,omitempty"`
 	AdvanceBy    string `json:"AdvanceBy,omitempty"`
+
+	// Block editor fields. These are intentionally stored in the same JSONB
+	// array so legacy dialogue lines and new production blocks can coexist
+	// while the runtime reader is migrated incrementally.
+	MediaID      string `json:"MediaID,omitempty"`
+	Position     string `json:"Position,omitempty"`
+	Size         string `json:"Size,omitempty"`
+	Autoplay     bool   `json:"Autoplay,omitempty"`
+	WaitUntilEnd bool   `json:"WaitUntilEnd,omitempty"`
+	BGMMode      string `json:"BGMMode,omitempty"`
 }
 
 // CreateReadingSectionRequest is the JSON body for POST /editor/themes/{themeID}/reading-sections.

--- a/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isDialogueBlock,
+  normalizeReadingBlocks,
+  parseReadingScriptToBlocks,
+} from "../readingBlockAdapter";
+
+const characters = [
+  { id: "char-1", name: "변상훈" },
+  { id: "char-2", name: "윤서연" },
+];
+
+const media = [
+  { id: "image-1", name: "저택 전경", type: "IMAGE" as const },
+  { id: "video-1", name: "CCTV 01", type: "VIDEO" as const },
+  { id: "bgm-1", name: "심문 테마", type: "BGM" as const },
+];
+
+describe("parseReadingScriptToBlocks", () => {
+  it("parses dialogue, media, bgm, and gm note blocks into API-compatible lines", () => {
+    const result = parseReadingScriptToBlocks(
+      [
+        "나레이션: 모두 눈을 감아주세요.",
+        "이미지: 저택 전경 large",
+        "변상훈: 저는 아무것도 보지 못했습니다.",
+        "영상: CCTV 01",
+        "BGM: 심문 테마 1회",
+        "GM: 진행자만 보는 메모",
+        "BGM: 정지",
+      ].join("\n"),
+      { characters, media },
+    );
+
+    expect(result.issues).toEqual([]);
+    expect(result.blocks).toMatchObject([
+      { Index: 0, Type: "dialogue", Speaker: "나레이션", Text: "모두 눈을 감아주세요.", AdvanceBy: "gm" },
+      { Index: 1, Type: "image", MediaID: "image-1", Position: "center", Size: "large", AdvanceBy: "gm" },
+      { Index: 2, Type: "dialogue", Speaker: "변상훈", Text: "저는 아무것도 보지 못했습니다.", AdvanceBy: "role:char-1" },
+      { Index: 3, Type: "video", MediaID: "video-1", Autoplay: true, WaitUntilEnd: true, AdvanceBy: "gm" },
+      { Index: 4, Type: "bgm", MediaID: "bgm-1", BGMMode: "once" },
+      { Index: 5, Type: "gmNote", Text: "진행자만 보는 메모" },
+      { Index: 6, Type: "bgm", MediaID: "", BGMMode: "stop" },
+    ]);
+  });
+
+  it("records unresolved speaker and media names instead of inventing IDs", () => {
+    const result = parseReadingScriptToBlocks(
+      ["모르는사람: 알리바이가 있습니다.", "이미지: 없는 사진", "BGM: 없는 음악 반복"].join("\n"),
+      { characters, media },
+    );
+
+    expect(result.blocks[0]).toMatchObject({ Type: "dialogue", Speaker: "모르는사람", AdvanceBy: "gm" });
+    expect(result.blocks[1]).toMatchObject({ Type: "image", MediaID: "" });
+    expect(result.blocks[2]).toMatchObject({ Type: "bgm", MediaID: "", BGMMode: "loop" });
+    expect(result.issues).toEqual([
+      { lineNumber: 1, kind: "unknown-speaker", value: "모르는사람" },
+      { lineNumber: 2, kind: "unknown-media", value: "없는 사진" },
+      { lineNumber: 3, kind: "unknown-media", value: "없는 음악 반복" },
+    ]);
+  });
+});
+
+describe("normalizeReadingBlocks", () => {
+  it("keeps legacy lines as dialogue blocks and rewrites indices", () => {
+    const normalized = normalizeReadingBlocks([
+      { Index: 99, Text: "legacy", Speaker: "나레이션", AdvanceBy: "gm" },
+      { Index: 42, Type: "gmNote", Text: "note" },
+    ]);
+
+    expect(normalized[0]).toMatchObject({ Index: 0, Type: "dialogue" });
+    expect(normalized[1]).toMatchObject({ Index: 1, Type: "gmNote" });
+    expect(isDialogueBlock(normalized[0])).toBe(true);
+    expect(isDialogueBlock(normalized[1])).toBe(false);
+  });
+});

--- a/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
@@ -1,75 +1,127 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
 import {
   isDialogueBlock,
   normalizeReadingBlocks,
   parseReadingScriptToBlocks,
-} from "../readingBlockAdapter";
+} from '../readingBlockAdapter';
 
 const characters = [
-  { id: "char-1", name: "변상훈" },
-  { id: "char-2", name: "윤서연" },
+  { id: 'char-1', name: '변상훈' },
+  { id: 'char-2', name: '윤서연' },
 ];
 
 const media = [
-  { id: "image-1", name: "저택 전경", type: "IMAGE" as const },
-  { id: "video-1", name: "CCTV 01", type: "VIDEO" as const },
-  { id: "bgm-1", name: "심문 테마", type: "BGM" as const },
+  { id: 'image-1', name: '저택 전경', type: 'IMAGE' as const },
+  { id: 'video-1', name: 'CCTV 01', type: 'VIDEO' as const },
+  { id: 'bgm-1', name: '심문 테마', type: 'BGM' as const },
 ];
 
-describe("parseReadingScriptToBlocks", () => {
-  it("parses dialogue, media, bgm, and gm note blocks into API-compatible lines", () => {
+describe('parseReadingScriptToBlocks', () => {
+  it('parses dialogue, media, bgm, and gm note blocks into API-compatible lines', () => {
     const result = parseReadingScriptToBlocks(
       [
-        "나레이션: 모두 눈을 감아주세요.",
-        "이미지: 저택 전경 large",
-        "변상훈: 저는 아무것도 보지 못했습니다.",
-        "영상: CCTV 01",
-        "BGM: 심문 테마 1회",
-        "GM: 진행자만 보는 메모",
-        "BGM: 정지",
-      ].join("\n"),
-      { characters, media },
+        '나레이션: 모두 눈을 감아주세요.',
+        '이미지: 저택 전경 large',
+        '변상훈: 저는 아무것도 보지 못했습니다.',
+        '영상: CCTV 01',
+        'BGM: 심문 테마 1회',
+        'GM: 진행자만 보는 메모',
+        'BGM: 정지',
+      ].join('\n'),
+      { characters, media }
     );
 
     expect(result.issues).toEqual([]);
     expect(result.blocks).toMatchObject([
-      { Index: 0, Type: "dialogue", Speaker: "나레이션", Text: "모두 눈을 감아주세요.", AdvanceBy: "gm" },
-      { Index: 1, Type: "image", MediaID: "image-1", Position: "center", Size: "large", AdvanceBy: "gm" },
-      { Index: 2, Type: "dialogue", Speaker: "변상훈", Text: "저는 아무것도 보지 못했습니다.", AdvanceBy: "role:char-1" },
-      { Index: 3, Type: "video", MediaID: "video-1", Autoplay: true, WaitUntilEnd: true, AdvanceBy: "gm" },
-      { Index: 4, Type: "bgm", MediaID: "bgm-1", BGMMode: "once" },
-      { Index: 5, Type: "gmNote", Text: "진행자만 보는 메모" },
-      { Index: 6, Type: "bgm", MediaID: "", BGMMode: "stop" },
+      {
+        Index: 0,
+        Type: 'dialogue',
+        Speaker: '나레이션',
+        Text: '모두 눈을 감아주세요.',
+        AdvanceBy: 'gm',
+      },
+      {
+        Index: 1,
+        Type: 'image',
+        MediaID: 'image-1',
+        Position: 'center',
+        Size: 'large',
+        AdvanceBy: 'gm',
+      },
+      {
+        Index: 2,
+        Type: 'dialogue',
+        Speaker: '변상훈',
+        Text: '저는 아무것도 보지 못했습니다.',
+        AdvanceBy: 'role:char-1',
+      },
+      {
+        Index: 3,
+        Type: 'video',
+        MediaID: 'video-1',
+        Autoplay: true,
+        WaitUntilEnd: true,
+        AdvanceBy: 'gm',
+      },
+      { Index: 4, Type: 'bgm', MediaID: 'bgm-1', BGMMode: 'once' },
+      { Index: 5, Type: 'gmNote', Text: '진행자만 보는 메모' },
+      { Index: 6, Type: 'bgm', MediaID: '', BGMMode: 'stop' },
     ]);
   });
 
-  it("records unresolved speaker and media names instead of inventing IDs", () => {
+  it('records unresolved speaker and media names instead of inventing IDs', () => {
     const result = parseReadingScriptToBlocks(
-      ["모르는사람: 알리바이가 있습니다.", "이미지: 없는 사진", "BGM: 없는 음악 반복"].join("\n"),
-      { characters, media },
+      ['모르는사람: 알리바이가 있습니다.', '이미지: 없는 사진', 'BGM: 없는 음악 반복'].join('\n'),
+      { characters, media }
     );
 
-    expect(result.blocks[0]).toMatchObject({ Type: "dialogue", Speaker: "모르는사람", AdvanceBy: "gm" });
-    expect(result.blocks[1]).toMatchObject({ Type: "image", MediaID: "" });
-    expect(result.blocks[2]).toMatchObject({ Type: "bgm", MediaID: "", BGMMode: "loop" });
+    expect(result.blocks[0]).toMatchObject({
+      Type: 'dialogue',
+      Speaker: '모르는사람',
+      AdvanceBy: 'gm',
+    });
+    expect(result.blocks[1]).toMatchObject({ Type: 'image', MediaID: '' });
+    expect(result.blocks[2]).toMatchObject({ Type: 'bgm', MediaID: '', BGMMode: 'loop' });
     expect(result.issues).toEqual([
-      { lineNumber: 1, kind: "unknown-speaker", value: "모르는사람" },
-      { lineNumber: 2, kind: "unknown-media", value: "없는 사진" },
-      { lineNumber: 3, kind: "unknown-media", value: "없는 음악 반복" },
+      { lineNumber: 1, kind: 'unknown-speaker', value: '모르는사람' },
+      { lineNumber: 2, kind: 'unknown-media', value: '없는 사진' },
+      { lineNumber: 3, kind: 'unknown-media', value: '없는 음악 반복' },
+    ]);
+  });
+
+  it('does not strip directive words embedded inside media names', () => {
+    const result = parseReadingScriptToBlocks(
+      ['이미지: leftover_theme', '영상: fullscreen_bg', 'BGM: stopper_bgm'].join('\n'),
+      {
+        characters,
+        media: [
+          ...media,
+          { id: 'image-leftover', name: 'leftover_theme', type: 'IMAGE' as const },
+          { id: 'video-fullscreen', name: 'fullscreen_bg', type: 'VIDEO' as const },
+          { id: 'bgm-stopper', name: 'stopper_bgm', type: 'BGM' as const },
+        ],
+      }
+    );
+
+    expect(result.issues).toEqual([]);
+    expect(result.blocks).toMatchObject([
+      { Type: 'image', MediaID: 'image-leftover', Position: 'center', Size: 'medium' },
+      { Type: 'video', MediaID: 'video-fullscreen' },
+      { Type: 'bgm', MediaID: 'bgm-stopper', BGMMode: 'loop' },
     ]);
   });
 });
 
-describe("normalizeReadingBlocks", () => {
-  it("keeps legacy lines as dialogue blocks and rewrites indices", () => {
+describe('normalizeReadingBlocks', () => {
+  it('keeps legacy lines as dialogue blocks and rewrites indices', () => {
     const normalized = normalizeReadingBlocks([
-      { Index: 99, Text: "legacy", Speaker: "나레이션", AdvanceBy: "gm" },
-      { Index: 42, Type: "gmNote", Text: "note" },
+      { Index: 99, Text: 'legacy', Speaker: '나레이션', AdvanceBy: 'gm' },
+      { Index: 42, Type: 'gmNote', Text: 'note' },
     ]);
 
-    expect(normalized[0]).toMatchObject({ Index: 0, Type: "dialogue" });
-    expect(normalized[1]).toMatchObject({ Index: 1, Type: "gmNote" });
+    expect(normalized[0]).toMatchObject({ Index: 0, Type: 'dialogue' });
+    expect(normalized[1]).toMatchObject({ Index: 1, Type: 'gmNote' });
     expect(isDialogueBlock(normalized[0])).toBe(true);
     expect(isDialogueBlock(normalized[1])).toBe(false);
   });

--- a/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
+++ b/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
@@ -1,0 +1,186 @@
+import type { AdvanceBy, ReadingBgmMode, ReadingBlockType, ReadingLineDTO } from "../../readingApi";
+import type { MediaType } from "../../mediaApi";
+
+export interface ReadingParserCharacter {
+  id: string;
+  name: string;
+}
+
+export interface ReadingParserMedia {
+  id: string;
+  name: string;
+  type: MediaType;
+}
+
+export interface ReadingParseIssue {
+  lineNumber: number;
+  kind: "unknown-speaker" | "unknown-media" | "empty-directive";
+  value: string;
+}
+
+export interface ReadingParseResult {
+  blocks: ReadingLineDTO[];
+  issues: ReadingParseIssue[];
+}
+
+export function parseReadingScriptToBlocks(
+  input: string,
+  options: {
+    characters: ReadingParserCharacter[];
+    media: ReadingParserMedia[];
+  },
+): ReadingParseResult {
+  const issues: ReadingParseIssue[] = [];
+  const blocks = input
+    .split(/\r?\n/)
+    .map((raw, index) => ({ raw: raw.trim(), lineNumber: index + 1 }))
+    .filter((line) => line.raw.length > 0)
+    .map(({ raw, lineNumber }, index): ReadingLineDTO => {
+      const [rawHead, ...rest] = raw.split(/[:：]/);
+      const head = rawHead.trim();
+      const body = rest.join(":").trim();
+
+      if (!head || rest.length === 0) {
+        issues.push({ lineNumber, kind: "empty-directive", value: raw });
+        return dialogueBlock(index, "나레이션", raw, "gm");
+      }
+
+      if (head === "이미지") {
+        const media = findMedia(body, "IMAGE", options.media);
+        if (!media) issues.push({ lineNumber, kind: "unknown-media", value: body });
+        return mediaBlock(index, "image", media?.id ?? "", "gm", {
+          Position: inferImagePosition(body),
+          Size: inferImageSize(body),
+        });
+      }
+
+      if (head === "영상") {
+        const media = findMedia(body, "VIDEO", options.media);
+        if (!media) issues.push({ lineNumber, kind: "unknown-media", value: body });
+        return mediaBlock(index, "video", media?.id ?? "", "gm", {
+          Autoplay: true,
+          WaitUntilEnd: true,
+        });
+      }
+
+      if (head.toUpperCase() === "BGM") {
+        const mode = inferBgmMode(body);
+        const media = mode === "stop" ? null : findMedia(body, "BGM", options.media);
+        if (mode !== "stop" && !media) {
+          issues.push({ lineNumber, kind: "unknown-media", value: body });
+        }
+        return {
+          Index: index,
+          Type: "bgm",
+          Text: "",
+          MediaID: media?.id ?? "",
+          BGMMode: mode,
+        };
+      }
+
+      if (head.toUpperCase() === "GM") {
+        return {
+          Index: index,
+          Type: "gmNote",
+          Text: body,
+        };
+      }
+
+      const character = options.characters.find((item) => item.name === head);
+      if (!character && head !== "나레이션") {
+        issues.push({ lineNumber, kind: "unknown-speaker", value: head });
+      }
+      return dialogueBlock(
+        index,
+        head || "나레이션",
+        body || raw,
+        character ? `role:${character.id}` : "gm",
+      );
+    });
+
+  return { blocks, issues };
+}
+
+export function normalizeReadingBlocks(lines: ReadingLineDTO[]): ReadingLineDTO[] {
+  return lines.map((line, index) => ({
+    ...line,
+    Index: index,
+    Type: normalizeBlockType(line.Type),
+    Text: line.Text ?? "",
+  }));
+}
+
+export function isDialogueBlock(line: ReadingLineDTO): boolean {
+  return normalizeBlockType(line.Type) === "dialogue";
+}
+
+function dialogueBlock(index: number, speaker: string, text: string, advanceBy: AdvanceBy): ReadingLineDTO {
+  return {
+    Index: index,
+    Type: "dialogue",
+    Text: text,
+    Speaker: speaker,
+    AdvanceBy: advanceBy,
+  };
+}
+
+function mediaBlock(
+  index: number,
+  type: Extract<ReadingBlockType, "image" | "video">,
+  mediaId: string,
+  advanceBy: AdvanceBy,
+  extras: Partial<ReadingLineDTO>,
+): ReadingLineDTO {
+  return {
+    Index: index,
+    Type: type,
+    Text: "",
+    MediaID: mediaId,
+    AdvanceBy: advanceBy,
+    ...extras,
+  };
+}
+
+function findMedia(name: string, type: MediaType, media: ReadingParserMedia[]): ReadingParserMedia | null {
+  const normalized = normalizeLookupName(name);
+  if (!normalized) return null;
+  return media.find((item) => item.type === type && normalizeLookupName(item.name) === normalized) ?? null;
+}
+
+function normalizeLookupName(value: string): string {
+  const controlWords = ["반복", "1회", "한번", "정지", "loop", "once", "stop", "full", "large", "small", "left", "right", "center"];
+  let normalized = value;
+  for (const word of controlWords) {
+    normalized = normalized.replaceAll(word, "");
+  }
+  return normalized
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function inferImagePosition(value: string): ReadingLineDTO["Position"] {
+  const lower = value.toLowerCase();
+  if (lower.includes("left")) return "left";
+  if (lower.includes("right")) return "right";
+  if (lower.includes("full")) return "full";
+  return "center";
+}
+
+function inferImageSize(value: string): ReadingLineDTO["Size"] {
+  const lower = value.toLowerCase();
+  if (lower.includes("small")) return "small";
+  if (lower.includes("large") || lower.includes("full")) return "large";
+  return "medium";
+}
+
+function inferBgmMode(value: string): ReadingBgmMode {
+  const lower = value.toLowerCase();
+  if (lower.includes("정지") || lower.includes("stop")) return "stop";
+  if (lower.includes("1회") || lower.includes("한번") || lower.includes("once")) return "once";
+  return "loop";
+}
+
+function normalizeBlockType(type: ReadingLineDTO["Type"]): ReadingBlockType {
+  return type ?? "dialogue";
+}

--- a/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
+++ b/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
@@ -1,5 +1,5 @@
-import type { AdvanceBy, ReadingBgmMode, ReadingBlockType, ReadingLineDTO } from "../../readingApi";
-import type { MediaType } from "../../mediaApi";
+import type { AdvanceBy, ReadingBgmMode, ReadingBlockType, ReadingLineDTO } from '../../readingApi';
+import type { MediaType } from '../../mediaApi';
 
 export interface ReadingParserCharacter {
   id: string;
@@ -14,7 +14,7 @@ export interface ReadingParserMedia {
 
 export interface ReadingParseIssue {
   lineNumber: number;
-  kind: "unknown-speaker" | "unknown-media" | "empty-directive";
+  kind: 'unknown-speaker' | 'unknown-media' | 'empty-directive';
   value: string;
 }
 
@@ -28,7 +28,7 @@ export function parseReadingScriptToBlocks(
   options: {
     characters: ReadingParserCharacter[];
     media: ReadingParserMedia[];
-  },
+  }
 ): ReadingParseResult {
   const issues: ReadingParseIssue[] = [];
   const blocks = input
@@ -38,67 +38,97 @@ export function parseReadingScriptToBlocks(
     .map(({ raw, lineNumber }, index): ReadingLineDTO => {
       const [rawHead, ...rest] = raw.split(/[:：]/);
       const head = rawHead.trim();
-      const body = rest.join(":").trim();
+      const body = rest.join(':').trim();
 
       if (!head || rest.length === 0) {
-        issues.push({ lineNumber, kind: "empty-directive", value: raw });
-        return dialogueBlock(index, "나레이션", raw, "gm");
+        issues.push({ lineNumber, kind: 'empty-directive', value: raw });
+        return dialogueBlock(index, '나레이션', raw, 'gm');
       }
 
-      if (head === "이미지") {
-        const media = findMedia(body, "IMAGE", options.media);
-        if (!media) issues.push({ lineNumber, kind: "unknown-media", value: body });
-        return mediaBlock(index, "image", media?.id ?? "", "gm", {
-          Position: inferImagePosition(body),
-          Size: inferImageSize(body),
-        });
-      }
-
-      if (head === "영상") {
-        const media = findMedia(body, "VIDEO", options.media);
-        if (!media) issues.push({ lineNumber, kind: "unknown-media", value: body });
-        return mediaBlock(index, "video", media?.id ?? "", "gm", {
-          Autoplay: true,
-          WaitUntilEnd: true,
-        });
-      }
-
-      if (head.toUpperCase() === "BGM") {
-        const mode = inferBgmMode(body);
-        const media = mode === "stop" ? null : findMedia(body, "BGM", options.media);
-        if (mode !== "stop" && !media) {
-          issues.push({ lineNumber, kind: "unknown-media", value: body });
-        }
-        return {
-          Index: index,
-          Type: "bgm",
-          Text: "",
-          MediaID: media?.id ?? "",
-          BGMMode: mode,
-        };
-      }
-
-      if (head.toUpperCase() === "GM") {
-        return {
-          Index: index,
-          Type: "gmNote",
-          Text: body,
-        };
-      }
-
-      const character = options.characters.find((item) => item.name === head);
-      if (!character && head !== "나레이션") {
-        issues.push({ lineNumber, kind: "unknown-speaker", value: head });
-      }
-      return dialogueBlock(
-        index,
-        head || "나레이션",
-        body || raw,
-        character ? `role:${character.id}` : "gm",
-      );
+      return parseDirectiveLine(index, lineNumber, head, body, raw, options, issues);
     });
 
   return { blocks, issues };
+}
+
+function parseDirectiveLine(
+  index: number,
+  lineNumber: number,
+  head: string,
+  body: string,
+  raw: string,
+  options: { characters: ReadingParserCharacter[]; media: ReadingParserMedia[] },
+  issues: ReadingParseIssue[]
+): ReadingLineDTO {
+  if (head === '이미지') return parseImageDirective(index, lineNumber, body, options.media, issues);
+  if (head === '영상') return parseVideoDirective(index, lineNumber, body, options.media, issues);
+  if (head.toUpperCase() === 'BGM')
+    return parseBgmDirective(index, lineNumber, body, options.media, issues);
+  if (head.toUpperCase() === 'GM') return { Index: index, Type: 'gmNote', Text: body };
+  return parseDialogueDirective(index, lineNumber, head, body || raw, options.characters, issues);
+}
+
+function parseImageDirective(
+  index: number,
+  lineNumber: number,
+  body: string,
+  media: ReadingParserMedia[],
+  issues: ReadingParseIssue[]
+): ReadingLineDTO {
+  const found = findMedia(body, 'IMAGE', media);
+  if (!found) issues.push({ lineNumber, kind: 'unknown-media', value: body });
+  return mediaBlock(index, 'image', found?.id ?? '', 'gm', {
+    Position: inferImagePosition(body),
+    Size: inferImageSize(body),
+  });
+}
+
+function parseVideoDirective(
+  index: number,
+  lineNumber: number,
+  body: string,
+  media: ReadingParserMedia[],
+  issues: ReadingParseIssue[]
+): ReadingLineDTO {
+  const found = findMedia(body, 'VIDEO', media);
+  if (!found) issues.push({ lineNumber, kind: 'unknown-media', value: body });
+  return mediaBlock(index, 'video', found?.id ?? '', 'gm', {
+    Autoplay: true,
+    WaitUntilEnd: true,
+  });
+}
+
+function parseBgmDirective(
+  index: number,
+  lineNumber: number,
+  body: string,
+  media: ReadingParserMedia[],
+  issues: ReadingParseIssue[]
+): ReadingLineDTO {
+  const mode = inferBgmMode(body);
+  const found = mode === 'stop' ? null : findMedia(body, 'BGM', media);
+  if (mode !== 'stop' && !found) issues.push({ lineNumber, kind: 'unknown-media', value: body });
+  return { Index: index, Type: 'bgm', Text: '', MediaID: found?.id ?? '', BGMMode: mode };
+}
+
+function parseDialogueDirective(
+  index: number,
+  lineNumber: number,
+  speaker: string,
+  text: string,
+  characters: ReadingParserCharacter[],
+  issues: ReadingParseIssue[]
+): ReadingLineDTO {
+  const character = characters.find((item) => item.name === speaker);
+  if (!character && speaker !== '나레이션') {
+    issues.push({ lineNumber, kind: 'unknown-speaker', value: speaker });
+  }
+  return dialogueBlock(
+    index,
+    speaker || '나레이션',
+    text,
+    character ? `role:${character.id}` : 'gm'
+  );
 }
 
 export function normalizeReadingBlocks(lines: ReadingLineDTO[]): ReadingLineDTO[] {
@@ -106,18 +136,23 @@ export function normalizeReadingBlocks(lines: ReadingLineDTO[]): ReadingLineDTO[
     ...line,
     Index: index,
     Type: normalizeBlockType(line.Type),
-    Text: line.Text ?? "",
+    Text: line.Text ?? '',
   }));
 }
 
 export function isDialogueBlock(line: ReadingLineDTO): boolean {
-  return normalizeBlockType(line.Type) === "dialogue";
+  return normalizeBlockType(line.Type) === 'dialogue';
 }
 
-function dialogueBlock(index: number, speaker: string, text: string, advanceBy: AdvanceBy): ReadingLineDTO {
+function dialogueBlock(
+  index: number,
+  speaker: string,
+  text: string,
+  advanceBy: AdvanceBy
+): ReadingLineDTO {
   return {
     Index: index,
-    Type: "dialogue",
+    Type: 'dialogue',
     Text: text,
     Speaker: speaker,
     AdvanceBy: advanceBy,
@@ -126,61 +161,93 @@ function dialogueBlock(index: number, speaker: string, text: string, advanceBy: 
 
 function mediaBlock(
   index: number,
-  type: Extract<ReadingBlockType, "image" | "video">,
+  type: Extract<ReadingBlockType, 'image' | 'video'>,
   mediaId: string,
   advanceBy: AdvanceBy,
-  extras: Partial<ReadingLineDTO>,
+  extras: Partial<ReadingLineDTO>
 ): ReadingLineDTO {
   return {
     Index: index,
     Type: type,
-    Text: "",
+    Text: '',
     MediaID: mediaId,
     AdvanceBy: advanceBy,
     ...extras,
   };
 }
 
-function findMedia(name: string, type: MediaType, media: ReadingParserMedia[]): ReadingParserMedia | null {
+function findMedia(
+  name: string,
+  type: MediaType,
+  media: ReadingParserMedia[]
+): ReadingParserMedia | null {
   const normalized = normalizeLookupName(name);
   if (!normalized) return null;
-  return media.find((item) => item.type === type && normalizeLookupName(item.name) === normalized) ?? null;
+  return (
+    media.find((item) => item.type === type && normalizeLookupName(item.name) === normalized) ??
+    null
+  );
 }
 
 function normalizeLookupName(value: string): string {
-  const controlWords = ["반복", "1회", "한번", "정지", "loop", "once", "stop", "full", "large", "small", "left", "right", "center"];
+  const controlWords = [
+    '반복',
+    '1회',
+    '한번',
+    '정지',
+    'loop',
+    'once',
+    'stop',
+    'full',
+    'large',
+    'small',
+    'left',
+    'right',
+    'center',
+  ];
   let normalized = value;
   for (const word of controlWords) {
-    normalized = normalized.replaceAll(word, "");
+    normalized = normalized.replace(controlWordPattern(word), '$1');
   }
-  return normalized
-    .replace(/\s+/g, " ")
-    .trim()
-    .toLowerCase();
+  return normalized.replace(/\s+/g, ' ').trim().toLowerCase();
 }
 
-function inferImagePosition(value: string): ReadingLineDTO["Position"] {
-  const lower = value.toLowerCase();
-  if (lower.includes("left")) return "left";
-  if (lower.includes("right")) return "right";
-  if (lower.includes("full")) return "full";
-  return "center";
+function inferImagePosition(value: string): ReadingLineDTO['Position'] {
+  if (hasControlWord(value, 'left')) return 'left';
+  if (hasControlWord(value, 'right')) return 'right';
+  if (hasControlWord(value, 'full')) return 'full';
+  return 'center';
 }
 
-function inferImageSize(value: string): ReadingLineDTO["Size"] {
-  const lower = value.toLowerCase();
-  if (lower.includes("small")) return "small";
-  if (lower.includes("large") || lower.includes("full")) return "large";
-  return "medium";
+function inferImageSize(value: string): ReadingLineDTO['Size'] {
+  if (hasControlWord(value, 'small')) return 'small';
+  if (hasControlWord(value, 'large') || hasControlWord(value, 'full')) return 'large';
+  return 'medium';
 }
 
 function inferBgmMode(value: string): ReadingBgmMode {
-  const lower = value.toLowerCase();
-  if (lower.includes("정지") || lower.includes("stop")) return "stop";
-  if (lower.includes("1회") || lower.includes("한번") || lower.includes("once")) return "once";
-  return "loop";
+  if (hasControlWord(value, '정지') || hasControlWord(value, 'stop')) return 'stop';
+  if (
+    hasControlWord(value, '1회') ||
+    hasControlWord(value, '한번') ||
+    hasControlWord(value, 'once')
+  )
+    return 'once';
+  return 'loop';
 }
 
-function normalizeBlockType(type: ReadingLineDTO["Type"]): ReadingBlockType {
-  return type ?? "dialogue";
+function normalizeBlockType(type: ReadingLineDTO['Type']): ReadingBlockType {
+  return type ?? 'dialogue';
+}
+
+function hasControlWord(value: string, word: string): boolean {
+  return controlWordPattern(word).test(value);
+}
+
+function controlWordPattern(word: string): RegExp {
+  return new RegExp(`(^|[\\s_-])${escapeRegExp(word)}(?=$|[\\s_-])`, 'iu');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/apps/web/src/features/editor/readingApi.ts
+++ b/apps/web/src/features/editor/readingApi.ts
@@ -30,12 +30,22 @@ export type AdvanceBy = "voice" | "gm" | `role:${string}` | "";
  */
 export interface ReadingLineDTO {
   Index: number;
+  Type?: ReadingBlockType;
   Text: string;
   Speaker?: string;
   VoiceMediaID?: string;
   ImageMediaID?: string;
   AdvanceBy?: AdvanceBy;
+  MediaID?: string;
+  Position?: "left" | "center" | "right" | "full";
+  Size?: "small" | "medium" | "large";
+  Autoplay?: boolean;
+  WaitUntilEnd?: boolean;
+  BGMMode?: ReadingBgmMode;
 }
+
+export type ReadingBlockType = "dialogue" | "image" | "video" | "bgm" | "gmNote";
+export type ReadingBgmMode = "loop" | "once" | "stop";
 
 export interface CreateReadingSectionRequest {
   name: string;

--- a/apps/web/src/features/editor/readingApi.ts
+++ b/apps/web/src/features/editor/readingApi.ts
@@ -1,7 +1,7 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { api } from "@/services/api";
-import { queryClient } from "@/services/queryClient";
+import { api } from '@/services/api';
+import { queryClient } from '@/services/queryClient';
 
 // ---------------------------------------------------------------------------
 // Types — match backend exactly
@@ -22,7 +22,7 @@ import { queryClient } from "@/services/queryClient";
  *  - "role:<id>"  → advances on action from the player assigned to that role
  *  - ""           → unset (defaults to engine policy)
  */
-export type AdvanceBy = "voice" | "gm" | `role:${string}` | "";
+export type AdvanceBy = 'voice' | 'gm' | `role:${string}` | '';
 
 /**
  * A single reading line. Field names are PascalCase to match the JSONB
@@ -31,21 +31,21 @@ export type AdvanceBy = "voice" | "gm" | `role:${string}` | "";
 export interface ReadingLineDTO {
   Index: number;
   Type?: ReadingBlockType;
-  Text: string;
+  Text?: string;
   Speaker?: string;
   VoiceMediaID?: string;
   ImageMediaID?: string;
   AdvanceBy?: AdvanceBy;
   MediaID?: string;
-  Position?: "left" | "center" | "right" | "full";
-  Size?: "small" | "medium" | "large";
+  Position?: 'left' | 'center' | 'right' | 'full';
+  Size?: 'small' | 'medium' | 'large';
   Autoplay?: boolean;
   WaitUntilEnd?: boolean;
   BGMMode?: ReadingBgmMode;
 }
 
-export type ReadingBlockType = "dialogue" | "image" | "video" | "bgm" | "gmNote";
-export type ReadingBgmMode = "loop" | "once" | "stop";
+export type ReadingBlockType = 'dialogue' | 'image' | 'video' | 'bgm' | 'gmNote';
+export type ReadingBgmMode = 'loop' | 'once' | 'stop';
 
 export interface CreateReadingSectionRequest {
   name: string;
@@ -90,8 +90,8 @@ export interface ReadingSectionResponse {
 // ---------------------------------------------------------------------------
 
 export const readingKeys = {
-  all: ["reading-sections"] as const,
-  list: (themeId: string) => ["reading-sections", themeId] as const,
+  all: ['reading-sections'] as const,
+  list: (themeId: string) => ['reading-sections', themeId] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -106,8 +106,8 @@ export const readingKeys = {
  *   - "role:<non-empty>"
  */
 export function isValidAdvanceBy(s: string): boolean {
-  if (s === "" || s === "voice" || s === "gm") return true;
-  return s.startsWith("role:") && s.length > "role:".length;
+  if (s === '' || s === 'voice' || s === 'gm') return true;
+  return s.startsWith('role:') && s.length > 'role:'.length;
 }
 
 /**
@@ -116,9 +116,7 @@ export function isValidAdvanceBy(s: string): boolean {
  * `null` values are preserved (backend sees *string pointing to nil =
  * "clear field"). This is the wire encoding for the triple-state pattern.
  */
-export function buildUpdateBody(
-  patch: UpdateReadingSectionRequest,
-): Record<string, unknown> {
+export function buildUpdateBody(patch: UpdateReadingSectionRequest): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(patch)) {
     if (value !== undefined) {
@@ -136,9 +134,7 @@ export function useReadingSections(themeId: string) {
   return useQuery<ReadingSectionResponse[]>({
     queryKey: readingKeys.list(themeId),
     queryFn: () =>
-      api.get<ReadingSectionResponse[]>(
-        `/v1/editor/themes/${themeId}/reading-sections`,
-      ),
+      api.get<ReadingSectionResponse[]>(`/v1/editor/themes/${themeId}/reading-sections`),
     enabled: !!themeId,
   });
 }
@@ -150,10 +146,7 @@ export function useReadingSections(themeId: string) {
 export function useCreateReadingSection(themeId: string) {
   return useMutation<ReadingSectionResponse, Error, CreateReadingSectionRequest>({
     mutationFn: (body) =>
-      api.post<ReadingSectionResponse>(
-        `/v1/editor/themes/${themeId}/reading-sections`,
-        body,
-      ),
+      api.post<ReadingSectionResponse>(`/v1/editor/themes/${themeId}/reading-sections`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: readingKeys.list(themeId) });
     },
@@ -169,7 +162,7 @@ export function useUpdateReadingSection(themeId: string) {
     mutationFn: ({ id, patch }) =>
       api.patch<ReadingSectionResponse>(
         `/v1/editor/reading-sections/${id}`,
-        buildUpdateBody(patch),
+        buildUpdateBody(patch)
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: readingKeys.list(themeId) });


### PR DESCRIPTION
## 요약
- 읽기 대사 `lines` JSONB에 기존 줄 단위 대사와 새 블록 타입이 함께 저장될 수 있도록 block type 필드를 추가했습니다.
- 이미지/영상/BGM/GM 메모 블록의 backend validation과 media ownership/type 검증을 추가했습니다.
- 대본 붙여넣기 입력을 API 호환 block payload로 변환하는 frontend parser/adapter를 추가했습니다.
- media delete reference scan/cleanup이 새 block `MediaID` 참조도 감지하고 정리하도록 확장했습니다.

## Coverage Plan
- `apps/server/internal/domain/editor/reading_types.go` / `reading_service.go`: image/video/bgm/gmNote block validation, media type/ownership, BGM stop 예외를 service test로 검증합니다.
- `apps/server/db/queries/reading_sections.sql` / `media.sql`: 새 block `MediaID`가 preview delete와 cleanup query에 포함되는지 fake + JSONB integration test로 검증합니다.
- `apps/web/src/features/editor/entities/story/readingBlockAdapter.ts`: 대본 입력 parser가 dialogue/image/video/bgm/gmNote를 API payload로 만들고 unresolved speaker/media를 issue로 남기는지 unit test로 검증합니다.
- E2E는 추가하지 않았습니다. 이번 PR은 저장 모델/검증/parser 기반이며, 실제 블록 편집 UI와 테스트 플레이어는 #473 후속 PR에서 사용자 흐름 E2E로 검증합니다.

## Local validation
- `go test ./internal/domain/editor -run 'TestReadingService_Create_Block|TestReadingService_Create_BGMBlock|TestMediaService_PreviewDelete_ReportsReadingBlock|TestFindMediaReferencesInReadingSections_JSONBIntegration'` 통과\n- `pnpm --filter @mmp/web test -- src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts` 통과 (1 file, 3 tests)\n- `pnpm --filter @mmp/web typecheck` 통과\n- `scripts/mmp-local-ci.sh quick` 통과\n  - mode: quick\n  - status: success\n  - head: `92ce0f847db0e4b957d28fe9063e8fd94960afdf`\n  - started_at: `2026-05-07T14:06:38Z`\n  - finished_at: `2026-05-07T14:10:27Z`\n  - web tests: 174 files / 1582 tests passed\n  - 기존 lint warning 47건과 기존 Rollup/chunk warning만 있으며 error는 없습니다.\n\nRefs #473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 읽기 섹션에서 이미지/비디오/BGM/GM노트 블록 지원 및 블록별 속성(위치, 크기, 자동재생, BGM 모드 등) 추가
  * 읽기 스크립트 파서 및 블록 정규화 도구 추가로 원시 스크립트를 구조화된 블록으로 변환·검증

* **버그 수정**
  * 읽기 섹션 내 JSON 미디어 참조 탐지·정리 범위 확장(추가적인 MediaID 필드 포함)
  * 블록 타입·미디어 일관성 검사 강화 및 관련 에러 메시지 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->