### PR TITLE
feat(editor): 역할지 미디어 참조 삭제 정책 확장

### DIFF
--- a/apps/server/db/queries/media.sql
+++ b/apps/server/db/queries/media.sql
@@ -169,35 +169,43 @@ WHERE rs.theme_id = t.id
   );
 
 -- name: ClearRoleSheetMediaReferencesWithOwner :execrows
-UPDATE theme_contents c
-SET body = jsonb_set(
+WITH cleaned_role_sheets AS (
+  SELECT
+    rc.id,
+    regexp_replace(
       regexp_replace(
-        c.body,
+        rc.body,
         '"media_id"\s*:\s*"' || sqlc.arg('media_id')::text || '"',
         '"media_id":null',
         'g'
-      )::jsonb,
-      '{images,image_media_ids}',
-      COALESCE((
-        SELECT jsonb_agg(page_id ORDER BY ord)
-        FROM jsonb_array_elements_text(
-          COALESCE(
-            regexp_replace(
-              c.body,
-              '"media_id"\s*:\s*"' || sqlc.arg('media_id')::text || '"',
-              '"media_id":null',
-              'g'
-            )::jsonb #> '{images,image_media_ids}',
-            '[]'::jsonb
-          )
-        ) WITH ORDINALITY AS elem(page_id, ord)
-        WHERE page_id <> sqlc.arg('media_id')::text
-      ), '[]'::jsonb),
-      true
-    )::text,
+      ),
+      '<MediaEmbed[^>]*[[:space:]]mediaId[[:space:]]*=[[:space:]]*\\?"' || sqlc.arg('media_id')::text || '\\?"[^>]*/?>',
+      '',
+      'g'
+    )::jsonb AS doc
+  FROM theme_contents rc
+  WHERE rc.theme_id = sqlc.arg('theme_id')
+    AND rc.key ~ '^role_sheet:'
+    AND rc.body ~ sqlc.arg('media_id')::text
+)
+UPDATE theme_contents c
+SET body = CASE
+      WHEN cleaned.doc #> '{images,image_media_ids}' IS NULL THEN cleaned.doc::text
+      ELSE jsonb_set(
+        cleaned.doc,
+        '{images,image_media_ids}',
+        COALESCE((
+          SELECT jsonb_agg(page_id ORDER BY ord)
+          FROM jsonb_array_elements_text(COALESCE(cleaned.doc #> '{images,image_media_ids}', '[]'::jsonb)) WITH ORDINALITY AS elem(page_id, ord)
+          WHERE page_id <> sqlc.arg('media_id')::text
+        ), '[]'::jsonb),
+        true
+      )::text
+    END,
     updated_at = NOW()
-FROM themes t
+FROM themes t, cleaned_role_sheets cleaned
 WHERE c.theme_id = t.id
+  AND c.id = cleaned.id
   AND t.creator_id = sqlc.arg('creator_id')
   AND c.theme_id = sqlc.arg('theme_id')
   AND c.key ~ '^role_sheet:'

--- a/apps/server/db/queries/reading_sections.sql
+++ b/apps/server/db/queries/reading_sections.sql
@@ -35,7 +35,7 @@ WHERE rs.id = $1 AND rs.theme_id = t.id AND t.creator_id = $2;
 
 -- name: FindMediaReferencesInReadingSections :many
 -- Returns reading sections that reference the given media as bgm_media_id
--- OR inside any line's VoiceMediaID/ImageMediaID (PascalCase keys — match engine struct serialization).
+-- OR inside any line's VoiceMediaID/ImageMediaID/MediaID (PascalCase keys — match engine struct serialization).
 SELECT DISTINCT rs.id, rs.name FROM reading_sections rs
 WHERE rs.theme_id = sqlc.arg('theme_id')
   AND (

--- a/apps/server/internal/db/media.sql.go
+++ b/apps/server/internal/db/media.sql.go
@@ -116,35 +116,43 @@ func (q *Queries) ClearReadingSectionMediaReferencesWithOwner(ctx context.Contex
 }
 
 const clearRoleSheetMediaReferencesWithOwner = `-- name: ClearRoleSheetMediaReferencesWithOwner :execrows
-UPDATE theme_contents c
-SET body = jsonb_set(
+WITH cleaned_role_sheets AS (
+  SELECT
+    rc.id,
+    regexp_replace(
       regexp_replace(
-        c.body,
+        rc.body,
         '"media_id"\s*:\s*"' || $1::text || '"',
         '"media_id":null',
         'g'
-      )::jsonb,
-      '{images,image_media_ids}',
-      COALESCE((
-        SELECT jsonb_agg(page_id ORDER BY ord)
-        FROM jsonb_array_elements_text(
-          COALESCE(
-            regexp_replace(
-              c.body,
-              '"media_id"\s*:\s*"' || $1::text || '"',
-              '"media_id":null',
-              'g'
-            )::jsonb #> '{images,image_media_ids}',
-            '[]'::jsonb
-          )
-        ) WITH ORDINALITY AS elem(page_id, ord)
-        WHERE page_id <> $1::text
-      ), '[]'::jsonb),
-      true
-    )::text,
+      ),
+      '<MediaEmbed[^>]*[[:space:]]mediaId[[:space:]]*=[[:space:]]*\\?"' || $1::text || '\\?"[^>]*/?>',
+      '',
+      'g'
+    )::jsonb AS doc
+  FROM theme_contents rc
+  WHERE rc.theme_id = $3
+    AND rc.key ~ '^role_sheet:'
+    AND rc.body ~ $1::text
+)
+UPDATE theme_contents c
+SET body = CASE
+      WHEN cleaned.doc #> '{images,image_media_ids}' IS NULL THEN cleaned.doc::text
+      ELSE jsonb_set(
+        cleaned.doc,
+        '{images,image_media_ids}',
+        COALESCE((
+          SELECT jsonb_agg(page_id ORDER BY ord)
+          FROM jsonb_array_elements_text(COALESCE(cleaned.doc #> '{images,image_media_ids}', '[]'::jsonb)) WITH ORDINALITY AS elem(page_id, ord)
+          WHERE page_id <> $1::text
+        ), '[]'::jsonb),
+        true
+      )::text
+    END,
     updated_at = NOW()
-FROM themes t
+FROM themes t, cleaned_role_sheets cleaned
 WHERE c.theme_id = t.id
+  AND c.id = cleaned.id
   AND t.creator_id = $2
   AND c.theme_id = $3
   AND c.key ~ '^role_sheet:'

--- a/apps/server/internal/db/reading_sections.sql.go
+++ b/apps/server/internal/db/reading_sections.sql.go
@@ -93,7 +93,7 @@ type FindMediaReferencesInReadingSectionsRow struct {
 }
 
 // Returns reading sections that reference the given media as bgm_media_id
-// OR inside any line's VoiceMediaID/ImageMediaID/MediaID (PascalCase keys — match engine struct serialization).
+// OR inside any line's VoiceMediaID/ImageMediaID (PascalCase keys — match engine struct serialization).
 func (q *Queries) FindMediaReferencesInReadingSections(ctx context.Context, arg FindMediaReferencesInReadingSectionsParams) ([]FindMediaReferencesInReadingSectionsRow, error) {
 	rows, err := q.db.Query(ctx, findMediaReferencesInReadingSections, arg.ThemeID, arg.MediaID)
 	if err != nil {

--- a/apps/server/internal/db/reading_sections.sql.go
+++ b/apps/server/internal/db/reading_sections.sql.go
@@ -93,7 +93,7 @@ type FindMediaReferencesInReadingSectionsRow struct {
 }
 
 // Returns reading sections that reference the given media as bgm_media_id
-// OR inside any line's VoiceMediaID/ImageMediaID (PascalCase keys — match engine struct serialization).
+// OR inside any line's VoiceMediaID/ImageMediaID/MediaID (PascalCase keys — match engine struct serialization).
 func (q *Queries) FindMediaReferencesInReadingSections(ctx context.Context, arg FindMediaReferencesInReadingSectionsParams) ([]FindMediaReferencesInReadingSectionsRow, error) {
 	rows, err := q.db.Query(ctx, findMediaReferencesInReadingSections, arg.ThemeID, arg.MediaID)
 	if err != nil {

--- a/apps/server/internal/domain/editor/media_service_delete.go
+++ b/apps/server/internal/domain/editor/media_service_delete.go
@@ -154,7 +154,7 @@ func (s *mediaService) collectMediaReferencesWithQueries(ctx context.Context, q 
 		return nil, apperror.Internal("failed to check media references")
 	}
 	for _, r := range roleSheetRefs {
-		refList = append(refList, mediaReferenceInfo{Type: roleSheetMediaReferenceType(r.Body, mediaID), ID: r.Key, Name: r.Key})
+		refList = append(refList, mediaReferenceInfo{Type: roleSheetMediaReferenceType(r.Body, mediaID, media.Type), ID: r.Key, Name: r.Key})
 	}
 
 	aliasIconRefs, err := q.FindCharacterAliasIconReferencesForMedia(ctx, db.FindCharacterAliasIconReferencesForMediaParams{
@@ -272,12 +272,12 @@ func (s *mediaService) cleanupMediaReferences(ctx context.Context, q mediaQuerie
 	return nil
 }
 
-func roleSheetMediaReferenceType(body string, mediaID uuid.UUID) string {
+func roleSheetMediaReferenceType(body string, mediaID uuid.UUID, mediaType string) string {
 	for _, embed := range extractRoleSheetMediaEmbeds(body) {
 		if embed.mediaID != mediaID {
 			continue
 		}
-		if embed.rawType == "video" {
+		if embed.rawType == "video" || (embed.rawType == "" && mediaType == MediaTypeVideo) {
 			return "role_sheet_embedded_video"
 		}
 		return "role_sheet_embedded_image"

--- a/apps/server/internal/domain/editor/media_service_delete.go
+++ b/apps/server/internal/domain/editor/media_service_delete.go
@@ -280,7 +280,10 @@ func roleSheetMediaReferenceType(body string, mediaID uuid.UUID, mediaType strin
 		if embed.rawType == "video" || (embed.rawType == "" && mediaType == MediaTypeVideo) {
 			return "role_sheet_embedded_video"
 		}
-		return "role_sheet_embedded_image"
+		if embed.rawType == "image" || (embed.rawType == "" && mediaType == MediaTypeImage) {
+			return "role_sheet_embedded_image"
+		}
+		return "role_sheet"
 	}
 	if strings.Contains(body, `"image_media_ids"`) && strings.Contains(body, mediaID.String()) {
 		return "role_sheet_image_page"

--- a/apps/server/internal/domain/editor/media_service_delete.go
+++ b/apps/server/internal/domain/editor/media_service_delete.go
@@ -273,6 +273,15 @@ func (s *mediaService) cleanupMediaReferences(ctx context.Context, q mediaQuerie
 }
 
 func roleSheetMediaReferenceType(body string, mediaID uuid.UUID) string {
+	for _, embed := range extractRoleSheetMediaEmbeds(body) {
+		if embed.mediaID != mediaID {
+			continue
+		}
+		if embed.rawType == "video" {
+			return "role_sheet_embedded_video"
+		}
+		return "role_sheet_embedded_image"
+	}
 	if strings.Contains(body, `"image_media_ids"`) && strings.Contains(body, mediaID.String()) {
 		return "role_sheet_image_page"
 	}

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -998,13 +998,13 @@ func TestMediaSQLContract_CategoryReplacementAndReferenceCleanupIntegration(t *t
 	if _, err := fixture.q.UpsertContent(ctx, db.UpsertContentParams{
 		ThemeID: themeID,
 		Key:     "role_sheet:detective",
-		Body:    fmt.Sprintf(`{"portrait":{"media_id":"%s"}}`, image.ID.String()),
+		Body:    fmt.Sprintf(`{"version":1,"format":"markdown","markdown":{"body":"사진 <MediaEmbed mediaId=\"%s\" type=\"image\" />"},"portrait":{"media_id":"%s"},"images":{"image_media_ids":["%s"]}}`, image.ID.String(), image.ID.String(), image.ID.String()),
 	}); err != nil {
 		t.Fatalf("UpsertContent role sheet: %v", err)
 	}
 	if refs, err := fixture.q.FindRoleSheetReferencesForMedia(ctx, db.FindRoleSheetReferencesForMediaParams{
 		ThemeID: themeID,
-		Body:    `"media_id"\s*:\s*"` + image.ID.String() + `"`,
+		Body:    image.ID.String(),
 	}); err != nil || len(refs) != 1 || refs[0].Key != "role_sheet:detective" {
 		t.Fatalf("FindRoleSheetReferencesForMedia err=%v refs=%#v", err, refs)
 	}
@@ -1014,6 +1014,16 @@ func TestMediaSQLContract_CategoryReplacementAndReferenceCleanupIntegration(t *t
 		ThemeID:   themeID,
 	}); err != nil || rows != 1 {
 		t.Fatalf("ClearRoleSheetMediaReferencesWithOwner rows=%d err=%v", rows, err)
+	}
+	cleanedRoleSheet, err := fixture.q.GetContent(ctx, db.GetContentParams{ThemeID: themeID, Key: "role_sheet:detective"})
+	if err != nil {
+		t.Fatalf("GetContent cleaned role sheet: %v", err)
+	}
+	if strings.Contains(cleanedRoleSheet.Body, image.ID.String()) || strings.Contains(cleanedRoleSheet.Body, "<MediaEmbed") {
+		t.Fatalf("role sheet media refs should be cleaned: %s", cleanedRoleSheet.Body)
+	}
+	if !strings.Contains(cleanedRoleSheet.Body, `"image_media_ids": []`) || !strings.Contains(cleanedRoleSheet.Body, `"media_id": null`) {
+		t.Fatalf("role sheet PDF/image references should be nulled/emptied: %s", cleanedRoleSheet.Body)
 	}
 
 	info, err := fixture.q.CreateStoryInfo(ctx, db.CreateStoryInfoParams{
@@ -1318,6 +1328,39 @@ func TestMediaService_PreviewDelete_ReportsRoleSheetImagePageReference(t *testin
 	refs := preview.References
 	if len(refs) != 1 || refs[0].Type != "role_sheet_image_page" || refs[0].ID != "role_sheet:char-1" {
 		t.Fatalf("unexpected role sheet image references: %#v", refs)
+	}
+}
+
+func TestMediaService_PreviewDelete_ReportsRoleSheetEmbeddedMediaReferences(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mediaTyp string
+		embedTyp string
+		wantTyp  string
+	}{
+		{name: "image", mediaTyp: MediaTypeImage, embedTyp: "image", wantTyp: "role_sheet_embedded_image"},
+		{name: "video", mediaTyp: MediaTypeVideo, embedTyp: "video", wantTyp: "role_sheet_embedded_video"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, q, creatorID, themeID := newMediaTestService(t)
+			mediaID := seedMedia(q, themeID, tc.mediaTyp)
+			q.roleSheetRefs[mediaID] = []db.FindRoleSheetReferencesForMediaRow{
+				{
+					ID:   uuid.New(),
+					Key:  "role_sheet:char-1",
+					Body: fmt.Sprintf(`{"format":"markdown","markdown":{"body":"증거 <MediaEmbed mediaId=\"%s\" type=\"%s\" />"}}`, mediaID.String(), tc.embedTyp),
+				},
+			}
+
+			preview, err := svc.PreviewDeleteMedia(context.Background(), creatorID, mediaID)
+			if err != nil {
+				t.Fatalf("PreviewDeleteMedia: %v", err)
+			}
+			refs := preview.References
+			if len(refs) != 1 || refs[0].Type != tc.wantTyp || refs[0].ID != "role_sheet:char-1" {
+				t.Fatalf("unexpected role sheet embedded references: %#v", refs)
+			}
+		})
 	}
 }
 

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -1384,6 +1384,7 @@ func TestMediaService_PreviewDelete_ReportsRoleSheetEmbeddedMediaReferences(t *t
 		{name: "image", mediaTyp: MediaTypeImage, embedTyp: "image", wantTyp: "role_sheet_embedded_image"},
 		{name: "video", mediaTyp: MediaTypeVideo, embedTyp: "video", wantTyp: "role_sheet_embedded_video"},
 		{name: "video without explicit embed type", mediaTyp: MediaTypeVideo, embedTyp: "", wantTyp: "role_sheet_embedded_video"},
+		{name: "unknown embed type", mediaTyp: MediaTypeImage, embedTyp: "audio", wantTyp: "role_sheet"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, q, creatorID, themeID := newMediaTestService(t)

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -1367,6 +1367,13 @@ func TestMediaService_PreviewDelete_ReportsRoleSheetImagePageReference(t *testin
 	}
 }
 
+func roleSheetEmbedBody(mediaID uuid.UUID, embedTyp string) string {
+	if embedTyp == "" {
+		return fmt.Sprintf(`{"format":"markdown","markdown":{"body":"증거 <MediaEmbed mediaId=\"%s\" />"}}`, mediaID.String())
+	}
+	return fmt.Sprintf(`{"format":"markdown","markdown":{"body":"증거 <MediaEmbed mediaId=\"%s\" type=\"%s\" />"}}`, mediaID.String(), embedTyp)
+}
+
 func TestMediaService_PreviewDelete_ReportsRoleSheetEmbeddedMediaReferences(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -1376,6 +1383,7 @@ func TestMediaService_PreviewDelete_ReportsRoleSheetEmbeddedMediaReferences(t *t
 	}{
 		{name: "image", mediaTyp: MediaTypeImage, embedTyp: "image", wantTyp: "role_sheet_embedded_image"},
 		{name: "video", mediaTyp: MediaTypeVideo, embedTyp: "video", wantTyp: "role_sheet_embedded_video"},
+		{name: "video without explicit embed type", mediaTyp: MediaTypeVideo, embedTyp: "", wantTyp: "role_sheet_embedded_video"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, q, creatorID, themeID := newMediaTestService(t)
@@ -1384,7 +1392,7 @@ func TestMediaService_PreviewDelete_ReportsRoleSheetEmbeddedMediaReferences(t *t
 				{
 					ID:   uuid.New(),
 					Key:  "role_sheet:char-1",
-					Body: fmt.Sprintf(`{"format":"markdown","markdown":{"body":"증거 <MediaEmbed mediaId=\"%s\" type=\"%s\" />"}}`, mediaID.String(), tc.embedTyp),
+					Body: roleSheetEmbedBody(mediaID, tc.embedTyp),
 				},
 			}
 

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -906,6 +906,7 @@ func TestService_UpsertCharacterRoleSheetMarkdown_ValidatesMediaEmbeds(t *testin
 		{name: "wrong type", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="image" />`, voice.ID.String()), wantErr: "wrong type or theme"},
 		{name: "other theme", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="image" />`, otherThemeImage.ID.String()), wantErr: "wrong type or theme"},
 		{name: "type mismatch", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="video" />`, image.ID.String()), wantErr: "type does not match"},
+		{name: "duplicate media id still validates each embed type", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="image" /><MediaEmbed mediaId="%s" type="video" />`, image.ID.String(), image.ID.String()), wantErr: "type does not match"},
 		{name: "unsupported type", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="audio" />`, image.ID.String()), wantErr: "unsupported role sheet MediaEmbed type"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -2,6 +2,7 @@ package editor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -849,6 +850,73 @@ func TestService_UpsertAndGetCharacterRoleSheet(t *testing.T) {
 	}
 	if got.Markdown == nil || got.Markdown.Body != "## 비밀\n알리바이" {
 		t.Fatalf("body mismatch after upsert: %+v", got)
+	}
+}
+
+func TestService_UpsertCharacterRoleSheetMarkdown_ValidatesMediaEmbeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	image := createMediaForReferenceTest(t, f.q, themeID, "role-sheet-inline-image", MediaTypeImage)
+	voice := createMediaForReferenceTest(t, f.q, themeID, "role-sheet-voice", MediaTypeVoice)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	otherThemeImage := createMediaForReferenceTest(t, f.q, otherThemeID, "other-role-sheet-inline-image", MediaTypeImage)
+	video, err := f.q.CreateMedia(ctx, db.CreateMediaParams{
+		ThemeID:    themeID,
+		Name:       "role-sheet-video",
+		Type:       MediaTypeVideo,
+		SourceType: SourceTypeYouTube,
+		Url:        pgtype.Text{String: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", Valid: true},
+		Tags:       []string{},
+		SortOrder:  0,
+	})
+	if err != nil {
+		t.Fatalf("CreateMedia video: %v", err)
+	}
+	char, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{Name: "미디어 역할지"})
+	if err != nil {
+		t.Fatalf("CreateCharacter: %v", err)
+	}
+
+	upserted, err := f.svc.UpsertCharacterRoleSheet(ctx, creatorID, char.ID, UpsertRoleSheetRequest{
+		Format: RoleSheetFormatMarkdown,
+		Markdown: &RoleSheetMarkdown{Body: fmt.Sprintf(
+			`증거 <MediaEmbed mediaId="%s" type="image" /> 영상 <MediaEmbed mediaId="%s" type="video" />`,
+			image.ID.String(),
+			video.ID.String(),
+		)},
+	})
+	if err != nil {
+		t.Fatalf("UpsertCharacterRoleSheet markdown embeds: %v", err)
+	}
+	if upserted.Markdown == nil || !strings.Contains(upserted.Markdown.Body, image.ID.String()) || !strings.Contains(upserted.Markdown.Body, video.ID.String()) {
+		t.Fatalf("embedded media markdown was not persisted: %+v", upserted)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{name: "invalid uuid", body: `<MediaEmbed mediaId="not-a-uuid" type="image" />`, wantErr: "invalid MediaEmbed mediaId"},
+		{name: "wrong type", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="image" />`, voice.ID.String()), wantErr: "wrong type or theme"},
+		{name: "other theme", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="image" />`, otherThemeImage.ID.String()), wantErr: "wrong type or theme"},
+		{name: "type mismatch", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="video" />`, image.ID.String()), wantErr: "type does not match"},
+		{name: "unsupported type", body: fmt.Sprintf(`<MediaEmbed mediaId="%s" type="audio" />`, image.ID.String()), wantErr: "unsupported role sheet MediaEmbed type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := f.svc.UpsertCharacterRoleSheet(ctx, creatorID, char.ID, UpsertRoleSheetRequest{
+				Format:   RoleSheetFormatMarkdown,
+				Markdown: &RoleSheetMarkdown{Body: tc.body},
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected %q error, got %v", tc.wantErr, err)
+			}
+		})
 	}
 }
 

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -897,6 +897,13 @@ func TestService_UpsertCharacterRoleSheetMarkdown_ValidatesMediaEmbeds(t *testin
 		t.Fatalf("embedded media markdown was not persisted: %+v", upserted)
 	}
 
+	if _, err := f.svc.UpsertCharacterRoleSheet(ctx, creatorID, char.ID, UpsertRoleSheetRequest{
+		Format:   RoleSheetFormatMarkdown,
+		Markdown: &RoleSheetMarkdown{Body: fmt.Sprintf(`증거 <MediaEmbed mediaId='%s' type='image' />`, image.ID.String())},
+	}); err != nil {
+		t.Fatalf("UpsertCharacterRoleSheet single quoted markdown embeds: %v", err)
+	}
+
 	for _, tc := range []struct {
 		name    string
 		body    string

--- a/apps/server/internal/domain/editor/service_role_sheet.go
+++ b/apps/server/internal/domain/editor/service_role_sheet.go
@@ -26,7 +26,7 @@ type roleSheetMediaEmbed struct {
 
 var (
 	roleSheetMediaEmbedRe = regexp.MustCompile(`(?s)<MediaEmbed\b([^>]*)/?>`)
-	roleSheetAttrRe       = regexp.MustCompile(`\b(mediaId|type)\s*=\s*\\?"([^"\\]*)\\?"`)
+	roleSheetAttrRe       = regexp.MustCompile(`\b(mediaId|type)\s*=\s*(?:\\?"([^"\\]*)\\?"|'([^'\\]*)')`)
 )
 
 type storedRoleSheet struct {
@@ -224,7 +224,11 @@ func extractRoleSheetMediaEmbeds(body string) []roleSheetMediaEmbed {
 	for _, match := range matches {
 		attrs := map[string]string{}
 		for _, attr := range roleSheetAttrRe.FindAllStringSubmatch(match[1], -1) {
-			attrs[attr[1]] = attr[2]
+			value := attr[2]
+			if value == "" {
+				value = attr[3]
+			}
+			attrs[attr[1]] = value
 		}
 		id, err := uuid.Parse(strings.TrimSpace(attrs["mediaId"]))
 		if err != nil {

--- a/apps/server/internal/domain/editor/service_role_sheet.go
+++ b/apps/server/internal/domain/editor/service_role_sheet.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
@@ -17,6 +18,16 @@ import (
 
 const maxRoleSheetBodyBytes = 50000
 const maxRoleSheetImagePages = 50
+
+type roleSheetMediaEmbed struct {
+	mediaID uuid.UUID
+	rawType string
+}
+
+var (
+	roleSheetMediaEmbedRe = regexp.MustCompile(`(?s)<MediaEmbed\b([^>]*)/?>`)
+	roleSheetAttrRe       = regexp.MustCompile(`\b(mediaId|type)\s*=\s*\\?"([^"\\]*)\\?"`)
+)
 
 type storedRoleSheet struct {
 	Version  int                `json:"version"`
@@ -146,6 +157,9 @@ func normalizeRoleSheetImages(images *RoleSheetImages, allowEmpty bool) (*RoleSh
 func (s *service) roleSheetStorageBody(ctx context.Context, creatorID uuid.UUID, char db.ThemeCharacter, req UpsertRoleSheetRequest) (string, error) {
 	switch req.Format {
 	case RoleSheetFormatMarkdown:
+		if err := s.assertRoleSheetMarkdownMediaEmbeds(ctx, creatorID, char.ThemeID, req.Markdown.Body); err != nil {
+			return "", err
+		}
 		body, err := json.Marshal(storedRoleSheet{Version: 1, Format: RoleSheetFormatMarkdown, Markdown: req.Markdown})
 		if err != nil {
 			s.logger.Error().Err(err).Msg("failed to marshal markdown role sheet")
@@ -199,6 +213,71 @@ func (s *service) assertRoleSheetImageMediaIDs(ctx context.Context, creatorID, t
 		}
 		if media.Type != MediaTypeImage {
 			return apperror.BadRequest("image role sheet media must be an image")
+		}
+	}
+	return nil
+}
+
+func extractRoleSheetMediaEmbeds(body string) []roleSheetMediaEmbed {
+	matches := roleSheetMediaEmbedRe.FindAllStringSubmatch(body, -1)
+	out := make([]roleSheetMediaEmbed, 0, len(matches))
+	for _, match := range matches {
+		attrs := map[string]string{}
+		for _, attr := range roleSheetAttrRe.FindAllStringSubmatch(match[1], -1) {
+			attrs[attr[1]] = attr[2]
+		}
+		id, err := uuid.Parse(strings.TrimSpace(attrs["mediaId"]))
+		if err != nil {
+			out = append(out, roleSheetMediaEmbed{})
+			continue
+		}
+		out = append(out, roleSheetMediaEmbed{
+			mediaID: id,
+			rawType: strings.ToLower(strings.TrimSpace(attrs["type"])),
+		})
+	}
+	return out
+}
+
+func (s *service) assertRoleSheetMarkdownMediaEmbeds(ctx context.Context, creatorID, themeID uuid.UUID, body string) error {
+	seen := map[uuid.UUID]struct{}{}
+	for _, embed := range extractRoleSheetMediaEmbeds(body) {
+		if embed.mediaID == uuid.Nil {
+			return apperror.New(apperror.ErrMediaNotInTheme, 400, "invalid MediaEmbed mediaId")
+		}
+		if _, ok := seen[embed.mediaID]; ok {
+			continue
+		}
+		seen[embed.mediaID] = struct{}{}
+		media, err := s.q.GetMediaWithOwner(ctx, db.GetMediaWithOwnerParams{
+			ID:        embed.mediaID,
+			CreatorID: creatorID,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return apperror.New(apperror.ErrMediaNotInTheme, 400, "embedded role sheet media not found")
+			}
+			s.logger.Error().Err(err).Str("media_id", embed.mediaID.String()).Msg("failed to verify role sheet embedded media")
+			return apperror.Internal("failed to verify role sheet media")
+		}
+		if media.ThemeID != themeID || (media.Type != MediaTypeImage && media.Type != MediaTypeVideo) {
+			return apperror.New(apperror.ErrMediaNotInTheme, 400, "embedded role sheet media has wrong type or theme")
+		}
+		if media.Type == MediaTypeVideo && media.SourceType != SourceTypeYouTube {
+			return apperror.New(apperror.ErrMediaNotInTheme, 400, "role sheet MediaEmbed video must reference a YouTube media item")
+		}
+		switch embed.rawType {
+		case "":
+		case "image":
+			if media.Type != MediaTypeImage {
+				return apperror.New(apperror.ErrMediaNotInTheme, 400, "role sheet MediaEmbed type does not match media")
+			}
+		case "video":
+			if media.Type != MediaTypeVideo {
+				return apperror.New(apperror.ErrMediaNotInTheme, 400, "role sheet MediaEmbed type does not match media")
+			}
+		default:
+			return apperror.New(apperror.ErrValidation, 422, "unsupported role sheet MediaEmbed type")
 		}
 	}
 	return nil

--- a/apps/server/internal/domain/editor/service_role_sheet.go
+++ b/apps/server/internal/domain/editor/service_role_sheet.go
@@ -240,25 +240,26 @@ func extractRoleSheetMediaEmbeds(body string) []roleSheetMediaEmbed {
 }
 
 func (s *service) assertRoleSheetMarkdownMediaEmbeds(ctx context.Context, creatorID, themeID uuid.UUID, body string) error {
-	seen := map[uuid.UUID]struct{}{}
+	checked := map[uuid.UUID]db.ThemeMedium{}
 	for _, embed := range extractRoleSheetMediaEmbeds(body) {
 		if embed.mediaID == uuid.Nil {
 			return apperror.New(apperror.ErrMediaNotInTheme, 400, "invalid MediaEmbed mediaId")
 		}
-		if _, ok := seen[embed.mediaID]; ok {
-			continue
-		}
-		seen[embed.mediaID] = struct{}{}
-		media, err := s.q.GetMediaWithOwner(ctx, db.GetMediaWithOwnerParams{
-			ID:        embed.mediaID,
-			CreatorID: creatorID,
-		})
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return apperror.New(apperror.ErrMediaNotInTheme, 400, "embedded role sheet media not found")
+		media, ok := checked[embed.mediaID]
+		if !ok {
+			var err error
+			media, err = s.q.GetMediaWithOwner(ctx, db.GetMediaWithOwnerParams{
+				ID:        embed.mediaID,
+				CreatorID: creatorID,
+			})
+			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					return apperror.New(apperror.ErrMediaNotInTheme, 400, "embedded role sheet media not found")
+				}
+				s.logger.Error().Err(err).Str("media_id", embed.mediaID.String()).Msg("failed to verify role sheet embedded media")
+				return apperror.Internal("failed to verify role sheet media")
 			}
-			s.logger.Error().Err(err).Str("media_id", embed.mediaID.String()).Msg("failed to verify role sheet embedded media")
-			return apperror.Internal("failed to verify role sheet media")
+			checked[embed.mediaID] = media
 		}
 		if media.ThemeID != themeID || (media.Type != MediaTypeImage && media.Type != MediaTypeVideo) {
 			return apperror.New(apperror.ErrMediaNotInTheme, 400, "embedded role sheet media has wrong type or theme")


### PR DESCRIPTION
## 요약
- 역할지 Markdown의 `<MediaEmbed mediaId="..." type="..."/>` 참조를 저장 시 검증합니다.
- 미디어 삭제 preview/cleanup에서 역할지 embedded image/video 참조를 감지하고 본문에서 제거합니다.
- 기존 역할지 PDF/image page 참조 cleanup과 함께 SQL contract/test를 보강했습니다.

Closes #470

## Coverage Plan
- `service_role_sheet.go`: Markdown MediaEmbed mediaId 파싱, 테마/타입/YouTube video 검증을 integration test로 확인합니다.
- `media_service_delete.go` + `media.sql`: 역할지 embedded image/video preview type과 cleanup SQL을 unit/integration test로 확인합니다.
- `media.sql.go` / `reading_sections.sql.go`: `sqlc generate -f db/sqlc.yaml`로 query 변경과 최신 main 병합 후 생성물을 재생성합니다.

## Local validation
- `sqlc generate -f db/sqlc.yaml` ✅
- `go test ./internal/domain/editor -run 'TestMediaSQLContract_CategoryReplacementAndReferenceCleanupIntegration|TestService_UpsertCharacterRoleSheetMarkdown_ValidatesMediaEmbeds|TestMediaService_PreviewDelete_ReportsRoleSheetEmbeddedMediaReferences|TestMediaService_PreviewDelete_ReportsReadingImageReference|TestMediaService_PreviewDelete_ReportsBgmReference'` ✅
- `go test ./internal/domain/editor` ✅ (`ok github.com/mmp-platform/server/internal/domain/editor 77.700s`)
- `scripts/mmp-local-ci.sh quick` ✅
  - backend tests passed, including `internal/domain/editor`
  - web tests: 174 files / 1585 tests passed
  - lint: existing warnings only, 0 errors
  - build passed with existing Rollup/manualChunks warnings

## CI policy
- `ready-for-ci` 라벨을 붙이지 않았고 workflow_dispatch를 실행하지 않았습니다.
- 기본 PR 처리는 CodeRabbit + focused local validation 기준으로 진행합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 역할 시트 마크다운에서 이미지·비디오 임베드 지원 및 임베드 타입 처리/검증 추가

* **Bug Fixes**
  * 미디어 삭제 시 역할 시트 내 임베드 마크업과 미디어 참조가 올바르게 제거되도록 개선

* **Refactor**
  * 역할 시트 미디어 참조 식별 및 정리 로직 개선

* **Tests**
  * 임베드 검증 및 삭제/미리보기 동작을 검증하는 통합 테스트 추가

* **Documentation**
  * 읽기 섹션의 미디어 참조 관련 설명 보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->