### PR TITLE
feat(editor): 읽기 대사 테스트 플레이어 추가

### DIFF
--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -98,6 +98,7 @@ export function ReadingSectionEditor({
   const mediaById = useMemo(() => new Map(allMedia.map((media) => [media.id, media])), [allMedia]);
 
   const isDirty = useMemo(() => isReadingDraftDirty(draft, section), [draft, section]);
+  const previewLines = useMemo(() => normalizeReadingBlocks(draft.lines), [draft.lines]);
 
   // -------------------------------------------------------------------------
   // Block operations
@@ -428,7 +429,7 @@ export function ReadingSectionEditor({
       <ReadingSectionPreviewModal
         open={previewOpen}
         sectionName={draft.name || section.name}
-        lines={normalizeReadingBlocks(draft.lines)}
+        lines={previewLines}
         characters={characters}
         mediaById={mediaById}
         dirty={isDirty}

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FileInput, Music, Save, Trash2, X } from 'lucide-react';
+import { FileInput, Music, Play, Save, Trash2, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { queryClient } from '@/services/queryClient';
@@ -18,6 +18,7 @@ import type { MediaResponse } from '../../mediaApi';
 import { useMediaList } from '../../mediaApi';
 import { normalizeReadingBlocks } from '../../entities/story/readingBlockAdapter';
 import { ReadingBlockRow } from './ReadingBlockRow';
+import { ReadingSectionPreviewModal } from './ReadingSectionPreviewModal';
 import { ReadingScriptImportModal } from './ReadingScriptImportModal';
 import { EditorSaveConflictBanner } from '../EditorSaveConflictBanner';
 import {
@@ -62,6 +63,7 @@ export function ReadingSectionEditor({
   );
   const [bgmPickerOpen, setBgmPickerOpen] = useState(false);
   const [scriptImportOpen, setScriptImportOpen] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [conflict, setConflict] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -305,6 +307,14 @@ export function ReadingSectionEditor({
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
+              onClick={() => setPreviewOpen(true)}
+              className="inline-flex items-center gap-1 rounded border border-amber-500/50 px-2 py-1 text-xs font-medium text-amber-200 hover:bg-amber-500/10"
+            >
+              <Play className="h-3.5 w-3.5" />
+              테스트
+            </button>
+            <button
+              type="button"
               onClick={() => setScriptImportOpen(true)}
               className="inline-flex items-center gap-1 rounded border border-slate-700 px-2 py-1 text-xs text-slate-200 hover:bg-slate-800"
             >
@@ -414,6 +424,15 @@ export function ReadingSectionEditor({
         media={allMedia.map(toParserMedia)}
         onClose={() => setScriptImportOpen(false)}
         onApply={handleApplyParsedBlocks}
+      />
+      <ReadingSectionPreviewModal
+        open={previewOpen}
+        sectionName={draft.name || section.name}
+        lines={normalizeReadingBlocks(draft.lines)}
+        characters={characters}
+        mediaById={mediaById}
+        dirty={isDirty}
+        onClose={() => setPreviewOpen(false)}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
@@ -50,12 +50,12 @@ export function ReadingSectionPreviewModal({
 }: ReadingSectionPreviewModalProps) {
   const [index, setIndex] = useState(0);
   const [waitReady, setWaitReady] = useState(false);
-  const [autoApplied, setAutoApplied] = useState(false);
+  const autoAppliedRef = useRef(false);
   const latestRef = useRef<HTMLDivElement | null>(null);
 
   const currentLine = lines[index];
   const visibleLines = lines.slice(0, index + 1);
-  const waitMediaId = getReadingPreviewWaitMediaId(currentLine);
+  const waitMediaId = currentLine ? getReadingPreviewWaitMediaId(currentLine) : null;
   const activeBgm = useMemo(
     () => getReadingPreviewActiveBgm(lines, index, mediaById),
     [index, lines, mediaById]
@@ -73,15 +73,16 @@ export function ReadingSectionPreviewModal({
     if (!open) return;
     setIndex(0);
     setWaitReady(false);
-    setAutoApplied(false);
+    autoAppliedRef.current = false;
   }, [open, lines]);
 
   useEffect(() => {
     if (!open) return;
     setWaitReady(!waitMediaId);
-    setAutoApplied(false);
+    autoAppliedRef.current = false;
     if (!waitMediaId) return;
 
+    if (!currentLine) return;
     const type = getReadingPreviewBlockType(currentLine);
     const duration =
       type === 'video' ? readingPreviewVideoDurationMs : readingPreviewVoiceDurationMs;
@@ -90,14 +91,19 @@ export function ReadingSectionPreviewModal({
   }, [currentLine, index, open, waitMediaId]);
 
   useEffect(() => {
-    if (!open || !currentLine || autoApplied || getReadingPreviewBlockType(currentLine) !== 'bgm') {
+    if (
+      !open ||
+      !currentLine ||
+      autoAppliedRef.current ||
+      getReadingPreviewBlockType(currentLine) !== 'bgm'
+    ) {
       return;
     }
-    setAutoApplied(true);
+    autoAppliedRef.current = true;
     if (isLast) return;
     const timer = window.setTimeout(() => goNext(), readingPreviewBgmAdvanceDelayMs);
     return () => window.clearTimeout(timer);
-  }, [autoApplied, currentLine, goNext, isLast, open]);
+  }, [currentLine, goNext, isLast, open]);
 
   useEffect(() => {
     if (!open) return;

--- a/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Check,
+  Clapperboard,
+  Image as ImageIcon,
+  Mic,
+  Music,
+  Pause,
+  Play,
+  SkipForward,
+  StickyNote,
+  Video,
+  X,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { ReadingLineDTO } from '../../readingApi';
+import type { MediaResponse } from '../../mediaApi';
+import type { CharacterOption } from './readingBlockUiTypes';
+import {
+  getReadingPreviewActiveBgm,
+  getReadingPreviewAdvanceLabel,
+  getReadingPreviewBlockType,
+  getReadingPreviewMediaLabel,
+  getReadingPreviewMediaUrl,
+  getReadingPreviewWaitMediaId,
+  readingPreviewBgmAdvanceDelayMs,
+  readingPreviewVideoDurationMs,
+  readingPreviewVoiceDurationMs,
+} from './readingPreviewModel';
+
+export interface ReadingSectionPreviewModalProps {
+  open: boolean;
+  sectionName: string;
+  lines: ReadingLineDTO[];
+  characters: CharacterOption[];
+  mediaById: Map<string, MediaResponse>;
+  dirty: boolean;
+  onClose: () => void;
+}
+
+export function ReadingSectionPreviewModal({
+  open,
+  sectionName,
+  lines,
+  characters,
+  mediaById,
+  dirty,
+  onClose,
+}: ReadingSectionPreviewModalProps) {
+  const [index, setIndex] = useState(0);
+  const [waitReady, setWaitReady] = useState(false);
+  const [autoApplied, setAutoApplied] = useState(false);
+  const latestRef = useRef<HTMLDivElement | null>(null);
+
+  const currentLine = lines[index];
+  const visibleLines = lines.slice(0, index + 1);
+  const waitMediaId = getReadingPreviewWaitMediaId(currentLine);
+  const activeBgm = useMemo(
+    () => getReadingPreviewActiveBgm(lines, index, mediaById),
+    [index, lines, mediaById]
+  );
+  const stepLabel = lines.length > 0 ? `${index + 1} / ${lines.length}` : '0 / 0';
+  const advanceLabel = getReadingPreviewAdvanceLabel(currentLine?.AdvanceBy, characters);
+  const canContinue = !waitMediaId || waitReady;
+  const isLast = lines.length === 0 || index >= lines.length - 1;
+
+  const goNext = useCallback(() => {
+    setIndex((currentIndex) => Math.min(currentIndex + 1, Math.max(lines.length - 1, 0)));
+  }, [lines.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    setIndex(0);
+    setWaitReady(false);
+    setAutoApplied(false);
+  }, [open, lines]);
+
+  useEffect(() => {
+    if (!open) return;
+    setWaitReady(!waitMediaId);
+    setAutoApplied(false);
+    if (!waitMediaId) return;
+
+    const type = getReadingPreviewBlockType(currentLine);
+    const duration =
+      type === 'video' ? readingPreviewVideoDurationMs : readingPreviewVoiceDurationMs;
+    const timer = window.setTimeout(() => setWaitReady(true), duration);
+    return () => window.clearTimeout(timer);
+  }, [currentLine, index, open, waitMediaId]);
+
+  useEffect(() => {
+    if (!open || !currentLine || autoApplied || getReadingPreviewBlockType(currentLine) !== 'bgm') {
+      return;
+    }
+    setAutoApplied(true);
+    if (isLast) return;
+    const timer = window.setTimeout(() => goNext(), readingPreviewBgmAdvanceDelayMs);
+    return () => window.clearTimeout(timer);
+  }, [autoApplied, currentLine, goNext, isLast, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    latestRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [index, open, waitReady]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-slate-950/80 p-3 backdrop-blur-sm md:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reading-preview-title"
+    >
+      <div className="mx-auto flex h-full max-w-6xl flex-col overflow-hidden rounded-lg border border-slate-700 bg-slate-950 text-slate-100 shadow-2xl shadow-black/50">
+        <header className="flex flex-col gap-3 border-b border-slate-800 px-4 py-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-300">
+              Reading Test Player
+            </p>
+            <h2 id="reading-preview-title" className="text-lg font-semibold">
+              {sectionName} 테스트
+            </h2>
+            {dirty && (
+              <p className="mt-1 text-xs text-amber-200">
+                저장 전 변경사항을 포함해 미리보기합니다.
+              </p>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusPill icon={Clapperboard} label={stepLabel} />
+            <StatusPill icon={Music} label={activeBgm} />
+            <button
+              type="button"
+              aria-label="테스트 화면 닫기"
+              onClick={onClose}
+              className="inline-flex h-9 w-9 items-center justify-center rounded border border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </header>
+
+        <main className="flex min-h-0 flex-1 flex-col gap-4 p-4 md:p-5">
+          {lines.length === 0 ? (
+            <div className="rounded border border-dashed border-slate-700 bg-slate-900/70 p-8 text-center text-sm text-slate-300">
+              테스트할 대본 블록이 없습니다.
+            </div>
+          ) : (
+            <>
+              <section className="min-h-0 flex-1 space-y-4 overflow-y-auto rounded border border-slate-800 bg-slate-900/55 p-3 md:p-5">
+                {visibleLines.map((line, visibleIndex) => (
+                  <div
+                    key={`${line.Index}-${visibleIndex}`}
+                    ref={visibleIndex === visibleLines.length - 1 ? latestRef : undefined}
+                  >
+                    <PreviewBlock
+                      line={line}
+                      active={visibleIndex === visibleLines.length - 1}
+                      waitMediaId={visibleIndex === visibleLines.length - 1 ? waitMediaId : null}
+                      waitReady={visibleIndex === visibleLines.length - 1 ? waitReady : true}
+                      mediaById={mediaById}
+                    />
+                  </div>
+                ))}
+              </section>
+              <footer className="flex justify-center">
+                <button
+                  type="button"
+                  onClick={goNext}
+                  disabled={!canContinue || isLast}
+                  className="inline-flex min-h-12 items-center gap-2 rounded-full bg-amber-500 px-6 text-sm font-semibold text-slate-950 shadow-lg shadow-black/30 hover:bg-amber-400 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+                >
+                  {canContinue ? (
+                    <SkipForward className="h-4 w-4" />
+                  ) : (
+                    <Pause className="h-4 w-4" />
+                  )}
+                  {isLast ? '섹션 종료' : canContinue ? advanceLabel : '종료 대기'}
+                </button>
+              </footer>
+            </>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function PreviewBlock({
+  line,
+  active,
+  waitMediaId,
+  waitReady,
+  mediaById,
+}: {
+  line: ReadingLineDTO;
+  active: boolean;
+  waitMediaId: string | null;
+  waitReady: boolean;
+  mediaById: Map<string, MediaResponse>;
+}) {
+  const type = getReadingPreviewBlockType(line);
+  if (type === 'image') return <ImageBlock line={line} mediaById={mediaById} />;
+  if (type === 'video')
+    return (
+      <VideoBlock
+        line={line}
+        active={active}
+        waitMediaId={waitMediaId}
+        waitReady={waitReady}
+        mediaById={mediaById}
+      />
+    );
+  if (type === 'bgm') return <BgmBlock line={line} mediaById={mediaById} />;
+  if (type === 'gmNote') return <GmNoteBlock line={line} />;
+  return (
+    <DialogueBlock
+      line={line}
+      waitMediaId={waitMediaId}
+      waitReady={waitReady}
+      mediaById={mediaById}
+    />
+  );
+}
+
+function DialogueBlock({
+  line,
+  waitMediaId,
+  waitReady,
+  mediaById,
+}: {
+  line: ReadingLineDTO;
+  waitMediaId: string | null;
+  waitReady: boolean;
+  mediaById: Map<string, MediaResponse>;
+}) {
+  const imageUrl = getReadingPreviewMediaUrl(line.ImageMediaID, mediaById);
+  return (
+    <article className="rounded-md border border-slate-700 bg-slate-950/80 p-4 shadow-lg shadow-black/20">
+      <BlockLabel icon={Mic} label={line.Speaker || '나레이션'} tone="text-amber-200" />
+      {imageUrl && (
+        <img
+          className="mt-3 max-h-72 w-full rounded border border-slate-700 object-cover"
+          src={imageUrl}
+          alt=""
+        />
+      )}
+      <p className="mt-3 whitespace-pre-wrap text-xl font-semibold leading-relaxed text-white md:text-2xl">
+        {line.Text || '대사 본문이 비어 있습니다.'}
+      </p>
+      {waitMediaId && (
+        <WaitProgress
+          label={getReadingPreviewMediaLabel(waitMediaId, mediaById)}
+          ready={waitReady}
+        />
+      )}
+    </article>
+  );
+}
+
+function ImageBlock({
+  line,
+  mediaById,
+}: {
+  line: ReadingLineDTO;
+  mediaById: Map<string, MediaResponse>;
+}) {
+  const imageUrl = getReadingPreviewMediaUrl(line.MediaID, mediaById);
+  const widthClass =
+    line.Size === 'small' ? 'max-w-md' : line.Size === 'large' ? 'max-w-4xl' : 'max-w-2xl';
+  return (
+    <article className="rounded-md border border-sky-500/25 bg-slate-950/80 p-4">
+      <BlockLabel
+        icon={ImageIcon}
+        label={`${getReadingPreviewMediaLabel(line.MediaID, mediaById)} · ${line.Position ?? 'center'}`}
+        tone="text-sky-200"
+      />
+      {imageUrl ? (
+        <img
+          className={`mx-auto mt-3 max-h-[58vh] ${widthClass} rounded border border-slate-700 object-cover`}
+          src={imageUrl}
+          alt=""
+        />
+      ) : (
+        <MissingMedia />
+      )}
+    </article>
+  );
+}
+
+function VideoBlock({
+  line,
+  active,
+  waitMediaId,
+  waitReady,
+  mediaById,
+}: {
+  line: ReadingLineDTO;
+  active: boolean;
+  waitMediaId: string | null;
+  waitReady: boolean;
+  mediaById: Map<string, MediaResponse>;
+}) {
+  return (
+    <article className="rounded-md border border-violet-500/25 bg-slate-950/80 p-4">
+      <BlockLabel
+        icon={Video}
+        label={getReadingPreviewMediaLabel(line.MediaID, mediaById)}
+        tone="text-violet-200"
+      />
+      <div className="mt-3 flex aspect-video max-h-[46vh] items-center justify-center rounded border border-slate-700 bg-black/55">
+        <div className="text-center text-sm text-slate-300">
+          <Play className="mx-auto mb-3 h-10 w-10 text-violet-200" />
+          {line.Autoplay ? '자동 재생' : '수동 재생'} ·{' '}
+          {line.WaitUntilEnd ? '종료 대기' : '즉시 진행 가능'}
+        </div>
+      </div>
+      {active && waitMediaId && <WaitProgress label="영상 종료" ready={waitReady} />}
+    </article>
+  );
+}
+
+function BgmBlock({
+  line,
+  mediaById,
+}: {
+  line: ReadingLineDTO;
+  mediaById: Map<string, MediaResponse>;
+}) {
+  const label =
+    line.BGMMode === 'stop'
+      ? '현재 BGM 정지'
+      : `${getReadingPreviewMediaLabel(line.MediaID, mediaById)} · ${
+          line.BGMMode === 'once' ? '1회 재생' : '반복 재생'
+        }`;
+  return (
+    <article className="rounded-md border border-emerald-500/25 bg-emerald-500/10 p-5 text-center">
+      <Music className="mx-auto mb-3 h-8 w-8 text-emerald-200" />
+      <p className="font-semibold text-emerald-100">{label}</p>
+      <p className="mt-2 text-xs text-emerald-100/70">
+        BGM 큐는 적용 후 자동으로 다음 블록으로 넘어갑니다.
+      </p>
+    </article>
+  );
+}
+
+function GmNoteBlock({ line }: { line: ReadingLineDTO }) {
+  return (
+    <article className="rounded-md border border-slate-600 bg-slate-800/70 p-4">
+      <BlockLabel icon={StickyNote} label="GM 진행 메모" tone="text-slate-200" />
+      <p className="mt-3 whitespace-pre-wrap text-base leading-relaxed text-slate-100">
+        {line.Text || '메모가 비어 있습니다.'}
+      </p>
+    </article>
+  );
+}
+
+function WaitProgress({ label, ready }: { label: string; ready: boolean }) {
+  return (
+    <div className="mt-4 rounded border border-slate-700 bg-black/25 p-3">
+      <div className="mb-2 flex items-center justify-between text-xs text-slate-300">
+        <span className="inline-flex items-center gap-2">
+          {ready ? (
+            <Check className="h-4 w-4 text-emerald-300" />
+          ) : (
+            <Pause className="h-4 w-4 text-blue-300" />
+          )}
+          {ready ? '종료됨' : '진행 중'}
+        </span>
+        <span>{label}</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded bg-slate-800">
+        <div className={`h-full rounded bg-blue-400 ${ready ? 'w-full' : 'w-2/3 animate-pulse'}`} />
+      </div>
+    </div>
+  );
+}
+
+function StatusPill({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-200">
+      <Icon className="h-4 w-4 text-amber-300" />
+      {label}
+    </span>
+  );
+}
+
+function BlockLabel({
+  icon: Icon,
+  label,
+  tone,
+}: {
+  icon: LucideIcon;
+  label: string;
+  tone: string;
+}) {
+  return (
+    <p
+      className={`inline-flex items-center gap-2 rounded-full border border-slate-700 bg-white/5 px-3 py-1.5 text-sm ${tone}`}
+    >
+      <Icon className="h-4 w-4" />
+      {label}
+    </p>
+  );
+}
+
+function MissingMedia() {
+  return (
+    <div className="mt-3 flex h-52 items-center justify-center rounded border border-dashed border-slate-700 bg-slate-900 text-sm text-slate-400">
+      미디어 프리뷰 없음
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -562,7 +562,21 @@ describe('ReadingSectionEditor', () => {
     expect(within(dialog).getByText('저택 전경 · center')).toBeTruthy();
   });
 
-  it('auto-advances BGM cue in the test player preview', () => {
+  it('renders an empty test player without crashing', () => {
+    renderEditor({
+      section: {
+        ...sampleSection,
+        lines: [],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '테스트' }));
+
+    const dialog = screen.getByRole('dialog', { name: '오프닝 테스트' });
+    expect(within(dialog).getByText('0 / 0')).toBeTruthy();
+  });
+
+  it('auto-advances BGM cue in the test player preview', async () => {
     vi.useFakeTimers();
     useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
       if (type === 'BGM') {
@@ -601,11 +615,13 @@ describe('ReadingSectionEditor', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '테스트' }));
 
-    expect(screen.getByText('오프닝 테마 · 반복 재생')).toBeTruthy();
+    const dialog = screen.getByRole('dialog', { name: '오프닝 테스트' });
+    expect(within(dialog).getByText('오프닝 테마 · 반복 재생')).toBeTruthy();
+    await act(async () => {});
     act(() => {
       vi.advanceTimersByTime(700);
     });
-    expect(screen.getByText('조명을 낮춘다.')).toBeTruthy();
+    expect(within(dialog).getByText('조명을 낮춘다.')).toBeTruthy();
   });
 
   it('save button is disabled when not dirty', () => {

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+  act,
+  within,
+} from '@testing-library/react';
 import { toast } from 'sonner';
 
 // ---------------------------------------------------------------------------
@@ -108,6 +116,7 @@ let mutateAsyncUpdate: ReturnType<typeof vi.fn>;
 let mutateAsyncDelete: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
   Object.assign(navigator, {
     clipboard: {
       writeText: writeTextMock,
@@ -139,6 +148,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -468,6 +478,134 @@ describe('ReadingSectionEditor', () => {
       { Index: 0, Text: '누구냐?' },
       { Index: 1, Text: '어두운 방 안.' },
     ]);
+  });
+
+  it('opens a test player preview and advances after voice playback finishes', async () => {
+    vi.useFakeTimers();
+    useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
+      if (type === 'VOICE') {
+        return {
+          data: [
+            {
+              id: 'voice-1',
+              theme_id: 'theme-1',
+              name: '나레이션 음성',
+              type: 'VOICE',
+              source_type: 'FILE',
+              url: 'https://example.com/voice.mp3',
+              tags: [],
+              sort_order: 1,
+              created_at: '2026-04-05T00:00:00Z',
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      if (type === 'IMAGE') {
+        return {
+          data: [
+            {
+              id: 'image-1',
+              theme_id: 'theme-1',
+              name: '저택 전경',
+              type: 'IMAGE',
+              source_type: 'FILE',
+              url: 'https://example.com/image.png',
+              tags: [],
+              sort_order: 2,
+              created_at: '2026-04-05T00:00:00Z',
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: [], isLoading: false };
+    });
+
+    renderEditor({
+      section: {
+        ...sampleSection,
+        lines: [
+          {
+            Index: 0,
+            Type: 'dialogue',
+            Text: '모두 눈을 감아주세요.',
+            Speaker: '나레이션',
+            VoiceMediaID: 'voice-1',
+            AdvanceBy: 'voice',
+          },
+          {
+            Index: 1,
+            Type: 'image',
+            MediaID: 'image-1',
+            Position: 'center',
+            Size: 'medium',
+            AdvanceBy: 'gm',
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '테스트' }));
+
+    const dialog = screen.getByRole('dialog', { name: '오프닝 테스트' });
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByText('모두 눈을 감아주세요.')).toBeTruthy();
+    expect(within(dialog).getByRole<HTMLButtonElement>('button', { name: '종료 대기' }).disabled)
+      .toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2600);
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: '음성 종료 후 계속' }));
+
+    expect(within(dialog).getByText('저택 전경 · center')).toBeTruthy();
+  });
+
+  it('auto-advances BGM cue in the test player preview', () => {
+    vi.useFakeTimers();
+    useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
+      if (type === 'BGM') {
+        return {
+          data: [
+            {
+              id: 'bgm-1',
+              theme_id: 'theme-1',
+              name: '오프닝 테마',
+              type: 'BGM',
+              source_type: 'FILE',
+              tags: [],
+              sort_order: 1,
+              created_at: '2026-04-05T00:00:00Z',
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: [], isLoading: false };
+    });
+
+    renderEditor({
+      section: {
+        ...sampleSection,
+        lines: [
+          { Index: 0, Type: 'bgm', MediaID: 'bgm-1', BGMMode: 'loop' },
+          {
+            Index: 1,
+            Type: 'gmNote',
+            Text: '조명을 낮춘다.',
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '테스트' }));
+
+    expect(screen.getByText('오프닝 테마 · 반복 재생')).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(screen.getByText('조명을 낮춘다.')).toBeTruthy();
   });
 
   it('save button is disabled when not dirty', () => {

--- a/apps/web/src/features/editor/components/reading/readingPreviewModel.ts
+++ b/apps/web/src/features/editor/components/reading/readingPreviewModel.ts
@@ -1,0 +1,64 @@
+import type { AdvanceBy, ReadingBlockType, ReadingLineDTO } from '../../readingApi';
+import type { MediaResponse } from '../../mediaApi';
+import type { CharacterOption } from './readingBlockUiTypes';
+
+export const readingPreviewVoiceDurationMs = 2600;
+export const readingPreviewVideoDurationMs = 1800;
+export const readingPreviewBgmAdvanceDelayMs = 700;
+
+export function getReadingPreviewBlockType(line: ReadingLineDTO): ReadingBlockType {
+  return line.Type ?? 'dialogue';
+}
+
+export function getReadingPreviewAdvanceLabel(
+  advanceBy: AdvanceBy | undefined,
+  characters: CharacterOption[]
+): string {
+  if (advanceBy === 'voice') return '음성 종료 후 계속';
+  if (advanceBy?.startsWith('role:')) {
+    const characterId = advanceBy.slice('role:'.length);
+    return `${characters.find((character) => character.id === characterId)?.name ?? '선택 캐릭터'} 계속`;
+  }
+  return '방장 계속';
+}
+
+export function getReadingPreviewWaitMediaId(line: ReadingLineDTO): string | null {
+  const type = getReadingPreviewBlockType(line);
+  if (type === 'dialogue' && line.AdvanceBy === 'voice' && line.VoiceMediaID) {
+    return line.VoiceMediaID;
+  }
+  if (type === 'video' && line.WaitUntilEnd && line.MediaID) {
+    return line.MediaID;
+  }
+  return null;
+}
+
+export function getReadingPreviewActiveBgm(
+  lines: ReadingLineDTO[],
+  currentIndex: number,
+  mediaById: Map<string, MediaResponse>
+): string {
+  const cues = lines
+    .slice(0, currentIndex + 1)
+    .filter((line) => getReadingPreviewBlockType(line) === 'bgm');
+  const lastCue = cues.at(-1);
+  if (!lastCue || lastCue.BGMMode === 'stop') return 'BGM 없음';
+  const mediaName = getReadingPreviewMediaLabel(lastCue.MediaID, mediaById);
+  return `${mediaName} ${lastCue.BGMMode === 'once' ? '1회' : '반복'}`;
+}
+
+export function getReadingPreviewMediaLabel(
+  mediaId: string | undefined,
+  mediaById: Map<string, MediaResponse>
+): string {
+  if (!mediaId) return '미디어 미선택';
+  return mediaById.get(mediaId)?.name ?? '삭제된 미디어';
+}
+
+export function getReadingPreviewMediaUrl(
+  mediaId: string | undefined,
+  mediaById: Map<string, MediaResponse>
+): string | undefined {
+  if (!mediaId) return undefined;
+  return mediaById.get(mediaId)?.url;
+}


### PR DESCRIPTION
## 요약
- 읽기 대사 섹션 편집기에서 현재 초안 대본을 바로 재생해 보는 `테스트` 모달을 추가했습니다.
- 대사/이미지/영상/BGM/GM 노트 블록을 순서대로 누적 표시하고, 음성/영상/BGM cue는 실제 진행 흐름처럼 일정 시간 후 다음 단계로 넘어갈 수 있게 했습니다.
- #496에서 추가한 블록 편집 UI와 연결해 제작자가 저장 전에도 플레이어 화면 흐름을 확인할 수 있게 했습니다.

Closes #473

## Coverage Plan
- `apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx`: `테스트` 버튼 wiring, 현재 draft lines 전달, unsaved 상태 안내를 `ReadingSectionEditor.test.tsx`에서 검증했습니다.
- `apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx`: 음성 대기, 이미지 표시, BGM cue 자동 진행, GM 노트 표시를 component test로 검증했습니다.
- `apps/web/src/features/editor/components/reading/readingPreviewModel.ts`: preview block 분류/label/media helper는 preview modal 테스트와 기존 reading block adapter 테스트 조합으로 검증했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts` PASS
- `pnpm --filter @mmp/web exec eslint src/features/editor/components/reading/ReadingSectionEditor.tsx src/features/editor/components/reading/ReadingSectionPreviewModal.tsx src/features/editor/components/reading/readingPreviewModel.ts src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx` PASS
- `pnpm --filter @mmp/web typecheck` PASS
- `scripts/mmp-local-ci.sh quick` PASS: backend tests, lint, typecheck, web tests 174 files / 1599 tests, web production build까지 성공

## Notes
- `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않았습니다.
- Vite build의 기존 Rollup circular re-export warning은 이번 변경 파일이 만든 신규 warning이 아니라 기존 editor API chunk 경고입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리딩 섹션에 "테스트" 미리보기 버튼 추가 — 미리보기 모달에서 블록별 재생 순서, 음성·영상·이미지·BGM 재생 및 자동 진행을 확인할 수 있습니다.
  * 미리보기는 현재 섹션명, 미리보기 라인, 캐릭터·미디어 정보를 반영해 실시간 상태를 보여줍니다.

* **테스트**
  * 플레이어 자동 진행, 음성/영상 완료 대기, 루프된 BGM 동작 및 빈 섹션 미리보기에 대한 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->