### PR TITLE
feat(editor): 결말 질문과 결과 관리 화면 분리

### DIFF
--- a/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Plus, Trash2, X } from "lucide-react";
 import type { Node } from "@xyflow/react";
 import type {
@@ -192,6 +192,15 @@ function EndingConditionModal({
   const [choice, setChoice] = useState(parsed?.choice ?? selectedQuestion?.choices[0] ?? "");
   const [aggregation, setAggregation] = useState<"threshold" | "winning">(parsed?.aggregation ?? "threshold");
   const [endingId, setEndingId] = useState(initialRow?.ending ?? draft.defaultEnding ?? endingNodes[0]?.id ?? "");
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" || event.key === "Esc") onClose();
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
 
   const preview = useMemo(() => {
     const questionText = selectedQuestion?.text.trim() || "질문";

--- a/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
@@ -1,10 +1,12 @@
-import { Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Plus, Trash2, X } from "lucide-react";
 import type { Node } from "@xyflow/react";
 import type {
   EndingBranchConfig,
+  EndingBranchMatrixRow,
   EndingBranchQuestion,
 } from "../../entities/ending/endingBranchAdapter";
-import { readChoiceCondition, updateMatrixCondition } from "../../entities/ending/endingBranchAdapter";
+import { createEndingBranchMatrixRow, readChoiceCondition, updateMatrixCondition } from "../../entities/ending/endingBranchAdapter";
 import type { FlowNodeData } from "../../flowTypes";
 
 interface EndingBranchOutcomeRulesProps {
@@ -13,7 +15,6 @@ interface EndingBranchOutcomeRulesProps {
   branchQuestions: EndingBranchQuestion[];
   canAddRule: boolean;
   onChange: (next: EndingBranchConfig) => void;
-  onAddRule: () => void;
 }
 
 function endingName(node: Node): string {
@@ -31,7 +32,6 @@ export function EndingBranchOutcomeRules({
   branchQuestions,
   canAddRule,
   onChange,
-  onAddRule,
 }: EndingBranchOutcomeRulesProps) {
   return (
     <div className="space-y-4">
@@ -42,7 +42,6 @@ export function EndingBranchOutcomeRules({
         branchQuestions={branchQuestions}
         canAddRule={canAddRule}
         onChange={onChange}
-        onAddRule={onAddRule}
       />
     </div>
   );
@@ -76,7 +75,21 @@ function DefaultEndingCard({ draft, endingNodes, onChange }: DefaultEndingCardPr
 
 type MatrixRulesCardProps = EndingBranchOutcomeRulesProps;
 
-function MatrixRulesCard({ draft, endingNodes, branchQuestions, canAddRule, onChange, onAddRule }: MatrixRulesCardProps) {
+function MatrixRulesCard({ draft, endingNodes, branchQuestions, canAddRule, onChange }: MatrixRulesCardProps) {
+  const [modalState, setModalState] = useState<{ mode: "create" | "edit"; rowIndex?: number } | null>(null);
+
+  const handleSaveRule = (row: EndingBranchMatrixRow) => {
+    if (modalState?.mode === "edit" && modalState.rowIndex !== undefined) {
+      onChange(reorderPriorities({
+        ...draft,
+        matrix: draft.matrix.map((item, index) => (index === modalState.rowIndex ? row : item)),
+      }));
+    } else {
+      onChange(reorderPriorities({ ...draft, matrix: [...draft.matrix, row] }));
+    }
+    setModalState(null);
+  };
+
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4">
       <div className="flex items-center justify-between gap-3">
@@ -84,8 +97,8 @@ function MatrixRulesCard({ draft, endingNodes, branchQuestions, canAddRule, onCh
           <h4 className="font-semibold text-slate-100">결말 규칙</h4>
           <p className="mt-1 text-xs leading-5 text-slate-400">위에서부터 먼저 맞는 규칙이 적용됩니다.</p>
         </div>
-        <button type="button" onClick={onAddRule} disabled={!canAddRule} className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-700 px-3 text-sm text-slate-100 hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50">
-          <Plus className="h-4 w-4" aria-hidden="true" /> 규칙 추가
+        <button type="button" onClick={() => setModalState({ mode: "create" })} disabled={!canAddRule} className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-700 px-3 text-sm text-slate-100 hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50">
+          <Plus className="h-4 w-4" aria-hidden="true" /> 조건 만들기
         </button>
       </div>
       <div className="mt-4 space-y-3">
@@ -99,9 +112,20 @@ function MatrixRulesCard({ draft, endingNodes, branchQuestions, canAddRule, onCh
             endingNodes={endingNodes}
             branchQuestions={branchQuestions}
             onChange={onChange}
+            onEdit={() => setModalState({ mode: "edit", rowIndex })}
           />
         ))}
       </div>
+      {modalState && (
+        <EndingConditionModal
+          draft={draft}
+          endingNodes={endingNodes}
+          branchQuestions={branchQuestions}
+          initialRow={modalState.mode === "edit" && modalState.rowIndex !== undefined ? draft.matrix[modalState.rowIndex] : null}
+          onClose={() => setModalState(null)}
+          onSave={handleSaveRule}
+        />
+      )}
     </div>
   );
 }
@@ -112,9 +136,10 @@ interface MatrixRuleRowProps {
   endingNodes: Node[];
   branchQuestions: EndingBranchQuestion[];
   onChange: (next: EndingBranchConfig) => void;
+  onEdit: () => void;
 }
 
-function MatrixRuleRow({ draft, rowIndex, endingNodes, branchQuestions, onChange }: MatrixRuleRowProps) {
+function MatrixRuleRow({ draft, rowIndex, endingNodes, branchQuestions, onChange, onEdit }: MatrixRuleRowProps) {
   const row = draft.matrix[rowIndex];
   const parsed = readChoiceCondition(row.condition);
   const selectedQuestion = parsed
@@ -124,112 +149,117 @@ function MatrixRuleRow({ draft, rowIndex, endingNodes, branchQuestions, onChange
     <article className="rounded-xl border border-slate-800 bg-slate-900/70 p-3">
       <div className="flex items-center justify-between gap-3">
         <p className="font-medium text-slate-100">규칙 {rowIndex + 1}</p>
-        <button type="button" onClick={() => onChange(reorderPriorities({ ...draft, matrix: draft.matrix.filter((_, index) => index !== rowIndex) }))} className="rounded-lg p-2 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200" aria-label={`규칙 ${rowIndex + 1} 삭제`}>
-          <Trash2 className="h-4 w-4" aria-hidden="true" />
-        </button>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={onEdit} className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-200 hover:bg-slate-800">
+            수정
+          </button>
+          <button type="button" onClick={() => onChange(reorderPriorities({ ...draft, matrix: draft.matrix.filter((_, index) => index !== rowIndex) }))} className="rounded-lg p-2 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200" aria-label={`규칙 ${rowIndex + 1} 삭제`}>
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
       </div>
-      <div className="mt-3 grid gap-3">
-        <QuestionSelect draft={draft} rowIndex={rowIndex} selectedQuestionId={parsed?.questionId ?? ""} branchQuestions={branchQuestions} onChange={onChange} />
-        <ChoiceSelect draft={draft} rowIndex={rowIndex} selectedQuestion={selectedQuestion} selectedChoice={parsed?.choice ?? ""} onChange={onChange} />
-        <AggregationSelect draft={draft} rowIndex={rowIndex} selectedQuestion={selectedQuestion} selectedChoice={parsed?.choice ?? ""} aggregation={parsed?.aggregation ?? "threshold"} onChange={onChange} />
-        <EndingSelect draft={draft} rowIndex={rowIndex} endingNodes={endingNodes} onChange={onChange} />
-      </div>
+      <p className="mt-3 rounded-xl border border-slate-800 bg-slate-950 p-3 text-sm leading-6 text-slate-300">
+        <span className="font-semibold text-slate-100">{selectedQuestion?.text || "질문 선택 필요"}</span>
+        {" 에서 "}
+        <span className="font-semibold text-amber-100">{parsed?.choice || "선택지 선택 필요"}</span>
+        {parsed?.aggregation === "winning" ? " 이 가장 많이 선택되면 " : " 이 기준 이상 선택되면 "}
+        <span className="font-semibold text-emerald-100">{endingName(endingNodes.find((node) => node.id === row.ending) ?? { id: "", type: "ending", position: { x: 0, y: 0 }, data: {} } as Node)}</span>
+        {" 결말을 보여줍니다."}
+      </p>
     </article>
   );
 }
 
-function QuestionSelect({ draft, rowIndex, selectedQuestionId, branchQuestions, onChange }: {
+function EndingConditionModal({
+  draft,
+  endingNodes,
+  branchQuestions,
+  initialRow,
+  onClose,
+  onSave,
+}: {
   draft: EndingBranchConfig;
-  rowIndex: number;
-  selectedQuestionId: string;
-  branchQuestions: EndingBranchQuestion[];
-  onChange: (next: EndingBranchConfig) => void;
-}) {
-  return (
-    <label className="block">
-      <span className="text-xs font-medium text-slate-400">어떤 질문에서</span>
-      <select value={selectedQuestionId} onChange={(event) => {
-        const question = branchQuestions.find((item) => item.id === event.target.value);
-        onChange({
-          ...draft,
-          matrix: draft.matrix.map((item, index) =>
-            index === rowIndex
-              ? (question ? updateMatrixCondition(item, question.id, "", "threshold") : { ...item, condition: {} })
-              : item,
-          ),
-        });
-      }} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
-        <option value="">질문 선택</option>
-        {branchQuestions.map((question) => <option key={question.id} value={question.id}>{question.text || "질문 내용 필요"}</option>)}
-      </select>
-    </label>
-  );
-}
-
-function AggregationSelect({ draft, rowIndex, selectedQuestion, selectedChoice, aggregation, onChange }: {
-  draft: EndingBranchConfig;
-  rowIndex: number;
-  selectedQuestion?: EndingBranchQuestion;
-  selectedChoice: string;
-  aggregation: "threshold" | "winning";
-  onChange: (next: EndingBranchConfig) => void;
-}) {
-  return (
-    <label className="block">
-      <span className="text-xs font-medium text-slate-400">어떤 기준이면</span>
-      <select
-        value={aggregation}
-        onChange={(event) =>
-          selectedQuestion && selectedChoice && onChange({
-            ...draft,
-            matrix: draft.matrix.map((item, index) =>
-              index === rowIndex
-                ? updateMatrixCondition(item, selectedQuestion.id, selectedChoice, event.target.value === "winning" ? "winning" : "threshold")
-                : item,
-            ),
-          })
-        }
-        disabled={!selectedQuestion || !selectedChoice}
-        className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        <option value="threshold">설정한 비율 이상 선택되면</option>
-        <option value="winning">가장 많이 선택되면</option>
-      </select>
-    </label>
-  );
-}
-
-function ChoiceSelect({ draft, rowIndex, selectedQuestion, selectedChoice, onChange }: {
-  draft: EndingBranchConfig;
-  rowIndex: number;
-  selectedQuestion?: EndingBranchQuestion;
-  selectedChoice: string;
-  onChange: (next: EndingBranchConfig) => void;
-}) {
-  return (
-    <label className="block">
-      <span className="text-xs font-medium text-slate-400">어떤 선택이면</span>
-      <select value={selectedChoice} onChange={(event) => selectedQuestion && event.target.value && onChange({ ...draft, matrix: draft.matrix.map((item, index) => index === rowIndex ? updateMatrixCondition(item, selectedQuestion.id, event.target.value) : item) })} disabled={!selectedQuestion} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100 disabled:cursor-not-allowed disabled:opacity-50">
-        <option value="">선택지 선택</option>
-        {selectedQuestion?.choices.map((choice) => <option key={choice} value={choice}>{choice}</option>)}
-      </select>
-    </label>
-  );
-}
-
-function EndingSelect({ draft, rowIndex, endingNodes, onChange }: {
-  draft: EndingBranchConfig;
-  rowIndex: number;
   endingNodes: Node[];
-  onChange: (next: EndingBranchConfig) => void;
+  branchQuestions: EndingBranchQuestion[];
+  initialRow: EndingBranchMatrixRow | null;
+  onClose: () => void;
+  onSave: (row: EndingBranchMatrixRow) => void;
 }) {
+  const parsed = initialRow ? readChoiceCondition(initialRow.condition) : null;
+  const firstQuestion = branchQuestions[0];
+  const [questionId, setQuestionId] = useState(parsed?.questionId ?? firstQuestion?.id ?? "");
+  const selectedQuestion = branchQuestions.find((question) => question.id === questionId);
+  const [choice, setChoice] = useState(parsed?.choice ?? selectedQuestion?.choices[0] ?? "");
+  const [aggregation, setAggregation] = useState<"threshold" | "winning">(parsed?.aggregation ?? "threshold");
+  const [endingId, setEndingId] = useState(initialRow?.ending ?? draft.defaultEnding ?? endingNodes[0]?.id ?? "");
+
+  const preview = useMemo(() => {
+    const questionText = selectedQuestion?.text.trim() || "질문";
+    const ending = endingName(endingNodes.find((node) => node.id === endingId) ?? { id: "", type: "ending", position: { x: 0, y: 0 }, data: {} } as Node);
+    return `${questionText}에서 '${choice || "선택지"}' 답변이 ${aggregation === "winning" ? "가장 많으면" : "설정 비율 이상이면"} '${ending}' 결말로 보냅니다.`;
+  }, [aggregation, choice, endingId, endingNodes, selectedQuestion]);
+
+  const handleQuestionChange = (nextQuestionId: string) => {
+    const nextQuestion = branchQuestions.find((question) => question.id === nextQuestionId);
+    setQuestionId(nextQuestionId);
+    setChoice(nextQuestion?.choices[0] ?? "");
+    setAggregation("threshold");
+  };
+
+  const handleSubmit = () => {
+    if (!selectedQuestion || !choice || !endingId) return;
+    const base = initialRow ?? createEndingBranchMatrixRow(draft, endingId);
+    onSave({
+      ...updateMatrixCondition(base, selectedQuestion.id, choice, aggregation),
+      ending: endingId,
+    });
+  };
+
   return (
-    <label className="block">
-      <span className="text-xs font-medium text-slate-400">보여줄 결말</span>
-      <select value={draft.matrix[rowIndex].ending} onChange={(event) => onChange({ ...draft, matrix: draft.matrix.map((item, index) => index === rowIndex ? { ...item, ending: event.target.value } : item) })} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
-        <option value="">결말 선택</option>
-        {endingNodes.map((node) => <option key={node.id} value={node.id}>{endingName(node)}</option>)}
-      </select>
-    </label>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-4" role="dialog" aria-modal="true" aria-label="조건 만들기">
+      <section className="w-full max-w-2xl rounded-2xl border border-slate-700 bg-slate-950 p-5 shadow-2xl">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-400">Condition</p>
+            <h3 className="mt-1 text-lg font-semibold text-slate-100">조건 만들기</h3>
+          </div>
+          <button type="button" onClick={onClose} className="rounded-lg p-2 text-slate-400 hover:bg-slate-800 hover:text-slate-100" aria-label="조건 만들기 닫기">
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="mt-5 grid gap-4">
+          <label className="block">
+            <span className="text-xs font-medium text-slate-400">질문</span>
+            <select value={questionId} onChange={(event) => handleQuestionChange(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
+              {branchQuestions.map((question) => <option key={question.id} value={question.id}>{question.text || "질문 내용 필요"}</option>)}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-slate-400">답변</span>
+            <select value={choice} onChange={(event) => setChoice(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
+              {(selectedQuestion?.choices ?? []).map((item) => <option key={item} value={item}>{item}</option>)}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-slate-400">집계 기준</span>
+            <select value={aggregation} onChange={(event) => setAggregation(event.target.value === "winning" ? "winning" : "threshold")} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
+              <option value="threshold">과반수 / 설정 비율 이상</option>
+              <option value="winning">가장 많이 선택</option>
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-slate-400">보여줄 결말</span>
+            <select value={endingId} onChange={(event) => setEndingId(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
+              {endingNodes.map((node) => <option key={node.id} value={node.id}>{endingName(node)}</option>)}
+            </select>
+          </label>
+          <p className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm leading-6 text-emerald-100">{preview}</p>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="min-h-11 rounded-xl border border-slate-700 px-4 text-sm text-slate-200 hover:bg-slate-800">취소</button>
+          <button type="button" onClick={handleSubmit} disabled={!selectedQuestion || !choice || !endingId} className="min-h-11 rounded-xl border border-amber-500/60 bg-amber-500/15 px-4 text-sm font-medium text-amber-100 hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-50">조건 저장</button>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingBranchQuestionList.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchQuestionList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import type { EditorCharacterResponse } from "@/features/editor/api";
 import { OptionList, type OptionItem } from "./InformationDeliveryOptionList";
@@ -26,76 +27,186 @@ export function EndingBranchQuestionList({
   onAddChoice,
   onRemoveChoice,
 }: EndingBranchQuestionListProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(questions[0]?.id ?? null);
+  const selectedQuestion = useMemo(
+    () => questions.find((question) => question.id === selectedId) ?? questions[0] ?? null,
+    [questions, selectedId],
+  );
+
+  useEffect(() => {
+    if (!selectedQuestion) {
+      setSelectedId(questions[0]?.id ?? null);
+    }
+  }, [questions, selectedQuestion]);
+
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h4 className="font-semibold text-slate-100">결말 질문</h4>
-          <p className="mt-1 text-xs leading-5 text-slate-400">플레이어에게 물어볼 질문과 선택지를 만듭니다.</p>
+          <h4 className="font-semibold text-slate-100">질문 관리</h4>
+          <p className="mt-1 text-xs leading-5 text-slate-400">공통 질문 풀을 만들고, 결말 규칙에 사용할 질문만 표시합니다.</p>
         </div>
         <button type="button" onClick={onAddQuestion} className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-700 px-3 text-sm text-slate-100 hover:bg-slate-800">
           <Plus className="h-4 w-4" aria-hidden="true" /> 질문 추가
         </button>
       </div>
 
-      <div className="mt-4 space-y-3">
+      <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(220px,320px)_minmax(0,1fr)]">
         {questions.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-slate-700 p-4 text-sm text-slate-400">아직 질문이 없습니다. 결말을 가를 질문을 추가해 주세요.</p>
-        ) : questions.map((question, questionIndex) => (
-          <article key={question.id} className="rounded-xl border border-slate-800 bg-slate-900/70 p-3">
-            <div className="flex items-start justify-between gap-3">
-              <p className="text-xs font-semibold text-slate-400">질문 {questionIndex + 1}</p>
-              <button type="button" onClick={() => onRemoveQuestion(question.id)} className="rounded-lg p-2 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200" aria-label={`질문 ${questionIndex + 1} 삭제`}>
-                <Trash2 className="h-4 w-4" aria-hidden="true" />
-              </button>
+          <p className="rounded-xl border border-dashed border-slate-700 p-4 text-sm text-slate-400 lg:col-span-2">아직 질문이 없습니다. 결말을 가를 질문을 추가해 주세요.</p>
+        ) : (
+          <>
+            <div className="space-y-2">
+              {questions.map((question, questionIndex) => (
+                <QuestionSummaryButton
+                  key={question.id}
+                  question={question}
+                  questionIndex={questionIndex}
+                  selected={selectedQuestion?.id === question.id}
+                  characters={characters}
+                  onSelect={() => setSelectedId(question.id)}
+                />
+              ))}
             </div>
-
-            <label className="mt-2 block">
-              <span className="text-xs font-medium text-slate-400">질문 내용</span>
-              <input
-                value={question.text}
-                aria-label={`질문 ${questionIndex + 1} 내용`}
-                onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, text: event.target.value }))}
-                className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+            {selectedQuestion && (
+              <QuestionDetail
+                question={selectedQuestion}
+                questionIndex={questions.findIndex((question) => question.id === selectedQuestion.id)}
+                characters={characters}
+                onRemoveQuestion={onRemoveQuestion}
+                onChangeQuestion={onChangeQuestion}
+                onChangeChoice={onChangeChoice}
+                onAddChoice={onAddChoice}
+                onRemoveChoice={onRemoveChoice}
               />
-            </label>
-
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              <label className="block">
-                <span className="text-xs font-medium text-slate-400">답변 방식</span>
-                <select value={question.type} onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, type: event.target.value === "multi" ? "multi" : "single" }))} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
-                  <option value="single">하나 선택</option>
-                  <option value="multi">복수 선택</option>
-                </select>
-              </label>
-              <label className="block">
-                <span className="text-xs font-medium text-slate-400">판정 방식</span>
-                <select value={question.impact} onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, impact: event.target.value === "score" ? "score" : "branch" }))} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
-                  <option value="branch">선택지별 결말 분기</option>
-                  <option value="score">선택지 점수 계산</option>
-                </select>
-              </label>
-            </div>
-
-            <QuestionTargetSelector
-              question={question}
-              questionIndex={questionIndex}
-              characters={characters}
-              onChangeQuestion={onChangeQuestion}
-            />
-
-            <ChoiceRows
-              question={question}
-              questionIndex={questionIndex}
-              onChangeChoice={onChangeChoice}
-              onAddChoice={onAddChoice}
-              onRemoveChoice={onRemoveChoice}
-              onChangeQuestion={onChangeQuestion}
-            />
-          </article>
-        ))}
+            )}
+          </>
+        )}
       </div>
     </div>
+  );
+}
+
+function hasScores(question: EndingBranchQuestion): boolean {
+  return Object.values(question.scoreMap ?? {}).some((score) => score !== 0);
+}
+
+function targetSummary(question: EndingBranchQuestion, characters: EditorCharacterResponse[]): string {
+  if (question.target.type === "all_players") return "모든 플레이어";
+  const names = question.target.characterIds.map((id) => characters.find((character) => character.id === id)?.name?.trim() || "삭제된 캐릭터");
+  return names.length > 0 ? names.join(", ") : "대상 필요";
+}
+
+function QuestionSummaryButton({
+  question,
+  questionIndex,
+  selected,
+  characters,
+  onSelect,
+}: {
+  question: EndingBranchQuestion;
+  questionIndex: number;
+  selected: boolean;
+  characters: EditorCharacterResponse[];
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`w-full rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-400/60 ${
+        selected ? "border-amber-500/70 bg-amber-500/10" : "border-slate-800 bg-slate-900/70 hover:border-slate-600"
+      }`}
+    >
+      <p className="text-xs font-semibold text-slate-400">Q{questionIndex + 1}</p>
+      <p className="mt-1 line-clamp-2 font-medium text-slate-100">{question.text || "질문 내용 필요"}</p>
+      <div className="mt-2 flex flex-wrap gap-1 text-[11px]">
+        <span className="rounded-full bg-slate-800 px-2 py-0.5 text-slate-300">{question.type === "multi" ? "복수 선택" : "하나 선택"}</span>
+        <span className="rounded-full bg-slate-800 px-2 py-0.5 text-slate-300">{targetSummary(question, characters)}</span>
+        {question.impact === "branch" && <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-amber-100">결말 규칙에서 사용</span>}
+        {hasScores(question) && <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-emerald-100">점수 있음</span>}
+      </div>
+    </button>
+  );
+}
+
+function QuestionDetail({
+  question,
+  questionIndex,
+  characters,
+  onRemoveQuestion,
+  onChangeQuestion,
+  onChangeChoice,
+  onAddChoice,
+  onRemoveChoice,
+}: {
+  question: EndingBranchQuestion;
+  questionIndex: number;
+  characters: EditorCharacterResponse[];
+  onRemoveQuestion: (questionId: string) => void;
+  onChangeQuestion: (questionId: string, updater: (question: EndingBranchQuestion) => EndingBranchQuestion) => void;
+  onChangeChoice: (questionId: string, choiceIndex: number, value: string) => void;
+  onAddChoice: (questionId: string) => void;
+  onRemoveChoice: (questionId: string, choice: string) => void;
+}) {
+  return (
+    <article className="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold text-slate-400">질문 {questionIndex + 1}</p>
+          <h5 className="mt-1 font-semibold text-slate-100">{question.text || "질문 내용 필요"}</h5>
+        </div>
+        <button type="button" onClick={() => onRemoveQuestion(question.id)} className="rounded-lg p-2 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200" aria-label={`질문 ${questionIndex + 1} 삭제`}>
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <label className="mt-4 block">
+        <span className="text-xs font-medium text-slate-400">질문 내용</span>
+        <input
+          value={question.text}
+          aria-label={`질문 ${questionIndex + 1} 내용`}
+          onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, text: event.target.value }))}
+          className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        />
+      </label>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="text-xs font-medium text-slate-400">답변 방식</span>
+          <select value={question.type} onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, type: event.target.value === "multi" ? "multi" : "single" }))} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+            <option value="single">하나 선택</option>
+            <option value="multi">복수 선택</option>
+          </select>
+        </label>
+        <label className="flex min-h-11 items-center gap-2 self-end rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+          <input
+            type="checkbox"
+            checked={question.impact === "branch"}
+            onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, impact: event.target.checked ? "branch" : "score" }))}
+            className="h-4 w-4 rounded border-slate-600 bg-slate-900 text-amber-500"
+          />
+          결말 규칙에서 사용
+        </label>
+      </div>
+
+      <QuestionTargetSelector
+        question={question}
+        questionIndex={questionIndex}
+        characters={characters}
+        onChangeQuestion={onChangeQuestion}
+      />
+
+      <ChoiceRows
+        question={question}
+        questionIndex={questionIndex}
+        onChangeChoice={onChangeChoice}
+        onAddChoice={onAddChoice}
+        onRemoveChoice={onRemoveChoice}
+        onChangeQuestion={onChangeQuestion}
+      />
+    </article>
   );
 }
 
@@ -197,15 +308,13 @@ function ChoiceRows({ question, questionIndex, onChangeChoice, onAddChoice, onRe
   return (
     <div className="mt-3 space-y-2">
       <div className="flex items-center justify-between gap-3">
-        <span className="text-xs font-medium text-slate-400">선택지</span>
+        <span className="text-xs font-medium text-slate-400">선택지 및 점수</span>
         <button type="button" onClick={() => onAddChoice(question.id)} className="text-xs font-medium text-amber-300 hover:text-amber-200">선택지 추가</button>
       </div>
       {question.choices.map((choice, choiceIndex) => (
         <div key={`${question.id}-${choiceIndex}`} className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_96px_40px]">
           <input value={choice} aria-label={`질문 ${questionIndex + 1} 선택지 ${choiceIndex + 1}`} onChange={(event) => onChangeChoice(question.id, choiceIndex, event.target.value)} className="min-h-10 rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100" />
-          {question.impact === "score" ? (
-            <input type="number" aria-label={`선택지 ${choiceIndex + 1} 점수`} value={question.scoreMap?.[choice] ?? 0} onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, scoreMap: { ...(item.scoreMap ?? {}), [choice]: Number(event.target.value) } }))} className="min-h-10 rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100" />
-          ) : <span className="hidden sm:block" />}
+          <input type="number" aria-label={`선택지 ${choiceIndex + 1} 점수`} value={question.scoreMap?.[choice] ?? 0} onChange={(event) => onChangeQuestion(question.id, (item) => ({ ...item, scoreMap: { ...(item.scoreMap ?? {}), [choice]: Number(event.target.value) } }))} className="min-h-10 rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100" />
           <button type="button" onClick={() => onRemoveChoice(question.id, choice)} className="min-h-10 rounded-xl border border-slate-800 text-slate-400 hover:border-rose-400/40 hover:text-rose-200" aria-label={`선택지 ${choiceIndex + 1} 삭제`}>×</button>
         </div>
       ))}

--- a/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
@@ -5,7 +5,6 @@ import type { Node } from "@xyflow/react";
 import type { EditorCharacterResponse, EditorThemeResponse } from "@/features/editor/api";
 import { useUpdateConfigJson } from "@/features/editor/editorConfigApi";
 import {
-  createEndingBranchMatrixRow,
   createEndingBranchQuestion,
   readChoiceCondition,
   readEndingBranchConfig,
@@ -22,6 +21,7 @@ interface EndingBranchRulesPanelProps {
   theme: EditorThemeResponse;
   endingNodes: Node[];
   characters: EditorCharacterResponse[];
+  section: "questions" | "endings";
 }
 
 function reorderPriorities(config: EndingBranchConfig): EndingBranchConfig {
@@ -71,7 +71,7 @@ function updateChoiceValues(
   return question.choices.map((choice, index) => (index === choiceIndex ? value : choice));
 }
 
-export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters }: EndingBranchRulesPanelProps) {
+export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters, section }: EndingBranchRulesPanelProps) {
   const updateConfig = useUpdateConfigJson(themeId);
   const serverConfig = useMemo(() => readEndingBranchConfig(theme.config_json), [theme.config_json]);
   const [draft, setDraft] = useState<EndingBranchConfig>(serverConfig);
@@ -161,7 +161,8 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
     <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300" aria-label="결말 판정 설정">
       <Header dirty={dirty} isPending={updateConfig.isPending} onSave={handleSave} />
       <Warnings warnings={viewModel.warnings} />
-      <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+      <div className="mt-5">
+        {section === "questions" ? (
         <EndingBranchQuestionList
           questions={draft.questions}
           characters={characters}
@@ -172,14 +173,15 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
           onAddChoice={(questionId) => applyDraft(updateQuestionAt(draft, questionId, (question) => ({ ...question, choices: [...question.choices, createUniqueChoiceLabel(question)] })))}
           onRemoveChoice={handleRemoveChoice}
         />
+        ) : (
         <EndingBranchOutcomeRules
           draft={draft}
           endingNodes={endingNodes}
           branchQuestions={branchQuestions}
           canAddRule={canAddRule}
           onChange={applyDraft}
-          onAddRule={() => applyDraft(reorderPriorities({ ...draft, matrix: [...draft.matrix, createEndingBranchMatrixRow(draft, draft.defaultEnding || endingNodes[0]?.id || "")] }))}
         />
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -13,13 +13,11 @@ import {
 import {
   endingVisibilityLabel,
   normalizeEndingVisibility,
-  type EndingCharacterEndcardSummary,
 } from "../../entities/ending/endingEntityAdapter";
 
 interface EndingEntityDetailProps {
   node: Node;
   themeId: string;
-  endcardSummary: EndingCharacterEndcardSummary;
   onChange: (nodeId: string, patch: Partial<FlowNodeData>) => void;
 }
 
@@ -28,7 +26,6 @@ const SAVE_DEBOUNCE_MS = 1000;
 export function EndingEntityDetail({
   node,
   themeId,
-  endcardSummary,
   onChange,
 }: EndingEntityDetailProps) {
   const fieldIdPrefix = useId();
@@ -82,9 +79,6 @@ export function EndingEntityDetail({
         <div className="mt-3 flex flex-wrap gap-2 text-xs">
           <span className="rounded-full border border-slate-800 bg-slate-900 px-3 py-1 text-slate-300">
             공개 범위: {endingVisibilityLabel(visibility)}
-          </span>
-          <span className="rounded-full border border-slate-800 bg-slate-900 px-3 py-1 text-slate-300">
-            캐릭터 결과 카드 {endcardSummary.readyCount}/{endcardSummary.totalCount}명 작성
           </span>
         </div>
       </div>
@@ -213,33 +207,6 @@ export function EndingEntityDetail({
           className="resize-y rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
         />
       </div>
-
-      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h4 className="text-sm font-semibold text-slate-100">캐릭터별 결과 카드 작성 현황</h4>
-            <p className="mt-1 text-xs leading-5 text-slate-400">
-              캐릭터별 결과 문구는 엔딩 관리 책임으로 이동합니다. 이곳에서는 기존 작성 현황과 누락된 캐릭터를 확인합니다.
-            </p>
-          </div>
-          <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-amber-100">
-            {endcardSummary.readyCount}/{endcardSummary.totalCount}
-          </span>
-        </div>
-        {endcardSummary.totalCount === 0 ? (
-          <p className="mt-3 rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-400">
-            등록된 등장인물이 없습니다.
-          </p>
-        ) : endcardSummary.missingNames.length === 0 ? (
-          <p className="mt-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-100">
-            모든 캐릭터의 결과 카드가 작성되었습니다.
-          </p>
-        ) : (
-          <p className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs leading-5 text-amber-100">
-            결과 카드가 비어 있는 캐릭터: {endcardSummary.missingNames.join(", ")}
-          </p>
-        )}
-      </section>
     </section>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -10,7 +10,6 @@ import { EndingEntityHeader } from './EndingEntityHeader';
 import { EndingBranchRulesPanel } from './EndingBranchRulesPanel';
 import {
   buildEndingDecisionSummary,
-  buildCharacterEndcardSummary,
   toEndingEditorViewModel,
 } from '../../entities/ending/endingEntityAdapter';
 import { getDisplayErrorMessage } from '@/lib/display-error';
@@ -23,6 +22,7 @@ interface EndingEntitySubTabProps {
 export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) {
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [section, setSection] = useState<'questions' | 'endings'>('questions');
   const { data: characters = [] } = useEditorCharacters(themeId);
   const {
     nodes,
@@ -52,7 +52,6 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
     filteredNodes.find((node) => node.id === selectedId) ?? filteredNodes[0] ?? null;
 
   const decisionSummary = useMemo(() => buildEndingDecisionSummary(nodes, edges), [nodes, edges]);
-  const endcardSummary = useMemo(() => buildCharacterEndcardSummary(characters), [characters]);
 
   const handleAddEnding = () => {
     addNode('ending', { x: 360 + endingNodes.length * 40, y: 220 });
@@ -98,9 +97,42 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
 
       <EndingDecisionSummaryPanel summary={decisionSummary} />
 
-      <EndingBranchRulesPanel themeId={themeId} theme={theme} endingNodes={endingNodes} characters={characters} />
+      <nav className="flex flex-wrap gap-2" aria-label="결말 편집 섹션">
+        <button
+          type="button"
+          onClick={() => setSection('questions')}
+          aria-pressed={section === 'questions'}
+          className={`min-h-11 rounded-xl border px-4 text-sm font-medium transition ${
+            section === 'questions'
+              ? 'border-amber-500/70 bg-amber-500/15 text-amber-100'
+              : 'border-slate-800 bg-slate-900 text-slate-300 hover:border-slate-600'
+          }`}
+        >
+          질문 관리
+        </button>
+        <button
+          type="button"
+          onClick={() => setSection('endings')}
+          aria-pressed={section === 'endings'}
+          className={`min-h-11 rounded-xl border px-4 text-sm font-medium transition ${
+            section === 'endings'
+              ? 'border-amber-500/70 bg-amber-500/15 text-amber-100'
+              : 'border-slate-800 bg-slate-900 text-slate-300 hover:border-slate-600'
+          }`}
+        >
+          결말 관리
+        </button>
+      </nav>
 
-      {endingNodes.length === 0 ? (
+      <EndingBranchRulesPanel
+        themeId={themeId}
+        theme={theme}
+        endingNodes={endingNodes}
+        characters={characters}
+        section={section}
+      />
+
+      {section !== 'endings' ? null : endingNodes.length === 0 ? (
         <EndingEmptyState />
       ) : (
         <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(260px,360px)_minmax(0,1fr)]">
@@ -167,7 +199,6 @@ export function EndingEntitySubTab({ themeId, theme }: EndingEntitySubTabProps) 
             <EndingEntityDetail
               node={selectedNode}
               themeId={themeId}
-              endcardSummary={endcardSummary}
               onChange={updateNodeData}
             />
           )}

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -48,6 +48,15 @@ function renderWithClient(ui: ReactNode) {
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
 }
 
+function openEndingManagement() {
+  fireEvent.click(screen.getByRole("button", { name: "결말 관리" }));
+}
+
+function clickLastButton(name: RegExp) {
+  const buttons = screen.getAllByRole("button", { name });
+  fireEvent.click(buttons[buttons.length - 1]);
+}
+
 
 const theme = {
   id: "theme-1",
@@ -162,6 +171,7 @@ afterEach(() => {
 describe("EndingEntitySubTab", () => {
   it("Flow의 ending 노드만 결말 목록에 표시한다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+    openEndingManagement();
 
     expect(screen.getByText("결말 목록")).toBeDefined();
     expect(screen.getAllByText("진실").length).toBeGreaterThan(0);
@@ -169,8 +179,7 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getByLabelText("결말 판정 준비")).toBeDefined();
     expect(screen.getByText("본문 작성")).toBeDefined();
     expect(screen.getAllByText("참가자에게만 공개").length).toBeGreaterThan(0);
-    expect(screen.getByText("캐릭터 결과 카드 1/2명 작성")).toBeDefined();
-    expect(screen.getByText("결과 카드가 비어 있는 캐릭터: 민재")).toBeDefined();
+    expect(screen.queryByText("캐릭터 결과 카드 1/2명 작성")).toBeNull();
     expect(screen.queryByText("1막")).toBeNull();
   });
 
@@ -187,6 +196,7 @@ describe("EndingEntitySubTab", () => {
     });
 
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+    openEndingManagement();
 
     expect(screen.getByText("아직 결말이 없습니다")).toBeDefined();
     expect(screen.getByText(/Flow에서 결말 노드를 추가하면/)).toBeDefined();
@@ -227,6 +237,7 @@ describe("EndingEntitySubTab", () => {
 
   it("검색어로 결말 목록을 좁힌다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+    openEndingManagement();
 
     fireEvent.change(screen.getByPlaceholderText("결말 검색"), { target: { value: "오판" } });
 
@@ -237,6 +248,7 @@ describe("EndingEntitySubTab", () => {
 
   it("상세 입력을 변경하면 선택한 결말 노드 데이터만 갱신한다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+    openEndingManagement();
 
     fireEvent.change(screen.getByLabelText("결말 이름"), { target: { value: "자비" } });
 
@@ -251,6 +263,7 @@ describe("EndingEntitySubTab", () => {
 
   it("결말 본문, 공개 범위, 스포일러 안내, 감상 공유 문구를 저장 payload로 보낸다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+    openEndingManagement();
 
     fireEvent.change(screen.getByLabelText("결말 본문"), {
       target: { value: "진실은 모두에게 남았다." },
@@ -313,8 +326,8 @@ describe("EndingEntitySubTab", () => {
   it("결말 질문 대상을 특정 플레이어 여러 명으로 저장한다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /하윤/ }));
-    fireEvent.click(screen.getByRole("button", { name: /민재/ }));
+    clickLastButton(/하윤/);
+    clickLastButton(/민재/);
     fireEvent.click(screen.getByRole("button", { name: "판정 설정 저장" }));
 
     expect(configMutateMock).toHaveBeenCalledWith(
@@ -339,8 +352,8 @@ describe("EndingEntitySubTab", () => {
   it("특정 플레이어 질문에서 대상이 비면 저장하지 않고 경고한다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /하윤/ }));
-    fireEvent.click(screen.getByRole("button", { name: /하윤/ }));
+    clickLastButton(/하윤/);
+    clickLastButton(/하윤/);
     fireEvent.click(screen.getByRole("button", { name: "판정 설정 저장" }));
 
     expect(configMutateMock).not.toHaveBeenCalled();
@@ -376,7 +389,7 @@ describe("EndingEntitySubTab", () => {
       />,
     );
 
-    expect(screen.getByText("삭제된 캐릭터")).toBeDefined();
+    expect(screen.getAllByText("삭제된 캐릭터").length).toBeGreaterThan(0);
   });
 
   it("결말 선택지는 같은 질문 안에서 중복 저장되지 않는다", () => {
@@ -405,8 +418,11 @@ describe("EndingEntitySubTab", () => {
 
   it("가장 많이 선택된 답 기준 결말 규칙을 저장한다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+    openEndingManagement();
 
-    fireEvent.change(screen.getByLabelText("어떤 기준이면"), { target: { value: "winning" } });
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("집계 기준"), { target: { value: "winning" } });
+    fireEvent.click(screen.getByRole("button", { name: "조건 저장" }));
     fireEvent.click(screen.getByRole("button", { name: "판정 설정 저장" }));
 
     expect(configMutateMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## 요약

- `결말` 엔티티 화면을 Figma 기준에 맞춰 `질문 관리`와 `결말 관리` 탭으로 분리했습니다.
- 질문 목록은 좌측 리스트 + 우측 상세 구조로 재구성하고, 결말 규칙에서 사용할지와 선택지 점수를 같은 화면에서 조정하게 했습니다.
- 결말 조건은 행 내부 select 나열 대신 `조건 만들기` 모달로 작성/수정하도록 정리했습니다.

## Figma 기준

- Figma file: `CErokaT60ctx8X0XhoO4bX`
- 확인 노드: `23:2` 질문 관리 - 통합/Desktop, `23:104` 조건 만들기 모달 - 단일 답, `23:149` 조건 만들기 모달 - 복수 답

## Coverage Plan

- `EndingEntitySubTab.tsx`: 질문 관리/결말 관리 탭 분기와 기본 진입 상태를 `EndingEntitySubTab.test.tsx`로 검증했습니다.
- `EndingBranchQuestionList.tsx`: 질문 카드, 상세 편집, 대상 요약, 점수 입력, 결말 규칙 포함 checkbox를 `EndingEntitySubTab.test.tsx`로 검증했습니다.
- `EndingBranchOutcomeRules.tsx`: 조건 만들기 모달 열기, 조건 저장, 기존 조건 수정 흐름을 `EndingEntitySubTab.test.tsx`로 검증했습니다.
- `endingBranchAdapter`: 기존 저장 shape 호환은 `endingBranchAdapter.test.ts`로 함께 확인했습니다.

## Local validation

- `pnpm --dir apps/web test -- src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts` 통과
- `pnpm --dir apps/web typecheck` 통과
- `scripts/mmp-local-ci.sh quick` 통과

## Deferred / Follow-up

- 복수 답변 조건의 all/any runtime 확장은 이번 UI 정리와 분리했습니다. Refs #525

Closes #510
Refs #525


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선 사항

* **New Features**
  * 끝내기 조건 편집을 위한 모달 워크플로우 추가(조건 생성/수정).

* **Refactor**
  * 질문 관리와 조건 관리를 탭(섹션)으로 분리한 탭 기반 UI 도입.
  * 질문 관리 UI를 마스터-디테일 레이아웃으로 재구성.
  * 일부 불필요한 인라인 편집/상태 출력 제거로 인터페이스 단순화.
  * 컴포넌트 props/시그니처 일부 정리(내부 상태로 이동).

* **Tests**
  * 끝내기 관리 관련 테스트 업데이트 및 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->