### PR TITLE
feat(editor): 장소 관리 IA 재구성

### DIFF
--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import { Info, MapPin, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import type { EditorThemeResponse, MapResponse, LocationResponse } from '@/features/editor/api';
@@ -6,7 +6,11 @@ import { useUpdateConfigJson, useUpdateLocation } from '@/features/editor/api';
 import { EntityTriggerPlacementCard } from '@/features/editor/components/triggers/EntityTriggerPlacementCard';
 import { readLocationClueIds } from '@/features/editor/editorTypes';
 import type { EditorConfig } from '@/features/editor/utils/configShape';
-import { toLocationEditorViewModel } from '@/features/editor/entities/location/locationEntityAdapter';
+import {
+  buildLocationParentOptions,
+  toLocationEditorViewModel,
+} from '@/features/editor/entities/location/locationEntityAdapter';
+import { readLocationMeta, writeLocationMeta } from '@/features/editor/utils/entityMeta';
 import { AddNameInput } from './AddNameInput';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import { LocationAccessPolicyPanel } from './LocationAccessPolicyPanel';
@@ -40,8 +44,11 @@ function roundToInput(value: number | null | undefined) {
   return value == null ? '' : String(value);
 }
 
-function getPathLabel(map: MapResponse, location: LocationResponse) {
-  return `${map.name} / ${location.name}`;
+interface LocationBasicDraft {
+  name: string;
+  publicDescription: string;
+  entryMessage: string;
+  parentLocationId: string;
 }
 
 export function LocationDetailPanel({
@@ -115,6 +122,7 @@ export function LocationDetailPanel({
           theme={theme}
           map={selectedMap}
           location={location}
+          mapLocations={mapLocations}
         />
       )}
     />
@@ -125,16 +133,38 @@ function SelectedLocationDetail({
   theme,
   map,
   location,
+  mapLocations,
 }: {
   themeId: string;
   theme: EditorThemeResponse;
   map: MapResponse;
   location: LocationResponse;
+  mapLocations: LocationResponse[];
 }) {
   const updateLocation = useUpdateLocation(themeId);
   const updateConfig = useUpdateConfigJson(themeId);
   const [fromRoundInput, setFromRoundInput] = useState(roundToInput(location.from_round));
   const [untilRoundInput, setUntilRoundInput] = useState(roundToInput(location.until_round));
+  const [visibilityMode, setVisibilityMode] = useState<VisibilityMode>(
+    getVisibilityMode(roundToInput(location.from_round), roundToInput(location.until_round))
+  );
+  const locationMeta = useMemo(
+    () => readLocationMeta(theme.config_json, location.id),
+    [theme.config_json, location.id]
+  );
+  const locationMetaById = useMemo(
+    () =>
+      Object.fromEntries(
+        mapLocations.map((item) => [item.id, readLocationMeta(theme.config_json, item.id)])
+      ),
+    [mapLocations, theme.config_json]
+  );
+  const [basicDraft, setBasicDraft] = useState({
+    name: location.name,
+    publicDescription: locationMeta.publicDescription ?? '',
+    entryMessage: locationMeta.entryMessage ?? '',
+    parentLocationId: locationMeta.parentLocationId ?? '',
+  });
   const assignedCount = useMemo(
     () => readLocationClueIds(theme.config_json, location.id).length,
     [theme.config_json, location.id]
@@ -142,12 +172,27 @@ function SelectedLocationDetail({
   const viewModel = toLocationEditorViewModel(location, {
     clueCount: assignedCount,
     mapName: map.name,
+    locationMeta,
+    allLocations: mapLocations,
   });
+  const parentOptions = useMemo(
+    () => buildLocationParentOptions(location.id, mapLocations, locationMetaById),
+    [location.id, locationMetaById, mapLocations]
+  );
 
   useEffect(() => {
     setFromRoundInput(roundToInput(location.from_round));
     setUntilRoundInput(roundToInput(location.until_round));
-  }, [location.id, location.from_round, location.until_round]);
+    setVisibilityMode(
+      getVisibilityMode(roundToInput(location.from_round), roundToInput(location.until_round))
+    );
+    setBasicDraft({
+      name: location.name,
+      publicDescription: locationMeta.publicDescription ?? '',
+      entryMessage: locationMeta.entryMessage ?? '',
+      parentLocationId: locationMeta.parentLocationId ?? '',
+    });
+  }, [location.id, location.name, location.from_round, location.until_round, locationMeta]);
 
   function saveLocation(patch: Partial<LocationResponse>) {
     const currentFrom = parseRound(fromRoundInput);
@@ -199,6 +244,28 @@ function SelectedLocationDetail({
     });
   }
 
+  function saveBasicInfo() {
+    const nextName = basicDraft.name.trim();
+    if (!nextName) {
+      toast.error('장소 이름을 입력해 주세요');
+      return;
+    }
+
+    const nextParentId = basicDraft.parentLocationId || null;
+    saveLocation({ name: nextName });
+    updateConfig.mutate(
+      writeLocationMeta(theme.config_json, location.id, {
+        publicDescription: basicDraft.publicDescription.trim(),
+        entryMessage: basicDraft.entryMessage.trim(),
+        parentLocationId: nextParentId,
+      }),
+      {
+        onSuccess: () => toast.success('장소 기본 정보가 저장되었습니다'),
+        onError: () => toast.error('장소 기본 정보 저장에 실패했습니다'),
+      }
+    );
+  }
+
   return (
     <div className="space-y-4">
       <section className="rounded-lg border border-slate-800 bg-slate-950/70 p-4">
@@ -208,7 +275,12 @@ function SelectedLocationDetail({
               장소 상세
             </p>
             <h3 className="mt-1 text-xl font-semibold text-slate-100">{viewModel.name}</h3>
-            <p className="mt-1 text-xs text-slate-500">트리 경로: {getPathLabel(map, location)}</p>
+            <p className="mt-1 text-xs text-slate-500">
+              트리 경로: {map.name} /{' '}
+              {viewModel.parentLabel === '최상위 장소'
+                ? location.name
+                : `${viewModel.parentLabel} / ${location.name}`}
+            </p>
             <p className="mt-1 text-xs text-slate-400">{viewModel.roundLabel}</p>
           </div>
           <div className="rounded-lg border border-slate-800 bg-slate-900/80 px-3 py-2 text-xs text-slate-400">
@@ -224,15 +296,33 @@ function SelectedLocationDetail({
             onClear={() => saveLocation({ image_media_id: null })}
           />
           <div className="space-y-3">
+            <LocationBasicInfoFields
+              locationName={location.name}
+              draft={basicDraft}
+              onDraftChange={setBasicDraft}
+              onSave={saveBasicInfo}
+              isSaving={updateLocation.isPending || updateConfig.isPending}
+            />
+            <LocationStructureFields
+              location={location}
+              mapName={map.name}
+              parentLabel={viewModel.parentLabel}
+              parentOptions={parentOptions}
+              selectedParentId={basicDraft.parentLocationId}
+              onParentChange={(parentLocationId) =>
+                setBasicDraft((current) => ({ ...current, parentLocationId }))
+              }
+            />
             <RoundFields
               location={location}
               fromRoundInput={fromRoundInput}
               untilRoundInput={untilRoundInput}
               setFromRoundInput={setFromRoundInput}
               setUntilRoundInput={setUntilRoundInput}
+              visibilityMode={visibilityMode}
+              setVisibilityMode={setVisibilityMode}
               onCommit={saveLocation}
             />
-            <InfoBox />
           </div>
         </div>
       </section>
@@ -251,58 +341,72 @@ function SelectedLocationDetail({
   );
 }
 
-function RoundFields({
-  location,
-  fromRoundInput,
-  untilRoundInput,
-  setFromRoundInput,
-  setUntilRoundInput,
-  onCommit,
+function LocationBasicInfoFields({
+  locationName,
+  draft,
+  onDraftChange,
+  onSave,
+  isSaving,
 }: {
-  location: LocationResponse;
-  fromRoundInput: string;
-  untilRoundInput: string;
-  setFromRoundInput: (value: string) => void;
-  setUntilRoundInput: (value: string) => void;
-  onCommit: (patch: Partial<LocationResponse>) => void;
+  locationName: string;
+  draft: LocationBasicDraft;
+  onDraftChange: Dispatch<SetStateAction<LocationBasicDraft>>;
+  onSave: () => void;
+  isSaving: boolean;
 }) {
-  function commitRound(kind: 'from_round' | 'until_round', raw: string) {
-    const parsed = parseRound(raw);
-    if (parsed === undefined) {
-      toast.error('라운드는 1 이상의 숫자로 입력해 주세요');
-      if (kind === 'from_round') setFromRoundInput(roundToInput(location.from_round));
-      else setUntilRoundInput(roundToInput(location.until_round));
-      return;
-    }
-    onCommit({ [kind]: parsed });
-  }
-
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-      <p className="mb-2 text-xs font-semibold text-slate-300">라운드 노출</p>
-      <div className="grid gap-2 sm:grid-cols-2">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-semibold text-slate-300">기본 정보</p>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={isSaving}
+          className="rounded-md border border-amber-500/40 px-3 py-1.5 text-xs font-medium text-amber-100 transition hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          저장
+        </button>
+      </div>
+      <div className="mt-3 grid gap-3">
         <label className="text-xs text-slate-500">
-          등장 라운드
+          장소 이름
           <input
-            type="number"
-            min={1}
-            aria-label={`${location.name} 등장 라운드`}
-            value={fromRoundInput}
-            onChange={(e) => setFromRoundInput(e.target.value)}
-            onBlur={() => commitRound('from_round', fromRoundInput)}
+            type="text"
+            aria-label={`${locationName} 장소 이름`}
+            value={draft.name}
+            onChange={(event) =>
+              onDraftChange((current) => ({ ...current, name: event.target.value }))
+            }
             className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
           />
         </label>
         <label className="text-xs text-slate-500">
-          퇴장 라운드
-          <input
-            type="number"
-            min={1}
-            aria-label={`${location.name} 퇴장 라운드`}
-            value={untilRoundInput}
-            onChange={(e) => setUntilRoundInput(e.target.value)}
-            onBlur={() => commitRound('until_round', untilRoundInput)}
-            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          공개 설명
+          <textarea
+            aria-label={`${locationName} 공개 설명`}
+            value={draft.publicDescription}
+            onChange={(event) =>
+              onDraftChange((current) => ({
+                ...current,
+                publicDescription: event.target.value,
+              }))
+            }
+            rows={3}
+            className="mt-1 w-full resize-none rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm leading-5 text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            placeholder="플레이어에게 항상 보이는 장소 설명"
+          />
+        </label>
+        <label className="text-xs text-slate-500">
+          진입 메시지
+          <textarea
+            aria-label={`${locationName} 진입 메시지`}
+            value={draft.entryMessage}
+            onChange={(event) =>
+              onDraftChange((current) => ({ ...current, entryMessage: event.target.value }))
+            }
+            rows={3}
+            className="mt-1 w-full resize-none rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm leading-5 text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            placeholder="플레이어가 이 장소에 들어왔을 때 보여줄 분위기 텍스트"
           />
         </label>
       </div>
@@ -310,16 +414,189 @@ function RoundFields({
   );
 }
 
-function InfoBox() {
+function LocationStructureFields({
+  location,
+  mapName,
+  parentLabel,
+  parentOptions,
+  selectedParentId,
+  onParentChange,
+}: {
+  location: LocationResponse;
+  mapName: string;
+  parentLabel: string;
+  parentOptions: Array<{ id: string; label: string; depth: number }>;
+  selectedParentId: string;
+  onParentChange: (parentLocationId: string) => void;
+}) {
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-xs leading-5 text-slate-500">
-      <div className="mb-1 flex items-center gap-1.5 font-semibold text-slate-300">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-2 flex items-center gap-1.5 font-semibold text-slate-300">
         <Info className="h-3.5 w-3.5 text-amber-400" />
-        기본정보
+        장소 구조
       </div>
-      부모 장소는 별도 입력하지 않습니다. 현재 구조에서는 맵과 장소 트리 위치가 곧 경로입니다.
+      <label className="text-xs text-slate-500">
+        부모 장소
+        <select
+          aria-label={`${location.name} 부모 장소`}
+          value={selectedParentId}
+          onChange={(event) => onParentChange(event.target.value)}
+          className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+        >
+          <option value="">최상위 장소</option>
+          {parentOptions.map((option) => (
+            <option key={option.id} value={option.id}>
+              {`${'· '.repeat(option.depth)}${option.label}`}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="mt-2 text-xs leading-5 text-slate-500">
+        현재 경로: {mapName} /{' '}
+        {parentLabel === '최상위 장소' ? location.name : `${parentLabel} / ${location.name}`}
+      </p>
     </div>
   );
+}
+
+function RoundFields({
+  location,
+  fromRoundInput,
+  untilRoundInput,
+  setFromRoundInput,
+  setUntilRoundInput,
+  visibilityMode,
+  setVisibilityMode,
+  onCommit,
+}: {
+  location: LocationResponse;
+  fromRoundInput: string;
+  untilRoundInput: string;
+  setFromRoundInput: (value: string) => void;
+  setUntilRoundInput: (value: string) => void;
+  visibilityMode: VisibilityMode;
+  setVisibilityMode: (value: VisibilityMode) => void;
+  onCommit: (patch: Partial<LocationResponse>) => void;
+}) {
+  function commitVisibility(nextFrom: string, nextUntil: string) {
+    const parsedFrom = parseRound(nextFrom);
+    const parsedUntil = parseRound(nextUntil);
+    if (parsedFrom === undefined || parsedUntil === undefined) {
+      toast.error('라운드는 1 이상의 숫자로 입력해 주세요');
+      setFromRoundInput(roundToInput(location.from_round));
+      setUntilRoundInput(roundToInput(location.until_round));
+      return;
+    }
+    onCommit({ from_round: parsedFrom, until_round: parsedUntil });
+  }
+
+  function commitRound(kind: 'from_round' | 'until_round', raw: string) {
+    const nextFrom = kind === 'from_round' ? raw : fromRoundInput;
+    const nextUntil = kind === 'until_round' ? raw : untilRoundInput;
+    const parsed = parseRound(raw);
+    if (parsed === undefined) {
+      toast.error('라운드는 1 이상의 숫자로 입력해 주세요');
+      if (kind === 'from_round') setFromRoundInput(roundToInput(location.from_round));
+      else setUntilRoundInput(roundToInput(location.until_round));
+      return;
+    }
+    commitVisibility(nextFrom, nextUntil);
+  }
+
+  function selectMode(nextMode: VisibilityMode) {
+    setVisibilityMode(nextMode);
+    if (nextMode === 'always') {
+      setFromRoundInput('');
+      setUntilRoundInput('');
+      onCommit({ from_round: null, until_round: null });
+      return;
+    }
+    const fallbackFrom = fromRoundInput || '1';
+    const fallbackUntil = untilRoundInput || fallbackFrom;
+    if (nextMode === 'from') {
+      setFromRoundInput(fallbackFrom);
+      setUntilRoundInput('');
+      commitVisibility(fallbackFrom, '');
+    } else if (nextMode === 'until') {
+      setFromRoundInput('');
+      setUntilRoundInput(fallbackUntil);
+      commitVisibility('', fallbackUntil);
+    } else {
+      setFromRoundInput(fallbackFrom);
+      setUntilRoundInput(fallbackUntil);
+      commitVisibility(fallbackFrom, fallbackUntil);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <p className="mb-2 text-xs font-semibold text-slate-300">공개 시점</p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {[
+          ['always', '처음부터 끝까지'],
+          ['from', '특정 라운드부터'],
+          ['until', '특정 라운드까지'],
+          ['range', '특정 구간만'],
+        ].map(([value, label]) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => selectMode(value as 'always' | 'from' | 'until' | 'range')}
+            className={`rounded-md border px-3 py-2 text-left text-xs transition ${
+              visibilityMode === value
+                ? 'border-amber-500/60 bg-amber-500/10 text-amber-100'
+                : 'border-slate-700 bg-slate-950 text-slate-400 hover:border-slate-600'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {visibilityMode !== 'always' ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          {visibilityMode === 'from' || visibilityMode === 'range' ? (
+            <label className="text-xs text-slate-500">
+              시작 라운드
+              <input
+                type="number"
+                min={1}
+                aria-label={`${location.name} 시작 라운드`}
+                value={fromRoundInput}
+                onChange={(e) => setFromRoundInput(e.target.value)}
+                onBlur={() => commitRound('from_round', fromRoundInput)}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+              />
+            </label>
+          ) : null}
+          {visibilityMode === 'until' || visibilityMode === 'range' ? (
+            <label className="text-xs text-slate-500">
+              종료 라운드
+              <input
+                type="number"
+                min={1}
+                aria-label={`${location.name} 종료 라운드`}
+                value={untilRoundInput}
+                onChange={(e) => setUntilRoundInput(e.target.value)}
+                onBlur={() => commitRound('until_round', untilRoundInput)}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+              />
+            </label>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type VisibilityMode = 'always' | 'from' | 'until' | 'range';
+
+function getVisibilityMode(fromRoundInput: string, untilRoundInput: string): VisibilityMode {
+  const hasFrom = fromRoundInput.trim() !== '';
+  const hasUntil = untilRoundInput.trim() !== '';
+  if (hasFrom && hasUntil) return 'range';
+  if (hasFrom) return 'from';
+  if (hasUntil) return 'until';
+  return 'always';
 }
 
 function LocationEmptyState({ message, compact = false }: { message: string; compact?: boolean }) {

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -194,7 +194,10 @@ function SelectedLocationDetail({
     });
   }, [location.id, location.name, location.from_round, location.until_round, locationMeta]);
 
-  function saveLocation(patch: Partial<LocationResponse>) {
+  function saveLocation(
+    patch: Partial<LocationResponse>,
+    options: { onSuccess?: () => void; onErrorMessage?: string } = {}
+  ) {
     const currentFrom = parseRound(fromRoundInput);
     const currentUntil = parseRound(untilRoundInput);
     const nextFrom =
@@ -233,7 +236,10 @@ function SelectedLocationDetail({
         locationId: location.id,
         body,
       },
-      { onError: () => toast.error('장소 저장에 실패했습니다') }
+      {
+        onSuccess: options.onSuccess,
+        onError: () => toast.error(options.onErrorMessage ?? '장소 저장에 실패했습니다'),
+      }
     );
   }
 
@@ -252,16 +258,23 @@ function SelectedLocationDetail({
     }
 
     const nextParentId = basicDraft.parentLocationId || null;
-    saveLocation({ name: nextName });
-    updateConfig.mutate(
-      writeLocationMeta(theme.config_json, location.id, {
-        publicDescription: basicDraft.publicDescription.trim(),
-        entryMessage: basicDraft.entryMessage.trim(),
-        parentLocationId: nextParentId,
-      }),
+    saveLocation(
+      { name: nextName },
       {
-        onSuccess: () => toast.success('장소 기본 정보가 저장되었습니다'),
-        onError: () => toast.error('장소 기본 정보 저장에 실패했습니다'),
+        onSuccess: () => {
+          updateConfig.mutate(
+            writeLocationMeta(theme.config_json, location.id, {
+              publicDescription: basicDraft.publicDescription.trim(),
+              entryMessage: basicDraft.entryMessage.trim(),
+              parentLocationId: nextParentId,
+            }),
+            {
+              onSuccess: () => toast.success('장소 기본 정보가 저장되었습니다'),
+              onError: () => toast.error('장소 기본 정보 저장에 실패했습니다'),
+            }
+          );
+        },
+        onErrorMessage: '장소 기본 정보 저장에 실패했습니다',
       }
     );
   }

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -473,6 +473,11 @@ describe('LocationsSubTab', () => {
         }),
         expect.any(Object)
       );
+      const [, updateLocationOptions] = updateLocationMutateMock.mock.calls[0] as [
+        unknown,
+        { onSuccess?: () => void },
+      ];
+      updateLocationOptions.onSuccess?.();
       const [config] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
       expect(config.locationMeta).toMatchObject({
         'loc-1': {

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -385,15 +385,18 @@ describe('LocationsSubTab', () => {
   describe('LocationRow 라운드 편집', () => {
     beforeEach(setupDefaultMocks);
 
-    it('등장/퇴장 라운드 입력이 각 장소 행마다 존재한다', () => {
+    it('공개 시점을 제작자용 선택지로 표시한다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      expect(screen.getByLabelText('거실 등장 라운드')).toBeDefined();
-      expect(screen.getByLabelText('거실 퇴장 라운드')).toBeDefined();
+      expect(screen.getByText('공개 시점')).toBeDefined();
+      expect(screen.getAllByText('처음부터 끝까지').length).toBeGreaterThan(0);
+      expect(screen.getByText('특정 라운드부터')).toBeDefined();
     });
 
-    it('라운드 값 입력 후 blur 하면 useUpdateLocation.mutate 가 호출된다', () => {
+    it('시작 라운드 값 입력 후 blur 하면 useUpdateLocation.mutate 가 호출된다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
+      fireEvent.click(screen.getByText('특정 라운드부터'));
+      updateLocationMutateMock.mockClear();
+      const fromInput = screen.getByLabelText('거실 시작 라운드') as HTMLInputElement;
       fireEvent.change(fromInput, { target: { value: '2' } });
       fireEvent.blur(fromInput);
       expect(updateLocationMutateMock).toHaveBeenCalledOnce();
@@ -407,8 +410,10 @@ describe('LocationsSubTab', () => {
 
     it('등장 > 퇴장 조합은 에러 토스트 후 저장되지 않는다', () => {
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
-      const untilInput = screen.getByLabelText('거실 퇴장 라운드') as HTMLInputElement;
+      fireEvent.click(screen.getByText('특정 구간만'));
+      updateLocationMutateMock.mockClear();
+      const fromInput = screen.getByLabelText('거실 시작 라운드') as HTMLInputElement;
+      const untilInput = screen.getByLabelText('거실 종료 라운드') as HTMLInputElement;
       fireEvent.change(untilInput, { target: { value: '2' } });
       fireEvent.blur(untilInput);
       updateLocationMutateMock.mockClear();
@@ -424,7 +429,7 @@ describe('LocationsSubTab', () => {
         isLoading: false,
       });
       render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
-      const fromInput = screen.getByLabelText('거실 등장 라운드') as HTMLInputElement;
+      const fromInput = screen.getByLabelText('거실 시작 라운드') as HTMLInputElement;
       fireEvent.change(fromInput, { target: { value: '' } });
       fireEvent.blur(fromInput);
       expect(updateLocationMutateMock).toHaveBeenCalledOnce();
@@ -433,6 +438,49 @@ describe('LocationsSubTab', () => {
       ];
       expect(payload.body.from_round).toBeNull();
       expect(payload.body.until_round).toBe(5);
+    });
+  });
+
+  describe('장소 기본 정보', () => {
+    beforeEach(setupDefaultMocks);
+
+    it('공개 설명, 진입 메시지, 부모 장소를 locationMeta 기반으로 편집한다', () => {
+      useEditorLocationsMock.mockReturnValue({
+        data: [{ ...mockLocations[0], name: '거실' }, ...mockLocations.slice(1)],
+        isLoading: false,
+      });
+
+      render(<LocationsSubTab themeId="theme-1" theme={mockTheme} />);
+
+      fireEvent.change(screen.getByLabelText('거실 장소 이름'), {
+        target: { value: '응접실' },
+      });
+      fireEvent.change(screen.getByLabelText('거실 공개 설명'), {
+        target: { value: '손님들이 모이는 공간' },
+      });
+      fireEvent.change(screen.getByLabelText('거실 진입 메시지'), {
+        target: { value: '낡은 시계 소리가 들린다.' },
+      });
+      fireEvent.change(screen.getByLabelText('거실 부모 장소'), {
+        target: { value: 'loc-2' },
+      });
+      fireEvent.click(screen.getByText('저장'));
+
+      expect(updateLocationMutateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          locationId: 'loc-1',
+          body: expect.objectContaining({ name: '응접실' }),
+        }),
+        expect.any(Object)
+      );
+      const [config] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
+      expect(config.locationMeta).toMatchObject({
+        'loc-1': {
+          publicDescription: '손님들이 모이는 공간',
+          entryMessage: '낡은 시계 소리가 들린다.',
+          parentLocationId: 'loc-2',
+        },
+      });
     });
   });
 

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { EditorCharacterResponse, LocationResponse } from '@/features/editor/api/types';
 import {
+  buildLocationParentOptions,
   buildLocationBadges,
   formatLocationAccessLabel,
   parseLocationRestrictedCharacterIds,
@@ -77,6 +78,38 @@ describe('locationEntityAdapter', () => {
       clueShortLabel: '단서 3개',
       badges: ['저택 1층', 'R2~4', '접근 제한 있음', '단서 3', '이미지 있음'],
     });
+  });
+
+  it('locationMeta를 제작자용 공개 설명과 부모 요약으로 변환한다', () => {
+    const vm = toLocationEditorViewModel(location(), {
+      locationMeta: {
+        publicDescription: '모든 플레이어에게 보이는 설명',
+        entryMessage: '차가운 바람이 분다.',
+        parentLocationId: 'loc-parent',
+      },
+      allLocations: [location({ id: 'loc-parent', name: '저택 1층' })],
+    });
+
+    expect(vm.publicDescription).toBe('모든 플레이어에게 보이는 설명');
+    expect(vm.entryMessage).toBe('차가운 바람이 분다.');
+    expect(vm.parentLocationId).toBe('loc-parent');
+    expect(vm.parentLabel).toBe('저택 1층');
+  });
+
+  it('부모 장소 후보에서 자기 자신과 자손을 제외한다', () => {
+    const locations = [
+      location({ id: 'loc-1', name: '저택' }),
+      location({ id: 'loc-2', name: '1층' }),
+      location({ id: 'loc-3', name: '서재' }),
+      location({ id: 'loc-4', name: '정원' }),
+    ];
+
+    expect(
+      buildLocationParentOptions('loc-1', locations, {
+        'loc-2': { parentLocationId: 'loc-1' },
+        'loc-3': { parentLocationId: 'loc-2' },
+      })
+    ).toEqual([{ id: 'loc-4', label: '정원', depth: 0 }]);
   });
 
   it('restricted character CSV를 trim/dedupe한다', () => {

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -1,5 +1,6 @@
 import type { EditorCharacterResponse, LocationResponse } from '@/features/editor/api/types';
 import { formatRoundRange } from '@/features/editor/utils/roundFormat';
+import type { LocationMeta } from '@/features/editor/utils/entityMeta';
 
 export interface LocationEditorViewModel {
   id: string;
@@ -8,16 +9,37 @@ export interface LocationEditorViewModel {
   imageMediaId: string | null;
   roundLabel: string;
   accessLabel: string;
+  publicDescription: string;
+  entryMessage: string;
+  parentLocationId: string | null;
+  parentLabel: string;
   clueCountLabel: string;
   clueShortLabel: string;
   badges: string[];
 }
 
+export interface LocationParentOption {
+  id: string;
+  label: string;
+  depth: number;
+}
+
 export function toLocationEditorViewModel(
   location: LocationResponse,
-  options: { characters?: EditorCharacterResponse[]; clueCount?: number; mapName?: string } = {}
+  options: {
+    characters?: EditorCharacterResponse[];
+    clueCount?: number;
+    mapName?: string;
+    locationMeta?: LocationMeta;
+    allLocations?: LocationResponse[];
+  } = {}
 ): LocationEditorViewModel {
   const clueCount = options.clueCount ?? 0;
+  const parentLocationId = normalizeParentLocationId(
+    location.id,
+    options.locationMeta?.parentLocationId
+  );
+  const parentLocation = options.allLocations?.find((item) => item.id === parentLocationId);
   return {
     id: location.id,
     name: location.name,
@@ -28,10 +50,29 @@ export function toLocationEditorViewModel(
       location.restricted_characters,
       options.characters ?? []
     ),
+    publicDescription: normalizeMetaText(options.locationMeta?.publicDescription),
+    entryMessage: normalizeMetaText(options.locationMeta?.entryMessage),
+    parentLocationId,
+    parentLabel: parentLocation?.name ?? '최상위 장소',
     clueCountLabel: `단서 조사 ${clueCount}개`,
     clueShortLabel: `단서 ${clueCount}개`,
     badges: buildLocationBadges(location, clueCount, options.mapName),
   };
+}
+
+export function buildLocationParentOptions(
+  currentLocationId: string,
+  locations: LocationResponse[],
+  metaByLocationId: Record<string, LocationMeta | undefined> = {}
+): LocationParentOption[] {
+  const blocked = collectDescendantLocationIds(currentLocationId, locations, metaByLocationId);
+  return locations
+    .filter((location) => location.id !== currentLocationId && !blocked.has(location.id))
+    .map((location) => ({
+      id: location.id,
+      label: location.name,
+      depth: getLocationDepth(location.id, locations, metaByLocationId, new Set<string>()),
+    }));
 }
 
 export function parseLocationRestrictedCharacterIds(value: string | null | undefined): string[] {
@@ -76,6 +117,62 @@ export function formatLocationRoundLabel(
   location: Pick<LocationResponse, 'from_round' | 'until_round'>
 ): string {
   return formatRoundRange(location.from_round, location.until_round) || '처음부터 끝까지';
+}
+
+function normalizeMetaText(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeParentLocationId(
+  currentLocationId: string,
+  parentLocationId: unknown
+): string | null {
+  if (typeof parentLocationId !== 'string') return null;
+  const trimmed = parentLocationId.trim();
+  if (!trimmed || trimmed === currentLocationId) return null;
+  return trimmed;
+}
+
+function collectDescendantLocationIds(
+  currentLocationId: string,
+  locations: LocationResponse[],
+  metaByLocationId: Record<string, LocationMeta | undefined>
+): Set<string> {
+  const descendants = new Set<string>();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const location of locations) {
+      if (descendants.has(location.id)) continue;
+      const parentId = normalizeParentLocationId(
+        location.id,
+        metaByLocationId[location.id]?.parentLocationId
+      );
+      if (parentId === currentLocationId || (parentId != null && descendants.has(parentId))) {
+        descendants.add(location.id);
+        changed = true;
+      }
+    }
+  }
+  return descendants;
+}
+
+function getLocationDepth(
+  locationId: string,
+  locations: LocationResponse[],
+  metaByLocationId: Record<string, LocationMeta | undefined>,
+  seen: Set<string>
+): number {
+  if (seen.has(locationId)) return 0;
+  seen.add(locationId);
+  const location = locations.find((item) => item.id === locationId);
+  if (!location) return 0;
+  const parentId = normalizeParentLocationId(
+    location.id,
+    metaByLocationId[location.id]?.parentLocationId
+  );
+  if (!parentId) return 0;
+  return 1 + getLocationDepth(parentId, locations, metaByLocationId, seen);
 }
 
 export function buildLocationBadges(

--- a/apps/web/src/features/editor/utils/entityMeta.ts
+++ b/apps/web/src/features/editor/utils/entityMeta.ts
@@ -2,6 +2,7 @@ import { normalizeConfigForSave, type EditorConfig } from './configShape';
 
 export interface LocationMeta extends Record<string, unknown> {
   parentLocationId?: string | null;
+  publicDescription?: string;
   entryMessage?: string;
   imageUrl?: string | null;
 }
@@ -11,18 +12,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function readLocationMetaMap(
-  configJson: EditorConfig | null | undefined,
+  configJson: EditorConfig | null | undefined
 ): Record<string, LocationMeta> {
   const raw = configJson?.locationMeta;
   if (!isRecord(raw)) return {};
   return Object.fromEntries(
-    Object.entries(raw).filter((entry): entry is [string, LocationMeta] => isRecord(entry[1])),
+    Object.entries(raw).filter((entry): entry is [string, LocationMeta] => isRecord(entry[1]))
   );
 }
 
 export function readLocationMeta(
   configJson: EditorConfig | null | undefined,
-  locationId: string,
+  locationId: string
 ): LocationMeta {
   return { ...(readLocationMetaMap(configJson)[locationId] ?? {}) };
 }
@@ -30,7 +31,7 @@ export function readLocationMeta(
 export function writeLocationMeta(
   configJson: EditorConfig | null | undefined,
   locationId: string,
-  patch: LocationMeta,
+  patch: LocationMeta
 ): EditorConfig {
   const next = normalizeConfigForSave(configJson);
   const map = readLocationMetaMap(next);


### PR DESCRIPTION
## 요약
- 장소 상세 패널을 기본 정보, 장소 구조, 공개 시점, 진입 조건 중심으로 재구성했습니다.
- 공개 설명, 진입 메시지, 부모 장소 선택을 `locationMeta`에 저장해 현재 API 계약 안에서 제작자 입력을 보존합니다.
- 장소 공개 시점을 라운드 숫자 직접 입력 대신 제작자 친화적인 모드 선택 UI로 바꿨습니다.

Closes #511
Refs #527

## Coverage Plan
- `LocationDetailPanel.tsx`: `LocationsSubTab.test.tsx`에서 장소 이름/공개 설명/진입 메시지/부모 장소 저장, 공개 시점 모드별 저장, invalid range validation을 검증합니다.
- `locationEntityAdapter.ts`: `locationEntityAdapter.test.ts`에서 `locationMeta` -> ViewModel 매핑, 부모 후보 self/descendant 제외, 기존 access/round badge를 검증합니다.
- `entityMeta.ts`: 컴포넌트 저장 payload와 quick 전체 테스트의 기존 entity meta 경로로 검증합니다.
- E2E: 이번 변경은 에디터 내부 IA와 폼 저장 동작 중심이라 focused component/unit test와 `mmp-local-ci quick`으로 대체했습니다.

## Local validation
- `pnpm --dir apps/web test -- src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx` 통과 (2 files, 35 tests)
- `pnpm --dir apps/web typecheck` 통과
- `scripts/mmp-local-ci.sh quick` 통과 (server test, web lint/typecheck/test/build 포함; 기존 lint warning만 존재)

## Follow-up
- #527: 장소 공개 설명·진입 메시지를 runtime/API 저장 계약으로 승격


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장소 기본 정보 편집: 이름, 공개 설명, 입장 메시지 편집 및 저장
  * 계층 구조 관리: 부모 장소 지정·선택 및 현재 경로 표기
  * 공개 시점 제어: 항상, 특정 라운드부터/까지, 구간 등 가시성 모드와 라운드 입력 동작 지원

* **테스트**
  * 장소 관련 UI와 메타 저장 동작을 검증하는 단위/통합 테스트 추가·수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->