### PR TITLE
feat(editor): 장면 진입 효과에 단서 지급 추가

### DIFF
--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -195,6 +195,7 @@ func ensureImplicitPhaseActionModules(cfg *GameConfig) error {
 	}
 	implicitActions := []PhaseAction{
 		ActionDeliverInformation,
+		ActionGrantClue,
 		ActionEvaluateEnding,
 		ActionPlaySound,
 		ActionPlayMedia,

--- a/apps/server/internal/engine/phase_actions.go
+++ b/apps/server/internal/engine/phase_actions.go
@@ -158,6 +158,7 @@ var legacyPhaseActionAliases = map[string]PhaseAction{
 	"stop_bgm":            ActionStopAudio,
 	"stop_audio":          ActionStopAudio,
 	"broadcast":           ActionBroadcastMessage,
+	"grant_clue":          ActionGrantClue,
 }
 
 // NormalizePhaseActionType maps editor/legacy action names to the backend

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -20,6 +20,7 @@ const (
 	ActionAllowExchange       PhaseAction = "ALLOW_EXCHANGE"
 	ActionBroadcastMessage    PhaseAction = "BROADCAST_MESSAGE"
 	ActionDeliverInformation  PhaseAction = "DELIVER_INFORMATION"
+	ActionGrantClue           PhaseAction = "GRANT_CLUE"
 	ActionEvaluateEnding      PhaseAction = "EVALUATE_ENDING"
 	ActionPlaySound           PhaseAction = "PLAY_SOUND"
 	ActionPlayMedia           PhaseAction = "PLAY_MEDIA"
@@ -69,6 +70,7 @@ var ActionRequiresModule = map[PhaseAction]string{
 	ActionCloseGroupChat:      "group_chat",
 	ActionApplyDiscussionRoom: "group_chat",
 	ActionDeliverInformation:  "information_delivery",
+	ActionGrantClue:           "clue_interaction",
 	ActionEvaluateEnding:      "ending_branch",
 	ActionPlaySound:           "audio",
 	ActionPlayMedia:           "audio",

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -45,10 +47,13 @@ type ClueInteractionModule struct {
 	playerDrawCounts map[uuid.UUID]int
 	currentClueLevel int
 	acquiredClues    map[uuid.UUID][]string
+	targetCodeClues  map[string][]string
+	allPlayerClues   []string
 	activeItemUse    *ItemUseState
 	usedItems        map[uuid.UUID][]uuid.UUID // playerID -> used clue IDs
 	revealedInfo     map[uuid.UUID]map[string]string
 	itemTimeout      *time.Timer
+	appliedGrantIDs  map[string]struct{}
 }
 
 // NewClueInteractionModule creates a new ClueInteractionModule instance.
@@ -65,8 +70,11 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 	m.deps = deps
 	m.playerDrawCounts = make(map[uuid.UUID]int)
 	m.acquiredClues = make(map[uuid.UUID][]string)
+	m.targetCodeClues = make(map[string][]string)
+	m.allPlayerClues = nil
 	m.usedItems = make(map[uuid.UUID][]uuid.UUID)
 	m.revealedInfo = make(map[uuid.UUID]map[string]string)
+	m.appliedGrantIDs = make(map[string]struct{})
 
 	// Apply defaults first.
 	m.config = ClueInteractionConfig{
@@ -103,6 +111,21 @@ type drawCluePayload struct {
 type transferCluePayload struct {
 	TargetCode string `json:"targetCode"`
 	ClueID     string `json:"clueId"`
+}
+
+type clueGrantTarget struct {
+	Type        string `json:"type"`
+	CharacterID string `json:"character_id,omitempty"`
+}
+
+type clueGrantDelivery struct {
+	ID      string          `json:"id"`
+	Target  clueGrantTarget `json:"target"`
+	ClueIDs []string        `json:"clue_ids"`
+}
+
+type grantClueParams struct {
+	Deliveries []clueGrantDelivery `json:"deliveries"`
 }
 
 func (m *ClueInteractionModule) HandleMessage(ctx context.Context, playerID uuid.UUID, msgType string, payload json.RawMessage) error {
@@ -206,7 +229,7 @@ func (m *ClueInteractionModule) handleTransferClue(_ context.Context, playerID u
 
 // --- PhaseReactor ---
 
-func (m *ClueInteractionModule) ReactTo(_ context.Context, action engine.PhaseActionPayload) error {
+func (m *ClueInteractionModule) ReactTo(ctx context.Context, action engine.PhaseActionPayload) error {
 	switch action.Action {
 	case engine.ActionResetDrawCount:
 		m.mu.Lock()
@@ -231,6 +254,13 @@ func (m *ClueInteractionModule) ReactTo(_ context.Context, action engine.PhaseAc
 		m.mu.Unlock()
 		return nil
 
+	case engine.ActionGrantClue:
+		var params grantClueParams
+		if err := json.Unmarshal(action.Params, &params); err != nil {
+			return fmt.Errorf("clue_interaction: invalid GRANT_CLUE params: %w", err)
+		}
+		return m.applyClueGrants(ctx, params.Deliveries)
+
 	default:
 		return fmt.Errorf("clue_interaction: unsupported action %q", action.Action)
 	}
@@ -240,7 +270,81 @@ func (m *ClueInteractionModule) SupportedActions() []engine.PhaseAction {
 	return []engine.PhaseAction{
 		engine.ActionResetDrawCount,
 		engine.ActionSetClueLevel,
+		engine.ActionGrantClue,
 	}
+}
+
+func (m *ClueInteractionModule) applyClueGrants(ctx context.Context, deliveries []clueGrantDelivery) error {
+	type preparedGrant struct {
+		delivery  clueGrantDelivery
+		clueIDs   []string
+		playerIDs []uuid.UUID
+	}
+	prepared := make([]preparedGrant, 0, len(deliveries))
+	for _, delivery := range deliveries {
+		delivery.ID = normalizeClueGrantID(delivery)
+		clueIDs := uniqueClueIDs(delivery.ClueIDs)
+		if len(clueIDs) == 0 {
+			return fmt.Errorf("clue_interaction: grant %q has empty clue_ids", delivery.ID)
+		}
+		next := preparedGrant{delivery: delivery, clueIDs: clueIDs}
+		switch delivery.Target.Type {
+		case "all_players":
+			if rosterProvider, ok := m.deps.PlayerInfoProvider.(engine.PlayerRuntimeRosterProvider); ok {
+				for _, player := range rosterProvider.PlayerRuntimeRoster(ctx) {
+					next.playerIDs = append(next.playerIDs, player.PlayerID)
+				}
+			}
+		case "character":
+			if delivery.Target.CharacterID == "" {
+				return fmt.Errorf("clue_interaction: grant %q missing character_id", delivery.ID)
+			}
+			if m.deps.PlayerInfoProvider != nil {
+				if playerID, ok := m.deps.PlayerInfoProvider.ResolvePlayerID(ctx, delivery.Target.CharacterID); ok {
+					next.playerIDs = append(next.playerIDs, playerID)
+				}
+			}
+		default:
+			return fmt.Errorf("clue_interaction: grant %q has unsupported target type %q", delivery.ID, delivery.Target.Type)
+		}
+		prepared = append(prepared, next)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, grant := range prepared {
+		if _, applied := m.appliedGrantIDs[grant.delivery.ID]; applied {
+			continue
+		}
+		switch grant.delivery.Target.Type {
+		case "all_players":
+			m.allPlayerClues = mergeClueList(m.allPlayerClues, grant.clueIDs)
+			for _, playerID := range grant.playerIDs {
+				m.acquiredClues[playerID] = mergeClueList(m.acquiredClues[playerID], grant.clueIDs)
+			}
+		case "character":
+			if len(grant.playerIDs) > 0 {
+				for _, playerID := range grant.playerIDs {
+					m.acquiredClues[playerID] = mergeClueList(m.acquiredClues[playerID], grant.clueIDs)
+				}
+			} else {
+				m.targetCodeClues[grant.delivery.Target.CharacterID] = mergeClueList(
+					m.targetCodeClues[grant.delivery.Target.CharacterID],
+					grant.clueIDs,
+				)
+			}
+		}
+		m.deps.EventBus.Publish(engine.Event{
+			Type: "clue.granted",
+			Payload: map[string]any{
+				"deliveryId": grant.delivery.ID,
+				"target":     grant.delivery.Target,
+				"clueIds":    grant.clueIDs,
+			},
+		})
+		m.appliedGrantIDs[grant.delivery.ID] = struct{}{}
+	}
+	return nil
 }
 
 // --- ConfigSchema ---
@@ -282,6 +386,7 @@ type clueInteractionState struct {
 	PlayerDrawCounts map[uuid.UUID]int               `json:"playerDrawCounts"`
 	CurrentClueLevel int                             `json:"currentClueLevel"`
 	AcquiredClues    map[uuid.UUID][]string          `json:"acquiredClues"`
+	AllPlayerClues   []string                        `json:"allPlayerClues,omitempty"`
 	Config           ClueInteractionConfig           `json:"config"`
 	UsedItems        map[uuid.UUID][]uuid.UUID       `json:"usedItems"`
 	RevealedInfo     map[uuid.UUID]map[string]string `json:"revealedInfo"`
@@ -296,6 +401,7 @@ func (m *ClueInteractionModule) BuildState() (json.RawMessage, error) {
 		PlayerDrawCounts: m.playerDrawCounts,
 		CurrentClueLevel: m.currentClueLevel,
 		AcquiredClues:    m.acquiredClues,
+		AllPlayerClues:   m.allPlayerClues,
 		Config:           m.config,
 		UsedItems:        m.usedItems,
 		RevealedInfo:     m.revealedInfo,
@@ -309,9 +415,12 @@ func (m *ClueInteractionModule) Cleanup(_ context.Context) error {
 
 	m.playerDrawCounts = nil
 	m.acquiredClues = nil
+	m.targetCodeClues = nil
+	m.allPlayerClues = nil
 	m.usedItems = nil
 	m.revealedInfo = nil
 	m.activeItemUse = nil
+	m.appliedGrantIDs = nil
 	if m.itemTimeout != nil {
 		m.itemTimeout.Stop()
 		m.itemTimeout = nil
@@ -359,15 +468,51 @@ func (m *ClueInteractionModule) BuildStateFor(playerID uuid.UUID) (json.RawMessa
 		cp := *m.activeItemUse
 		activeItemUse = &cp
 	}
+	acquiredClues := engine.FilterByPlayer(m.acquiredClues, playerID)
+	acquiredClues[playerID] = mergeClueList(acquiredClues[playerID], m.allPlayerClues)
+	if m.deps.PlayerInfoProvider != nil {
+		if info, ok := m.deps.PlayerInfoProvider.PlayerRuntimeInfo(context.Background(), playerID); ok {
+			acquiredClues[playerID] = mergeClueList(acquiredClues[playerID], m.targetCodeClues[info.TargetCode])
+		}
+	}
 	return json.Marshal(clueInteractionState{
 		PlayerDrawCounts: engine.FilterByPlayer(m.playerDrawCounts, playerID),
 		CurrentClueLevel: m.currentClueLevel,
-		AcquiredClues:    engine.FilterByPlayer(m.acquiredClues, playerID),
+		AcquiredClues:    acquiredClues,
+		AllPlayerClues:   m.allPlayerClues,
 		Config:           m.configForPlayerState(),
 		UsedItems:        engine.FilterByPlayer(m.usedItems, playerID),
 		RevealedInfo:     engine.FilterByPlayer(m.revealedInfo, playerID),
 		ActiveItemUse:    activeItemUse,
 	})
+}
+
+func normalizeClueGrantID(delivery clueGrantDelivery) string {
+	if delivery.ID != "" {
+		return delivery.ID
+	}
+	return delivery.Target.Type + ":" + delivery.Target.CharacterID + ":clues:" + strings.Join(uniqueClueIDs(delivery.ClueIDs), ",")
+}
+
+func uniqueClueIDs(ids []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func mergeClueList(current []string, next []string) []string {
+	return uniqueClueIDs(append(append([]string{}, current...), next...))
 }
 
 func (m *ClueInteractionModule) configForPlayerState() ClueInteractionConfig {

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -280,6 +280,7 @@ func (m *ClueInteractionModule) applyClueGrants(ctx context.Context, deliveries 
 		clueIDs   []string
 		playerIDs []uuid.UUID
 	}
+	events := make([]engine.Event, 0, len(deliveries))
 	prepared := make([]preparedGrant, 0, len(deliveries))
 	for _, delivery := range deliveries {
 		delivery.ID = normalizeClueGrantID(delivery)
@@ -311,7 +312,6 @@ func (m *ClueInteractionModule) applyClueGrants(ctx context.Context, deliveries 
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	for _, grant := range prepared {
 		if _, applied := m.appliedGrantIDs[grant.delivery.ID]; applied {
 			continue
@@ -334,7 +334,7 @@ func (m *ClueInteractionModule) applyClueGrants(ctx context.Context, deliveries 
 				)
 			}
 		}
-		m.deps.EventBus.Publish(engine.Event{
+		events = append(events, engine.Event{
 			Type: "clue.granted",
 			Payload: map[string]any{
 				"deliveryId": grant.delivery.ID,
@@ -343,6 +343,10 @@ func (m *ClueInteractionModule) applyClueGrants(ctx context.Context, deliveries 
 			},
 		})
 		m.appliedGrantIDs[grant.delivery.ID] = struct{}{}
+	}
+	m.mu.Unlock()
+	for _, event := range events {
+		m.deps.EventBus.Publish(event)
 	}
 	return nil
 }
@@ -475,6 +479,7 @@ func (m *ClueInteractionModule) BuildStateFor(playerID uuid.UUID) (json.RawMessa
 			acquiredClues[playerID] = mergeClueList(acquiredClues[playerID], m.targetCodeClues[info.TargetCode])
 		}
 	}
+	acquiredClues[playerID] = mergeClueList(acquiredClues[playerID], m.targetCodeClues[playerID.String()])
 	return json.Marshal(clueInteractionState{
 		PlayerDrawCounts: engine.FilterByPlayer(m.playerDrawCounts, playerID),
 		CurrentClueLevel: m.currentClueLevel,

--- a/apps/server/internal/module/core/clue_interaction_test.go
+++ b/apps/server/internal/module/core/clue_interaction_test.go
@@ -332,6 +332,67 @@ func TestClueInteractionModule_ReactTo_GrantClueToCharacter(t *testing.T) {
 	}
 }
 
+func TestClueInteractionModule_ReactTo_GrantClueOfflinePlayerIDFallback(t *testing.T) {
+	playerID := uuid.New()
+	deps := newTestDeps()
+	m := NewClueInteractionModule()
+	_ = m.Init(context.Background(), deps, nil)
+
+	params := json.RawMessage(`{"deliveries":[{"id":"grant-offline","target":{"type":"character","character_id":"` + playerID.String() + `"},"clue_ids":["clue-late"]}]}`)
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionGrantClue, Params: params}); err != nil {
+		t.Fatalf("ReactTo GRANT_CLUE failed: %v", err)
+	}
+
+	m.deps.PlayerInfoProvider = clueGrantTestProvider{
+		players: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			playerID: {PlayerID: playerID, TargetCode: "detective"},
+		},
+	}
+	data, err := m.BuildStateFor(playerID)
+	if err != nil {
+		t.Fatalf("BuildStateFor failed: %v", err)
+	}
+	var state clueInteractionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	if !reflect.DeepEqual(state.AcquiredClues[playerID], []string{"clue-late"}) {
+		t.Fatalf("acquired clues = %#v, want offline grant", state.AcquiredClues[playerID])
+	}
+}
+
+func TestClueInteractionModule_ReactTo_GrantCluePublishesAfterUnlock(t *testing.T) {
+	playerID := uuid.New()
+	deps := newTestDeps()
+	deps.PlayerInfoProvider = clueGrantTestProvider{
+		players: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			playerID: {PlayerID: playerID, TargetCode: "detective"},
+		},
+	}
+	m := NewClueInteractionModule()
+	_ = m.Init(context.Background(), deps, nil)
+	deps.EventBus.Subscribe("clue.granted", func(engine.Event) {
+		if _, err := m.BuildStateFor(playerID); err != nil {
+			t.Errorf("BuildStateFor in event handler failed: %v", err)
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		params := json.RawMessage(`{"deliveries":[{"id":"grant-publish","target":{"type":"character","character_id":"detective"},"clue_ids":["clue-1"]}]}`)
+		done <- m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionGrantClue, Params: params})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ReactTo GRANT_CLUE failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ReactTo GRANT_CLUE timed out; event publish likely held module lock")
+	}
+}
+
 func TestClueInteractionModule_ReactTo_GrantClueToAllPlayers(t *testing.T) {
 	p1 := uuid.New()
 	p2 := uuid.New()

--- a/apps/server/internal/module/core/clue_interaction_test.go
+++ b/apps/server/internal/module/core/clue_interaction_test.go
@@ -4,12 +4,39 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/mmp-platform/server/internal/engine"
 )
+
+type clueGrantTestProvider struct {
+	players map[uuid.UUID]engine.PlayerRuntimeInfo
+}
+
+func (p clueGrantTestProvider) ResolvePlayerID(_ context.Context, targetCode string) (uuid.UUID, bool) {
+	for id, info := range p.players {
+		if info.TargetCode == targetCode || id.String() == targetCode {
+			return id, true
+		}
+	}
+	return uuid.Nil, false
+}
+
+func (p clueGrantTestProvider) PlayerRuntimeInfo(_ context.Context, playerID uuid.UUID) (engine.PlayerRuntimeInfo, bool) {
+	info, ok := p.players[playerID]
+	return info, ok
+}
+
+func (p clueGrantTestProvider) PlayerRuntimeRoster(context.Context) []engine.PlayerRuntimeInfo {
+	out := make([]engine.PlayerRuntimeInfo, 0, len(p.players))
+	for _, info := range p.players {
+		out = append(out, info)
+	}
+	return out
+}
 
 func TestClueInteractionModule_Name(t *testing.T) {
 	m := NewClueInteractionModule()
@@ -207,12 +234,13 @@ func TestClueInteractionModule_UnknownMessage(t *testing.T) {
 func TestClueInteractionModule_SupportedActions(t *testing.T) {
 	m := NewClueInteractionModule()
 	actions := m.SupportedActions()
-	if len(actions) != 2 {
-		t.Fatalf("expected 2 supported actions, got %d", len(actions))
+	if len(actions) != 3 {
+		t.Fatalf("expected 3 supported actions, got %d", len(actions))
 	}
 	expected := map[engine.PhaseAction]bool{
 		engine.ActionResetDrawCount: true,
 		engine.ActionSetClueLevel:   true,
+		engine.ActionGrantClue:      true,
 	}
 	for _, a := range actions {
 		if !expected[a] {
@@ -274,6 +302,73 @@ func TestClueInteractionModule_ReactTo_SetClueLevel_InvalidLevel(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for level <= 0")
+	}
+}
+
+func TestClueInteractionModule_ReactTo_GrantClueToCharacter(t *testing.T) {
+	playerID := uuid.New()
+	deps := newTestDeps()
+	deps.PlayerInfoProvider = clueGrantTestProvider{
+		players: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			playerID: {PlayerID: playerID, TargetCode: "detective"},
+		},
+	}
+	m := NewClueInteractionModule()
+	_ = m.Init(context.Background(), deps, nil)
+
+	params := json.RawMessage(`{"deliveries":[{"id":"grant-1","target":{"type":"character","character_id":"detective"},"clue_ids":["clue-2","clue-1","clue-1"]}]}`)
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionGrantClue, Params: params}); err != nil {
+		t.Fatalf("ReactTo GRANT_CLUE failed: %v", err)
+	}
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionGrantClue, Params: params}); err != nil {
+		t.Fatalf("idempotent GRANT_CLUE failed: %v", err)
+	}
+
+	m.mu.RLock()
+	got := append([]string{}, m.acquiredClues[playerID]...)
+	m.mu.RUnlock()
+	if !reflect.DeepEqual(got, []string{"clue-1", "clue-2"}) {
+		t.Fatalf("acquired clues = %#v, want sorted unique clue list", got)
+	}
+}
+
+func TestClueInteractionModule_ReactTo_GrantClueToAllPlayers(t *testing.T) {
+	p1 := uuid.New()
+	p2 := uuid.New()
+	deps := newTestDeps()
+	deps.PlayerInfoProvider = clueGrantTestProvider{
+		players: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			p1: {PlayerID: p1, TargetCode: "detective"},
+			p2: {PlayerID: p2, TargetCode: "suspect"},
+		},
+	}
+	m := NewClueInteractionModule()
+	_ = m.Init(context.Background(), deps, nil)
+
+	params := json.RawMessage(`{"deliveries":[{"id":"grant-all","target":{"type":"all_players"},"clue_ids":["clue-common"]}]}`)
+	if err := m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionGrantClue, Params: params}); err != nil {
+		t.Fatalf("ReactTo GRANT_CLUE failed: %v", err)
+	}
+
+	m.mu.RLock()
+	gotP1 := append([]string{}, m.acquiredClues[p1]...)
+	gotP2 := append([]string{}, m.acquiredClues[p2]...)
+	m.mu.RUnlock()
+	if !reflect.DeepEqual(gotP1, []string{"clue-common"}) || !reflect.DeepEqual(gotP2, []string{"clue-common"}) {
+		t.Fatalf("all-player grant = %#v / %#v, want clue-common for both players", gotP1, gotP2)
+	}
+}
+
+func TestClueInteractionModule_ReactTo_GrantClueValidatesPayload(t *testing.T) {
+	m := NewClueInteractionModule()
+	_ = m.Init(context.Background(), newTestDeps(), nil)
+
+	err := m.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionGrantClue,
+		Params: json.RawMessage(`{"deliveries":[{"id":"empty","target":{"type":"character","character_id":"detective"},"clue_ids":[]}]}`),
+	})
+	if err == nil {
+		t.Fatal("expected empty clue_ids to fail")
 	}
 }
 

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanel.tsx
@@ -1,19 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
-import { useEditorCharacters } from "../../api";
+import { useEditorCharacters, useEditorClues, type ClueResponse } from "../../api";
 import { useStoryInfos, type StoryInfoResponse } from "../../storyInfoApi";
 import {
   InformationDeliveryContent,
   InformationDeliveryHeader,
+  type ClueOption,
   type StoryInfoOption,
 } from "./InformationDeliveryPanelViews";
 import type { FlowNodeData } from "../../flowTypes";
 import {
-  flowNodeToInformationDeliveries,
-  informationDeliveriesToFlowNodePatch,
-  isCompleteInformationDelivery,
-  makeEmptyInformationDelivery,
-  type InformationDeliveryViewModel,
-} from "../../entities/shared/informationDeliveryAdapter";
+  flowNodeToSceneEntryEffects,
+  isCompleteSceneEntryEffect,
+  makeEmptySceneEntryEffect,
+  sceneEntryEffectsToFlowNodePatch,
+  type SceneEntryEffectViewModel,
+} from "../../entities/shared/sceneEntryEffectAdapter";
 
 interface InformationDeliveryPanelProps {
   themeId: string;
@@ -38,14 +39,17 @@ export function InformationDeliveryPanel({
     isError: storyInfosError,
     refetch: refetchStoryInfos,
   } = useStoryInfos(themeId);
+  const {
+    data: clues = [],
+    isLoading: cluesLoading,
+    isError: cluesError,
+    refetch: refetchClues,
+  } = useEditorClues(themeId);
   const [characterQuery, setCharacterQuery] = useState("");
   const [infoQuery, setInfoQuery] = useState("");
+  const [clueQuery, setClueQuery] = useState("");
   const savedDeliveries = useMemo(
-    () =>
-      flowNodeToInformationDeliveries(phaseData).map((delivery) => ({
-        ...delivery,
-        readingSectionIds: [],
-      })),
+    () => flowNodeToSceneEntryEffects(phaseData),
     [phaseData],
   );
   const [draftDeliveries, setDraftDeliveries] = useState(() => savedDeliveries);
@@ -54,7 +58,7 @@ export function InformationDeliveryPanel({
     setDraftDeliveries((current) => {
       const savedIds = new Set(savedDeliveries.map((delivery) => delivery.id));
       const incompleteDrafts = current.filter(
-        (delivery) => !savedIds.has(delivery.id) && !isCompleteInformationDelivery(delivery),
+        (delivery) => !savedIds.has(delivery.id) && !isCompleteSceneEntryEffect(delivery),
       );
       return [...savedDeliveries, ...incompleteDrafts];
     });
@@ -67,26 +71,31 @@ export function InformationDeliveryPanel({
   }, [characters, characterQuery]);
 
   const storyInfoOptions = useMemo(() => toStoryInfoOptions(storyInfos), [storyInfos]);
+  const clueOptions = useMemo(() => toClueOptions(clues), [clues]);
 
   const filteredStoryInfos = useMemo(
     () => filterStoryInfoOptions(storyInfoOptions, infoQuery),
     [storyInfoOptions, infoQuery],
   );
+  const filteredClues = useMemo(
+    () => filterClueOptions(clueOptions, clueQuery),
+    [clueOptions, clueQuery],
+  );
 
-  const updateDeliveries = (next: InformationDeliveryViewModel[]) => {
+  const updateDeliveries = (next: SceneEntryEffectViewModel[]) => {
     setDraftDeliveries(next);
-    onChange(informationDeliveriesToFlowNodePatch(phaseData, next));
+    onChange(sceneEntryEffectsToFlowNodePatch(phaseData, next));
   };
 
   const addCharacterDelivery = () => {
-    updateDeliveries([...draftDeliveries, makeEmptyInformationDelivery("character")]);
+    updateDeliveries([...draftDeliveries, makeEmptySceneEntryEffect("character")]);
   };
 
   const addAllPlayersDelivery = () => {
-    updateDeliveries([...draftDeliveries, makeEmptyInformationDelivery("all_players")]);
+    updateDeliveries([...draftDeliveries, makeEmptySceneEntryEffect("all_players")]);
   };
 
-  const updateDelivery = (deliveryId: string, patch: Partial<InformationDeliveryViewModel>) => {
+  const updateDelivery = (deliveryId: string, patch: Partial<SceneEntryEffectViewModel>) => {
     updateDeliveries(
       draftDeliveries.map((delivery) =>
         delivery.id === deliveryId ? { ...delivery, ...patch } : delivery,
@@ -98,7 +107,7 @@ export function InformationDeliveryPanel({
     updateDeliveries(draftDeliveries.filter((delivery) => delivery.id !== deliveryId));
   };
 
-  const toggleStoryInfo = (delivery: InformationDeliveryViewModel, storyInfoId: string) => {
+  const toggleStoryInfo = (delivery: SceneEntryEffectViewModel, storyInfoId: string) => {
     const hasStoryInfo = delivery.storyInfoIds.includes(storyInfoId);
     updateDelivery(delivery.id, {
       storyInfoIds: hasStoryInfo
@@ -107,13 +116,23 @@ export function InformationDeliveryPanel({
     });
   };
 
-  const loading = charactersLoading || storyInfosLoading;
-  const hasLoadError = charactersError || storyInfosError;
+  const toggleClue = (delivery: SceneEntryEffectViewModel, clueId: string) => {
+    const hasClue = delivery.clueIds.includes(clueId);
+    updateDelivery(delivery.id, {
+      clueIds: hasClue
+        ? delivery.clueIds.filter((id) => id !== clueId)
+        : [...delivery.clueIds, clueId],
+    });
+  };
+
+  const loading = charactersLoading || storyInfosLoading || cluesLoading;
+  const hasLoadError = charactersError || storyInfosError || cluesError;
   const canAddCharacterDelivery = characters.length > 0;
 
   const retryLoad = () => {
     if (charactersError) void refetchCharacters();
     if (storyInfosError) void refetchStoryInfos();
+    if (cluesError) void refetchClues();
   };
 
   return (
@@ -129,22 +148,37 @@ export function InformationDeliveryPanel({
         hasLoadError={hasLoadError}
         hasCharacters={characters.length > 0}
         hasStoryInfos={storyInfos.length > 0}
+        hasClues={clues.length > 0}
         characterQuery={characterQuery}
         infoQuery={infoQuery}
+        clueQuery={clueQuery}
         deliveries={draftDeliveries}
         characters={filteredCharacters}
         allCharacters={characters}
         storyInfos={filteredStoryInfos}
         allStoryInfos={storyInfoOptions}
+        clues={filteredClues}
+        allClues={clueOptions}
         onRetryLoad={retryLoad}
         onCharacterQueryChange={setCharacterQuery}
         onInfoQueryChange={setInfoQuery}
+        onClueQueryChange={setClueQuery}
         onSelectCharacter={(deliveryId, characterId) => updateDelivery(deliveryId, { characterId })}
         onToggleStoryInfo={toggleStoryInfo}
+        onToggleClue={toggleClue}
         onRemoveDelivery={removeDelivery}
       />
     </section>
   );
+}
+
+function toClueOptions(clues: ClueResponse[]): ClueOption[] {
+  return clues.map((clue) => ({
+    id: clue.id,
+    name: clue.name,
+    summary: clue.description?.trim() || undefined,
+    metaLabel: typeof clue.reveal_round === "number" ? `R${clue.reveal_round}` : undefined,
+  }));
 }
 
 function toStoryInfoOptions(infos: StoryInfoResponse[]): StoryInfoOption[] {
@@ -154,6 +188,16 @@ function toStoryInfoOptions(infos: StoryInfoResponse[]): StoryInfoOption[] {
     summary: summarizeInfo(info.body),
     metaLabel: info.imageMediaId ? "이미지 포함" : undefined,
   }));
+}
+
+function filterClueOptions(options: ClueOption[], query: string): ClueOption[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return options;
+  return options.filter(
+    (option) =>
+      option.name.toLowerCase().includes(normalized) ||
+      (option.summary?.toLowerCase().includes(normalized) ?? false),
+  );
 }
 
 function filterStoryInfoOptions(options: StoryInfoOption[], query: string): StoryInfoOption[] {

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
@@ -136,7 +136,7 @@ export function InformationDeliveryContent({
     );
   }
 
-  if (!hasStoryInfos && !hasClues) {
+  if (!hasStoryInfos && !hasClues && deliveries.length === 0) {
     return (
       <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-400">
         연결할 정보나 단서가 없습니다. 먼저 정보 관리 또는 단서 관리에서 장면 효과로 쓸 항목을 만들어 주세요.

--- a/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryPanelViews.tsx
@@ -1,5 +1,5 @@
 import { Plus, Trash2, Users } from "lucide-react";
-import type { InformationDeliveryViewModel } from "../../entities/shared/informationDeliveryAdapter";
+import type { SceneEntryEffectViewModel } from "../../entities/shared/sceneEntryEffectAdapter";
 import { OptionList, SearchField } from "./InformationDeliveryOptionList";
 
 interface InformationDeliveryHeaderProps {
@@ -16,9 +16,9 @@ export function InformationDeliveryHeader({
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div>
-        <h4 className="text-sm font-semibold text-slate-100">정보 공개</h4>
+        <h4 className="text-sm font-semibold text-slate-100">장면 진입 효과</h4>
         <p className="mt-1 text-xs leading-5 text-slate-400">
-          이 장면에서 공개할 정보 카드를 대상별로 연결합니다.
+          이 장면에 들어왔을 때 대상에게 공개할 정보와 지급할 단서를 연결합니다.
         </p>
       </div>
       <div className="flex flex-wrap gap-2">
@@ -53,22 +53,35 @@ interface InformationDeliveryContentProps {
   hasLoadError: boolean;
   hasCharacters: boolean;
   hasStoryInfos: boolean;
+  hasClues: boolean;
   characterQuery: string;
   infoQuery: string;
-  deliveries: InformationDeliveryViewModel[];
+  clueQuery: string;
+  deliveries: SceneEntryEffectViewModel[];
   characters: { id: string; name: string }[];
   allCharacters: { id: string; name: string }[];
   storyInfos: StoryInfoOption[];
   allStoryInfos: StoryInfoOption[];
+  clues: ClueOption[];
+  allClues: ClueOption[];
   onRetryLoad: () => void;
   onCharacterQueryChange: (value: string) => void;
   onInfoQueryChange: (value: string) => void;
+  onClueQueryChange: (value: string) => void;
   onSelectCharacter: (deliveryId: string, characterId: string) => void;
-  onToggleStoryInfo: (delivery: InformationDeliveryViewModel, storyInfoId: string) => void;
+  onToggleStoryInfo: (delivery: SceneEntryEffectViewModel, storyInfoId: string) => void;
+  onToggleClue: (delivery: SceneEntryEffectViewModel, clueId: string) => void;
   onRemoveDelivery: (deliveryId: string) => void;
 }
 
 export interface StoryInfoOption {
+  id: string;
+  name: string;
+  summary?: string;
+  metaLabel?: string;
+}
+
+export interface ClueOption {
   id: string;
   name: string;
   summary?: string;
@@ -80,24 +93,30 @@ export function InformationDeliveryContent({
   hasLoadError,
   hasCharacters,
   hasStoryInfos,
+  hasClues,
   characterQuery,
   infoQuery,
+  clueQuery,
   deliveries,
   characters,
   allCharacters,
   storyInfos,
   allStoryInfos,
+  clues,
+  allClues,
   onRetryLoad,
   onCharacterQueryChange,
   onInfoQueryChange,
+  onClueQueryChange,
   onSelectCharacter,
   onToggleStoryInfo,
+  onToggleClue,
   onRemoveDelivery,
 }: InformationDeliveryContentProps) {
   if (loading) {
     return (
       <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs text-slate-400">
-        캐릭터와 정보를 불러오는 중입니다.
+        캐릭터, 정보, 단서 목록을 불러오는 중입니다.
       </p>
     );
   }
@@ -105,7 +124,7 @@ export function InformationDeliveryContent({
   if (hasLoadError) {
     return (
       <div className="mt-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-3 text-xs text-red-100">
-        <p>정보 공개에 필요한 캐릭터와 정보 목록을 불러오지 못했습니다.</p>
+        <p>장면 진입 효과에 필요한 캐릭터, 정보, 단서 목록을 불러오지 못했습니다.</p>
         <button
           type="button"
           onClick={onRetryLoad}
@@ -117,17 +136,17 @@ export function InformationDeliveryContent({
     );
   }
 
-  if (!hasStoryInfos) {
+  if (!hasStoryInfos && !hasClues) {
     return (
       <p className="mt-4 rounded border border-slate-800 bg-slate-900 px-3 py-3 text-xs leading-5 text-slate-400">
-        공개할 정보가 없습니다. 먼저 정보 관리에서 장면에 연결할 항목을 만들어 주세요.
+        연결할 정보나 단서가 없습니다. 먼저 정보 관리 또는 단서 관리에서 장면 효과로 쓸 항목을 만들어 주세요.
       </p>
     );
   }
 
   return (
     <>
-      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
         <SearchField
           label="캐릭터 검색"
           value={characterQuery}
@@ -139,6 +158,12 @@ export function InformationDeliveryContent({
           value={infoQuery}
           onChange={onInfoQueryChange}
           placeholder="정보 제목으로 찾기"
+        />
+        <SearchField
+          label="단서 검색"
+          value={clueQuery}
+          onChange={onClueQueryChange}
+          placeholder="단서 이름으로 찾기"
         />
       </div>
 
@@ -157,8 +182,11 @@ export function InformationDeliveryContent({
               allCharacters={allCharacters}
               storyInfos={storyInfos}
               allStoryInfos={allStoryInfos}
+              clues={clues}
+              allClues={allClues}
               onSelectCharacter={(characterId) => onSelectCharacter(delivery.id, characterId)}
               onToggleStoryInfo={(storyInfoId) => onToggleStoryInfo(delivery, storyInfoId)}
+              onToggleClue={(clueId) => onToggleClue(delivery, clueId)}
               onRemove={() => onRemoveDelivery(delivery.id)}
             />
           ))}
@@ -171,20 +199,23 @@ export function InformationDeliveryContent({
 
 function getEmptyDeliveryMessage(hasCharacters: boolean): string {
   if (!hasCharacters) {
-    return "아직 정보 공개 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 정보를 연결해 주세요.";
+    return "아직 장면 진입 효과 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어에게 적용할 효과를 연결해 주세요.";
   }
-  return "아직 정보 공개 대상이 없습니다. 전체 대상 추가 또는 캐릭터별 대상 추가를 눌러 대상을 정해 주세요.";
+  return "아직 장면 진입 효과 대상이 없습니다. 전체 대상 추가 또는 캐릭터별 대상 추가를 눌러 대상을 정해 주세요.";
 }
 
 interface DeliveryCardProps {
   index: number;
-  delivery: InformationDeliveryViewModel;
+  delivery: SceneEntryEffectViewModel;
   characters: { id: string; name: string }[];
   allCharacters: { id: string; name: string }[];
   storyInfos: StoryInfoOption[];
   allStoryInfos: StoryInfoOption[];
+  clues: ClueOption[];
+  allClues: ClueOption[];
   onSelectCharacter: (characterId: string) => void;
   onToggleStoryInfo: (storyInfoId: string) => void;
+  onToggleClue: (clueId: string) => void;
   onRemove: () => void;
 }
 
@@ -195,8 +226,11 @@ function DeliveryCard({
   allCharacters,
   storyInfos,
   allStoryInfos,
+  clues,
+  allClues,
   onSelectCharacter,
   onToggleStoryInfo,
+  onToggleClue,
   onRemove,
 }: DeliveryCardProps) {
   const selectedCharacterName =
@@ -208,15 +242,15 @@ function DeliveryCard({
     <article className="rounded-lg border border-slate-800 bg-slate-900/80 p-3">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold text-slate-200">정보 공개 {index + 1}</p>
+          <p className="text-xs font-semibold text-slate-200">진입 효과 {index + 1}</p>
           <p className="mt-1 text-[11px] text-slate-400">
-            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · 정보 {delivery.storyInfoIds.length}개
+            {selectedCharacterName ?? "받을 캐릭터를 선택하세요"} · 정보 {delivery.storyInfoIds.length}개 · 단서 {delivery.clueIds.length}개
           </p>
         </div>
         <button
           type="button"
           onClick={onRemove}
-          aria-label={`정보 공개 ${index + 1} 삭제`}
+          aria-label={`진입 효과 ${index + 1} 삭제`}
           className="rounded p-1 text-slate-400 hover:bg-red-500/10 hover:text-red-300"
         >
           <Trash2 className="h-4 w-4" />
@@ -227,7 +261,7 @@ function DeliveryCard({
         {delivery.recipientType === "all_players" ? (
           <div className="flex items-center gap-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
             <Users className="h-4 w-4" />
-            이 장면의 공개 정보로 모든 플레이어에게 보여집니다.
+            이 장면의 진입 효과가 모든 플레이어에게 적용됩니다.
           </div>
         ) : (
           <OptionList
@@ -249,6 +283,15 @@ function DeliveryCard({
           getMeta={(info) => info.metaLabel}
           onToggle={onToggleStoryInfo}
           allItems={allStoryInfos}
+        />
+        <OptionList
+          title="단서 지급"
+          emptyText="검색 결과가 없습니다."
+          items={clues}
+          selectedIds={delivery.clueIds}
+          getMeta={(clue) => clue.metaLabel}
+          onToggle={onToggleClue}
+          allItems={allClues}
         />
       </div>
     </article>

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -18,6 +18,7 @@ import {
 import { InformationDeliveryPanel } from "./InformationDeliveryPanel";
 import { StoryProgressionPanel } from "./StoryProgressionPanel";
 import { DELIVER_INFORMATION_ACTION } from "../../entities/phase/phaseEntityAdapter";
+import { GRANT_CLUE_ACTION } from "../../entities/shared/actionAdapter";
 import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
 import { PhasePanelTimerSettings } from "./PhasePanelTimerSettings";
 import { PhasePanelAdvanceToggle } from "./PhasePanelAdvanceToggle";
@@ -141,6 +142,8 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
           ...PRESENTATION_CUE_ACTION_TYPES,
           DELIVER_INFORMATION_ACTION,
           "deliver_information",
+          GRANT_CLUE_ACTION,
+          "grant_clue",
         ]}
         themeId={themeId}
       />

--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -279,6 +279,44 @@ describe("InformationDeliveryPanel", () => {
     expect(refetchStoryInfos).toHaveBeenCalledTimes(1);
   });
 
+  it("옵션 목록이 비어도 저장된 장면 진입 효과는 계속 표시한다", () => {
+    useStoryInfosMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    useEditorCluesMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    const phaseData: FlowNodeData = {
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-1" },
+                story_info_ids: ["missing-info"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    render(<InformationDeliveryPanel themeId="theme-1" phaseData={phaseData} onChange={vi.fn()} />);
+
+    expect(screen.getByText("탐정 A · 정보 1개 · 단서 0개")).toBeDefined();
+    expect(screen.queryByText(/연결할 정보나 단서가 없습니다/)).toBeNull();
+  });
+
   it("phaseData onEnter 변경이 들어오면 저장된 장면 연결 설정을 다시 반영한다", () => {
     const firstPhaseData: FlowNodeData = {
       onEnter: [

--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -3,14 +3,17 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { FlowNodeData } from "../../../flowTypes";
 import { InformationDeliveryPanel } from "../InformationDeliveryPanel";
 import { DELIVER_INFORMATION_ACTION } from "../phaseEditorAdapter";
+import { GRANT_CLUE_ACTION } from "../../../entities/shared/actionAdapter";
 
-const { useEditorCharactersMock, useStoryInfosMock } = vi.hoisted(() => ({
+const { useEditorCharactersMock, useEditorCluesMock, useStoryInfosMock } = vi.hoisted(() => ({
   useEditorCharactersMock: vi.fn(),
+  useEditorCluesMock: vi.fn(),
   useStoryInfosMock: vi.fn(),
 }));
 
 vi.mock("../../../api", () => ({
   useEditorCharacters: () => useEditorCharactersMock(),
+  useEditorClues: () => useEditorCluesMock(),
 }));
 
 vi.mock("../../../storyInfoApi", () => ({
@@ -55,6 +58,47 @@ const storyInfos = [
   },
 ];
 
+const clues = [
+  {
+    id: "clue-1",
+    theme_id: "theme-1",
+    location_id: null,
+    name: "혈흔",
+    description: "현장에서 발견된 흔적",
+    image_url: null,
+    image_media_id: null,
+    is_common: false,
+    level: 1,
+    sort_order: 0,
+    created_at: "2026-05-06T00:00:00Z",
+    is_usable: false,
+    use_effect: null,
+    use_target: null,
+    use_consumed: false,
+    reveal_round: 1,
+    hide_round: null,
+  },
+  {
+    id: "clue-2",
+    theme_id: "theme-1",
+    location_id: null,
+    name: "비밀 편지",
+    description: "봉인된 편지",
+    image_url: null,
+    image_media_id: null,
+    is_common: false,
+    level: 1,
+    sort_order: 1,
+    created_at: "2026-05-06T00:00:00Z",
+    is_usable: false,
+    use_effect: null,
+    use_target: null,
+    use_consumed: false,
+    reveal_round: 2,
+    hide_round: null,
+  },
+];
+
 beforeEach(() => {
   useEditorCharactersMock.mockReturnValue({
     data: characters,
@@ -68,6 +112,12 @@ beforeEach(() => {
     isError: false,
     refetch: vi.fn(),
   });
+  useEditorCluesMock.mockReturnValue({
+    data: clues,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
 });
 
 afterEach(() => {
@@ -76,17 +126,17 @@ afterEach(() => {
 });
 
 describe("InformationDeliveryPanel", () => {
-  it("모든 페이즈에서 캐릭터별 장면 연결 설정을 추가할 수 있다", () => {
+  it("모든 페이즈에서 캐릭터별 장면 진입 효과 설정을 추가할 수 있다", () => {
     const onChange = vi.fn();
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={onChange} />);
 
     fireEvent.click(screen.getByRole("button", { name: "캐릭터별 대상 추가" }));
 
-    expect(screen.getByText("받을 캐릭터를 선택하세요 · 정보 0개")).toBeDefined();
+    expect(screen.getByText("받을 캐릭터를 선택하세요 · 정보 0개 · 단서 0개")).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 
-  it("캐릭터와 공개 정보를 검색하고 선택/삭제할 수 있다", () => {
+  it("캐릭터, 공개 정보, 단서를 검색하고 선택/삭제할 수 있다", () => {
     const onChange = vi.fn();
     const phaseData: FlowNodeData = {
       onEnter: [
@@ -156,7 +206,44 @@ describe("InformationDeliveryPanel", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "정보 공개 1 삭제" }));
+    fireEvent.change(screen.getByPlaceholderText("단서 이름으로 찾기"), {
+      target: { value: "편지" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /비밀 편지/ }));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      onEnter: [
+        {
+          id: "info",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-2" },
+                reading_section_ids: [],
+                story_info_ids: ["info-1", "info-2"],
+              },
+            ],
+          },
+        },
+        {
+          id: "delivery-new",
+          type: GRANT_CLUE_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "d1",
+                target: { type: "character", character_id: "char-2" },
+                clue_ids: ["clue-2"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "진입 효과 1 삭제" }));
     expect(onChange).toHaveBeenLastCalledWith({ onEnter: [] });
   });
 
@@ -176,10 +263,16 @@ describe("InformationDeliveryPanel", () => {
       isError: true,
       refetch: refetchStoryInfos,
     });
+    useEditorCluesMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    });
 
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
-    expect(screen.getByText("정보 공개에 필요한 캐릭터와 정보 목록을 불러오지 못했습니다.")).toBeDefined();
+    expect(screen.getByText("장면 진입 효과에 필요한 캐릭터, 정보, 단서 목록을 불러오지 못했습니다.")).toBeDefined();
     fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
 
     expect(refetchCharacters).toHaveBeenCalledTimes(1);
@@ -227,11 +320,11 @@ describe("InformationDeliveryPanel", () => {
     const { rerender } = render(
       <InformationDeliveryPanel themeId="theme-1" phaseData={firstPhaseData} onChange={vi.fn()} />,
     );
-    expect(screen.getByText("탐정 A · 정보 1개")).toBeDefined();
+    expect(screen.getByText("탐정 A · 정보 1개 · 단서 0개")).toBeDefined();
 
     rerender(<InformationDeliveryPanel themeId="theme-1" phaseData={nextPhaseData} onChange={vi.fn()} />);
 
-    expect(screen.getByText("용의자 B · 정보 0개")).toBeDefined();
+    expect(screen.queryByText("용의자 B · 정보 0개 · 단서 0개")).toBeNull();
   });
 
 
@@ -246,7 +339,7 @@ describe("InformationDeliveryPanel", () => {
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
     expect((screen.getByRole("button", { name: "캐릭터별 대상 추가" }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText("아직 정보 공개 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어가 볼 정보를 연결해 주세요.")).toBeDefined();
+    expect(screen.getByText("아직 장면 진입 효과 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어에게 적용할 효과를 연결해 주세요.")).toBeDefined();
   });
 
   it("모든 페이즈에서 모든 플레이어 공통 전달을 추가할 수 있다", () => {
@@ -261,7 +354,7 @@ describe("InformationDeliveryPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "전체 대상 추가" }));
 
-    expect(screen.getByText("모든 플레이어 · 정보 0개")).toBeDefined();
+    expect(screen.getByText("모든 플레이어 · 정보 0개 · 단서 0개")).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -161,7 +161,7 @@ describe("PhaseNodePanel extended fields", () => {
     expect(screen.queryByPlaceholderText("정보 제목으로 찾기")).toBeNull();
   });
 
-  it("일반 장면은 정보 공개만 표시하고 읽기 대사 검색을 숨긴다", () => {
+  it("일반 장면은 장면 진입 효과를 표시하고 읽기 대사 검색을 숨긴다", () => {
     renderWithQC(
       <PhaseNodePanel
         node={makeNode({ phase_type: "investigation" })}
@@ -170,7 +170,7 @@ describe("PhaseNodePanel extended fields", () => {
       />,
     );
 
-    expect(screen.getByText("정보 공개")).toBeDefined();
+    expect(screen.getByText("장면 진입 효과")).toBeDefined();
     expect(screen.queryByPlaceholderText("대사 이름으로 찾기")).toBeNull();
   });
 

--- a/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   DELIVER_INFORMATION_ACTION,
+  GRANT_CLUE_ACTION,
   getCreatorActionLabel,
   getVisibleCreatorActionOptions,
+  isClueGrantAction,
   isInformationDeliveryAction,
   toCreatorActionLabels,
 } from "../actionAdapter";
@@ -19,6 +21,12 @@ describe("actionAdapter", () => {
     expect(isInformationDeliveryAction({ type: "SET_BGM" })).toBe(false);
   });
 
+  it("단서 지급 action의 legacy/current 타입을 동일하게 판정한다", () => {
+    expect(isClueGrantAction({ type: GRANT_CLUE_ACTION })).toBe(true);
+    expect(isClueGrantAction({ type: "grant_clue" })).toBe(true);
+    expect(isClueGrantAction({ type: "SET_BGM" })).toBe(false);
+  });
+
   it("hidden type을 제외한 선택 옵션을 반환한다", () => {
     expect(getVisibleCreatorActionOptions(["SET_BGM"]).map((option) => option.value)).not.toContain(
       "SET_BGM",
@@ -29,6 +37,7 @@ describe("actionAdapter", () => {
       "UNMUTE_CHAT",
       "MUTE_CHAT",
       "DELIVER_INFORMATION",
+      "GRANT_CLUE",
       "BROADCAST_MESSAGE",
       "SET_BGM",
       "PLAY_SOUND",

--- a/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
@@ -232,4 +232,55 @@ describe("sceneEntryEffectAdapter", () => {
       ],
     });
   });
+
+  it("읽기 대사 delivery 연결은 같은 effect id라도 대상이 다르면 섞지 않는다", () => {
+    expect(
+      sceneEntryEffectsToFlowNodePatch(
+        {
+          onEnter: [
+            {
+              id: "info-action",
+              type: DELIVER_INFORMATION_ACTION,
+              params: {
+                deliveries: [
+                  {
+                    id: "effect-1",
+                    target: { type: "character", character_id: "char-old" },
+                    reading_section_ids: ["reading-old"],
+                    story_info_ids: ["old-info"],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        [
+          {
+            id: "effect-1",
+            recipientType: "character",
+            characterId: "char-new",
+            storyInfoIds: ["new-info"],
+            clueIds: [],
+          },
+        ],
+      ),
+    ).toEqual({
+      onEnter: [
+        {
+          id: "info-action",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "effect-1",
+                target: { type: "character", character_id: "char-new" },
+                reading_section_ids: [],
+                story_info_ids: ["new-info"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
 });

--- a/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import {
   DELIVER_INFORMATION_ACTION,
   GRANT_CLUE_ACTION,
@@ -7,6 +7,10 @@ import {
 } from "../sceneEntryEffectAdapter";
 
 vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("sceneEntryEffectAdapter", () => {
   it("정보 공개와 단서 지급 action을 대상별 장면 진입 효과로 병합한다", () => {

--- a/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
@@ -181,4 +181,55 @@ describe("sceneEntryEffectAdapter", () => {
       ],
     });
   });
+
+  it("장면 진입 효과 저장 시 기존 읽기 대사 delivery 연결을 보존한다", () => {
+    expect(
+      sceneEntryEffectsToFlowNodePatch(
+        {
+          onEnter: [
+            {
+              id: "info-action",
+              type: DELIVER_INFORMATION_ACTION,
+              params: {
+                deliveries: [
+                  {
+                    id: "effect-1",
+                    target: { type: "character", character_id: "char-1" },
+                    reading_section_ids: ["reading-1", "reading-1"],
+                    story_info_ids: ["old-info"],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        [
+          {
+            id: "effect-1",
+            recipientType: "character",
+            characterId: "char-1",
+            storyInfoIds: ["new-info"],
+            clueIds: [],
+          },
+        ],
+      ),
+    ).toEqual({
+      onEnter: [
+        {
+          id: "info-action",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "effect-1",
+                target: { type: "character", character_id: "char-1" },
+                reading_section_ids: ["reading-1"],
+                story_info_ids: ["new-info"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
 });

--- a/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
@@ -52,6 +52,82 @@ describe("sceneEntryEffectAdapter", () => {
     ]);
   });
 
+  it("같은 타입의 장면 진입 action이 여러 개면 모두 읽어서 병합한다", () => {
+    expect(
+      flowNodeToSceneEntryEffects({
+        onEnter: [
+          {
+            id: "info-action-1",
+            type: DELIVER_INFORMATION_ACTION,
+            params: {
+              deliveries: [
+                {
+                  id: "effect-1",
+                  target: { type: "character", character_id: "char-1" },
+                  story_info_ids: ["info-1"],
+                },
+              ],
+            },
+          },
+          {
+            id: "info-action-2",
+            type: DELIVER_INFORMATION_ACTION,
+            params: {
+              deliveries: [
+                {
+                  id: "effect-2",
+                  target: { type: "character", character_id: "char-2" },
+                  story_info_ids: ["info-2"],
+                },
+              ],
+            },
+          },
+          {
+            id: "clue-action-1",
+            type: GRANT_CLUE_ACTION,
+            params: {
+              deliveries: [
+                {
+                  id: "effect-1",
+                  target: { type: "character", character_id: "char-1" },
+                  clue_ids: ["clue-1"],
+                },
+              ],
+            },
+          },
+          {
+            id: "clue-action-2",
+            type: GRANT_CLUE_ACTION,
+            params: {
+              deliveries: [
+                {
+                  id: "effect-2",
+                  target: { type: "character", character_id: "char-2" },
+                  clue_ids: ["clue-2"],
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "effect-1",
+        recipientType: "character",
+        characterId: "char-1",
+        storyInfoIds: ["info-1"],
+        clueIds: ["clue-1"],
+      },
+      {
+        id: "effect-2",
+        recipientType: "character",
+        characterId: "char-2",
+        storyInfoIds: ["info-2"],
+        clueIds: ["clue-2"],
+      },
+    ]);
+  });
+
   it("정보와 단서를 각각 런타임 action으로 저장하고 빈 effect는 제거한다", () => {
     expect(
       sceneEntryEffectsToFlowNodePatch(

--- a/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DELIVER_INFORMATION_ACTION,
+  GRANT_CLUE_ACTION,
+  flowNodeToSceneEntryEffects,
+  sceneEntryEffectsToFlowNodePatch,
+} from "../sceneEntryEffectAdapter";
+
+vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
+
+describe("sceneEntryEffectAdapter", () => {
+  it("정보 공개와 단서 지급 action을 대상별 장면 진입 효과로 병합한다", () => {
+    expect(
+      flowNodeToSceneEntryEffects({
+        onEnter: [
+          {
+            id: "info-action",
+            type: DELIVER_INFORMATION_ACTION,
+            params: {
+              deliveries: [
+                {
+                  id: "effect-1",
+                  target: { type: "character", character_id: "char-1" },
+                  story_info_ids: ["info-1", "info-1"],
+                },
+              ],
+            },
+          },
+          {
+            id: "clue-action",
+            type: GRANT_CLUE_ACTION,
+            params: {
+              deliveries: [
+                {
+                  id: "effect-1",
+                  target: { type: "character", character_id: "char-1" },
+                  clue_ids: ["clue-2", "clue-1", "clue-1"],
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "effect-1",
+        recipientType: "character",
+        characterId: "char-1",
+        storyInfoIds: ["info-1"],
+        clueIds: ["clue-2", "clue-1"],
+      },
+    ]);
+  });
+
+  it("정보와 단서를 각각 런타임 action으로 저장하고 빈 effect는 제거한다", () => {
+    expect(
+      sceneEntryEffectsToFlowNodePatch(
+        { onEnter: [{ id: "keep", type: "SET_BGM" }] },
+        [
+          {
+            id: "empty",
+            recipientType: "character",
+            characterId: "char-1",
+            storyInfoIds: [],
+            clueIds: [],
+          },
+          {
+            id: "effect-1",
+            recipientType: "all_players",
+            storyInfoIds: ["info-1", "info-1"],
+            clueIds: ["clue-1", "clue-1"],
+          },
+        ],
+      ),
+    ).toEqual({
+      onEnter: [
+        { id: "keep", type: "SET_BGM" },
+        {
+          id: "generated-id",
+          type: DELIVER_INFORMATION_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "effect-1",
+                target: { type: "all_players" },
+                reading_section_ids: [],
+                story_info_ids: ["info-1"],
+              },
+            ],
+          },
+        },
+        {
+          id: "generated-id",
+          type: GRANT_CLUE_ACTION,
+          params: {
+            deliveries: [
+              {
+                id: "effect-1",
+                target: { type: "all_players" },
+                clue_ids: ["clue-1"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/features/editor/entities/shared/actionAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/actionAdapter.ts
@@ -7,13 +7,16 @@ export interface CreatorActionOption {
 
 export const DELIVER_INFORMATION_ACTION = "DELIVER_INFORMATION";
 export const LEGACY_DELIVER_INFORMATION_ACTION = "deliver_information";
+export const GRANT_CLUE_ACTION = "GRANT_CLUE";
+export const LEGACY_GRANT_CLUE_ACTION = "grant_clue";
 
 export const CREATOR_ACTION_OPTIONS: CreatorActionOption[] = [
   { value: "OPEN_VOTING", label: "투표 시작" },
   { value: "CLOSE_VOTING", label: "투표 종료" },
   { value: "UNMUTE_CHAT", label: "채팅 열기" },
   { value: "MUTE_CHAT", label: "채팅 닫기" },
-  { value: DELIVER_INFORMATION_ACTION, label: "읽기 대사 공개" },
+  { value: DELIVER_INFORMATION_ACTION, label: "정보 공개" },
+  { value: GRANT_CLUE_ACTION, label: "단서 지급" },
   { value: "BROADCAST_MESSAGE", label: "알림 보내기" },
   { value: "SET_BGM", label: "BGM 재생" },
   { value: "PLAY_SOUND", label: "효과음 재생" },
@@ -27,6 +30,8 @@ const ACTION_LABELS = new Map<string, string>([
   ...CREATOR_ACTION_OPTIONS.map((option) => [option.value, option.label] as const),
   [DELIVER_INFORMATION_ACTION, "정보 공개"],
   [LEGACY_DELIVER_INFORMATION_ACTION, "정보 공개"],
+  [GRANT_CLUE_ACTION, "단서 지급"],
+  [LEGACY_GRANT_CLUE_ACTION, "단서 지급"],
   ["OPEN_GROUP_CHAT", "토론방 열기"],
   ["CLOSE_GROUP_CHAT", "토론방 닫기"],
   ["BROADCAST_MESSAGE", "알림 보내기"],
@@ -49,6 +54,10 @@ export function getCreatorActionLabel(type: string): string {
 
 export function isInformationDeliveryAction(action: PhaseAction): boolean {
   return action.type === DELIVER_INFORMATION_ACTION || action.type === LEGACY_DELIVER_INFORMATION_ACTION;
+}
+
+export function isClueGrantAction(action: PhaseAction): boolean {
+  return action.type === GRANT_CLUE_ACTION || action.type === LEGACY_GRANT_CLUE_ACTION;
 }
 
 export function getVisibleCreatorActionOptions(hiddenTypes: string[] = []): CreatorActionOption[] {

--- a/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
@@ -1,0 +1,208 @@
+import type { FlowNodeData, PhaseAction } from "../../flowTypes";
+import {
+  DELIVER_INFORMATION_ACTION,
+  GRANT_CLUE_ACTION,
+  isClueGrantAction,
+  isInformationDeliveryAction,
+} from "./actionAdapter";
+import type { InformationRecipientType } from "./informationDeliveryAdapter";
+
+export interface SceneEntryEffectViewModel {
+  id: string;
+  recipientType: InformationRecipientType;
+  characterId?: string;
+  storyInfoIds: string[];
+  clueIds: string[];
+}
+
+interface StoredEffectDelivery {
+  id?: string;
+  target?: {
+    type?: unknown;
+    character_id?: unknown;
+  };
+  recipient_type?: unknown;
+  character_id?: unknown;
+  story_info_ids?: unknown;
+  storyInfoIds?: unknown;
+  clue_ids?: unknown;
+  clueIds?: unknown;
+}
+
+interface DeliveryParams {
+  deliveries?: unknown;
+}
+
+export { DELIVER_INFORMATION_ACTION, GRANT_CLUE_ACTION };
+
+export function flowNodeToSceneEntryEffects(data: FlowNodeData): SceneEntryEffectViewModel[] {
+  const merged = new Map<string, SceneEntryEffectViewModel>();
+  for (const delivery of readDeliveries(findAction(data.onEnter ?? [], isInformationDeliveryAction)?.params)) {
+    mergeEffect(merged, normalizeStoredDelivery(delivery, "story"));
+  }
+  for (const delivery of readDeliveries(findAction(data.onEnter ?? [], isClueGrantAction)?.params)) {
+    mergeEffect(merged, normalizeStoredDelivery(delivery, "clue"));
+  }
+  return Array.from(merged.values()).map(normalizeViewModel).filter(hasAnyEffect);
+}
+
+export function sceneEntryEffectsToFlowNodePatch(
+  data: FlowNodeData,
+  effects: SceneEntryEffectViewModel[],
+): Pick<FlowNodeData, "onEnter"> {
+  const nextActions = (data.onEnter ?? []).filter(
+    (action) => !isInformationDeliveryAction(action) && !isClueGrantAction(action),
+  );
+  const normalized = effects.map(normalizeViewModel).filter(isCompleteSceneEntryEffect);
+  const infoDeliveries = normalized.filter((effect) => effect.storyInfoIds.length > 0);
+  const clueDeliveries = normalized.filter((effect) => effect.clueIds.length > 0);
+
+  if (infoDeliveries.length > 0) {
+    nextActions.push({
+      id: findAction(data.onEnter ?? [], isInformationDeliveryAction)?.id ?? makeId(),
+      type: DELIVER_INFORMATION_ACTION,
+      params: {
+        deliveries: infoDeliveries.map((effect) => ({
+          id: effect.id,
+          target: toStoredTarget(effect),
+          reading_section_ids: [],
+          story_info_ids: effect.storyInfoIds,
+        })),
+      },
+    });
+  }
+
+  if (clueDeliveries.length > 0) {
+    nextActions.push({
+      id: findAction(data.onEnter ?? [], isClueGrantAction)?.id ?? makeId(),
+      type: GRANT_CLUE_ACTION,
+      params: {
+        deliveries: clueDeliveries.map((effect) => ({
+          id: effect.id,
+          target: toStoredTarget(effect),
+          clue_ids: effect.clueIds,
+        })),
+      },
+    });
+  }
+
+  return { onEnter: nextActions };
+}
+
+export function makeEmptySceneEntryEffect(
+  recipientType: InformationRecipientType = "character",
+): SceneEntryEffectViewModel {
+  return {
+    id: makeId(),
+    recipientType,
+    storyInfoIds: [],
+    clueIds: [],
+  };
+}
+
+export function isCompleteSceneEntryEffect(effect: SceneEntryEffectViewModel): boolean {
+  if (!hasAnyEffect(effect)) return false;
+  return effect.recipientType === "all_players" || Boolean(effect.characterId);
+}
+
+function findAction(
+  actions: PhaseAction[],
+  predicate: (action: PhaseAction) => boolean,
+): PhaseAction | undefined {
+  return actions.find(predicate);
+}
+
+function readDeliveries(params: PhaseAction["params"]): StoredEffectDelivery[] {
+  if (!params || typeof params !== "object") return [];
+  const maybeDeliveries = (params as DeliveryParams).deliveries;
+  return Array.isArray(maybeDeliveries) ? (maybeDeliveries as StoredEffectDelivery[]) : [];
+}
+
+function normalizeStoredDelivery(
+  delivery: StoredEffectDelivery,
+  source: "story" | "clue",
+): SceneEntryEffectViewModel {
+  const rawStoryInfoIds =
+    source === "story"
+      ? Array.isArray(delivery.story_info_ids)
+        ? delivery.story_info_ids
+        : Array.isArray(delivery.storyInfoIds)
+          ? delivery.storyInfoIds
+          : []
+      : [];
+  const rawClueIds =
+    source === "clue"
+      ? Array.isArray(delivery.clue_ids)
+        ? delivery.clue_ids
+        : Array.isArray(delivery.clueIds)
+          ? delivery.clueIds
+          : []
+      : [];
+  return normalizeViewModel({
+    id: typeof delivery.id === "string" && delivery.id ? delivery.id : makeId(),
+    recipientType:
+      delivery.target?.type === "all_players" || delivery.recipient_type === "all_players"
+        ? "all_players"
+        : "character",
+    characterId:
+      typeof delivery.target?.character_id === "string"
+        ? delivery.target.character_id
+        : typeof delivery.character_id === "string"
+          ? delivery.character_id
+          : undefined,
+    storyInfoIds: rawStoryInfoIds.filter((id): id is string => typeof id === "string" && id.length > 0),
+    clueIds: rawClueIds.filter((id): id is string => typeof id === "string" && id.length > 0),
+  });
+}
+
+function mergeEffect(
+  merged: Map<string, SceneEntryEffectViewModel>,
+  effect: SceneEntryEffectViewModel,
+) {
+  const key = effect.recipientType === "all_players" ? "all_players" : `character:${effect.characterId ?? effect.id}`;
+  const current = merged.get(key);
+  if (!current) {
+    merged.set(key, effect);
+    return;
+  }
+  merged.set(key, normalizeViewModel({
+    ...current,
+    storyInfoIds: [...current.storyInfoIds, ...effect.storyInfoIds],
+    clueIds: [...current.clueIds, ...effect.clueIds],
+  }));
+}
+
+function normalizeViewModel(effect: SceneEntryEffectViewModel): SceneEntryEffectViewModel {
+  const storyInfoIds = uniqueStrings(effect.storyInfoIds);
+  const clueIds = uniqueStrings(effect.clueIds);
+  if (effect.recipientType === "all_players") {
+    return { id: effect.id || makeId(), recipientType: "all_players", storyInfoIds, clueIds };
+  }
+  return {
+    id: effect.id || makeId(),
+    recipientType: "character",
+    characterId: effect.characterId,
+    storyInfoIds,
+    clueIds,
+  };
+}
+
+function hasAnyEffect(effect: SceneEntryEffectViewModel): boolean {
+  return effect.storyInfoIds.length > 0 || effect.clueIds.length > 0;
+}
+
+function toStoredTarget(effect: SceneEntryEffectViewModel) {
+  return effect.recipientType === "all_players"
+    ? { type: "all_players" }
+    : { type: "character", character_id: effect.characterId };
+}
+
+function uniqueStrings(ids: string[]): string[] {
+  return Array.from(new Set(ids)).filter(Boolean);
+}
+
+function makeId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `effect-${Math.random().toString(36).slice(2)}`;
+}

--- a/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
@@ -145,7 +145,6 @@ function isSameStoredDelivery(
   delivery: StoredEffectDelivery,
   effect: SceneEntryEffectViewModel,
 ): boolean {
-  if (delivery.id === effect.id) return true;
   const deliveryType =
     delivery.target?.type === "all_players" || delivery.recipient_type === "all_players"
       ? "all_players"

--- a/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
@@ -37,11 +37,15 @@ export { DELIVER_INFORMATION_ACTION, GRANT_CLUE_ACTION };
 
 export function flowNodeToSceneEntryEffects(data: FlowNodeData): SceneEntryEffectViewModel[] {
   const merged = new Map<string, SceneEntryEffectViewModel>();
-  for (const delivery of readDeliveries(findAction(data.onEnter ?? [], isInformationDeliveryAction)?.params)) {
-    mergeEffect(merged, normalizeStoredDelivery(delivery, "story"));
+  for (const action of (data.onEnter ?? []).filter(isInformationDeliveryAction)) {
+    for (const delivery of readDeliveries(action.params)) {
+      mergeEffect(merged, normalizeStoredDelivery(delivery, "story"));
+    }
   }
-  for (const delivery of readDeliveries(findAction(data.onEnter ?? [], isClueGrantAction)?.params)) {
-    mergeEffect(merged, normalizeStoredDelivery(delivery, "clue"));
+  for (const action of (data.onEnter ?? []).filter(isClueGrantAction)) {
+    for (const delivery of readDeliveries(action.params)) {
+      mergeEffect(merged, normalizeStoredDelivery(delivery, "clue"));
+    }
   }
   return Array.from(merged.values()).map(normalizeViewModel).filter(hasAnyEffect);
 }

--- a/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/sceneEntryEffectAdapter.ts
@@ -23,6 +23,7 @@ interface StoredEffectDelivery {
   };
   recipient_type?: unknown;
   character_id?: unknown;
+  reading_section_ids?: unknown;
   story_info_ids?: unknown;
   storyInfoIds?: unknown;
   clue_ids?: unknown;
@@ -69,7 +70,7 @@ export function sceneEntryEffectsToFlowNodePatch(
         deliveries: infoDeliveries.map((effect) => ({
           id: effect.id,
           target: toStoredTarget(effect),
-          reading_section_ids: [],
+          reading_section_ids: findExistingReadingSectionIds(data.onEnter ?? [], effect),
           story_info_ids: effect.storyInfoIds,
         })),
       },
@@ -120,6 +121,44 @@ function readDeliveries(params: PhaseAction["params"]): StoredEffectDelivery[] {
   if (!params || typeof params !== "object") return [];
   const maybeDeliveries = (params as DeliveryParams).deliveries;
   return Array.isArray(maybeDeliveries) ? (maybeDeliveries as StoredEffectDelivery[]) : [];
+}
+
+function findExistingReadingSectionIds(
+  actions: PhaseAction[],
+  effect: SceneEntryEffectViewModel,
+): string[] {
+  const matchingDeliveries = actions
+    .filter(isInformationDeliveryAction)
+    .flatMap((action) => readDeliveries(action.params))
+    .filter((delivery) => isSameStoredDelivery(delivery, effect));
+
+  return uniqueStrings(
+    matchingDeliveries.flatMap((delivery) =>
+      Array.isArray(delivery.reading_section_ids)
+        ? delivery.reading_section_ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+        : [],
+    ),
+  );
+}
+
+function isSameStoredDelivery(
+  delivery: StoredEffectDelivery,
+  effect: SceneEntryEffectViewModel,
+): boolean {
+  if (delivery.id === effect.id) return true;
+  const deliveryType =
+    delivery.target?.type === "all_players" || delivery.recipient_type === "all_players"
+      ? "all_players"
+      : "character";
+  if (deliveryType !== effect.recipientType) return false;
+  if (effect.recipientType === "all_players") return true;
+  const deliveryCharacterId =
+    typeof delivery.target?.character_id === "string"
+      ? delivery.target.character_id
+      : typeof delivery.character_id === "string"
+        ? delivery.character_id
+        : undefined;
+  return Boolean(effect.characterId) && deliveryCharacterId === effect.characterId;
 }
 
 function normalizeStoredDelivery(


### PR DESCRIPTION
## 요약

- 일반 장면의 `InformationDeliveryPanel`을 `장면 진입 효과` 역할로 개편해 정보 공개와 단서 지급을 대상별로 함께 설정합니다.
- `GRANT_CLUE` phase action을 backend runtime에 추가하고 `clue_interaction` module에서 캐릭터/전체 대상 지급을 처리합니다.
- 일반 트리거 추가 메뉴에서는 `DELIVER_INFORMATION`/`GRANT_CLUE`가 중복 노출되지 않게 숨겼습니다.

Closes #504

## Coverage Plan

- backend engine/action:
  - `GRANT_CLUE` action 등록, legacy alias, implicit module 연결을 확인합니다.
  - `clue_interaction`의 캐릭터 대상 지급, 전체 대상 지급, 중복 실행 방지, 빈 clue validation을 테스트합니다.
- frontend adapter:
  - 기존 `DELIVER_INFORMATION`과 신규 `GRANT_CLUE` action을 하나의 `SceneEntryEffectViewModel`로 병합합니다.
  - 저장 시 정보 공개와 단서 지급을 별도 runtime action으로 쓰고, 빈 effect와 중복 id를 정리합니다.
- frontend component:
  - 캐릭터 대상 추가, 전체 대상 추가, 정보 선택/삭제, 단서 선택/삭제, empty/error 상태를 테스트합니다.
  - 일반 장면과 `story_progression` 노드의 패널 분리를 유지합니다.

## Local validation

- `cd apps/server && go test ./internal/engine ./internal/module/core` 성공
- `pnpm --dir apps/web exec vitest run src/features/editor/entities/shared/__tests__/actionAdapter.test.ts src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx` 성공: 4 files / 30 tests
- `pnpm --dir apps/web typecheck` 성공
- Browser smoke 성공:
  - 일반 장면에서 `장면 진입 효과` 표시 확인
  - `장면 시작 트리거` 추가 메뉴에 `정보 공개`/`단서 지급` 중복 노출 없음 확인
  - E2E fixture에 정보/단서 데이터가 없어 실제 선택 UI는 component test로 보강
- `scripts/mmp-local-ci.sh quick` 성공
  - marker: `0b9d43a1d3191dac34638f0268a37430048984d9`, status `success`

## 참고

- `GRANT_CLUE`는 frontend-only로 저장하면 runtime 효과가 없기 때문에 이번 PR에 작은 backend action/module 처리를 함께 포함했습니다.
- `vite build` 중 기존 editor API barrel re-export 순환 warning이 출력되지만 build는 성공했습니다. 이 PR에서 새로 만든 직접 원인은 아니며 기존 파일들도 같은 warning을 내고 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 런타임에서 특정 캐릭터 또는 모든 플레이어에게 단서를 지급하는 동작이 추가되어 지급 적용, 중복 방지, 타깃 해석 및 지급 이벤트 발행을 지원합니다.
  * 에디터에 단서 검색·선택 및 단서 토글을 포함한 “장면 진입 효과” UI와 옵션이 추가되어 단서 지정이 가능해졌습니다.

* **리팩터**
  * 정보 공개 흐름이 장면 진입 효과 모델로 통합되어 관련 어댑터·뷰모델이 정리되고 편집기 문구가 갱신되었습니다.

* **테스트**
  * 단서 지급 로직, 어댑터 변환, 편집기 UI를 검증하는 단위·통합 테스트가 대폭 추가·확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->