### PR TITLE
feat(editor): 게임 설계 IA 단일화

### DIFF
--- a/apps/web/src/features/editor/__tests__/routeSegments.test.ts
+++ b/apps/web/src/features/editor/__tests__/routeSegments.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
   buildEditorRouteForTab,
   EDITOR_ROUTE_MATRIX,
-  readDesignSubTabFromRouteSegment,
   readEditorTabFromRouteSegment,
 } from '../routeSegments';
 
@@ -14,16 +13,8 @@ describe('editor route segment matrix', () => {
     }
   );
 
-  it.each(EDITOR_ROUTE_MATRIX.filter((entry) => entry.editorTab === 'design'))(
-    '$path 직접 URL을 올바른 design subtab으로 매핑한다',
-    ({ routeSegment, designSubTab }) => {
-      expect(readDesignSubTabFromRouteSegment(routeSegment)).toBe(designSubTab);
-    }
-  );
-
   it('알 수 없는 segment는 제작 흐름의 안전한 기본 화면으로 되돌린다', () => {
     expect(readEditorTabFromRouteSegment('unknown')).toBe('storyMap');
-    expect(readDesignSubTabFromRouteSegment('unknown')).toBe('modules');
   });
 
   it.each([
@@ -32,7 +23,9 @@ describe('editor route segment matrix', () => {
     ['story', '/editor/theme-1/reading'],
     ['characters', '/editor/theme-1/characters'],
     ['clues', '/editor/theme-1/clues'],
-    ['design', '/editor/theme-1/design/modules'],
+    ['design', '/editor/theme-1/design'],
+    ['endings', '/editor/theme-1/endings'],
+    ['locations', '/editor/theme-1/locations'],
     ['media', '/editor/theme-1/media'],
     ['overview', '/editor/theme-1/overview'],
     ['template', '/editor/theme-1/template'],
@@ -49,5 +42,18 @@ describe('editor route segment matrix', () => {
     expect(buildEditorRouteForTab('theme/with space', 'characters')).toBe(
       '/editor/theme%2Fwith%20space/characters',
     );
+  });
+
+  it.each([
+    ['design/flow', 'storyMap'],
+    ['flow', 'storyMap'],
+    ['design/endings', 'endings'],
+    ['endings', 'endings'],
+    ['design/locations', 'locations'],
+    ['locations', 'locations'],
+    ['design/modules', 'design'],
+    ['modules', 'design'],
+  ] as const)('legacy segment %s를 새 상위 탭 구조로 매핑한다', (segment, expectedTab) => {
+    expect(readEditorTabFromRouteSegment(segment)).toBe(expectedTab);
   });
 });

--- a/apps/web/src/features/editor/components/DesignTab.tsx
+++ b/apps/web/src/features/editor/components/DesignTab.tsx
@@ -1,15 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { Puzzle, GitBranch, MapPin, Drama } from 'lucide-react';
 import type { EditorThemeResponse } from '@/features/editor/api';
-import {
-  readDesignSubTabFromRouteSegment,
-  type DesignSubTab,
-} from '@/features/editor/routeSegments';
 import { ModulesSubTab } from './design/ModulesSubTab';
-import { FlowSubTab } from './design/FlowSubTab';
-import { LocationsSubTab } from './design/LocationsSubTab';
-import { EndingEntitySubTab } from './design/EndingEntitySubTab';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -21,64 +11,12 @@ interface DesignTabProps {
   routeSegment?: string;
 }
 
-const SUB_TABS: { key: DesignSubTab; label: string; icon: React.ElementType }[] = [
-  { key: 'modules', label: '모듈', icon: Puzzle },
-  { key: 'flow', label: '흐름', icon: GitBranch },
-  { key: 'endings', label: '결말', icon: Drama },
-  { key: 'locations', label: '장소', icon: MapPin },
-];
-
 // ---------------------------------------------------------------------------
-export function DesignTab({ themeId, theme, routeSegment }: DesignTabProps) {
-  const navigate = useNavigate();
-  const [activeSubTab, setActiveSubTab] = useState<DesignSubTab>(() =>
-    readDesignSubTabFromRouteSegment(routeSegment),
-  );
-
-  useEffect(() => {
-    setActiveSubTab(readDesignSubTabFromRouteSegment(routeSegment));
-  }, [routeSegment]);
-
-  const handleSubTabClick = (key: DesignSubTab) => {
-    setActiveSubTab(key);
-    navigate(`/editor/${themeId}/design/${key}`);
-  };
-
+export function DesignTab({ themeId, theme }: DesignTabProps) {
   return (
     <div className="flex h-full flex-col">
-      {/* ── SubTab Navigation ── */}
-      <nav className="flex shrink-0 border-b border-slate-800 bg-slate-950 px-2">
-        {SUB_TABS.map(({ key, label, icon: Icon }) => (
-          <button
-            key={key}
-            type="button"
-            onClick={() => handleSubTabClick(key)}
-            className={`flex items-center gap-1.5 border-b-2 px-4 py-2.5 text-xs font-medium transition-colors ${
-              activeSubTab === key
-                ? 'border-amber-500 text-amber-400'
-                : 'border-transparent text-slate-500 hover:text-slate-300'
-            }`}
-          >
-            <Icon className="h-3.5 w-3.5" />
-            {label}
-          </button>
-        ))}
-      </nav>
-
-      {/* ── SubTab Content ── */}
       <div className="min-h-0 flex-1">
-        {activeSubTab === 'modules' && (
-          <ModulesSubTab themeId={themeId} theme={theme} />
-        )}
-        {activeSubTab === 'flow' && (
-          <FlowSubTab themeId={themeId} />
-        )}
-        {activeSubTab === 'endings' && (
-          <EndingEntitySubTab themeId={themeId} theme={theme} />
-        )}
-        {activeSubTab === 'locations' && (
-          <LocationsSubTab themeId={themeId} theme={theme} />
-        )}
+        <ModulesSubTab themeId={themeId} theme={theme} />
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/TabContent.tsx
+++ b/apps/web/src/features/editor/components/TabContent.tsx
@@ -24,6 +24,12 @@ const CharactersTab = lazy(() =>
 const DesignTab = lazy(() =>
   import("./DesignTab").then((m) => ({ default: m.DesignTab })),
 );
+const EndingEntitySubTab = lazy(() =>
+  import("./design/EndingEntitySubTab").then((m) => ({ default: m.EndingEntitySubTab })),
+);
+const LocationsSubTab = lazy(() =>
+  import("./design/LocationsSubTab").then((m) => ({ default: m.LocationsSubTab })),
+);
 const MediaTab = lazy(() =>
   import("./media/MediaTab").then((m) => ({ default: m.MediaTab })),
 );
@@ -64,6 +70,10 @@ export function TabContent({ tab, theme, themeId, routeSegment }: TabContentProp
       return <CluesTab themeId={themeId} routeSegment={routeSegment} />;
     case "design":
       return <DesignTab theme={theme} themeId={themeId} routeSegment={routeSegment} />;
+    case "endings":
+      return <EndingEntitySubTab theme={theme} themeId={themeId} />;
+    case "locations":
+      return <LocationsSubTab theme={theme} themeId={themeId} />;
     case "media":
       return <MediaTab themeId={themeId} />;
     case "advanced":

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -80,6 +80,8 @@ describe("EditorTabNav dynamic tabs", () => {
     expect(screen.getByText("등장인물 관리")).toBeDefined();
     expect(screen.getByText("단서 관리")).toBeDefined();
     expect(screen.getByText("게임 설계")).toBeDefined();
+    expect(screen.getByText("결말 관리")).toBeDefined();
+    expect(screen.getByText("장소 관리")).toBeDefined();
     expect(screen.getByText("미디어 관리")).toBeDefined();
     expect(screen.getByText("기본 설정")).toBeDefined();
     expect(screen.getByText("고급 설정")).toBeDefined();
@@ -116,6 +118,8 @@ describe("EditorTabNav dynamic tabs", () => {
       "등장인물 관리",
       "단서 관리",
       "게임 설계",
+      "결말 관리",
+      "장소 관리",
       "미디어 관리",
       "기본 설정",
       "템플릿",
@@ -138,7 +142,7 @@ describe("EditorTabNav dynamic tabs", () => {
     fireEvent.click(screen.getByRole("tab", { name: /게임 설계/ }));
 
     expect(mockSetActiveTab).toHaveBeenCalledWith("design");
-    expect(mockNavigate).toHaveBeenCalledWith("/editor/theme-1/design/modules");
+    expect(mockNavigate).toHaveBeenCalledWith("/editor/theme-1/design");
   });
 
   it("항상 표시되는 미디어 현재 탭은 스토리 진행 URL로 되돌리지 않는다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/DesignTab.test.tsx
@@ -1,14 +1,13 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { mutateMock, navigateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(
+const { mutateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(
   () => ({
     mutateMock: vi.fn(),
-    navigateMock: vi.fn(),
     useUpdateConfigJsonMock: vi.fn(),
     useModuleSchemasMock: vi.fn(),
   })
@@ -23,7 +22,7 @@ vi.mock('sonner', () => ({
 }));
 
 vi.mock('react-router', () => ({
-  useNavigate: () => navigateMock,
+  useNavigate: () => vi.fn(),
 }));
 
 vi.mock('@/features/editor/api', () => ({
@@ -47,17 +46,6 @@ vi.mock('@/features/editor/templateApi', () => ({}));
 
 vi.mock('@/features/editor/components/SchemaDrivenForm', () => ({
   SchemaDrivenForm: () => null,
-}));
-
-// Mock subtab components that have external dependencies
-vi.mock('../../design/FlowSubTab', () => ({
-  FlowSubTab: () => <div>FlowSubTab 콘텐츠</div>,
-}));
-vi.mock('../../design/LocationsSubTab', () => ({
-  LocationsSubTab: () => <div>LocationsSubTab 콘텐츠</div>,
-}));
-vi.mock('../../design/EndingEntitySubTab', () => ({
-  EndingEntitySubTab: () => <div>EndingEntitySubTab 콘텐츠</div>,
 }));
 
 vi.mock('@/features/editor/constants', () => ({
@@ -135,63 +123,34 @@ describe('DesignTab', () => {
     useModuleSchemasMock.mockReturnValue({ data: null, isLoading: false });
   });
 
-  it('서브탭 4개를 모두 렌더링한다', () => {
+  it('모듈 설정 단일 화면을 렌더링한다', () => {
     render(<DesignTab themeId="theme-1" theme={mockTheme} />);
 
-    expect(screen.getByText('모듈')).toBeDefined();
-    expect(screen.getByText('흐름')).toBeDefined();
-    expect(screen.getByText('장소')).toBeDefined();
-    expect(screen.getByText('결말')).toBeDefined();
+    expect(screen.getByText('진행')).toBeDefined();
+    expect(screen.getByRole('switch', { name: '리딩 활성화' })).toBeDefined();
   });
 
-  it('배치, 설정 탭이 없다', () => {
+  it('게임 설계 내부 서브탭을 렌더링하지 않는다', () => {
     render(<DesignTab themeId="theme-1" theme={mockTheme} />);
 
+    expect(screen.queryByRole('button', { name: '흐름' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '장소' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '결말' })).toBeNull();
     expect(screen.queryByText('배치')).toBeNull();
     expect(screen.queryByText('설정')).toBeNull();
   });
 
-  it('기본 선택 탭은 모듈이다', () => {
-    render(<DesignTab themeId="theme-1" theme={mockTheme} />);
-
-    const modulesTab = screen.getByText('모듈').closest('button');
-    expect(modulesTab?.className).toContain('border-amber-500');
-  });
-
-  it('흐름 탭 클릭 시 흐름 콘텐츠로 전환된다', () => {
-    render(<DesignTab themeId="theme-1" theme={mockTheme} />);
-
-    fireEvent.click(screen.getByText('흐름'));
-    expect(screen.getByText('FlowSubTab 콘텐츠')).toBeDefined();
-    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/design/flow');
-  });
-
-  it('장소 탭 클릭 시 장소 콘텐츠로 전환된다', () => {
-    render(<DesignTab themeId="theme-1" theme={mockTheme} />);
-
-    fireEvent.click(screen.getByText('장소'));
-    expect(screen.getByText('LocationsSubTab 콘텐츠')).toBeDefined();
-    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/design/locations');
-  });
-
-  it('결말 탭 클릭 시 결말 entity 콘텐츠로 전환된다', () => {
-    render(<DesignTab themeId="theme-1" theme={mockTheme} />);
-
-    fireEvent.click(screen.getByText('결말'));
-    expect(screen.getByText('EndingEntitySubTab 콘텐츠')).toBeDefined();
-    expect(navigateMock).toHaveBeenCalledWith('/editor/theme-1/design/endings');
-  });
-
-  it.each([
-    ['modules', '진행'],
-    ['locations', 'LocationsSubTab 콘텐츠'],
-    ['endings', 'EndingEntitySubTab 콘텐츠'],
-    ['flow', 'FlowSubTab 콘텐츠'],
-  ] as const)('routeSegment=%s이면 해당 제작 서브탭을 바로 연다', (routeSegment, expectedText) => {
+  it.each(['modules', 'design/flow', 'design/locations', 'design/endings'] as const)(
+    'legacy routeSegment=%s이어도 게임 설계 화면은 모듈 설정만 보여준다',
+    (routeSegment) => {
     render(<DesignTab themeId="theme-1" theme={mockTheme} routeSegment={routeSegment} />);
 
-    expect(screen.getByText(expectedText)).toBeDefined();
-  });
+    expect(screen.getByText('진행')).toBeDefined();
+    expect(screen.queryByText('FlowSubTab 콘텐츠')).toBeNull();
+    expect(screen.queryByText('LocationsSubTab 콘텐츠')).toBeNull();
+    expect(screen.queryByText('EndingEntitySubTab 콘텐츠')).toBeNull();
+  },
+  );
 
   it('모듈 탭이 기본 선택되어 모듈 사이드바가 표시된다', () => {
     render(<DesignTab themeId="theme-1" theme={mockTheme} />);

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -9,6 +9,8 @@ import {
   Search,
   GitBranch,
   Info,
+  MapPin,
+  Drama,
 } from "lucide-react";
 import type { ThemeStatus } from "./api";
 
@@ -23,6 +25,8 @@ export const EDITOR_TABS = [
   { key: "characters" as const, label: "등장인물 관리", icon: Users, always: true, group: "manage" },
   { key: "clues" as const, label: "단서 관리", icon: Search, always: true, group: "manage" },
   { key: "design" as const, label: "게임 설계", icon: Settings, always: true, group: "manage" },
+  { key: "endings" as const, label: "결말 관리", icon: Drama, always: true, group: "manage" },
+  { key: "locations" as const, label: "장소 관리", icon: MapPin, always: true, group: "manage" },
   { key: "media" as const, label: "미디어 관리", icon: Music, always: true, group: "manage" },
   { key: "overview" as const, label: "기본 설정", icon: FileText, always: true, group: "settings" },
   { key: "template" as const, label: "템플릿", icon: LayoutTemplate, always: true, group: "settings" },

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -1,12 +1,9 @@
 import type { EditorTab } from './constants';
 
-export type DesignSubTab = 'modules' | 'flow' | 'locations' | 'endings';
-
 export interface EditorRouteMatrixEntry {
   path: string;
   routeSegment?: string;
   editorTab: EditorTab;
-  designSubTab?: DesignSubTab;
   alias?: boolean;
 }
 
@@ -23,27 +20,15 @@ const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
   modules: 'design',
   flow: 'storyMap',
   'design/modules': 'design',
-  'design/flow': 'design',
-  'design/locations': 'design',
-  'design/endings': 'design',
-  locations: 'design',
-  endings: 'design',
+  'design/flow': 'storyMap',
+  'design/locations': 'locations',
+  'design/endings': 'endings',
+  locations: 'locations',
+  endings: 'endings',
   media: 'media',
   advanced: 'advanced',
   templates: 'template',
   template: 'template',
-};
-
-const DESIGN_ROUTE_SUBTAB_MAP: Record<string, DesignSubTab> = {
-  design: 'modules',
-  'design/modules': 'modules',
-  modules: 'modules',
-  'design/flow': 'flow',
-  flow: 'flow',
-  'design/locations': 'locations',
-  locations: 'locations',
-  'design/endings': 'endings',
-  endings: 'endings',
 };
 
 const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
@@ -52,7 +37,9 @@ const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
   story: 'reading',
   characters: 'characters',
   clues: 'clues',
-  design: 'design/modules',
+  design: 'design',
+  endings: 'endings',
+  locations: 'locations',
   media: 'media',
   overview: 'overview',
   template: 'template',
@@ -76,65 +63,54 @@ export const EDITOR_ROUTE_MATRIX = [
     path: '/editor/:id/design/modules',
     routeSegment: 'design/modules',
     editorTab: 'design',
-    designSubTab: 'modules',
+    alias: true,
   },
   {
     path: '/editor/:id/design/flow',
     routeSegment: 'design/flow',
-    editorTab: 'design',
-    designSubTab: 'flow',
+    editorTab: 'storyMap',
+    alias: true,
   },
   {
     path: '/editor/:id/design/locations',
     routeSegment: 'design/locations',
-    editorTab: 'design',
-    designSubTab: 'locations',
+    editorTab: 'locations',
+    alias: true,
   },
   {
     path: '/editor/:id/design/endings',
     routeSegment: 'design/endings',
-    editorTab: 'design',
-    designSubTab: 'endings',
+    editorTab: 'endings',
+    alias: true,
   },
   { path: '/editor/:id/media', routeSegment: 'media', editorTab: 'media' },
   {
     path: '/editor/:id/modules',
     routeSegment: 'modules',
     editorTab: 'design',
-    designSubTab: 'modules',
     alias: true,
   },
   {
     path: '/editor/:id/flow',
     routeSegment: 'flow',
     editorTab: 'storyMap',
-    designSubTab: 'flow',
     alias: true,
   },
   {
     path: '/editor/:id/locations',
     routeSegment: 'locations',
-    editorTab: 'design',
-    designSubTab: 'locations',
-    alias: true,
+    editorTab: 'locations',
   },
   {
     path: '/editor/:id/endings',
     routeSegment: 'endings',
-    editorTab: 'design',
-    designSubTab: 'endings',
-    alias: true,
+    editorTab: 'endings',
   },
 ] as const satisfies readonly EditorRouteMatrixEntry[];
 
 export function readEditorTabFromRouteSegment(routeSegment?: string): EditorTab {
   if (!routeSegment) return 'storyMap';
   return EDITOR_ROUTE_TAB_MAP[routeSegment] ?? 'storyMap';
-}
-
-export function readDesignSubTabFromRouteSegment(routeSegment?: string): DesignSubTab {
-  if (!routeSegment) return 'modules';
-  return DESIGN_ROUTE_SUBTAB_MAP[routeSegment] ?? 'modules';
 }
 
 export function buildEditorRouteForTab(themeId: string, tab: EditorTab): string {

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -47,35 +47,36 @@ const routeMatrixCases = [
   ['직접 URL /editor/:id/template', { id: 'theme-1', tab: 'template' }, 'template', 'template'],
   ['alias URL /editor/:id/templates', { id: 'theme-1', tab: 'templates' }, 'templates', 'template'],
   ['직접 URL /editor/:id/advanced', { id: 'theme-1', tab: 'advanced' }, 'advanced', 'advanced'],
+  ['직접 URL /editor/:id/design', { id: 'theme-1', tab: 'design' }, 'design', 'design'],
   [
-    '직접 URL /editor/:id/design/modules',
+    'alias URL /editor/:id/design/modules',
     { id: 'theme-1', tab: 'design', designTab: 'modules' },
     'design/modules',
     'design',
   ],
   [
-    '직접 URL /editor/:id/design/flow',
+    'alias URL /editor/:id/design/flow',
     { id: 'theme-1', tab: 'design', designTab: 'flow' },
     'design/flow',
-    'design',
+    'storyMap',
   ],
   [
-    '직접 URL /editor/:id/design/locations',
+    'alias URL /editor/:id/design/locations',
     { id: 'theme-1', tab: 'design', designTab: 'locations' },
     'design/locations',
-    'design',
+    'locations',
   ],
   [
-    '직접 URL /editor/:id/design/endings',
+    'alias URL /editor/:id/design/endings',
     { id: 'theme-1', tab: 'design', designTab: 'endings' },
     'design/endings',
-    'design',
+    'endings',
   ],
   ['alias URL /editor/:id/modules', { id: 'theme-1', tab: 'modules' }, 'modules', 'design'],
   ['alias URL /editor/:id/flow', { id: 'theme-1', tab: 'flow' }, 'flow', 'storyMap'],
   ['sample slug URL /editor/e2e-test-theme/flow', { id: 'e2e-test-theme', tab: 'flow' }, 'flow', 'storyMap'],
-  ['alias URL /editor/:id/locations', { id: 'theme-1', tab: 'locations' }, 'locations', 'design'],
-  ['alias URL /editor/:id/endings', { id: 'theme-1', tab: 'endings' }, 'endings', 'design'],
+  ['직접 URL /editor/:id/locations', { id: 'theme-1', tab: 'locations' }, 'locations', 'locations'],
+  ['직접 URL /editor/:id/endings', { id: 'theme-1', tab: 'endings' }, 'endings', 'endings'],
 ] as const;
 
 afterEach(() => {
@@ -129,7 +130,7 @@ describe('EditorPage', () => {
     render(<EditorPage />);
 
     expect(screen.getByText(/테마 에디터 theme-1 design\/flow/)).toBeDefined();
-    expect(setActiveTabMock).toHaveBeenCalledWith('design');
+    expect(setActiveTabMock).toHaveBeenCalledWith('storyMap');
   });
 
   it('modules 라우트 segment를 design 탭으로 매핑한다', () => {


### PR DESCRIPTION
## 요약
- `게임 설계`를 모듈 설정 단일 화면으로 정리하고 내부 `모듈 / 흐름 / 결말 / 장소` 서브탭을 제거했습니다.
- `결말 관리`와 `장소 관리`를 상위 에디터 탭으로 승격했습니다.
- 기존 deep link는 빈 화면으로 떨어지지 않도록 새 상위 탭 구조로 매핑했습니다.
  - `/editor/:id/design/flow` → 스토리 진행
  - `/editor/:id/design/endings` → 결말 관리
  - `/editor/:id/design/locations` → 장소 관리
  - `/editor/:id/design/modules` → 게임 설계

## Coverage Plan
- `routeSegments.test.ts`: canonical URL, legacy `/design/*` segment, 상위 `endings`/`locations` 탭 매핑을 검증합니다.
- `DesignTab.test.tsx`: 게임 설계 내부 서브탭 미노출과 모듈 설정 단일 화면 렌더링을 검증합니다.
- `EditorTabNav.test.tsx`: 새 상위 탭 노출 순서와 `게임 설계` canonical URL을 검증합니다.
- `EditorPage.test.tsx`: 직접 URL과 legacy deep link가 올바른 active tab으로 연결되는지 검증합니다.
- E2E는 추가하지 않았습니다. 이번 변경은 route/tab IA와 component rendering 경계라 focused component/unit test + quick local CI로 검증했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/__tests__/routeSegments.test.ts src/features/editor/components/design/__tests__/DesignTab.test.tsx src/features/editor/components/__tests__/EditorTabNav.test.tsx src/pages/__tests__/EditorPage.test.tsx` 통과
  - 4 files, 87 tests passed
- `pnpm --filter @mmp/web typecheck` 통과
- `scripts/mmp-local-ci.sh quick` 통과
  - mode: quick
  - status: success
  - head: `b5ca43f73e4c7edafad81e5cfbdb9577c9a64903`
  - web tests: 173 files / 1581 tests passed
  - 기존 lint 47 warnings 및 기존 Rollup chunk warnings만 남음

Closes #478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경 사항

* **새로운 기능**
  * 에디터 탭에 '결말 관리'와 '장소 관리' 탭이 새로 추가되었습니다. 각각 Drama와 MapPin 아이콘으로 표시됩니다.

* **인터페이스 개선**
  * 게임 설계 탭의 내부 서브탭 구조가 제거되었습니다. 이제 모듈 설정 화면만 통합되어 더 단순하고 직관적인 인터페이스를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->