### PR TITLE
feat(editor): 읽기 대사 오디오와 테스트 플레이어 UX 재설계

### DIFF
--- a/apps/server/db/migrations/00043_reading_section_bgm_mode.sql
+++ b/apps/server/db/migrations/00043_reading_section_bgm_mode.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+ALTER TABLE reading_sections
+ADD COLUMN bgm_mode VARCHAR(16) NOT NULL DEFAULT 'loop'
+CHECK (bgm_mode IN ('loop', 'once'));
+
+-- +goose Down
+ALTER TABLE reading_sections
+DROP COLUMN IF EXISTS bgm_mode;

--- a/apps/server/db/queries/reading_sections.sql
+++ b/apps/server/db/queries/reading_sections.sql
@@ -14,19 +14,20 @@ JOIN themes t ON rs.theme_id = t.id
 WHERE rs.id = $1 AND t.creator_id = $2;
 
 -- name: CreateReadingSection :one
-INSERT INTO reading_sections (theme_id, name, bgm_media_id, lines, sort_order)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO reading_sections (theme_id, name, bgm_media_id, bgm_mode, lines, sort_order)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
 -- name: UpdateReadingSection :one
 UPDATE reading_sections
 SET name = $2,
     bgm_media_id = $3,
-    lines = $4,
-    sort_order = $5,
+    bgm_mode = $4,
+    lines = $5,
+    sort_order = $6,
     version = version + 1,
     updated_at = NOW()
-WHERE id = $1 AND version = $6
+WHERE id = $1 AND version = $7
 RETURNING *;
 
 -- name: DeleteReadingSectionWithOwner :execrows

--- a/apps/server/internal/bridge/reading_bridge.go
+++ b/apps/server/internal/bridge/reading_bridge.go
@@ -111,6 +111,7 @@ func (a *ReadingModuleAdapter) GetReadingStateSnapshot() ws.ReadingStateSnapshot
 		CurrentIndex: wire.CurrentIndex,
 		Status:       wire.Status,
 		BgmMediaID:   wire.BgmMediaID,
+		BgmMode:      wire.BgmMode,
 		Lines:        convertLinesToCamelCase(wire.Lines),
 	}
 }

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -184,6 +184,7 @@ type ReadingSection struct {
 	Version    int32           `json:"version"`
 	CreatedAt  time.Time       `json:"created_at"`
 	UpdatedAt  time.Time       `json:"updated_at"`
+	BgmMode    string          `json:"bgm_mode"`
 }
 
 type RevokeLog struct {

--- a/apps/server/internal/db/reading_sections.sql.go
+++ b/apps/server/internal/db/reading_sections.sql.go
@@ -14,15 +14,16 @@ import (
 )
 
 const createReadingSection = `-- name: CreateReadingSection :one
-INSERT INTO reading_sections (theme_id, name, bgm_media_id, lines, sort_order)
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at
+INSERT INTO reading_sections (theme_id, name, bgm_media_id, bgm_mode, lines, sort_order)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at, bgm_mode
 `
 
 type CreateReadingSectionParams struct {
 	ThemeID    uuid.UUID       `json:"theme_id"`
 	Name       string          `json:"name"`
 	BgmMediaID pgtype.UUID     `json:"bgm_media_id"`
+	BgmMode    string          `json:"bgm_mode"`
 	Lines      json.RawMessage `json:"lines"`
 	SortOrder  int32           `json:"sort_order"`
 }
@@ -32,6 +33,7 @@ func (q *Queries) CreateReadingSection(ctx context.Context, arg CreateReadingSec
 		arg.ThemeID,
 		arg.Name,
 		arg.BgmMediaID,
+		arg.BgmMode,
 		arg.Lines,
 		arg.SortOrder,
 	)
@@ -46,6 +48,7 @@ func (q *Queries) CreateReadingSection(ctx context.Context, arg CreateReadingSec
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.BgmMode,
 	)
 	return i, err
 }
@@ -115,7 +118,7 @@ func (q *Queries) FindMediaReferencesInReadingSections(ctx context.Context, arg 
 }
 
 const getReadingSection = `-- name: GetReadingSection :one
-SELECT id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at FROM reading_sections WHERE id = $1
+SELECT id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at, bgm_mode FROM reading_sections WHERE id = $1
 `
 
 func (q *Queries) GetReadingSection(ctx context.Context, id uuid.UUID) (ReadingSection, error) {
@@ -131,12 +134,13 @@ func (q *Queries) GetReadingSection(ctx context.Context, id uuid.UUID) (ReadingS
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.BgmMode,
 	)
 	return i, err
 }
 
 const getReadingSectionWithOwner = `-- name: GetReadingSectionWithOwner :one
-SELECT rs.id, rs.theme_id, rs.name, rs.bgm_media_id, rs.lines, rs.sort_order, rs.version, rs.created_at, rs.updated_at FROM reading_sections rs
+SELECT rs.id, rs.theme_id, rs.name, rs.bgm_media_id, rs.lines, rs.sort_order, rs.version, rs.created_at, rs.updated_at, rs.bgm_mode FROM reading_sections rs
 JOIN themes t ON rs.theme_id = t.id
 WHERE rs.id = $1 AND t.creator_id = $2
 `
@@ -159,13 +163,14 @@ func (q *Queries) GetReadingSectionWithOwner(ctx context.Context, arg GetReading
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.BgmMode,
 	)
 	return i, err
 }
 
 const listReadingSectionsByTheme = `-- name: ListReadingSectionsByTheme :many
 
-SELECT id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at FROM reading_sections WHERE theme_id = $1 ORDER BY sort_order, created_at
+SELECT id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at, bgm_mode FROM reading_sections WHERE theme_id = $1 ORDER BY sort_order, created_at
 `
 
 // ============================================================
@@ -190,6 +195,7 @@ func (q *Queries) ListReadingSectionsByTheme(ctx context.Context, themeID uuid.U
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.BgmMode,
 		); err != nil {
 			return nil, err
 		}
@@ -205,18 +211,20 @@ const updateReadingSection = `-- name: UpdateReadingSection :one
 UPDATE reading_sections
 SET name = $2,
     bgm_media_id = $3,
-    lines = $4,
-    sort_order = $5,
+    bgm_mode = $4,
+    lines = $5,
+    sort_order = $6,
     version = version + 1,
     updated_at = NOW()
-WHERE id = $1 AND version = $6
-RETURNING id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at
+WHERE id = $1 AND version = $7
+RETURNING id, theme_id, name, bgm_media_id, lines, sort_order, version, created_at, updated_at, bgm_mode
 `
 
 type UpdateReadingSectionParams struct {
 	ID         uuid.UUID       `json:"id"`
 	Name       string          `json:"name"`
 	BgmMediaID pgtype.UUID     `json:"bgm_media_id"`
+	BgmMode    string          `json:"bgm_mode"`
 	Lines      json.RawMessage `json:"lines"`
 	SortOrder  int32           `json:"sort_order"`
 	Version    int32           `json:"version"`
@@ -227,6 +235,7 @@ func (q *Queries) UpdateReadingSection(ctx context.Context, arg UpdateReadingSec
 		arg.ID,
 		arg.Name,
 		arg.BgmMediaID,
+		arg.BgmMode,
 		arg.Lines,
 		arg.SortOrder,
 		arg.Version,
@@ -242,6 +251,7 @@ func (q *Queries) UpdateReadingSection(ctx context.Context, arg UpdateReadingSec
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.BgmMode,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -810,6 +810,7 @@ func TestFindMediaReferencesInReadingSections_JSONBIntegration(t *testing.T) {
 	section, err := fixture.q.CreateReadingSection(ctx, db.CreateReadingSectionParams{
 		ThemeID:   themeID,
 		Name:      "JSONB refs",
+		BgmMode:   ReadingBGMModeLoop,
 		Lines:     linesJSON,
 		SortOrder: 0,
 	})
@@ -955,6 +956,7 @@ func TestMediaSQLContract_CategoryReplacementAndReferenceCleanupIntegration(t *t
 		ThemeID:    themeID,
 		Name:       "참조 읽기",
 		BgmMediaID: pgtype.UUID{Bytes: bgm.ID, Valid: true},
+		BgmMode:    ReadingBGMModeLoop,
 		Lines:      json.RawMessage(fmt.Sprintf(`[{"Text":"사진","ImageMediaID":%q,"VoiceMediaID":%q}]`, image.ID.String(), image.ID.String())),
 		SortOrder:  1,
 	})

--- a/apps/server/internal/domain/editor/reading_service.go
+++ b/apps/server/internal/domain/editor/reading_service.go
@@ -102,6 +102,21 @@ func validateAdvanceBy(s string) bool {
 	return false
 }
 
+func normalizeSectionBgmMode(raw string) string {
+	if raw == "" {
+		return ReadingBGMModeLoop
+	}
+	return raw
+}
+
+func validateSectionBgmMode(raw string) error {
+	mode := normalizeSectionBgmMode(raw)
+	if mode == ReadingBGMModeLoop || mode == ReadingBGMModeOnce {
+		return nil
+	}
+	return apperror.New(apperror.ErrValidation, 422, "invalid bgm mode")
+}
+
 // validateLines applies per-line invariants and cross-checks every referenced
 // media ID against the same theme.
 func (s *readingService) validateLines(ctx context.Context, themeID uuid.UUID, lines []ReadingLineDTO) error {
@@ -171,10 +186,10 @@ func (s *readingService) validateStructuredReadingBlock(ctx context.Context, the
 	case ReadingBlockBGM:
 		mode := ln.BGMMode
 		if mode == "" {
-			mode = ReadingBGMModeLoop
+			mode = ReadingBGMModeOnce
 		}
 		if mode != ReadingBGMModeLoop && mode != ReadingBGMModeOnce && mode != ReadingBGMModeStop {
-			return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": invalid bgm mode")
+			return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": invalid effect sound mode")
 		}
 		if err := validateBlockAdvanceBy(ln.AdvanceBy, lineIndex); err != nil {
 			return err
@@ -188,7 +203,7 @@ func (s *readingService) validateStructuredReadingBlock(ctx context.Context, the
 		if ln.MediaID == "" {
 			return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId is required")
 		}
-		return s.assertLineMediaInTheme(ctx, themeID, ln.MediaID, MediaTypeBGM, "mediaId", lineIndex)
+		return s.assertEffectSoundMediaInTheme(ctx, themeID, ln.MediaID, lineIndex)
 	case ReadingBlockGMNote:
 		if ln.MediaID != "" {
 			return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": mediaId is not allowed")
@@ -197,6 +212,28 @@ func (s *readingService) validateStructuredReadingBlock(ctx context.Context, the
 	default:
 		return apperror.New(apperror.ErrValidation, 422, "line "+itoa(lineIndex)+": invalid reading block type")
 	}
+}
+
+func (s *readingService) assertEffectSoundMediaInTheme(ctx context.Context, themeID uuid.UUID, raw string, lineIndex int) error {
+	mediaID, err := uuid.Parse(raw)
+	if err != nil {
+		return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": invalid mediaId")
+	}
+	media, err := s.q.GetMedia(ctx, mediaID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId: media not found")
+		}
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to get media")
+		return apperror.Internal("failed to verify media reference")
+	}
+	if media.ThemeID != themeID {
+		return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId: media does not belong to this theme")
+	}
+	if media.Type != MediaTypeSFX && media.Type != MediaTypeBGM {
+		return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId: media has wrong type for this slot")
+	}
+	return nil
 }
 
 func validateBlockAdvanceBy(advanceBy string, lineIndex int) error {
@@ -289,6 +326,9 @@ func (s *readingService) Create(ctx context.Context, creatorID, themeID uuid.UUI
 	if err := s.validateLines(ctx, themeID, req.Lines); err != nil {
 		return nil, err
 	}
+	if err := validateSectionBgmMode(req.BgmMode); err != nil {
+		return nil, err
+	}
 
 	bgmParam, err := s.resolveBgmMediaID(ctx, themeID, req.BgmMediaID)
 	if err != nil {
@@ -305,6 +345,7 @@ func (s *readingService) Create(ctx context.Context, creatorID, themeID uuid.UUI
 		ThemeID:    themeID,
 		Name:       req.Name,
 		BgmMediaID: bgmParam,
+		BgmMode:    normalizeSectionBgmMode(req.BgmMode),
 		Lines:      linesJSON,
 		SortOrder:  req.SortOrder,
 	})
@@ -332,6 +373,14 @@ func (s *readingService) Update(ctx context.Context, creatorID, sectionID uuid.U
 	sortOrder := current.SortOrder
 	if req.SortOrder != nil {
 		sortOrder = *req.SortOrder
+	}
+
+	bgmMode := normalizeSectionBgmMode(current.BgmMode)
+	if req.BgmMode != nil {
+		if err := validateSectionBgmMode(*req.BgmMode); err != nil {
+			return nil, err
+		}
+		bgmMode = normalizeSectionBgmMode(*req.BgmMode)
 	}
 
 	// Lines: if patch supplies new lines, validate them; otherwise keep current.
@@ -375,6 +424,7 @@ func (s *readingService) Update(ctx context.Context, creatorID, sectionID uuid.U
 		ID:         sectionID,
 		Name:       name,
 		BgmMediaID: bgmParam,
+		BgmMode:    bgmMode,
 		Lines:      linesJSON,
 		SortOrder:  sortOrder,
 		Version:    req.Version,
@@ -444,6 +494,7 @@ func toReadingSectionResponse(r db.ReadingSection) (*ReadingSectionResponse, err
 		ID:        r.ID,
 		ThemeID:   r.ThemeID,
 		Name:      r.Name,
+		BgmMode:   normalizeSectionBgmMode(r.BgmMode),
 		Lines:     lines,
 		SortOrder: r.SortOrder,
 		Version:   r.Version,

--- a/apps/server/internal/domain/editor/reading_service.go
+++ b/apps/server/internal/domain/editor/reading_service.go
@@ -158,7 +158,7 @@ func normalizeReadingBlockType(raw string) string {
 	switch raw {
 	case "", ReadingBlockDialogue:
 		return ReadingBlockDialogue
-	case ReadingBlockImage, ReadingBlockVideo, ReadingBlockBGM, ReadingBlockGMNote:
+	case ReadingBlockImage, ReadingBlockVideo, ReadingBlockSFX, ReadingBlockBGM, ReadingBlockGMNote:
 		return raw
 	default:
 		return ""
@@ -183,7 +183,7 @@ func (s *readingService) validateStructuredReadingBlock(ctx context.Context, the
 			return err
 		}
 		return validateBlockAdvanceBy(ln.AdvanceBy, lineIndex)
-	case ReadingBlockBGM:
+	case ReadingBlockSFX, ReadingBlockBGM:
 		mode := ln.BGMMode
 		if mode == "" {
 			mode = ReadingBGMModeOnce
@@ -202,6 +202,9 @@ func (s *readingService) validateStructuredReadingBlock(ctx context.Context, the
 		}
 		if ln.MediaID == "" {
 			return apperror.New(apperror.ErrMediaNotInTheme, 400, "line "+itoa(lineIndex)+": mediaId is required")
+		}
+		if blockType == ReadingBlockSFX {
+			return s.assertLineMediaInTheme(ctx, themeID, ln.MediaID, MediaTypeSFX, "mediaId", lineIndex)
 		}
 		return s.assertEffectSoundMediaInTheme(ctx, themeID, ln.MediaID, lineIndex)
 	case ReadingBlockGMNote:

--- a/apps/server/internal/domain/editor/reading_service_test.go
+++ b/apps/server/internal/domain/editor/reading_service_test.go
@@ -83,6 +83,7 @@ func (f *fakeReadingQueries) CreateReadingSection(_ context.Context, arg db.Crea
 		ThemeID:    arg.ThemeID,
 		Name:       arg.Name,
 		BgmMediaID: arg.BgmMediaID,
+		BgmMode:    arg.BgmMode,
 		Lines:      arg.Lines,
 		SortOrder:  arg.SortOrder,
 		Version:    1,
@@ -103,6 +104,7 @@ func (f *fakeReadingQueries) UpdateReadingSection(_ context.Context, arg db.Upda
 	}
 	s.Name = arg.Name
 	s.BgmMediaID = arg.BgmMediaID
+	s.BgmMode = arg.BgmMode
 	s.Lines = arg.Lines
 	s.SortOrder = arg.SortOrder
 	s.Version++
@@ -132,6 +134,7 @@ type readingTestFixture struct {
 	creatorID uuid.UUID
 	themeID   uuid.UUID
 	bgmID     uuid.UUID
+	sfxID     uuid.UUID
 	voiceID   uuid.UUID
 	imageID   uuid.UUID
 	videoID   uuid.UUID
@@ -152,6 +155,9 @@ func newReadingFixture(t *testing.T) *readingTestFixture {
 	bgmID := uuid.New()
 	q.media[bgmID] = db.ThemeMedium{ID: bgmID, ThemeID: themeID, Type: MediaTypeBGM}
 
+	sfxID := uuid.New()
+	q.media[sfxID] = db.ThemeMedium{ID: sfxID, ThemeID: themeID, Type: MediaTypeSFX}
+
 	voiceID := uuid.New()
 	q.media[voiceID] = db.ThemeMedium{ID: voiceID, ThemeID: themeID, Type: MediaTypeVoice}
 
@@ -170,6 +176,7 @@ func newReadingFixture(t *testing.T) *readingTestFixture {
 		creatorID: creatorID,
 		themeID:   themeID,
 		bgmID:     bgmID,
+		sfxID:     sfxID,
 		voiceID:   voiceID,
 		imageID:   imageID,
 		videoID:   videoID,
@@ -216,6 +223,9 @@ func TestReadingService_Create_Success(t *testing.T) {
 	}
 	if resp.BgmMediaID == nil || *resp.BgmMediaID != bgm {
 		t.Fatalf("bgm not persisted")
+	}
+	if resp.BgmMode != ReadingBGMModeLoop {
+		t.Fatalf("BgmMode = %q, want %q", resp.BgmMode, ReadingBGMModeLoop)
 	}
 	// Indices must be normalized.
 	for i, ln := range resp.Lines {
@@ -298,7 +308,7 @@ func TestReadingService_Create_BlockMediaReferences(t *testing.T) {
 		Lines: []ReadingLineDTO{
 			{Type: ReadingBlockImage, MediaID: f.imageID.String(), AdvanceBy: AdvanceByGM, Position: "center", Size: "large"},
 			{Type: ReadingBlockVideo, MediaID: f.videoID.String(), AdvanceBy: AdvanceByGM, Autoplay: true, WaitUntilEnd: true},
-			{Type: ReadingBlockBGM, MediaID: f.bgmID.String(), BGMMode: ReadingBGMModeOnce},
+			{Type: ReadingBlockBGM, MediaID: f.sfxID.String(), BGMMode: ReadingBGMModeOnce},
 			{Type: ReadingBlockBGM, BGMMode: ReadingBGMModeStop},
 			{Type: ReadingBlockGMNote, Text: "GM only"},
 		},
@@ -318,6 +328,33 @@ func TestReadingService_Create_BlockMediaReferences(t *testing.T) {
 	if got := resp.Lines[2].BGMMode; got != ReadingBGMModeOnce {
 		t.Fatalf("BGMMode = %q, want %q", got, ReadingBGMModeOnce)
 	}
+}
+
+func TestReadingService_Create_SectionBgmModeOnce(t *testing.T) {
+	f := newReadingFixture(t)
+	bgm := f.bgmID.String()
+	resp, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name:       "One shot BGM",
+		BgmMediaID: &bgm,
+		BgmMode:    ReadingBGMModeOnce,
+		Lines:      []ReadingLineDTO{},
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if resp.BgmMode != ReadingBGMModeOnce {
+		t.Fatalf("BgmMode = %q, want %q", resp.BgmMode, ReadingBGMModeOnce)
+	}
+}
+
+func TestReadingService_Create_RejectsInvalidSectionBgmMode(t *testing.T) {
+	f := newReadingFixture(t)
+	_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name:    "Invalid BGM mode",
+		BgmMode: ReadingBGMModeStop,
+		Lines:   []ReadingLineDTO{},
+	})
+	assertAppCode(t, err, apperror.ErrValidation)
 }
 
 func TestReadingService_Create_BlockMediaMustMatchType(t *testing.T) {
@@ -420,12 +457,37 @@ func TestReadingService_Update_OptimisticLock(t *testing.T) {
 	if updated.Version != created.Version+1 {
 		t.Fatalf("version did not bump: %d → %d", created.Version, updated.Version)
 	}
+	if updated.BgmMode != ReadingBGMModeLoop {
+		t.Fatalf("BgmMode = %q, want %q", updated.BgmMode, ReadingBGMModeLoop)
+	}
 	// Second update with stale version fails with conflict.
 	_, err = f.svc.Update(context.Background(), f.creatorID, created.ID, UpdateReadingSectionRequest{
 		Name:    ptr("Stale"),
 		Version: created.Version, // stale
 	})
 	assertAppCode(t, err, apperror.ErrConflict)
+}
+
+func TestReadingService_Update_SectionBgmMode(t *testing.T) {
+	f := newReadingFixture(t)
+	created, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name:  "Original",
+		Lines: []ReadingLineDTO{},
+	})
+	if err != nil {
+		t.Fatalf("seed create failed: %v", err)
+	}
+
+	updated, err := f.svc.Update(context.Background(), f.creatorID, created.ID, UpdateReadingSectionRequest{
+		BgmMode: ptr(ReadingBGMModeOnce),
+		Version: created.Version,
+	})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if updated.BgmMode != ReadingBGMModeOnce {
+		t.Fatalf("BgmMode = %q, want %q", updated.BgmMode, ReadingBGMModeOnce)
+	}
 }
 
 func TestReadingService_List_SortedBySortOrder(t *testing.T) {

--- a/apps/server/internal/domain/editor/reading_service_test.go
+++ b/apps/server/internal/domain/editor/reading_service_test.go
@@ -308,7 +308,7 @@ func TestReadingService_Create_BlockMediaReferences(t *testing.T) {
 		Lines: []ReadingLineDTO{
 			{Type: ReadingBlockImage, MediaID: f.imageID.String(), AdvanceBy: AdvanceByGM, Position: "center", Size: "large"},
 			{Type: ReadingBlockVideo, MediaID: f.videoID.String(), AdvanceBy: AdvanceByGM, Autoplay: true, WaitUntilEnd: true},
-			{Type: ReadingBlockBGM, MediaID: f.sfxID.String(), BGMMode: ReadingBGMModeOnce},
+			{Type: ReadingBlockSFX, MediaID: f.sfxID.String(), BGMMode: ReadingBGMModeOnce},
 			{Type: ReadingBlockBGM, BGMMode: ReadingBGMModeStop},
 			{Type: ReadingBlockGMNote, Text: "GM only"},
 		},
@@ -377,6 +377,17 @@ func TestReadingService_Create_BGMBlockRequiresMediaUnlessStop(t *testing.T) {
 		Name: "Missing bgm media",
 		Lines: []ReadingLineDTO{
 			{Type: ReadingBlockBGM, BGMMode: ReadingBGMModeLoop},
+		},
+	})
+	assertAppCode(t, err, apperror.ErrMediaNotInTheme)
+}
+
+func TestReadingService_Create_SFXBlockRejectsBGMReference(t *testing.T) {
+	f := newReadingFixture(t)
+	_, err := f.svc.Create(context.Background(), f.creatorID, f.themeID, CreateReadingSectionRequest{
+		Name: "Wrong sfx media",
+		Lines: []ReadingLineDTO{
+			{Type: ReadingBlockSFX, MediaID: f.bgmID.String(), BGMMode: ReadingBGMModeOnce},
 		},
 	})
 	assertAppCode(t, err, apperror.ErrMediaNotInTheme)

--- a/apps/server/internal/domain/editor/reading_types.go
+++ b/apps/server/internal/domain/editor/reading_types.go
@@ -63,6 +63,7 @@ type ReadingLineDTO struct {
 type CreateReadingSectionRequest struct {
 	Name       string           `json:"name" validate:"required,min=1,max=200"`
 	BgmMediaID *string          `json:"bgmMediaId,omitempty"`
+	BgmMode    string           `json:"bgmMode,omitempty"`
 	Lines      []ReadingLineDTO `json:"lines"`
 	SortOrder  int32            `json:"sortOrder"`
 }
@@ -76,6 +77,7 @@ type CreateReadingSectionRequest struct {
 type UpdateReadingSectionRequest struct {
 	Name       *string           `json:"name,omitempty" validate:"omitempty,min=1,max=200"`
 	BgmMediaID **string          `json:"bgmMediaId,omitempty"`
+	BgmMode    *string           `json:"bgmMode,omitempty"`
 	Lines      *[]ReadingLineDTO `json:"lines,omitempty"`
 	SortOrder  *int32            `json:"sortOrder,omitempty"`
 	Version    int32             `json:"version"`
@@ -87,6 +89,7 @@ type ReadingSectionResponse struct {
 	ThemeID    uuid.UUID        `json:"themeId"`
 	Name       string           `json:"name"`
 	BgmMediaID *string          `json:"bgmMediaId,omitempty"`
+	BgmMode    string           `json:"bgmMode"`
 	Lines      []ReadingLineDTO `json:"lines"`
 	SortOrder  int32            `json:"sortOrder"`
 	Version    int32            `json:"version"`

--- a/apps/server/internal/domain/editor/reading_types.go
+++ b/apps/server/internal/domain/editor/reading_types.go
@@ -25,6 +25,7 @@ const (
 	ReadingBlockDialogue = "dialogue"
 	ReadingBlockImage    = "image"
 	ReadingBlockVideo    = "video"
+	ReadingBlockSFX      = "sfx"
 	ReadingBlockBGM      = "bgm"
 	ReadingBlockGMNote   = "gmNote"
 )

--- a/apps/server/internal/module/progression/reading/config.go
+++ b/apps/server/internal/module/progression/reading/config.go
@@ -9,6 +9,7 @@ type readingConfig struct {
 	TotalLines     int                 `json:"TotalLines"`
 	Lines          []readingLineConfig `json:"Lines,omitempty"`
 	BGMId          string              `json:"BGMId,omitempty"`
+	BGMMode        string              `json:"BGMMode,omitempty"`
 }
 
 // readingLineConfig describes a single script line's storage representation.
@@ -28,9 +29,10 @@ func (m *ReadingModule) Schema() json.RawMessage {
 		"properties": {
 			"AdvanceMode": {"type": "string", "enum": ["gm", "auto", "player"], "default": "gm"},
 			"DefaultVoiceID": {"type": "string"},
-			"TotalLines": {"type": "integer", "minimum": 0},
-			"BGMId": {"type": "string"},
-			"Lines": {
+				"TotalLines": {"type": "integer", "minimum": 0},
+				"BGMId": {"type": "string"},
+				"BGMMode": {"type": "string", "enum": ["loop", "once"], "default": "loop"},
+				"Lines": {
 				"type": "array",
 				"items": {
 					"type": "object",

--- a/apps/server/internal/module/progression/reading/helpers.go
+++ b/apps/server/internal/module/progression/reading/helpers.go
@@ -12,6 +12,13 @@ const (
 	readingStatusPaused  readingStatus = "paused"
 )
 
+func normalizeBGMMode(raw string) string {
+	if raw == "once" {
+		return "once"
+	}
+	return "loop"
+}
+
 // validAdvanceBy reports whether s is a recognized advanceBy value:
 //   - "" (empty falls back to module-level advanceMode default; treated as "gm")
 //   - "gm"

--- a/apps/server/internal/module/progression/reading/module.go
+++ b/apps/server/internal/module/progression/reading/module.go
@@ -24,6 +24,7 @@ type ReadingModule struct {
 	advanceMode    string // "gm", "auto", "player"
 	defaultVoiceID string
 	bgmId          string
+	bgmMode        string
 	lines          []readingLineConfig
 
 	// state
@@ -64,6 +65,7 @@ func (m *ReadingModule) Init(ctx context.Context, deps engine.ModuleDeps, config
 	m.advanceMode = cfg.AdvanceMode
 	m.defaultVoiceID = cfg.DefaultVoiceID
 	m.bgmId = cfg.BGMId
+	m.bgmMode = normalizeBGMMode(cfg.BGMMode)
 	m.lines = cfg.Lines
 	m.totalLines = cfg.TotalLines
 	if m.totalLines == 0 && len(m.lines) > 0 {
@@ -78,7 +80,7 @@ func (m *ReadingModule) Init(ctx context.Context, deps engine.ModuleDeps, config
 	if m.bgmId != "" {
 		deps.EventBus.Publish(engine.Event{
 			Type:    "audio.set_bgm",
-			Payload: map[string]any{"mediaId": m.bgmId, "fadeMs": 1000},
+			Payload: map[string]any{"mediaId": m.bgmId, "fadeMs": 1000, "mode": m.bgmMode},
 		})
 	}
 
@@ -94,6 +96,7 @@ func (m *ReadingModule) Init(ctx context.Context, deps engine.ModuleDeps, config
 		Payload: map[string]any{
 			"lines":      linesCopy,
 			"bgmMediaId": m.bgmId,
+			"bgmMode":    m.bgmMode,
 			"totalLines": m.totalLines,
 		},
 	})

--- a/apps/server/internal/module/progression/reading/state.go
+++ b/apps/server/internal/module/progression/reading/state.go
@@ -13,6 +13,7 @@ type ReadingState struct {
 	CurrentIndex int                 `json:"currentIndex"`
 	Lines        []readingLineConfig `json:"lines"`
 	BgmMediaID   string              `json:"bgmMediaId,omitempty"`
+	BgmMode      string              `json:"bgmMode"`
 	Status       string              `json:"status"`
 }
 
@@ -25,6 +26,7 @@ type ReadingStateWire struct {
 	CurrentIndex int             `json:"currentIndex"`
 	Lines        json.RawMessage `json:"lines"`
 	BgmMediaID   string          `json:"bgmMediaId,omitempty"`
+	BgmMode      string          `json:"bgmMode"`
 	Status       string          `json:"status"`
 }
 
@@ -55,6 +57,7 @@ func (m *ReadingModule) GetState() ReadingState {
 		CurrentIndex: m.currentLineIndex,
 		Lines:        linesCopy,
 		BgmMediaID:   m.bgmId,
+		BgmMode:      normalizeBGMMode(m.bgmMode),
 		Status:       status,
 	}
 }
@@ -76,6 +79,7 @@ func (m *ReadingModule) GetReadingStateWire() ReadingStateWire {
 		CurrentIndex: state.CurrentIndex,
 		Lines:        linesJSON,
 		BgmMediaID:   state.BgmMediaID,
+		BgmMode:      state.BgmMode,
 		Status:       state.Status,
 	}
 }

--- a/apps/server/internal/ws/reading_handler.go
+++ b/apps/server/internal/ws/reading_handler.go
@@ -46,6 +46,7 @@ type ReadingStateSnapshot struct {
 	CurrentIndex int             `json:"currentIndex"`
 	Lines        json.RawMessage `json:"lines"`
 	BgmMediaID   string          `json:"bgmMediaId,omitempty"`
+	BgmMode      string          `json:"bgmMode"`
 	Status       string          `json:"status"`
 }
 
@@ -304,6 +305,7 @@ type readingStartedPayloadWire struct {
 	SectionID  string                   `json:"sectionId"`
 	Lines      []readingStartedLineWire `json:"lines"`
 	BgmMediaID string                   `json:"bgmMediaId,omitempty"`
+	BgmMode    string                   `json:"bgmMode"`
 	TotalLines int                      `json:"totalLines,omitempty"`
 }
 
@@ -327,6 +329,7 @@ func (h *ReadingWSHandler) convertReadingStartedPayload(sessionID uuid.UUID, pay
 	var decoded struct {
 		Lines      []readingStartedLineStorage `json:"lines"`
 		BgmMediaID string                      `json:"bgmMediaId,omitempty"`
+		BgmMode    string                      `json:"bgmMode,omitempty"`
 		TotalLines int                         `json:"totalLines,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &decoded); err != nil {
@@ -334,6 +337,7 @@ func (h *ReadingWSHandler) convertReadingStartedPayload(sessionID uuid.UUID, pay
 		return out
 	}
 	out.BgmMediaID = decoded.BgmMediaID
+	out.BgmMode = normalizeReadingBgmMode(decoded.BgmMode)
 	out.TotalLines = decoded.TotalLines
 	wire := make([]readingStartedLineWire, len(decoded.Lines))
 	for i, s := range decoded.Lines {
@@ -348,6 +352,13 @@ func (h *ReadingWSHandler) convertReadingStartedPayload(sessionID uuid.UUID, pay
 	}
 	out.Lines = wire
 	return out
+}
+
+func normalizeReadingBgmMode(raw string) string {
+	if raw == "once" {
+		return "once"
+	}
+	return "loop"
 }
 
 // ForwardEvent converts an engine reading.* event to a ws envelope and

--- a/apps/web/src/features/audio/AudioOrchestrator.test.ts
+++ b/apps/web/src/features/audio/AudioOrchestrator.test.ts
@@ -124,8 +124,23 @@ describe("AudioOrchestrator", () => {
       expect(h.bgmManager.play).toHaveBeenCalledWith({
         id: "m1",
         url: "https://example.com/a.mp3",
+        mode: "loop",
       });
       expect(h.onBgmMediaIdChange).toHaveBeenCalledWith("m1");
+    });
+
+    it("forwards once mode to the file BGM manager", async () => {
+      await h.orchestrator.handleSetBgm({
+        mediaId: "m1",
+        sourceType: "FILE",
+        url: "https://example.com/a.mp3",
+        mode: "once",
+      });
+      expect(h.bgmManager.play).toHaveBeenCalledWith({
+        id: "m1",
+        url: "https://example.com/a.mp3",
+        mode: "once",
+      });
     });
 
     it("ignores FILE payload missing url", async () => {
@@ -194,7 +209,7 @@ describe("AudioOrchestrator", () => {
         url: "u1",
       });
       expect(yt.destroy).toHaveBeenCalled();
-      expect(h.bgmManager.play).toHaveBeenCalledWith({ id: "f1", url: "u1" });
+      expect(h.bgmManager.play).toHaveBeenCalledWith({ id: "f1", url: "u1", mode: "loop" });
     });
 
     it("YOUTUBE → YOUTUBE: destroys previous and creates new player", async () => {
@@ -226,6 +241,22 @@ describe("AudioOrchestrator", () => {
       });
       expect(h.bgmManager.play).toHaveBeenCalledTimes(1);
       expect(h.onBgmMediaIdChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("same mediaId with a new mode reconfigures the current file track", async () => {
+      await h.orchestrator.handleSetBgm({
+        mediaId: "m1",
+        sourceType: "FILE",
+        url: "u1",
+      });
+      await h.orchestrator.handleSetBgm({
+        mediaId: "m1",
+        sourceType: "FILE",
+        url: "u1",
+        mode: "once",
+      });
+      expect(h.bgmManager.play).toHaveBeenCalledTimes(2);
+      expect(h.bgmManager.play).toHaveBeenLastCalledWith({ id: "m1", url: "u1", mode: "once" });
     });
   });
 

--- a/apps/web/src/features/audio/AudioOrchestrator.ts
+++ b/apps/web/src/features/audio/AudioOrchestrator.ts
@@ -22,6 +22,7 @@ export interface SetBgmPayload {
   url?: string; // for FILE
   videoId?: string; // for YOUTUBE
   fadeMs?: number;
+  mode?: "loop" | "once";
 }
 
 export interface PlayVoicePayload {
@@ -73,7 +74,9 @@ export function createAudioOrchestrator(
 
   let activeBgmKind: "file" | "youtube" | null = null;
   let activeBgmMediaId: string | null = null;
+  let activeBgmMode: "loop" | "once" = "loop";
   let activeYouTubePlayer: YouTubePlayer | null = null;
+  let activeYouTubeEndedUnsubscribe: (() => void) | null = null;
   let lastCutsceneBehavior: BgmBehavior | null = null;
   let cutsceneBgmKindAtStart: "file" | "youtube" | null = null;
   let disposed = false;
@@ -114,6 +117,10 @@ export function createAudioOrchestrator(
   }
 
   function destroyYouTube(): void {
+    if (activeYouTubeEndedUnsubscribe) {
+      activeYouTubeEndedUnsubscribe();
+      activeYouTubeEndedUnsubscribe = null;
+    }
     if (activeYouTubePlayer) {
       try {
         activeYouTubePlayer.destroy();
@@ -126,9 +133,10 @@ export function createAudioOrchestrator(
 
   async function handleSetBgm(payload: SetBgmPayload): Promise<void> {
     if (disposed) return;
+    const mode = payload.mode ?? "loop";
 
     // Idempotent: same mediaId — skip.
-    if (activeBgmMediaId === payload.mediaId) return;
+    if (activeBgmMediaId === payload.mediaId && activeBgmMode === mode) return;
 
     if (payload.sourceType === "FILE") {
       if (!payload.url) {
@@ -144,8 +152,9 @@ export function createAudioOrchestrator(
       if (activeBgmKind === "youtube") {
         destroyYouTube();
       }
-      await bgmManager.play({ id: payload.mediaId, url: payload.url });
+      await bgmManager.play({ id: payload.mediaId, url: payload.url, mode });
       activeBgmKind = "file";
+      activeBgmMode = mode;
       notifyBgmId(payload.mediaId);
       return;
     }
@@ -177,6 +186,13 @@ export function createAudioOrchestrator(
         } catch {
           // ignore
         }
+        activeYouTubeEndedUnsubscribe = player.onEnded(() => {
+          if (activeBgmKind !== "youtube" || activeBgmMediaId !== payload.mediaId) return;
+          if (mode !== "loop") return;
+          void player.play().catch(() => {
+            // ignore
+          });
+        });
         await player.play();
       } catch (err) {
         if (import.meta.env?.DEV) {
@@ -188,6 +204,7 @@ export function createAudioOrchestrator(
         return;
       }
       activeBgmKind = "youtube";
+      activeBgmMode = mode;
       notifyBgmId(payload.mediaId);
     }
   }

--- a/apps/web/src/features/audio/BgmManager.test.ts
+++ b/apps/web/src/features/audio/BgmManager.test.ts
@@ -44,6 +44,7 @@ class MockAudio {
   src = "";
   crossOrigin: string | null = null;
   preload = "";
+  loop = false;
   volume = 1;
   currentTime = 0;
   paused = true;
@@ -108,6 +109,28 @@ describe("BgmManager", () => {
     const playing = allAudios.filter((a) => a.src === "https://example.com/bgm.mp3");
     expect(playing.length).toBe(1);
     expect(playing[0].play).toHaveBeenCalled();
+  });
+
+  it("defaults BGM tracks to loop mode", async () => {
+    const mgr = createBgmManager({ graph: makeGraph() });
+    await mgr.play({ id: "t1", url: "u1" });
+    const playing = allAudios.find((a) => a.src === "u1")!;
+    expect(playing.loop).toBe(true);
+  });
+
+  it("supports once mode for section BGM tracks", async () => {
+    const mgr = createBgmManager({ graph: makeGraph() });
+    await mgr.play({ id: "t1", url: "u1", mode: "once" });
+    const playing = allAudios.find((a) => a.src === "u1")!;
+    expect(playing.loop).toBe(false);
+  });
+
+  it("updates loop mode when the same track is reconfigured", async () => {
+    const mgr = createBgmManager({ graph: makeGraph() });
+    await mgr.play({ id: "t1", url: "u1", mode: "loop" });
+    const playing = allAudios.find((a) => a.src === "u1")!;
+    await mgr.play({ id: "t1", url: "u1", mode: "once" });
+    expect(playing.loop).toBe(false);
   });
 
   it("play with same id is a no-op", async () => {

--- a/apps/web/src/features/audio/BgmManager.ts
+++ b/apps/web/src/features/audio/BgmManager.ts
@@ -14,6 +14,7 @@ import type { AudioGraph } from "./audioGraph";
 export interface BgmTrack {
   id: string;
   url: string;
+  mode?: "loop" | "once";
 }
 
 export interface BgmManagerOptions {
@@ -92,6 +93,18 @@ export function createBgmManager(opts: BgmManagerOptions): BgmManager {
     return slots[activeIdx];
   }
 
+  function applyTrackMode(slot: Slot, track: BgmTrack): void {
+    slot.audio.loop = (track.mode ?? "loop") === "loop";
+  }
+
+  function updateCurrentTrackMode(track: BgmTrack): void {
+    for (const slot of slots) {
+      if (slot.trackId === track.id) {
+        applyTrackMode(slot, track);
+      }
+    }
+  }
+
   // Force any in-progress crossfade to its end state.
   function settleInFlightFade(): void {
     if (pendingFadeEnd === null) return;
@@ -121,7 +134,10 @@ export function createBgmManager(opts: BgmManagerOptions): BgmManager {
     if (disposed) return;
 
     // Same-track no-op
-    if (currentTrackId === track.id) return;
+    if (currentTrackId === track.id) {
+      updateCurrentTrackMode(track);
+      return;
+    }
 
     // Cancel any pending cleanup/stop timers — a new track is starting.
     clearTimers();
@@ -144,6 +160,7 @@ export function createBgmManager(opts: BgmManagerOptions): BgmManager {
     const target = inactive();
     target.audio.src = track.url;
     target.audio.currentTime = 0;
+    applyTrackMode(target, track);
     target.trackId = track.id;
 
     // Schedule gain ramp on inactive: 0 → 1

--- a/apps/web/src/features/editor/components/reading/BgmBlockFields.tsx
+++ b/apps/web/src/features/editor/components/reading/BgmBlockFields.tsx
@@ -18,7 +18,7 @@ export function BgmBlockFields({ line, mediaById, themeId, onPatch }: BlockField
         icon={Music}
         selectedClassName="text-emerald-300"
         onSelect={(media) => onPatch({ MediaID: media.id, BGMMode: 'once' })}
-        onClear={() => onPatch({ MediaID: '' })}
+        onClear={() => onPatch({ MediaID: '', BGMMode: 'once' })}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/reading/BgmBlockFields.tsx
+++ b/apps/web/src/features/editor/components/reading/BgmBlockFields.tsx
@@ -1,36 +1,24 @@
 import { Music } from 'lucide-react';
 
-import type { ReadingLineDTO } from '../../readingApi';
 import { MediaControl } from './MediaControl';
-import { SelectField } from './SelectField';
 import type { BlockFieldProps } from './readingBlockFieldProps';
 
 export function BgmBlockFields({ line, mediaById, themeId, onPatch }: BlockFieldProps) {
   return (
-    <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_12rem]">
+    <div className="grid gap-2">
       <MediaControl
         themeId={themeId}
-        label="BGM"
-        emptyLabel="BGM 선택"
-        removeLabel="BGM 제거"
-        pickerTitle="BGM 선택"
-        filterType="BGM"
+        label="효과음"
+        emptyLabel="효과음 선택"
+        removeLabel="효과음 제거"
+        pickerTitle="효과음 선택"
+        filterType="SFX"
         selectedId={line.MediaID}
         selectedMedia={mediaById.get(line.MediaID ?? '') ?? null}
         icon={Music}
         selectedClassName="text-emerald-300"
-        onSelect={(media) => onPatch({ MediaID: media.id, BGMMode: line.BGMMode ?? 'loop' })}
+        onSelect={(media) => onPatch({ MediaID: media.id, BGMMode: 'once' })}
         onClear={() => onPatch({ MediaID: '' })}
-      />
-      <SelectField
-        label="동작"
-        value={line.BGMMode ?? 'loop'}
-        onChange={(value) => onPatch({ BGMMode: value as ReadingLineDTO['BGMMode'] })}
-        options={[
-          ['loop', '반복'],
-          ['once', '1회'],
-          ['stop', '정지'],
-        ]}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/reading/ReadingBlockFields.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingBlockFields.tsx
@@ -37,13 +37,9 @@ export function ReadingBlockFields({
 
   if (type === 'gmNote') {
     return (
-      <textarea
-        aria-label="GM 메모"
-        className="min-h-20 w-full resize-y rounded border border-slate-700 bg-slate-800 px-3 py-2 text-sm leading-6 text-slate-100"
-        value={line.Text ?? ''}
-        onChange={(event) => onPatch({ Text: event.target.value })}
-        placeholder="진행자만 보는 메모"
-      />
+      <p className="rounded border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-300">
+        이전 버전의 GM 메모입니다. 저장하면 새 대본에서는 제거됩니다.
+      </p>
     );
   }
 

--- a/apps/web/src/features/editor/components/reading/ReadingBlockFields.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingBlockFields.tsx
@@ -31,7 +31,7 @@ export function ReadingBlockFields({
     return <VideoBlockFields {...fieldProps} />;
   }
 
-  if (type === 'bgm') {
+  if (type === 'sfx' || type === 'bgm') {
     return <BgmBlockFields {...fieldProps} />;
   }
 

--- a/apps/web/src/features/editor/components/reading/ReadingBlockFields.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingBlockFields.tsx
@@ -31,14 +31,22 @@ export function ReadingBlockFields({
     return <VideoBlockFields {...fieldProps} />;
   }
 
-  if (type === 'sfx' || type === 'bgm') {
+  if (type === 'sfx') {
     return <BgmBlockFields {...fieldProps} />;
+  }
+
+  if (type === 'bgm') {
+    return (
+      <p className="rounded border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-300">
+        이전 버전의 BGM 블록입니다. 내용은 보존되며 새 효과음은 SFX 블록으로 추가해 주세요.
+      </p>
+    );
   }
 
   if (type === 'gmNote') {
     return (
       <p className="rounded border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-300">
-        이전 버전의 GM 메모입니다. 저장하면 새 대본에서는 제거됩니다.
+        이전 버전의 GM 메모입니다. 편집 화면에는 표시하지 않지만 저장 시 내용은 보존됩니다.
       </p>
     );
   }

--- a/apps/web/src/features/editor/components/reading/ReadingBlockRow.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingBlockRow.tsx
@@ -47,6 +47,11 @@ const blockMeta: Record<ReadingBlockType, { label: string; icon: LucideIcon; cla
       icon: Video,
       className: 'border-violet-500/30 bg-violet-500/5 text-violet-200',
     },
+    sfx: {
+      label: '효과음',
+      icon: Music,
+      className: 'border-emerald-500/30 bg-emerald-500/5 text-emerald-200',
+    },
     bgm: {
       label: '효과음',
       icon: Music,

--- a/apps/web/src/features/editor/components/reading/ReadingBlockRow.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingBlockRow.tsx
@@ -5,7 +5,6 @@ import {
   Image as ImageIcon,
   Mic,
   Music,
-  StickyNote,
   Trash2,
   Video,
   type LucideIcon,
@@ -49,13 +48,13 @@ const blockMeta: Record<ReadingBlockType, { label: string; icon: LucideIcon; cla
       className: 'border-violet-500/30 bg-violet-500/5 text-violet-200',
     },
     bgm: {
-      label: 'BGM',
+      label: '효과음',
       icon: Music,
       className: 'border-emerald-500/30 bg-emerald-500/5 text-emerald-200',
     },
     gmNote: {
-      label: 'GM 메모',
-      icon: StickyNote,
+      label: '레거시 메모',
+      icon: Mic,
       className: 'border-slate-500/30 bg-slate-800/70 text-slate-200',
     },
   };

--- a/apps/web/src/features/editor/components/reading/ReadingScriptImportModal.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingScriptImportModal.tsx
@@ -22,8 +22,7 @@ const sampleScript = [
   '나레이션: 모두 눈을 감아주세요.',
   '이미지: 저택 전경 large',
   '변상훈: 저는 아무것도 보지 못했습니다.',
-  'BGM: 심문 테마 반복',
-  'GM: 다음 장면 준비',
+  '효과음: 문 닫히는 소리',
 ].join('\n');
 
 export function ReadingScriptImportModal({
@@ -116,8 +115,7 @@ export function ReadingScriptImportModal({
               <p className="mt-1">화자: 대사</p>
               <p>이미지: 미디어명</p>
               <p>영상: 미디어명</p>
-              <p>BGM: 미디어명 반복 / 1회 / 정지</p>
-              <p>GM: 진행자 메모</p>
+              <p>효과음: 미디어명</p>
             </div>
           </aside>
         </div>

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -309,6 +309,7 @@ export function ReadingSectionEditor({
               key={mode}
               type="button"
               onClick={() => handleBgmModeChange(mode)}
+              aria-pressed={draft.bgmMode === mode}
               className={`rounded px-3 py-1.5 text-xs ${
                 draft.bgmMode === mode
                   ? 'bg-amber-500 text-slate-950'

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -87,13 +87,14 @@ export function ReadingSectionEditor({
   const { data: imageList = [] } = useMediaList(themeId, 'IMAGE');
   const { data: voiceList = [] } = useMediaList(themeId, 'VOICE');
   const { data: videoList = [] } = useMediaList(themeId, 'VIDEO');
+  const { data: sfxList = [] } = useMediaList(themeId, 'SFX');
   const selectedBgm = useMemo(
     () => bgmList.find((m) => m.id === draft.bgmMediaId) ?? null,
     [bgmList, draft.bgmMediaId]
   );
   const allMedia = useMemo(
-    () => [...bgmList, ...imageList, ...voiceList, ...videoList],
-    [bgmList, imageList, voiceList, videoList]
+    () => [...bgmList, ...imageList, ...voiceList, ...videoList, ...sfxList],
+    [bgmList, imageList, voiceList, sfxList, videoList]
   );
   const mediaById = useMemo(() => new Map(allMedia.map((media) => [media.id, media])), [allMedia]);
 
@@ -172,6 +173,10 @@ export function ReadingSectionEditor({
     setDraft((d) => ({ ...d, bgmMediaId: null }));
   }
 
+  function handleBgmModeChange(mode: typeof draft.bgmMode) {
+    setDraft((d) => ({ ...d, bgmMode: mode }));
+  }
+
   // -------------------------------------------------------------------------
   // Save / Delete
   // -------------------------------------------------------------------------
@@ -191,6 +196,7 @@ export function ReadingSectionEditor({
       name: draft.name,
       // bgmMediaId uses triple-state: null = clear, string = set, undefined = keep
       bgmMediaId: draft.bgmMediaId,
+      bgmMode: draft.bgmMode,
       lines: normalizedLines,
       sortOrder: draft.sortOrder,
     };
@@ -267,31 +273,52 @@ export function ReadingSectionEditor({
         />
       </div>
 
-      {/* BGM picker */}
-      <div className="flex items-center gap-2">
-        <label className="text-xs text-slate-400">배경 BGM:</label>
-        {draft.bgmMediaId ? (
-          <span className="flex items-center gap-1 text-xs text-amber-300">
-            <Music className="h-3 w-3" />
-            {selectedBgm?.name ?? '(선택됨)'}
+      {/* Section BGM picker */}
+      <div className="flex flex-col gap-2 rounded border border-slate-800 bg-slate-900/60 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <label className="text-xs font-medium text-slate-300">섹션 배경음악</label>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            {draft.bgmMediaId ? (
+              <span className="inline-flex items-center gap-1 text-xs text-amber-300">
+                <Music className="h-3 w-3" />
+                {selectedBgm?.name ?? '(선택됨)'}
+                <button
+                  type="button"
+                  onClick={handleBgmClear}
+                  aria-label="배경음악 제거"
+                  className="ml-1 text-amber-300 hover:text-amber-200"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ) : (
+              <span className="text-xs text-slate-500">선택하면 이 섹션이 시작될 때 재생됩니다.</span>
+            )}
             <button
               type="button"
-              onClick={handleBgmClear}
-              aria-label="BGM 제거"
-              className="ml-1 text-amber-300 hover:text-amber-200"
+              onClick={() => setBgmPickerOpen(true)}
+              className="text-xs text-slate-400 underline hover:text-slate-200"
             >
-              <X className="h-3 w-3" />
+              {draft.bgmMediaId ? '변경' : '배경음악 선택'}
             </button>
-          </span>
-        ) : (
-          <button
-            type="button"
-            onClick={() => setBgmPickerOpen(true)}
-            className="text-xs text-slate-400 underline hover:text-slate-200"
-          >
-            BGM 선택
-          </button>
-        )}
+          </div>
+        </div>
+        <div className="inline-flex rounded border border-slate-700 bg-slate-950 p-0.5">
+          {(['loop', 'once'] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => handleBgmModeChange(mode)}
+              className={`rounded px-3 py-1.5 text-xs ${
+                draft.bgmMode === mode
+                  ? 'bg-amber-500 text-slate-950'
+                  : 'text-slate-300 hover:bg-slate-800'
+              }`}
+            >
+              {mode === 'loop' ? '반복' : '1회'}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Blocks */}
@@ -414,10 +441,10 @@ export function ReadingSectionEditor({
         onClose={() => setBgmPickerOpen(false)}
         onSelect={handleBgmSelect}
         themeId={themeId}
-        filterType="BGM"
-        selectedId={draft.bgmMediaId}
-        title="BGM 선택"
-      />
+	        filterType="BGM"
+	        selectedId={draft.bgmMediaId}
+	        title="배경음악 선택"
+	      />
       <ReadingScriptImportModal
         open={scriptImportOpen}
         hasExistingBlocks={draft.lines.length > 0}
@@ -428,8 +455,10 @@ export function ReadingSectionEditor({
       />
       <ReadingSectionPreviewModal
         open={previewOpen}
-        sectionName={draft.name || section.name}
-        lines={previewLines}
+	        sectionName={draft.name || section.name}
+	        bgmMediaId={draft.bgmMediaId}
+	        bgmMode={draft.bgmMode}
+	        lines={previewLines}
         characters={characters}
         mediaById={mediaById}
         dirty={isDirty}

--- a/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
@@ -8,7 +8,6 @@ import {
   Pause,
   Play,
   SkipForward,
-  StickyNote,
   Video,
   X,
   type LucideIcon,
@@ -16,6 +15,7 @@ import {
 
 import type { ReadingLineDTO } from '../../readingApi';
 import type { MediaResponse } from '../../mediaApi';
+import { useMediaDownloadUrl } from '../../mediaApi';
 import type { CharacterOption } from './readingBlockUiTypes';
 import {
   getReadingPreviewActiveBgm,
@@ -24,7 +24,7 @@ import {
   getReadingPreviewMediaLabel,
   getReadingPreviewMediaUrl,
   getReadingPreviewWaitMediaId,
-  readingPreviewBgmAdvanceDelayMs,
+  readingPreviewEffectSoundAdvanceDelayMs,
   readingPreviewVideoDurationMs,
   readingPreviewVoiceDurationMs,
 } from './readingPreviewModel';
@@ -32,6 +32,8 @@ import {
 export interface ReadingSectionPreviewModalProps {
   open: boolean;
   sectionName: string;
+  bgmMediaId?: string | null;
+  bgmMode: 'loop' | 'once';
   lines: ReadingLineDTO[];
   characters: CharacterOption[];
   mediaById: Map<string, MediaResponse>;
@@ -42,6 +44,8 @@ export interface ReadingSectionPreviewModalProps {
 export function ReadingSectionPreviewModal({
   open,
   sectionName,
+  bgmMediaId,
+  bgmMode,
   lines,
   characters,
   mediaById,
@@ -57,8 +61,8 @@ export function ReadingSectionPreviewModal({
   const visibleLines = lines.slice(0, index + 1);
   const waitMediaId = currentLine ? getReadingPreviewWaitMediaId(currentLine) : null;
   const activeBgm = useMemo(
-    () => getReadingPreviewActiveBgm(lines, index, mediaById),
-    [index, lines, mediaById]
+    () => getReadingPreviewActiveBgm(bgmMediaId, bgmMode, mediaById),
+    [bgmMediaId, bgmMode, mediaById]
   );
   const stepLabel = lines.length > 0 ? `${index + 1} / ${lines.length}` : '0 / 0';
   const advanceLabel = getReadingPreviewAdvanceLabel(currentLine?.AdvanceBy, characters);
@@ -101,7 +105,7 @@ export function ReadingSectionPreviewModal({
     }
     autoAppliedRef.current = true;
     if (isLast) return;
-    const timer = window.setTimeout(() => goNext(), readingPreviewBgmAdvanceDelayMs);
+    const timer = window.setTimeout(() => goNext(), readingPreviewEffectSoundAdvanceDelayMs);
     return () => window.clearTimeout(timer);
   }, [currentLine, goNext, isLast, open]);
 
@@ -219,8 +223,8 @@ function PreviewBlock({
         mediaById={mediaById}
       />
     );
-  if (type === 'bgm') return <BgmBlock line={line} mediaById={mediaById} />;
-  if (type === 'gmNote') return <GmNoteBlock line={line} />;
+  if (type === 'bgm') return <EffectSoundBlock line={line} mediaById={mediaById} />;
+  if (type === 'gmNote') return null;
   return (
     <DialogueBlock
       line={line}
@@ -246,11 +250,11 @@ function DialogueBlock({
   return (
     <article className="rounded-md border border-slate-700 bg-slate-950/80 p-4 shadow-lg shadow-black/20">
       <BlockLabel icon={Mic} label={line.Speaker || '나레이션'} tone="text-amber-200" />
-      {imageUrl && (
-        <img
+      {line.ImageMediaID && (
+        <PreviewImage
           className="mt-3 max-h-72 w-full rounded border border-slate-700 object-cover"
+          mediaId={line.ImageMediaID}
           src={imageUrl}
-          alt=""
         />
       )}
       <p className="mt-3 whitespace-pre-wrap text-xl font-semibold leading-relaxed text-white md:text-2xl">
@@ -283,11 +287,11 @@ function ImageBlock({
         label={`${getReadingPreviewMediaLabel(line.MediaID, mediaById)} · ${line.Position ?? 'center'}`}
         tone="text-sky-200"
       />
-      {imageUrl ? (
-        <img
+      {line.MediaID ? (
+        <PreviewImage
           className={`mx-auto mt-3 max-h-[58vh] ${widthClass} rounded border border-slate-700 object-cover`}
+          mediaId={line.MediaID}
           src={imageUrl}
-          alt=""
         />
       ) : (
         <MissingMedia />
@@ -328,36 +332,20 @@ function VideoBlock({
   );
 }
 
-function BgmBlock({
+function EffectSoundBlock({
   line,
   mediaById,
 }: {
   line: ReadingLineDTO;
   mediaById: Map<string, MediaResponse>;
 }) {
-  const label =
-    line.BGMMode === 'stop'
-      ? '현재 BGM 정지'
-      : `${getReadingPreviewMediaLabel(line.MediaID, mediaById)} · ${
-          line.BGMMode === 'once' ? '1회 재생' : '반복 재생'
-        }`;
+  const label = `${getReadingPreviewMediaLabel(line.MediaID, mediaById)} · 효과음 1회 재생`;
   return (
     <article className="rounded-md border border-emerald-500/25 bg-emerald-500/10 p-5 text-center">
       <Music className="mx-auto mb-3 h-8 w-8 text-emerald-200" />
       <p className="font-semibold text-emerald-100">{label}</p>
       <p className="mt-2 text-xs text-emerald-100/70">
-        BGM 큐는 적용 후 자동으로 다음 블록으로 넘어갑니다.
-      </p>
-    </article>
-  );
-}
-
-function GmNoteBlock({ line }: { line: ReadingLineDTO }) {
-  return (
-    <article className="rounded-md border border-slate-600 bg-slate-800/70 p-4">
-      <BlockLabel icon={StickyNote} label="GM 진행 메모" tone="text-slate-200" />
-      <p className="mt-3 whitespace-pre-wrap text-base leading-relaxed text-slate-100">
-        {line.Text || '메모가 비어 있습니다.'}
+        효과음은 적용 후 자동으로 다음 블록으로 넘어갑니다.
       </p>
     </article>
   );
@@ -418,4 +406,21 @@ function MissingMedia() {
       미디어 프리뷰 없음
     </div>
   );
+}
+
+function PreviewImage({
+  mediaId,
+  src,
+  className,
+}: {
+  mediaId?: string;
+  src?: string;
+  className: string;
+}) {
+  const needsDownloadUrl = Boolean(mediaId && !src);
+  const { data } = useMediaDownloadUrl(needsDownloadUrl ? mediaId : undefined);
+  const resolvedSrc = src ?? data?.url;
+
+  if (!resolvedSrc) return <MissingMedia />;
+  return <img className={className} src={resolvedSrc} alt="선택된 이미지 미리보기" />;
 }

--- a/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
@@ -223,7 +223,8 @@ function PreviewBlock({
         mediaById={mediaById}
       />
     );
-  if (type === 'sfx' || type === 'bgm') return <EffectSoundBlock line={line} mediaById={mediaById} />;
+  if (type === 'sfx') return <EffectSoundBlock line={line} mediaById={mediaById} />;
+  if (type === 'bgm') return <LegacyBgmBlock line={line} mediaById={mediaById} />;
   if (type === 'gmNote') return null;
   return (
     <DialogueBlock
@@ -237,7 +238,7 @@ function PreviewBlock({
 
 function isEffectSoundBlock(line: ReadingLineDTO): boolean {
   const type = getReadingPreviewBlockType(line);
-  return type === 'sfx' || type === 'bgm';
+  return type === 'sfx';
 }
 
 function DialogueBlock({
@@ -351,6 +352,28 @@ function EffectSoundBlock({
       <p className="font-semibold text-emerald-100">{label}</p>
       <p className="mt-2 text-xs text-emerald-100/70">
         효과음은 적용 후 자동으로 다음 블록으로 넘어갑니다.
+      </p>
+    </article>
+  );
+}
+
+function LegacyBgmBlock({
+  line,
+  mediaById,
+}: {
+  line: ReadingLineDTO;
+  mediaById: Map<string, MediaResponse>;
+}) {
+  const mode =
+    line.BGMMode === 'stop' ? '정지' : line.BGMMode === 'once' ? '1회 재생' : '반복 재생';
+  return (
+    <article className="rounded-md border border-amber-500/25 bg-amber-500/10 p-5 text-center">
+      <Music className="mx-auto mb-3 h-8 w-8 text-amber-200" />
+      <p className="font-semibold text-amber-100">
+        {getReadingPreviewMediaLabel(line.MediaID, mediaById)} · 레거시 BGM {mode}
+      </p>
+      <p className="mt-2 text-xs text-amber-100/70">
+        이전 버전의 BGM 블록 의미를 보존해 미리보기합니다.
       </p>
     </article>
   );

--- a/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionPreviewModal.tsx
@@ -99,7 +99,7 @@ export function ReadingSectionPreviewModal({
       !open ||
       !currentLine ||
       autoAppliedRef.current ||
-      getReadingPreviewBlockType(currentLine) !== 'bgm'
+      !isEffectSoundBlock(currentLine)
     ) {
       return;
     }
@@ -223,7 +223,7 @@ function PreviewBlock({
         mediaById={mediaById}
       />
     );
-  if (type === 'bgm') return <EffectSoundBlock line={line} mediaById={mediaById} />;
+  if (type === 'sfx' || type === 'bgm') return <EffectSoundBlock line={line} mediaById={mediaById} />;
   if (type === 'gmNote') return null;
   return (
     <DialogueBlock
@@ -233,6 +233,11 @@ function PreviewBlock({
       mediaById={mediaById}
     />
   );
+}
+
+function isEffectSoundBlock(line: ReadingLineDTO): boolean {
+  const type = getReadingPreviewBlockType(line);
+  return type === 'sfx' || type === 'bgm';
 }
 
 function DialogueBlock({

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -18,6 +18,7 @@ const {
   useUpdateReadingSectionMock,
   useDeleteReadingSectionMock,
   useMediaListMock,
+  useMediaDownloadUrlMock,
   useMediaCategoriesMock,
   useRequestUploadUrlMock,
   useConfirmUploadMock,
@@ -27,6 +28,7 @@ const {
   useUpdateReadingSectionMock: vi.fn(),
   useDeleteReadingSectionMock: vi.fn(),
   useMediaListMock: vi.fn(),
+  useMediaDownloadUrlMock: vi.fn(),
   useMediaCategoriesMock: vi.fn(),
   useRequestUploadUrlMock: vi.fn(),
   useConfirmUploadMock: vi.fn(),
@@ -47,6 +49,7 @@ vi.mock('@/features/editor/readingApi', async () => {
 
 vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
+  useMediaDownloadUrl: (...args: unknown[]) => useMediaDownloadUrlMock(...args),
   useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
   useRequestUploadUrl: (...args: unknown[]) => useRequestUploadUrlMock(...args),
   useConfirmUpload: (...args: unknown[]) => useConfirmUploadMock(...args),
@@ -135,6 +138,7 @@ beforeEach(() => {
     isPending: false,
   });
   useMediaListMock.mockReturnValue({ data: [], isLoading: false });
+  useMediaDownloadUrlMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
   useMediaCategoriesMock.mockReturnValue({ data: [] });
   useRequestUploadUrlMock.mockReturnValue({
     mutateAsync: vi.fn(),
@@ -209,6 +213,45 @@ describe('ReadingSectionEditor', () => {
     renderEditor();
     expect(screen.getByDisplayValue('어두운 방 안.')).toBeTruthy();
     expect(screen.getByDisplayValue('누구냐?')).toBeTruthy();
+  });
+
+  it('offers effect sound blocks but not new GM memo blocks', () => {
+    renderEditor();
+    expect(screen.getByRole('button', { name: '효과음' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'GM 메모' })).toBeNull();
+  });
+
+  it('saves section background music playback mode', async () => {
+    useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
+      if (type === 'BGM') {
+        return {
+          data: [
+            {
+              id: 'bgm-1',
+              theme_id: 'theme-1',
+              name: '오프닝 배경음악',
+              type: 'BGM',
+              source_type: 'FILE',
+              tags: [],
+              sort_order: 1,
+              created_at: '2026-04-05T00:00:00Z',
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: [], isLoading: false };
+    });
+
+    renderEditor();
+    fireEvent.click(screen.getByRole('button', { name: '배경음악 선택' }));
+    fireEvent.click(screen.getByText('오프닝 배경음악').closest('button') as HTMLElement);
+    fireEvent.click(screen.getByRole('button', { name: '1회' }));
+    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+
+    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate.mock.calls[0][0].patch.bgmMediaId).toBe('bgm-1');
+    expect(mutateAsyncUpdate.mock.calls[0][0].patch.bgmMode).toBe('once');
   });
 
   it('add dialogue block appends a new empty row', () => {
@@ -351,14 +394,14 @@ describe('ReadingSectionEditor', () => {
           isLoading: false,
         };
       }
-      if (type === 'BGM') {
+      if (type === 'SFX') {
         return {
           data: [
             {
-              id: 'bgm-1',
+              id: 'sfx-1',
               theme_id: 'theme-1',
-              name: '심문 테마',
-              type: 'BGM',
+              name: '문 닫히는 소리',
+              type: 'SFX',
               source_type: 'FILE',
               tags: [],
               sort_order: 2,
@@ -378,8 +421,7 @@ describe('ReadingSectionEditor', () => {
         value: [
           '나레이션: 모두 눈을 감아주세요.',
           '이미지: 현장 사진',
-          'BGM: 심문 테마 반복',
-          'GM: 조명을 낮춘다',
+          '효과음: 문 닫히는 소리',
         ].join('\n'),
       },
     });
@@ -391,8 +433,7 @@ describe('ReadingSectionEditor', () => {
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines).toMatchObject([
       { Index: 0, Type: 'dialogue', Speaker: '나레이션' },
       { Index: 1, Type: 'image', MediaID: 'image-1' },
-      { Index: 2, Type: 'bgm', MediaID: 'bgm-1', BGMMode: 'loop' },
-      { Index: 3, Type: 'gmNote', Text: '조명을 낮춘다' },
+      { Index: 2, Type: 'bgm', MediaID: 'sfx-1', BGMMode: 'once' },
     ]);
   });
 
@@ -562,6 +603,56 @@ describe('ReadingSectionEditor', () => {
     expect(within(dialog).getByText('저택 전경 · center')).toBeTruthy();
   });
 
+  it('uses a download URL for selected preview images without inline URLs', async () => {
+    useMediaDownloadUrlMock.mockReturnValue({
+      data: { url: 'https://download.example/image.png', expires_at: '2026-04-05T00:15:00Z' },
+      isLoading: false,
+      isError: false,
+    });
+    useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
+      if (type === 'IMAGE') {
+        return {
+          data: [
+            {
+              id: 'image-1',
+              theme_id: 'theme-1',
+              name: '저택 전경',
+              type: 'IMAGE',
+              source_type: 'FILE',
+              tags: [],
+              sort_order: 2,
+              created_at: '2026-04-05T00:00:00Z',
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return { data: [], isLoading: false };
+    });
+
+    renderEditor({
+      section: {
+        ...sampleSection,
+        lines: [
+          {
+            Index: 0,
+            Type: 'image',
+            MediaID: 'image-1',
+            Position: 'center',
+            Size: 'medium',
+            AdvanceBy: 'gm',
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '테스트' }));
+
+    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith('image-1');
+    const image = screen.getByRole('img', { name: '선택된 이미지 미리보기' }) as HTMLImageElement;
+    expect(image.src).toBe('https://download.example/image.png');
+  });
+
   it('renders an empty test player without crashing', () => {
     renderEditor({
       section: {
@@ -576,17 +667,17 @@ describe('ReadingSectionEditor', () => {
     expect(within(dialog).getByText('0 / 0')).toBeTruthy();
   });
 
-  it('auto-advances BGM cue in the test player preview', async () => {
+  it('auto-advances effect sound cue in the test player preview', async () => {
     vi.useFakeTimers();
     useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
-      if (type === 'BGM') {
+      if (type === 'SFX') {
         return {
           data: [
             {
-              id: 'bgm-1',
+              id: 'sfx-1',
               theme_id: 'theme-1',
-              name: '오프닝 테마',
-              type: 'BGM',
+              name: '문 닫힘',
+              type: 'SFX',
               source_type: 'FILE',
               tags: [],
               sort_order: 1,
@@ -603,11 +694,13 @@ describe('ReadingSectionEditor', () => {
       section: {
         ...sampleSection,
         lines: [
-          { Index: 0, Type: 'bgm', MediaID: 'bgm-1', BGMMode: 'loop' },
+          { Index: 0, Type: 'bgm', MediaID: 'sfx-1', BGMMode: 'once' },
           {
             Index: 1,
-            Type: 'gmNote',
+            Type: 'dialogue',
             Text: '조명을 낮춘다.',
+            Speaker: '나레이션',
+            AdvanceBy: 'gm',
           },
         ],
       },
@@ -616,10 +709,10 @@ describe('ReadingSectionEditor', () => {
     fireEvent.click(screen.getByRole('button', { name: '테스트' }));
 
     const dialog = screen.getByRole('dialog', { name: '오프닝 테스트' });
-    expect(within(dialog).getByText('오프닝 테마 · 반복 재생')).toBeTruthy();
+    expect(within(dialog).getByText('문 닫힘 · 효과음 1회 재생')).toBeTruthy();
     await act(async () => {});
     act(() => {
-      vi.advanceTimersByTime(700);
+      vi.advanceTimersByTime(500);
     });
     expect(within(dialog).getByText('조명을 낮춘다.')).toBeTruthy();
   });
@@ -658,6 +751,7 @@ describe('ReadingSectionEditor', () => {
         {
           name: 'x',
           bgmMediaId: sampleSection.bgmMediaId,
+          bgmMode: 'loop',
           lines: sampleSection.lines,
           sortOrder: sampleSection.sortOrder,
         },

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -433,7 +433,7 @@ describe('ReadingSectionEditor', () => {
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines).toMatchObject([
       { Index: 0, Type: 'dialogue', Speaker: '나레이션' },
       { Index: 1, Type: 'image', MediaID: 'image-1' },
-      { Index: 2, Type: 'bgm', MediaID: 'sfx-1', BGMMode: 'once' },
+      { Index: 2, Type: 'sfx', MediaID: 'sfx-1', BGMMode: 'once' },
     ]);
   });
 
@@ -694,7 +694,7 @@ describe('ReadingSectionEditor', () => {
       section: {
         ...sampleSection,
         lines: [
-          { Index: 0, Type: 'bgm', MediaID: 'sfx-1', BGMMode: 'once' },
+          { Index: 0, Type: 'sfx', MediaID: 'sfx-1', BGMMode: 'once' },
           {
             Index: 1,
             Type: 'dialogue',

--- a/apps/web/src/features/editor/components/reading/readingPreviewModel.ts
+++ b/apps/web/src/features/editor/components/reading/readingPreviewModel.ts
@@ -4,7 +4,7 @@ import type { CharacterOption } from './readingBlockUiTypes';
 
 export const readingPreviewVoiceDurationMs = 2600;
 export const readingPreviewVideoDurationMs = 1800;
-export const readingPreviewBgmAdvanceDelayMs = 700;
+export const readingPreviewEffectSoundAdvanceDelayMs = 500;
 
 export function getReadingPreviewBlockType(line: ReadingLineDTO): ReadingBlockType {
   return line.Type ?? 'dialogue';
@@ -34,17 +34,12 @@ export function getReadingPreviewWaitMediaId(line: ReadingLineDTO): string | nul
 }
 
 export function getReadingPreviewActiveBgm(
-  lines: ReadingLineDTO[],
-  currentIndex: number,
+  bgmMediaId: string | null | undefined,
+  bgmMode: 'loop' | 'once',
   mediaById: Map<string, MediaResponse>
 ): string {
-  const cues = lines
-    .slice(0, currentIndex + 1)
-    .filter((line) => getReadingPreviewBlockType(line) === 'bgm');
-  const lastCue = cues.at(-1);
-  if (!lastCue || lastCue.BGMMode === 'stop') return 'BGM 없음';
-  const mediaName = getReadingPreviewMediaLabel(lastCue.MediaID, mediaById);
-  return `${mediaName} ${lastCue.BGMMode === 'once' ? '1회' : '반복'}`;
+  if (!bgmMediaId) return '배경음악 없음';
+  return `${getReadingPreviewMediaLabel(bgmMediaId, mediaById)} ${bgmMode === 'once' ? '1회' : '반복'}`;
 }
 
 export function getReadingPreviewMediaLabel(
@@ -60,5 +55,6 @@ export function getReadingPreviewMediaUrl(
   mediaById: Map<string, MediaResponse>
 ): string | undefined {
   if (!mediaId) return undefined;
-  return mediaById.get(mediaId)?.url;
+  const media = mediaById.get(mediaId);
+  return media?.url;
 }

--- a/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
+++ b/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
@@ -1,13 +1,19 @@
-import { Image as ImageIcon, Mic, Music, StickyNote, Video, type LucideIcon } from 'lucide-react';
+import { Image as ImageIcon, Mic, Music, Video, type LucideIcon } from 'lucide-react';
 
 import { isApiHttpError } from '@/lib/api-error';
 
-import type { ReadingBlockType, ReadingLineDTO, ReadingSectionResponse } from '../../readingApi';
+import type {
+  ReadingBlockType,
+  ReadingLineDTO,
+  ReadingSectionBgmMode,
+  ReadingSectionResponse,
+} from '../../readingApi';
 import type { MediaResponse, MediaType } from '../../mediaApi';
 
 export interface ReadingSectionDraft {
   name: string;
   bgmMediaId: string | null;
+  bgmMode: ReadingSectionBgmMode;
   lines: ReadingLineDTO[];
   sortOrder: number;
 }
@@ -20,15 +26,15 @@ export const blockActions: Array<{
   { type: 'dialogue', label: '대사', icon: Mic },
   { type: 'image', label: '이미지', icon: ImageIcon },
   { type: 'video', label: '영상', icon: Video },
-  { type: 'bgm', label: 'BGM', icon: Music },
-  { type: 'gmNote', label: 'GM 메모', icon: StickyNote },
+  { type: 'bgm', label: '효과음', icon: Music },
 ];
 
 export function toDraft(section: ReadingSectionResponse): ReadingSectionDraft {
   return {
     name: section.name,
     bgmMediaId: section.bgmMediaId ?? null,
-    lines: section.lines.map((line) => ({ ...line })),
+    bgmMode: section.bgmMode ?? 'loop',
+    lines: section.lines.filter((line) => line.Type !== 'gmNote').map((line) => ({ ...line })),
     sortOrder: section.sortOrder,
   };
 }
@@ -46,11 +52,13 @@ export function isReadingDraftDirty(
 ): boolean {
   if (draft.name !== section.name) return true;
   if ((draft.bgmMediaId ?? null) !== (section.bgmMediaId ?? null)) return true;
+  if (draft.bgmMode !== (section.bgmMode ?? 'loop')) return true;
   if (draft.sortOrder !== section.sortOrder) return true;
-  if (draft.lines.length !== section.lines.length) return true;
+  const savedLines = section.lines.filter((line) => line.Type !== 'gmNote');
+  if (draft.lines.length !== savedLines.length) return true;
 
   return draft.lines.some((draftLine, index) => {
-    const savedLine = section.lines[index];
+    const savedLine = savedLines[index];
     return (
       draftLine.Index !== savedLine.Index ||
       draftLine.Text !== savedLine.Text ||
@@ -91,10 +99,7 @@ export function createBlock(type: ReadingBlockType, index: number): ReadingLineD
     };
   }
   if (type === 'bgm') {
-    return { Index: index, Type: type, MediaID: '', BGMMode: 'loop' };
-  }
-  if (type === 'gmNote') {
-    return { Index: index, Type: type, Text: '' };
+    return { Index: index, Type: type, MediaID: '', BGMMode: 'once' };
   }
   return {
     Index: index,

--- a/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
+++ b/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
@@ -34,7 +34,7 @@ export function toDraft(section: ReadingSectionResponse): ReadingSectionDraft {
     name: section.name,
     bgmMediaId: section.bgmMediaId ?? null,
     bgmMode: section.bgmMode ?? 'loop',
-    lines: section.lines.filter((line) => line.Type !== 'gmNote').map((line) => ({ ...line })),
+    lines: section.lines.map((line) => ({ ...line })),
     sortOrder: section.sortOrder,
   };
 }
@@ -54,7 +54,7 @@ export function isReadingDraftDirty(
   if ((draft.bgmMediaId ?? null) !== (section.bgmMediaId ?? null)) return true;
   if (draft.bgmMode !== (section.bgmMode ?? 'loop')) return true;
   if (draft.sortOrder !== section.sortOrder) return true;
-  const savedLines = section.lines.filter((line) => line.Type !== 'gmNote');
+  const savedLines = section.lines;
   if (draft.lines.length !== savedLines.length) return true;
 
   return draft.lines.some((draftLine, index) => {

--- a/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
+++ b/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
@@ -26,7 +26,7 @@ export const blockActions: Array<{
   { type: 'dialogue', label: '대사', icon: Mic },
   { type: 'image', label: '이미지', icon: ImageIcon },
   { type: 'video', label: '영상', icon: Video },
-  { type: 'bgm', label: '효과음', icon: Music },
+  { type: 'sfx', label: '효과음', icon: Music },
 ];
 
 export function toDraft(section: ReadingSectionResponse): ReadingSectionDraft {
@@ -98,7 +98,7 @@ export function createBlock(type: ReadingBlockType, index: number): ReadingLineD
       AdvanceBy: 'gm',
     };
   }
-  if (type === 'bgm') {
+  if (type === 'sfx' || type === 'bgm') {
     return { Index: index, Type: type, MediaID: '', BGMMode: 'once' };
   }
   return {

--- a/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
+++ b/apps/web/src/features/editor/components/reading/readingSectionEditorModel.ts
@@ -98,8 +98,11 @@ export function createBlock(type: ReadingBlockType, index: number): ReadingLineD
       AdvanceBy: 'gm',
     };
   }
-  if (type === 'sfx' || type === 'bgm') {
-    return { Index: index, Type: type, MediaID: '', BGMMode: 'once' };
+  if (type === 'sfx') {
+    return { Index: index, Type: 'sfx', MediaID: '', BGMMode: 'once' };
+  }
+  if (type === 'bgm') {
+    return { Index: index, Type: 'bgm', MediaID: '', BGMMode: 'loop' };
   }
   return {
     Index: index,

--- a/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
@@ -15,19 +15,19 @@ const media = [
   { id: 'image-1', name: '저택 전경', type: 'IMAGE' as const },
   { id: 'video-1', name: 'CCTV 01', type: 'VIDEO' as const },
   { id: 'bgm-1', name: '심문 테마', type: 'BGM' as const },
+  { id: 'sfx-1', name: '문 닫히는 소리', type: 'SFX' as const },
 ];
 
 describe('parseReadingScriptToBlocks', () => {
-  it('parses dialogue, media, bgm, and gm note blocks into API-compatible lines', () => {
+  it('parses dialogue, media, and effect sound blocks into API-compatible lines', () => {
     const result = parseReadingScriptToBlocks(
       [
         '나레이션: 모두 눈을 감아주세요.',
         '이미지: 저택 전경 large',
         '변상훈: 저는 아무것도 보지 못했습니다.',
         '영상: CCTV 01',
-        'BGM: 심문 테마 1회',
+        '효과음: 문 닫히는 소리',
         'GM: 진행자만 보는 메모',
-        'BGM: 정지',
       ].join('\n'),
       { characters, media }
     );
@@ -64,15 +64,14 @@ describe('parseReadingScriptToBlocks', () => {
         WaitUntilEnd: true,
         AdvanceBy: 'gm',
       },
-      { Index: 4, Type: 'bgm', MediaID: 'bgm-1', BGMMode: 'once' },
-      { Index: 5, Type: 'gmNote', Text: '진행자만 보는 메모' },
-      { Index: 6, Type: 'bgm', MediaID: '', BGMMode: 'stop' },
+      { Index: 4, Type: 'bgm', MediaID: 'sfx-1', BGMMode: 'once' },
+      { Index: 5, Type: 'dialogue', Speaker: '나레이션', Text: '진행자만 보는 메모' },
     ]);
   });
 
   it('records unresolved speaker and media names instead of inventing IDs', () => {
     const result = parseReadingScriptToBlocks(
-      ['모르는사람: 알리바이가 있습니다.', '이미지: 없는 사진', 'BGM: 없는 음악 반복'].join('\n'),
+      ['모르는사람: 알리바이가 있습니다.', '이미지: 없는 사진', '효과음: 없는 소리'].join('\n'),
       { characters, media }
     );
 
@@ -82,24 +81,24 @@ describe('parseReadingScriptToBlocks', () => {
       AdvanceBy: 'gm',
     });
     expect(result.blocks[1]).toMatchObject({ Type: 'image', MediaID: '' });
-    expect(result.blocks[2]).toMatchObject({ Type: 'bgm', MediaID: '', BGMMode: 'loop' });
+    expect(result.blocks[2]).toMatchObject({ Type: 'bgm', MediaID: '', BGMMode: 'once' });
     expect(result.issues).toEqual([
       { lineNumber: 1, kind: 'unknown-speaker', value: '모르는사람' },
       { lineNumber: 2, kind: 'unknown-media', value: '없는 사진' },
-      { lineNumber: 3, kind: 'unknown-media', value: '없는 음악 반복' },
+      { lineNumber: 3, kind: 'unknown-media', value: '없는 소리' },
     ]);
   });
 
   it('does not strip directive words embedded inside media names', () => {
     const result = parseReadingScriptToBlocks(
-      ['이미지: leftover_theme', '영상: fullscreen_bg', 'BGM: stopper_bgm'].join('\n'),
+      ['이미지: leftover_theme', '영상: fullscreen_bg', '효과음: stopper_sfx'].join('\n'),
       {
         characters,
         media: [
           ...media,
           { id: 'image-leftover', name: 'leftover_theme', type: 'IMAGE' as const },
           { id: 'video-fullscreen', name: 'fullscreen_bg', type: 'VIDEO' as const },
-          { id: 'bgm-stopper', name: 'stopper_bgm', type: 'BGM' as const },
+          { id: 'sfx-stopper', name: 'stopper_sfx', type: 'SFX' as const },
         ],
       }
     );
@@ -108,7 +107,7 @@ describe('parseReadingScriptToBlocks', () => {
     expect(result.blocks).toMatchObject([
       { Type: 'image', MediaID: 'image-leftover', Position: 'center', Size: 'medium' },
       { Type: 'video', MediaID: 'video-fullscreen' },
-      { Type: 'bgm', MediaID: 'bgm-stopper', BGMMode: 'loop' },
+      { Type: 'bgm', MediaID: 'sfx-stopper', BGMMode: 'once' },
     ]);
   });
 });

--- a/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts
@@ -64,7 +64,7 @@ describe('parseReadingScriptToBlocks', () => {
         WaitUntilEnd: true,
         AdvanceBy: 'gm',
       },
-      { Index: 4, Type: 'bgm', MediaID: 'sfx-1', BGMMode: 'once' },
+      { Index: 4, Type: 'sfx', MediaID: 'sfx-1', BGMMode: 'once' },
       { Index: 5, Type: 'dialogue', Speaker: '나레이션', Text: '진행자만 보는 메모' },
     ]);
   });
@@ -81,7 +81,7 @@ describe('parseReadingScriptToBlocks', () => {
       AdvanceBy: 'gm',
     });
     expect(result.blocks[1]).toMatchObject({ Type: 'image', MediaID: '' });
-    expect(result.blocks[2]).toMatchObject({ Type: 'bgm', MediaID: '', BGMMode: 'once' });
+    expect(result.blocks[2]).toMatchObject({ Type: 'sfx', MediaID: '', BGMMode: 'once' });
     expect(result.issues).toEqual([
       { lineNumber: 1, kind: 'unknown-speaker', value: '모르는사람' },
       { lineNumber: 2, kind: 'unknown-media', value: '없는 사진' },
@@ -107,7 +107,7 @@ describe('parseReadingScriptToBlocks', () => {
     expect(result.blocks).toMatchObject([
       { Type: 'image', MediaID: 'image-leftover', Position: 'center', Size: 'medium' },
       { Type: 'video', MediaID: 'video-fullscreen' },
-      { Type: 'bgm', MediaID: 'sfx-stopper', BGMMode: 'once' },
+      { Type: 'sfx', MediaID: 'sfx-stopper', BGMMode: 'once' },
     ]);
   });
 });

--- a/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
+++ b/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
@@ -1,4 +1,4 @@
-import type { AdvanceBy, ReadingBgmMode, ReadingBlockType, ReadingLineDTO } from '../../readingApi';
+import type { AdvanceBy, ReadingBlockType, ReadingLineDTO } from '../../readingApi';
 import type { MediaType } from '../../mediaApi';
 
 export interface ReadingParserCharacter {
@@ -62,9 +62,9 @@ function parseDirectiveLine(
 ): ReadingLineDTO {
   if (head === '이미지') return parseImageDirective(index, lineNumber, body, options.media, issues);
   if (head === '영상') return parseVideoDirective(index, lineNumber, body, options.media, issues);
-  if (head.toUpperCase() === 'BGM')
-    return parseBgmDirective(index, lineNumber, body, options.media, issues);
-  if (head.toUpperCase() === 'GM') return { Index: index, Type: 'gmNote', Text: body };
+  if (head === '효과음' || head.toUpperCase() === 'SFX' || head.toUpperCase() === 'BGM')
+    return parseEffectSoundDirective(index, lineNumber, body, options.media, issues);
+  if (head.toUpperCase() === 'GM') return dialogueBlock(index, '나레이션', body, 'gm');
   return parseDialogueDirective(index, lineNumber, head, body || raw, options.characters, issues);
 }
 
@@ -98,17 +98,16 @@ function parseVideoDirective(
   });
 }
 
-function parseBgmDirective(
+function parseEffectSoundDirective(
   index: number,
   lineNumber: number,
   body: string,
   media: ReadingParserMedia[],
   issues: ReadingParseIssue[]
 ): ReadingLineDTO {
-  const mode = inferBgmMode(body);
-  const found = mode === 'stop' ? null : findMedia(body, 'BGM', media);
-  if (mode !== 'stop' && !found) issues.push({ lineNumber, kind: 'unknown-media', value: body });
-  return { Index: index, Type: 'bgm', Text: '', MediaID: found?.id ?? '', BGMMode: mode };
+  const found = findMedia(body, 'SFX', media) ?? findMedia(body, 'BGM', media);
+  if (!found) issues.push({ lineNumber, kind: 'unknown-media', value: body });
+  return { Index: index, Type: 'bgm', Text: '', MediaID: found?.id ?? '', BGMMode: 'once' };
 }
 
 function parseDialogueDirective(
@@ -196,13 +195,9 @@ function findMedia(
 
 function normalizeLookupName(value: string): string {
   const controlWords = [
-    '반복',
     '1회',
     '한번',
-    '정지',
-    'loop',
     'once',
-    'stop',
     'full',
     'large',
     'small',
@@ -228,17 +223,6 @@ function inferImageSize(value: string): ReadingLineDTO['Size'] {
   if (hasControlWord(value, 'small')) return 'small';
   if (hasControlWord(value, 'large') || hasControlWord(value, 'full')) return 'large';
   return 'medium';
-}
-
-function inferBgmMode(value: string): ReadingBgmMode {
-  if (hasControlWord(value, '정지') || hasControlWord(value, 'stop')) return 'stop';
-  if (
-    hasControlWord(value, '1회') ||
-    hasControlWord(value, '한번') ||
-    hasControlWord(value, 'once')
-  )
-    return 'once';
-  return 'loop';
 }
 
 function normalizeBlockType(type: ReadingLineDTO['Type']): ReadingBlockType {

--- a/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
+++ b/apps/web/src/features/editor/entities/story/readingBlockAdapter.ts
@@ -105,9 +105,9 @@ function parseEffectSoundDirective(
   media: ReadingParserMedia[],
   issues: ReadingParseIssue[]
 ): ReadingLineDTO {
-  const found = findMedia(body, 'SFX', media) ?? findMedia(body, 'BGM', media);
+  const found = findMedia(body, 'SFX', media);
   if (!found) issues.push({ lineNumber, kind: 'unknown-media', value: body });
-  return { Index: index, Type: 'bgm', Text: '', MediaID: found?.id ?? '', BGMMode: 'once' };
+  return { Index: index, Type: 'sfx', Text: '', MediaID: found?.id ?? '', BGMMode: 'once' };
 }
 
 function parseDialogueDirective(

--- a/apps/web/src/features/editor/readingApi.ts
+++ b/apps/web/src/features/editor/readingApi.ts
@@ -44,7 +44,7 @@ export interface ReadingLineDTO {
   BGMMode?: ReadingBgmMode;
 }
 
-export type ReadingBlockType = 'dialogue' | 'image' | 'video' | 'bgm' | 'gmNote';
+export type ReadingBlockType = 'dialogue' | 'image' | 'video' | 'sfx' | 'bgm' | 'gmNote';
 export type ReadingBgmMode = 'loop' | 'once' | 'stop';
 
 export interface CreateReadingSectionRequest {

--- a/apps/web/src/features/editor/readingApi.ts
+++ b/apps/web/src/features/editor/readingApi.ts
@@ -50,6 +50,7 @@ export type ReadingBgmMode = 'loop' | 'once' | 'stop';
 export interface CreateReadingSectionRequest {
   name: string;
   bgmMediaId?: string | null;
+  bgmMode?: ReadingSectionBgmMode;
   lines: ReadingLineDTO[];
   sortOrder: number;
 }
@@ -67,6 +68,7 @@ export interface CreateReadingSectionRequest {
 export interface UpdateReadingSectionRequest {
   name?: string;
   bgmMediaId?: string | null;
+  bgmMode?: ReadingSectionBgmMode;
   lines?: ReadingLineDTO[];
   sortOrder?: number;
   /** Optimistic-lock version. Required on every PATCH. */
@@ -78,12 +80,15 @@ export interface ReadingSectionResponse {
   themeId: string;
   name: string;
   bgmMediaId?: string | null;
+  bgmMode?: ReadingSectionBgmMode;
   lines: ReadingLineDTO[];
   sortOrder: number;
   version: number;
   createdAt: string;
   updatedAt: string;
 }
+
+export type ReadingSectionBgmMode = 'loop' | 'once';
 
 // ---------------------------------------------------------------------------
 // Query Keys


### PR DESCRIPTION
## Summary
- Closes #506
- 섹션 상단 BGM에 반복/1회 모드를 저장하고 런타임 `audio.set_bgm`까지 전달했습니다.
- 대본 내부 BGM 블록을 효과음 1회 재생 블록으로 정리하고, GM 메모는 신규 작성 UI에서 제거했습니다.
- 테스트 플레이어에서 섹션 BGM, 효과음, 선택 이미지 다운로드 URL 프리뷰, 읽기 카드 표시를 갱신했습니다.

## Coverage Plan
- `apps/server/internal/domain/editor/reading_service.go`: section `bgmMode` 생성/수정/검증, 효과음 SFX/legacy BGM 검증은 `reading_service_test.go`로 덮었습니다.
- `apps/server/internal/module/progression/reading/*`, `apps/server/internal/ws/reading_handler.go`, `apps/server/internal/bridge/reading_bridge.go`: runtime `bgmMode` 전달은 backend focused test와 local quick로 덮었습니다.
- `apps/web/src/features/audio/{AudioOrchestrator,BgmManager}.ts`: loop/once 재생 모드는 audio unit test로 덮었습니다.
- `apps/web/src/features/editor/components/reading/*`, `readingBlockAdapter.ts`: 에디터 UI, import parser, preview image/effect sound 흐름은 ReadingSectionEditor/readingBlockAdapter tests로 덮었습니다.

## Local validation
- `go test ./internal/domain/editor ./internal/module/progression/reading ./internal/ws ./internal/bridge`
- `pnpm --dir apps/web exec vitest run src/features/audio/BgmManager.test.ts src/features/audio/AudioOrchestrator.test.ts src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/entities/story/__tests__/readingBlockAdapter.test.ts`
- `pnpm --dir apps/web typecheck`
- `scripts/mmp-local-ci.sh quick` on `730b149e` passed.

## Notes
- GitHub Actions heavy CI는 개발 최소 워커 모드 정책에 따라 수동 실행하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 읽기 섹션별 BGM 재생 모드 추가: loop(기본) / once 선택 가능 및 저장/전달
  * 에디터에 효과음(SFX) 블록 추가 및 섹션 BGM 선택 UI와 모드 토글·프리뷰 반영
  * 스크립트 임포트와 미리보기에 효과음 샘플·렌더링 지원 추가

* **버그 수정/개선**
  * 플레이백/프리뷰의 반복 동작 일관성 개선(같은 트랙 재설정 시 모드 적용)
  * 미디어 미리보기에서 다운로드 URL 폴백 처리 및 관련 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->