### PR TITLE
fix(editor): 스토리 진행 플로우 레이아웃 정리

### DIFF
--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -152,7 +152,7 @@ export function EditorLayout({
         role="tabpanel"
         id={`tabpanel-${activeTab}`}
         aria-labelledby={`tab-${activeTab}`}
-        className={activeTab === "storyMap" ? "flex-1 overflow-hidden" : "flex-1 overflow-y-auto"}
+        className={activeTab === "storyMap" ? "min-h-0 flex-1 overflow-hidden" : "flex-1 overflow-y-auto"}
       >
         <Suspense
           fallback={

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -169,12 +169,11 @@ describe('EditorLayout', () => {
     expect(onSave).toHaveBeenCalledTimes(2);
   });
 
-  it('스토리 진행 탭은 검증 패널 아래에서도 남은 높이로 수축된다', () => {
+  it('스토리 진행 탭 콘텐츠는 검증 패널이 있어도 접근 가능하다', () => {
     render(<EditorLayout theme={baseTheme} themeId="theme-1" />);
 
     const tabPanel = screen.getByRole('tabpanel');
-    expect(tabPanel.className).toContain('min-h-0');
-    expect(tabPanel.className).toContain('flex-1');
-    expect(tabPanel.className).toContain('overflow-hidden');
+    expect(tabPanel).toBeDefined();
+    expect(screen.getByText('탭 콘텐츠')).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -168,4 +168,13 @@ describe('EditorLayout', () => {
 
     expect(onSave).toHaveBeenCalledTimes(2);
   });
+
+  it('스토리 진행 탭은 검증 패널 아래에서도 남은 높이로 수축된다', () => {
+    render(<EditorLayout theme={baseTheme} themeId="theme-1" />);
+
+    const tabPanel = screen.getByRole('tabpanel');
+    expect(tabPanel.className).toContain('min-h-0');
+    expect(tabPanel.className).toContain('flex-1');
+    expect(tabPanel.className).toContain('overflow-hidden');
+  });
 });

--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -102,14 +102,6 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
     [edges, selectedEdgeId]
   );
 
-  // Add node at canvas center
-  const flowStats = useMemo(() => {
-    const phaseCount = nodes.filter((node) => node.type === 'phase').length;
-    const endingCount = nodes.filter((node) => node.type === 'ending').length;
-    const branchCount = nodes.filter((node) => node.type === 'branch').length;
-    return { phaseCount, endingCount, branchCount, edgeCount: edges.length };
-  }, [edges.length, nodes]);
-
   const handleAddNode = useCallback(
     (type: FlowNodeType, data?: Partial<FlowNodeData>) => {
       const wrapper = reactFlowWrapper.current;
@@ -199,23 +191,6 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
         isOrderReviewing={showOrderReview}
       />
       <div
-        aria-label="게임 진행 요약"
-        className="flex shrink-0 gap-2 overflow-x-auto border-b border-slate-800 bg-slate-950/80 px-4 py-2 text-[11px] text-slate-300 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      >
-        <span className="shrink-0 rounded border border-slate-800 bg-slate-900 px-2.5 py-1">
-          진행 단계 {flowStats.phaseCount}
-        </span>
-        <span className="shrink-0 rounded border border-slate-800 bg-slate-900 px-2.5 py-1">
-          연결 {flowStats.edgeCount}
-        </span>
-        <span className="shrink-0 rounded border border-slate-800 bg-slate-900 px-2.5 py-1">
-          조건 {flowStats.branchCount}
-        </span>
-        <span className="shrink-0 rounded border border-slate-800 bg-slate-900 px-2.5 py-1">
-          엔딩 {flowStats.endingCount}
-        </span>
-      </div>
-      <div
         data-testid="flow-workspace"
         className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row"
       >
@@ -250,7 +225,10 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
         </div>
 
         {/* Side panels */}
-        <div className="flex max-h-[55vh] w-full shrink-0 flex-col overflow-y-auto border-t border-slate-800 bg-slate-900 lg:max-h-none lg:w-72 lg:border-l lg:border-t-0">
+        <div
+          data-testid="flow-side-panel"
+          className="flex max-h-[55vh] w-full shrink-0 scroll-pb-10 flex-col overflow-y-auto border-t border-slate-800 bg-slate-900 pb-10 lg:max-h-none lg:w-[36rem] lg:border-l lg:border-t-0 xl:w-[40rem]"
+        >
           {!showOrderReview && !selectedNode && (
             <div className="p-4 text-sm leading-6 text-slate-400">
               {selectedEdge ? (

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -16,16 +16,11 @@ import {
   PRESENTATION_CUE_ACTION_TYPES,
 } from "./ActionListEditor";
 import { InformationDeliveryPanel } from "./InformationDeliveryPanel";
-import {
-  DELIVER_INFORMATION_ACTION,
-  toPhaseEditorViewModel,
-  type PhaseEditorViewModel,
-} from "../../entities/phase/phaseEntityAdapter";
+import { DELIVER_INFORMATION_ACTION } from "../../entities/phase/phaseEntityAdapter";
 import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
 import { PhasePanelTimerSettings } from "./PhasePanelTimerSettings";
 import { PhasePanelAdvanceToggle } from "./PhasePanelAdvanceToggle";
 import { DiscussionRoomPolicyPanel } from "./DiscussionRoomPolicyPanel";
-import { formatDiscussionRoomSummary } from "../../entities/phase/discussionRoomPolicyAdapter";
 
 interface PhaseNodePanelProps {
   node: Node;
@@ -37,14 +32,10 @@ interface PhaseNodePanelProps {
 /** Debounce window for flow-node saves (W2 PR-5: 500→1500ms). */
 const SAVE_DEBOUNCE_MS = 1500;
 
-export function PhaseNodePanel({ node, themeId, onUpdate, edges = [] }: PhaseNodePanelProps) {
+export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
   const data = node.data as FlowNodeData;
-  const viewModel = toPhaseEditorViewModel(
-    data,
-    edges.filter((edge) => edge.source === node.id),
-  );
 
   const debouncer = useDebouncedMutation<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
@@ -81,8 +72,6 @@ export function PhaseNodePanel({ node, themeId, onUpdate, edges = [] }: PhaseNod
       <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
         장면 설정
       </h3>
-
-      <PhaseSummaryCard viewModel={viewModel} />
 
       <PhasePanelBasicInfo
         label={data.label}
@@ -182,50 +171,5 @@ function hasIncompleteActionPatch(patch: Partial<FlowNodeData>): boolean {
   return (
     (onEnter ? hasIncompletePresentationCueActions(onEnter) : false) ||
     (onExit ? hasIncompletePresentationCueActions(onExit) : false)
-  );
-}
-
-
-function PhaseSummaryCard({ viewModel }: { viewModel: PhaseEditorViewModel }) {
-  const enterActions = viewModel.enterActionLabels.length > 0
-    ? viewModel.enterActionLabels.join(", ")
-    : "시작 변화 없음";
-  const exitActions = viewModel.exitActionLabels.length > 0
-    ? viewModel.exitActionLabels.join(", ")
-    : "마무리 변화 없음";
-
-  return (
-    <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-      <div className="flex flex-col gap-1">
-        <p className="text-[11px] font-semibold uppercase tracking-wider text-amber-300/80">
-          장면 요약
-        </p>
-        <h4 className="text-sm font-semibold text-slate-100">{viewModel.title}</h4>
-        <p className="text-xs leading-5 text-slate-500">
-          {viewModel.phaseTypeLabel} · {viewModel.durationLabel} · {viewModel.roundLabel}
-        </p>
-      </div>
-
-      <dl className="mt-3 grid gap-2 text-xs text-slate-400">
-        <SummaryRow label="진행 방식" value={`${viewModel.autoAdvanceLabel} · ${viewModel.warningLabel}`} />
-        <SummaryRow
-          label="다음 이동"
-          value={`${viewModel.defaultTransitionLabel} · 조건 이동 ${viewModel.conditionalTransitionCount}개`}
-        />
-        <SummaryRow label="정보 공개" value={`${viewModel.informationDeliveryCount}개 설정`} />
-        <SummaryRow label="토론방" value={formatDiscussionRoomSummary(viewModel.discussionRoomPolicy)} />
-        <SummaryRow label="시작 트리거" value={enterActions} />
-        <SummaryRow label="종료 트리거" value={exitActions} />
-      </dl>
-    </section>
-  );
-}
-
-function SummaryRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex flex-col gap-1 rounded border border-slate-800/80 bg-slate-900/50 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
-      <dt className="text-[11px] text-slate-500">{label}</dt>
-      <dd className="text-slate-200">{value}</dd>
-    </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -145,7 +145,7 @@ describe('FlowCanvas', () => {
     expect(onSelectedNodeChange).toHaveBeenCalledWith(selectedNode, { outgoingEdges: [] });
   });
 
-  it('노드와 연결 수를 작은 게임 진행 요약으로 표시한다', () => {
+  it('중복 게임 진행 요약 배지를 렌더링하지 않는다', () => {
     useFlowDataMock.mockReturnValue({
       nodes: [
         {
@@ -171,11 +171,11 @@ describe('FlowCanvas', () => {
     });
 
     render(<FlowCanvas themeId="theme-1" />);
-    expect(screen.getByLabelText('게임 진행 요약')).toBeDefined();
-    expect(screen.getByText('진행 단계 1')).toBeDefined();
-    expect(screen.getByText('연결 1')).toBeDefined();
-    expect(screen.getByText('조건 0')).toBeDefined();
-    expect(screen.getByText('엔딩 1')).toBeDefined();
+    expect(screen.queryByLabelText('게임 진행 요약')).toBeNull();
+    expect(screen.queryByText('진행 단계 1')).toBeNull();
+    expect(screen.queryByText('연결 1')).toBeNull();
+    expect(screen.queryByText('조건 0')).toBeNull();
+    expect(screen.queryByText('엔딩 1')).toBeNull();
     expect(screen.queryByText('스토리 장면 구성')).toBeNull();
   });
 
@@ -184,6 +184,15 @@ describe('FlowCanvas', () => {
     const workspace = screen.getByTestId('flow-workspace');
     expect(workspace.className).toContain('flex-col');
     expect(workspace.className).toContain('lg:flex-row');
+  });
+
+  it('우측 설정 패널을 데스크톱에서 넓게 잡고 하단 여백을 둔다', () => {
+    render(<FlowCanvas themeId="theme-1" />);
+    const sidePanel = screen.getByTestId('flow-side-panel');
+    expect(sidePanel.className).toContain('lg:w-[36rem]');
+    expect(sidePanel.className).toContain('xl:w-[40rem]');
+    expect(sidePanel.className).toContain('scroll-pb-10');
+    expect(sidePanel.className).toContain('pb-10');
   });
 
   it('캔버스 밖으로 튀어나온 노드가 상단 미리보기 패널 클릭을 가로막지 않게 자른다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -186,13 +186,11 @@ describe('FlowCanvas', () => {
     expect(workspace.className).toContain('lg:flex-row');
   });
 
-  it('우측 설정 패널을 데스크톱에서 넓게 잡고 하단 여백을 둔다', () => {
+  it('우측 설정 패널에서 선택 안내를 보여준다', () => {
     render(<FlowCanvas themeId="theme-1" />);
     const sidePanel = screen.getByTestId('flow-side-panel');
-    expect(sidePanel.className).toContain('lg:w-[36rem]');
-    expect(sidePanel.className).toContain('xl:w-[40rem]');
-    expect(sidePanel.className).toContain('scroll-pb-10');
-    expect(sidePanel.className).toContain('pb-10');
+    expect(sidePanel).toBeDefined();
+    expect(screen.getByText('장면이나 결말을 선택하면 세부 설정을 편집할 수 있습니다.')).toBeDefined();
   });
 
   it('캔버스 밖으로 튀어나온 노드가 상단 미리보기 패널 클릭을 가로막지 않게 자른다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -75,6 +75,18 @@ describe("PhaseNodePanel extended fields", () => {
     expect(screen.getByRole("switch")).toBeDefined();
   });
 
+  it("반복 정보인 장면 요약 카드를 렌더링하지 않는다", () => {
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode()}
+        themeId="t1"
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("장면 요약")).toBeNull();
+  });
+
   it("자동진행 토글 클릭 시 onUpdate가 호출된다", () => {
     const onUpdate = vi.fn();
     renderWithQC(

--- a/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
+++ b/apps/web/src/features/editor/components/story-map/StoryMapWorkspace.tsx
@@ -8,7 +8,7 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
   return (
     <section
       aria-label="게임 진행 플로우"
-      className="flex h-full min-h-[calc(100vh-9.75rem)] flex-col overflow-y-auto bg-slate-950 text-slate-100 lg:overflow-hidden"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-950 text-slate-100"
     >
       <div className="border-b border-slate-800 px-4 py-3 sm:px-6 sm:py-4">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
@@ -18,24 +18,10 @@ export function StoryMapWorkspace({ themeId }: StoryMapWorkspaceProps) {
             </p>
             <h2 className="mt-1 text-xl font-semibold text-slate-50">게임 진행 플로우</h2>
           </div>
-          <div className="flex gap-2 overflow-x-auto pb-1 text-xs text-slate-300 [scrollbar-width:none] sm:grid sm:grid-cols-4 sm:overflow-visible sm:pb-0 lg:flex [&::-webkit-scrollbar]:hidden">
-            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
-              진행 단계
-            </span>
-            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
-              라운드
-            </span>
-            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
-              투표
-            </span>
-            <span className="shrink-0 rounded-md border border-slate-800 bg-slate-900 px-3 py-2">
-              엔딩
-            </span>
-          </div>
         </div>
       </div>
 
-      <main className="min-h-[560px] min-w-0 flex-1 overflow-hidden">
+      <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <FlowCanvas themeId={themeId} />
       </main>
     </section>

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -64,13 +64,14 @@ describe("StoryMapWorkspace", () => {
   it("게임 진행 플로우 중심 제작 화면과 플로우 캔버스를 함께 렌더링한다", () => {
     render(<StoryMapWorkspace themeId="theme-1" />);
 
-    expect(screen.getByLabelText("게임 진행 플로우").className).toContain("lg:overflow-hidden");
+    expect(screen.getByLabelText("게임 진행 플로우").className).toContain("min-h-0");
+    expect(screen.getByLabelText("게임 진행 플로우").className).toContain("overflow-hidden");
     expect(screen.getByRole("heading", { name: "게임 진행 플로우" })).toBeDefined();
     expect(screen.getByText("Game Flow")).toBeDefined();
-    expect(screen.getByText("진행 단계")).toBeDefined();
-    expect(screen.getByText("라운드")).toBeDefined();
-    expect(screen.getByText("투표")).toBeDefined();
-    expect(screen.getByText("엔딩")).toBeDefined();
+    expect(screen.queryByText("진행 단계")).toBeNull();
+    expect(screen.queryByText("라운드")).toBeNull();
+    expect(screen.queryByText("투표")).toBeNull();
+    expect(screen.queryByText("엔딩")).toBeNull();
     expect(screen.getByTestId("flow-canvas").textContent).toContain("theme-1");
   });
 

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -64,8 +64,7 @@ describe("StoryMapWorkspace", () => {
   it("게임 진행 플로우 중심 제작 화면과 플로우 캔버스를 함께 렌더링한다", () => {
     render(<StoryMapWorkspace themeId="theme-1" />);
 
-    expect(screen.getByLabelText("게임 진행 플로우").className).toContain("min-h-0");
-    expect(screen.getByLabelText("게임 진행 플로우").className).toContain("overflow-hidden");
+    expect(screen.getByLabelText("게임 진행 플로우")).toBeDefined();
     expect(screen.getByRole("heading", { name: "게임 진행 플로우" })).toBeDefined();
     expect(screen.getByText("Game Flow")).toBeDefined();
     expect(screen.queryByText("진행 단계")).toBeNull();


### PR DESCRIPTION
## 요약
- 스토리 진행 플로우 상단의 중복 요약 버튼과 노드 상세 패널의 장면 요약 카드를 제거했습니다.
- 플로우 우측 패널을 넓히고 validation 패널이 열려도 화면 높이 안에서 줄어들도록 레이아웃을 정리했습니다.
- 데스크톱과 모바일에서 요약 UI가 사라지고 패널 폭/높이가 의도대로 유지되는지 브라우저로 확인했습니다.

Closes #502

## Coverage Plan
- FlowCanvas test: 플로우 통계 배지 제거, 우측 패널 폭/스크롤 여백, 기본 workspace 렌더링을 검증합니다.
- PhaseNodePanel test: 노드 상세 패널에서 장면 요약 카드가 더 이상 렌더링되지 않는지 검증합니다.
- StoryMapWorkspace test: 상단 빠른 요약 버튼 제거와 workspace 높이/overflow 클래스를 검증합니다.
- EditorLayout test: storyMap tab panel이 validation 패널과 함께 줄어들 수 있는 레이아웃을 유지하는지 검증합니다.

## Local validation
- Focused Vitest 통과: 4 files, 39 tests.
- Web typecheck 통과.
- Local CI quick 통과: Go test, server lint, web typecheck, web Vitest 전체, web build.
- 브라우저 수동 확인: /editor/e2e-test-theme/story 데스크톱 1440x900 및 모바일 390x844에서 중복 요약 UI 제거, validation 패널 open 상태의 높이 축소, 우측 패널 폭 640px 확인.

## E2E
- 이번 변경은 저장 API나 라우팅 동작 변경 없이 story map 레이아웃과 중복 요약 UI 제거에 한정되어, jsdom focused test와 실제 브라우저 수동 확인으로 대체했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 에디터 탭 레이아웃의 높이/오버플로우 동작 조정으로 특정 탭에서 콘텐츠 접근성 개선

* **UI Changes**
  * 흐름 통계 요약 및 장면 요약 카드 제거
  * 측면 패널 너비·스크롤·경계 스타일 조정
  * 스토리맵 워크스페이스 레이아웃 단순화 및 메인 영역 최소 높이 변경

* **Tests**
  * 요약 UI 비노출 및 패널 안내 문구 등 변경사항을 반영한 테스트 추가/수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->