### PR TITLE
feat(editor): 캐릭터 미션 설정 UX 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
 import type { CharacterAliasRule } from '@/features/editor/api';
-import type { SelectOption } from './condition/ConditionRule';
-import { ConditionBuilder } from './condition/ConditionBuilder';
 import { groupToRecord, type ConditionGroup } from './condition/conditionTypes';
 import { normalizeCharacterAliasRules } from '@/features/editor/entities/character/characterEditorAdapter';
 import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
@@ -9,9 +7,7 @@ import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
 interface CharacterAliasRulesEditorProps {
   themeId: string;
   characterName: string;
-  characterImageUrl?: string | null;
   rules: CharacterAliasRule[];
-  characterOptions: SelectOption[];
   disabled: boolean;
   onChange: (rules: CharacterAliasRule[]) => void;
   onSave: (rules: CharacterAliasRule[]) => void;
@@ -22,8 +18,6 @@ interface CharacterAliasRuleItemProps {
   rule: CharacterAliasRule;
   index: number;
   characterName: string;
-  characterImageUrl?: string | null;
-  characterOptions: SelectOption[];
   disabled: boolean;
   onUpdate: (index: number, patch: Partial<CharacterAliasRule>) => void;
   onRemove: (index: number) => void;
@@ -32,9 +26,7 @@ interface CharacterAliasRuleItemProps {
 export function CharacterAliasRulesEditor({
   themeId,
   characterName,
-  characterImageUrl,
   rules,
-  characterOptions,
   disabled,
   onChange,
   onSave,
@@ -58,7 +50,7 @@ export function CharacterAliasRulesEditor({
         display_icon_url: '',
         display_icon_media_id: '',
         priority: nextPriority,
-        condition: groupToRecord(createDefaultAliasCondition()),
+        condition: groupToRecord(createAliasPresetCondition('game_start')),
       },
     ]);
   };
@@ -114,8 +106,6 @@ export function CharacterAliasRulesEditor({
             rule={rule}
             index={index}
             characterName={characterName}
-            characterImageUrl={characterImageUrl}
-            characterOptions={characterOptions}
             disabled={disabled}
             onUpdate={updateRule}
             onRemove={removeRule}
@@ -145,13 +135,12 @@ function CharacterAliasRuleItem({
   rule,
   index,
   characterName,
-  characterImageUrl,
-  characterOptions,
   disabled,
   onUpdate,
   onRemove,
 }: CharacterAliasRuleItemProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const selectedPreset = inferAliasPreset(rule.condition);
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
       <div className="grid gap-2 sm:grid-cols-[1fr_1fr_5rem]">
@@ -186,16 +175,11 @@ function CharacterAliasRuleItem({
           />
         </label>
       </div>
-      <label className="mt-2 block text-[11px] text-slate-400">
-        표시 아이콘 URL
-        <input
-          value={rule.display_icon_url ?? ''}
-          placeholder={characterImageUrl ?? 'https://...'}
-          disabled={disabled}
-          onChange={(event) => onUpdate(index, { display_icon_url: event.currentTarget.value })}
-          className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
-        />
-      </label>
+      {rule.display_icon_url && !rule.display_icon_media_id ? (
+        <p className="mt-2 rounded-md border border-amber-500/20 bg-amber-500/5 px-2 py-1.5 text-[11px] leading-4 text-amber-100">
+          이전 URL 아이콘이 저장되어 있습니다. 새 아이콘을 선택하면 미디어 관리 이미지로 교체됩니다.
+        </p>
+      ) : null}
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <button
           type="button"
@@ -221,14 +205,31 @@ function CharacterAliasRuleItem({
           </span>
         ) : null}
       </div>
-      <div className="mt-3">
-        <ConditionBuilder
-          label="표시 조건"
-          condition={rule.condition}
-          onChange={(condition) => onUpdate(index, { condition })}
-          characters={characterOptions}
-        />
-      </div>
+      <label className="mt-3 block text-[11px] text-slate-400">
+        언제부터 보여줄까요?
+        <select
+          value={selectedPreset}
+          disabled={disabled}
+          onChange={(event) => {
+            const preset = event.currentTarget.value as AliasPreset;
+            if (preset === 'custom') return;
+            onUpdate(index, { condition: groupToRecord(createAliasPresetCondition(preset)) });
+          }}
+          className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
+          aria-label="별칭 표시 시점"
+        >
+          {ALIAS_PRESETS.map((preset) => (
+            <option key={preset.value} value={preset.value}>
+              {preset.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {selectedPreset === 'custom' ? (
+        <p className="mt-2 rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-[11px] leading-4 text-slate-500">
+          기존 고급 조건이 저장되어 있습니다. 프리셋을 고르면 제작자용 조건으로 바뀝니다.
+        </p>
+      ) : null}
       <div className="mt-3 flex justify-end">
         <button
           type="button"
@@ -275,16 +276,43 @@ function createAliasRuleID(): string {
   return `alias-${Date.now()}-${aliasRuleIdSeq}`;
 }
 
-function createDefaultAliasCondition(): ConditionGroup {
+type AliasPreset =
+  | 'game_start'
+  | 'intro_start'
+  | 'intro_end'
+  | 'round_start'
+  | 'node_reached'
+  | 'custom';
+
+const ALIAS_PRESETS: Array<{ value: AliasPreset; label: string; flagKey?: string }> = [
+  { value: 'game_start', label: '게임 시작 후 표시', flagKey: 'game_started' },
+  { value: 'intro_start', label: '자기소개 시작부터 표시', flagKey: 'intro_started' },
+  { value: 'intro_end', label: '자기소개 이후 표시', flagKey: 'intro_finished' },
+  { value: 'round_start', label: '특정 라운드 시작부터 표시', flagKey: 'round_started' },
+  { value: 'node_reached', label: '특정 진행 노드 도달 후 표시', flagKey: 'story_node_reached' },
+  { value: 'custom', label: '기존 고급 조건 유지' },
+];
+
+function createAliasPresetCondition(preset: Exclude<AliasPreset, 'custom'>): ConditionGroup {
+  const option = ALIAS_PRESETS.find((item) => item.value === preset);
   return {
     id: createAliasRuleID(),
     operator: 'AND',
     rules: [{
       id: createAliasRuleID(),
       variable: 'custom_flag',
-      target_flag_key: 'alias_ready',
+      target_flag_key: option?.flagKey ?? 'game_started',
       comparator: '=',
       value: 'true',
     }],
   };
+}
+
+function inferAliasPreset(raw: CharacterAliasRule['condition']): AliasPreset {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return 'custom';
+  const rules = (raw as { rules?: unknown }).rules;
+  if (!Array.isArray(rules) || rules.length !== 1) return 'custom';
+  const rule = rules[0] as { variable?: unknown; target_flag_key?: unknown; comparator?: unknown; value?: unknown };
+  if (rule.variable !== 'custom_flag' || rule.comparator !== '=' || rule.value !== 'true') return 'custom';
+  return ALIAS_PRESETS.find((preset) => preset.flagKey === rule.target_flag_key)?.value ?? 'custom';
 }

--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -141,6 +141,7 @@ function CharacterAliasRuleItem({
 }: CharacterAliasRuleItemProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const selectedPreset = inferAliasPreset(rule.condition);
+  const presetValue = inferAliasPresetValue(rule.condition);
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
       <div className="grid gap-2 sm:grid-cols-[1fr_1fr_5rem]">
@@ -213,7 +214,7 @@ function CharacterAliasRuleItem({
           onChange={(event) => {
             const preset = event.currentTarget.value as AliasPreset;
             if (preset === 'custom') return;
-            onUpdate(index, { condition: groupToRecord(createAliasPresetCondition(preset)) });
+            onUpdate(index, { condition: groupToRecord(createAliasPresetCondition(preset, presetValue)) });
           }}
           className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
           aria-label="별칭 표시 시점"
@@ -225,6 +226,41 @@ function CharacterAliasRuleItem({
           ))}
         </select>
       </label>
+      {selectedPreset === 'round_start' ? (
+        <label className="mt-2 block text-[11px] text-slate-400">
+          표시 라운드
+          <input
+            type="number"
+            min={1}
+            value={presetValue.round}
+            disabled={disabled}
+            onChange={(event) => {
+              const round = normalizePositiveNumber(event.currentTarget.value);
+              onUpdate(index, { condition: groupToRecord(createAliasPresetCondition('round_start', { ...presetValue, round })) });
+            }}
+            className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
+          />
+        </label>
+      ) : null}
+      {selectedPreset === 'node_reached' ? (
+        <label className="mt-2 block text-[11px] text-slate-400">
+          표시 진행 노드
+          <select
+            value={presetValue.nodeId}
+            disabled={disabled}
+            onChange={(event) => {
+              onUpdate(index, { condition: groupToRecord(createAliasPresetCondition('node_reached', { ...presetValue, nodeId: event.currentTarget.value })) });
+            }}
+            className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
+          >
+            {ALIAS_NODE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
       {selectedPreset === 'custom' ? (
         <p className="mt-2 rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-[11px] leading-4 text-slate-500">
           기존 고급 조건이 저장되어 있습니다. 프리셋을 고르면 제작자용 조건으로 바뀝니다.
@@ -268,6 +304,12 @@ function normalizePriorityInput(value: string): number {
   return Math.max(0, priority);
 }
 
+function normalizePositiveNumber(value: string): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n) || n < 1) return 1;
+  return n;
+}
+
 function createAliasRuleID(): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
     return crypto.randomUUID();
@@ -293,7 +335,21 @@ const ALIAS_PRESETS: Array<{ value: AliasPreset; label: string; flagKey?: string
   { value: 'custom', label: '기존 고급 조건 유지' },
 ];
 
-function createAliasPresetCondition(preset: Exclude<AliasPreset, 'custom'>): ConditionGroup {
+const ALIAS_NODE_OPTIONS = [
+  { value: 'intro_finished', label: '자기소개 종료' },
+  { value: 'round_summary', label: '라운드 정리' },
+  { value: 'voting_started', label: '투표 시작' },
+] as const;
+
+interface AliasPresetValue {
+  round: number;
+  nodeId: string;
+}
+
+function createAliasPresetCondition(
+  preset: Exclude<AliasPreset, 'custom'>,
+  value: AliasPresetValue = { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value },
+): ConditionGroup {
   const option = ALIAS_PRESETS.find((item) => item.value === preset);
   return {
     id: createAliasRuleID(),
@@ -303,7 +359,11 @@ function createAliasPresetCondition(preset: Exclude<AliasPreset, 'custom'>): Con
       variable: 'custom_flag',
       target_flag_key: option?.flagKey ?? 'game_started',
       comparator: '=',
-      value: 'true',
+      value: preset === 'round_start'
+        ? String(value.round)
+        : preset === 'node_reached'
+          ? value.nodeId
+          : 'true',
     }],
   };
 }
@@ -313,6 +373,27 @@ function inferAliasPreset(raw: CharacterAliasRule['condition']): AliasPreset {
   const rules = (raw as { rules?: unknown }).rules;
   if (!Array.isArray(rules) || rules.length !== 1) return 'custom';
   const rule = rules[0] as { variable?: unknown; target_flag_key?: unknown; comparator?: unknown; value?: unknown };
-  if (rule.variable !== 'custom_flag' || rule.comparator !== '=' || rule.value !== 'true') return 'custom';
+  if (rule.variable !== 'custom_flag' || rule.comparator !== '=') return 'custom';
+  if (rule.target_flag_key === 'round_started') return 'round_start';
+  if (rule.target_flag_key === 'story_node_reached') return 'node_reached';
+  if (rule.value !== 'true') return 'custom';
   return ALIAS_PRESETS.find((preset) => preset.flagKey === rule.target_flag_key)?.value ?? 'custom';
+}
+
+function inferAliasPresetValue(raw: CharacterAliasRule['condition']): AliasPresetValue {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value };
+  }
+  const rules = (raw as { rules?: unknown }).rules;
+  if (!Array.isArray(rules) || rules.length !== 1) {
+    return { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value };
+  }
+  const rule = rules[0] as { target_flag_key?: unknown; value?: unknown };
+  if (rule.target_flag_key === 'round_started' && typeof rule.value === 'string') {
+    return { round: normalizePositiveNumber(rule.value), nodeId: ALIAS_NODE_OPTIONS[0].value };
+  }
+  if (rule.target_flag_key === 'story_node_reached' && typeof rule.value === 'string') {
+    return { round: 1, nodeId: rule.value || ALIAS_NODE_OPTIONS[0].value };
+  }
+  return { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value };
 }

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Accordion } from '@/shared/components/ui';
 import type { CharacterAliasRule, MysteryRole } from '@/features/editor/api';
 import type { Mission } from './MissionEditor';
@@ -84,10 +84,6 @@ export function CharacterDetailPanel({
 }: CharacterDetailPanelProps) {
   const [aliasDrafts, setAliasDrafts] = useState<CharacterAliasRule[]>([]);
   const aliasDraftCharacterIdRef = useRef<string | null>(null);
-  const characterOptions = useMemo(
-    () => characters.map((char) => ({ id: char.id, name: char.name })),
-    [characters]
-  );
 
   useEffect(() => {
     if (aliasDraftCharacterIdRef.current === (selectedChar?.id ?? null)) return;
@@ -152,119 +148,117 @@ export function CharacterDetailPanel({
             defaultOpen: true,
             forceOpen: true,
             children: (
-              <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_14rem]">
-                <div className="space-y-2.5">
-                  <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-4">
+                <div className="grid gap-4 lg:grid-cols-[14rem_minmax(0,1fr)_minmax(16rem,0.9fr)]">
+                  <div className="min-w-0">
+                    {onProfileImageChange ? (
+                      <ImageMediaReferenceField
+                        themeId={themeId}
+                        label="프로필 이미지"
+                        imageMediaId={selectedChar.image_media_id ?? null}
+                        legacyImageUrl={selectedChar.image_url ?? null}
+                        pickerTitle="프로필 이미지 선택"
+                        emptyLabel="이미지 선택"
+                        compact
+                        onSelect={(media) => onProfileImageChange(media.id)}
+                        onClear={() => onProfileImageChange(null)}
+                      />
+                    ) : (
+                      <div className="rounded-lg border border-slate-800 bg-slate-950 p-3 text-center">
+                        <span className="px-2 text-[11px] leading-5 text-slate-500">
+                          현재 프로필 이미지를 편집할 수 없습니다.
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-3">
                     <div>
                       <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">이름</p>
                       <p className="mt-1 text-sm text-slate-200">{selectedChar.name}</p>
                     </div>
                     <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">공개 소개</p>
-                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-400">
-                        {selectedChar.description || '공개 소개가 없습니다.'}
-                      </p>
+                      <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">역할</p>
+                      <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                        {characterRoleOptions.map((option) => {
+                          const active = selectedRole === option.value;
+                          return (
+                            <button
+                              key={option.value}
+                              type="button"
+                              disabled={!onMysteryRoleChange}
+                              aria-label={option.label}
+                              aria-pressed={active}
+                              title={option.description}
+                              onClick={() => onMysteryRoleChange?.(option.value)}
+                              className={`min-h-11 rounded-lg border px-3 py-2 text-center transition ${
+                                active
+                                  ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
+                                  : 'border-slate-800 bg-slate-950 text-slate-400 hover:border-slate-700'
+                              } disabled:cursor-default disabled:opacity-80`}
+                            >
+                              <span className="block text-xs font-semibold">{option.label}</span>
+                              <span className="sr-only">{option.description}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
                     </div>
                   </div>
                   <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">역할</p>
-                    <div className="mt-2 grid gap-2 sm:grid-cols-4">
-                      {characterRoleOptions.map((option) => {
-                        const active = selectedRole === option.value;
-                        return (
-                          <button
-                            key={option.value}
-                            type="button"
-                            disabled={!onMysteryRoleChange}
-                            aria-label={option.label}
-                            aria-pressed={active}
-                            title={option.description}
-                            onClick={() => onMysteryRoleChange?.(option.value)}
-                            className={`min-h-11 rounded-lg border px-3 py-2 text-center transition ${
-                              active
-                                ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
-                                : 'border-slate-800 bg-slate-950 text-slate-400 hover:border-slate-700'
-                            } disabled:cursor-default disabled:opacity-80`}
-                          >
-                            <span className="block text-xs font-semibold">{option.label}</span>
-                            <span className="sr-only">{option.description}</span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                  <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
-                      등장인물 유형
+                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">공개 소개</p>
+                    <p className="mt-2 min-h-24 rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-xs leading-5 text-slate-400">
+                      {selectedChar.description || '공개 소개가 없습니다.'}
                     </p>
-                    <div className="mt-2 grid gap-2 sm:grid-cols-2">
-                      <VisibilityToggle
-                        label="플레이어 캐릭터"
-                        description="참가자가 선택하고 플레이하는 인물입니다."
-                        checked={selectedView.isPlayable}
-                        disabled={!onVisibilityChange}
-                        onChange={(checked) => onVisibilityChange?.('is_playable', checked)}
-                      />
-                      <VisibilityToggle
-                        label="등장인물 소개에 표시"
-                        description="플레이 중 공개 소개 화면에 노출합니다."
-                        checked={selectedView.showInIntro}
-                        disabled={!onVisibilityChange}
-                        onChange={(checked) => onVisibilityChange?.('show_in_intro', checked)}
-                      />
-                      <VisibilityToggle
-                        label="읽기 대사에 사용"
-                        description="스토리 읽기 화면에서 이 인물의 대사를 사용할 수 있습니다."
-                        checked={selectedView.canSpeakInReading}
-                        disabled={!onVisibilityChange}
-                        onChange={(checked) =>
-                          onVisibilityChange?.('can_speak_in_reading', checked)
-                        }
-                      />
-                      <VisibilityToggle
-                        label="투표 후보에 포함"
-                        description="투표 단계에서 선택 가능한 대상으로 표시합니다."
-                        checked={selectedView.isVotingCandidate}
-                        disabled={!onVisibilityChange}
-                        onChange={(checked) => onVisibilityChange?.('is_voting_candidate', checked)}
-                      />
-                    </div>
                   </div>
-                  <CharacterAliasRulesEditor
-                    themeId={themeId}
-                    characterName={selectedChar.name}
-                    characterImageUrl={selectedChar.image_url}
-                    rules={aliasDrafts}
-                    characterOptions={characterOptions}
-                    disabled={!onAliasRulesSave}
-                    onChange={setAliasDrafts}
-                    onSave={(rules) => {
-                      if (!onAliasRulesSave) return;
-                      onAliasRulesSave(rules);
-                    }}
-                  />
                 </div>
-                <div className="min-w-0 xl:order-last">
-                  {onProfileImageChange ? (
-                    <ImageMediaReferenceField
-                      themeId={themeId}
-                      label="프로필 이미지"
-                      imageMediaId={selectedChar.image_media_id ?? null}
-                      legacyImageUrl={selectedChar.image_url ?? null}
-                      pickerTitle="프로필 이미지 선택"
-                      emptyLabel="이미지 선택"
-                      compact
-                      onSelect={(media) => onProfileImageChange(media.id)}
-                      onClear={() => onProfileImageChange(null)}
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
+                    등장인물 유형
+                  </p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    <VisibilityToggle
+                      label="플레이어 캐릭터"
+                      description="참가자가 선택하고 플레이하는 인물입니다."
+                      checked={selectedView.isPlayable}
+                      disabled={!onVisibilityChange}
+                      onChange={(checked) => onVisibilityChange?.('is_playable', checked)}
                     />
-                  ) : (
-                    <div className="rounded-lg border border-slate-800 bg-slate-950 p-3 text-center">
-                      <span className="px-2 text-[11px] leading-5 text-slate-500">
-                        현재 프로필 이미지를 편집할 수 없습니다.
-                      </span>
-                    </div>
-                  )}
+                    <VisibilityToggle
+                      label="등장인물 소개에 표시"
+                      description="플레이 중 공개 소개 화면에 노출합니다."
+                      checked={selectedView.showInIntro}
+                      disabled={!onVisibilityChange}
+                      onChange={(checked) => onVisibilityChange?.('show_in_intro', checked)}
+                    />
+                    <VisibilityToggle
+                      label="읽기 대사에 사용"
+                      description="스토리 읽기 화면에서 이 인물의 대사를 사용할 수 있습니다."
+                      checked={selectedView.canSpeakInReading}
+                      disabled={!onVisibilityChange}
+                      onChange={(checked) =>
+                        onVisibilityChange?.('can_speak_in_reading', checked)
+                      }
+                    />
+                    <VisibilityToggle
+                      label="투표 후보에 포함"
+                      description="투표 단계에서 선택 가능한 대상으로 표시합니다."
+                      checked={selectedView.isVotingCandidate}
+                      disabled={!onVisibilityChange}
+                      onChange={(checked) => onVisibilityChange?.('is_voting_candidate', checked)}
+                    />
+                  </div>
                 </div>
+                <CharacterAliasRulesEditor
+                  themeId={themeId}
+                  characterName={selectedChar.name}
+                  rules={aliasDrafts}
+                  disabled={!onAliasRulesSave}
+                  onChange={setAliasDrafts}
+                  onSave={(rules) => {
+                    if (!onAliasRulesSave) return;
+                    onAliasRulesSave(rules);
+                  }}
+                />
               </div>
             ),
           },

--- a/apps/web/src/features/editor/components/design/MissionEditor.tsx
+++ b/apps/web/src/features/editor/components/design/MissionEditor.tsx
@@ -2,7 +2,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { MissionTypeFields } from './MissionTypeFields';
 import {
   MISSION_TYPES,
-  getMissionVerificationOptions,
+  MISSION_REVEAL_OPTIONS,
   toMissionViewModel,
   type Mission,
   type MissionEditorCharacter,
@@ -83,7 +83,6 @@ function MissionCard({
   onDelete: (missionId: string) => void;
 }) {
   const viewModel = toMissionViewModel(mission);
-  const verificationOptions = getMissionVerificationOptions(viewModel.runtimeType);
   const descriptionId = `mission-description-${mission.id}`;
   return (
     <div className="rounded border border-slate-800 bg-slate-900 p-3">
@@ -129,14 +128,14 @@ function MissionCard({
           />
         </label>
         <label className="flex items-center gap-2">
-          <span>판정:</span>
+          <span>공개:</span>
           <select
-            value={viewModel.verification}
-            onChange={(e) => onChange(mission.id, 'verification', e.target.value)}
+            value={mission.visibleFrom ?? 'game_start'}
+            onChange={(e) => onChange(mission.id, 'visibleFrom', e.target.value)}
             className="min-w-0 flex-1 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
-            aria-label="미션 판정 방식"
+            aria-label="미션 공개 시점"
           >
-            {verificationOptions.map((option) => (
+            {MISSION_REVEAL_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -144,8 +143,32 @@ function MissionCard({
           </select>
         </label>
       </div>
+      {mission.visibleFrom === 'round_start' ? (
+        <label className="mb-2 flex max-w-xs items-center gap-2 text-xs text-slate-500">
+          <span>시작 라운드:</span>
+          <input
+            type="number"
+            min={1}
+            value={mission.revealRound ?? 1}
+            onChange={(e) => onChange(mission.id, 'revealRound', Number(e.target.value))}
+            className="w-20 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
+          />
+        </label>
+      ) : null}
+      {mission.visibleFrom === 'node_reached' ? (
+        <label className="mb-2 block text-xs text-slate-500">
+          진행 노드
+          <input
+            type="text"
+            value={mission.revealNodeId ?? ''}
+            onChange={(e) => onChange(mission.id, 'revealNodeId', e.target.value)}
+            placeholder="예: intro-complete"
+            className="mt-1 w-full rounded bg-slate-800 px-2 py-1 text-xs text-slate-300 placeholder-slate-600"
+          />
+        </label>
+      ) : null}
       <div className="mb-2 flex flex-wrap gap-2 text-[11px] text-slate-400">
-        <span className="rounded-full bg-slate-800 px-2 py-0.5">{viewModel.resultVisibilityLabel}</span>
+        <span className="rounded-full bg-slate-800 px-2 py-0.5">{viewModel.revealLabel}</span>
         <span className="rounded-full bg-slate-800 px-2 py-0.5">{viewModel.verificationLabel}</span>
         <span className="rounded-full bg-slate-800 px-2 py-0.5">{viewModel.engineOwnerLabel}</span>
       </div>

--- a/apps/web/src/features/editor/components/design/MissionEditor.tsx
+++ b/apps/web/src/features/editor/components/design/MissionEditor.tsx
@@ -3,6 +3,7 @@ import { MissionTypeFields } from './MissionTypeFields';
 import {
   MISSION_TYPES,
   MISSION_REVEAL_OPTIONS,
+  MISSION_REVEAL_NODE_OPTIONS,
   toMissionViewModel,
   type Mission,
   type MissionEditorCharacter,
@@ -158,13 +159,17 @@ function MissionCard({
       {mission.visibleFrom === 'node_reached' ? (
         <label className="mb-2 block text-xs text-slate-500">
           진행 노드
-          <input
-            type="text"
-            value={mission.revealNodeId ?? ''}
+          <select
+            value={mission.revealNodeId ?? MISSION_REVEAL_NODE_OPTIONS[0].value}
             onChange={(e) => onChange(mission.id, 'revealNodeId', e.target.value)}
-            placeholder="예: intro-complete"
             className="mt-1 w-full rounded bg-slate-800 px-2 py-1 text-xs text-slate-300 placeholder-slate-600"
-          />
+          >
+            {MISSION_REVEAL_NODE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </label>
       ) : null}
       <div className="mb-2 flex flex-wrap gap-2 text-[11px] text-slate-400">

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
@@ -163,6 +163,48 @@ describe('CharacterAliasRulesEditor', () => {
     })]);
   });
 
+  it('특정 라운드와 진행 노드 별칭 조건 값을 함께 저장한다', () => {
+    const onSave = vi.fn();
+    const rules: CharacterAliasRule[] = [{
+      id: 'alias-1',
+      label: '라운드 공개',
+      display_name: '밤의 목격자',
+      priority: 1,
+      condition: {
+        id: 'group-1',
+        operator: 'AND',
+        rules: [{
+          id: 'rule-1',
+          variable: 'custom_flag',
+          target_flag_key: 'game_started',
+          comparator: '=',
+          value: 'true',
+        }],
+      },
+    }];
+
+    renderStatefulEditor(rules, onSave);
+    fireEvent.change(screen.getByLabelText('별칭 표시 시점'), { target: { value: 'round_start' } });
+    fireEvent.change(screen.getByLabelText('표시 라운드'), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
+
+    expect(onSave).toHaveBeenLastCalledWith([expect.objectContaining({
+      condition: expect.objectContaining({
+        rules: [expect.objectContaining({ target_flag_key: 'round_started', value: '3' })],
+      }),
+    })]);
+
+    fireEvent.change(screen.getByLabelText('별칭 표시 시점'), { target: { value: 'node_reached' } });
+    fireEvent.change(screen.getByLabelText('표시 진행 노드'), { target: { value: 'voting_started' } });
+    fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
+
+    expect(onSave).toHaveBeenLastCalledWith([expect.objectContaining({
+      condition: expect.objectContaining({
+        rules: [expect.objectContaining({ target_flag_key: 'story_node_reached', value: 'voting_started' })],
+      }),
+    })]);
+  });
+
   it('미디어 아이콘을 선택하면 URL 아이콘을 비우고 media id로 저장한다', () => {
     const onSave = vi.fn();
     const rules: CharacterAliasRule[] = [{

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
@@ -43,7 +43,6 @@ function renderEditor(overrides: Partial<{
     <CharacterAliasRulesEditor
       themeId="theme-1"
       characterName="홍길동"
-      characterImageUrl="https://cdn.example/base.webp"
       rules={overrides.rules ?? []}
       characterOptions={characterOptions}
       disabled={overrides.disabled ?? false}
@@ -61,7 +60,6 @@ function renderStatefulEditor(initialRules: CharacterAliasRule[], onSave = vi.fn
       <CharacterAliasRulesEditor
         themeId="theme-1"
         characterName="홍길동"
-        characterImageUrl="https://cdn.example/base.webp"
         rules={rules}
         characterOptions={characterOptions}
         disabled={false}
@@ -91,7 +89,7 @@ describe('CharacterAliasRulesEditor', () => {
           operator: 'AND',
           rules: [expect.objectContaining({
             variable: 'custom_flag',
-            target_flag_key: 'alias_ready',
+            target_flag_key: 'game_started',
             comparator: '=',
             value: 'true',
           })],
@@ -128,7 +126,7 @@ describe('CharacterAliasRulesEditor', () => {
     ]);
   });
 
-  it('표시 이름, 아이콘, 우선순위를 수정해 저장한다', () => {
+  it('표시 이름, 우선순위, 공개 시점 프리셋을 수정해 저장한다', () => {
     const onSave = vi.fn();
     const rules: CharacterAliasRule[] = [{
       id: 'alias-1',
@@ -142,7 +140,7 @@ describe('CharacterAliasRulesEditor', () => {
         rules: [{
           id: 'rule-1',
           variable: 'custom_flag',
-          target_flag_key: 'alias_ready',
+          target_flag_key: 'game_started',
           comparator: '=',
           value: 'true',
         }],
@@ -151,15 +149,17 @@ describe('CharacterAliasRulesEditor', () => {
 
     renderStatefulEditor(rules, onSave);
     fireEvent.change(screen.getByLabelText('표시 이름'), { target: { value: '밤의 목격자' } });
-    fireEvent.change(screen.getByLabelText('표시 아이콘 URL'), { target: { value: 'https://cdn.example/night.webp' } });
     fireEvent.change(screen.getByLabelText('우선순위'), { target: { value: '3' } });
+    fireEvent.change(screen.getByLabelText('별칭 표시 시점'), { target: { value: 'intro_end' } });
     fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
 
     expect(onSave).toHaveBeenCalledWith([expect.objectContaining({
       id: 'alias-1',
       display_name: '밤의 목격자',
-      display_icon_url: 'https://cdn.example/night.webp',
       priority: 3,
+      condition: expect.objectContaining({
+        rules: [expect.objectContaining({ target_flag_key: 'intro_finished' })],
+      }),
     })]);
   });
 
@@ -188,7 +188,7 @@ describe('CharacterAliasRulesEditor', () => {
     fireEvent.click(screen.getByRole('button', { name: '미디어에서 아이콘 선택' }));
     fireEvent.click(screen.getByRole('button', { name: '별칭 아이콘 선택' }));
     expect(screen.getByText('미디어 이미지 선택됨')).toBeTruthy();
-    expect((screen.getByLabelText('표시 아이콘 URL') as HTMLInputElement).value).toBe('');
+    expect(screen.queryByLabelText('표시 아이콘 URL')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
 
@@ -236,7 +236,7 @@ describe('CharacterAliasRulesEditor', () => {
     expect((screen.getByRole('button', { name: '플레이 중 표시 저장' }) as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: '삭제' }) as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByLabelText('표시 이름') as HTMLInputElement).disabled).toBe(true);
-    expect((screen.getByLabelText('표시 아이콘 URL') as HTMLInputElement).disabled).toBe(true);
+    expect(screen.queryByLabelText('표시 아이콘 URL')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: '삭제' }));
     expect(onChange).not.toHaveBeenCalled();
@@ -278,7 +278,6 @@ describe('CharacterAliasRulesEditor', () => {
       <CharacterAliasRulesEditor
         themeId="theme-1"
         characterName="홍길동"
-        characterImageUrl="https://cdn.example/base.webp"
         rules={[incompleteRule]}
         characterOptions={characterOptions}
         disabled={false}
@@ -294,7 +293,6 @@ describe('CharacterAliasRulesEditor', () => {
       <CharacterAliasRulesEditor
         themeId="theme-1"
         characterName="김영희"
-        characterImageUrl="https://cdn.example/next.webp"
         rules={[completeRule]}
         characterOptions={characterOptions}
         disabled={false}

--- a/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
@@ -113,41 +113,40 @@ describe('MissionEditor', () => {
     expect(onDelete).toHaveBeenCalled();
   });
 
-  it('결과 공개 시점과 백엔드 판정 경계를 제작자용 문구로 표시한다', () => {
+  it('미션 공개 시점과 백엔드 판정 경계를 제작자용 문구로 표시한다', () => {
     const onChange = vi.fn();
     render(
       <MissionEditor
-        missions={[baseMission({ type: 'secret' })]}
+        missions={[baseMission({ type: 'secret', visibleFrom: 'intro_end' })]}
         onAdd={noop}
         onChange={onChange}
         onDelete={noop}
       />,
     );
 
-    expect(screen.getByText('결과 화면에서만 공개')).toBeDefined();
-    expect(screen.getAllByText('플레이어 신고').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('자기소개 종료 후').length).toBeGreaterThan(0);
+    expect(screen.getByText('자동 판정')).toBeDefined();
     expect(screen.getByText('게임 판정은 백엔드가 담당')).toBeDefined();
 
-    fireEvent.change(screen.getByLabelText('미션 판정 방식'), { target: { value: 'gm_verify' } });
-    expect(onChange).toHaveBeenCalledWith('mission-1', 'verification', 'gm_verify');
+    fireEvent.change(screen.getByLabelText('미션 공개 시점'), { target: { value: 'round_start' } });
+    expect(onChange).toHaveBeenCalledWith('mission-1', 'visibleFrom', 'round_start');
   });
 
-  it('수동 판정 미션에서는 자동 판정을 선택지에서 숨긴다', () => {
+  it('라운드와 진행 노드 공개 시점의 추가 입력을 저장한다', () => {
+    const onChange = vi.fn();
     render(
       <MissionEditor
-        missions={[baseMission({ type: 'secret', verification: 'auto' })]}
+        missions={[baseMission({ visibleFrom: 'round_start', revealRound: 2 })]}
         onAdd={noop}
-        onChange={noop}
+        onChange={onChange}
         onDelete={noop}
       />,
     );
 
-    const select = screen.getByLabelText('미션 판정 방식') as HTMLSelectElement;
-    expect(select.value).toBe('self_report');
-    expect(Array.from(select.options).map((option) => option.value)).toEqual([
-      'self_report',
-      'gm_verify',
-    ]);
+    fireEvent.change(screen.getByLabelText('미션 공개 시점'), { target: { value: 'node_reached' } });
+    expect(onChange).toHaveBeenCalledWith('mission-1', 'visibleFrom', 'node_reached');
+    fireEvent.change(screen.getByLabelText('시작 라운드:'), { target: { value: '3' } });
+    expect(onChange).toHaveBeenCalledWith('mission-1', 'revealRound', 3);
   });
 
   it('MISSION_TYPES에 kill/possess/secret/protect가 포함된다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
@@ -125,7 +125,7 @@ describe('MissionEditor', () => {
     );
 
     expect(screen.getAllByText('자기소개 종료 후').length).toBeGreaterThan(0);
-    expect(screen.getByText('자동 판정')).toBeDefined();
+    expect(screen.getByText('엔진 연동 필요')).toBeDefined();
     expect(screen.getByText('게임 판정은 백엔드가 담당')).toBeDefined();
 
     fireEvent.change(screen.getByLabelText('미션 공개 시점'), { target: { value: 'round_start' } });
@@ -134,7 +134,7 @@ describe('MissionEditor', () => {
 
   it('라운드와 진행 노드 공개 시점의 추가 입력을 저장한다', () => {
     const onChange = vi.fn();
-    render(
+    const { rerender } = render(
       <MissionEditor
         missions={[baseMission({ visibleFrom: 'round_start', revealRound: 2 })]}
         onAdd={noop}
@@ -147,6 +147,17 @@ describe('MissionEditor', () => {
     expect(onChange).toHaveBeenCalledWith('mission-1', 'visibleFrom', 'node_reached');
     fireEvent.change(screen.getByLabelText('시작 라운드:'), { target: { value: '3' } });
     expect(onChange).toHaveBeenCalledWith('mission-1', 'revealRound', 3);
+
+    rerender(
+      <MissionEditor
+        missions={[baseMission({ visibleFrom: 'node_reached', revealNodeId: 'intro_finished' })]}
+        onAdd={noop}
+        onChange={onChange}
+        onDelete={noop}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('진행 노드'), { target: { value: 'voting_started' } });
+    expect(onChange).toHaveBeenCalledWith('mission-1', 'revealNodeId', 'voting_started');
   });
 
   it('MISSION_TYPES에 kill/possess/secret/protect가 포함된다', () => {

--- a/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createMissionDraft,
-  getMissionVerificationOptions,
   readCharacterMissionMap,
   toMissionEngineContractDraft,
   toMissionRuntimeDraft,
@@ -33,6 +32,8 @@ describe("missionAdapter", () => {
       type: "secret",
       description: "",
       points: 0,
+      verification: "auto",
+      visibleFrom: "game_start",
     });
     vi.restoreAllMocks();
   });
@@ -53,6 +54,7 @@ describe("missionAdapter", () => {
       verification: "auto",
       resultVisibility: "result_only",
       engineOwner: "backend_engine",
+      visibleFrom: "game_start",
       targetClueId: "clue-1",
       legacyConditionNote: "토론 이후 공개",
     });
@@ -88,22 +90,23 @@ describe("missionAdapter", () => {
       verification: "auto",
       resultVisibility: "result_only",
       engineOwner: "backend_engine",
+      visibleFrom: "game_start",
     }));
     vi.restoreAllMocks();
   });
 
-  it("custom 런타임은 저장값이 auto여도 수동 판정으로 정규화한다", () => {
+  it("legacy 수동 판정값이 있어도 runtime 후보는 auto로 정규화한다", () => {
     const runtime = toMissionRuntimeDraft({
       id: "m-custom",
       type: "secret",
       description: "비밀을 지킨다",
       points: 3,
-      verification: "auto",
+      verification: "gm_verify",
     });
 
     expect(runtime).toEqual(expect.objectContaining({
       type: "custom",
-      verification: "self_report",
+      verification: "auto",
     }));
     expect(toMissionEngineContractDraft({
       "char-1": [
@@ -112,29 +115,17 @@ describe("missionAdapter", () => {
           type: "secret",
           description: "비밀을 지킨다",
           points: 3,
-          verification: "auto",
+          verification: "gm_verify",
         },
       ],
     }).assignments[0]).toEqual(expect.objectContaining({
-      autoVerifiableCount: 0,
-      manualReviewCount: 1,
+      autoVerifiableCount: 1,
+      manualReviewCount: 0,
     }));
   });
 
-  it("판정 방식 선택지는 runtime 타입에 맞게 제한한다", () => {
-    expect(getMissionVerificationOptions("custom").map((option) => option.value)).toEqual([
-      "self_report",
-      "gm_verify",
-    ]);
-    expect(getMissionVerificationOptions("hold_clue").map((option) => option.value)).toEqual([
-      "auto",
-      "self_report",
-      "gm_verify",
-    ]);
-  });
-
   it("제작자가 이해할 요약과 자동 판정 경고를 만든다", () => {
-    expect(toMissionViewModel({ id: "m2", type: "kill", description: "", points: -1, condition: "공모" })).toEqual({
+    expect(toMissionViewModel({ id: "m2", type: "kill", description: "", points: -1, condition: "공모", visibleFrom: "round_start", revealRound: 2 })).toEqual({
       id: "m2",
       title: "미션 내용을 입력해 주세요",
       typeLabel: "살해",
@@ -143,6 +134,7 @@ describe("missionAdapter", () => {
       runtimeType: "vote_target",
       verification: "auto",
       verificationLabel: "자동 판정",
+      revealLabel: "2라운드 시작부터",
       engineOwnerLabel: "게임 판정은 백엔드가 담당",
       warnings: [
         "플레이어가 이해할 미션 내용을 입력해 주세요.",
@@ -167,14 +159,37 @@ describe("missionAdapter", () => {
         {
           characterId: "char-1",
           totalPoints: 5,
-          autoVerifiableCount: 1,
-          manualReviewCount: 1,
+          autoVerifiableCount: 2,
+          manualReviewCount: 0,
           missions: [
             expect.objectContaining({ id: "m1", type: "hold_clue", verification: "auto" }),
-            expect.objectContaining({ id: "m2", type: "custom", verification: "self_report" }),
+            expect.objectContaining({ id: "m2", type: "custom", verification: "auto" }),
           ],
         },
       ],
+    });
+  });
+
+  it("미션 공개 시점 필드를 저장 DTO와 runtime 후보에 유지한다", () => {
+    expect(toMissionRuntimeDraft({
+      id: "m-round",
+      type: "possess",
+      description: "2라운드 이후 단서를 가진다",
+      points: 5,
+      targetClueId: "clue-1",
+      visibleFrom: "round_start",
+      revealRound: 2,
+    })).toEqual(expect.objectContaining({
+      visibleFrom: "round_start",
+      revealRound: 2,
+    }));
+
+    expect(writeCharacterMissionMap(
+      { title: "기존 설정" },
+      { "char-1": [{ id: "m1", type: "secret", description: "비밀", points: 0, visibleFrom: "intro_end" }] },
+    )).toEqual({
+      title: "기존 설정",
+      character_missions: { "char-1": [{ id: "m1", type: "secret", description: "비밀", points: 0, visibleFrom: "intro_end" }] },
     });
   });
 

--- a/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/mission/__tests__/missionAdapter.test.ts
@@ -95,7 +95,7 @@ describe("missionAdapter", () => {
     vi.restoreAllMocks();
   });
 
-  it("legacy 수동 판정값이 있어도 runtime 후보는 auto로 정규화한다", () => {
+  it("legacy 수동 판정값이 있어도 runtime 후보는 auto로 정규화하되 자동 판정 집계와 분리한다", () => {
     const runtime = toMissionRuntimeDraft({
       id: "m-custom",
       type: "secret",
@@ -119,7 +119,7 @@ describe("missionAdapter", () => {
         },
       ],
     }).assignments[0]).toEqual(expect.objectContaining({
-      autoVerifiableCount: 1,
+      autoVerifiableCount: 0,
       manualReviewCount: 0,
     }));
   });
@@ -133,7 +133,7 @@ describe("missionAdapter", () => {
       resultVisibilityLabel: "결과 화면에서만 공개",
       runtimeType: "vote_target",
       verification: "auto",
-      verificationLabel: "자동 판정",
+      verificationLabel: "엔진 연동 필요",
       revealLabel: "2라운드 시작부터",
       engineOwnerLabel: "게임 판정은 백엔드가 담당",
       warnings: [
@@ -159,7 +159,7 @@ describe("missionAdapter", () => {
         {
           characterId: "char-1",
           totalPoints: 5,
-          autoVerifiableCount: 2,
+          autoVerifiableCount: 1,
           manualReviewCount: 0,
           missions: [
             expect.objectContaining({ id: "m1", type: "hold_clue", verification: "auto" }),

--- a/apps/web/src/features/editor/entities/mission/missionAdapter.ts
+++ b/apps/web/src/features/editor/entities/mission/missionAdapter.ts
@@ -8,6 +8,12 @@ export type MissionRuntimeType = "hold_clue" | "vote_target" | "transfer_clue" |
 export type MissionVerification = "auto" | "self_report" | "gm_verify";
 export type MissionResultVisibility = "result_only";
 export type MissionRuntimeOwner = "backend_engine";
+export type MissionRevealTiming =
+  | "game_start"
+  | "intro_start"
+  | "intro_end"
+  | "round_start"
+  | "node_reached";
 
 export interface Mission {
   id: string;
@@ -22,6 +28,9 @@ export interface Mission {
   penalty?: number;
   difficulty?: number;
   verification?: MissionVerification;
+  visibleFrom?: MissionRevealTiming;
+  revealRound?: number;
+  revealNodeId?: string;
 }
 
 export interface MissionEditorCharacter {
@@ -43,6 +52,7 @@ export interface MissionViewModel {
   runtimeType: MissionRuntimeType;
   verification: MissionVerification;
   verificationLabel: string;
+  revealLabel: string;
   engineOwnerLabel: string;
   warnings: string[];
 }
@@ -55,6 +65,9 @@ export interface MissionRuntimeDraft {
   verification: MissionVerification;
   resultVisibility: MissionResultVisibility;
   engineOwner: MissionRuntimeOwner;
+  visibleFrom: MissionRevealTiming;
+  revealRound?: number;
+  revealNodeId?: string;
   targetCharacterId?: string;
   targetClueId?: string;
   legacyConditionNote?: string;
@@ -86,14 +99,17 @@ const MISSION_TYPE_LABELS: Record<string, string> = Object.fromEntries(
   MISSION_TYPES.map((type) => [type.value, type.label]),
 );
 
-const VERIFICATION_LABELS: Record<MissionVerification, string> = {
-  auto: "자동 판정",
-  self_report: "플레이어 신고",
-  gm_verify: "진행자 확인",
-};
+export const MISSION_REVEAL_OPTIONS: Array<{ value: MissionRevealTiming; label: string }> = [
+  { value: "game_start", label: "게임 시작부터" },
+  { value: "intro_start", label: "자기소개 시작부터" },
+  { value: "intro_end", label: "자기소개 종료 후" },
+  { value: "round_start", label: "특정 라운드 시작부터" },
+  { value: "node_reached", label: "특정 진행 노드 도달 후" },
+];
 
-const MANUAL_VERIFICATIONS: MissionVerification[] = ["self_report", "gm_verify"];
-const AUTO_VERIFICATIONS: MissionVerification[] = ["auto", ...MANUAL_VERIFICATIONS];
+const REVEAL_LABELS: Record<MissionRevealTiming, string> = Object.fromEntries(
+  MISSION_REVEAL_OPTIONS.map((option) => [option.value, option.label]),
+) as Record<MissionRevealTiming, string>;
 
 function isRecord(value: unknown): value is EditorConfig {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -101,6 +117,16 @@ function isRecord(value: unknown): value is EditorConfig {
 
 function isMissionVerification(value: unknown): value is MissionVerification {
   return value === "auto" || value === "self_report" || value === "gm_verify";
+}
+
+function isMissionRevealTiming(value: unknown): value is MissionRevealTiming {
+  return (
+    value === "game_start" ||
+    value === "intro_start" ||
+    value === "intro_end" ||
+    value === "round_start" ||
+    value === "node_reached"
+  );
 }
 
 function normalizeMission(value: unknown, index: number): Mission | null {
@@ -122,6 +148,11 @@ function normalizeMission(value: unknown, index: number): Mission | null {
     ...(typeof value.penalty === "number" ? { penalty: value.penalty } : {}),
     ...(typeof value.difficulty === "number" ? { difficulty: value.difficulty } : {}),
     ...(isMissionVerification(value.verification) ? { verification: value.verification } : {}),
+    visibleFrom: isMissionRevealTiming(value.visibleFrom) ? value.visibleFrom : "game_start",
+    ...(typeof value.revealRound === "number" && Number.isFinite(value.revealRound)
+      ? { revealRound: Math.max(1, Math.trunc(value.revealRound)) }
+      : {}),
+    ...(typeof value.revealNodeId === "string" ? { revealNodeId: value.revealNodeId } : {}),
   };
 }
 
@@ -131,6 +162,8 @@ export function createMissionDraft(): Mission {
     type: "secret",
     description: "",
     points: 0,
+    verification: "auto",
+    visibleFrom: "game_start",
   };
 }
 
@@ -160,24 +193,25 @@ export function getMissionTypeLabel(type: string): string {
   return MISSION_TYPE_LABELS[type] ?? "직접 설정";
 }
 
-export function getMissionVerificationOptions(
-  runtimeType: MissionRuntimeType,
-): Array<{ value: MissionVerification; label: string }> {
-  const values = runtimeType === "custom" ? MANUAL_VERIFICATIONS : AUTO_VERIFICATIONS;
-  return values.map((value) => ({ value, label: VERIFICATION_LABELS[value] }));
-}
-
 export function toMissionRuntimeDraft(mission: Mission): MissionRuntimeDraft {
   const runtimeType = toRuntimeType(mission);
   const legacyConditionNote = mission.condition?.trim();
+  const visibleFrom = normalizeRevealTiming(mission.visibleFrom);
   return {
     id: mission.id,
     type: runtimeType,
     description: mission.description.trim(),
     points: Math.max(0, Math.trunc(mission.points || 0)),
-    verification: normalizeVerificationForRuntime(runtimeType, mission.verification),
+    verification: "auto",
     resultVisibility: "result_only",
     engineOwner: "backend_engine",
+    visibleFrom,
+    ...(visibleFrom === "round_start" && typeof mission.revealRound === "number"
+      ? { revealRound: Math.max(1, Math.trunc(mission.revealRound)) }
+      : {}),
+    ...(visibleFrom === "node_reached" && mission.revealNodeId?.trim()
+      ? { revealNodeId: mission.revealNodeId.trim() }
+      : {}),
     ...(mission.targetCharacterId ? { targetCharacterId: mission.targetCharacterId } : {}),
     ...(mission.targetClueId ? { targetClueId: mission.targetClueId } : {}),
     ...(legacyConditionNote ? { legacyConditionNote } : {}),
@@ -195,7 +229,7 @@ export function toMissionEngineContractDraft(
         missions: runtimeMissions,
         totalPoints: runtimeMissions.reduce((sum, mission) => sum + mission.points, 0),
         autoVerifiableCount: runtimeMissions.filter((mission) => mission.verification === "auto").length,
-        manualReviewCount: runtimeMissions.filter((mission) => mission.verification !== "auto").length,
+        manualReviewCount: 0,
       };
     })
     .filter((assignment) => assignment.missions.length > 0);
@@ -219,7 +253,8 @@ export function toMissionViewModel(mission: Mission): MissionViewModel {
     resultVisibilityLabel: "결과 화면에서만 공개",
     runtimeType: runtimeDraft.type,
     verification: runtimeDraft.verification,
-    verificationLabel: VERIFICATION_LABELS[runtimeDraft.verification],
+    verificationLabel: "자동 판정",
+    revealLabel: formatRevealLabel(runtimeDraft),
     engineOwnerLabel: "게임 판정은 백엔드가 담당",
     warnings,
   };
@@ -232,23 +267,18 @@ function toRuntimeType(mission: Mission): MissionRuntimeType {
   return "custom";
 }
 
-function defaultVerification(runtimeType: MissionRuntimeType): MissionVerification {
-  return runtimeType === "custom" ? "self_report" : "auto";
+function normalizeRevealTiming(value: unknown): MissionRevealTiming {
+  return isMissionRevealTiming(value) ? value : "game_start";
 }
 
-function normalizeVerificationForRuntime(
-  runtimeType: MissionRuntimeType,
-  verification: unknown,
-): MissionVerification {
-  const normalized = isMissionVerification(verification)
-    ? verification
-    : defaultVerification(runtimeType);
-
-  if (runtimeType === "custom" && normalized === "auto") {
-    return "self_report";
+function formatRevealLabel(mission: MissionRuntimeDraft): string {
+  if (mission.visibleFrom === "round_start" && mission.revealRound) {
+    return `${mission.revealRound}라운드 시작부터`;
   }
-
-  return normalized;
+  if (mission.visibleFrom === "node_reached" && mission.revealNodeId) {
+    return `진행 노드 ${mission.revealNodeId} 도달 후`;
+  }
+  return REVEAL_LABELS[mission.visibleFrom];
 }
 
 function buildMissionWarnings(mission: Mission, runtimeDraft: MissionRuntimeDraft): string[] {
@@ -261,7 +291,13 @@ function buildMissionWarnings(mission: Mission, runtimeDraft: MissionRuntimeDraf
     warnings.push("투표형 미션은 대상 캐릭터를 선택해야 자동 판정할 수 있습니다.");
   }
   if (runtimeDraft.type === "custom") {
-    warnings.push("이 미션은 자동 판정 대신 플레이어 신고 또는 진행자 확인으로 처리됩니다.");
+    warnings.push("직접 작성 미션은 자동 판정 조건이 아직 없으므로 결과 판정 엔진 확장이 필요합니다.");
+  }
+  if (runtimeDraft.visibleFrom === "round_start" && !runtimeDraft.revealRound) {
+    warnings.push("라운드 공개 시점은 시작 라운드를 입력해야 합니다.");
+  }
+  if (runtimeDraft.visibleFrom === "node_reached" && !runtimeDraft.revealNodeId) {
+    warnings.push("진행 노드 공개 시점은 노드 식별자를 입력해야 합니다.");
   }
   if (mission.condition?.trim()) {
     warnings.push("미션 조건 메모는 제작자 참고용이며, 실제 진행 분기는 스토리 이동 조건에서 판정됩니다.");

--- a/apps/web/src/features/editor/entities/mission/missionAdapter.ts
+++ b/apps/web/src/features/editor/entities/mission/missionAdapter.ts
@@ -107,6 +107,12 @@ export const MISSION_REVEAL_OPTIONS: Array<{ value: MissionRevealTiming; label: 
   { value: "node_reached", label: "특정 진행 노드 도달 후" },
 ];
 
+export const MISSION_REVEAL_NODE_OPTIONS = [
+  { value: "intro_finished", label: "자기소개 종료" },
+  { value: "round_summary", label: "라운드 정리" },
+  { value: "voting_started", label: "투표 시작" },
+] as const;
+
 const REVEAL_LABELS: Record<MissionRevealTiming, string> = Object.fromEntries(
   MISSION_REVEAL_OPTIONS.map((option) => [option.value, option.label]),
 ) as Record<MissionRevealTiming, string>;
@@ -228,7 +234,7 @@ export function toMissionEngineContractDraft(
         characterId,
         missions: runtimeMissions,
         totalPoints: runtimeMissions.reduce((sum, mission) => sum + mission.points, 0),
-        autoVerifiableCount: runtimeMissions.filter((mission) => mission.verification === "auto").length,
+        autoVerifiableCount: runtimeMissions.filter(isAutoVerifiable).length,
         manualReviewCount: 0,
       };
     })
@@ -245,6 +251,7 @@ export function toMissionEngineContractDraft(
 export function toMissionViewModel(mission: Mission): MissionViewModel {
   const runtimeDraft = toMissionRuntimeDraft(mission);
   const warnings = buildMissionWarnings(mission, runtimeDraft);
+  const autoVerifiable = isAutoVerifiable(runtimeDraft);
   return {
     id: mission.id,
     title: mission.description.trim() || "미션 내용을 입력해 주세요",
@@ -253,11 +260,17 @@ export function toMissionViewModel(mission: Mission): MissionViewModel {
     resultVisibilityLabel: "결과 화면에서만 공개",
     runtimeType: runtimeDraft.type,
     verification: runtimeDraft.verification,
-    verificationLabel: "자동 판정",
+    verificationLabel: autoVerifiable ? "자동 판정" : "엔진 연동 필요",
     revealLabel: formatRevealLabel(runtimeDraft),
     engineOwnerLabel: "게임 판정은 백엔드가 담당",
     warnings,
   };
+}
+
+export function isAutoVerifiable(mission: MissionRuntimeDraft): boolean {
+  if (mission.type === "hold_clue") return Boolean(mission.targetClueId);
+  if (mission.type === "vote_target") return Boolean(mission.targetCharacterId);
+  return false;
 }
 
 function toRuntimeType(mission: Mission): MissionRuntimeType {
@@ -297,7 +310,7 @@ function buildMissionWarnings(mission: Mission, runtimeDraft: MissionRuntimeDraf
     warnings.push("라운드 공개 시점은 시작 라운드를 입력해야 합니다.");
   }
   if (runtimeDraft.visibleFrom === "node_reached" && !runtimeDraft.revealNodeId) {
-    warnings.push("진행 노드 공개 시점은 노드 식별자를 입력해야 합니다.");
+    warnings.push("진행 노드 공개 시점은 노드를 선택해야 합니다.");
   }
   if (mission.condition?.trim()) {
     warnings.push("미션 조건 메모는 제작자 참고용이며, 실제 진행 분기는 스토리 이동 조건에서 판정됩니다.");


### PR DESCRIPTION
## 요약
- 캐릭터 기본 정보 영역을 프로필 이미지, 이름/역할, 공개 소개 중심으로 재배치했습니다.
- 캐릭터 별칭 조건 입력을 제작자용 공개 시점 프리셋으로 단순화하고, 레거시 URL 아이콘은 보존 안내만 남겼습니다.
- 히든 미션 판정 UI를 자동 판정 전제로 정리하고, 공개 시점(`visibleFrom`, `revealRound`, `revealNodeId`)을 저장/요약/테스트 경계에 추가했습니다.

Closes #508
Refs #520

## Coverage Plan
- `CharacterAliasRulesEditor.tsx`: 별칭 추가/저장, 미디어 아이콘 선택, 레거시 URL 보존 안내, custom 조건 안내를 `CharacterAliasRulesEditor.test.tsx`로 검증했습니다.
- `CharacterDetailPanel.tsx`: 캐릭터 기본 정보 레이아웃과 기존 할당 패널 회귀는 `CharacterAssignPanel.test.tsx`가 덮습니다.
- `MissionEditor.tsx`: 공개 시점 select, 라운드/노드 입력, 자동 판정 배지를 `MissionEditor.test.tsx`로 검증했습니다.
- `missionAdapter.ts`: 공개 시점 DTO 보존, runtime 후보 정규화, 자동 판정 카운트, 경고 문구를 `missionAdapter.test.ts`로 검증했습니다.
- E2E는 내부 에디터 설정 UI 재배치와 adapter 저장 경계 변경이라 이번 PR에서는 unit/component test와 local-ci quick으로 대체했습니다.

## Local validation
- `pnpm --dir apps/web exec vitest run src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx src/features/editor/components/design/__tests__/MissionEditor.test.tsx src/features/editor/entities/mission/__tests__/missionAdapter.test.ts src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx` ✅ 63 tests
- `pnpm --dir apps/web typecheck` ✅
- `scripts/mmp-local-ci.sh quick` ✅ backend tests, web lint/typecheck/test/build 통과

## Follow-up
- #520: 제작자 UI에 저장한 별칭/히든 미션 공개 시점을 실제 runtime/player 화면에 연결합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 미션 공개 시점 선택 옵션 추가 (게임 시작, 인트로 시작/종료, 라운드 시작, 노드 도달) 및 관련 입력(라운드/노드)

* **개선 사항**
  * 캐릭터 별칭 규칙에 '표시 시점' 프리셋 도입(프리셋별 추가 필드 자동 노출)
  * 별칭 아이콘 관리를 텍스트 입력에서 미디어 선택기 워크플로로 전환
  * 캐릭터 상세 패널 레이아웃 및 미션 카드 편집 UI 정리(공개 시점 기반 입력 표시)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->