### PR TITLE
docs(ops): CI/security 워커 재활성화 기준 정리

### DIFF
--- a/docs/architecture/06-infra-cicd.md
+++ b/docs/architecture/06-infra-cicd.md
@@ -2,13 +2,13 @@
 file: 06-infra-cicd.md
 purpose: Docker · Nginx · ARC self-hosted runner · CI 정책 — AI가 배포·검증 파이프라인 파악
 audience: design-AI
-last_verified: 2026-04-30
+last_verified: 2026-05-07
 sources_of_truth:
   - docker-compose.yml + docker-compose.dev.yml
   - apps/web/nginx.conf
   - .github/workflows/
   - memory/project_infra_docker.md
-  - memory/project_ci_admin_skip_until_2026-05-01.md
+  - docs/ops/ci-security-worker-reactivation.md
   - memory/sessions/2026-04-28-debt-cleanup-runner-network.md
   - memory/sessions/2026-04-29-phase-23-custom-runner-image-merge.md
 related: [07-tech-stack.md, 09-issues-debt.md, 08-roadmap.md]
@@ -18,7 +18,7 @@ related: [07-tech-stack.md, 09-issues-debt.md, 08-roadmap.md]
 
 ## 한 줄 요약 {#tldr}
 
-Docker compose가 dev/prod 모두 단일 진입점 — Nginx:80 외부 노출 + 나머지(server/postgres/redis)는 internal network. CI는 GitHub Actions + ARC self-hosted runner (KT Cloud K8s, 5 runner pool). admin-skip 머지 정책 유지 중 (부채 정리 phase 종료까지). Phase 23에서 KT registry → GHCR custom image로 전환.
+Docker compose가 dev/prod 모두 단일 진입점 — Nginx:80 외부 노출 + 나머지(server/postgres/redis)는 internal network. CI는 GitHub Actions + ARC self-hosted runner (KT Cloud K8s, runner pool). 현재 PR 기본 게이트는 개발 최소 워커 모드로 운영하며, CodeRabbit + 로컬 컨테이너 검증을 우선한다. 자동 CI/security worker 재활성화 기준은 `docs/ops/ci-security-worker-reactivation.md`가 최신 카논이다.
 
 ## Docker Compose 구성 {#compose}
 
@@ -79,17 +79,18 @@ HOST_UID=$(id -u) HOST_GID=$(id -g) \
 - **`runner-image.yml`** (Phase 23 도입) — custom runner image 빌드 + GHCR push
 - **arc.yml** (UNVERIFIED 정확한 파일명) — ARC RunnerScaleSet values + smoke test (PR #179)
 
-### 13~15 required status checks
+### 현재 required status checks
 
-> Phase 18.7 + 19 Residual에 걸쳐 누적된 status check 묶음. 정확한 개수·이름은 GitHub branch protection 설정 직접 확인.
+> 2026-05-07 기준 `gh api repos/sabyunrepo/muder_platform/branches/main/protection`로 확인.
 
-대표:
-- Go: build, test, vet, gofmt, staticcheck, race
-- Web: typecheck, lint, test, coverage
-- Migration drift gate
-- Security: govulncheck, gitleaks, trivy, OSV, CodeQL
-- Supply chain: SBOM, provenance
-- E2E: chromium shard 1~4, firefox shard 1
+- Required check: `CodeRabbit`
+- Strict up-to-date: enabled
+- Required approving review count: 0
+- Stale PR review dismissal: enabled
+
+개발 최소 워커 모드에서는 GitHub Actions full CI/E2E/security worker를 PR 생성이나 push만으로 자동 실행하지 않는다. 코드 변경 PR은 PR 생성 전 `scripts/mmp-local-ci.sh quick`을 기본 실행하고, 위험도에 따라 `coverage`, `e2e`, `full`로 넓힌다.
+
+서비스 운영 전 자동 worker를 다시 켜는 기준과 branch protection 갱신 절차는 `docs/ops/ci-security-worker-reactivation.md`를 따른다.
 
 ## ARC Self-hosted Runner (Phase 22~23) {#arc}
 
@@ -114,24 +115,21 @@ HOST_UID=$(id -u) HOST_GID=$(id -g) \
   - `runners-net` 동적 검출 (compose project prefix 회피)
   - host 재배포 후 4 shard 진행
 
-## 머지 정책 (admin-skip) {#admin-skip}
+## 머지 정책 {#merge-policy}
 
-> 출처: `memory/project_ci_admin_skip_until_2026-05-01.md`.
+> 출처: `AGENTS.md`, `.codex/skills/mmp-pr-lifecycle/SKILL.md`, `docs/ops/ci-security-worker-reactivation.md`.
 
-### 현 상태 (2026-04-30 기준)
-- **`gh pr merge --admin --squash` 유지** — 만료 시도 reverse, 부채 정리 phase 종료까지.
-- **2026-04-28 만료 시도 → reverse 사유**: PR-166 + PR-165 CI 결과로 main 누적 부채 5건 노출 (DEBT-1~5).
+### 현 상태 (2026-05-07 기준)
 
-### 진입 조건 (정상 머지 모드 복귀)
-1. DEBT-1/2 (Go gofmt 3 + staticcheck 1) fix → ✅ PR #167 (`6fa7460`)
-2. DEBT-3 (E2E `/api/v1/auth/register` HTTP 500) fix → ✅ PR #167
-3. DEBT-4 (gitleaks) — false positive 분석 또는 baseline 추가
-4. DEBT-5 (govulncheck) — CRITICAL/HIGH CVE 검토 + 5분 timeout fix
-5. main의 13 required check 5 PR 연속 green
+- `main` 직접 커밋 금지.
+- feature branch/worktree → PR → merge.
+- PR 기본 게이트는 CodeRabbit clear, unresolved review thread 0, focused local validation evidence.
+- 기본 PR 처리에서는 `ready-for-ci` 라벨과 `workflow_dispatch`를 사용하지 않는다.
+- GitHub Actions full CI는 위험 PR의 명시적 최종 확인 버튼으로만 사용한다.
 
-### 카논 ref
-- `memory/feedback_branch_pr_workflow.md` — main 보호 + PR 필수 (2026-04-17 `d1262a7` 사건)
-- `memory/feedback_4agent_review_before_admin_merge.md` — HIGH 잔존 머지 금지 (PR-2c #107 사고 이후)
+### 정상 자동 worker 모드 복귀
+
+자동 CI/security worker 복귀는 `docs/ops/ci-security-worker-reactivation.md`의 Phase 1/2 기준을 따른다. required status check는 실제 PR head에서 안정적으로 생성되는 check만 추가한다.
 
 ## 4-agent Review (admin-merge 전 강제) {#4-agent-review}
 

--- a/docs/ops/ci-security-worker-reactivation.md
+++ b/docs/ops/ci-security-worker-reactivation.md
@@ -1,0 +1,230 @@
+# CI/security worker reactivation policy
+
+Last verified: 2026-05-07
+
+## Current state
+
+MMP is in development-minimum mode.
+
+- Default PR gate: CodeRabbit only.
+- Local gate before PR: `scripts/mmp-local-ci.sh quick`, or `coverage` / `e2e` / `full` for higher-risk changes.
+- Branch protection on `main`: required status check is `CodeRabbit`; strict up-to-date is enabled.
+- GitHub Actions workers for CI, E2E, gitleaks, security scans, flaky retry, module isolation, and runner image builds are manual unless noted below.
+- Release workflow still runs only for `v*` tags.
+
+This mode is intentional while active feature work is moving quickly. It avoids burning self-hosted runner minutes on every small PR while still keeping CodeRabbit review and local container validation as the merge evidence.
+
+## External basis
+
+This policy follows three practical constraints from current CI/CD guidance:
+
+- GitHub branch protection only blocks merges on required checks that actually run on the PR head. Required checks should therefore match the workflow mode, not a future target mode.
+- GitHub Actions hardening guidance recommends least-privilege workflow permissions and explicit security workflow ownership.
+- OWASP CI/CD guidance treats repeatable automation and security controls as core pipeline safeguards. Before service operations, secret scanning and scheduled/deep security scans must become automatic again.
+
+References:
+
+- GitHub Docs: required status checks and branch protection.
+- GitHub Docs: secure use of GitHub Actions and least-privilege `GITHUB_TOKEN`.
+- OWASP CI/CD Security Cheat Sheet.
+- Gitleaks Action documentation for PR, push, schedule, and manual scan patterns.
+
+## Cost and failure impact
+
+Worker cost here is mostly self-hosted runner occupancy, not GitHub-hosted billing. The operational symptom of over-enabling checks is that active PRs wait on ARC runner capacity, CodeRabbit fixes get delayed by unrelated workflow queues, and strict branch protection can block merge on checks that were never supposed to run for that PR.
+
+Low-cost checks:
+
+- CodeRabbit review
+- local focused tests before PR
+- `Gitleaks` on same-repo PRs
+- path-filtered security-fast checks
+
+Medium-cost checks:
+
+- full `CI` on same-repo PRs
+- `Module Isolation` for backend runtime paths
+- `E2E — Stubbed Backend` on main push
+
+High-cost checks:
+
+- matrix E2E on every PR
+- deep container/SARIF scans on every PR
+- runner image builds on broad push triggers
+- real-backend E2E on every PR
+
+Recommended failure handling:
+
+- Secret scan failure: stop merge immediately. A leaked secret remains in git history even if a later commit removes it.
+- CI or unit failure: stop merge unless the failing check is confirmed unrelated runner debt and local equivalent passes.
+- E2E failure: stop merge for touched user flows; otherwise triage as flaky only after a retry lane or fresh run confirms it.
+- Deep security finding: block service release on critical/high exploitable findings; track lower-signal findings with owner and deadline.
+- Scheduled scan failure: do not block an unrelated PR retroactively, but open or update an issue before the next release candidate.
+
+## Reactivation phases
+
+### Phase 0: Development-minimum mode
+
+Use now.
+
+Keep:
+
+- `CodeRabbit` as the only required branch-protection check.
+- `CI`, `E2E — Stubbed Backend`, `Security — Fast Feedback`, `Gitleaks`, `Security — Deep Scan`, `Flaky Test Report`, `Module Isolation`, and `Build Runner Image` manual.
+- No `ready-for-ci` label in the default PR lifecycle.
+
+Run manually only when the PR touches one of these high-risk areas:
+
+- database migration or generated SQL
+- auth, realtime, runtime engine, or player-aware redaction
+- Docker, runner image, workflow, or security configuration
+- Playwright E2E flow or browser runtime behavior
+
+### Phase 1: Pre-service hardening
+
+Enter this phase when one of these is true:
+
+- external testers or external contributors get access
+- production-like deployment is scheduled
+- payment, auth, profile, creator revenue, or admin workflows become service-blocking
+- runner pool has enough capacity to absorb scheduled scans without blocking feature PRs
+
+Enable:
+
+- `Gitleaks Secret Scan`
+  - `pull_request` for secret regression detection
+  - `push` on `main`
+  - keep `workflow_dispatch`
+- `Security — Fast Feedback`
+  - `pull_request` for dependency/security-sensitive path changes only
+  - `push` on `main`
+  - keep current warn-only policy until a separate vulnerability baseline issue is closed
+- `Security — Deep Scan`
+  - `schedule` nightly or weekly
+  - `push` on `main`
+  - keep `workflow_dispatch`
+- `Phase 18.1 — Real-Backend E2E`
+  - `schedule` nightly or twice weekly
+  - `push` on `main` only after runner stability is confirmed
+
+Do not restore `ready-for-ci` as a normal workflow trigger. The label made the PR flow harder to reason about. Prefer one of these:
+
+- path-based `pull_request` triggers for cheap or critical checks
+- `push` to `main` for post-merge observation
+- `schedule` for expensive deep scans
+- `workflow_dispatch` for explicit maintainer confirmation
+
+Branch protection:
+
+- Keep `CodeRabbit` required at phase entry.
+- Do not add scheduled-only checks to branch protection.
+- Add `Gitleaks Secret Scan / gitleaks (Secret scan)` only after five consecutive same-repo PR runs pass and the check name is stable.
+- Add a CI summary check only if `CI` is restored to PR events and passes five consecutive same-repo PRs without runner flake.
+
+### Phase 2: Service operations
+
+Enter this phase when the service has production traffic or paid creator/user workflows.
+
+Enable:
+
+- `CI` on same-repo `pull_request` and `push` to `main`.
+- `E2E — Stubbed Backend` on same-repo `pull_request` for E2E path changes and `push` to `main`.
+- `Gitleaks Secret Scan` on `pull_request`, `push` to `main`, and weekly `schedule`.
+- `Security — Fast Feedback` on same-repo `pull_request`, `push` to `main`, and weekly `schedule`.
+- `Security — Deep Scan` on nightly or weekly `schedule` and `push` to `main`.
+- `Flaky Test Report` weekly after at least one known flaky tag exists.
+- `Module Isolation` on same-repo `pull_request` when module/runtime code changes, and `push` to `main`.
+- `Build Runner Image` on manual dispatch, plus path-based `push` only for `infra/runners/**` or workflow-owned runner image files.
+
+Branch protection:
+
+- Required checks should be limited to checks that run for every protected PR in this phase.
+- Recommended required set:
+  - `CodeRabbit`
+  - one CI summary check, if `CI` has a stable summary job
+  - `Gitleaks Secret Scan / gitleaks (Secret scan)`, after the five-green rule
+- Do not require matrix shard names directly unless the workflow emits a stable merge/summary check.
+
+## Exact status commands
+
+Check current branch protection:
+
+```bash
+gh api repos/sabyunrepo/muder_platform/branches/main/protection \
+  --jq '{required_status_checks:.required_status_checks, required_pull_request_reviews:.required_pull_request_reviews}'
+```
+
+Check workflow trigger headers:
+
+```bash
+for f in .github/workflows/*.yml; do
+  echo "== $f =="
+  sed -n '1,35p' "$f"
+done
+```
+
+Check PR CI scope under development-minimum mode:
+
+```bash
+scripts/mmp-pr-ci-scope.sh <PR_NUMBER>
+```
+
+Check merge gate before merging:
+
+```bash
+scripts/mmp-pr-status.sh <PR_NUMBER> --fail-on-blocker --allow-behind
+```
+
+## Exact branch-protection update shape
+
+Use this only after the phase criteria above are met and the exact check names have been observed on real PR heads.
+
+```bash
+gh api \
+  --method PATCH \
+  repos/sabyunrepo/muder_platform/branches/main/protection/required_status_checks \
+  -f strict=true \
+  -f contexts[]=CodeRabbit \
+  -f contexts[]='<STABLE_CHECK_NAME>'
+```
+
+Remove a stale required check:
+
+```bash
+gh api \
+  --method PATCH \
+  repos/sabyunrepo/muder_platform/branches/main/protection/required_status_checks \
+  -f strict=true \
+  -f contexts[]=CodeRabbit
+```
+
+## Workflow trigger changes by file
+
+Apply these only when entering Phase 1 or Phase 2.
+
+| Workflow | Phase 0 | Phase 1 | Phase 2 |
+| --- | --- | --- | --- |
+| `.github/workflows/ci.yml` | `workflow_dispatch` | manual, or path-based PR for high-risk changes | same-repo PR + main push |
+| `.github/workflows/e2e-stubbed.yml` | `workflow_dispatch` | scheduled/main-push observation | path-based PR + main push |
+| `.github/workflows/security-fast.yml` | `workflow_dispatch` | path-based PR + main push | PR + main push + schedule |
+| `.github/workflows/gitleaks.yml` | `workflow_dispatch` | PR + main push | PR + main push + schedule |
+| `.github/workflows/security-deep.yml` | `workflow_dispatch` | schedule + main push | schedule + main push |
+| `.github/workflows/phase-18.1-real-backend.yml` | `workflow_dispatch` | schedule | schedule + main push |
+| `.github/workflows/flaky-report.yml` | `workflow_dispatch` | manual | weekly schedule after flaky tags exist |
+| `.github/workflows/module-isolation.yml` | `workflow_dispatch` | manual | path-based PR + main push |
+| `.github/workflows/build-runner-image.yml` | `workflow_dispatch` | manual | path-based push for runner image files |
+
+## Stop conditions
+
+Do not move from Phase 0 to Phase 1 if any of these are true:
+
+- ARC runner capacity cannot finish one manual `CI` and one manual `E2E — Stubbed Backend` run without starving active PR work.
+- `Gitleaks` or SCA tools still produce untriaged high-signal findings without an exception process.
+- Required status check names have not been confirmed from real PR runs.
+- The workflow change would require secrets not already present in the repository settings.
+
+Do not move from Phase 1 to Phase 2 if:
+
+- five consecutive same-repo PR runs are not green for the proposed required check.
+- scheduled deep scans produce repeated flakes.
+- service launch criteria are still unknown.


### PR DESCRIPTION
## Summary
- 현재 개발 최소 워커 모드의 실제 branch protection 상태를 문서화했습니다.
- 서비스 전/운영 단계에서 어떤 GitHub Actions worker를 언제 다시 켤지 Phase 0/1/2 기준으로 정리했습니다.
- `ready-for-ci` 라벨은 기본 PR trigger로 복원하지 않고, path-based PR / main push / schedule / workflow_dispatch 조합으로 전환하는 정책을 명시했습니다.
- stale한 `docs/architecture/06-infra-cicd.md`의 required checks/admin-skip 설명을 현재 CodeRabbit-only 정책과 새 ops 문서로 갱신했습니다.

Closes #474

## Coverage Plan
- 문서/운영 정책 PR이라 런타임 unit/E2E 테스트 대상은 없습니다.
- `.github/workflows/*.yml` 파싱으로 기존 workflow YAML이 깨지지 않았는지 확인했습니다.
- `gh api .../branches/main/protection` 조회 결과로 문서의 현재 branch protection 근거를 확인했습니다.
- `git diff --check`로 문서 공백 오류를 확인했습니다.

## Local validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }'` ✅
- `gh api repos/sabyunrepo/muder_platform/branches/main/protection --jq '{required_status_checks:.required_status_checks, required_pull_request_reviews:.required_pull_request_reviews}'` ✅
  - required check: `CodeRabbit`
  - strict: `true`
  - required approving review count: `0`
- `git diff --check` ✅

## Notes
- 실제 workflow trigger 재활성화는 아직 적용하지 않았습니다. 문서의 Phase 1/2 조건이 충족될 때 별도 운영 PR에서 진행해야 합니다.
- No `ready-for-ci` label and no workflow dispatch were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* CI/CD 인프라 관련 문서가 업데이트되었습니다.
* GitHub 브랜치 보호 및 필수 상태 확인 정책이 최신화되었습니다.
* 워커 재활성화 정책 문서가 신규 추가되었습니다.
* 병합 정책 관련 문서가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->