### PR TITLE
feat(editor): 단서 인라인 편집과 공개 규칙 통합

### DIFF
--- a/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
@@ -11,6 +11,7 @@ const {
   useEditorThemeMock,
   useEditorLocationsMock,
   useEditorCharactersMock,
+  useUpdateClueMock,
   useUpdateConfigJsonMock,
 } = vi.hoisted(() => ({
   useEditorCluesMock: vi.fn(),
@@ -18,6 +19,7 @@ const {
   useEditorThemeMock: vi.fn(),
   useEditorLocationsMock: vi.fn(),
   useEditorCharactersMock: vi.fn(),
+  useUpdateClueMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
 }));
 
@@ -47,6 +49,7 @@ vi.mock('@/features/editor/api', () => ({
   useEditorTheme: () => useEditorThemeMock(),
   useEditorLocations: () => useEditorLocationsMock(),
   useEditorCharacters: () => useEditorCharactersMock(),
+  useUpdateClue: () => useUpdateClueMock(),
   useUpdateConfigJson: () => useUpdateConfigJsonMock(),
   editorKeys: { clues: (id: string) => ['clues', id] },
 }));
@@ -55,6 +58,11 @@ vi.mock('../ClueForm', () => ({
 }));
 vi.mock('../clues/ClueEdgeGraph', () => ({
   ClueEdgeGraph: () => <div>단서 관계 그래프</div>,
+}));
+vi.mock('@/features/editor/components/media/ImageMediaReferenceField', () => ({
+  ImageMediaReferenceField: ({ label }: { label: string }) => (
+    <div data-testid="image-media-field">{label}</div>
+  ),
 }));
 vi.mock('@/features/editor/flowApi', () => ({
   useFlowGraph: () => ({
@@ -94,6 +102,7 @@ describe('CluesTab', () => {
     useEditorThemeMock.mockReturnValue({ data: { config_json: {} } });
     useEditorLocationsMock.mockReturnValue({ data: [] });
     useEditorCharactersMock.mockReturnValue({ data: [] });
+    useUpdateClueMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
     useUpdateConfigJsonMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
   });
 
@@ -132,7 +141,7 @@ describe('CluesTab', () => {
     useEditorCluesMock.mockReturnValue({ data: mockClues, isLoading: false });
     render(<CluesTab themeId="theme-1" />);
     expect(screen.getAllByText('피 묻은 칼').length).toBeGreaterThan(0);
-    expect(screen.getByText('단서 상세')).toBeDefined();
+    expect(screen.getByText('단서 기본 정보')).toBeDefined();
     expect(screen.getByText('이 단서가 쓰이는 곳')).toBeDefined();
   });
 

--- a/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react';
+import { Save, Trash2 } from 'lucide-react';
+import type { ClueResponse, UpdateClueRequest } from '@/features/editor/api';
+import { ImageMediaReferenceField } from '@/features/editor/components/media/ImageMediaReferenceField';
+import { buildClueUsePayload, toClueEditorViewModel } from '@/features/editor/entities/clue/clueEntityAdapter';
+
+interface ClueBasicInfoCardProps {
+  themeId: string;
+  clue: ClueResponse;
+  isSaving?: boolean;
+  onSave: (clueId: string, body: UpdateClueRequest) => void;
+  onDelete: (clue: ClueResponse) => void;
+}
+
+interface DraftState {
+  name: string;
+  description: string;
+  imageUrl: string;
+  imageMediaId: string | null;
+  isCommon: boolean;
+  revealRound: number | null;
+  hideRound: number | null;
+}
+
+function toDraft(clue: ClueResponse): DraftState {
+  return {
+    name: clue.name,
+    description: clue.description ?? '',
+    imageUrl: clue.image_url ?? '',
+    imageMediaId: clue.image_media_id ?? null,
+    isCommon: clue.is_common,
+    revealRound: clue.reveal_round ?? null,
+    hideRound: clue.hide_round ?? null,
+  };
+}
+
+function parseRoundInput(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return Math.floor(n);
+}
+
+function isDirty(draft: DraftState, clue: ClueResponse): boolean {
+  return (
+    draft.name !== clue.name ||
+    draft.description !== (clue.description ?? '') ||
+    draft.imageUrl !== (clue.image_url ?? '') ||
+    draft.imageMediaId !== (clue.image_media_id ?? null) ||
+    draft.isCommon !== clue.is_common ||
+    draft.revealRound !== (clue.reveal_round ?? null) ||
+    draft.hideRound !== (clue.hide_round ?? null)
+  );
+}
+
+function validate(draft: DraftState): Record<string, string> {
+  const errors: Record<string, string> = {};
+  const name = draft.name.trim();
+  if (!name) errors.name = '이름은 필수입니다';
+  if (name.length > 100) errors.name = '이름은 100자 이하여야 합니다';
+  if (draft.description.length > 2000) errors.description = '설명은 2000자 이하여야 합니다';
+  if (draft.revealRound != null && draft.hideRound != null && draft.revealRound > draft.hideRound) {
+    errors.round = '공개 라운드는 사라짐 라운드보다 클 수 없습니다';
+  }
+  return errors;
+}
+
+export function ClueBasicInfoCard({
+  themeId,
+  clue,
+  isSaving = false,
+  onSave,
+  onDelete,
+}: ClueBasicInfoCardProps) {
+  const [draft, setDraft] = useState<DraftState>(() => toDraft(clue));
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const view = toClueEditorViewModel(clue);
+  const dirty = isDirty(draft, clue);
+
+  useEffect(() => {
+    setDraft(toDraft(clue));
+    setErrors({});
+  }, [clue]);
+
+  function patch(next: Partial<DraftState>) {
+    setDraft((current) => ({ ...current, ...next }));
+  }
+
+  function handleSave() {
+    const nextErrors = validate(draft);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+
+    const imageUrl = draft.imageMediaId
+      ? ''
+      : clue.image_url && draft.imageUrl === ''
+        ? ''
+        : draft.imageUrl || undefined;
+
+    onSave(
+      clue.id,
+      buildClueUsePayload({
+        name: draft.name.trim(),
+        description: draft.description || undefined,
+        image_url: imageUrl,
+        image_media_id: draft.imageMediaId,
+        level: clue.level,
+        sort_order: clue.sort_order,
+        is_common: draft.isCommon,
+        is_usable: clue.is_usable,
+        use_effect: clue.use_effect ?? undefined,
+        use_target: clue.use_target ?? undefined,
+        use_consumed: clue.use_consumed,
+        reveal_round: draft.revealRound,
+        hide_round: draft.hideRound,
+      })
+    );
+  }
+
+  return (
+    <article className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
+            단서 기본 정보
+          </p>
+          <h3 className="mt-1 text-xl font-bold text-slate-100">{clue.name}</h3>
+          <p className="mt-1 text-sm leading-6 text-slate-400">
+            선택한 단서를 이 화면에서 바로 수정합니다.
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!dirty || isSaving}
+            className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-amber-500/30 px-3 py-2 text-xs font-semibold text-amber-200 hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
+          >
+            <Save className="h-3.5 w-3.5" />
+            {isSaving ? '저장 중' : '기본 정보 저장'}
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(clue)}
+            aria-label={`${clue.name} 삭제`}
+            className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-red-500/20 px-3 py-2 text-xs font-semibold text-red-300 hover:bg-red-500/10"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            삭제
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 space-y-4">
+        <ImageMediaReferenceField
+          themeId={themeId}
+          label="단서 이미지"
+          imageMediaId={draft.imageMediaId}
+          legacyImageUrl={draft.imageUrl || null}
+          pickerTitle="단서 이미지 선택"
+          emptyLabel="단서 이미지 선택"
+          compact
+          disabled={isSaving}
+          onSelect={(media) => patch({ imageMediaId: media.id, imageUrl: '' })}
+          onClear={() => patch({ imageMediaId: null, imageUrl: '' })}
+        />
+
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_14rem]">
+          <label className="min-w-0 text-sm font-medium text-slate-300">
+            이름
+            <input
+              value={draft.name}
+              onChange={(event) => patch({ name: event.target.value })}
+              maxLength={100}
+              className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            />
+            {errors.name && <span className="mt-1 block text-xs text-red-400">{errors.name}</span>}
+          </label>
+
+          <label className="flex items-center gap-2 rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-300">
+            <input
+              type="checkbox"
+              checked={draft.isCommon}
+              onChange={(event) => patch({ isCommon: event.target.checked })}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+            />
+            모든 플레이어가 공유
+          </label>
+        </div>
+
+        <label className="block text-sm font-medium text-slate-300">
+          설명
+          <textarea
+            value={draft.description}
+            onChange={(event) => patch({ description: event.target.value })}
+            maxLength={2000}
+            rows={4}
+            placeholder="플레이어에게 보일 단서 설명"
+            className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          />
+          {errors.description && (
+            <span className="mt-1 block text-xs text-red-400">{errors.description}</span>
+          )}
+        </label>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="text-sm font-medium text-slate-300">
+            등장 라운드
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={draft.revealRound ?? ''}
+              onChange={(event) => patch({ revealRound: parseRoundInput(event.target.value) })}
+              placeholder="처음부터"
+              className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            />
+          </label>
+          <label className="text-sm font-medium text-slate-300">
+            사라짐 라운드
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={draft.hideRound ?? ''}
+              onChange={(event) => patch({ hideRound: parseRoundInput(event.target.value) })}
+              placeholder="끝까지"
+              className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            />
+          </label>
+        </div>
+        {errors.round && <p className="text-xs text-red-400">{errors.round}</p>}
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-3">
+        <InfoBlock title="공개 범위" value={view.publicScopeLabel} />
+        <InfoBlock title="등장 라운드" value={view.roundLabel} />
+        <InfoBlock title="사용 후 처리" value={view.consumeLabel} />
+      </div>
+    </article>
+  );
+}
+
+function InfoBlock({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <p className="text-xs font-semibold text-slate-500">{title}</p>
+      <p className="mt-1 text-sm text-slate-200">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
@@ -20,6 +20,12 @@ vi.mock('@/features/editor/readingApi', () => ({
   }),
 }));
 
+vi.mock('@/features/editor/components/media/ImageMediaReferenceField', () => ({
+  ImageMediaReferenceField: ({ label }: { label: string }) => (
+    <div data-testid="image-media-field">{label}</div>
+  ),
+}));
+
 function clue(overrides: Partial<ClueResponse>): ClueResponse {
   return {
     id: 'clue-1',
@@ -77,9 +83,10 @@ const characters: EditorCharacterResponse[] = [
 afterEach(cleanup);
 
 describe('ClueEntityWorkspace', () => {
-  it('선택한 단서의 실제 편집 상세와 사용 효과를 제작자 언어로 보여준다', () => {
+  it('선택한 단서의 인라인 편집 상세와 사용 공개 규칙을 제작자 언어로 보여준다', () => {
     render(
       <ClueEntityWorkspace
+        themeId="theme-1"
         clues={[clue({ id: 'clue-1' }), clue({ id: 'clue-2', name: '비밀 편지', is_usable: false })]}
         configJson={{
           locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
@@ -88,27 +95,30 @@ describe('ClueEntityWorkspace', () => {
         locations={locations}
         characters={characters}
         onCreate={vi.fn()}
-        onEdit={vi.fn()}
+        onUpdate={vi.fn()}
         onDelete={vi.fn()}
       />,
     );
 
-    expect(screen.getByText('단서 상세')).toBeDefined();
-    expect(screen.getByText('다른 플레이어에게서 단서 가져오기')).toBeDefined();
+    expect(screen.getByText('단서 기본 정보')).toBeDefined();
+    expect(screen.getByText('단서 사용 / 공개 규칙')).toBeDefined();
     expect(screen.getAllByText('사용하면 내 단서함에서 사라짐').length).toBeGreaterThan(0);
     expect(screen.getByText('서재의 발견 단서')).toBeDefined();
     expect(screen.getByText('탐정의 시작 단서')).toBeDefined();
+    expect(screen.queryByText('단서 트리거')).toBeNull();
+    expect(screen.queryByText('투표 시작')).toBeNull();
   });
 
   it('목록에서 다른 단서를 클릭하면 상세가 교체된다', () => {
     render(
       <ClueEntityWorkspace
+        themeId="theme-1"
         clues={[clue({ id: 'clue-1' }), clue({ id: 'clue-2', name: '비밀 편지', description: '숨겨진 메시지', is_usable: false })]}
         configJson={{}}
         locations={[]}
         characters={[]}
         onCreate={vi.fn()}
-        onEdit={vi.fn()}
+        onUpdate={vi.fn()}
         onDelete={vi.fn()}
       />,
     );
@@ -116,6 +126,41 @@ describe('ClueEntityWorkspace', () => {
     fireEvent.click(screen.getByRole('button', { name: '비밀 편지 선택' }));
 
     expect(screen.getAllByText('숨겨진 메시지').length).toBeGreaterThan(0);
-    expect(screen.getByText('사용 효과 없음')).toBeDefined();
+    expect(screen.getByRole('button', { name: '효과 없음' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    );
+  });
+
+  it('인라인 기본 정보 저장 시 선택 단서 update payload를 보낸다', () => {
+    const onUpdate = vi.fn();
+
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1' })]}
+        configJson={{}}
+        locations={[]}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '피 묻은 열쇠 조각' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '기본 정보 저장' }));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      'clue-1',
+      expect.objectContaining({
+        name: '피 묻은 열쇠 조각',
+        is_usable: true,
+        use_effect: 'steal',
+        use_target: 'player',
+        use_consumed: true,
+      }),
+    );
   });
 });

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react';
-import { Edit3, Trash2 } from 'lucide-react';
 import type {
   ClueResponse,
   EditorCharacterResponse,
   LocationResponse,
+  UpdateClueRequest,
 } from '@/features/editor/api';
 import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
@@ -14,10 +14,9 @@ import {
 } from '@/features/editor/utils/entityReferences';
 import {
   buildClueBadges,
-  toClueEditorViewModel,
 } from '@/features/editor/entities/clue/clueEntityAdapter';
-import { EntityTriggerPlacementCard } from '@/features/editor/components/triggers/EntityTriggerPlacementCard';
 import { ClueRuntimeEffectCard } from './ClueRuntimeEffectCard';
+import { ClueBasicInfoCard } from './ClueBasicInfoCard';
 
 interface ClueEntityWorkspaceProps {
   themeId?: string;
@@ -26,8 +25,9 @@ interface ClueEntityWorkspaceProps {
   locations: LocationResponse[];
   characters: EditorCharacterResponse[];
   onCreate: () => void;
-  onEdit: (clue: ClueResponse) => void;
+  onUpdate: (clueId: string, body: UpdateClueRequest) => void;
   onDelete: (clue: ClueResponse) => void;
+  isClueSaving?: boolean;
   onConfigChange?: (configJson: EditorConfig) => void;
   isConfigSaving?: boolean;
 }
@@ -39,8 +39,9 @@ export function ClueEntityWorkspace({
   locations,
   characters,
   onCreate,
-  onEdit,
+  onUpdate,
   onDelete,
+  isClueSaving,
   onConfigChange,
   isConfigSaving,
 }: ClueEntityWorkspaceProps) {
@@ -63,19 +64,16 @@ export function ClueEntityWorkspace({
       getItemBadges={(clue) => buildClueBadges(clue, usageMap[clue.id]?.references.length ?? 0)}
       renderDetail={(clue) => (
         <div className="space-y-4">
-          <ClueDetailCard clue={clue} onEdit={onEdit} onDelete={onDelete} />
+          <ClueBasicInfoCard
+            themeId={themeId ?? ''}
+            clue={clue}
+            isSaving={isClueSaving}
+            onSave={onUpdate}
+            onDelete={onDelete}
+          />
           <ClueRuntimeEffectCard
             clue={clue}
             clues={clues}
-            configJson={configJson}
-            onConfigChange={onConfigChange}
-            isSaving={isConfigSaving}
-          />
-          <EntityTriggerPlacementCard
-            themeId={themeId}
-            entityKind="clue"
-            entityId={clue.id}
-            entityName={clue.name}
             configJson={configJson}
             onConfigChange={onConfigChange}
             isSaving={isConfigSaving}
@@ -84,59 +82,6 @@ export function ClueEntityWorkspace({
       )}
       renderInspector={(clue) => <ClueUsageCard references={getClueBacklinks(usageMap, clue.id)} />}
     />
-  );
-}
-function ClueDetailCard({
-  clue,
-  onEdit,
-  onDelete,
-}: {
-  clue: ClueResponse;
-  onEdit: (clue: ClueResponse) => void;
-  onDelete: (clue: ClueResponse) => void;
-}) {
-  const view = toClueEditorViewModel(clue);
-
-  return (
-    <article className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
-            단서 상세
-          </p>
-          <h3 className="mt-1 text-xl font-bold text-slate-100">{clue.name}</h3>
-          <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-400">
-            {view.description}
-          </p>
-        </div>
-        <div className="flex shrink-0 gap-2">
-          <button
-            type="button"
-            onClick={() => onEdit(clue)}
-            className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-200 hover:border-amber-500/50 hover:text-amber-300"
-          >
-            <Edit3 className="h-3.5 w-3.5" />
-            수정
-          </button>
-          <button
-            type="button"
-            onClick={() => onDelete(clue)}
-            aria-label={`${clue.name} 삭제`}
-            className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-red-500/20 px-3 py-2 text-xs font-semibold text-red-300 hover:bg-red-500/10"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            삭제
-          </button>
-        </div>
-      </div>
-
-      <div className="mt-5 grid gap-3 md:grid-cols-2">
-        <InfoBlock title="공개 범위" value={view.publicScopeLabel} />
-        <InfoBlock title="등장 라운드" value={view.roundLabel} />
-        <InfoBlock title="사용 효과" value={view.useEffectLabel} />
-        <InfoBlock title="사용 후 처리" value={view.consumeLabel} />
-      </div>
-    </article>
   );
 }
 
@@ -164,15 +109,6 @@ function ClueUsageCard({ references }: { references: EntityReference[] }) {
         </ul>
       )}
     </aside>
-  );
-}
-
-function InfoBlock({ title, value }: { title: string; value: string }) {
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-      <p className="text-xs font-semibold text-slate-500">{title}</p>
-      <p className="mt-1 text-sm text-slate-200">{value}</p>
-    </div>
   );
 }
 

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -9,8 +9,10 @@ import {
   useEditorLocations,
   useEditorClues,
   useDeleteClue,
+  useUpdateClue,
   useUpdateConfigJson,
   type ClueResponse,
+  type UpdateClueRequest,
 } from '@/features/editor/api';
 import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { buildClueUsageMap, type EntityReference } from '@/features/editor/utils/entityReferences';
@@ -35,24 +37,27 @@ export function ClueListView({ themeId }: ClueListViewProps) {
   const { data: locations = [] } = useEditorLocations(themeId);
   const { data: characters = [] } = useEditorCharacters(themeId);
   const deleteClue = useDeleteClue(themeId);
+  const updateClue = useUpdateClue(themeId);
   const updateConfig = useUpdateConfigJson(themeId);
   const [isFormOpen, setIsFormOpen] = useState(false);
-  const [editingClue, setEditingClue] = useState<ClueResponse | undefined>(undefined);
   const [deletingClue, setDeletingClue] = useState<ClueResponse | undefined>(undefined);
 
   function handleCreate() {
-    setEditingClue(undefined);
-    setIsFormOpen(true);
-  }
-
-  function handleEdit(clue: ClueResponse) {
-    setEditingClue(clue);
     setIsFormOpen(true);
   }
 
   function handleFormClose() {
     setIsFormOpen(false);
-    setEditingClue(undefined);
+  }
+
+  function handleUpdate(clueId: string, body: UpdateClueRequest) {
+    updateClue.mutate(
+      { clueId, body },
+      {
+        onSuccess: () => toast.success('단서가 수정되었습니다'),
+        onError: (err) => toast.error(err.message || '단서 수정에 실패했습니다'),
+      }
+    );
   }
 
   function handleDeleteConfirm() {
@@ -125,18 +130,14 @@ export function ClueListView({ themeId }: ClueListViewProps) {
         locations={locations}
         characters={characters}
         onCreate={handleCreate}
-        onEdit={handleEdit}
+        onUpdate={handleUpdate}
         onDelete={setDeletingClue}
+        isClueSaving={updateClue.isPending}
         onConfigChange={handleConfigChange}
         isConfigSaving={updateConfig.isPending}
       />
 
-      <ClueForm
-        themeId={themeId}
-        clue={editingClue}
-        isOpen={isFormOpen}
-        onClose={handleFormClose}
-      />
+      <ClueForm themeId={themeId} isOpen={isFormOpen} onClose={handleFormClose} />
 
       <Modal
         isOpen={!!deletingClue}

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
@@ -44,6 +44,8 @@ describe('ClueRuntimeEffectCard', () => {
               'clue-1': {
                 effect: 'reveal',
                 target: 'self',
+                trigger: 'on_view',
+                condition: { kind: 'password', value: '0427' },
                 revealText: '숫자 0427이 보입니다.',
                 consume: false,
               },
@@ -62,7 +64,9 @@ describe('ClueRuntimeEffectCard', () => {
       />,
     );
 
-    expect(screen.getByText('게임 중 사용 효과')).toBeDefined();
+    expect(screen.getByText('단서 사용 / 공개 규칙')).toBeDefined();
+    expect(screen.getByRole('button', { name: '단서 확인 시' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByLabelText('암호')).toHaveProperty('value', '0427');
     expect(screen.queryByText('itemEffects')).toBeNull();
     expect(screen.queryByText('grant_clue')).toBeNull();
 
@@ -70,13 +74,15 @@ describe('ClueRuntimeEffectCard', () => {
       target: { value: '열쇠 뒤에 새 숫자 1234가 보입니다.' },
     });
     fireEvent.click(screen.getByLabelText(/사용하면 내 단서함에서 사라짐/));
-    fireEvent.click(screen.getByRole('button', { name: '효과 저장' }));
+    fireEvent.click(screen.getByRole('button', { name: '규칙 저장' }));
 
     expect(onConfigChange).toHaveBeenCalledTimes(1);
     const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
     expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
       effect: 'reveal',
       target: 'self',
+      trigger: 'on_view',
+      condition: { kind: 'password', value: '0427' },
       revealText: '열쇠 뒤에 새 숫자 1234가 보입니다.',
       consume: true,
     });
@@ -99,15 +105,19 @@ describe('ClueRuntimeEffectCard', () => {
       target: { value: '금고' },
     });
     fireEvent.click(screen.getByRole('button', { name: '금고 비밀번호' }));
+    fireEvent.click(screen.getByRole('button', { name: '암호 입력 후 공개' }));
+    fireEvent.change(screen.getByLabelText('암호'), { target: { value: 'gold' } });
 
     expect(screen.getByText('선택된 지급 단서')).toBeDefined();
-    fireEvent.click(screen.getByRole('button', { name: '효과 저장' }));
+    fireEvent.click(screen.getByRole('button', { name: '규칙 저장' }));
 
     expect(onConfigChange).toHaveBeenCalledTimes(1);
     const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
     expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
       effect: 'grant_clue',
       target: 'self',
+      trigger: 'on_use',
+      condition: { kind: 'password', value: 'gold' },
       grantClueIds: ['clue-2'],
     });
   });
@@ -136,7 +146,7 @@ describe('ClueRuntimeEffectCard', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: '효과 없음' }));
-    fireEvent.click(screen.getByRole('button', { name: '효과 저장' }));
+    fireEvent.click(screen.getByRole('button', { name: '규칙 저장' }));
 
     const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
     expect(readClueItemEffect(saved, 'clue-1')).toBeNull();

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/features/editor/utils/configShape';
 
 type EffectMode = 'none' | 'reveal' | 'grant';
+type TriggerMode = 'on_view' | 'on_use';
+type ConditionMode = 'none' | 'password';
 
 interface ClueRuntimeEffectCardProps {
   clue: ClueResponse;
@@ -21,15 +23,42 @@ interface ClueRuntimeEffectCardProps {
 
 interface DraftState {
   mode: EffectMode;
+  trigger: TriggerMode;
+  condition: ConditionMode;
+  password: string;
   revealText: string;
   grantClueIds: string[];
   consume: boolean;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readTrigger(config: ClueItemEffectConfig | null): TriggerMode {
+  return config?.trigger === 'on_view' || config?.trigger === 'on_use' ? config.trigger : 'on_use';
+}
+
+function readPassword(config: ClueItemEffectConfig | null): string {
+  const condition = config?.condition;
+  if (isRecord(condition) && condition.kind === 'password' && typeof condition.value === 'string') {
+    return condition.value;
+  }
+  return typeof config?.password === 'string' ? config.password : '';
+}
+
 function draftFromConfig(config: ClueItemEffectConfig | null): DraftState {
+  const password = readPassword(config);
+  const base = {
+    trigger: readTrigger(config),
+    condition: password ? 'password' as ConditionMode : 'none' as ConditionMode,
+    password,
+  };
+
   if (config?.effect === 'reveal') {
     return {
       mode: 'reveal',
+      ...base,
       revealText: config.revealText ?? '',
       grantClueIds: [],
       consume: config.consume === true,
@@ -38,12 +67,26 @@ function draftFromConfig(config: ClueItemEffectConfig | null): DraftState {
   if (config?.effect === 'grant_clue') {
     return {
       mode: 'grant',
+      ...base,
       revealText: '',
       grantClueIds: config.grantClueIds ?? [],
       consume: config.consume === true,
     };
   }
-  return { mode: 'none', revealText: '', grantClueIds: [], consume: false };
+  return { mode: 'none', ...base, revealText: '', grantClueIds: [], consume: false };
+}
+
+function ruleFields(draft: DraftState): EditorConfig & {
+  trigger: TriggerMode;
+  condition?: { kind: 'password'; value: string };
+} {
+  const password = draft.password.trim();
+  return {
+    trigger: draft.trigger,
+    ...(draft.condition === 'password' && password
+      ? { condition: { kind: 'password' as const, value: password } }
+      : {}),
+  };
 }
 
 function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
@@ -51,6 +94,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
     return {
       effect: 'reveal',
       target: 'self',
+      ...ruleFields(draft),
       revealText: draft.revealText.trim(),
       consume: draft.consume,
     };
@@ -59,6 +103,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
     return {
       effect: 'grant_clue',
       target: 'self',
+      ...ruleFields(draft),
       grantClueIds: draft.grantClueIds,
       consume: draft.consume,
     };
@@ -67,6 +112,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
 }
 
 function isDraftValid(draft: DraftState) {
+  if (draft.condition === 'password' && draft.password.trim().length === 0) return false;
   if (draft.mode === 'reveal') return draft.revealText.trim().length > 0;
   if (draft.mode === 'grant') return draft.grantClueIds.length > 0;
   return true;
@@ -133,11 +179,11 @@ export function ClueRuntimeEffectCard({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
-            게임 중 사용 효과
+            단서 사용 / 공개 규칙
           </p>
-          <h4 className="mt-1 text-lg font-bold text-slate-100">이 단서를 사용하면</h4>
+          <h4 className="mt-1 text-lg font-bold text-slate-100">언제, 어떤 조건으로 공개할지</h4>
           <p className="mt-1 text-sm leading-6 text-slate-400">
-            플레이어가 이 단서를 눌렀을 때 공개할 정보나 지급할 단서를 설정합니다.
+            플레이어가 단서를 확인하거나 사용할 때의 공개 조건과 보상을 한곳에서 설정합니다.
           </p>
         </div>
         <button
@@ -147,9 +193,48 @@ export function ClueRuntimeEffectCard({
           className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-amber-500/30 px-3 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
         >
           <Save className="h-4 w-4" />
-          {isSaving ? '저장 중' : '효과 저장'}
+          {isSaving ? '저장 중' : '규칙 저장'}
         </button>
       </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        <RuleGroup label="발동 시점">
+          <RuleChoice
+            selected={draft.trigger === 'on_view'}
+            label="단서 확인 시"
+            onSelect={() => updateDraft({ trigger: 'on_view' })}
+          />
+          <RuleChoice
+            selected={draft.trigger === 'on_use'}
+            label="사용 버튼 클릭 시"
+            onSelect={() => updateDraft({ trigger: 'on_use' })}
+          />
+        </RuleGroup>
+        <RuleGroup label="공개 조건">
+          <RuleChoice
+            selected={draft.condition === 'none'}
+            label="즉시 공개"
+            onSelect={() => updateDraft({ condition: 'none', password: '' })}
+          />
+          <RuleChoice
+            selected={draft.condition === 'password'}
+            label="암호 입력 후 공개"
+            onSelect={() => updateDraft({ condition: 'password' })}
+          />
+        </RuleGroup>
+      </div>
+
+      {draft.condition === 'password' && (
+        <label className="mt-3 block text-sm font-medium text-slate-300">
+          암호
+          <input
+            value={draft.password}
+            onChange={(e) => updateDraft({ password: e.target.value })}
+            placeholder="플레이어가 입력해야 하는 암호"
+            className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          />
+        </label>
+      )}
 
       <fieldset className="mt-4 grid gap-2 sm:grid-cols-3">
         <EffectChoice mode="none" current={draft.mode} label="효과 없음" onSelect={() => updateDraft({ mode: 'none' })} />
@@ -201,6 +286,40 @@ export function ClueRuntimeEffectCard({
         </label>
       )}
     </section>
+  );
+}
+
+function RuleGroup({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <fieldset className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+      <legend className="px-1 text-sm font-semibold text-slate-200">{label}</legend>
+      <div className="mt-2 grid gap-2 sm:grid-cols-2">{children}</div>
+    </fieldset>
+  );
+}
+
+function RuleChoice({
+  selected,
+  label,
+  onSelect,
+}: {
+  selected: boolean;
+  label: string;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`min-h-10 rounded-lg border px-3 py-2 text-sm font-semibold ${
+        selected
+          ? 'border-amber-500/70 bg-amber-500/10 text-amber-200'
+          : 'border-slate-800 bg-slate-950/70 text-slate-300 hover:border-slate-700'
+      }`}
+    >
+      {label}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
- 선택한 단서의 기본 정보, 이미지, 공개 범위를 상세 패널에서 바로 편집/저장하도록 변경했습니다.
- 단서 사용 효과와 공개 조건을 `단서 사용 / 공개 규칙` 카드로 통합했습니다.
- 단서 기본 UX에서 범용 trigger/action editor 노출을 제거해 `투표 시작` 같은 게임 진행 액션이 섞이지 않게 했습니다.

## Issue
Closes #476

## Coverage Plan
- `ClueBasicInfoCard` / `ClueEntityWorkspace`: inline 기본 정보 저장 payload, 선택 전환, generic trigger 미노출을 검증합니다.
- `ClueRuntimeEffectCard`: reveal/grant/none 효과, `on_view`/`on_use` trigger, password condition 저장과 roundtrip을 검증합니다.
- `CluesTab`: 새 `useUpdateClue` 연결과 기본 렌더링 mock을 보강합니다.

## Local validation
- `pnpm --filter @mmp/web typecheck` passed
- `pnpm --filter @mmp/web exec eslint apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx apps/web/src/features/editor/components/clues/ClueListView.tsx apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx` passed
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/__tests__/CluesTab.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx` passed (14 tests)
- `git diff --check` passed
- `scripts/mmp-local-ci.sh quick` passed (`head=543cbb8159e1c494afb0a88de9904715efdcbe62`, finished `2026-05-07T15:39:12Z`)

## E2E
별도 Playwright E2E는 추가하지 않았습니다. 이번 변경은 기존 clue config 저장 구조 위의 editor component flow라서 focused component tests와 full local quick CI로 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 단서 기본 정보 편집 카드 추가: 단서 이름, 설명, 공유 설정, 공개/숨김 라운드 관리 가능
  * 조건부 해제 기능 추가: 비밀번호 기반 규칙을 통한 단서 공개 조건 설정
  * 발동 시점 설정: 단서 조회 시 또는 사용 시 규칙 적용 옵션 추가

* **Tests**
  * 단서 편집 UI 및 동작 검증 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->