### PR TITLE
feat(editor): 결말 플로우 노드 책임 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingNodePanel.tsx
@@ -1,10 +1,5 @@
-import { useId } from "react";
 import type { Node } from "@xyflow/react";
-import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { useUpdateFlowNode } from "../../flowApi";
-import { flowKeys, type FlowGraphResponse, type FlowNodeData } from "../../flowTypes";
-import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+import type { FlowNodeData } from "../../flowTypes";
 import { toEndingEditorViewModel } from "../../entities/ending/endingEntityAdapter";
 
 // ---------------------------------------------------------------------------
@@ -18,66 +13,28 @@ interface EndingNodePanelProps {
   onUpdate: (id: string, data: Partial<FlowNodeData>) => void;
 }
 
-/** Debounce window for ending-node saves. Preserves prior 500ms behavior. */
-const SAVE_DEBOUNCE_MS = 500;
-
 // ---------------------------------------------------------------------------
-// EndingNodePanel — 엔딩 노드 편집 패널
+// EndingNodePanel — flow 안에서는 결말 연결 요약만 보여준다.
 // ---------------------------------------------------------------------------
 
 export function EndingNodePanel({
   node,
-  themeId,
   edges = [],
-  onUpdate,
+  themeId: _themeId,
+  onUpdate: _onUpdate,
 }: EndingNodePanelProps) {
-  const labelInputId = useId();
-  const descriptionInputId = useId();
-  const iconInputId = useId();
-  const colorInputId = useId();
-  const updateNode = useUpdateFlowNode(themeId);
-  const queryClient = useQueryClient();
-  const data = node.data as FlowNodeData;
   const incomingCount = edges.filter((edge) => edge.target === node.id).length;
   const viewModel = toEndingEditorViewModel(node, incomingCount);
-
-  const debouncer = useDebouncedMutation<FlowNodeData>({
-    debounceMs: SAVE_DEBOUNCE_MS,
-    mutate: (body, opts) =>
-      updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
-    applyOptimistic: (body) => {
-      const cacheKey = flowKeys.graph(themeId);
-      const previous = queryClient.getQueryData<FlowGraphResponse>(cacheKey);
-      if (!previous) return null;
-      queryClient.setQueryData<FlowGraphResponse>(cacheKey, {
-        ...previous,
-        nodes: previous.nodes.map((n) =>
-          n.id === node.id ? { ...n, data: { ...n.data, ...body } } : n,
-        ),
-      });
-      return () => queryClient.setQueryData(cacheKey, previous);
-    },
-    onError: () => toast.error("저장에 실패했습니다"),
-  });
-  const flush = debouncer.flush;
-
-  const handleChange = (patch: Partial<FlowNodeData>) => {
-    onUpdate(node.id, patch);
-    debouncer.schedule(
-      { ...data, ...patch },
-      (prev) => ({ ...data, ...(prev ?? {}), ...patch }),
-    );
-  };
 
   return (
     <div className="flex flex-col gap-3 p-4">
       <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-        엔딩 설정
+        결말 연결
       </h3>
 
       <section className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
         <p className="text-[11px] font-semibold uppercase tracking-wider text-amber-300/80">
-          결말 연결 요약
+          플로우 진행 노드
         </p>
         <h4 className="mt-1 text-sm font-semibold text-slate-100">{viewModel.name}</h4>
         <p className="mt-1 text-xs leading-5 text-slate-400">{viewModel.contentPreview}</p>
@@ -93,61 +50,13 @@ export function EndingNodePanel({
         </p>
       </section>
 
-      {/* Label */}
-      <div className="flex flex-col gap-1">
-        <label htmlFor={labelInputId} className="text-[11px] text-slate-400">라벨</label>
-        <input
-          id={labelInputId}
-          type="text"
-          value={data.label ?? ""}
-          onChange={(e) => handleChange({ label: e.target.value })}
-          onBlur={flush}
-          placeholder="엔딩 이름"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        />
-      </div>
-
-      {/* Description */}
-      <div className="flex flex-col gap-1">
-        <label htmlFor={descriptionInputId} className="text-[11px] text-slate-400">설명</label>
-        <textarea
-          id={descriptionInputId}
-          value={data.description ?? ""}
-          onChange={(e) => handleChange({ description: e.target.value })}
-          onBlur={flush}
-          placeholder="엔딩 설명"
-          rows={3}
-          className="resize-none rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        />
-      </div>
-
-      {/* Icon */}
-      <div className="flex flex-col gap-1">
-        <label htmlFor={iconInputId} className="text-[11px] text-slate-400">아이콘</label>
-        <input
-          id={iconInputId}
-          type="text"
-          value={data.icon ?? ""}
-          onChange={(e) => handleChange({ icon: e.target.value })}
-          onBlur={flush}
-          placeholder="예: 🎭"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        />
-      </div>
-
-      {/* Color */}
-      <div className="flex flex-col gap-1">
-        <label htmlFor={colorInputId} className="text-[11px] text-slate-400">표시 색상</label>
-        <input
-          id={colorInputId}
-          type="text"
-          value={data.color ?? ""}
-          onChange={(e) => handleChange({ color: e.target.value })}
-          onBlur={flush}
-          placeholder="예: amber, emerald, rose"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 placeholder-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-        />
-      </div>
+      <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+        <h4 className="text-xs font-semibold text-slate-200">편집 위치</h4>
+        <p className="mt-1 text-xs leading-5 text-slate-400">
+          이 노드는 장면 흐름이 결말로 이어지는 위치만 나타냅니다. 결말 이름, 본문,
+          공개 범위, 결과 카드는 왼쪽 탭의 결말 관리에서 수정하세요.
+        </p>
+      </section>
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/FlowToolbar.tsx
+++ b/apps/web/src/features/editor/components/design/FlowToolbar.tsx
@@ -48,8 +48,7 @@ const NODE_OPTIONS: NodeOption[] = [
     description: "범인 지목 단계",
     data: { label: "투표", phase_type: "voting" },
   },
-  { id: "ending", type: "ending", label: "엔딩", description: "게임 종료" },
-  { id: "condition-branch", type: "branch", label: "조건 분기", description: "진행 조건" },
+  { id: "ending", type: "ending", label: "결말 연결", description: "결말 관리 항목으로 진행" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx
@@ -1,241 +1,65 @@
-/**
- * EndingNodePanel — Phase 21 E-1 동등화 회귀 테스트.
- *
- * Phase 18.5 종료 시점에는 EndingNodePanel이 debounce(500ms) + unmount cleanup만
- * 가지고 있었고 optimistic / rollback / onBlur flush가 누락된 미완성 상태였다.
- * useDebouncedMutation 훅 도입으로 PhaseNodePanel 수준의 보호가 자동 적용되었으므로,
- * 본 spec은 동등화된 동작을 회귀 가드로 잠근다:
- *
- *   1. debounce 500ms (window 보존)
- *   2. 연속 change는 한 번만 저장 (debounce 재시작)
- *   3. onBlur → 즉시 flush (timer 대기 없음)
- *   4. optimistic graph cache 갱신
- *   5. mutate onError → rollback + toast.error
- */
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ReactNode } from "react";
-
-const { mutateMock, useUpdateFlowNodeMock, toastError } = vi.hoisted(() => ({
-  mutateMock: vi.fn(),
-  useUpdateFlowNodeMock: vi.fn(),
-  toastError: vi.fn(),
-}));
-
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: toastError },
-}));
-
-vi.mock("../../../flowApi", () => ({
-  useUpdateFlowNode: () => useUpdateFlowNodeMock(),
-}));
-
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EndingNodePanel } from "../EndingNodePanel";
-import { flowKeys, type FlowGraphResponse } from "../../../flowTypes";
-
-function renderWithClient(ui: ReactNode) {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
-  return {
-    qc,
-    ...render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>),
-  };
-}
-
-const makeGraph = (nodeId = "ending-1", data: Record<string, unknown> = {}): FlowGraphResponse => ({
-  nodes: [
-    {
-      id: nodeId,
-      theme_id: "t1",
-      type: "ending",
-      position_x: 0,
-      position_y: 0,
-      data: { label: "엔딩 A", ...data },
-      created_at: "2026-04-30T00:00:00Z",
-      updated_at: "2026-04-30T00:00:00Z",
-    },
-  ],
-  edges: [],
-});
 
 const makeNode = (data: Record<string, unknown> = {}) => ({
   id: "ending-1",
   type: "ending" as const,
   position: { x: 0, y: 0 },
-  data: { label: "엔딩 A", ...data },
+  data: { label: "진실", ...data },
 });
 
-beforeEach(() => {
-  vi.useFakeTimers();
-  useUpdateFlowNodeMock.mockReturnValue({ mutate: mutateMock });
-});
+describe("EndingNodePanel", () => {
+  afterEach(() => cleanup());
 
-afterEach(() => {
-  cleanup();
-  vi.useRealTimers();
-  vi.clearAllMocks();
-});
-
-describe("EndingNodePanel debounce + onBlur flush", () => {
-
-  it("Phase 24 정책에 따라 점수 배율 입력을 표시하지 않는다", () => {
-    renderWithClient(
-      <EndingNodePanel node={makeNode({ score_multiplier: 2 })} themeId="t1" onUpdate={vi.fn()} />,
+  it("플로우 안에서는 결말 연결 요약만 표시하고 본문 편집 폼을 숨긴다", () => {
+    render(
+      <EndingNodePanel
+        node={makeNode({
+          endingContent: "범인은 밝혀졌다.",
+          endingVisibility: "players_only",
+          endingSpoilerWarning: "스포일러 주의",
+          endingShareText: "공유 문구",
+        })}
+        themeId="theme-1"
+        edges={[{ target: "ending-1" }, { target: "other" }]}
+        onUpdate={vi.fn()}
+      />,
     );
 
+    expect(screen.getByText("결말 연결")).toBeDefined();
+    expect(screen.getByText("플로우 진행 노드")).toBeDefined();
+    expect(screen.getByText("진실")).toBeDefined();
+    expect(screen.getByText("본문 작성됨")).toBeDefined();
+    expect(screen.getByText("참가자에게만 공개")).toBeDefined();
+    expect(screen.getByText("도달 경로 1개")).toBeDefined();
+    expect(screen.getByText(/결말 관리에서 수정하세요/)).toBeDefined();
+
+    expect(screen.queryByLabelText("결말 본문")).toBeNull();
+    expect(screen.queryByLabelText("공개 범위")).toBeNull();
+    expect(screen.queryByPlaceholderText("엔딩 이름")).toBeNull();
+    expect(screen.queryByPlaceholderText("예: 🎭")).toBeNull();
+  });
+
+  it("기존 상세 data는 유실 없이 읽기 전용 요약으로 로딩한다", () => {
+    const onUpdate = vi.fn();
+    render(
+      <EndingNodePanel
+        node={makeNode({
+          label: "오판",
+          description: "잘못된 추리",
+          endingContent: "",
+          score_multiplier: 2,
+        })}
+        themeId="theme-1"
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expect(screen.getByText("오판")).toBeDefined();
+    expect(screen.getByText("결말 본문을 아직 작성하지 않았습니다.")).toBeDefined();
+    expect(screen.getByText("본문 필요")).toBeDefined();
     expect(screen.queryByText("점수 배율")).toBeNull();
-  });
-
-  it("아이콘과 표시 색상을 저장할 수 있다", () => {
-    renderWithClient(
-      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
-    );
-
-    fireEvent.change(screen.getByPlaceholderText("예: 🎭"), { target: { value: "💚" } });
-    fireEvent.blur(screen.getByPlaceholderText("예: 🎭"));
-
-    expect(mutateMock).toHaveBeenCalledTimes(1);
-    const [arg] = mutateMock.mock.calls[0] as [
-      { nodeId: string; body: { data: { icon: string } } },
-    ];
-    expect(arg.body.data.icon).toBe("💚");
-  });
-  it("debounce 500ms 후에 mutate가 1회 호출된다", async () => {
-    renderWithClient(
-      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
-    );
-
-    const labelInput = screen.getByPlaceholderText("엔딩 이름");
-    fireEvent.change(labelInput, { target: { value: "정의 승리" } });
-
-    // 499ms — must NOT fire yet.
-    await act(async () => {
-      vi.advanceTimersByTime(499);
-    });
-    expect(mutateMock).not.toHaveBeenCalled();
-
-    await act(async () => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(mutateMock).toHaveBeenCalledTimes(1);
-    const [arg] = mutateMock.mock.calls[0] as [
-      { nodeId: string; body: { data: { label: string } } },
-    ];
-    expect(arg.nodeId).toBe("ending-1");
-    expect(arg.body.data.label).toBe("정의 승리");
-  });
-
-  it("연속 change는 한 번만 저장된다 (debounce 재시작)", async () => {
-    renderWithClient(
-      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
-    );
-
-    const labelInput = screen.getByPlaceholderText("엔딩 이름");
-    fireEvent.change(labelInput, { target: { value: "A" } });
-    await act(async () => {
-      vi.advanceTimersByTime(300);
-    });
-    fireEvent.change(labelInput, { target: { value: "AB" } });
-    await act(async () => {
-      vi.advanceTimersByTime(300);
-    });
-    expect(mutateMock).not.toHaveBeenCalled();
-    await act(async () => {
-      vi.advanceTimersByTime(200);
-    });
-    expect(mutateMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("onBlur 발생 시 timer 대기 없이 즉시 저장된다", () => {
-    renderWithClient(
-      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
-    );
-
-    const labelInput = screen.getByPlaceholderText("엔딩 이름");
-    fireEvent.change(labelInput, { target: { value: "즉시" } });
-    expect(mutateMock).not.toHaveBeenCalled();
-
-    fireEvent.blur(labelInput);
-    expect(mutateMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("optimistic update: flush 시점에 graph cache가 갱신된다", async () => {
-    // Phase 21 round-2 (perf-H2): applyOptimistic은 schedule이 아닌 flush
-    // 시점에만 호출되어 빠른 타이핑 시 canvas re-render 폭증을 회피한다.
-    // schedule 직후에는 cache 그대로, debounce window가 지나면 갱신.
-    const { qc } = renderWithClient(
-      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
-    );
-    qc.setQueryData(flowKeys.graph("t1"), makeGraph());
-
-    const labelInput = screen.getByPlaceholderText("엔딩 이름");
-    fireEvent.change(labelInput, { target: { value: "엔딩 B" } });
-
-    // Schedule 직후 — cache 변경 없음 (perf-H2 fix).
-    const beforeFlush = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
-    const beforeNode = beforeFlush?.nodes.find((n) => n.id === "ending-1");
-    expect((beforeNode?.data as { label?: string }).label).toBe("엔딩 A");
-    expect(mutateMock).not.toHaveBeenCalled();
-
-    // Debounce window 종료 → flush → applyOptimistic + mutate.
-    await act(async () => {
-      vi.advanceTimersByTime(500);
-    });
-    const afterFlush = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
-    const afterNode = afterFlush?.nodes.find((n) => n.id === "ending-1");
-    expect((afterNode?.data as { label?: string }).label).toBe("엔딩 B");
-    expect(mutateMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("pending body가 있는 상태에서 unmount 시 자동 flush된다", async () => {
-    // E-12 회귀: schedule 직후 (debounce window 만료 전) 컴포넌트가 unmount되면
-    // useDebouncedMutation의 useUnmountFlush가 pending body를 즉시 발화해야 한다.
-    // 다른 panel로 이동하거나 탭을 떠나도 마지막 입력이 사라지지 않도록 보장.
-    const { unmount } = renderWithClient(
-      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
-    );
-
-    const labelInput = screen.getByPlaceholderText("엔딩 이름");
-    fireEvent.change(labelInput, { target: { value: "마지막 입력" } });
-    expect(mutateMock).not.toHaveBeenCalled();
-
-    // Unmount — debounce timer 만료 전이라도 pending body는 자동 flush.
-    unmount();
-    expect(mutateMock).toHaveBeenCalledTimes(1);
-    const [arg] = mutateMock.mock.calls[0] as [
-      { nodeId: string; body: { data: { label: string } } },
-    ];
-    expect(arg.body.data.label).toBe("마지막 입력");
-  });
-
-  it("mutate 실패 시 graph cache가 rollback되고 toast.error가 발화한다", async () => {
-    const { qc } = renderWithClient(
-      <EndingNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
-    );
-    const original = makeGraph("ending-1", { label: "원본" });
-    qc.setQueryData(flowKeys.graph("t1"), original);
-
-    const labelInput = screen.getByPlaceholderText("엔딩 이름");
-    fireEvent.change(labelInput, { target: { value: "변경" } });
-
-    await act(async () => {
-      vi.advanceTimersByTime(500);
-    });
-    expect(mutateMock).toHaveBeenCalledTimes(1);
-    const [, opts] = mutateMock.mock.calls[0] as [
-      unknown,
-      { onError?: (e: Error) => void },
-    ];
-    expect(typeof opts?.onError).toBe("function");
-
-    act(() => {
-      opts.onError?.(new Error("boom"));
-    });
-    const cached = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
-    const node = cached?.nodes.find((n) => n.id === "ending-1");
-    expect((node?.data as { label?: string }).label).toBe("원본");
-    expect(toastError).toHaveBeenCalledWith("저장에 실패했습니다");
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -348,8 +348,8 @@ describe('FlowToolbar', () => {
     expect(screen.getByText('게임 라운드')).toBeDefined();
     expect(screen.getByText('장면')).toBeDefined();
     expect(screen.getByText('투표')).toBeDefined();
-    expect(screen.getByText('엔딩')).toBeDefined();
-    expect(screen.getByText('조건 분기')).toBeDefined();
+    expect(screen.getByText('결말 연결')).toBeDefined();
+    expect(screen.queryByText('조건 분기')).toBeNull();
   });
 
   it('드롭다운에서 게임 라운드 선택 시 phase 기본값과 함께 onAddNode가 호출된다', () => {


### PR DESCRIPTION
## 요약
- 플로우의 ending node panel을 읽기 전용 `결말 연결` 요약으로 축소했습니다.
- 결말 이름/본문/공개 범위/결과 카드 편집은 `결말 관리` 탭으로만 유도합니다.
- 새 조건 분기 node 추가 옵션을 `FlowToolbar`에서 숨기고, 기존 branch node와 panel은 보존했습니다.

Closes #505

## Coverage Plan
- `EndingNodePanel`: 상세 data를 읽기 전용 요약으로 표시하고, 본문/공개 범위/name/icon 편집 필드가 사라졌는지 검증합니다.
- `BranchNodePanel`: 기존 조건 분기 노드는 계속 렌더링되는지 focused test로 보존합니다.
- `FlowToolbar`/`FlowCanvas`: 항목 추가 메뉴에서 `결말 연결`은 보이고 `조건 분기`는 숨겨졌는지 검증합니다.

## Local validation
- `pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/EndingNodePanel.test.tsx src/features/editor/components/design/__tests__/BranchNodePanel.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx` 성공: 3 files / 21 tests
- `pnpm --dir apps/web typecheck` 성공
- Browser smoke 성공: `/editor/e2e-test-theme/story`에서 `항목 추가` 메뉴는 `결말 연결` 표시, `조건 분기` 미표시. 기존 ending node 선택 시 오른쪽 panel은 읽기 전용 `결말 연결` 요약이며 input/textarea/select 0개 확인
- `scripts/mmp-local-ci.sh quick` 성공: head `70d096707a16cc3e866d11c32a0c27c78549f3fe`, 2026-05-08T03:32:22Z 완료

## Notes
- 이번 PR은 새 조건 생성 UX를 만들지 않습니다. 기존 조건 분기 데이터와 패널은 유지하고, 미완성 생성入口만 숨깁니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 업데이트 사항

* **UI/UX 개선**
  * 결말 연결 패널이 단순화되어 요약 정보만 표시하도록 변경되었습니다.
  * 패널 스타일이 개선되었으며, 상세 편집 위치에 대한 안내가 추가되었습니다.
  * 항목 추가 메뉴의 결말 옵션 레이블이 "결말 연결"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->