### PR TITLE
feat(editor): 스토리 진행 읽기 대사 배치 패널 분리

### DIFF
--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useEditorCharacters } from "../../api";
-import { useReadingSections } from "../../readingApi";
 import { useStoryInfos, type StoryInfoResponse } from "../../storyInfoApi";
-import {
-  filterReadingSectionOptions,
-  toReadingSectionPickerOptions,
-} from "../../entities/story/readingSectionAdapter";
 import {
   InformationDeliveryContent,
   InformationDeliveryHeader,
@@ -38,22 +33,19 @@ export function InformationDeliveryPanel({
     refetch: refetchCharacters,
   } = useEditorCharacters(themeId);
   const {
-    data: sections = [],
-    isLoading: sectionsLoading,
-    isError: sectionsError,
-    refetch: refetchSections,
-  } = useReadingSections(themeId);
-  const {
     data: storyInfos = [],
     isLoading: storyInfosLoading,
     isError: storyInfosError,
     refetch: refetchStoryInfos,
   } = useStoryInfos(themeId);
   const [characterQuery, setCharacterQuery] = useState("");
-  const [sectionQuery, setSectionQuery] = useState("");
   const [infoQuery, setInfoQuery] = useState("");
   const savedDeliveries = useMemo(
-    () => flowNodeToInformationDeliveries(phaseData),
+    () =>
+      flowNodeToInformationDeliveries(phaseData).map((delivery) => ({
+        ...delivery,
+        readingSectionIds: [],
+      })),
     [phaseData],
   );
   const [draftDeliveries, setDraftDeliveries] = useState(() => savedDeliveries);
@@ -74,13 +66,8 @@ export function InformationDeliveryPanel({
     return characters.filter((character) => character.name.toLowerCase().includes(query));
   }, [characters, characterQuery]);
 
-  const sectionOptions = useMemo(() => toReadingSectionPickerOptions(sections), [sections]);
   const storyInfoOptions = useMemo(() => toStoryInfoOptions(storyInfos), [storyInfos]);
 
-  const filteredSections = useMemo(
-    () => filterReadingSectionOptions(sectionOptions, sectionQuery),
-    [sectionOptions, sectionQuery],
-  );
   const filteredStoryInfos = useMemo(
     () => filterStoryInfoOptions(storyInfoOptions, infoQuery),
     [storyInfoOptions, infoQuery],
@@ -111,14 +98,6 @@ export function InformationDeliveryPanel({
     updateDeliveries(draftDeliveries.filter((delivery) => delivery.id !== deliveryId));
   };
 
-  const toggleSection = (delivery: InformationDeliveryViewModel, sectionId: string) => {
-    const hasSection = delivery.readingSectionIds.includes(sectionId);
-    updateDelivery(delivery.id, {
-      readingSectionIds: hasSection
-        ? delivery.readingSectionIds.filter((id) => id !== sectionId)
-        : [...delivery.readingSectionIds, sectionId],
-    });
-  };
   const toggleStoryInfo = (delivery: InformationDeliveryViewModel, storyInfoId: string) => {
     const hasStoryInfo = delivery.storyInfoIds.includes(storyInfoId);
     updateDelivery(delivery.id, {
@@ -128,13 +107,12 @@ export function InformationDeliveryPanel({
     });
   };
 
-  const loading = charactersLoading || sectionsLoading || storyInfosLoading;
-  const hasLoadError = charactersError || sectionsError || storyInfosError;
+  const loading = charactersLoading || storyInfosLoading;
+  const hasLoadError = charactersError || storyInfosError;
   const canAddCharacterDelivery = characters.length > 0;
 
   const retryLoad = () => {
     if (charactersError) void refetchCharacters();
-    if (sectionsError) void refetchSections();
     if (storyInfosError) void refetchStoryInfos();
   };
 
@@ -150,24 +128,18 @@ export function InformationDeliveryPanel({
         loading={loading}
         hasLoadError={hasLoadError}
         hasCharacters={characters.length > 0}
-        hasSections={sections.length > 0}
         hasStoryInfos={storyInfos.length > 0}
         characterQuery={characterQuery}
-        sectionQuery={sectionQuery}
         infoQuery={infoQuery}
         deliveries={draftDeliveries}
         characters={filteredCharacters}
         allCharacters={characters}
-        sections={filteredSections}
-        allSections={sectionOptions}
         storyInfos={filteredStoryInfos}
         allStoryInfos={storyInfoOptions}
         onRetryLoad={retryLoad}
         onCharacterQueryChange={setCharacterQuery}
-        onSectionQueryChange={setSectionQuery}
         onInfoQueryChange={setInfoQuery}
         onSelectCharacter={(deliveryId, characterId) => updateDelivery(deliveryId, { characterId })}
-        onToggleSection={toggleSection}
         onToggleStoryInfo={toggleStoryInfo}
         onRemoveDelivery={removeDelivery}
       />

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
@@ -1,6 +1,5 @@
 import { Plus, Trash2, Users } from "lucide-react";
 import type { InformationDeliveryViewModel } from "../../entities/shared/informationDeliveryAdapter";
-import type { ReadingSectionPickerOption } from "../../entities/story/readingSectionAdapter";
 import { OptionList, SearchField } from "./InformationDeliveryOptionList";
 
 interface InformationDeliveryHeaderProps {
@@ -17,9 +16,9 @@ export function InformationDeliveryHeader({
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div>
-        <h4 className="text-sm font-semibold text-slate-100">읽기 대사 배치와 정보 공개</h4>
+        <h4 className="text-sm font-semibold text-slate-100">정보 공개</h4>
         <p className="mt-1 text-xs leading-5 text-slate-400">
-          이 장면에서 보여줄 읽기 대사와 공개할 정보 카드를 대상별로 연결합니다.
+          이 장면에서 공개할 정보 카드를 대상별로 연결합니다.
         </p>
       </div>
       <div className="flex flex-wrap gap-2">
@@ -53,24 +52,18 @@ interface InformationDeliveryContentProps {
   loading: boolean;
   hasLoadError: boolean;
   hasCharacters: boolean;
-  hasSections: boolean;
   hasStoryInfos: boolean;
   characterQuery: string;
-  sectionQuery: string;
   infoQuery: string;
   deliveries: InformationDeliveryViewModel[];
   characters: { id: string; name: string }[];
   allCharacters: { id: string; name: string }[];
-  sections: ReadingSectionPickerOption[];
-  allSections: ReadingSectionPickerOption[];
   storyInfos: StoryInfoOption[];
   allStoryInfos: StoryInfoOption[];
   onRetryLoad: () => void;
   onCharacterQueryChange: (value: string) => void;
-  onSectionQueryChange: (value: string) => void;
   onInfoQueryChange: (value: string) => void;
   onSelectCharacter: (deliveryId: string, characterId: string) => void;
-  onToggleSection: (delivery: InformationDeliveryViewModel, sectionId: string) => void;
   onToggleStoryInfo: (delivery: InformationDeliveryViewModel, storyInfoId: string) => void;
   onRemoveDelivery: (deliveryId: string) => void;
 }
@@ -86,31 +79,25 @@ export function InformationDeliveryContent({
   loading,
   hasLoadError,
   hasCharacters,
-  hasSections,
   hasStoryInfos,
   characterQuery,
-  sectionQuery,
   infoQuery,
   deliveries,
   characters,
   allCharacters,
-  sections,
-  allSections,
   storyInfos,
   allStoryInfos,
   onRetryLoad,
   onCharacterQueryChange,
-  onSectionQueryChange,
   onInfoQueryChange,
   onSelectCharacter,
-  onToggleSection,
   onToggleStoryInfo,
   onRemoveDelivery,
 }: InformationDeliveryContentProps) {
   if (loading) {
     return (
       <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-400">
-        캐릭터, 읽기 대사, 정보를 불러오는 중입니다.
+        캐릭터와 정보를 불러오는 중입니다.
       </p>
     );
   }
@@ -118,7 +105,7 @@ export function InformationDeliveryContent({
   if (hasLoadError) {
     return (
       <div className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-3 text-xs text-red-100">
-        <p>장면 연결에 필요한 캐릭터, 읽기 대사, 정보 목록을 불러오지 못했습니다.</p>
+        <p>정보 공개에 필요한 캐릭터와 정보 목록을 불러오지 못했습니다.</p>
         <button
           type="button"
           onClick={onRetryLoad}
@@ -130,28 +117,22 @@ export function InformationDeliveryContent({
     );
   }
 
-  if (!hasSections && !hasStoryInfos) {
+  if (!hasStoryInfos) {
     return (
       <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-400">
-        배치할 읽기 대사와 공개할 정보가 없습니다. 먼저 읽기 대사 또는 정보 관리에서 장면에 연결할 항목을 만들어 주세요.
+        공개할 정보가 없습니다. 먼저 정보 관리에서 장면에 연결할 항목을 만들어 주세요.
       </p>
     );
   }
 
   return (
     <>
-      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
         <SearchField
           label="캐릭터 검색"
           value={characterQuery}
           onChange={onCharacterQueryChange}
           placeholder="이름으로 찾기"
-        />
-        <SearchField
-          label="읽기 대사 검색"
-          value={sectionQuery}
-          onChange={onSectionQueryChange}
-          placeholder="대사 이름으로 찾기"
         />
         <SearchField
           label="정보 검색"
@@ -174,12 +155,9 @@ export function InformationDeliveryContent({
               delivery={delivery}
               characters={characters}
               allCharacters={allCharacters}
-              sections={sections}
-              allSections={allSections}
               storyInfos={storyInfos}
               allStoryInfos={allStoryInfos}
               onSelectCharacter={(characterId) => onSelectCharacter(delivery.id, characterId)}
-              onToggleSection={(sectionId) => onToggleSection(delivery, sectionId)}
               onToggleStoryInfo={(storyInfoId) => onToggleStoryInfo(delivery, storyInfoId)}
               onRemove={() => onRemoveDelivery(delivery.id)}
             />
@@ -193,9 +171,9 @@ export function InformationDeliveryContent({
 
 function getEmptyDeliveryMessage(hasCharacters: boolean): string {
   if (!hasCharacters) {
-    return "아직 장면 연결이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 대사나 정보를 연결해 주세요.";
+    return "아직 정보 공개 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 정보를 연결해 주세요.";
   }
-  return "아직 장면 연결이 없습니다. 전체 대상 추가 또는 캐릭터별 대상 추가를 눌러 대상을 정해 주세요.";
+  return "아직 정보 공개 대상이 없습니다. 전체 대상 추가 또는 캐릭터별 대상 추가를 눌러 대상을 정해 주세요.";
 }
 
 interface DeliveryCardProps {
@@ -203,12 +181,9 @@ interface DeliveryCardProps {
   delivery: InformationDeliveryViewModel;
   characters: { id: string; name: string }[];
   allCharacters: { id: string; name: string }[];
-  sections: ReadingSectionPickerOption[];
-  allSections: ReadingSectionPickerOption[];
   storyInfos: StoryInfoOption[];
   allStoryInfos: StoryInfoOption[];
   onSelectCharacter: (characterId: string) => void;
-  onToggleSection: (sectionId: string) => void;
   onToggleStoryInfo: (storyInfoId: string) => void;
   onRemove: () => void;
 }
@@ -218,12 +193,9 @@ function DeliveryCard({
   delivery,
   characters,
   allCharacters,
-  sections,
-  allSections,
   storyInfos,
   allStoryInfos,
   onSelectCharacter,
-  onToggleSection,
   onToggleStoryInfo,
   onRemove,
 }: DeliveryCardProps) {
@@ -236,15 +208,15 @@ function DeliveryCard({
     <article className="rounded-lg border border-slate-800 bg-slate-900/80 p-3">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold text-slate-200">장면 연결 {index + 1}</p>
+          <p className="text-xs font-semibold text-slate-200">정보 공개 {index + 1}</p>
           <p className="mt-1 text-[11px] text-slate-400">
-            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · 대사 {delivery.readingSectionIds.length}개 · 정보 {delivery.storyInfoIds.length}개
+            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · 정보 {delivery.storyInfoIds.length}개
           </p>
         </div>
         <button
           type="button"
           onClick={onRemove}
-          aria-label={`장면 연결 ${index + 1} 삭제`}
+          aria-label={`정보 공개 ${index + 1} 삭제`}
           className="rounded p-1 text-slate-400 hover:bg-red-500/10 hover:text-red-300"
         >
           <Trash2 className="h-4 w-4" />
@@ -255,7 +227,7 @@ function DeliveryCard({
         {delivery.recipientType === "all_players" ? (
           <div className="flex items-center gap-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
             <Users className="h-4 w-4" />
-            이 장면의 공통 읽기 대사와 공개 정보로 모든 플레이어에게 보여집니다.
+            이 장면의 공개 정보로 모든 플레이어에게 보여집니다.
           </div>
         ) : (
           <OptionList
@@ -269,15 +241,6 @@ function DeliveryCard({
           />
         )}
 
-        <OptionList
-          title="읽기 대사 배치"
-          emptyText="검색 결과가 없습니다."
-          items={sections}
-          selectedIds={delivery.readingSectionIds}
-          getMeta={(section) => section.metaLabel}
-          onToggle={onToggleSection}
-          allItems={allSections}
-        />
         <OptionList
           title="정보 공개"
           emptyText="검색 결과가 없습니다."

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -16,6 +16,7 @@ import {
   PRESENTATION_CUE_ACTION_TYPES,
 } from "./ActionListEditor";
 import { InformationDeliveryPanel } from "./InformationDeliveryPanel";
+import { StoryProgressionPanel } from "./StoryProgressionPanel";
 import { DELIVER_INFORMATION_ACTION } from "../../entities/phase/phaseEntityAdapter";
 import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
 import { PhasePanelTimerSettings } from "./PhasePanelTimerSettings";
@@ -36,6 +37,7 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
   const data = node.data as FlowNodeData;
+  const isStoryProgression = data.phase_type === "story_progression";
 
   const debouncer = useDebouncedMutation<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
@@ -94,12 +96,21 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
 
       <div className="border-t border-slate-800" />
 
-      <InformationDeliveryPanel
-        key={node.id}
-        themeId={themeId}
-        phaseData={data}
-        onChange={handleChange}
-      />
+      {isStoryProgression ? (
+        <StoryProgressionPanel
+          key={node.id}
+          themeId={themeId}
+          phaseData={data}
+          onChange={handleChange}
+        />
+      ) : (
+        <InformationDeliveryPanel
+          key={node.id}
+          themeId={themeId}
+          phaseData={data}
+          onChange={handleChange}
+        />
+      )}
 
       <div className="border-t border-slate-800" />
 

--- a/apps/web/src/features/editor/components/design/ReadingPlacementPanel.tsx
+++ b/apps/web/src/features/editor/components/design/ReadingPlacementPanel.tsx
@@ -1,0 +1,95 @@
+import { useMemo, useState } from "react";
+import { useReadingSections } from "../../readingApi";
+import type { FlowNodeData } from "../../flowTypes";
+import {
+  filterReadingSectionOptions,
+  toReadingSectionPickerOptions,
+} from "../../entities/story/readingSectionAdapter";
+import {
+  flowNodeToReadingPlacement,
+  readingPlacementToFlowNodePatch,
+} from "../../entities/phase/readingPlacementAdapter";
+import { ReadingSectionPicker } from "./ReadingSectionPicker";
+
+interface ReadingPlacementPanelProps {
+  themeId: string;
+  phaseData: FlowNodeData;
+  onChange: (patch: Partial<FlowNodeData>) => void;
+}
+
+export function ReadingPlacementPanel({
+  themeId,
+  phaseData,
+  onChange,
+}: ReadingPlacementPanelProps) {
+  const {
+    data: sections = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useReadingSections(themeId);
+  const [sectionQuery, setSectionQuery] = useState("");
+  const placement = useMemo(() => flowNodeToReadingPlacement(phaseData), [phaseData]);
+  const sectionOptions = useMemo(() => toReadingSectionPickerOptions(sections), [sections]);
+  const filteredSections = useMemo(
+    () => filterReadingSectionOptions(sectionOptions, sectionQuery),
+    [sectionOptions, sectionQuery],
+  );
+
+  const toggleSection = (sectionId: string) => {
+    const hasSection = placement.readingSectionIds.includes(sectionId);
+    const nextIds = hasSection
+      ? placement.readingSectionIds.filter((id) => id !== sectionId)
+      : [...placement.readingSectionIds, sectionId];
+    onChange(readingPlacementToFlowNodePatch(phaseData, nextIds));
+  };
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+      <div>
+        <h4 className="text-sm font-semibold text-slate-100">읽기 대사 배치</h4>
+        <p className="mt-1 text-xs leading-5 text-slate-400">
+          스토리 진행 중 플레이어에게 순서대로 보여줄 읽기 대사를 연결합니다.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-400">
+          읽기 대사를 불러오는 중입니다.
+        </p>
+      ) : null}
+
+      {isError ? (
+        <div className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-3 text-xs text-red-100">
+          <p>읽기 대사 목록을 불러오지 못했습니다.</p>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="mt-2 rounded border border-red-300/30 px-2 py-1 text-red-50 hover:bg-red-500/20"
+          >
+            다시 불러오기
+          </button>
+        </div>
+      ) : null}
+
+      {!isLoading && !isError && sections.length === 0 ? (
+        <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-400">
+          배치할 읽기 대사가 없습니다. 먼저 읽기 대사 관리에서 대사를 만들어 주세요.
+        </p>
+      ) : null}
+
+      {!isLoading && !isError && sections.length > 0 ? (
+        <div className="mt-3">
+          <ReadingSectionPicker
+            query={sectionQuery}
+            sections={filteredSections}
+            allSections={sectionOptions}
+            selectedIds={placement.readingSectionIds}
+            onQueryChange={setSectionQuery}
+            onToggle={toggleSection}
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/ReadingSectionPicker.tsx
+++ b/apps/web/src/features/editor/components/design/ReadingSectionPicker.tsx
@@ -1,0 +1,40 @@
+import type { ReadingSectionPickerOption } from "../../entities/story/readingSectionAdapter";
+import { OptionList, SearchField } from "./InformationDeliveryOptionList";
+
+interface ReadingSectionPickerProps {
+  query: string;
+  sections: ReadingSectionPickerOption[];
+  allSections: ReadingSectionPickerOption[];
+  selectedIds: string[];
+  onQueryChange: (value: string) => void;
+  onToggle: (sectionId: string) => void;
+}
+
+export function ReadingSectionPicker({
+  query,
+  sections,
+  allSections,
+  selectedIds,
+  onQueryChange,
+  onToggle,
+}: ReadingSectionPickerProps) {
+  return (
+    <div className="grid gap-3">
+      <SearchField
+        label="읽기 대사 검색"
+        value={query}
+        onChange={onQueryChange}
+        placeholder="대사 이름으로 찾기"
+      />
+      <OptionList
+        title="읽기 대사 배치"
+        emptyText="검색 결과가 없습니다."
+        items={sections}
+        selectedIds={selectedIds}
+        getMeta={(section) => section.metaLabel}
+        onToggle={onToggle}
+        allItems={allSections}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/design/StoryProgressionPanel.tsx
+++ b/apps/web/src/features/editor/components/design/StoryProgressionPanel.tsx
@@ -1,0 +1,22 @@
+import type { FlowNodeData } from "../../flowTypes";
+import { ReadingPlacementPanel } from "./ReadingPlacementPanel";
+
+interface StoryProgressionPanelProps {
+  themeId: string;
+  phaseData: FlowNodeData;
+  onChange: (patch: Partial<FlowNodeData>) => void;
+}
+
+export function StoryProgressionPanel({
+  themeId,
+  phaseData,
+  onChange,
+}: StoryProgressionPanelProps) {
+  return (
+    <ReadingPlacementPanel
+      themeId={themeId}
+      phaseData={phaseData}
+      onChange={onChange}
+    />
+  );
+}

--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -4,18 +4,13 @@ import type { FlowNodeData } from "../../../flowTypes";
 import { InformationDeliveryPanel } from "../InformationDeliveryPanel";
 import { DELIVER_INFORMATION_ACTION } from "../phaseEditorAdapter";
 
-const { useEditorCharactersMock, useReadingSectionsMock, useStoryInfosMock } = vi.hoisted(() => ({
+const { useEditorCharactersMock, useStoryInfosMock } = vi.hoisted(() => ({
   useEditorCharactersMock: vi.fn(),
-  useReadingSectionsMock: vi.fn(),
   useStoryInfosMock: vi.fn(),
 }));
 
 vi.mock("../../../api", () => ({
   useEditorCharacters: () => useEditorCharactersMock(),
-}));
-
-vi.mock("../../../readingApi", () => ({
-  useReadingSections: () => useReadingSectionsMock(),
 }));
 
 vi.mock("../../../storyInfoApi", () => ({
@@ -29,10 +24,6 @@ const characters = [
   { id: "char-2", name: "용의자 B" },
 ];
 
-const sections = [
-  { id: "rs-1", name: "비밀 편지", lines: [{ Text: "편지" }] },
-  { id: "rs-2", name: "저택 소문", lines: [{ Text: "소문" }, { Text: "증언" }] },
-];
 const storyInfos = [
   {
     id: "info-1",
@@ -71,12 +62,6 @@ beforeEach(() => {
     isError: false,
     refetch: vi.fn(),
   });
-  useReadingSectionsMock.mockReturnValue({
-    data: sections,
-    isLoading: false,
-    isError: false,
-    refetch: vi.fn(),
-  });
   useStoryInfosMock.mockReturnValue({
     data: storyInfos,
     isLoading: false,
@@ -97,11 +82,11 @@ describe("InformationDeliveryPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "캐릭터별 대상 추가" }));
 
-    expect(screen.getByText("받을 캐릭터를 선택하세요 · 대사 0개 · 정보 0개")).toBeDefined();
+    expect(screen.getByText("받을 캐릭터를 선택하세요 · 정보 0개")).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 
-  it("캐릭터, 읽기 대사, 공개 정보를 검색하고 선택/삭제할 수 있다", () => {
+  it("캐릭터와 공개 정보를 검색하고 선택/삭제할 수 있다", () => {
     const onChange = vi.fn();
     const phaseData: FlowNodeData = {
       onEnter: [
@@ -113,7 +98,6 @@ describe("InformationDeliveryPanel", () => {
               {
                 id: "d1",
                 target: { type: "character" },
-                reading_section_ids: ["rs-1"],
                 story_info_ids: ["info-1"],
               },
             ],
@@ -139,31 +123,7 @@ describe("InformationDeliveryPanel", () => {
               {
                 id: "d1",
                 target: { type: "character", character_id: "char-2" },
-                reading_section_ids: ["rs-1"],
-                story_info_ids: ["info-1"],
-              },
-            ],
-          },
-        },
-      ],
-    });
-
-    fireEvent.change(screen.getByPlaceholderText("대사 이름으로 찾기"), {
-      target: { value: "저택" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /저택 소문/ }));
-
-    expect(onChange).toHaveBeenLastCalledWith({
-      onEnter: [
-        {
-          id: "info",
-          type: DELIVER_INFORMATION_ACTION,
-          params: {
-            deliveries: [
-              {
-                id: "d1",
-                target: { type: "character", character_id: "char-2" },
-                reading_section_ids: ["rs-1", "rs-2"],
+                reading_section_ids: [],
                 story_info_ids: ["info-1"],
               },
             ],
@@ -187,7 +147,7 @@ describe("InformationDeliveryPanel", () => {
               {
                 id: "d1",
                 target: { type: "character", character_id: "char-2" },
-                reading_section_ids: ["rs-1", "rs-2"],
+                reading_section_ids: [],
                 story_info_ids: ["info-1", "info-2"],
               },
             ],
@@ -196,26 +156,19 @@ describe("InformationDeliveryPanel", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "장면 연결 1 삭제" }));
+    fireEvent.click(screen.getByRole("button", { name: "정보 공개 1 삭제" }));
     expect(onChange).toHaveBeenLastCalledWith({ onEnter: [] });
   });
 
 
-  it("캐릭터 또는 읽기 대사 조회 실패를 빈 상태와 구분하고 재시도할 수 있다", () => {
+  it("캐릭터 또는 정보 조회 실패를 빈 상태와 구분하고 재시도할 수 있다", () => {
     const refetchCharacters = vi.fn();
-    const refetchSections = vi.fn();
     const refetchStoryInfos = vi.fn();
     useEditorCharactersMock.mockReturnValue({
       data: [],
       isLoading: false,
       isError: true,
       refetch: refetchCharacters,
-    });
-    useReadingSectionsMock.mockReturnValue({
-      data: [],
-      isLoading: false,
-      isError: true,
-      refetch: refetchSections,
     });
     useStoryInfosMock.mockReturnValue({
       data: [],
@@ -226,11 +179,10 @@ describe("InformationDeliveryPanel", () => {
 
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
-    expect(screen.getByText("장면 연결에 필요한 캐릭터, 읽기 대사, 정보 목록을 불러오지 못했습니다.")).toBeDefined();
+    expect(screen.getByText("정보 공개에 필요한 캐릭터와 정보 목록을 불러오지 못했습니다.")).toBeDefined();
     fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
 
     expect(refetchCharacters).toHaveBeenCalledTimes(1);
-    expect(refetchSections).toHaveBeenCalledTimes(1);
     expect(refetchStoryInfos).toHaveBeenCalledTimes(1);
   });
 
@@ -275,11 +227,11 @@ describe("InformationDeliveryPanel", () => {
     const { rerender } = render(
       <InformationDeliveryPanel themeId="theme-1" phaseData={firstPhaseData} onChange={vi.fn()} />,
     );
-    expect(screen.getByText("탐정 A · 대사 1개 · 정보 1개")).toBeDefined();
+    expect(screen.getByText("탐정 A · 정보 1개")).toBeDefined();
 
     rerender(<InformationDeliveryPanel themeId="theme-1" phaseData={nextPhaseData} onChange={vi.fn()} />);
 
-    expect(screen.getByText("용의자 B · 대사 1개 · 정보 0개")).toBeDefined();
+    expect(screen.getByText("용의자 B · 정보 0개")).toBeDefined();
   });
 
 
@@ -294,7 +246,7 @@ describe("InformationDeliveryPanel", () => {
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
     expect((screen.getByRole("button", { name: "캐릭터별 대상 추가" }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText("아직 장면 연결이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 대사나 정보를 연결해 주세요.")).toBeDefined();
+    expect(screen.getByText("아직 정보 공개 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 정보를 연결해 주세요.")).toBeDefined();
   });
 
   it("모든 페이즈에서 모든 플레이어 공통 전달을 추가할 수 있다", () => {
@@ -309,7 +261,7 @@ describe("InformationDeliveryPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "전체 대상 추가" }));
 
-    expect(screen.getByText("모든 플레이어 · 대사 0개 · 정보 0개")).toBeDefined();
+    expect(screen.getByText("모든 플레이어 · 정보 0개")).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -15,6 +15,15 @@ vi.mock("../../../flowApi", () => ({
   useUpdateFlowNode: () => ({ mutate: vi.fn() }),
 }));
 
+vi.mock("../../../readingApi", () => ({
+  useReadingSections: () => ({
+    data: [{ id: "rs-1", name: "오프닝 낭독", lines: [{ Text: "시작" }] }],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+
 vi.mock("../../../mediaApi", () => ({
   useMediaList: () => ({
     data: [
@@ -134,6 +143,35 @@ describe("PhaseNodePanel extended fields", () => {
     expect(screen.getByText("장면 시작 트리거")).toBeDefined();
     expect(screen.getByText("장면 종료 트리거")).toBeDefined();
     expect(screen.getAllByText("트리거 실행 결과 없음")).toHaveLength(3);
+  });
+
+  it("스토리 진행 노드는 읽기 대사 배치만 표시하고 정보 공개 대상 UI를 숨긴다", () => {
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({ phase_type: "story_progression" })}
+        themeId="t1"
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("읽기 대사 배치").length).toBeGreaterThan(0);
+    expect(screen.getByPlaceholderText("대사 이름으로 찾기")).toBeDefined();
+    expect(screen.queryByText("정보 공개")).toBeNull();
+    expect(screen.queryByRole("button", { name: "캐릭터별 대상 추가" })).toBeNull();
+    expect(screen.queryByPlaceholderText("정보 제목으로 찾기")).toBeNull();
+  });
+
+  it("일반 장면은 정보 공개만 표시하고 읽기 대사 검색을 숨긴다", () => {
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({ phase_type: "investigation" })}
+        themeId="t1"
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("정보 공개")).toBeDefined();
+    expect(screen.queryByPlaceholderText("대사 이름으로 찾기")).toBeNull();
   });
 
   it("장면 연출 cue를 시작 트리거와 분리해 저장한다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/ReadingPlacementPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ReadingPlacementPanel.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { DELIVER_INFORMATION_ACTION } from "../../../entities/shared/actionAdapter";
+import { ReadingPlacementPanel } from "../ReadingPlacementPanel";
+
+const { useReadingSectionsMock } = vi.hoisted(() => ({
+  useReadingSectionsMock: vi.fn(),
+}));
+
+vi.mock("../../../readingApi", () => ({
+  useReadingSections: () => useReadingSectionsMock(),
+}));
+
+const sections = [
+  { id: "rs-1", name: "오프닝 낭독", lines: [{ Text: "시작" }] },
+  { id: "rs-2", name: "비밀 편지", lines: [{ Text: "편지" }] },
+];
+
+beforeEach(() => {
+  useReadingSectionsMock.mockReturnValue({
+    data: sections,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ReadingPlacementPanel", () => {
+  it("읽기 대사를 검색하고 선택/제거할 수 있다", () => {
+    const onChange = vi.fn();
+    render(<ReadingPlacementPanel themeId="theme-1" phaseData={{}} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText("대사 이름으로 찾기"), {
+      target: { value: "편지" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /비밀 편지/ }));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      onEnter: [
+        {
+          id: expect.any(String),
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "reading-placement",
+                target: { type: "all_players" },
+                reading_section_ids: ["rs-2"],
+                story_info_ids: [],
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("기존 저장된 읽기 대사 연결을 선택 상태로 표시한다", () => {
+    render(
+      <ReadingPlacementPanel
+        themeId="theme-1"
+        phaseData={{
+          onEnter: [
+            {
+              id: "info",
+              type: DELIVER_INFORMATION_ACTION,
+              params: {
+                deliveries: [
+                  { id: "d1", target: { type: "character", character_id: "char-1" }, reading_section_ids: ["rs-1"] },
+                ],
+              },
+            },
+          ],
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("1개 선택")).toBeDefined();
+    expect(screen.getAllByText("오프닝 낭독").length).toBeGreaterThan(0);
+  });
+
+  it("조회 실패를 빈 상태와 구분하고 재시도할 수 있다", () => {
+    const refetch = vi.fn();
+    useReadingSectionsMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+      refetch,
+    });
+
+    render(<ReadingPlacementPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
+
+    expect(screen.getByText("읽기 대사 목록을 불러오지 못했습니다.")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/editor/entities/phase/__tests__/readingPlacementAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/phase/__tests__/readingPlacementAdapter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { FlowNodeData } from "../../../flowTypes";
+import { DELIVER_INFORMATION_ACTION } from "../../shared/actionAdapter";
+import {
+  flowNodeToReadingPlacement,
+  readingPlacementToFlowNodePatch,
+} from "../readingPlacementAdapter";
+
+describe("readingPlacementAdapter", () => {
+  it("기존 정보 공개 action에 섞인 읽기 대사 id를 전용 ViewModel로 모은다", () => {
+    const data: FlowNodeData = {
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              { id: "d1", target: { type: "character", character_id: "char-1" }, reading_section_ids: ["rs-1", "rs-2", "rs-1"] },
+              { id: "d2", target: { type: "all_players" }, readingSectionIds: ["rs-common"] },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(flowNodeToReadingPlacement(data)).toEqual({
+      readingSectionIds: ["rs-1", "rs-2", "rs-common"],
+    });
+  });
+
+  it("신규 저장은 모든 플레이어 대상의 읽기 대사 전용 delivery로 분리한다", () => {
+    const patch = readingPlacementToFlowNodePatch(
+      { onEnter: [{ id: "bgm", type: "play_bgm" }] },
+      ["rs-1", "rs-2", "rs-1"],
+    );
+
+    expect(patch.onEnter).toEqual([
+      { id: "bgm", type: "play_bgm" },
+      {
+        id: expect.any(String),
+        type: DELIVER_INFORMATION_ACTION,
+        params: {
+          deliveries: [
+            {
+              id: "reading-placement",
+              target: { type: "all_players" },
+              reading_section_ids: ["rs-1", "rs-2"],
+              story_info_ids: [],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("읽기 대사만 제거해도 기존 정보 공개 delivery는 보존한다", () => {
+    const data: FlowNodeData = {
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "mixed",
+                target: { type: "character", character_id: "char-1" },
+                reading_section_ids: ["rs-1"],
+                story_info_ids: ["info-1"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(readingPlacementToFlowNodePatch(data, [])).toEqual({
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "mixed",
+                target: { type: "character", character_id: "char-1" },
+                reading_section_ids: [],
+                story_info_ids: ["info-1"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/features/editor/entities/phase/readingPlacementAdapter.ts
+++ b/apps/web/src/features/editor/entities/phase/readingPlacementAdapter.ts
@@ -1,0 +1,55 @@
+import type { FlowNodeData } from "../../flowTypes";
+import {
+  flowNodeToInformationDeliveries,
+  informationDeliveriesToFlowNodePatch,
+  type InformationDeliveryViewModel,
+} from "../shared/informationDeliveryAdapter";
+
+export interface ReadingPlacementViewModel {
+  readingSectionIds: string[];
+}
+
+export function flowNodeToReadingPlacement(data: FlowNodeData): ReadingPlacementViewModel {
+  return {
+    readingSectionIds: unique(
+      flowNodeToInformationDeliveries(data).flatMap((delivery) => delivery.readingSectionIds),
+    ),
+  };
+}
+
+export function readingPlacementToFlowNodePatch(
+  data: FlowNodeData,
+  readingSectionIds: string[],
+): Pick<FlowNodeData, "onEnter"> {
+  const storyInfoDeliveries = flowNodeToInformationDeliveries(data)
+    .map((delivery): InformationDeliveryViewModel => ({
+      ...delivery,
+      readingSectionIds: [],
+    }))
+    .filter((delivery) => delivery.storyInfoIds.length > 0);
+  const normalizedReadingSectionIds = unique(readingSectionIds);
+
+  if (normalizedReadingSectionIds.length === 0) {
+    return informationDeliveriesToFlowNodePatch(data, storyInfoDeliveries);
+  }
+
+  return informationDeliveriesToFlowNodePatch(data, [
+    ...storyInfoDeliveries,
+    {
+      id: findExistingReadingDeliveryId(data) ?? "reading-placement",
+      recipientType: "all_players",
+      readingSectionIds: normalizedReadingSectionIds,
+      storyInfoIds: [],
+    },
+  ]);
+}
+
+function findExistingReadingDeliveryId(data: FlowNodeData): string | undefined {
+  return flowNodeToInformationDeliveries(data).find(
+    (delivery) => delivery.readingSectionIds.length > 0,
+  )?.id;
+}
+
+function unique(ids: string[]): string[] {
+  return Array.from(new Set(ids.filter(Boolean)));
+}


### PR DESCRIPTION
## 요약
- story_progression 노드 전용 `ReadingPlacementPanel`을 추가해 읽기 대사 배치를 일반 장면의 정보 공개 UI에서 분리했습니다.
- 일반 장면의 `InformationDeliveryPanel`에서는 읽기 대사 검색/선택 UI를 제거하고, 캐릭터/스토리 정보 공개만 다루도록 정리했습니다.
- 기존 저장 데이터 호환을 위해 mixed `DELIVER_INFORMATION` action에서 읽기 대사 ID를 읽고, 저장 시 읽기 대사 전용 delivery로 정규화하는 adapter를 추가했습니다.

Closes #503

## Coverage Plan
- `apps/web/src/features/editor/entities/phase/readingPlacementAdapter.ts`
  - 기존 mixed delivery에서 읽기 대사 ID를 읽는 호환 경로
  - story info delivery를 보존하면서 읽기 대사 ID만 전용 delivery로 저장하는 경로
  - 중복 읽기 대사 ID 제거 경로
- `apps/web/src/features/editor/components/design/ReadingPlacementPanel.tsx`
  - 읽기 대사 목록 검색/선택, 기존 선택 표시, 조회 실패 후 재시도 UI
- `apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx`
  - 일반 정보 공개 패널에서 읽기 대사 UI가 사라진 상태
  - 캐릭터/스토리 정보 선택과 저장 상태 갱신
- `apps/web/src/features/editor/components/design/PhaseNodePanel.tsx`
  - `story_progression` 노드는 읽기 대사 배치 패널만 표시
  - 일반 investigation 노드는 정보 공개 패널만 표시

## Local validation
- `pnpm --dir apps/web exec vitest run src/features/editor/entities/phase/__tests__/readingPlacementAdapter.test.ts src/features/editor/components/design/__tests__/ReadingPlacementPanel.test.tsx src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx` 통과: 4 files, 27 tests
- `pnpm --dir apps/web typecheck` 통과
- `scripts/mmp-local-ci.sh quick` 통과: Go test, server lint, web typecheck, web Vitest, web build
- Browser smoke: `/editor/e2e-test-theme/story`에서 일반 장면 패널에 읽기 대사 검색/배치 UI가 더 이상 보이지 않는 것을 확인했습니다. 현재 fixture에는 `story_progression` 노드가 없어 해당 경로는 component test로 검증했습니다.

## E2E
- 별도 Playwright E2E는 추가하지 않았습니다. 이번 변경은 editor 우측 패널 라우팅/UI와 adapter 정규화에 한정되고, 현재 브라우저 fixture에 `story_progression` 노드가 없어 focused component/unit test와 browser smoke로 대체했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 읽기 대사 배치 기능 추가 - 편집기에서 읽기 대사를 관리할 수 있습니다.
  * 단계별 유형에 따른 패널 자동 전환 - 단계 유형에 맞는 편집 인터페이스가 자동으로 표시됩니다.

* **개선 사항**
  * 정보 공개 기능을 스토리 정보 중심으로 개선 - 더 명확한 정보 전달 관리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->