### PR TITLE
feat(editor): 단서 공개 상태와 아이템 효과 UX 정리

### DIFF
--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -375,27 +375,46 @@ func validateClueInteractionConfigShape(cfg map[string]any) error {
 	if !ok {
 		return fmt.Errorf("config_json: modules.clue_interaction.config must be an object")
 	}
-	rawEffects, exists := moduleConfig["itemEffects"]
-	if !exists {
-		return nil
-	}
-	if rawEffects == nil {
-		return fmt.Errorf("config_json: modules.clue_interaction.config.itemEffects cannot be null")
-	}
-	itemEffects, ok := rawEffects.(map[string]any)
-	if !ok {
-		return fmt.Errorf("config_json: modules.clue_interaction.config.itemEffects must be an object")
-	}
-	for clueID, rawEffect := range itemEffects {
-		if _, err := uuid.Parse(clueID); err != nil {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects invalid clue id %q", clueID)
+	if rawEffects, exists := moduleConfig["itemEffects"]; exists {
+		if rawEffects == nil {
+			return fmt.Errorf("config_json: modules.clue_interaction.config.itemEffects cannot be null")
 		}
-		effect, ok := rawEffect.(map[string]any)
+		itemEffects, ok := rawEffects.(map[string]any)
 		if !ok {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s] must be an object", clueID)
+			return fmt.Errorf("config_json: modules.clue_interaction.config.itemEffects must be an object")
 		}
-		if err := validateClueItemEffectShape(clueID, effect); err != nil {
-			return err
+		for clueID, rawEffect := range itemEffects {
+			if _, err := uuid.Parse(clueID); err != nil {
+				return fmt.Errorf("config_json: clue_interaction.itemEffects invalid clue id %q", clueID)
+			}
+			effect, ok := rawEffect.(map[string]any)
+			if !ok {
+				return fmt.Errorf("config_json: clue_interaction.itemEffects[%s] must be an object", clueID)
+			}
+			if err := validateClueItemEffectShape(clueID, effect); err != nil {
+				return err
+			}
+		}
+	}
+	if rawPolicies, exists := moduleConfig["cluePolicies"]; exists {
+		if rawPolicies == nil {
+			return fmt.Errorf("config_json: modules.clue_interaction.config.cluePolicies cannot be null")
+		}
+		policies, ok := rawPolicies.(map[string]any)
+		if !ok {
+			return fmt.Errorf("config_json: modules.clue_interaction.config.cluePolicies must be an object")
+		}
+		for clueID, rawPolicy := range policies {
+			if _, err := uuid.Parse(clueID); err != nil {
+				return fmt.Errorf("config_json: clue_interaction.cluePolicies invalid clue id %q", clueID)
+			}
+			policy, ok := rawPolicy.(map[string]any)
+			if !ok {
+				return fmt.Errorf("config_json: clue_interaction.cluePolicies[%s] must be an object", clueID)
+			}
+			if err := validateCluePolicyShape(clueID, policy); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -403,7 +422,7 @@ func validateClueInteractionConfigShape(cfg map[string]any) error {
 
 func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 	for key := range effect {
-		if key != "effect" && key != "target" && key != "consume" && key != "revealText" && key != "grantClueIds" {
+		if key != "effect" && key != "target" && key != "consume" && key != "descriptionText" && key != "revealText" && key != "grantClueIds" && key != "condition" && key != "password" && key != "trigger" {
 			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].%s is not supported", clueID, key)
 		}
 	}
@@ -411,7 +430,7 @@ func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 	if !ok || kind == "" {
 		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].effect is required", clueID)
 	}
-	if kind != "peek" && kind != "reveal" && kind != "grant_clue" {
+	if kind != "description_change" && kind != "peek" && kind != "steal" && kind != "reveal" && kind != "grant_clue" {
 		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].effect %q is not supported", clueID, kind)
 	}
 	if target, exists := effect["target"]; exists {
@@ -428,6 +447,12 @@ func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 		}
 		if _, ok := consume.(bool); !ok {
 			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].consume must be boolean", clueID)
+		}
+	}
+	if kind == "description_change" {
+		text, ok := effect["descriptionText"].(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].descriptionText is required for description_change", clueID)
 		}
 	}
 	if kind == "reveal" {
@@ -449,6 +474,21 @@ func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 			if _, err := uuid.Parse(grantClueID); err != nil {
 				return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].grantClueIds has invalid clue id %q", clueID, grantClueID)
 			}
+		}
+	}
+	return nil
+}
+
+func validateCluePolicyShape(clueID string, policy map[string]any) error {
+	for key, value := range policy {
+		if key != "revealable" && key != "protected" {
+			return fmt.Errorf("config_json: clue_interaction.cluePolicies[%s].%s is not supported", clueID, key)
+		}
+		if value == nil {
+			return fmt.Errorf("config_json: clue_interaction.cluePolicies[%s].%s cannot be null", clueID, key)
+		}
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("config_json: clue_interaction.cluePolicies[%s].%s must be boolean", clueID, key)
 		}
 	}
 	return nil

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -465,12 +465,25 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 							"target": "self",
 							"consume": true,
 							"grantClueIds": ["%s"]
+						},
+						"%s": {
+							"effect": "description_change",
+							"target": "self",
+							"condition": {"kind": "password", "value": "open"},
+							"descriptionText": "사용 후 설명"
+						},
+						"%s": {
+							"effect": "steal",
+							"target": "player"
 						}
+					},
+					"cluePolicies": {
+						"%s": {"revealable": true, "protected": true}
 					}
 				}
 			}
 		}
-	}`, clueID, rewardClueID))
+	}`, clueID, rewardClueID, uuid.NewString(), uuid.NewString(), clueID))
 	if _, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, valid); err != nil {
 		t.Fatalf("valid clue_interaction itemEffects must save: %v", err)
 	}
@@ -705,11 +718,35 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 				"modules": {
 					"clue_interaction": {
 						"enabled": true,
-						"config": {"itemEffects": {"%s": {"effect": "steal"}}}
+						"config": {"itemEffects": {"%s": {"effect": "kill"}}}
 					}
 				}
 			}`, clueID)),
 			want: "is not supported",
+		},
+		{
+			name: "description change requires text",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "description_change"}}}
+					}
+				}
+			}`, clueID)),
+			want: "descriptionText is required",
+		},
+		{
+			name: "policy must be boolean",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"cluePolicies": {"%s": {"protected": "yes"}}}
+					}
+				}
+			}`, clueID)),
+			want: "protected must be boolean",
 		},
 		{
 			name: "unknown effect field",

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -562,6 +562,7 @@ func mergeClueList(current []string, next []string) []string {
 func (m *ClueInteractionModule) configForPlayerState() ClueInteractionConfig {
 	config := m.config
 	config.ItemEffects = nil
+	config.CluePolicies = nil
 	return config
 }
 

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -26,6 +26,12 @@ type ClueInteractionConfig struct {
 	CommonClueVisibility string                          `json:"commonClueVisibility"`
 	AutoRevealClues      bool                            `json:"autoRevealClues"`
 	ItemEffects          map[string]ClueItemEffectConfig `json:"itemEffects,omitempty"`
+	CluePolicies         map[string]CluePolicyConfig     `json:"cluePolicies,omitempty"`
+}
+
+type CluePolicyConfig struct {
+	Revealable bool `json:"revealable"`
+	Protected  bool `json:"protected"`
 }
 
 // ItemUseState tracks an in-progress item use action.
@@ -41,19 +47,20 @@ type ItemUseState struct {
 
 // ClueInteractionModule handles clue drawing and transfer mechanics.
 type ClueInteractionModule struct {
-	mu               sync.RWMutex
-	deps             engine.ModuleDeps
-	config           ClueInteractionConfig
-	playerDrawCounts map[uuid.UUID]int
-	currentClueLevel int
-	acquiredClues    map[uuid.UUID][]string
-	targetCodeClues  map[string][]string
-	allPlayerClues   []string
-	activeItemUse    *ItemUseState
-	usedItems        map[uuid.UUID][]uuid.UUID // playerID -> used clue IDs
-	revealedInfo     map[uuid.UUID]map[string]string
-	itemTimeout      *time.Timer
-	appliedGrantIDs  map[string]struct{}
+	mu                  sync.RWMutex
+	deps                engine.ModuleDeps
+	config              ClueInteractionConfig
+	playerDrawCounts    map[uuid.UUID]int
+	currentClueLevel    int
+	acquiredClues       map[uuid.UUID][]string
+	targetCodeClues     map[string][]string
+	allPlayerClues      []string
+	activeItemUse       *ItemUseState
+	usedItems           map[uuid.UUID][]uuid.UUID // playerID -> used clue IDs
+	revealedInfo        map[uuid.UUID]map[string]string
+	changedDescriptions map[uuid.UUID]map[string]string
+	itemTimeout         *time.Timer
+	appliedGrantIDs     map[string]struct{}
 }
 
 // NewClueInteractionModule creates a new ClueInteractionModule instance.
@@ -74,6 +81,7 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 	m.allPlayerClues = nil
 	m.usedItems = make(map[uuid.UUID][]uuid.UUID)
 	m.revealedInfo = make(map[uuid.UUID]map[string]string)
+	m.changedDescriptions = make(map[uuid.UUID]map[string]string)
 	m.appliedGrantIDs = make(map[string]struct{})
 
 	// Apply defaults first.
@@ -85,6 +93,7 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 		CommonClueVisibility: "all",
 		AutoRevealClues:      false,
 		ItemEffects:          map[string]ClueItemEffectConfig{},
+		CluePolicies:         map[string]CluePolicyConfig{},
 	}
 
 	// Unmarshal directly into m.config — only provided JSON fields overwrite defaults.
@@ -95,6 +104,9 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 	}
 	if m.config.ItemEffects == nil {
 		m.config.ItemEffects = map[string]ClueItemEffectConfig{}
+	}
+	if m.config.CluePolicies == nil {
+		m.config.CluePolicies = map[string]CluePolicyConfig{}
 	}
 	if err := validateClueItemEffectConfig(m.config.ItemEffects); err != nil {
 		return err
@@ -368,16 +380,39 @@ func (m *ClueInteractionModule) Schema() json.RawMessage {
 				"additionalProperties": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
-						"effect":       map[string]any{"type": "string", "enum": []string{"peek", "reveal", "grant_clue"}},
-						"target":       map[string]any{"type": "string", "enum": []string{"player", "self"}},
-						"consume":      map[string]any{"type": "boolean", "default": false},
-						"revealText":   map[string]any{"type": "string"},
-						"grantClueIds": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+						"effect":          map[string]any{"type": "string", "enum": []string{"description_change", "peek", "steal", "reveal", "grant_clue"}},
+						"target":          map[string]any{"type": "string", "enum": []string{"player", "self"}},
+						"consume":         map[string]any{"type": "boolean", "default": false},
+						"descriptionText": map[string]any{"type": "string"},
+						"revealText":      map[string]any{"type": "string"},
+						"grantClueIds":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+						"trigger":         map[string]any{"type": "string", "enum": []string{"on_view", "on_use"}},
+						"password":        map[string]any{"type": "string"},
+						"condition": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"kind":  map[string]any{"type": "string", "enum": []string{"password"}},
+								"value": map[string]any{"type": "string"},
+							},
+							"additionalProperties": false,
+						},
 					},
 					"required":             []string{"effect"},
 					"additionalProperties": false,
 				},
 				"description": "Runtime clue use effects keyed by clue ID",
+			},
+			"cluePolicies": map[string]any{
+				"type": "object",
+				"additionalProperties": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"revealable": map[string]any{"type": "boolean", "default": true},
+						"protected":  map[string]any{"type": "boolean", "default": false},
+					},
+					"additionalProperties": false,
+				},
+				"description": "Editor-owned clue visibility and protection policies keyed by clue ID",
 			},
 		},
 		"additionalProperties": false,
@@ -387,14 +422,15 @@ func (m *ClueInteractionModule) Schema() json.RawMessage {
 }
 
 type clueInteractionState struct {
-	PlayerDrawCounts map[uuid.UUID]int               `json:"playerDrawCounts"`
-	CurrentClueLevel int                             `json:"currentClueLevel"`
-	AcquiredClues    map[uuid.UUID][]string          `json:"acquiredClues"`
-	AllPlayerClues   []string                        `json:"allPlayerClues,omitempty"`
-	Config           ClueInteractionConfig           `json:"config"`
-	UsedItems        map[uuid.UUID][]uuid.UUID       `json:"usedItems"`
-	RevealedInfo     map[uuid.UUID]map[string]string `json:"revealedInfo"`
-	ActiveItemUse    *ItemUseState                   `json:"activeItemUse,omitempty"`
+	PlayerDrawCounts    map[uuid.UUID]int               `json:"playerDrawCounts"`
+	CurrentClueLevel    int                             `json:"currentClueLevel"`
+	AcquiredClues       map[uuid.UUID][]string          `json:"acquiredClues"`
+	AllPlayerClues      []string                        `json:"allPlayerClues,omitempty"`
+	Config              ClueInteractionConfig           `json:"config"`
+	UsedItems           map[uuid.UUID][]uuid.UUID       `json:"usedItems"`
+	RevealedInfo        map[uuid.UUID]map[string]string `json:"revealedInfo"`
+	ChangedDescriptions map[uuid.UUID]map[string]string `json:"changedDescriptions"`
+	ActiveItemUse       *ItemUseState                   `json:"activeItemUse,omitempty"`
 }
 
 func (m *ClueInteractionModule) BuildState() (json.RawMessage, error) {
@@ -402,14 +438,15 @@ func (m *ClueInteractionModule) BuildState() (json.RawMessage, error) {
 	defer m.mu.RUnlock()
 
 	return json.Marshal(clueInteractionState{
-		PlayerDrawCounts: m.playerDrawCounts,
-		CurrentClueLevel: m.currentClueLevel,
-		AcquiredClues:    m.acquiredClues,
-		AllPlayerClues:   m.allPlayerClues,
-		Config:           m.config,
-		UsedItems:        m.usedItems,
-		RevealedInfo:     m.revealedInfo,
-		ActiveItemUse:    m.activeItemUse,
+		PlayerDrawCounts:    m.playerDrawCounts,
+		CurrentClueLevel:    m.currentClueLevel,
+		AcquiredClues:       m.acquiredClues,
+		AllPlayerClues:      m.allPlayerClues,
+		Config:              m.config,
+		UsedItems:           m.usedItems,
+		RevealedInfo:        m.revealedInfo,
+		ChangedDescriptions: m.changedDescriptions,
+		ActiveItemUse:       m.activeItemUse,
 	})
 }
 
@@ -423,6 +460,7 @@ func (m *ClueInteractionModule) Cleanup(_ context.Context) error {
 	m.allPlayerClues = nil
 	m.usedItems = nil
 	m.revealedInfo = nil
+	m.changedDescriptions = nil
 	m.activeItemUse = nil
 	m.appliedGrantIDs = nil
 	if m.itemTimeout != nil {
@@ -481,14 +519,15 @@ func (m *ClueInteractionModule) BuildStateFor(playerID uuid.UUID) (json.RawMessa
 	}
 	acquiredClues[playerID] = mergeClueList(acquiredClues[playerID], m.targetCodeClues[playerID.String()])
 	return json.Marshal(clueInteractionState{
-		PlayerDrawCounts: engine.FilterByPlayer(m.playerDrawCounts, playerID),
-		CurrentClueLevel: m.currentClueLevel,
-		AcquiredClues:    acquiredClues,
-		AllPlayerClues:   m.allPlayerClues,
-		Config:           m.configForPlayerState(),
-		UsedItems:        engine.FilterByPlayer(m.usedItems, playerID),
-		RevealedInfo:     engine.FilterByPlayer(m.revealedInfo, playerID),
-		ActiveItemUse:    activeItemUse,
+		PlayerDrawCounts:    engine.FilterByPlayer(m.playerDrawCounts, playerID),
+		CurrentClueLevel:    m.currentClueLevel,
+		AcquiredClues:       acquiredClues,
+		AllPlayerClues:      m.allPlayerClues,
+		Config:              m.configForPlayerState(),
+		UsedItems:           engine.FilterByPlayer(m.usedItems, playerID),
+		RevealedInfo:        engine.FilterByPlayer(m.revealedInfo, playerID),
+		ChangedDescriptions: engine.FilterByPlayer(m.changedDescriptions, playerID),
+		ActiveItemUse:       activeItemUse,
 	})
 }
 

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -386,16 +386,6 @@ func (m *ClueInteractionModule) Schema() json.RawMessage {
 						"descriptionText": map[string]any{"type": "string"},
 						"revealText":      map[string]any{"type": "string"},
 						"grantClueIds":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-						"trigger":         map[string]any{"type": "string", "enum": []string{"on_view", "on_use"}},
-						"password":        map[string]any{"type": "string"},
-						"condition": map[string]any{
-							"type": "object",
-							"properties": map[string]any{
-								"kind":  map[string]any{"type": "string", "enum": []string{"password"}},
-								"value": map[string]any{"type": "string"},
-							},
-							"additionalProperties": false,
-						},
 					},
 					"required":             []string{"effect"},
 					"additionalProperties": false,

--- a/apps/server/internal/module/core/clue_interaction_test.go
+++ b/apps/server/internal/module/core/clue_interaction_test.go
@@ -859,4 +859,11 @@ func TestClueInteractionModule_BuildStateFor_NoCrossLeak(t *testing.T) {
 	if bytes.Contains(aliceData, []byte("cluePolicies")) || bytes.Contains(aliceData, []byte("hidden-clue")) {
 		t.Fatalf("alice leaked clue policy config: %s", aliceData)
 	}
+	var aliceState clueInteractionState
+	if err := json.Unmarshal(aliceData, &aliceState); err != nil {
+		t.Fatalf("unmarshal alice state: %v", err)
+	}
+	if len(aliceState.Config.CluePolicies) > 0 {
+		t.Fatalf("alice state contains clue policies: %+v", aliceState.Config.CluePolicies)
+	}
 }

--- a/apps/server/internal/module/core/clue_interaction_test.go
+++ b/apps/server/internal/module/core/clue_interaction_test.go
@@ -844,6 +844,9 @@ func TestClueInteractionModule_BuildStateFor_NoCrossLeak(t *testing.T) {
 	m.mu.Lock()
 	m.acquiredClues[bob] = []string{"bob-clue"}
 	m.playerDrawCounts[bob] = 99
+	m.config.CluePolicies = map[string]CluePolicyConfig{
+		"hidden-clue": {Revealable: false, Protected: true},
+	}
 	m.mu.Unlock()
 
 	aliceData, _ := m.BuildStateFor(alice)
@@ -852,5 +855,8 @@ func TestClueInteractionModule_BuildStateFor_NoCrossLeak(t *testing.T) {
 	}
 	if bytes.Contains(aliceData, []byte(bob.String())) {
 		t.Fatalf("alice leaked bob's uuid: %s", aliceData)
+	}
+	if bytes.Contains(aliceData, []byte("cluePolicies")) || bytes.Contains(aliceData, []byte("hidden-clue")) {
+		t.Fatalf("alice leaked clue policy config: %s", aliceData)
 	}
 }

--- a/apps/server/internal/module/core/clue_item_effects.go
+++ b/apps/server/internal/module/core/clue_item_effects.go
@@ -11,20 +11,23 @@ import (
 )
 
 const (
-	clueEffectPeek      = "peek"
-	clueEffectReveal    = "reveal"
-	clueEffectGrantClue = "grant_clue"
+	clueEffectDescriptionChange = "description_change"
+	clueEffectPeek              = "peek"
+	clueEffectSteal             = "steal"
+	clueEffectReveal            = "reveal"
+	clueEffectGrantClue         = "grant_clue"
 )
 
 // ClueItemEffectConfig is the runtime-owned contract for configured clue use.
 // Editor labels are mapped to this contract by adapters; the engine executes
 // only this typed shape and never trusts client-side labels as runtime truth.
 type ClueItemEffectConfig struct {
-	Effect       string   `json:"effect"`
-	Target       string   `json:"target,omitempty"`
-	Consume      bool     `json:"consume"`
-	RevealText   string   `json:"revealText,omitempty"`
-	GrantClueIDs []string `json:"grantClueIds,omitempty"`
+	Effect          string   `json:"effect"`
+	Target          string   `json:"target,omitempty"`
+	Consume         bool     `json:"consume"`
+	DescriptionText string   `json:"descriptionText,omitempty"`
+	RevealText      string   `json:"revealText,omitempty"`
+	GrantClueIDs    []string `json:"grantClueIds,omitempty"`
 }
 
 type itemUsePayload struct {
@@ -69,7 +72,7 @@ func (m *ClueInteractionModule) handleItemUse(ctx context.Context, playerID uuid
 		state.Consume = effectCfg.Consume
 	}
 
-	if state.Configured && (state.Target == "self" || state.Effect == clueEffectReveal || state.Effect == clueEffectGrantClue) {
+	if state.Configured && (state.Target == "self" || state.Effect == clueEffectReveal || state.Effect == clueEffectGrantClue || state.Effect == clueEffectDescriptionChange) {
 		m.publishItemDeclared(playerID, clueID)
 		return m.resolveItemUse(ctx, state, "")
 	}
@@ -113,6 +116,14 @@ func (m *ClueInteractionModule) resolveItemUse(ctx context.Context, state ItemUs
 	switch state.Effect {
 	case clueEffectPeek:
 		resolveErr = m.handlePeekEffect(ctx, state.UserID, state.ClueID, targetPlayerID)
+	case clueEffectSteal:
+		resolveErr = m.handleStealEffect(state.UserID, state.ClueID, targetPlayerID)
+	case clueEffectDescriptionChange:
+		if state.Configured {
+			resolveErr = m.handleDescriptionChangeEffect(state.UserID, state.ClueID)
+		} else {
+			resolveErr = fmt.Errorf("clue_interaction: effect %q not implemented", state.Effect)
+		}
 	case clueEffectReveal:
 		if state.Configured {
 			resolveErr = m.handleRevealEffect(state.UserID, state.ClueID)
@@ -173,8 +184,11 @@ func validateSingleClueItemEffectConfig(clueID string, cfg ClueItemEffectConfig)
 	if cfg.Effect == "" {
 		return fmt.Errorf("clue_interaction: item effect missing for clue %q", clueID)
 	}
-	if cfg.Effect != clueEffectReveal && cfg.Effect != clueEffectGrantClue && cfg.Effect != clueEffectPeek {
+	if cfg.Effect != clueEffectDescriptionChange && cfg.Effect != clueEffectReveal && cfg.Effect != clueEffectGrantClue && cfg.Effect != clueEffectPeek && cfg.Effect != clueEffectSteal {
 		return fmt.Errorf("clue_interaction: effect %q not implemented", cfg.Effect)
+	}
+	if cfg.Effect == clueEffectDescriptionChange && cfg.DescriptionText == "" {
+		return fmt.Errorf("clue_interaction: description_change requires descriptionText")
 	}
 	if cfg.Effect == clueEffectGrantClue && len(cfg.GrantClueIDs) == 0 {
 		return fmt.Errorf("clue_interaction: grant_clue requires grantClueIds")
@@ -192,8 +206,7 @@ func (m *ClueInteractionModule) handlePeekEffect(_ context.Context, _ uuid.UUID,
 	}
 
 	m.mu.RLock()
-	clues := make([]string, len(m.acquiredClues[targetPlayerID]))
-	copy(clues, m.acquiredClues[targetPlayerID])
+	clues := m.visibleTargetCluesLocked(targetPlayerID)
 	m.mu.RUnlock()
 
 	m.deps.EventBus.Publish(engine.Event{
@@ -201,6 +214,66 @@ func (m *ClueInteractionModule) handlePeekEffect(_ context.Context, _ uuid.UUID,
 		Payload: map[string]any{
 			"targetPlayerId": targetPlayerID.String(),
 			"clues":          clues,
+		},
+	})
+	return nil
+}
+
+func (m *ClueInteractionModule) handleStealEffect(playerID uuid.UUID, usedClueID uuid.UUID, targetPlayerIDStr string) error {
+	targetPlayerID, err := uuid.Parse(targetPlayerIDStr)
+	if err != nil {
+		return fmt.Errorf("clue_interaction: invalid targetPlayerId: %w", err)
+	}
+
+	m.mu.Lock()
+	targetClues := m.visibleTargetCluesLocked(targetPlayerID)
+	if len(targetClues) == 0 {
+		m.mu.Unlock()
+		return fmt.Errorf("clue_interaction: target has no stealable clues")
+	}
+	stolenClueID := targetClues[0]
+	m.removePlayerClueLocked(targetPlayerID, stolenClueID)
+	if !m.playerHasClueLocked(playerID, stolenClueID) {
+		m.acquiredClues[playerID] = append(m.acquiredClues[playerID], stolenClueID)
+	}
+	m.mu.Unlock()
+
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.steal_result",
+		Payload: map[string]any{
+			"playerId":       playerID.String(),
+			"targetPlayerId": targetPlayerID.String(),
+			"clueId":         stolenClueID,
+			"usedClue":       usedClueID.String(),
+		},
+	})
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.acquired",
+		Payload: map[string]any{
+			"playerId": playerID.String(),
+			"clueId":   stolenClueID,
+			"source":   "clue_steal",
+			"usedClue": usedClueID.String(),
+		},
+	})
+	return nil
+}
+
+func (m *ClueInteractionModule) handleDescriptionChangeEffect(playerID uuid.UUID, clueID uuid.UUID) error {
+	cfg := m.config.ItemEffects[clueID.String()]
+	m.mu.Lock()
+	if m.changedDescriptions[playerID] == nil {
+		m.changedDescriptions[playerID] = make(map[string]string)
+	}
+	m.changedDescriptions[playerID][clueID.String()] = cfg.DescriptionText
+	m.mu.Unlock()
+
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "clue.description_changed",
+		Payload: map[string]any{
+			"playerId":        playerID.String(),
+			"clueId":          clueID.String(),
+			"descriptionText": cfg.DescriptionText,
 		},
 	})
 	return nil
@@ -346,6 +419,21 @@ func (m *ClueInteractionModule) playerHasClueLocked(playerID uuid.UUID, clueID s
 		}
 	}
 	return false
+}
+
+func (m *ClueInteractionModule) visibleTargetCluesLocked(playerID uuid.UUID) []string {
+	clues := m.acquiredClues[playerID]
+	out := make([]string, 0, len(clues))
+	for _, clueID := range clues {
+		if !m.isProtectedClue(clueID) {
+			out = append(out, clueID)
+		}
+	}
+	return out
+}
+
+func (m *ClueInteractionModule) isProtectedClue(clueID string) bool {
+	return m.config.CluePolicies[clueID].Protected
 }
 
 func (m *ClueInteractionModule) removePlayerClueLocked(playerID uuid.UUID, clueID string) {

--- a/apps/server/internal/module/core/clue_item_effects_test.go
+++ b/apps/server/internal/module/core/clue_item_effects_test.go
@@ -108,6 +108,97 @@ func TestClueInteractionModule_ConfiguredGrantClueIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestClueInteractionModule_ConfiguredDescriptionChangeStoresPerPlayerText(t *testing.T) {
+	deps := newTestDeps()
+	m := NewClueInteractionModule()
+	playerID := uuid.New()
+	clueID := uuid.New()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		clueID.String(): {Effect: clueEffectDescriptionChange, Target: "self", DescriptionText: "열쇠 안쪽 문장이 바뀝니다."},
+	}})
+	if err := m.Init(context.Background(), deps, cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	m.mu.Lock()
+	m.acquiredClues[playerID] = []string{clueID.String()}
+	m.mu.Unlock()
+
+	var changed, resolved bool
+	deps.EventBus.Subscribe("clue.description_changed", func(e engine.Event) { changed = true })
+	deps.EventBus.Subscribe("clue.item_resolved", func(e engine.Event) { resolved = true })
+
+	payload, _ := json.Marshal(itemUsePayload{ClueID: clueID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", payload); err != nil {
+		t.Fatalf("clue:use description_change: %v", err)
+	}
+	if !changed || !resolved {
+		t.Fatalf("expected changed/resolved events, got changed=%v resolved=%v", changed, resolved)
+	}
+	m.mu.RLock()
+	if got := m.changedDescriptions[playerID][clueID.String()]; got != "열쇠 안쪽 문장이 바뀝니다." {
+		t.Fatalf("changed description = %q", got)
+	}
+	m.mu.RUnlock()
+}
+
+func TestClueInteractionModule_PeekAndStealSkipProtectedClues(t *testing.T) {
+	deps := newTestDeps()
+	m := NewClueInteractionModule()
+	playerID := uuid.New()
+	targetID := uuid.New()
+	usedClueID := uuid.New()
+	protectedClueID := uuid.New().String()
+	openClueID := uuid.New().String()
+	cfg, _ := json.Marshal(ClueInteractionConfig{
+		ItemEffects: map[string]ClueItemEffectConfig{
+			usedClueID.String(): {Effect: clueEffectSteal, Target: "player"},
+		},
+		CluePolicies: map[string]CluePolicyConfig{
+			protectedClueID: {Revealable: true, Protected: true},
+		},
+	})
+	if err := m.Init(context.Background(), deps, cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	m.mu.Lock()
+	m.acquiredClues[playerID] = []string{usedClueID.String()}
+	m.acquiredClues[targetID] = []string{protectedClueID, openClueID}
+	m.mu.Unlock()
+
+	var peeked []string
+	deps.EventBus.Subscribe("clue.peek_result", func(e engine.Event) {
+		payload := e.Payload.(map[string]any)
+		peeked = payload["clues"].([]string)
+	})
+	if err := m.handlePeekEffect(context.Background(), playerID, usedClueID, targetID.String()); err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	if len(peeked) != 1 || peeked[0] != openClueID {
+		t.Fatalf("peeked clues = %#v", peeked)
+	}
+
+	payload, _ := json.Marshal(itemUsePayload{ClueID: usedClueID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", payload); err != nil {
+		t.Fatalf("clue:use steal: %v", err)
+	}
+	targetPayload, _ := json.Marshal(itemUseTargetPayload{TargetPlayerID: targetID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use_target", targetPayload); err != nil {
+		t.Fatalf("clue:use_target steal: %v", err)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.playerHasClueLocked(playerID, openClueID) {
+		t.Fatal("player should receive unprotected clue")
+	}
+	if !m.playerHasClueLocked(targetID, protectedClueID) {
+		t.Fatal("protected clue should remain with target")
+	}
+	if m.playerHasClueLocked(targetID, openClueID) {
+		t.Fatal("stolen clue should be removed from target")
+	}
+}
+
 func TestClueInteractionModule_ConfiguredEffectRequiresOwnership(t *testing.T) {
 	m := NewClueInteractionModule()
 	clueID := uuid.New()

--- a/apps/server/internal/ws/envelope_catalog_s2c.go
+++ b/apps/server/internal/ws/envelope_catalog_s2c.go
@@ -62,6 +62,8 @@ func init() {
 		EventDef{Type: "clue.item_declared", Direction: DirS2C, Category: "clue"},
 		EventDef{Type: "clue.item_resolved", Direction: DirS2C, Category: "clue"},
 		EventDef{Type: "clue.peek_result", Direction: DirS2C, Category: "clue"},
+		EventDef{Type: "clue.steal_result", Direction: DirS2C, Category: "clue"},
+		EventDef{Type: "clue.description_changed", Direction: DirS2C, Category: "clue"},
 
 		// --- ending (engine relay) ---
 		EventDef{Type: "ending.reveal_step", Direction: DirS2C, Category: "ending"},

--- a/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/CluesTab.test.tsx
@@ -154,7 +154,7 @@ describe('CluesTab', () => {
   it('공통 단서에 제작자 친화적인 공개 범위 badge가 표시된다', () => {
     useEditorCluesMock.mockReturnValue({ data: mockClues, isLoading: false });
     render(<CluesTab themeId="theme-1" />);
-    expect(screen.getByText('모두에게 공개')).toBeDefined();
+    expect(screen.getAllByText('전체 공개').length).toBeGreaterThan(0);
   });
 
   it('단서 개수를 표시한다', () => {

--- a/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
@@ -3,12 +3,20 @@ import { Save, Trash2 } from 'lucide-react';
 import type { ClueResponse, UpdateClueRequest } from '@/features/editor/api';
 import { ImageMediaReferenceField } from '@/features/editor/components/media/ImageMediaReferenceField';
 import { buildClueUsePayload, toClueEditorViewModel } from '@/features/editor/entities/clue/clueEntityAdapter';
+import {
+  readCluePolicy,
+  writeCluePolicy,
+  type EditorConfig,
+} from '@/features/editor/utils/configShape';
 
 interface ClueBasicInfoCardProps {
   themeId: string;
   clue: ClueResponse;
+  configJson: EditorConfig | null | undefined;
   isSaving?: boolean;
+  isConfigSaving?: boolean;
   onSave: (clueId: string, body: UpdateClueRequest) => void;
+  onConfigChange?: (nextConfig: EditorConfig) => void;
   onDelete: (clue: ClueResponse) => void;
 }
 
@@ -18,17 +26,22 @@ interface DraftState {
   imageUrl: string;
   imageMediaId: string | null;
   isCommon: boolean;
+  isRevealable: boolean;
+  isProtected: boolean;
   revealRound: number | null;
   hideRound: number | null;
 }
 
-function toDraft(clue: ClueResponse): DraftState {
+function toDraft(clue: ClueResponse, configJson: EditorConfig | null | undefined): DraftState {
+  const policy = readCluePolicy(configJson, clue.id);
   return {
     name: clue.name,
     description: clue.description ?? '',
     imageUrl: clue.image_url ?? '',
     imageMediaId: clue.image_media_id ?? null,
     isCommon: clue.is_common,
+    isRevealable: clue.is_common ? true : policy.revealable,
+    isProtected: policy.protected,
     revealRound: clue.reveal_round ?? null,
     hideRound: clue.hide_round ?? null,
   };
@@ -42,13 +55,20 @@ function parseRoundInput(raw: string): number | null {
   return Math.floor(n);
 }
 
-function isDirty(draft: DraftState, clue: ClueResponse): boolean {
+function isDirty(
+  draft: DraftState,
+  clue: ClueResponse,
+  configJson: EditorConfig | null | undefined
+): boolean {
+  const policy = readCluePolicy(configJson, clue.id);
   return (
     draft.name !== clue.name ||
     draft.description !== (clue.description ?? '') ||
     draft.imageUrl !== (clue.image_url ?? '') ||
     draft.imageMediaId !== (clue.image_media_id ?? null) ||
     draft.isCommon !== clue.is_common ||
+    (!draft.isCommon && draft.isRevealable !== policy.revealable) ||
+    draft.isProtected !== policy.protected ||
     draft.revealRound !== (clue.reveal_round ?? null) ||
     draft.hideRound !== (clue.hide_round ?? null)
   );
@@ -69,22 +89,30 @@ function validate(draft: DraftState): Record<string, string> {
 export function ClueBasicInfoCard({
   themeId,
   clue,
+  configJson,
   isSaving = false,
+  isConfigSaving = false,
   onSave,
+  onConfigChange,
   onDelete,
 }: ClueBasicInfoCardProps) {
-  const [draft, setDraft] = useState<DraftState>(() => toDraft(clue));
+  const [draft, setDraft] = useState<DraftState>(() => toDraft(clue, configJson));
   const [errors, setErrors] = useState<Record<string, string>>({});
   const view = toClueEditorViewModel(clue);
-  const dirty = isDirty(draft, clue);
+  const dirty = isDirty(draft, clue, configJson);
+  const saving = isSaving || isConfigSaving;
 
   useEffect(() => {
-    setDraft(toDraft(clue));
+    setDraft(toDraft(clue, configJson));
     setErrors({});
-  }, [clue]);
+  }, [clue, configJson]);
 
   function patch(next: Partial<DraftState>) {
-    setDraft((current) => ({ ...current, ...next }));
+    setDraft((current) => {
+      const patched = { ...current, ...next };
+      if (next.isCommon === true) patched.isRevealable = true;
+      return patched;
+    });
   }
 
   function handleSave() {
@@ -116,6 +144,12 @@ export function ClueBasicInfoCard({
         hide_round: draft.hideRound,
       })
     );
+    onConfigChange?.(
+      writeCluePolicy(configJson, clue.id, {
+        revealable: draft.isCommon ? true : draft.isRevealable,
+        protected: draft.isProtected,
+      })
+    );
   }
 
   return (
@@ -134,11 +168,11 @@ export function ClueBasicInfoCard({
           <button
             type="button"
             onClick={handleSave}
-            disabled={!dirty || isSaving}
+            disabled={!dirty || saving}
             className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-amber-500/30 px-3 py-2 text-xs font-semibold text-amber-200 hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
           >
             <Save className="h-3.5 w-3.5" />
-            {isSaving ? '저장 중' : '기본 정보 저장'}
+            {saving ? '저장 중' : '기본 정보 저장'}
           </button>
           <button
             type="button"
@@ -185,7 +219,39 @@ export function ClueBasicInfoCard({
               onChange={(event) => patch({ isCommon: event.target.checked })}
               className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
             />
-            모든 플레이어가 공유
+            전체 공개
+          </label>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className={`flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm ${draft.isCommon ? 'text-slate-500' : 'text-slate-300'}`}>
+            <input
+              type="checkbox"
+              checked={draft.isRevealable}
+              disabled={draft.isCommon}
+              onChange={(event) => patch({ isRevealable: event.target.checked })}
+              className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+            />
+            <span>
+              <span className="font-semibold text-slate-200">공개 가능</span>
+              <span className="mt-1 block text-xs leading-5 text-slate-500">
+                전체 공개가 아닌 단서를 장면, 라운드, 암호, 아이템 효과로 나중에 공개할 수 있게 둡니다.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-300">
+            <input
+              type="checkbox"
+              checked={draft.isProtected}
+              onChange={(event) => patch({ isProtected: event.target.checked })}
+              className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+            />
+            <span>
+              <span className="font-semibold text-slate-200">단서 보호</span>
+              <span className="mt-1 block text-xs leading-5 text-slate-500">
+                보호된 단서는 훔쳐보기와 가져오기 효과의 대상에서 제외됩니다.
+              </span>
+            </span>
           </label>
         </div>
 
@@ -206,28 +272,40 @@ export function ClueBasicInfoCard({
 
         <div className="grid gap-3 md:grid-cols-2">
           <label className="text-sm font-medium text-slate-300">
-            등장 라운드
-            <input
-              type="number"
-              min={1}
-              step={1}
-              value={draft.revealRound ?? ''}
-              onChange={(event) => patch({ revealRound: parseRoundInput(event.target.value) })}
-              placeholder="처음부터"
+            공개 시점
+            <select
+              value={roundSelectValue(draft.revealRound, 'start')}
+              onChange={(event) => patch({ revealRound: parseRoundSelect(event.target.value) })}
               className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-            />
+            >
+              <option value="start">처음부터</option>
+              <option value="round:1">1라운드 시작</option>
+              <option value="round:2">2라운드 시작</option>
+              <option value="round:3">3라운드 시작</option>
+              <option value="round:4">4라운드 시작</option>
+              <option value="round:5">5라운드 시작</option>
+              {draft.revealRound != null && draft.revealRound > 5 && (
+                <option value={`round:${draft.revealRound}`}>{draft.revealRound}라운드 시작</option>
+              )}
+            </select>
           </label>
           <label className="text-sm font-medium text-slate-300">
-            사라짐 라운드
-            <input
-              type="number"
-              min={1}
-              step={1}
-              value={draft.hideRound ?? ''}
-              onChange={(event) => patch({ hideRound: parseRoundInput(event.target.value) })}
-              placeholder="끝까지"
+            숨김 시점
+            <select
+              value={roundSelectValue(draft.hideRound, 'end')}
+              onChange={(event) => patch({ hideRound: parseRoundSelect(event.target.value) })}
               className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-            />
+            >
+              <option value="end">끝까지</option>
+              <option value="round:1">1라운드 종료</option>
+              <option value="round:2">2라운드 종료</option>
+              <option value="round:3">3라운드 종료</option>
+              <option value="round:4">4라운드 종료</option>
+              <option value="round:5">5라운드 종료</option>
+              {draft.hideRound != null && draft.hideRound > 5 && (
+                <option value={`round:${draft.hideRound}`}>{draft.hideRound}라운드 종료</option>
+              )}
+            </select>
           </label>
         </div>
         {errors.round && <p className="text-xs text-red-400">{errors.round}</p>}
@@ -240,6 +318,16 @@ export function ClueBasicInfoCard({
       </div>
     </article>
   );
+}
+
+function roundSelectValue(value: number | null, emptyValue: 'start' | 'end'): string {
+  return value == null ? emptyValue : `round:${value}`;
+}
+
+function parseRoundSelect(value: string): number | null {
+  if (value === 'start' || value === 'end') return null;
+  if (!value.startsWith('round:')) return null;
+  return parseRoundInput(value.slice('round:'.length));
 }
 
 function InfoBlock({ title, value }: { title: string; value: string }) {

--- a/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
@@ -16,7 +16,7 @@ interface ClueBasicInfoCardProps {
   isSaving?: boolean;
   isConfigSaving?: boolean;
   onSave: (clueId: string, body: UpdateClueRequest) => void;
-  onConfigChange?: (nextConfig: EditorConfig) => void;
+  onConfigChange: (nextConfig: EditorConfig) => void;
   onDelete: (clue: ClueResponse) => void;
 }
 
@@ -99,13 +99,35 @@ export function ClueBasicInfoCard({
   const [draft, setDraft] = useState<DraftState>(() => toDraft(clue, configJson));
   const [errors, setErrors] = useState<Record<string, string>>({});
   const view = toClueEditorViewModel(clue);
+  const policy = readCluePolicy(configJson, clue.id);
   const dirty = isDirty(draft, clue, configJson);
   const saving = isSaving || isConfigSaving;
 
   useEffect(() => {
-    setDraft(toDraft(clue, configJson));
+    setDraft({
+      name: clue.name,
+      description: clue.description ?? '',
+      imageUrl: clue.image_url ?? '',
+      imageMediaId: clue.image_media_id ?? null,
+      isCommon: clue.is_common,
+      isRevealable: clue.is_common ? true : policy.revealable,
+      isProtected: policy.protected,
+      revealRound: clue.reveal_round ?? null,
+      hideRound: clue.hide_round ?? null,
+    });
     setErrors({});
-  }, [clue, configJson]);
+  }, [
+    clue.id,
+    clue.name,
+    clue.description,
+    clue.image_url,
+    clue.image_media_id,
+    clue.is_common,
+    clue.reveal_round,
+    clue.hide_round,
+    policy.revealable,
+    policy.protected,
+  ]);
 
   function patch(next: Partial<DraftState>) {
     setDraft((current) => {
@@ -144,7 +166,7 @@ export function ClueBasicInfoCard({
         hide_round: draft.hideRound,
       })
     );
-    onConfigChange?.(
+    onConfigChange(
       writeCluePolicy(configJson, clue.id, {
         revealable: draft.isCommon ? true : draft.isRevealable,
         protected: draft.isProtected,

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
@@ -101,7 +101,10 @@ describe('ClueEntityWorkspace', () => {
     );
 
     expect(screen.getByText('단서 기본 정보')).toBeDefined();
-    expect(screen.getByText('단서 사용 / 공개 규칙')).toBeDefined();
+    expect(screen.getByText('단서 공개 조건')).toBeDefined();
+    expect(screen.getByLabelText('전체 공개')).toBeDefined();
+    expect(screen.getByLabelText(/공개 가능/)).toBeDefined();
+    expect(screen.getByLabelText(/단서 보호/)).toBeDefined();
     expect(screen.getAllByText('사용하면 내 단서함에서 사라짐').length).toBeGreaterThan(0);
     expect(screen.getByText('서재의 발견 단서')).toBeDefined();
     expect(screen.getByText('탐정의 시작 단서')).toBeDefined();
@@ -126,13 +129,14 @@ describe('ClueEntityWorkspace', () => {
     fireEvent.click(screen.getByRole('button', { name: '비밀 편지 선택' }));
 
     expect(screen.getAllByText('숨겨진 메시지').length).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: '효과 없음' }).getAttribute('aria-pressed')).toBe(
+    expect(screen.getByRole('button', { name: '설명 변경' }).getAttribute('aria-pressed')).toBe(
       'true',
     );
   });
 
-  it('인라인 기본 정보 저장 시 선택 단서 update payload를 보낸다', () => {
+  it('인라인 기본 정보 저장 시 선택 단서 update payload와 보호 정책을 보낸다', () => {
     const onUpdate = vi.fn();
+    const onConfigChange = vi.fn();
 
     render(
       <ClueEntityWorkspace
@@ -143,6 +147,7 @@ describe('ClueEntityWorkspace', () => {
         characters={[]}
         onCreate={vi.fn()}
         onUpdate={onUpdate}
+        onConfigChange={onConfigChange}
         onDelete={vi.fn()}
       />,
     );
@@ -150,6 +155,7 @@ describe('ClueEntityWorkspace', () => {
     fireEvent.change(screen.getByLabelText('이름'), {
       target: { value: '피 묻은 열쇠 조각' },
     });
+    fireEvent.click(screen.getByLabelText(/단서 보호/));
     fireEvent.click(screen.getByRole('button', { name: '기본 정보 저장' }));
 
     expect(onUpdate).toHaveBeenCalledWith(
@@ -160,6 +166,19 @@ describe('ClueEntityWorkspace', () => {
         use_effect: 'steal',
         use_target: 'player',
         use_consumed: true,
+      }),
+    );
+    expect(onConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modules: expect.objectContaining({
+          clue_interaction: expect.objectContaining({
+            config: expect.objectContaining({
+              cluePolicies: expect.objectContaining({
+                'clue-1': expect.objectContaining({ revealable: true, protected: true }),
+              }),
+            }),
+          }),
+        }),
       }),
     );
   });

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -67,8 +67,11 @@ export function ClueEntityWorkspace({
           <ClueBasicInfoCard
             themeId={themeId ?? ''}
             clue={clue}
+            configJson={configJson}
             isSaving={isClueSaving}
+            isConfigSaving={isConfigSaving}
             onSave={onUpdate}
+            onConfigChange={onConfigChange}
             onDelete={onDelete}
           />
           <ClueRuntimeEffectCard

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
@@ -64,9 +64,9 @@ describe('ClueRuntimeEffectCard', () => {
       />,
     );
 
-    expect(screen.getByText('단서 사용 / 공개 규칙')).toBeDefined();
-    expect(screen.getByRole('button', { name: '단서 확인 시' }).getAttribute('aria-pressed')).toBe('true');
-    expect(screen.getByLabelText('암호')).toHaveProperty('value', '0427');
+    expect(screen.getByText('단서 공개 조건')).toBeDefined();
+    expect(screen.queryByRole('button', { name: '즉시 공개' })).toBeNull();
+    expect(screen.getByLabelText(/암호 입력 후 공개/)).toHaveProperty('value', '0427');
     expect(screen.queryByText('itemEffects')).toBeNull();
     expect(screen.queryByText('grant_clue')).toBeNull();
 
@@ -74,14 +74,13 @@ describe('ClueRuntimeEffectCard', () => {
       target: { value: '열쇠 뒤에 새 숫자 1234가 보입니다.' },
     });
     fireEvent.click(screen.getByLabelText(/사용하면 내 단서함에서 사라짐/));
-    fireEvent.click(screen.getByRole('button', { name: '규칙 저장' }));
+    fireEvent.click(screen.getByRole('button', { name: '공개 조건 저장' }));
 
     expect(onConfigChange).toHaveBeenCalledTimes(1);
     const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
     expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
       effect: 'reveal',
       target: 'self',
-      trigger: 'on_view',
       condition: { kind: 'password', value: '0427' },
       revealText: '열쇠 뒤에 새 숫자 1234가 보입니다.',
       consume: true,
@@ -105,24 +104,22 @@ describe('ClueRuntimeEffectCard', () => {
       target: { value: '금고' },
     });
     fireEvent.click(screen.getByRole('button', { name: '금고 비밀번호' }));
-    fireEvent.click(screen.getByRole('button', { name: '암호 입력 후 공개' }));
-    fireEvent.change(screen.getByLabelText('암호'), { target: { value: 'gold' } });
+    fireEvent.change(screen.getByLabelText(/암호 입력 후 공개/), { target: { value: 'gold' } });
 
     expect(screen.getByText('선택된 지급 단서')).toBeDefined();
-    fireEvent.click(screen.getByRole('button', { name: '규칙 저장' }));
+    fireEvent.click(screen.getByRole('button', { name: '공개 조건 저장' }));
 
     expect(onConfigChange).toHaveBeenCalledTimes(1);
     const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
     expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
       effect: 'grant_clue',
       target: 'self',
-      trigger: 'on_use',
       condition: { kind: 'password', value: 'gold' },
       grantClueIds: ['clue-2'],
     });
   });
 
-  it('효과 없음으로 저장하면 기존 런타임 효과를 제거한다', () => {
+  it('설명 변경 효과를 입력하고 저장한다', () => {
     const onConfigChange = vi.fn();
 
     render(
@@ -134,8 +131,14 @@ describe('ClueRuntimeEffectCard', () => {
             clue_interaction: {
               enabled: true,
               config: {
-                itemEffects: {
-                  'clue-1': { effect: 'grant_clue', grantClueIds: ['clue-2'] },
+            itemEffects: {
+                  'clue-1': {
+                    effect: 'description_change',
+                    target: 'self',
+                    condition: { kind: 'password', value: 'open' },
+                    descriptionText: '사용 후 새 설명',
+                    consume: false,
+                  },
                 },
               },
             },
@@ -145,10 +148,42 @@ describe('ClueRuntimeEffectCard', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: '효과 없음' }));
-    fireEvent.click(screen.getByRole('button', { name: '규칙 저장' }));
+    fireEvent.change(screen.getByLabelText('사용 후 바뀔 설명'), {
+      target: { value: '사용 후 다른 문장이 보입니다.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '공개 조건 저장' }));
 
     const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
-    expect(readClueItemEffect(saved, 'clue-1')).toBeNull();
+    expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
+      effect: 'description_change',
+      target: 'self',
+      condition: { kind: 'password', value: 'open' },
+      descriptionText: '사용 후 다른 문장이 보입니다.',
+    });
+  });
+
+  it('암호가 비어 있으면 저장을 막고 훔쳐보기/가져오기 효과를 저장한다', () => {
+    const onConfigChange = vi.fn();
+
+    render(
+      <ClueRuntimeEffectCard
+        clue={clues[0]}
+        clues={clues}
+        configJson={{}}
+        onConfigChange={onConfigChange}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: '공개 조건 저장' })).toHaveProperty('disabled', true);
+    fireEvent.change(screen.getByLabelText(/암호 입력 후 공개/), { target: { value: 'peek' } });
+    fireEvent.click(screen.getByRole('button', { name: '단서 가져오기' }));
+    fireEvent.click(screen.getByRole('button', { name: '공개 조건 저장' }));
+
+    const saved = onConfigChange.mock.calls[0][0] as EditorConfig;
+    expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
+      effect: 'steal',
+      target: 'player',
+      condition: { kind: 'password', value: 'peek' },
+    });
   });
 });

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Eye, Gift, Save, Search, X } from 'lucide-react';
+import { Eye, FileText, Gift, Save, Search, Shuffle, X } from 'lucide-react';
 import type { ClueResponse } from '@/features/editor/api';
 import {
   readClueItemEffect,
@@ -9,9 +9,7 @@ import {
   type EditorConfig,
 } from '@/features/editor/utils/configShape';
 
-type EffectMode = 'none' | 'reveal' | 'grant';
-type TriggerMode = 'on_view' | 'on_use';
-type ConditionMode = 'none' | 'password';
+type EffectMode = 'description' | 'reveal' | 'grant' | 'peek' | 'steal';
 
 interface ClueRuntimeEffectCardProps {
   clue: ClueResponse;
@@ -23,9 +21,8 @@ interface ClueRuntimeEffectCardProps {
 
 interface DraftState {
   mode: EffectMode;
-  trigger: TriggerMode;
-  condition: ConditionMode;
   password: string;
+  descriptionText: string;
   revealText: string;
   grantClueIds: string[];
   consume: boolean;
@@ -33,10 +30,6 @@ interface DraftState {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function readTrigger(config: ClueItemEffectConfig | null): TriggerMode {
-  return config?.trigger === 'on_view' || config?.trigger === 'on_use' ? config.trigger : 'on_use';
 }
 
 function readPassword(config: ClueItemEffectConfig | null): string {
@@ -49,52 +42,76 @@ function readPassword(config: ClueItemEffectConfig | null): string {
 
 function draftFromConfig(config: ClueItemEffectConfig | null): DraftState {
   const password = readPassword(config);
-  const base = {
-    trigger: readTrigger(config),
-    condition: password ? 'password' as ConditionMode : 'none' as ConditionMode,
-    password,
-  };
+  const base = { password, consume: config?.consume === true };
+
+  if (config?.effect === 'description_change') {
+    return {
+      mode: 'description',
+      ...base,
+      descriptionText: config.descriptionText ?? '',
+      revealText: '',
+      grantClueIds: [],
+    };
+  }
 
   if (config?.effect === 'reveal') {
     return {
       mode: 'reveal',
       ...base,
+      descriptionText: '',
       revealText: config.revealText ?? '',
       grantClueIds: [],
-      consume: config.consume === true,
     };
   }
   if (config?.effect === 'grant_clue') {
     return {
       mode: 'grant',
       ...base,
+      descriptionText: '',
       revealText: '',
       grantClueIds: config.grantClueIds ?? [],
-      consume: config.consume === true,
     };
   }
-  return { mode: 'none', ...base, revealText: '', grantClueIds: [], consume: false };
+  if (config?.effect === 'peek') {
+    return { mode: 'peek', ...base, descriptionText: '', revealText: '', grantClueIds: [] };
+  }
+  if (config?.effect === 'steal') {
+    return { mode: 'steal', ...base, descriptionText: '', revealText: '', grantClueIds: [] };
+  }
+  return {
+    mode: 'description',
+    password: '',
+    descriptionText: '',
+    revealText: '',
+    grantClueIds: [],
+    consume: false,
+  };
 }
 
-function ruleFields(draft: DraftState): EditorConfig & {
-  trigger: TriggerMode;
+function passwordCondition(draft: DraftState): EditorConfig & {
   condition?: { kind: 'password'; value: string };
 } {
   const password = draft.password.trim();
   return {
-    trigger: draft.trigger,
-    ...(draft.condition === 'password' && password
-      ? { condition: { kind: 'password' as const, value: password } }
-      : {}),
+    condition: { kind: 'password' as const, value: password },
   };
 }
 
 function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
+  if (draft.mode === 'description') {
+    return {
+      effect: 'description_change',
+      target: 'self',
+      ...passwordCondition(draft),
+      descriptionText: draft.descriptionText.trim(),
+      consume: draft.consume,
+    };
+  }
   if (draft.mode === 'reveal') {
     return {
       effect: 'reveal',
       target: 'self',
-      ...ruleFields(draft),
+      ...passwordCondition(draft),
       revealText: draft.revealText.trim(),
       consume: draft.consume,
     };
@@ -103,16 +120,30 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
     return {
       effect: 'grant_clue',
       target: 'self',
-      ...ruleFields(draft),
+      ...passwordCondition(draft),
       grantClueIds: draft.grantClueIds,
       consume: draft.consume,
     };
   }
-  return null;
+  if (draft.mode === 'peek') {
+    return {
+      effect: 'peek',
+      target: 'player',
+      ...passwordCondition(draft),
+      consume: draft.consume,
+    };
+  }
+  return {
+    effect: 'steal',
+    target: 'player',
+    ...passwordCondition(draft),
+    consume: draft.consume,
+  };
 }
 
 function isDraftValid(draft: DraftState) {
-  if (draft.condition === 'password' && draft.password.trim().length === 0) return false;
+  if (draft.password.trim().length === 0) return false;
+  if (draft.mode === 'description') return draft.descriptionText.trim().length > 0;
   if (draft.mode === 'reveal') return draft.revealText.trim().length > 0;
   if (draft.mode === 'grant') return draft.grantClueIds.length > 0;
   return true;
@@ -179,11 +210,11 @@ export function ClueRuntimeEffectCard({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
-            단서 사용 / 공개 규칙
+            단서 공개 조건
           </p>
-          <h4 className="mt-1 text-lg font-bold text-slate-100">언제, 어떤 조건으로 공개할지</h4>
+          <h4 className="mt-1 text-lg font-bold text-slate-100">암호로 열람하고, 사용하면 효과를 실행합니다</h4>
           <p className="mt-1 text-sm leading-6 text-slate-400">
-            플레이어가 단서를 확인하거나 사용할 때의 공개 조건과 보상을 한곳에서 설정합니다.
+            공개 조건은 암호 입력으로 고정하고, 아이템 사용 효과는 아래에서 따로 고릅니다.
           </p>
         </div>
         <button
@@ -193,54 +224,47 @@ export function ClueRuntimeEffectCard({
           className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-amber-500/30 px-3 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
         >
           <Save className="h-4 w-4" />
-          {isSaving ? '저장 중' : '규칙 저장'}
+          {isSaving ? '저장 중' : '공개 조건 저장'}
         </button>
       </div>
 
-      <div className="mt-4 grid gap-3 lg:grid-cols-2">
-        <RuleGroup label="발동 시점">
-          <RuleChoice
-            selected={draft.trigger === 'on_view'}
-            label="단서 확인 시"
-            onSelect={() => updateDraft({ trigger: 'on_view' })}
-          />
-          <RuleChoice
-            selected={draft.trigger === 'on_use'}
-            label="사용 버튼 클릭 시"
-            onSelect={() => updateDraft({ trigger: 'on_use' })}
-          />
-        </RuleGroup>
-        <RuleGroup label="공개 조건">
-          <RuleChoice
-            selected={draft.condition === 'none'}
-            label="즉시 공개"
-            onSelect={() => updateDraft({ condition: 'none', password: '' })}
-          />
-          <RuleChoice
-            selected={draft.condition === 'password'}
-            label="암호 입력 후 공개"
-            onSelect={() => updateDraft({ condition: 'password' })}
-          />
-        </RuleGroup>
-      </div>
+      <label className="mt-4 block text-sm font-medium text-slate-300">
+        암호 입력 후 공개
+        <input
+          value={draft.password}
+          onChange={(e) => updateDraft({ password: e.target.value })}
+          placeholder="플레이어가 입력해야 하는 암호"
+          className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+        />
+        {draft.password.trim().length === 0 && (
+          <span className="mt-1 block text-xs text-red-400">암호를 입력해야 저장할 수 있습니다.</span>
+        )}
+      </label>
 
-      {draft.condition === 'password' && (
-        <label className="mt-3 block text-sm font-medium text-slate-300">
-          암호
-          <input
-            value={draft.password}
-            onChange={(e) => updateDraft({ password: e.target.value })}
-            placeholder="플레이어가 입력해야 하는 암호"
-            className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-          />
-        </label>
-      )}
-
-      <fieldset className="mt-4 grid gap-2 sm:grid-cols-3">
-        <EffectChoice mode="none" current={draft.mode} label="효과 없음" onSelect={() => updateDraft({ mode: 'none' })} />
+      <fieldset className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        <legend className="mb-2 text-sm font-semibold text-slate-200">아이템 사용 시</legend>
+        <EffectChoice mode="description" current={draft.mode} label="설명 변경" icon={<FileText className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'description' })} />
         <EffectChoice mode="reveal" current={draft.mode} label="정보 공개" icon={<Eye className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'reveal' })} />
         <EffectChoice mode="grant" current={draft.mode} label="새 단서 지급" icon={<Gift className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'grant' })} />
+        <EffectChoice mode="peek" current={draft.mode} label="단서 훔쳐보기" icon={<Search className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'peek' })} />
+        <EffectChoice mode="steal" current={draft.mode} label="단서 가져오기" icon={<Shuffle className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'steal' })} />
       </fieldset>
+
+      {draft.mode === 'description' && (
+        <div className="mt-4 space-y-2">
+          <label htmlFor="clue-runtime-description" className="text-sm font-semibold text-slate-200">
+            사용 후 바뀔 설명
+          </label>
+          <textarea
+            id="clue-runtime-description"
+            value={draft.descriptionText}
+            onChange={(e) => updateDraft({ descriptionText: e.target.value })}
+            rows={4}
+            placeholder="예: 열쇠를 돌리자 손잡이 안쪽의 새 문장이 드러난다."
+            className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-600 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          />
+        </div>
+      )}
 
       {draft.mode === 'reveal' && (
         <div className="mt-4 space-y-2">
@@ -269,57 +293,21 @@ export function ClueRuntimeEffectCard({
         />
       )}
 
-      {draft.mode !== 'none' && (
-        <label className="mt-4 flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-sm text-slate-300">
-          <input
-            type="checkbox"
-            checked={draft.consume}
-            onChange={(e) => updateDraft({ consume: e.target.checked })}
-            className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
-          />
-          <span>
-            <span className="font-semibold text-slate-200">사용하면 내 단서함에서 사라짐</span>
-            <span className="mt-1 block text-xs leading-5 text-slate-500">
-              일회용 열쇠처럼 효과를 발동한 뒤 보유 단서에서 제거할 때 켭니다.
-            </span>
+      <label className="mt-4 flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-sm text-slate-300">
+        <input
+          type="checkbox"
+          checked={draft.consume}
+          onChange={(e) => updateDraft({ consume: e.target.checked })}
+          className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-800 text-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        />
+        <span>
+          <span className="font-semibold text-slate-200">사용하면 내 단서함에서 사라짐</span>
+          <span className="mt-1 block text-xs leading-5 text-slate-500">
+            일회용 열쇠처럼 효과를 발동한 뒤 보유 단서에서 제거할 때 켭니다.
           </span>
-        </label>
-      )}
+        </span>
+      </label>
     </section>
-  );
-}
-
-function RuleGroup({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <fieldset className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
-      <legend className="px-1 text-sm font-semibold text-slate-200">{label}</legend>
-      <div className="mt-2 grid gap-2 sm:grid-cols-2">{children}</div>
-    </fieldset>
-  );
-}
-
-function RuleChoice({
-  selected,
-  label,
-  onSelect,
-}: {
-  selected: boolean;
-  label: string;
-  onSelect: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-pressed={selected}
-      className={`min-h-10 rounded-lg border px-3 py-2 text-sm font-semibold ${
-        selected
-          ? 'border-amber-500/70 bg-amber-500/10 text-amber-200'
-          : 'border-slate-800 bg-slate-950/70 text-slate-300 hover:border-slate-700'
-      }`}
-    >
-      {label}
-    </button>
   );
 }
 

--- a/apps/web/src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts
@@ -40,7 +40,7 @@ describe('clueEntityAdapter', () => {
       description: '잠긴 상자를 열 수 있다.',
       publicScopeLabel: '지정된 캐릭터나 장소에서만 획득',
       roundLabel: 'R2~4',
-      useEffectLabel: '다른 플레이어에게서 단서 가져오기',
+      useEffectLabel: '단서 가져오기',
       consumeLabel: '사용하면 내 단서함에서 사라짐',
       badges: ['사용 가능', '연결 3'],
     });
@@ -61,6 +61,7 @@ describe('clueEntityAdapter', () => {
 
   it('효과별 권장 대상 선택 방식을 제공한다', () => {
     expect(getClueUseEffectOption('peek')).toMatchObject({ target: 'player', requiresTargetSelection: true });
+    expect(getClueUseEffectOption('description_change')).toMatchObject({ target: 'self', requiresTargetSelection: false });
     expect(getClueUseEffectOption('reveal')).toMatchObject({ target: 'self', requiresTargetSelection: false });
     expect(getClueUseEffectOption('unknown')).toBeNull();
   });
@@ -93,6 +94,6 @@ describe('clueEntityAdapter', () => {
   });
 
   it('목록 배지는 공개/사용/연결 상태만 제작자 언어로 표시한다', () => {
-    expect(buildClueBadges(clue({ is_common: true }), 0)).toEqual(['모두에게 공개', '사용 가능', '미배치']);
+    expect(buildClueBadges(clue({ is_common: true }), 0)).toEqual(['전체 공개', '사용 가능', '미배치']);
   });
 });

--- a/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/clue/clueEntityAdapter.ts
@@ -1,7 +1,7 @@
 import type { ClueResponse, CreateClueRequest, UpdateClueRequest } from '@/features/editor/api/types';
 import { formatRoundRange } from '@/features/editor/utils/roundFormat';
 
-export type ClueUseEffect = 'peek' | 'steal' | 'reveal' | 'block' | 'swap';
+export type ClueUseEffect = 'description_change' | 'peek' | 'steal' | 'reveal' | 'block' | 'swap';
 export type ClueUseTarget = 'player' | 'clue' | 'self';
 
 export interface ClueUseEffectOption {
@@ -28,17 +28,24 @@ export interface ClueEditorViewModel {
 
 export const clueUseEffectOptions: ClueUseEffectOption[] = [
   {
+    value: 'description_change',
+    target: 'self',
+    label: '설명 변경',
+    description: '사용 후 단서 설명을 새 내용으로 바꿉니다.',
+    requiresTargetSelection: false,
+  },
+  {
     value: 'peek',
     target: 'player',
-    label: '다른 플레이어 단서 보기',
-    description: '사용자가 선택한 플레이어의 보유 단서 목록을 확인합니다.',
+    label: '단서 훔쳐보기',
+    description: '대상 플레이어의 보호되지 않은 보유 단서를 확인합니다.',
     requiresTargetSelection: true,
   },
   {
     value: 'steal',
     target: 'player',
-    label: '다른 플레이어에게서 단서 가져오기',
-    description: '대상 플레이어의 단서 하나를 가져오는 효과입니다. 실제 양도 기능은 후속 엔진에서 분리합니다.',
+    label: '단서 가져오기',
+    description: '대상 플레이어의 보호되지 않은 단서 하나를 가져옵니다.',
     requiresTargetSelection: true,
   },
   {
@@ -81,7 +88,7 @@ export function toClueEditorViewModel(clue: ClueResponse, referenceCount = 0): C
     description: clue.description?.trim() || '플레이어에게 보일 단서 설명을 입력하세요.',
     imageUrl: clue.image_url ?? null,
     imageMediaId: clue.image_media_id ?? null,
-    publicScopeLabel: clue.is_common ? '모든 플레이어가 공유' : '지정된 캐릭터나 장소에서만 획득',
+    publicScopeLabel: clue.is_common ? '전체 공개' : '지정된 캐릭터나 장소에서만 획득',
     roundLabel: formatRoundRange(clue.reveal_round, clue.hide_round) || '처음부터 끝까지',
     useEffectLabel: effect?.label ?? '사용 효과 없음',
     useEffectDescription: effect?.description ?? '플레이어가 이 단서를 눌러 실행하는 효과가 없습니다.',
@@ -92,7 +99,7 @@ export function toClueEditorViewModel(clue: ClueResponse, referenceCount = 0): C
 
 export function buildClueBadges(clue: ClueResponse, referenceCount: number): string[] {
   return [
-    clue.is_common ? '모두에게 공개' : null,
+    clue.is_common ? '전체 공개' : null,
     clue.is_usable ? '사용 가능' : null,
     referenceCount > 0 ? `연결 ${referenceCount}` : '미배치',
   ].filter((badge): badge is string => Boolean(badge));

--- a/apps/web/src/features/editor/utils/__tests__/configClueCleanup.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configClueCleanup.test.ts
@@ -65,4 +65,34 @@ describe('removeClueReferencesFromConfig', () => {
       combination: { enabled: true, config: { recipes: [{ required: ['clue-3'] }] } },
     });
   });
+
+  it('removes deleted clue policy map entries keyed by clue id', () => {
+    const next = removeClueReferencesFromConfig(
+      {
+        modules: {
+          clue_interaction: {
+            enabled: true,
+            config: {
+              cluePolicies: {
+                'clue-1': { revealable: false, protected: true },
+                'clue-2': { revealable: true, protected: false },
+              },
+            },
+          },
+        },
+      },
+      'clue-1'
+    );
+
+    expect(next.modules).toMatchObject({
+      clue_interaction: {
+        config: {
+          cluePolicies: {
+            'clue-2': { revealable: true, protected: false },
+          },
+        },
+      },
+    });
+    expect(next.modules.clue_interaction.config.cluePolicies).not.toHaveProperty('clue-1');
+  });
 });

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeConfigForSave,
   readClueItemEffect,
   readClueItemEffects,
+  readCluePolicy,
   readCharacterStartingClueMap,
   readLocationDiscoveries,
   readCluePlacement,
@@ -11,6 +12,7 @@ import {
   readModuleConfig,
   writeCharacterStartingClueMap,
   writeClueItemEffect,
+  writeCluePolicy,
   writeLocationDiscoveries,
   writeCluePlacement,
   writeLocationClueIds,
@@ -299,6 +301,11 @@ describe('configShape', () => {
                 revealText: '숫자 0427이 보입니다.',
                 consume: true,
               },
+              'clue-3': {
+                effect: 'description_change',
+                target: 'self',
+                descriptionText: '새 설명',
+              },
               'clue-2': { effect: 'unknown', revealText: '무시' },
             },
           },
@@ -313,6 +320,11 @@ describe('configShape', () => {
         target: 'self',
         revealText: '숫자 0427이 보입니다.',
         consume: true,
+      },
+      'clue-3': {
+        effect: 'description_change',
+        target: 'self',
+        descriptionText: '새 설명',
       },
     });
     expect(effects).not.toHaveProperty('root-decoy');
@@ -378,5 +390,20 @@ describe('configShape', () => {
     expect(readClueItemEffect(next, 'missing-clue')).toBeNull();
     expect(readModuleConfig(next, 'clue_interaction')).toEqual({});
     expect(readModuleConfig(next, 'timer')).toEqual({ seconds: 30 });
+  });
+
+  it('writes clue visibility and protection policy in clue interaction config', () => {
+    const next = writeCluePolicy({}, 'clue-1', { revealable: false, protected: true });
+
+    expect(readCluePolicy(next, 'clue-1')).toEqual({
+      revealable: false,
+      protected: true,
+    });
+    expect(readModuleConfig(next, 'clue_interaction')).toMatchObject({
+      cluePolicies: {
+        'clue-1': { revealable: false, protected: true },
+      },
+    });
+    expect(readCluePolicy(next, 'missing')).toEqual({ revealable: true, protected: false });
   });
 });

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -24,19 +24,26 @@ export interface LocationDiscoveryConfig extends EditorConfig {
   oncePerPlayer: boolean;
 }
 
-export type ClueItemEffectKind = 'peek' | 'reveal' | 'grant_clue';
+export type ClueItemEffectKind = 'description_change' | 'peek' | 'steal' | 'reveal' | 'grant_clue';
 
 export interface ClueItemEffectConfig extends EditorConfig {
   effect: ClueItemEffectKind;
   target?: 'player' | 'self';
   consume?: boolean;
+  descriptionText?: string;
   revealText?: string;
   grantClueIds?: string[];
+}
+
+export interface CluePolicyConfig extends EditorConfig {
+  revealable: boolean;
+  protected: boolean;
 }
 
 const LEGACY_KEYS = ['module_configs', 'clue_placement', 'character_clues'] as const;
 const CLUE_INTERACTION_MODULE_ID = 'clue_interaction';
 const CLUE_ITEM_EFFECTS_KEY = 'itemEffects';
+const CLUE_POLICIES_KEY = 'cluePolicies';
 const LOCATION_MODULE_ID = 'location';
 const LOCATION_DISCOVERIES_KEY = 'discoveries';
 
@@ -63,10 +70,17 @@ function readClueItemEffectConfig(value: unknown): ClueItemEffectConfig | null {
   if (!isRecord(value)) return null;
 
   const effect = value.effect;
-  if (effect !== 'peek' && effect !== 'reveal' && effect !== 'grant_clue') return null;
+  if (
+    effect !== 'description_change' &&
+    effect !== 'peek' &&
+    effect !== 'steal' &&
+    effect !== 'reveal' &&
+    effect !== 'grant_clue'
+  ) return null;
 
   const target = value.target === 'player' || value.target === 'self' ? value.target : undefined;
   const consume = typeof value.consume === 'boolean' ? value.consume : undefined;
+  const descriptionText = typeof value.descriptionText === 'string' ? value.descriptionText : undefined;
   const revealText = typeof value.revealText === 'string' ? value.revealText : undefined;
   const grantClueIds = stringList(value.grantClueIds);
 
@@ -75,6 +89,7 @@ function readClueItemEffectConfig(value: unknown): ClueItemEffectConfig | null {
     effect,
     ...(target ? { target } : {}),
     ...(consume !== undefined ? { consume } : {}),
+    ...(descriptionText !== undefined ? { descriptionText } : {}),
     ...(revealText !== undefined ? { revealText } : {}),
     ...(grantClueIds.length > 0 ? { grantClueIds } : {}),
   };
@@ -94,9 +109,27 @@ function stripKnownClueEffectFields(value: unknown): EditorConfig {
   delete next.effect;
   delete next.target;
   delete next.consume;
+  delete next.descriptionText;
   delete next.revealText;
   delete next.grantClueIds;
   return next;
+}
+
+function readRawCluePolicies(
+  configJson: EditorConfig | null | undefined
+): Record<string, unknown> {
+  const moduleConfig = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
+  const rawPolicies = moduleConfig[CLUE_POLICIES_KEY];
+  return isRecord(rawPolicies) ? { ...rawPolicies } : {};
+}
+
+function readCluePolicyConfig(value: unknown): CluePolicyConfig | null {
+  if (!isRecord(value)) return null;
+  return {
+    ...value,
+    revealable: value.revealable !== false,
+    protected: value.protected === true,
+  };
 }
 
 function readLegacyModuleConfigs(configJson: EditorConfig | null | undefined) {
@@ -270,6 +303,35 @@ export function writeClueItemEffect(
   return writeModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID, {
     ...current,
     [CLUE_ITEM_EFFECTS_KEY]: itemEffects,
+  });
+}
+
+export function readCluePolicy(
+  configJson: EditorConfig | null | undefined,
+  clueId: string
+): CluePolicyConfig {
+  return readCluePolicyConfig(readRawCluePolicies(configJson)[clueId]) ?? {
+    revealable: true,
+    protected: false,
+  };
+}
+
+export function writeCluePolicy(
+  configJson: EditorConfig | null | undefined,
+  clueId: string,
+  policy: CluePolicyConfig
+): EditorConfig {
+  const current = readModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID);
+  const cluePolicies = readRawCluePolicies(configJson);
+  cluePolicies[clueId] = {
+    ...(isRecord(cluePolicies[clueId]) ? cluePolicies[clueId] as EditorConfig : {}),
+    revealable: policy.revealable,
+    protected: policy.protected,
+  };
+
+  return writeModuleConfig(configJson, CLUE_INTERACTION_MODULE_ID, {
+    ...current,
+    [CLUE_POLICIES_KEY]: cluePolicies,
   });
 }
 

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -647,5 +647,18 @@ export function removeClueReferencesFromConfig(
   clueId: string
 ): EditorConfig {
   const normalized = normalizeConfigForSave(configJson);
-  return removeClueIdFromValue(normalized, clueId) as EditorConfig;
+  const cleaned = removeClueIdFromValue(normalized, clueId) as EditorConfig;
+  const moduleConfig = readModuleConfig(cleaned, CLUE_INTERACTION_MODULE_ID);
+  const rawPolicies = moduleConfig[CLUE_POLICIES_KEY];
+  if (!isRecord(rawPolicies) || !hasOwnKey(rawPolicies, clueId)) return cleaned;
+
+  const cluePolicies = { ...rawPolicies };
+  delete cluePolicies[clueId];
+  const nextModuleConfig = { ...moduleConfig };
+  if (Object.keys(cluePolicies).length > 0) {
+    nextModuleConfig[CLUE_POLICIES_KEY] = cluePolicies;
+  } else {
+    delete nextModuleConfig[CLUE_POLICIES_KEY];
+  }
+  return writeModuleConfig(cleaned, CLUE_INTERACTION_MODULE_ID, nextModuleConfig);
 }

--- a/packages/shared/src/ws/types.generated.ts
+++ b/packages/shared/src/ws/types.generated.ts
@@ -7,7 +7,7 @@
 // Any hand edit will be overwritten by the next go generate run.
 // Phase 19 PR-1 (2026-04-18).
 //
-// Catalog: 135 events (active=130, stub=3, deprec=2) · 10 //wsgen:payload structs.
+// Catalog: 137 events (active=132, stub=3, deprec=2) · 10 //wsgen:payload structs.
 
 /* eslint-disable */
 /* prettier-ignore */
@@ -91,11 +91,15 @@ export const WsEventType = {
   /** S2C · clue */
   CLUE_ACQUIRED: "clue.acquired",
   /** S2C · clue */
+  CLUE_DESCRIPTION_CHANGED: "clue.description_changed",
+  /** S2C · clue */
   CLUE_ITEM_DECLARED: "clue.item_declared",
   /** S2C · clue */
   CLUE_ITEM_RESOLVED: "clue.item_resolved",
   /** S2C · clue */
   CLUE_PEEK_RESULT: "clue.peek_result",
+  /** S2C · clue */
+  CLUE_STEAL_RESULT: "clue.steal_result",
   /** C2S · clue */
   CLUE_SHOW_ACCEPT: "clue:show_accept",
   /** C2S · clue */
@@ -390,9 +394,11 @@ export const WsEventDirection: Readonly<Record<WsEventType, "c2s" | "s2c" | "bid
   "chat:typing_indicator": "s2c",
   "chat:whisper": "s2c",
   "clue.acquired": "s2c",
+  "clue.description_changed": "s2c",
   "clue.item_declared": "s2c",
   "clue.item_resolved": "s2c",
   "clue.peek_result": "s2c",
+  "clue.steal_result": "s2c",
   "clue:show_accept": "c2s",
   "clue:show_decline": "c2s",
   "clue:show_request": "c2s",
@@ -529,9 +535,11 @@ export const WsEventCategory: Readonly<Record<WsEventType, string>> = {
   "chat:typing_indicator": "chat",
   "chat:whisper": "chat",
   "clue.acquired": "clue",
+  "clue.description_changed": "clue",
   "clue.item_declared": "clue",
   "clue.item_resolved": "clue",
   "clue.peek_result": "clue",
+  "clue.steal_result": "clue",
   "clue:show_accept": "clue",
   "clue:show_decline": "clue",
   "clue:show_request": "clue",
@@ -668,9 +676,11 @@ export const WsEventStatus: Readonly<Record<WsEventType, "active" | "stub" | "de
   "chat:typing_indicator": "active",
   "chat:whisper": "active",
   "clue.acquired": "active",
+  "clue.description_changed": "active",
   "clue.item_declared": "active",
   "clue.item_resolved": "active",
   "clue.peek_result": "active",
+  "clue.steal_result": "active",
   "clue:show_accept": "active",
   "clue:show_decline": "active",
   "clue:show_request": "active",


### PR DESCRIPTION
## 요약
- 단서 기본 정보에서 `전체 공개`, `공개 가능`, `단서 보호`, 공개/숨김 시점을 제작자 언어로 정리했습니다.
- 단서 아이템 효과를 `설명 변경`, `정보 공개`, `새 단서 지급`, `단서 훔쳐보기`, `단서 가져오기`로 재구성하고 암호 입력 후 공개 흐름을 명확히 했습니다.
- backend clue runtime에 설명 변경/훔쳐보기 보호/단서 가져오기 처리를 연결하고 WebSocket S2C catalog/type을 갱신했습니다.

Closes #509
Refs #522
Refs #523

## Coverage Plan
- `ClueBasicInfoCard` / `ClueEntityWorkspace`: 공개 상태, 공개 가능, 단서 보호, 라운드 시점 저장 흐름을 component test로 검증합니다.
- `ClueRuntimeEffectCard`: 암호 필수 저장 guard, 설명 변경/공개/지급/훔쳐보기/가져오기 effect mapping을 component test로 검증합니다.
- `configShape` / `clueEntityAdapter`: clue policy와 item effect config read/write, 목록 badge/label mapping을 unit test로 검증합니다.
- `clue_interaction` / `clue_item_effects`: description_change, protected peek filtering, steal result/acquire publish를 Go unit test로 검증합니다.
- `service_config` / `ws`: editor config validation과 S2C event catalog generation을 local-ci quick으로 검증합니다.

## Local validation
- `pnpm --dir apps/web test -- src/features/editor/components/__tests__/CluesTab.test.tsx src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/utils/__tests__/configShape.test.ts src/features/editor/entities/clue/__tests__/clueEntityAdapter.test.ts` passed: 5 files, 39 tests.
- `pnpm --dir apps/web typecheck` passed.
- `go test ./internal/module/core ./internal/domain/editor ./internal/ws` passed.
- `scripts/mmp-local-ci.sh quick` passed on final HEAD.

## Deferred / Follow-up
- 공개 시점 select를 실제 진행 플로우 데이터와 연결하는 작업은 #522로 분리했습니다.
- 단서 아이템의 살해 효과 runtime 책임 설계는 #523으로 분리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 단서별 공개/보호 정책(cluePolicies) 추가 및 편집 가능
  * 새로운 단서 효과 추가: 설명 변경(description_change), 절도(steal), 엿보기(peek)
  * 단서 설명 변경 시 설명 보존 및 이벤트 발행(clue.description_changed, clue.steal_result)

* **개선**
  * 구성 스키마 검증 강화(효과별 필수 필드·정책 불리언 검사·UUID 키 검사)
  * 보호된 단서는 조회/절도 결과에서 제외 및 구성 노출 차단
  * 에디터 UI: 정책 저장/편집, 비밀번호 기반 효과 모드 도입, 라운드 선택 드롭다운 전환

* **테스트**
  * 구성/효과/동시성 충돌 검증 테스트 확장 및 관련 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->