### PR TITLE
feat(editor): 결말 판정 규칙 런타임 연결

### DIFF
--- a/apps/server/internal/module/decision/ending_branch/config.go
+++ b/apps/server/internal/module/decision/ending_branch/config.go
@@ -1,23 +1,54 @@
 package ending_branch
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // Question represents one editor-defined question (D-12 + D-24).
 // Impact is "branch" (matrix-driving) OR "score" (per-respondent accumulation).
 type Question struct {
-	ID          string         `json:"id"`
-	Text        string         `json:"text"`
-	Type        string         `json:"type"` // "single" | "multi"
-	Choices     []string       `json:"choices"`
-	Respondents any            `json:"respondents,omitempty"` // []string | "all" — validated at config apply
-	Impact      string         `json:"impact"`                // "branch" | "score"
-	ScoreMap    map[string]int `json:"scoreMap,omitempty"`
+	ID          string          `json:"id"`
+	Text        string          `json:"text"`
+	Type        string          `json:"type"` // "single" | "multi"
+	Choices     []string        `json:"choices"`
+	Respondents any             `json:"respondents,omitempty"` // []string | "all" — validated at config apply
+	Target      *QuestionTarget `json:"target,omitempty"`
+	Impact      string          `json:"impact"` // "branch" | "score"
+	ScoreMap    map[string]int  `json:"scoreMap,omitempty"`
+}
+
+type QuestionTarget struct {
+	Type         string   `json:"type"`
+	CharacterIDs []string `json:"characterIds,omitempty"`
 }
 
 // MatrixRow is one priority-ordered branching rule. Runtime evaluation passes
 // Conditions to the shared JSONLogic evaluator.
 type MatrixRow struct {
+	ID         string         `json:"id,omitempty"`
 	Priority   int            `json:"priority"`
 	Conditions map[string]any `json:"conditions"`
 	Ending     string         `json:"ending"`
+}
+
+func (r *MatrixRow) UnmarshalJSON(data []byte) error {
+	type matrixRowAlias MatrixRow
+	var raw struct {
+		matrixRowAlias
+		Condition map[string]any `json:"condition"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*r = MatrixRow(raw.matrixRowAlias)
+	if r.Conditions != nil && raw.Condition != nil {
+		return fmt.Errorf("matrix row cannot contain both conditions and legacy condition")
+	}
+	if r.Conditions == nil {
+		r.Conditions = raw.Condition
+	}
+	return nil
 }
 
 // Config is the typed shape of module_configs.ending_branch.

--- a/apps/server/internal/module/decision/ending_branch/config_validation.go
+++ b/apps/server/internal/module/decision/ending_branch/config_validation.go
@@ -26,6 +26,9 @@ func validateConfig(cfg Config) error {
 		if len(question.Choices) == 0 {
 			return fmt.Errorf("question %q requires at least one choice", question.ID)
 		}
+		if err := validateQuestionTarget(question.ID, question.Target); err != nil {
+			return err
+		}
 		if err := validateRespondents(question.ID, question.Respondents); err != nil {
 			return err
 		}
@@ -60,6 +63,28 @@ func validateConfig(cfg Config) error {
 	return nil
 }
 
+func validateQuestionTarget(questionID string, target *QuestionTarget) error {
+	if target == nil {
+		return nil
+	}
+	switch target.Type {
+	case "all_players":
+		return nil
+	case "specific_players":
+		if len(target.CharacterIDs) == 0 {
+			return fmt.Errorf("question %q target must contain at least one character id", questionID)
+		}
+		for _, characterID := range target.CharacterIDs {
+			if characterID == "" {
+				return fmt.Errorf("question %q target must contain non-empty character ids", questionID)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("question %q has invalid target type %q", questionID, target.Type)
+	}
+}
+
 func validateRespondents(questionID string, respondents any) error {
 	switch value := respondents.(type) {
 	case nil:
@@ -71,7 +96,7 @@ func validateRespondents(questionID string, respondents any) error {
 		case "some":
 			return fmt.Errorf("question %q respondents value %q is not supported; use explicit player or target codes", questionID, value)
 		default:
-			return fmt.Errorf("question %q has invalid respondents value %q", questionID, value)
+			return nil
 		}
 	case []any:
 		if len(value) == 0 {

--- a/apps/server/internal/module/decision/ending_branch/module.go
+++ b/apps/server/internal/module/decision/ending_branch/module.go
@@ -150,7 +150,10 @@ func (m *Module) ReactTo(_ context.Context, action engine.PhaseActionPayload) er
 			Type: "ending.evaluated",
 			Payload: map[string]any{
 				"selectedEnding":  result.SelectedEnding,
+				"matchedRuleId":   result.MatchedRuleID,
 				"matchedPriority": result.MatchedPriority,
+				"fallback":        result.Fallback,
+				"answerSummary":   result.AnswerSummary,
 			},
 		})
 	}
@@ -161,7 +164,10 @@ func evaluationResultsEqual(a, b *evaluationResult) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	if a.SelectedEnding != b.SelectedEnding || !matchedPriorityEqual(a.MatchedPriority, b.MatchedPriority) {
+	if a.SelectedEnding != b.SelectedEnding ||
+		a.MatchedRuleID != b.MatchedRuleID ||
+		a.Fallback != b.Fallback ||
+		!matchedPriorityEqual(a.MatchedPriority, b.MatchedPriority) {
 		return false
 	}
 	if len(a.Scores) != len(b.Scores) {
@@ -218,6 +224,15 @@ func (m *Module) Schema() json.RawMessage {
 						"respondents": map[string]any{
 							"description": "all or array of player IDs / character target codes",
 						},
+						"target": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"type":         map[string]any{"type": "string", "enum": []string{"all_players", "specific_players"}},
+								"characterIds": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+							},
+							"required":             []string{"type"},
+							"additionalProperties": false,
+						},
 						"impact": map[string]any{"type": "string", "enum": []string{"branch", "score"}},
 						"scoreMap": map[string]any{
 							"type":                 "object",
@@ -233,6 +248,7 @@ func (m *Module) Schema() json.RawMessage {
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
+						"id":         map[string]any{"type": "string"},
 						"priority":   map[string]any{"type": "integer", "minimum": 1},
 						"conditions": map[string]any{"type": "object"},
 						"ending":     map[string]any{"type": "string"},

--- a/apps/server/internal/module/decision/ending_branch/module_test.go
+++ b/apps/server/internal/module/decision/ending_branch/module_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/mmp-platform/server/internal/engine"
 )
 
+type endingBranchTestPlayerProvider struct {
+	byTarget map[string]uuid.UUID
+}
+
+func (p endingBranchTestPlayerProvider) ResolvePlayerID(_ context.Context, targetCode string) (uuid.UUID, bool) {
+	id, ok := p.byTarget[targetCode]
+	return id, ok
+}
+
+func (p endingBranchTestPlayerProvider) PlayerRuntimeInfo(_ context.Context, playerID uuid.UUID) (engine.PlayerRuntimeInfo, bool) {
+	return engine.PlayerRuntimeInfo{PlayerID: playerID}, true
+}
+
 func TestModule_Name(t *testing.T) {
 	m := NewModule()
 	assert.Equal(t, "ending_branch", m.Name())
@@ -154,6 +167,39 @@ func TestModule_HandleMessage_SubmitAnswerAndPlayerAwareState(t *testing.T) {
 	assert.NotEqual(t, answersA["q1"], answersB["q1"], "players must not receive sibling answers")
 }
 
+func TestModule_HandleMessage_UsesSpecificPlayerTarget(t *testing.T) {
+	playerA := uuid.New()
+	playerB := uuid.New()
+	playerC := uuid.New()
+	provider := endingBranchTestPlayerProvider{byTarget: map[string]uuid.UUID{
+		"char-1": playerA,
+		"char-2": playerB,
+	}}
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [
+			{
+				"id": "q1",
+				"text": "대상 질문",
+				"type": "single",
+				"choices": ["A","B"],
+				"respondents": "char-1",
+				"target": {"type":"specific_players","characterIds":["char-1","char-2"]},
+				"impact": "branch"
+			}
+		],
+		"matrix": [],
+		"defaultEnding": "미해결"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{PlayerInfoProvider: provider}, cfg))
+
+	require.NoError(t, m.HandleMessage(context.Background(), playerA, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"A"}`)))
+	require.NoError(t, m.HandleMessage(context.Background(), playerB, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"B"}`)))
+	err := m.HandleMessage(context.Background(), playerC, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"A"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
 func TestModule_ReactTo_EvaluatesPriorityMatrixAndPublishesEvent(t *testing.T) {
 	bus := engine.NewEventBus(nil)
 	var events []engine.Event
@@ -218,6 +264,89 @@ func TestModule_ReactTo_SelectedEndingPreservesFlowNodeID(t *testing.T) {
 	require.Len(t, events, 1)
 	payload := events[0].Payload.(map[string]any)
 	assert.Equal(t, endingID, payload["selectedEnding"])
+}
+
+func TestModule_ApplyConfig_AcceptsLegacyConditionKey(t *testing.T) {
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [
+			{"id": "q1", "text": "진범은?", "type": "single", "choices": ["A","B"], "impact": "branch"}
+		],
+		"matrix": [
+			{"priority": 1, "condition": {"==": [{"var":"answers.q1.winning"}, "A"]}, "ending": "진실"}
+		],
+		"defaultEnding": "미해결"
+	}`)
+
+	require.NoError(t, m.ApplyConfig(context.Background(), cfg))
+	require.Len(t, m.cfg.Matrix, 1)
+	assert.Equal(t, map[string]any{"==": []any{map[string]any{"var": "answers.q1.winning"}, "A"}}, m.cfg.Matrix[0].Conditions)
+}
+
+func TestModule_ReactTo_ThresholdRuleReturnsAnswerSummary(t *testing.T) {
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [
+			{"id": "q1", "text": "진범은?", "type": "single", "choices": ["A","B"], "impact": "branch"}
+		],
+		"matrix": [
+			{"id":"rule-a-majority","priority": 1, "conditions": {"in": ["A", {"var":"answers.q1.choices"}]}, "ending": "진실"}
+		],
+		"defaultEnding": "미해결",
+		"multiVoteThreshold": 0.5
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{}, cfg))
+	playerA := uuid.New()
+	playerB := uuid.New()
+	playerC := uuid.New()
+	require.NoError(t, m.HandleMessage(context.Background(), playerA, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"A"}`)))
+	require.NoError(t, m.HandleMessage(context.Background(), playerB, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"A"}`)))
+	require.NoError(t, m.HandleMessage(context.Background(), playerC, "submit_answer", json.RawMessage(`{"question_id":"q1","choice":"B"}`)))
+
+	require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+	raw, err := m.BuildState()
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal(raw, &state))
+	result := state["result"].(map[string]any)
+	assert.Equal(t, "진실", result["selectedEnding"])
+	assert.Equal(t, false, result["fallback"])
+	assert.Equal(t, "rule-a-majority", result["matchedRuleId"])
+	summaries := result["answerSummary"].([]any)
+	require.Len(t, summaries, 1)
+	summary := summaries[0].(map[string]any)
+	assert.Equal(t, "q1", summary["questionId"])
+	assert.Equal(t, float64(3), summary["answered"])
+	assert.Equal(t, "A", summary["winningChoice"])
+	assert.Equal(t, []any{"A"}, summary["thresholdChoices"])
+	counts := summary["counts"].(map[string]any)
+	assert.Equal(t, float64(2), counts["A"])
+	assert.Equal(t, float64(1), counts["B"])
+}
+
+func TestModule_ReactTo_FallbackWhenNoRuleMatches(t *testing.T) {
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [
+			{"id": "q1", "text": "진범은?", "type": "single", "choices": ["A","B"], "impact": "branch"}
+		],
+		"matrix": [
+			{"priority": 1, "conditions": {"==": [{"var":"answers.q1.winning"}, "A"]}, "ending": "진실"}
+		],
+		"defaultEnding": "미해결"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{}, cfg))
+	require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+	raw, err := m.BuildState()
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal(raw, &state))
+	result := state["result"].(map[string]any)
+	assert.Equal(t, "미해결", result["selectedEnding"])
+	assert.Equal(t, true, result["fallback"])
+	assert.NotContains(t, result, "matchedPriority")
 }
 
 func TestModule_BuildStateAfterEvaluationSeparatesAdminScoresFromPlayerState(t *testing.T) {

--- a/apps/server/internal/module/decision/ending_branch/runtime.go
+++ b/apps/server/internal/module/decision/ending_branch/runtime.go
@@ -18,9 +18,20 @@ type submittedAnswer struct {
 }
 
 type evaluationResult struct {
-	SelectedEnding  string         `json:"selectedEnding"`
-	MatchedPriority *int           `json:"matchedPriority,omitempty"`
-	Scores          map[string]int `json:"scores,omitempty"`
+	SelectedEnding  string          `json:"selectedEnding"`
+	MatchedRuleID   string          `json:"matchedRuleId,omitempty"`
+	MatchedPriority *int            `json:"matchedPriority,omitempty"`
+	Fallback        bool            `json:"fallback"`
+	AnswerSummary   []answerSummary `json:"answerSummary,omitempty"`
+	Scores          map[string]int  `json:"scores,omitempty"`
+}
+
+type answerSummary struct {
+	QuestionID       string         `json:"questionId"`
+	Answered         int            `json:"answered"`
+	Counts           map[string]int `json:"counts"`
+	WinningChoice    string         `json:"winningChoice,omitempty"`
+	ThresholdChoices []string       `json:"thresholdChoices,omitempty"`
 }
 
 func (m *Module) submitAnswer(ctx context.Context, playerID uuid.UUID, payload json.RawMessage) error {
@@ -76,10 +87,22 @@ func (m *Module) evaluateLocked() (*evaluationResult, error) {
 		}
 		if res.Bool {
 			priority := row.Priority
-			return &evaluationResult{SelectedEnding: row.Ending, MatchedPriority: &priority, Scores: scoreTotals(ctx)}, nil
+			return &evaluationResult{
+				SelectedEnding:  row.Ending,
+				MatchedRuleID:   row.ID,
+				MatchedPriority: &priority,
+				Fallback:        false,
+				AnswerSummary:   m.answerSummariesLocked(),
+				Scores:          scoreTotals(ctx),
+			}, nil
 		}
 	}
-	return &evaluationResult{SelectedEnding: m.cfg.DefaultEnding, Scores: scoreTotals(ctx)}, nil
+	return &evaluationResult{
+		SelectedEnding: m.cfg.DefaultEnding,
+		Fallback:       true,
+		AnswerSummary:  m.answerSummariesLocked(),
+		Scores:         scoreTotals(ctx),
+	}, nil
 }
 
 func (m *Module) evaluationContextLocked() map[string]any {
@@ -116,6 +139,31 @@ func scoreTotals(ctx map[string]any) map[string]int {
 		out[k] = v
 	}
 	return out
+}
+
+func (m *Module) answerSummariesLocked() []answerSummary {
+	if len(m.cfg.Questions) == 0 {
+		return nil
+	}
+	summaries := make([]answerSummary, 0, len(m.cfg.Questions))
+	threshold := m.thresholdLocked()
+	for _, question := range m.cfg.Questions {
+		byPlayer := m.answers[question.ID]
+		counts := make(map[string]int, len(question.Choices))
+		for _, choices := range byPlayer {
+			for _, choice := range choices {
+				counts[choice]++
+			}
+		}
+		summaries = append(summaries, answerSummary{
+			QuestionID:       question.ID,
+			Answered:         len(byPlayer),
+			Counts:           counts,
+			WinningChoice:    winningChoice(counts),
+			ThresholdChoices: thresholdChoices(counts, len(byPlayer), threshold),
+		})
+	}
+	return summaries
 }
 
 func findQuestion(questions []Question, questionID string) (Question, bool) {
@@ -158,6 +206,21 @@ func normalizeAnswerChoices(question Question, input submittedAnswer) ([]string,
 }
 
 func respondentAllowed(ctx context.Context, deps engine.ModuleDeps, question Question, playerID uuid.UUID) bool {
+	if question.Target != nil {
+		switch question.Target.Type {
+		case "all_players", "":
+			return true
+		case "specific_players":
+			items := make([]any, len(question.Target.CharacterIDs))
+			for i, item := range question.Target.CharacterIDs {
+				items[i] = item
+			}
+			return respondentListAllows(ctx, deps, items, playerID)
+		default:
+			return false
+		}
+	}
+
 	switch respondents := question.Respondents.(type) {
 	case nil:
 		return true
@@ -165,7 +228,10 @@ func respondentAllowed(ctx context.Context, deps engine.ModuleDeps, question Que
 		if respondents == "some" && deps.Logger != nil {
 			deps.Logger.Printf("ending_branch: unsupported respondents value %q", respondents)
 		}
-		return respondents == "" || respondents == "all"
+		if respondents == "" || respondents == "all" {
+			return true
+		}
+		return respondentListAllows(ctx, deps, []any{respondents}, playerID)
 	case []any:
 		return respondentListAllows(ctx, deps, respondents, playerID)
 	case []string:
@@ -238,11 +304,17 @@ func (m *Module) stateLocked(playerID *uuid.UUID) (json.RawMessage, error) {
 	}
 	if m.result != nil {
 		state["selectedEnding"] = m.result.SelectedEnding
+		state["fallback"] = m.result.Fallback
 		if m.result.MatchedPriority != nil {
 			state["matchedPriority"] = *m.result.MatchedPriority
 		}
 		result := map[string]any{
 			"selectedEnding": m.result.SelectedEnding,
+			"fallback":       m.result.Fallback,
+			"answerSummary":  m.result.AnswerSummary,
+		}
+		if m.result.MatchedRuleID != "" {
+			result["matchedRuleId"] = m.result.MatchedRuleID
 		}
 		if m.result.MatchedPriority != nil {
 			result["matchedPriority"] = *m.result.MatchedPriority

--- a/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
@@ -131,6 +131,7 @@ function MatrixRuleRow({ draft, rowIndex, endingNodes, branchQuestions, onChange
       <div className="mt-3 grid gap-3">
         <QuestionSelect draft={draft} rowIndex={rowIndex} selectedQuestionId={parsed?.questionId ?? ""} branchQuestions={branchQuestions} onChange={onChange} />
         <ChoiceSelect draft={draft} rowIndex={rowIndex} selectedQuestion={selectedQuestion} selectedChoice={parsed?.choice ?? ""} onChange={onChange} />
+        <AggregationSelect draft={draft} rowIndex={rowIndex} selectedQuestion={selectedQuestion} selectedChoice={parsed?.choice ?? ""} aggregation={parsed?.aggregation ?? "threshold"} onChange={onChange} />
         <EndingSelect draft={draft} rowIndex={rowIndex} endingNodes={endingNodes} onChange={onChange} />
       </div>
     </article>
@@ -153,13 +154,46 @@ function QuestionSelect({ draft, rowIndex, selectedQuestionId, branchQuestions, 
           ...draft,
           matrix: draft.matrix.map((item, index) =>
             index === rowIndex
-              ? (question ? updateMatrixCondition(item, question.id, "") : { ...item, condition: {} })
+              ? (question ? updateMatrixCondition(item, question.id, "", "threshold") : { ...item, condition: {} })
               : item,
           ),
         });
       }} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
         <option value="">질문 선택</option>
         {branchQuestions.map((question) => <option key={question.id} value={question.id}>{question.text || "질문 내용 필요"}</option>)}
+      </select>
+    </label>
+  );
+}
+
+function AggregationSelect({ draft, rowIndex, selectedQuestion, selectedChoice, aggregation, onChange }: {
+  draft: EndingBranchConfig;
+  rowIndex: number;
+  selectedQuestion?: EndingBranchQuestion;
+  selectedChoice: string;
+  aggregation: "threshold" | "winning";
+  onChange: (next: EndingBranchConfig) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-medium text-slate-400">어떤 기준이면</span>
+      <select
+        value={aggregation}
+        onChange={(event) =>
+          selectedQuestion && selectedChoice && onChange({
+            ...draft,
+            matrix: draft.matrix.map((item, index) =>
+              index === rowIndex
+                ? updateMatrixCondition(item, selectedQuestion.id, selectedChoice, event.target.value === "winning" ? "winning" : "threshold")
+                : item,
+            ),
+          })
+        }
+        disabled={!selectedQuestion || !selectedChoice}
+        className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <option value="threshold">설정한 비율 이상 선택되면</option>
+        <option value="winning">가장 많이 선택되면</option>
       </select>
     </label>
   );

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -298,7 +298,7 @@ describe("EndingEntitySubTab", () => {
               matrix: [
                 expect.objectContaining({
                   ending: "ending-1",
-                  condition: { in: ["하윤", { var: "answers.q1.choices" }] },
+                  conditions: { in: ["하윤", { var: "answers.q1.choices" }] },
                 }),
               ],
               defaultEnding: "ending-2",
@@ -393,6 +393,31 @@ describe("EndingEntitySubTab", () => {
               questions: [
                 expect.objectContaining({
                   choices: ["하윤", "민재"],
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("가장 많이 선택된 답 기준 결말 규칙을 저장한다", () => {
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    fireEvent.change(screen.getByLabelText("어떤 기준이면"), { target: { value: "winning" } });
+    fireEvent.click(screen.getByRole("button", { name: "판정 설정 저장" }));
+
+    expect(configMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modules: expect.objectContaining({
+          ending_branch: expect.objectContaining({
+            config: expect.objectContaining({
+              matrix: [
+                expect.objectContaining({
+                  ending: "ending-1",
+                  conditions: { "==": [{ var: "answers.q1.winning" }, "하윤"] },
                 }),
               ],
             }),

--- a/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { Node } from "@xyflow/react";
 import {
   buildChoiceCondition,
+  buildWinningChoiceCondition,
   createEndingBranchMatrixRow,
   createEndingBranchQuestion,
   readChoiceCondition,
@@ -44,7 +45,11 @@ describe("endingBranchAdapter", () => {
       modules: {
         ending_branch: {
           enabled: true,
-          config: expect.objectContaining({ defaultEnding: "end-2", multiVoteThreshold: 0.6 }),
+          config: expect.objectContaining({
+            defaultEnding: "end-2",
+            multiVoteThreshold: 0.6,
+            matrix: [{ priority: 2, ending: "end-1", conditions: buildChoiceCondition("q1", "A") }],
+          }),
         },
       },
     });
@@ -66,7 +71,7 @@ describe("endingBranchAdapter", () => {
     }, [endingNode("end-truth", "진실"), endingNode("end-fail", "미해결")]);
 
     expect(viewModel.questions[0]).toMatchObject({ label: "누가 진범인가?", typeLabel: "하나 선택", impactLabel: "결말 분기" });
-    expect(viewModel.matrix[0]).toMatchObject({ questionId: "q1", choice: "하윤", endingName: "진실" });
+    expect(viewModel.matrix[0]).toMatchObject({ questionId: "q1", choice: "하윤", aggregation: "threshold", endingName: "진실" });
     expect(viewModel.defaultEndingName).toBe("미해결");
     expect(viewModel.thresholdPercent).toBe(50);
     expect(viewModel.warnings).toEqual([]);
@@ -161,9 +166,18 @@ describe("endingBranchAdapter", () => {
   it("선택지 조건을 JSONLogic으로 숨겨 저장하고 다시 읽는다", () => {
     const condition = buildChoiceCondition("q1", "비밀 편지 획득");
     expect(condition).toEqual({ in: ["비밀 편지 획득", { var: "answers.q1.choices" }] });
-    expect(readChoiceCondition(condition)).toEqual({ questionId: "q1", choice: "비밀 편지 획득" });
+    expect(readChoiceCondition(condition)).toEqual({ questionId: "q1", choice: "비밀 편지 획득", aggregation: "threshold" });
     expect(updateMatrixCondition({ priority: 1, ending: "end-1", condition: {} }, "q2", "A").condition)
       .toEqual({ in: ["A", { var: "answers.q2.choices" }] });
+  });
+
+  it("가장 많이 선택된 답 기준 조건도 읽고 저장한다", () => {
+    const condition = buildWinningChoiceCondition("q1", "하윤");
+
+    expect(condition).toEqual({ "==": [{ var: "answers.q1.winning" }, "하윤"] });
+    expect(readChoiceCondition(condition)).toEqual({ questionId: "q1", choice: "하윤", aggregation: "winning" });
+    expect(updateMatrixCondition({ priority: 1, ending: "end-1", condition: {} }, "q2", "B", "winning").condition)
+      .toEqual({ "==": [{ var: "answers.q2.winning" }, "B"] });
   });
 
   it("새 질문과 규칙의 기본값은 제작자가 바로 수정 가능한 형태다", () => {
@@ -172,6 +186,6 @@ describe("endingBranchAdapter", () => {
 
     expect(question).toMatchObject({ id: "ending-question-1234-1", choices: ["선택지 1", "선택지 2"], respondents: "all", target: { type: "all_players" } });
     expect(row).toMatchObject({ priority: 1, ending: "end-1" });
-    expect(readChoiceCondition(row.condition)).toEqual({ questionId: question.id, choice: "선택지 1" });
+    expect(readChoiceCondition(row.condition)).toEqual({ questionId: question.id, choice: "선택지 1", aggregation: "threshold" });
   });
 });

--- a/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
@@ -10,6 +10,7 @@ export const ENDING_BRANCH_MODULE_ID = "ending_branch";
 
 export type EndingBranchQuestionType = "single" | "multi";
 export type EndingBranchQuestionImpact = "branch" | "score";
+export type EndingBranchAggregation = "threshold" | "winning";
 export type EndingBranchQuestionTarget =
   | { type: "all_players" }
   | { type: "specific_players"; characterIds: string[] };
@@ -51,6 +52,7 @@ export interface EndingBranchMatrixDraft {
   priority: number;
   questionId: string | null;
   choice: string | null;
+  aggregation: EndingBranchAggregation;
   endingId: string;
   endingName: string;
 }
@@ -139,7 +141,11 @@ function normalizeQuestion(value: unknown, index: number): EndingBranchQuestion 
 function normalizeMatrixRow(value: unknown, index: number): EndingBranchMatrixRow | null {
   if (!isRecord(value)) return null;
   const ending = typeof value.ending === "string" ? value.ending : "";
-  const condition = isRecord(value.condition) ? value.condition : {};
+  const condition = isRecord(value.conditions)
+    ? value.conditions
+    : isRecord(value.condition)
+      ? value.condition
+      : {};
   const priority = typeof value.priority === "number" && Number.isFinite(value.priority)
     ? value.priority
     : index + 1;
@@ -178,7 +184,11 @@ export function writeEndingBranchConfig(
 ): EditorConfig {
   return writeModuleConfig(configJson, ENDING_BRANCH_MODULE_ID, {
     questions: config.questions,
-    matrix: config.matrix,
+    matrix: config.matrix.map((row) => ({
+      priority: row.priority,
+      ending: row.ending,
+      conditions: row.condition,
+    })),
     defaultEnding: config.defaultEnding,
     ...(config.multiVoteThreshold !== undefined
       ? { multiVoteThreshold: config.multiVoteThreshold }
@@ -217,23 +227,42 @@ export function buildChoiceCondition(questionId: string, choice: string): Editor
   return { in: [choice, { var: `answers.${questionId}.choices` }] };
 }
 
+export function buildWinningChoiceCondition(questionId: string, choice: string): EditorConfig {
+  return { "==": [{ var: `answers.${questionId}.winning` }, choice] };
+}
+
 export function updateMatrixCondition(
   row: EndingBranchMatrixRow,
   questionId: string,
   choice: string,
+  aggregation: EndingBranchAggregation = readChoiceCondition(row.condition)?.aggregation ?? "threshold",
 ): EndingBranchMatrixRow {
-  return { ...row, condition: buildChoiceCondition(questionId, choice) };
+  return {
+    ...row,
+    condition: aggregation === "winning"
+      ? buildWinningChoiceCondition(questionId, choice)
+      : buildChoiceCondition(questionId, choice),
+  };
 }
 
 export function readChoiceCondition(
   condition: EditorConfig,
-): { questionId: string; choice: string } | null {
+): { questionId: string; choice: string; aggregation: EndingBranchAggregation } | null {
   const raw = condition.in;
-  if (!Array.isArray(raw) || raw.length < 2) return null;
-  const [choice, source] = raw;
-  if (typeof choice !== "string" || !isRecord(source) || typeof source.var !== "string") return null;
-  const match = source.var.match(/^answers\.(.+)\.choices$/);
-  return match ? { questionId: match[1], choice } : null;
+  if (Array.isArray(raw) && raw.length >= 2) {
+    const [choice, source] = raw;
+    if (typeof choice === "string" && isRecord(source) && typeof source.var === "string") {
+      const match = source.var.match(/^answers\.(.+)\.choices$/);
+      if (match) return { questionId: match[1], choice, aggregation: "threshold" };
+    }
+  }
+
+  const equals = condition["=="];
+  if (!Array.isArray(equals) || equals.length < 2) return null;
+  const [source, choice] = equals;
+  if (!isRecord(source) || typeof source.var !== "string" || typeof choice !== "string") return null;
+  const match = source.var.match(/^answers\.(.+)\.winning$/);
+  return match ? { questionId: match[1], choice, aggregation: "winning" } : null;
 }
 
 function endingNameById(nodes: Node[]): Map<string, string> {
@@ -282,6 +311,7 @@ export function toEndingBranchEditorViewModel(
       priority: row.priority,
       questionId: question?.id ?? null,
       choice,
+      aggregation: parsed?.aggregation ?? "threshold",
       endingId: row.ending,
       endingName: names.get(row.ending) ?? "결말 선택 필요",
     };


### PR DESCRIPTION
## 요약
- 결말 판정 에디터가 저장하는 규칙 키를 백엔드 `ending_branch` 엔진의 canonical 계약인 `conditions`로 맞췄습니다.
- 기존 `condition` 단수 키로 저장된 legacy 규칙도 계속 읽고 backend에서도 수용하도록 해 이전 데이터가 깨지지 않게 했습니다.
- 규칙 UI에 “설정한 비율 이상 선택되면”과 “가장 많이 선택되면” 기준을 추가해 MVP 판정 방식의 핵심 두 가지를 지원합니다.
- 런타임 엔진 결과에 fallback 여부, 적용 규칙 id/priority, 질문별 답변 집계 요약을 포함했습니다.
- #479에서 저장하는 질문 대상 `target`을 backend strict decode와 runtime respondent check가 실제로 해석하도록 연결했습니다.

Closes #483

## Coverage Plan
- `apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts`: `condition`/`conditions` 호환 로드, canonical `conditions` 저장, threshold/winning JSONLogic 변환을 adapter test로 검증했습니다.
- `apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx`: 집계 기준 선택 UI와 저장 payload를 `EndingEntitySubTab.test.tsx`에서 검증했습니다.
- `apps/server/internal/module/decision/ending_branch/*`: legacy condition 수용, specific player target 검증, threshold rule 판정, fallback, answer summary를 Go unit test로 검증했습니다.

## Local validation
- `go test ./internal/module/decision/ending_branch` PASS
- `pnpm --filter @mmp/web test -- src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx` PASS: 2 files / 22 tests
- `pnpm --filter @mmp/web exec eslint src/features/editor/entities/ending/endingBranchAdapter.ts src/features/editor/components/design/EndingBranchOutcomeRules.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts` PASS
- `pnpm --filter @mmp/web typecheck` PASS
- `scripts/mmp-local-ci.sh quick` PASS: backend tests, lint, typecheck, web tests 174 files / 1599 tests, web production build까지 성공

## Notes
- `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않았습니다.
- Vite/Rollup circular re-export warning과 기존 lint warnings는 이번 변경 파일에서 새로 만든 오류가 아니며, quick 검증은 exit 0으로 완료됐습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 질문에 대해 특정 플레이어 또는 모든 플레이어를 대상으로 지정할 수 있습니다
  * 행렬 규칙 편집기에서 "임계값" 및 "승리" 집계 모드를 선택할 수 있습니다
  * 엔딩 평가 이벤트에 답변 요약, 매칭된 규칙 ID, 폴백 상태가 포함됩니다

* **개선 사항**
  * 엔딩 브랜치 편집기 UI에서 집계 모드 선택 기능이 추가되었습니다
  * 조건 유효성 검사가 강화되어 대상 구성의 정확성을 보장합니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->