### PR TITLE
feat(editor): 결말 질문 대상 설정 추가

### DIFF
--- a/apps/web/src/features/editor/components/design/EndingBranchQuestionList.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchQuestionList.tsx
@@ -1,8 +1,13 @@
 import { Plus, Trash2 } from "lucide-react";
-import type { EndingBranchQuestion } from "../../entities/ending/endingBranchAdapter";
+import type { EditorCharacterResponse } from "@/features/editor/api";
+import { OptionList, type OptionItem } from "./InformationDeliveryOptionList";
+import type { EndingBranchQuestion, EndingBranchQuestionTarget } from "../../entities/ending/endingBranchAdapter";
+
+const ALL_PLAYERS_TARGET_ID = "__all_players__";
 
 interface EndingBranchQuestionListProps {
   questions: EndingBranchQuestion[];
+  characters: EditorCharacterResponse[];
   onAddQuestion: () => void;
   onRemoveQuestion: (questionId: string) => void;
   onChangeQuestion: (questionId: string, updater: (question: EndingBranchQuestion) => EndingBranchQuestion) => void;
@@ -13,6 +18,7 @@ interface EndingBranchQuestionListProps {
 
 export function EndingBranchQuestionList({
   questions,
+  characters,
   onAddQuestion,
   onRemoveQuestion,
   onChangeQuestion,
@@ -71,6 +77,13 @@ export function EndingBranchQuestionList({
               </label>
             </div>
 
+            <QuestionTargetSelector
+              question={question}
+              questionIndex={questionIndex}
+              characters={characters}
+              onChangeQuestion={onChangeQuestion}
+            />
+
             <ChoiceRows
               question={question}
               questionIndex={questionIndex}
@@ -82,6 +95,91 @@ export function EndingBranchQuestionList({
           </article>
         ))}
       </div>
+    </div>
+  );
+}
+
+interface TargetOption extends OptionItem {
+  roleLabel?: string;
+}
+
+interface QuestionTargetSelectorProps {
+  question: EndingBranchQuestion;
+  questionIndex: number;
+  characters: EditorCharacterResponse[];
+  onChangeQuestion: (questionId: string, updater: (question: EndingBranchQuestion) => EndingBranchQuestion) => void;
+}
+
+function characterSummary(character: EditorCharacterResponse): string | undefined {
+  if (!character.is_playable) return "비플레이어";
+  if (character.mystery_role === "detective") return "탐정";
+  if (character.mystery_role === "culprit") return "범인";
+  if (character.mystery_role === "accomplice") return "공범";
+  return "플레이어 캐릭터";
+}
+
+function targetToSelectedIds(target: EndingBranchQuestionTarget): string[] {
+  return target.type === "specific_players" ? target.characterIds : [ALL_PLAYERS_TARGET_ID];
+}
+
+function targetFromToggle(target: EndingBranchQuestionTarget, id: string): EndingBranchQuestionTarget {
+  if (id === ALL_PLAYERS_TARGET_ID) return { type: "all_players" };
+  const currentIds = target.type === "specific_players" ? target.characterIds : [];
+  const nextIds = currentIds.includes(id)
+    ? currentIds.filter((characterId) => characterId !== id)
+    : [...currentIds, id];
+  return { type: "specific_players", characterIds: nextIds };
+}
+
+function legacyRespondents(target: EndingBranchQuestionTarget): "all" | string {
+  return target.type === "specific_players" ? target.characterIds[0] ?? "" : "all";
+}
+
+function QuestionTargetSelector({
+  question,
+  questionIndex,
+  characters,
+  onChangeQuestion,
+}: QuestionTargetSelectorProps) {
+  const characterOptions: TargetOption[] = characters.map((character) => ({
+    id: character.id,
+    name: character.name.trim() || "이름 없는 캐릭터",
+    summary: character.description?.trim() || characterSummary(character),
+  }));
+  const knownIds = new Set(characterOptions.map((item) => item.id));
+  const deletedOptions: TargetOption[] = question.target.type === "specific_players"
+    ? question.target.characterIds
+      .filter((id) => !knownIds.has(id))
+      .map((id) => ({ id, name: "삭제된 캐릭터", summary: id }))
+    : [];
+  const allPlayerOption: TargetOption = {
+    id: ALL_PLAYERS_TARGET_ID,
+    name: "모든 플레이어",
+    summary: "공통 종료 질문",
+  };
+  const items = [allPlayerOption, ...characterOptions];
+  const allItems = [...items, ...deletedOptions];
+  const selectedIds = targetToSelectedIds(question.target);
+
+  return (
+    <div className="mt-3">
+      <OptionList
+        title="받을 대상"
+        emptyText="선택 가능한 캐릭터가 없습니다."
+        items={items}
+        allItems={allItems}
+        selectedIds={selectedIds}
+        getMeta={(item) => item.id === ALL_PLAYERS_TARGET_ID ? "공통 종료 질문" : item.summary}
+        onToggle={(id) => onChangeQuestion(question.id, (item) => {
+          const target = targetFromToggle(item.target, id);
+          return { ...item, target, respondents: legacyRespondents(target) };
+        })}
+      />
+      {question.target.type === "specific_players" && question.target.characterIds.length === 0 && (
+        <p className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          질문 {questionIndex + 1}을 받을 캐릭터를 1명 이상 선택해 주세요.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, CheckCircle2, Save } from "lucide-react";
 import { toast } from "sonner";
 import type { Node } from "@xyflow/react";
-import type { EditorThemeResponse } from "@/features/editor/api";
+import type { EditorCharacterResponse, EditorThemeResponse } from "@/features/editor/api";
 import { useUpdateConfigJson } from "@/features/editor/editorConfigApi";
 import {
   createEndingBranchMatrixRow,
@@ -21,6 +21,7 @@ interface EndingBranchRulesPanelProps {
   themeId: string;
   theme: EditorThemeResponse;
   endingNodes: Node[];
+  characters: EditorCharacterResponse[];
 }
 
 function reorderPriorities(config: EndingBranchConfig): EndingBranchConfig {
@@ -70,7 +71,7 @@ function updateChoiceValues(
   return question.choices.map((choice, index) => (index === choiceIndex ? value : choice));
 }
 
-export function EndingBranchRulesPanel({ themeId, theme, endingNodes }: EndingBranchRulesPanelProps) {
+export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters }: EndingBranchRulesPanelProps) {
   const updateConfig = useUpdateConfigJson(themeId);
   const serverConfig = useMemo(() => readEndingBranchConfig(theme.config_json), [theme.config_json]);
   const [draft, setDraft] = useState<EndingBranchConfig>(serverConfig);
@@ -101,6 +102,10 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes }: EndingBr
 
   const handleSave = () => {
     const submittedDraft = draft;
+    if (draft.questions.some((question) => question.target.type === "specific_players" && question.target.characterIds.length === 0)) {
+      toast.error("특정 플레이어 질문은 받을 캐릭터를 1명 이상 선택해야 합니다");
+      return;
+    }
     updateConfig.mutate(
       { ...writeEndingBranchConfig(theme.config_json, draft), version: theme.version },
       {
@@ -159,6 +164,7 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes }: EndingBr
       <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
         <EndingBranchQuestionList
           questions={draft.questions}
+          characters={characters}
           onAddQuestion={() => applyDraft({ ...draft, questions: [...draft.questions, createEndingBranchQuestion(draft.questions.length)] })}
           onRemoveQuestion={handleRemoveQuestion}
           onChangeQuestion={(questionId, updater) => applyDraft(updateQuestionAt(draft, questionId, updater))}

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -98,7 +98,7 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
 
       <EndingDecisionSummaryPanel summary={decisionSummary} />
 
-      <EndingBranchRulesPanel themeId={themeId} theme={theme} endingNodes={endingNodes} />
+      <EndingBranchRulesPanel themeId={themeId} theme={theme} endingNodes={endingNodes} characters={characters} />
 
       {endingNodes.length === 0 ? (
         <EndingEmptyState />

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
-const { useFlowDataMock, useEditorCharactersMock, addNodeMock, updateNodeDataMock, mutateMock, configMutateMock, useUpdateFlowNodeMock, refetchMock } = vi.hoisted(() => ({
+const { useFlowDataMock, useEditorCharactersMock, addNodeMock, updateNodeDataMock, mutateMock, configMutateMock, useUpdateFlowNodeMock, refetchMock, toastErrorMock } = vi.hoisted(() => ({
   useFlowDataMock: vi.fn(),
   useEditorCharactersMock: vi.fn(),
   addNodeMock: vi.fn(),
@@ -12,6 +12,7 @@ const { useFlowDataMock, useEditorCharactersMock, addNodeMock, updateNodeDataMoc
   configMutateMock: vi.fn(),
   useUpdateFlowNodeMock: vi.fn(),
   refetchMock: vi.fn(),
+  toastErrorMock: vi.fn(),
 }));
 
 vi.mock("../../../hooks/useFlowData", () => ({
@@ -35,7 +36,7 @@ vi.mock("../../../editorConfigApi", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn() },
+  toast: { error: toastErrorMock, success: vi.fn() },
 }));
 
 import { EndingEntitySubTab } from "../EndingEntitySubTab";
@@ -307,6 +308,75 @@ describe("EndingEntitySubTab", () => {
       }),
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
     );
+  });
+
+  it("결말 질문 대상을 특정 플레이어 여러 명으로 저장한다", () => {
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /하윤/ }));
+    fireEvent.click(screen.getByRole("button", { name: /민재/ }));
+    fireEvent.click(screen.getByRole("button", { name: "판정 설정 저장" }));
+
+    expect(configMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modules: expect.objectContaining({
+          ending_branch: expect.objectContaining({
+            config: expect.objectContaining({
+              questions: [
+                expect.objectContaining({
+                  respondents: "char-1",
+                  target: { type: "specific_players", characterIds: ["char-1", "char-2"] },
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("특정 플레이어 질문에서 대상이 비면 저장하지 않고 경고한다", () => {
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /하윤/ }));
+    fireEvent.click(screen.getByRole("button", { name: /하윤/ }));
+    fireEvent.click(screen.getByRole("button", { name: "판정 설정 저장" }));
+
+    expect(configMutateMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith("특정 플레이어 질문은 받을 캐릭터를 1명 이상 선택해야 합니다");
+  });
+
+  it("삭제된 캐릭터 참조를 깨지지 않는 fallback으로 표시한다", () => {
+    renderWithClient(
+      <EndingEntitySubTab
+        themeId="theme-1"
+        theme={{
+          ...theme,
+          config_json: {
+            modules: {
+              ending_branch: {
+                enabled: true,
+                config: {
+                  questions: [{
+                    id: "q1",
+                    text: "사라진 대상 질문",
+                    type: "single",
+                    choices: ["A", "B"],
+                    impact: "branch",
+                    target: { type: "specific_players", characterIds: ["missing-character"] },
+                  }],
+                  matrix: [{ priority: 1, ending: "ending-1", condition: { in: ["A", { var: "answers.q1.choices" }] } }],
+                  defaultEnding: "ending-2",
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("삭제된 캐릭터")).toBeDefined();
   });
 
   it("결말 선택지는 같은 질문 안에서 중복 저장되지 않는다", () => {

--- a/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
@@ -72,6 +72,74 @@ describe("endingBranchAdapter", () => {
     expect(viewModel.warnings).toEqual([]);
   });
 
+  it("target 없는 기존 질문은 모든 플레이어 대상으로 보정한다", () => {
+    const config = readEndingBranchConfig({
+      modules: {
+        ending_branch: {
+          enabled: true,
+          config: {
+            questions: [{ id: "q1", text: "범인은?", type: "single", choices: ["A", "B"], impact: "branch" }],
+          },
+        },
+      },
+    });
+
+    expect(config.questions[0]).toMatchObject({
+      respondents: "all",
+      target: { type: "all_players" },
+    });
+  });
+
+  it("legacy respondents 캐릭터 id를 specific_players target으로 읽는다", () => {
+    const config = readEndingBranchConfig({
+      modules: {
+        ending_branch: {
+          enabled: true,
+          config: {
+            questions: [{ id: "q1", text: "개인 질문", type: "single", choices: ["A", "B"], impact: "branch", respondents: "char-1" }],
+          },
+        },
+      },
+    });
+
+    expect(config.questions[0]).toMatchObject({
+      respondents: "char-1",
+      target: { type: "specific_players", characterIds: ["char-1"] },
+    });
+  });
+
+  it("specific_players target은 중복 없는 캐릭터 id 배열로 저장/로드한다", () => {
+    const saved = writeEndingBranchConfig(null, {
+      questions: [{
+        id: "q1",
+        text: "비밀 선택",
+        type: "multi",
+        choices: ["A", "B"],
+        respondents: "char-1",
+        target: { type: "specific_players", characterIds: ["char-1", "char-2"] },
+        impact: "score",
+      }],
+      matrix: [],
+      defaultEnding: "",
+    });
+
+    expect(saved).toMatchObject({
+      modules: {
+        ending_branch: {
+          config: {
+            questions: [expect.objectContaining({
+              target: { type: "specific_players", characterIds: ["char-1", "char-2"] },
+            })],
+          },
+        },
+      },
+    });
+    expect(readEndingBranchConfig(saved).questions[0].target).toEqual({
+      type: "specific_players",
+      characterIds: ["char-1", "char-2"],
+    });
+  });
+
   it("선택지가 비어 있는 결말 규칙은 저장 전 경고로 표시한다", () => {
     const viewModel = toEndingBranchEditorViewModel({
       modules: {
@@ -102,7 +170,7 @@ describe("endingBranchAdapter", () => {
     const question = createEndingBranchQuestion(0);
     const row = createEndingBranchMatrixRow({ questions: [question], matrix: [], defaultEnding: "" }, "end-1");
 
-    expect(question).toMatchObject({ id: "ending-question-1234-1", choices: ["선택지 1", "선택지 2"], respondents: "all" });
+    expect(question).toMatchObject({ id: "ending-question-1234-1", choices: ["선택지 1", "선택지 2"], respondents: "all", target: { type: "all_players" } });
     expect(row).toMatchObject({ priority: 1, ending: "end-1" });
     expect(readChoiceCondition(row.condition)).toEqual({ questionId: question.id, choice: "선택지 1" });
   });

--- a/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
@@ -10,6 +10,9 @@ export const ENDING_BRANCH_MODULE_ID = "ending_branch";
 
 export type EndingBranchQuestionType = "single" | "multi";
 export type EndingBranchQuestionImpact = "branch" | "score";
+export type EndingBranchQuestionTarget =
+  | { type: "all_players" }
+  | { type: "specific_players"; characterIds: string[] };
 
 export interface EndingBranchQuestion {
   id: string;
@@ -17,6 +20,7 @@ export interface EndingBranchQuestion {
   type: EndingBranchQuestionType;
   choices: string[];
   respondents: "all" | string;
+  target: EndingBranchQuestionTarget;
   impact: EndingBranchQuestionImpact;
   scoreMap?: Record<string, number>;
 }
@@ -85,6 +89,29 @@ function readScoreMap(value: unknown): Record<string, number> | undefined {
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
+function uniqueNonEmptyStrings(value: unknown): string[] {
+  return Array.from(new Set(stringList(value).map((item) => item.trim()).filter(Boolean)));
+}
+
+function readQuestionTarget(value: EditorConfig): EndingBranchQuestionTarget {
+  const target = isRecord(value.target) ? value.target : null;
+  if (target?.type === "specific_players") {
+    return { type: "specific_players", characterIds: uniqueNonEmptyStrings(target.characterIds) };
+  }
+  if (target?.type === "all_players") {
+    return { type: "all_players" };
+  }
+
+  if (typeof value.respondents === "string" && value.respondents.trim() && value.respondents !== "all") {
+    return { type: "specific_players", characterIds: [value.respondents.trim()] };
+  }
+  return { type: "all_players" };
+}
+
+function legacyRespondentsFromTarget(target: EndingBranchQuestionTarget): "all" | string {
+  return target.type === "specific_players" ? target.characterIds[0] ?? "" : "all";
+}
+
 function normalizeThreshold(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? Math.min(1, Math.max(0, value))
@@ -96,14 +123,14 @@ function normalizeQuestion(value: unknown, index: number): EndingBranchQuestion 
   const id = typeof value.id === "string" && value.id.trim() ? value.id.trim() : `question-${index + 1}`;
   const text = typeof value.text === "string" ? value.text : "";
   const choices = stringList(value.choices).filter((choice) => choice.trim());
+  const target = readQuestionTarget(value);
   return {
     id,
     text,
     type: readQuestionType(value.type),
     choices,
-    respondents: typeof value.respondents === "string" && value.respondents.trim()
-      ? value.respondents
-      : "all",
+    respondents: legacyRespondentsFromTarget(target),
+    target,
     impact: readQuestionImpact(value.impact),
     ...(readScoreMap(value.scoreMap) ? { scoreMap: readScoreMap(value.scoreMap) } : {}),
   };
@@ -166,6 +193,7 @@ export function createEndingBranchQuestion(index: number): EndingBranchQuestion 
     type: "single",
     choices: ["선택지 1", "선택지 2"],
     respondents: "all",
+    target: { type: "all_players" },
     impact: "branch",
   };
 }
@@ -279,6 +307,9 @@ function buildEndingBranchWarnings(config: EndingBranchConfig, endingNodes: Node
   for (const question of config.questions) {
     if (!question.text.trim()) warnings.push("내용이 비어 있는 결말 질문이 있습니다.");
     if (question.choices.length < 2) warnings.push(`'${question.text || "이름 없는 질문"}' 질문은 선택지가 2개 이상 필요합니다.`);
+    if (question.target.type === "specific_players" && question.target.characterIds.length === 0) {
+      warnings.push(`'${question.text || "이름 없는 질문"}' 질문의 받을 대상을 1명 이상 선택해 주세요.`);
+    }
   }
   for (const row of config.matrix) {
     if (!endingIds.has(row.ending)) warnings.push("결말 규칙 중 도착 결말이 비어 있습니다.");


### PR DESCRIPTION
## Summary
- 결말 질문에 `target` 저장 구조를 추가하고 기존 `respondents` payload를 `all_players` / `specific_players` 대상으로 보정합니다.
- 질문 카드 안에 기존 `OptionList` 패턴의 받을 대상 선택 UI를 추가했습니다.
- 특정 플레이어 대상이 비어 있으면 저장을 막고, 삭제된 캐릭터 참조는 `삭제된 캐릭터` fallback으로 표시합니다.

## Issue
Closes #479

## Coverage Plan
- `endingBranchAdapter`: target 없는 기존 payload의 `all_players` 기본값, legacy respondents 변환, `specific_players` 저장/로드 round-trip을 검증합니다.
- `EndingBranchQuestionList` / `EndingBranchRulesPanel`: 모든 플레이어 특수 항목, 여러 캐릭터 선택 저장 payload, 대상 미선택 저장 차단, 삭제된 캐릭터 fallback 표시를 검증합니다.
- `EndingEntitySubTab`: 실제 결말 설정 패널에서 characters query 데이터를 대상 선택 UI로 전달하는 흐름을 검증합니다.

## Local validation
- Figma `질문 관리 - 통합 / Desktop` node `23:2` 확인: 대상 선택은 `OptionList`형 카드와 `모든 플레이어` 특수 항목 기준으로 반영했습니다.
- `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx` passed (20 tests)
- `pnpm --filter @mmp/web typecheck` passed
- `pnpm --filter @mmp/web exec eslint src/features/editor/entities/ending/endingBranchAdapter.ts src/features/editor/components/design/EndingBranchQuestionList.tsx src/features/editor/components/design/EndingBranchRulesPanel.tsx src/features/editor/components/design/EndingEntitySubTab.tsx src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx` passed
- `git diff --check` passed
- `scripts/mmp-local-ci.sh quick` passed (`head=f2933f848600b88c55aba73e4b304ba4c73a03bb`, finished `2026-05-07T15:52:29Z`)

## E2E
별도 Playwright E2E는 추가하지 않았습니다. 이번 변경은 기존 결말 설정 패널 내부의 저장 payload/adapter/UI 선택 흐름이며, focused component tests와 local quick CI로 저장/로드 회귀를 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 엔딩 브랜치 질문에 대해 대상 캐릭터를 선택할 수 있는 UI 추가

* **버그 수정**
  * 특정 플레이어를 대상으로 하는 질문에서 캐릭터 미선택 시 저장 방지
  * 삭제된 캐릭터 참조 시 폴백 레이블 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->