### PR TITLE
feat(editor): 템플릿 설정을 기본 설정으로 통합

### DIFF
--- a/apps/web/src/features/editor/__tests__/routeSegments.test.ts
+++ b/apps/web/src/features/editor/__tests__/routeSegments.test.ts
@@ -28,7 +28,6 @@ describe('editor route segment matrix', () => {
     ['locations', '/editor/theme-1/locations'],
     ['media', '/editor/theme-1/media'],
     ['overview', '/editor/theme-1/overview'],
-    ['template', '/editor/theme-1/template'],
     ['advanced', '/editor/theme-1/advanced'],
   ] as const)('%s 탭의 canonical URL을 만든다', (tab, expectedPath) => {
     const route = buildEditorRouteForTab('theme-1', tab);
@@ -40,7 +39,7 @@ describe('editor route segment matrix', () => {
 
   it('theme id를 URL segment로 안전하게 인코딩한다', () => {
     expect(buildEditorRouteForTab('theme/with space', 'characters')).toBe(
-      '/editor/theme%2Fwith%20space/characters',
+      '/editor/theme%2Fwith%20space/characters'
     );
   });
 
@@ -53,6 +52,8 @@ describe('editor route segment matrix', () => {
     ['locations', 'locations'],
     ['design/modules', 'design'],
     ['modules', 'design'],
+    ['template', 'overview'],
+    ['templates', 'overview'],
   ] as const)('legacy segment %s를 새 상위 탭 구조로 매핑한다', (segment, expectedTab) => {
     expect(readEditorTabFromRouteSegment(segment)).toBe(expectedTab);
   });

--- a/apps/web/src/features/editor/components/OverviewTab.tsx
+++ b/apps/web/src/features/editor/components/OverviewTab.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/features/editor/api';
 import { SectionDivider } from './SectionDivider';
 import { ImageMediaReferenceField } from '@/features/editor/components/media/ImageMediaReferenceField';
+import { TemplateSettingsSection } from './TemplateConfigTab';
 
 // ---------------------------------------------------------------------------
 // SpecField — inline number input with label + unit
@@ -278,6 +279,9 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
           error={errors.coinPrice}
         />
       </div>
+
+      <SectionDivider label="게임 유형" />
+      <TemplateSettingsSection />
 
       {/* Save */}
       <div className="mt-8 flex justify-end">

--- a/apps/web/src/features/editor/components/TabContent.tsx
+++ b/apps/web/src/features/editor/components/TabContent.tsx
@@ -1,47 +1,30 @@
-import { lazy } from "react";
-import type { EditorTab } from "@/features/editor/constants";
-import type { EditorThemeResponse } from "@/features/editor/api";
+import { lazy } from 'react';
+import type { EditorTab } from '@/features/editor/constants';
+import type { EditorThemeResponse } from '@/features/editor/api';
 
 // ---------------------------------------------------------------------------
 // Lazy tab components
 // ---------------------------------------------------------------------------
 
-const OverviewTab = lazy(() =>
-  import("./OverviewTab").then((m) => ({ default: m.OverviewTab })),
-);
+const OverviewTab = lazy(() => import('./OverviewTab').then((m) => ({ default: m.OverviewTab })));
 const StoryMapWorkspace = lazy(() =>
-  import("./story-map/StoryMapWorkspace").then((m) => ({ default: m.StoryMapWorkspace })),
+  import('./story-map/StoryMapWorkspace').then((m) => ({ default: m.StoryMapWorkspace }))
 );
-const StoryTab = lazy(() =>
-  import("./StoryTab").then((m) => ({ default: m.StoryTab })),
-);
-const InfoTab = lazy(() =>
-  import("./info/InfoTab").then((m) => ({ default: m.InfoTab })),
-);
+const StoryTab = lazy(() => import('./StoryTab').then((m) => ({ default: m.StoryTab })));
+const InfoTab = lazy(() => import('./info/InfoTab').then((m) => ({ default: m.InfoTab })));
 const CharactersTab = lazy(() =>
-  import("./CharactersTab").then((m) => ({ default: m.CharactersTab })),
+  import('./CharactersTab').then((m) => ({ default: m.CharactersTab }))
 );
-const DesignTab = lazy(() =>
-  import("./DesignTab").then((m) => ({ default: m.DesignTab })),
-);
+const DesignTab = lazy(() => import('./DesignTab').then((m) => ({ default: m.DesignTab })));
 const EndingEntitySubTab = lazy(() =>
-  import("./design/EndingEntitySubTab").then((m) => ({ default: m.EndingEntitySubTab })),
+  import('./design/EndingEntitySubTab').then((m) => ({ default: m.EndingEntitySubTab }))
 );
 const LocationsSubTab = lazy(() =>
-  import("./design/LocationsSubTab").then((m) => ({ default: m.LocationsSubTab })),
+  import('./design/LocationsSubTab').then((m) => ({ default: m.LocationsSubTab }))
 );
-const MediaTab = lazy(() =>
-  import("./media/MediaTab").then((m) => ({ default: m.MediaTab })),
-);
-const CluesTab = lazy(() =>
-  import("./CluesTab").then((m) => ({ default: m.CluesTab })),
-);
-const AdvancedTab = lazy(() =>
-  import("./AdvancedTab").then((m) => ({ default: m.AdvancedTab })),
-);
-const TemplateConfigTab = lazy(() =>
-  import("./TemplateConfigTab").then((m) => ({ default: m.TemplateConfigTab })),
-);
+const MediaTab = lazy(() => import('./media/MediaTab').then((m) => ({ default: m.MediaTab })));
+const CluesTab = lazy(() => import('./CluesTab').then((m) => ({ default: m.CluesTab })));
+const AdvancedTab = lazy(() => import('./AdvancedTab').then((m) => ({ default: m.AdvancedTab })));
 
 // ---------------------------------------------------------------------------
 // TabContent
@@ -56,29 +39,27 @@ interface TabContentProps {
 
 export function TabContent({ tab, theme, themeId, routeSegment }: TabContentProps) {
   switch (tab) {
-    case "storyMap":
+    case 'storyMap':
       return <StoryMapWorkspace themeId={themeId} />;
-    case "info":
+    case 'info':
       return <InfoTab themeId={themeId} />;
-    case "overview":
+    case 'overview':
       return <OverviewTab theme={theme} themeId={themeId} />;
-    case "story":
+    case 'story':
       return <StoryTab themeId={themeId} />;
-    case "characters":
+    case 'characters':
       return <CharactersTab theme={theme} themeId={themeId} />;
-    case "clues":
+    case 'clues':
       return <CluesTab themeId={themeId} routeSegment={routeSegment} />;
-    case "design":
+    case 'design':
       return <DesignTab theme={theme} themeId={themeId} routeSegment={routeSegment} />;
-    case "endings":
+    case 'endings':
       return <EndingEntitySubTab theme={theme} themeId={themeId} />;
-    case "locations":
+    case 'locations':
       return <LocationsSubTab theme={theme} themeId={themeId} />;
-    case "media":
+    case 'media':
       return <MediaTab themeId={themeId} />;
-    case "advanced":
+    case 'advanced':
       return <AdvancedTab theme={theme} themeId={themeId} />;
-    case "template":
-      return <TemplateConfigTab />;
   }
 }

--- a/apps/web/src/features/editor/components/TemplateConfigTab.tsx
+++ b/apps/web/src/features/editor/components/TemplateConfigTab.tsx
@@ -1,27 +1,25 @@
-import { useThemeStore } from "@/stores/themeStore";
-import { useTemplateSchema } from "@/features/editor/templateApi";
-import { GenreSelect } from "./GenreSelect";
-import { PresetSelect } from "./PresetSelect";
-import { SchemaDrivenForm } from "./SchemaDrivenForm";
+import { useThemeStore } from '@/stores/themeStore';
+import { useTemplateSchema } from '@/features/editor/templateApi';
+import { GenreSelect } from './GenreSelect';
+import { PresetSelect } from './PresetSelect';
+import { SchemaDrivenForm } from './SchemaDrivenForm';
 
 // ---------------------------------------------------------------------------
 // TemplateConfigTab
 // ---------------------------------------------------------------------------
 
-export function TemplateConfigTab() {
+export function TemplateSettingsSection() {
   const { selectedPresetId, configValues, updateField } = useThemeStore();
 
-  const {
-    data: schema,
-    isLoading: schemaLoading,
-  } = useTemplateSchema(selectedPresetId ?? "");
+  const { data: schema, isLoading: schemaLoading } = useTemplateSchema(selectedPresetId ?? '');
 
   return (
-    <div className="space-y-6 p-6">
-      <div>
-        <h2 className="text-lg font-semibold text-slate-100">템플릿 설정</h2>
-        <p className="mt-1 text-sm text-slate-400">
-          장르와 프리셋을 선택하고 세부 설정을 조정하세요.
+    <section className="space-y-5 rounded-sm border border-slate-800 bg-slate-950/40 p-4">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-slate-100">게임 유형과 초기 프리셋</h3>
+        <p className="text-xs leading-5 text-slate-400">
+          장르와 초기 구조 프리셋을 고릅니다. 이 영역은 기본 메타데이터와 함께 관리되지만, 스토리
+          진행 화면의 플로우 프리셋처럼 노드와 장면을 즉시 덮어쓰지는 않습니다.
         </p>
       </div>
 
@@ -42,7 +40,7 @@ export function TemplateConfigTab() {
             />
           ) : schemaLoading ? (
             <SchemaDrivenForm
-              schema={{ type: "object", properties: {} }}
+              schema={{ type: 'object', properties: {} }}
               values={configValues}
               onChange={updateField}
               isLoading={true}
@@ -52,6 +50,14 @@ export function TemplateConfigTab() {
           )}
         </div>
       )}
+    </section>
+  );
+}
+
+export function TemplateConfigTab() {
+  return (
+    <div className="space-y-6 p-6">
+      <TemplateSettingsSection />
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks (available inside vi.mock factories)
@@ -41,7 +41,7 @@ const {
 // Mock: react-router
 // ---------------------------------------------------------------------------
 
-vi.mock("react-router", () => ({
+vi.mock('react-router', () => ({
   useNavigate: () => navigateMock,
 }));
 
@@ -49,20 +49,23 @@ vi.mock("react-router", () => ({
 // Mock: sonner
 // ---------------------------------------------------------------------------
 
-vi.mock("sonner", () => ({
+vi.mock('sonner', () => ({
   toast: { success: toastSuccess, error: toastError },
 }));
 
-vi.mock("@/features/editor/templateApi", () => ({}));
-vi.mock("@/features/editor/components/SchemaDrivenForm", () => ({
+vi.mock('@/features/editor/templateApi', () => ({
+  useTemplates: () => ({ data: [], isLoading: false, isError: false }),
+  useTemplateSchema: () => ({ data: null, isLoading: false }),
+}));
+vi.mock('@/features/editor/components/SchemaDrivenForm', () => ({
   SchemaDrivenForm: () => null,
 }));
 
-vi.mock("@/features/editor/mediaApi", () => ({
+vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: () => useMediaListMock(),
 }));
 
-vi.mock("@/features/editor/components/media/MediaPicker", () => ({
+vi.mock('@/features/editor/components/media/MediaPicker', () => ({
   MediaPicker: ({
     open,
     filterType,
@@ -77,10 +80,10 @@ vi.mock("@/features/editor/components/media/MediaPicker", () => ({
     open ? (
       <div>
         <span>filter:{filterType}</span>
-        <span>selected:{selectedId ?? "none"}</span>
+        <span>selected:{selectedId ?? 'none'}</span>
         <button
           type="button"
-          onClick={() => onSelect({ id: "image-1", name: "커버 이미지", type: "IMAGE" })}
+          onClick={() => onSelect({ id: 'image-1', name: '커버 이미지', type: 'IMAGE' })}
         >
           커버 이미지 선택
         </button>
@@ -92,7 +95,7 @@ vi.mock("@/features/editor/components/media/MediaPicker", () => ({
 // Mock: @/features/editor/api
 // ---------------------------------------------------------------------------
 
-vi.mock("@/features/editor/api", () => ({
+vi.mock('@/features/editor/api', () => ({
   useEditorThemes: () => useEditorThemesMock(),
   useCreateTheme: () => useCreateThemeMock(),
   useDeleteTheme: () => useDeleteThemeMock(),
@@ -110,63 +113,57 @@ vi.mock("@/features/editor/api", () => ({
 // Mock: @/features/editor/constants
 // ---------------------------------------------------------------------------
 
-vi.mock("@/features/editor/constants", () => ({
-  STATUS_LABEL: { DRAFT: "초안", PUBLISHED: "출판됨" },
+vi.mock('@/features/editor/constants', () => ({
+  STATUS_LABEL: { DRAFT: '초안', PUBLISHED: '출판됨' },
   STATUS_COLOR: {
-    DRAFT: "bg-slate-600 text-slate-200",
-    PUBLISHED: "bg-emerald-600 text-emerald-100",
+    DRAFT: 'bg-slate-600 text-slate-200',
+    PUBLISHED: 'bg-emerald-600 text-emerald-100',
   },
   MODULE_CATEGORIES: [
     {
-      key: "core",
-      label: "코어",
+      key: 'core',
+      label: '코어',
       modules: [
-        { id: "connection", name: "접속 관리", description: "플레이어 접속/재접속 처리" },
-        { id: "room", name: "방 관리", description: "방 생성/참가/나가기" },
+        { id: 'connection', name: '접속 관리', description: '플레이어 접속/재접속 처리' },
+        { id: 'room', name: '방 관리', description: '방 생성/참가/나가기' },
       ],
     },
     {
-      key: "progression",
-      label: "진행",
+      key: 'progression',
+      label: '진행',
       modules: [
-        { id: "script_progression", name: "스크립트 진행", description: "순차적 페이즈 진행" },
+        { id: 'script_progression', name: '스크립트 진행', description: '순차적 페이즈 진행' },
       ],
     },
     {
-      key: "communication",
-      label: "소통",
-      modules: [
-        { id: "text_chat", name: "텍스트 채팅", description: "전체/그룹 채팅" },
-      ],
+      key: 'communication',
+      label: '소통',
+      modules: [{ id: 'text_chat', name: '텍스트 채팅', description: '전체/그룹 채팅' }],
     },
     {
-      key: "decision",
-      label: "결정",
-      modules: [
-        { id: "voting", name: "투표", description: "다수결 투표 시스템" },
-      ],
+      key: 'decision',
+      label: '결정',
+      modules: [{ id: 'voting', name: '투표', description: '다수결 투표 시스템' }],
     },
     {
-      key: "exploration",
-      label: "탐색",
-      modules: [
-        { id: "floor_exploration", name: "층 탐색", description: "건물 층별 탐색" },
-      ],
+      key: 'exploration',
+      label: '탐색',
+      modules: [{ id: 'floor_exploration', name: '층 탐색', description: '건물 층별 탐색' }],
     },
     {
-      key: "clue_distribution",
-      label: "단서 배포",
+      key: 'clue_distribution',
+      label: '단서 배포',
       modules: [
-        { id: "conditional_clue", name: "조건부 단서", description: "조건 충족 시 단서 제공" },
+        { id: 'conditional_clue', name: '조건부 단서', description: '조건 충족 시 단서 제공' },
       ],
     },
   ],
-  REQUIRED_MODULE_IDS: ["connection", "room"],
+  REQUIRED_MODULE_IDS: ['connection', 'room'],
   EDITOR_TABS: [
-    { key: "overview", label: "개요" },
-    { key: "characters", label: "캐릭터" },
-    { key: "modules", label: "모듈" },
-    { key: "config", label: "설정 JSON" },
+    { key: 'overview', label: '개요' },
+    { key: 'characters', label: '캐릭터' },
+    { key: 'modules', label: '모듈' },
+    { key: 'config', label: '설정 JSON' },
   ],
 }));
 
@@ -174,11 +171,11 @@ vi.mock("@/features/editor/constants", () => ({
 // Mock: CharacterForm (used inside CharactersTab)
 // ---------------------------------------------------------------------------
 
-vi.mock("../CharacterForm", () => ({
+vi.mock('../CharacterForm', () => ({
   CharacterForm: () => <div data-testid="character-form" />,
 }));
 
-vi.mock("../design/CharacterAssignPanel", () => ({
+vi.mock('../design/CharacterAssignPanel', () => ({
   CharacterAssignPanel: () => <div>CharacterAssignPanel 콘텐츠</div>,
 }));
 
@@ -186,58 +183,58 @@ vi.mock("../design/CharacterAssignPanel", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { EditorDashboard } from "../EditorDashboard";
-import { PublishBar } from "../PublishBar";
-import { OverviewTab } from "../OverviewTab";
-import { CharactersTab } from "../CharactersTab";
-import { ConfigJsonTab } from "../ConfigJsonTab";
-import { ModulesTab } from "../ModulesTab";
+import { EditorDashboard } from '../EditorDashboard';
+import { PublishBar } from '../PublishBar';
+import { OverviewTab } from '../OverviewTab';
+import { CharactersTab } from '../CharactersTab';
+import { ConfigJsonTab } from '../ConfigJsonTab';
+import { ModulesTab } from '../ModulesTab';
 
 // ---------------------------------------------------------------------------
 // Mock data
 // ---------------------------------------------------------------------------
 
 const mockTheme = {
-  id: "theme-1",
-  title: "테스트 테마",
-  slug: "test-theme",
-  description: "테스트 설명",
+  id: 'theme-1',
+  title: '테스트 테마',
+  slug: 'test-theme',
+  description: '테스트 설명',
   cover_image: null,
   min_players: 4,
   max_players: 6,
   duration_min: 90,
   price: 0,
-  status: "DRAFT" as const,
-  config_json: { modules: ["text_chat", "voting"] },
+  status: 'DRAFT' as const,
+  config_json: { modules: ['text_chat', 'voting'] },
   version: 1,
-  created_at: "2026-04-05T00:00:00Z",
+  created_at: '2026-04-05T00:00:00Z',
 };
 
 const mockPublishedTheme = {
   ...mockTheme,
-  id: "theme-2",
-  title: "출판된 테마",
-  status: "PUBLISHED" as const,
+  id: 'theme-2',
+  title: '출판된 테마',
+  status: 'PUBLISHED' as const,
 };
 
 const mockThemeSummaries = [
   {
-    id: "theme-1",
-    title: "테스트 테마",
-    status: "DRAFT" as const,
+    id: 'theme-1',
+    title: '테스트 테마',
+    status: 'DRAFT' as const,
     min_players: 4,
     max_players: 6,
     version: 1,
-    created_at: "2026-04-05T00:00:00Z",
+    created_at: '2026-04-05T00:00:00Z',
   },
   {
-    id: "theme-2",
-    title: "출판된 테마",
-    status: "PUBLISHED" as const,
+    id: 'theme-2',
+    title: '출판된 테마',
+    status: 'PUBLISHED' as const,
     min_players: 3,
     max_players: 8,
     version: 2,
-    created_at: "2026-04-04T00:00:00Z",
+    created_at: '2026-04-04T00:00:00Z',
   },
 ];
 
@@ -262,13 +259,13 @@ afterEach(() => {
 // 1. EditorDashboard
 // =========================================================================
 
-describe("EditorDashboard", () => {
+describe('EditorDashboard', () => {
   beforeEach(() => {
     useCreateThemeMock.mockReturnValue(defaultMutationReturn());
     useDeleteThemeMock.mockReturnValue(defaultMutationReturn());
   });
 
-  it("로딩 중일 때 스피너를 표시한다", () => {
+  it('로딩 중일 때 스피너를 표시한다', () => {
     useEditorThemesMock.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -280,7 +277,7 @@ describe("EditorDashboard", () => {
     expect(spinner).not.toBeNull();
   });
 
-  it("테마가 없을 때 빈 상태를 표시한다", () => {
+  it('테마가 없을 때 빈 상태를 표시한다', () => {
     useEditorThemesMock.mockReturnValue({
       data: [],
       isLoading: false,
@@ -288,10 +285,10 @@ describe("EditorDashboard", () => {
     });
 
     render(<EditorDashboard />);
-    expect(screen.getByText("아직 테마가 없습니다")).toBeDefined();
+    expect(screen.getByText('아직 테마가 없습니다')).toBeDefined();
   });
 
-  it("테마 카드에 제목과 상태를 렌더링한다", () => {
+  it('테마 카드에 제목과 상태를 렌더링한다', () => {
     useEditorThemesMock.mockReturnValue({
       data: mockThemeSummaries,
       isLoading: false,
@@ -299,10 +296,10 @@ describe("EditorDashboard", () => {
     });
 
     render(<EditorDashboard />);
-    expect(screen.getByText("테스트 테마")).toBeDefined();
-    expect(screen.getByText("출판된 테마")).toBeDefined();
-    expect(screen.getByText("초안")).toBeDefined();
-    expect(screen.getByText("출판됨")).toBeDefined();
+    expect(screen.getByText('테스트 테마')).toBeDefined();
+    expect(screen.getByText('출판된 테마')).toBeDefined();
+    expect(screen.getByText('초안')).toBeDefined();
+    expect(screen.getByText('출판됨')).toBeDefined();
   });
 
   it("'새 테마 만들기' 버튼이 존재한다", () => {
@@ -313,7 +310,7 @@ describe("EditorDashboard", () => {
     });
 
     render(<EditorDashboard />);
-    const buttons = screen.getAllByText("새 테마 만들기");
+    const buttons = screen.getAllByText('새 테마 만들기');
     expect(buttons.length).toBeGreaterThan(0);
   });
 
@@ -327,15 +324,15 @@ describe("EditorDashboard", () => {
     render(<EditorDashboard />);
 
     // 헤더의 '새 테마 만들기' 버튼 클릭
-    const createButton = screen.getByText("새 테마 만들기");
+    const createButton = screen.getByText('새 테마 만들기');
     fireEvent.click(createButton);
 
     // Modal이 열리면 title="새 테마 만들기"인 dialog가 나타남
-    const dialog = screen.getByRole("dialog", { name: "새 테마 만들기" });
+    const dialog = screen.getByRole('dialog', { name: '새 테마 만들기' });
     expect(dialog).toBeDefined();
   });
 
-  it("에러 발생 시 에러 메시지를 표시한다", () => {
+  it('에러 발생 시 에러 메시지를 표시한다', () => {
     useEditorThemesMock.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -343,9 +340,7 @@ describe("EditorDashboard", () => {
     });
 
     render(<EditorDashboard />);
-    expect(
-      screen.getByText("테마 목록을 불러오는 데 실패했습니다."),
-    ).toBeDefined();
+    expect(screen.getByText('테마 목록을 불러오는 데 실패했습니다.')).toBeDefined();
   });
 });
 
@@ -353,36 +348,36 @@ describe("EditorDashboard", () => {
 // 2. PublishBar
 // =========================================================================
 
-describe("PublishBar", () => {
+describe('PublishBar', () => {
   beforeEach(() => {
     usePublishThemeMock.mockReturnValue(defaultMutationReturn());
     useUnpublishThemeMock.mockReturnValue(defaultMutationReturn());
   });
 
-  it("테마 제목과 상태 배지를 표시한다", () => {
+  it('테마 제목과 상태 배지를 표시한다', () => {
     render(<PublishBar theme={mockTheme} />);
-    expect(screen.getByText("테스트 테마")).toBeDefined();
-    expect(screen.getByText("초안")).toBeDefined();
+    expect(screen.getByText('테스트 테마')).toBeDefined();
+    expect(screen.getByText('초안')).toBeDefined();
   });
 
   it("DRAFT 테마에 '심사 요청' 버튼을 표시한다", () => {
     render(<PublishBar theme={mockTheme} />);
-    expect(screen.getByText("심사 요청")).toBeDefined();
+    expect(screen.getByText('심사 요청')).toBeDefined();
   });
 
   it("PUBLISHED 테마에 '비공개 전환' 버튼을 표시한다", () => {
     render(<PublishBar theme={mockPublishedTheme} />);
-    expect(screen.getByText("비공개 전환")).toBeDefined();
+    expect(screen.getByText('비공개 전환')).toBeDefined();
   });
 
   it("PUBLISHED 테마에는 '심사 요청' 버튼이 없다", () => {
     render(<PublishBar theme={mockPublishedTheme} />);
-    expect(screen.queryByText("심사 요청")).toBeNull();
+    expect(screen.queryByText('심사 요청')).toBeNull();
   });
 
   it("DRAFT 테마에는 '비공개 전환' 버튼이 없다", () => {
     render(<PublishBar theme={mockTheme} />);
-    expect(screen.queryByText("비공개 전환")).toBeNull();
+    expect(screen.queryByText('비공개 전환')).toBeNull();
   });
 });
 
@@ -390,74 +385,75 @@ describe("PublishBar", () => {
 // 3. OverviewTab
 // =========================================================================
 
-describe("OverviewTab", () => {
+describe('OverviewTab', () => {
   beforeEach(() => {
     useUpdateThemeMock.mockReturnValue(defaultMutationReturn());
     useMediaListMock.mockReturnValue({
-      data: [{ id: "image-1", name: "커버 이미지", type: "IMAGE" }],
+      data: [{ id: 'image-1', name: '커버 이미지', type: 'IMAGE' }],
       isLoading: false,
     });
   });
 
-  it("테마 데이터가 폼에 미리 채워져 렌더링된다", () => {
+  it('테마 데이터가 폼에 미리 채워져 렌더링된다', () => {
     render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
 
     // Input의 id는 label을 lowercase + 하이픈 변환한 값
-    const titleInput = screen.getByDisplayValue("테스트 테마");
+    const titleInput = screen.getByDisplayValue('테스트 테마');
     expect(titleInput).toBeDefined();
 
     // description textarea
-    const descInput = screen.getByDisplayValue("테스트 설명");
+    const descInput = screen.getByDisplayValue('테스트 설명');
     expect(descInput).toBeDefined();
+    expect(screen.getByText('게임 유형과 초기 프리셋')).toBeDefined();
   });
 
-  it("빈 제목으로 제출 시 에러를 표시한다", () => {
+  it('빈 제목으로 제출 시 에러를 표시한다', () => {
     render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
 
     // 제목을 공백만으로 설정 (trim 후 빈 문자열)
-    const titleInput = screen.getByDisplayValue("테스트 테마");
-    fireEvent.change(titleInput, { target: { value: "   " } });
+    const titleInput = screen.getByDisplayValue('테스트 테마');
+    fireEvent.change(titleInput, { target: { value: '   ' } });
 
     // 폼 제출 (저장 버튼 클릭)
-    const submitButton = screen.getByText("저장");
+    const submitButton = screen.getByText('저장');
     fireEvent.click(submitButton);
 
     // 에러 메시지 표시
-    expect(screen.getByText("제목은 필수입니다")).toBeDefined();
+    expect(screen.getByText('제목은 필수입니다')).toBeDefined();
     // mutate가 호출되지 않아야 한다
     expect(mutateMock).not.toHaveBeenCalled();
   });
 
-  it("유효한 제출 시 mutate를 올바른 body로 호출한다", () => {
+  it('유효한 제출 시 mutate를 올바른 body로 호출한다', () => {
     render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
 
     // 제목 변경
-    const titleInput = screen.getByDisplayValue("테스트 테마");
-    fireEvent.change(titleInput, { target: { value: "수정된 제목" } });
+    const titleInput = screen.getByDisplayValue('테스트 테마');
+    fireEvent.change(titleInput, { target: { value: '수정된 제목' } });
 
     // 폼 제출
-    const submitButton = screen.getByText("저장");
+    const submitButton = screen.getByText('저장');
     fireEvent.click(submitButton);
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const [body] = mutateMock.mock.calls[0];
-    expect(body).toHaveProperty("title", "수정된 제목");
-    expect(body).toHaveProperty("min_players", 4);
-    expect(body).toHaveProperty("max_players", 6);
-    expect(body).toHaveProperty("duration_min", 90);
+    expect(body).toHaveProperty('title', '수정된 제목');
+    expect(body).toHaveProperty('min_players', 4);
+    expect(body).toHaveProperty('max_players', 6);
+    expect(body).toHaveProperty('duration_min', 90);
   });
 
-  it("미디어 관리 IMAGE를 커버 이미지 참조로 저장한다", () => {
+  it('미디어 관리 IMAGE를 커버 이미지 참조로 저장한다', () => {
     render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
 
-    fireEvent.click(screen.getByText("미디어에서 커버 선택"));
-    expect(screen.getByText("filter:IMAGE")).toBeDefined();
-    fireEvent.click(screen.getByText("커버 이미지 선택"));
-    fireEvent.click(screen.getByText("저장"));
+    fireEvent.click(screen.getByText('미디어에서 커버 선택'));
+    expect(screen.getByText('filter:IMAGE')).toBeDefined();
+    fireEvent.click(screen.getByText('커버 이미지 선택'));
+    fireEvent.click(screen.getByText('저장'));
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const [body] = mutateMock.mock.calls[0];
-    expect(body).toHaveProperty("cover_image_media_id", "image-1");
+    expect(body).toHaveProperty('cover_image_media_id', 'image-1');
     expect(body.cover_image).toBeUndefined();
   });
 });
@@ -466,29 +462,29 @@ describe("OverviewTab", () => {
 // 4. CharactersTab
 // =========================================================================
 
-describe("CharactersTab", () => {
+describe('CharactersTab', () => {
   beforeEach(() => {
     useDeleteCharacterMock.mockReturnValue(defaultMutationReturn());
   });
 
-  it("캐릭터 제작 workspace를 바로 표시한다", () => {
+  it('캐릭터 제작 workspace를 바로 표시한다', () => {
     useEditorCharactersMock.mockReturnValue({
       data: undefined,
       isLoading: true,
     });
 
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
-    expect(screen.getByText("CharacterAssignPanel 콘텐츠")).toBeDefined();
+    expect(screen.getByText('CharacterAssignPanel 콘텐츠')).toBeDefined();
   });
 
-  it("빠른 목록 서브탭을 노출하지 않는다", () => {
+  it('빠른 목록 서브탭을 노출하지 않는다', () => {
     useEditorCharactersMock.mockReturnValue({
       data: [],
       isLoading: false,
     });
 
     render(<CharactersTab themeId="theme-1" theme={mockTheme} />);
-    expect(screen.queryByRole("button", { name: "빠른 목록" })).toBeNull();
+    expect(screen.queryByRole('button', { name: '빠른 목록' })).toBeNull();
   });
 });
 
@@ -496,71 +492,63 @@ describe("CharactersTab", () => {
 // 5. ConfigJsonTab
 // =========================================================================
 
-describe("ConfigJsonTab", () => {
+describe('ConfigJsonTab', () => {
   beforeEach(() => {
     useUpdateConfigJsonMock.mockReturnValue(defaultMutationReturn());
   });
 
-  it("JSON 콘텐츠가 textarea에 렌더링된다", () => {
-    const { container } = render(
-      <ConfigJsonTab themeId="theme-1" theme={mockTheme} />,
-    );
-    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+  it('JSON 콘텐츠가 textarea에 렌더링된다', () => {
+    const { container } = render(<ConfigJsonTab themeId="theme-1" theme={mockTheme} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     expect(textarea).not.toBeNull();
-    expect(textarea.value).toContain("text_chat");
-    expect(textarea.value).toContain("voting");
+    expect(textarea.value).toContain('text_chat');
+    expect(textarea.value).toContain('voting');
   });
 
   it("텍스트 수정 시 '변경사항 있음' 배지를 표시한다", () => {
-    const { container } = render(
-      <ConfigJsonTab themeId="theme-1" theme={mockTheme} />,
-    );
-    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    const { container } = render(<ConfigJsonTab themeId="theme-1" theme={mockTheme} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 
     // 초기에는 배지가 없어야 한다
-    expect(screen.queryByText("변경사항 있음")).toBeNull();
+    expect(screen.queryByText('변경사항 있음')).toBeNull();
 
     // 텍스트 수정
     fireEvent.change(textarea, { target: { value: '{"modules":["voting"]}' } });
 
-    expect(screen.getByText("변경사항 있음")).toBeDefined();
+    expect(screen.getByText('변경사항 있음')).toBeDefined();
   });
 
-  it("유효하지 않은 JSON 저장 시 에러를 표시한다", () => {
-    const { container } = render(
-      <ConfigJsonTab themeId="theme-1" theme={mockTheme} />,
-    );
-    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+  it('유효하지 않은 JSON 저장 시 에러를 표시한다', () => {
+    const { container } = render(<ConfigJsonTab themeId="theme-1" theme={mockTheme} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 
     // 잘못된 JSON 입력
-    fireEvent.change(textarea, { target: { value: "{invalid json" } });
+    fireEvent.change(textarea, { target: { value: '{invalid json' } });
 
     // 저장 버튼 클릭
-    const saveButton = screen.getByText("저장");
+    const saveButton = screen.getByText('저장');
     fireEvent.click(saveButton);
 
-    expect(screen.getByText("유효하지 않은 JSON 형식입니다")).toBeDefined();
+    expect(screen.getByText('유효하지 않은 JSON 형식입니다')).toBeDefined();
     expect(mutateMock).not.toHaveBeenCalled();
   });
 
-  it("유효한 JSON 저장 시 mutate를 호출한다", () => {
-    const { container } = render(
-      <ConfigJsonTab themeId="theme-1" theme={mockTheme} />,
-    );
-    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+  it('유효한 JSON 저장 시 mutate를 호출한다', () => {
+    const { container } = render(<ConfigJsonTab themeId="theme-1" theme={mockTheme} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 
     // 유효한 JSON으로 수정
     const newJson = '{"modules":["voting"]}';
     fireEvent.change(textarea, { target: { value: newJson } });
 
     // 저장 버튼 클릭
-    const saveButton = screen.getByText("저장");
+    const saveButton = screen.getByText('저장');
     fireEvent.click(saveButton);
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const [parsed] = mutateMock.mock.calls[0];
-    expect(parsed).toHaveProperty("modules");
-    expect((parsed as Record<string, unknown>).modules).toContain("voting");
+    expect(parsed).toHaveProperty('modules');
+    expect((parsed as Record<string, unknown>).modules).toContain('voting');
   });
 });
 
@@ -568,39 +556,39 @@ describe("ConfigJsonTab", () => {
 // 6. ModulesTab
 // =========================================================================
 
-describe("ModulesTab", () => {
+describe('ModulesTab', () => {
   beforeEach(() => {
     useUpdateConfigJsonMock.mockReturnValue(defaultMutationReturn());
   });
 
-  it("6개 카테고리 라벨을 모두 렌더링한다", () => {
+  it('6개 카테고리 라벨을 모두 렌더링한다', () => {
     render(<ModulesTab themeId="theme-1" theme={mockTheme} />);
 
-    expect(screen.getByText("코어")).toBeDefined();
-    expect(screen.getByText("진행")).toBeDefined();
-    expect(screen.getByText("소통")).toBeDefined();
-    expect(screen.getByText("결정")).toBeDefined();
-    expect(screen.getByText("탐색")).toBeDefined();
-    expect(screen.getByText("단서 배포")).toBeDefined();
+    expect(screen.getByText('코어')).toBeDefined();
+    expect(screen.getByText('진행')).toBeDefined();
+    expect(screen.getByText('소통')).toBeDefined();
+    expect(screen.getByText('결정')).toBeDefined();
+    expect(screen.getByText('탐색')).toBeDefined();
+    expect(screen.getByText('단서 배포')).toBeDefined();
   });
 
-  it("선택된 모듈의 체크박스가 체크되어 있다", () => {
+  it('선택된 모듈의 체크박스가 체크되어 있다', () => {
     render(<ModulesTab themeId="theme-1" theme={mockTheme} />);
 
     // mockTheme.config_json.modules = ["text_chat", "voting"]
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = screen.getAllByRole('checkbox');
 
     // text_chat과 voting에 해당하는 체크박스 찾기
     // 라벨에서 모듈 이름으로 찾기
-    const textChatLabel = screen.getByText("텍스트 채팅");
-    const votingLabel = screen.getByText("투표");
+    const textChatLabel = screen.getByText('텍스트 채팅');
+    const votingLabel = screen.getByText('투표');
 
     // 체크박스는 label의 자식으로 있음 — label 요소 내부의 input을 찾는다
     const textChatCheckbox = textChatLabel
-      .closest("label")
+      .closest('label')
       ?.querySelector("input[type='checkbox']") as HTMLInputElement;
     const votingCheckbox = votingLabel
-      .closest("label")
+      .closest('label')
       ?.querySelector("input[type='checkbox']") as HTMLInputElement;
 
     expect(textChatCheckbox).not.toBeNull();
@@ -609,17 +597,17 @@ describe("ModulesTab", () => {
     expect(votingCheckbox.checked).toBe(true);
 
     // 필수 모듈(connection, room)도 항상 체크됨
-    const connectionLabel = screen.getByText("접속 관리");
+    const connectionLabel = screen.getByText('접속 관리');
     const connectionCheckbox = connectionLabel
-      .closest("label")
+      .closest('label')
       ?.querySelector("input[type='checkbox']") as HTMLInputElement;
     expect(connectionCheckbox.checked).toBe(true);
   });
 
-  it("총 선택 개수를 표시한다", () => {
+  it('총 선택 개수를 표시한다', () => {
     render(<ModulesTab themeId="theme-1" theme={mockTheme} />);
 
     // mockTheme에서 text_chat, voting + 필수 connection, room = 4개 / 총 7개 모듈
-    expect(screen.getByText("4/7 모듈 선택됨")).toBeDefined();
+    expect(screen.getByText('4/7 모듈 선택됨')).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -7,13 +7,13 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 const mockSetActiveTab = vi.fn();
 const mockNavigate = vi.fn();
-const mockActiveTab = { current: "storyMap" };
+const mockActiveTab = { current: 'storyMap' };
 
-vi.mock("react-router", () => ({
+vi.mock('react-router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-vi.mock("../../stores/editorUIStore", () => ({
+vi.mock('../../stores/editorUIStore', () => ({
   useEditorUI: () => ({
     activeTab: mockActiveTab.current,
     setActiveTab: mockSetActiveTab,
@@ -24,13 +24,13 @@ vi.mock("../../stores/editorUIStore", () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 
-import { EditorTabNav } from "../EditorTabNav";
+import { EditorTabNav } from '../EditorTabNav';
 
 const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
 
 beforeAll(() => {
   if (!originalScrollIntoView) {
-    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
       configurable: true,
       value: () => {},
     });
@@ -41,7 +41,7 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   vi.clearAllMocks();
-  mockActiveTab.current = "storyMap";
+  mockActiveTab.current = 'storyMap';
 });
 
 afterAll(() => {
@@ -57,99 +57,99 @@ afterAll(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("EditorTabNav dynamic tabs", () => {
-  it("선택된 탭을 모바일 가로 탭바 중앙으로 자동 스크롤한다", () => {
+describe('EditorTabNav dynamic tabs', () => {
+  it('선택된 탭을 모바일 가로 탭바 중앙으로 자동 스크롤한다', () => {
     const scrollIntoView = vi
-      .spyOn(window.HTMLElement.prototype, "scrollIntoView")
+      .spyOn(window.HTMLElement.prototype, 'scrollIntoView')
       .mockImplementation(() => {});
-    mockActiveTab.current = "media";
+    mockActiveTab.current = 'media';
 
     render(<EditorTabNav activeModules={[]} />);
 
     expect(scrollIntoView).toHaveBeenCalledWith({
-      block: "nearest",
-      inline: "center",
+      block: 'nearest',
+      inline: 'center',
     });
   });
 
-  it("모듈 미지정 시 always=true 탭만 표시된다", () => {
+  it('모듈 미지정 시 always=true 탭만 표시된다', () => {
     render(<EditorTabNav />);
-    expect(screen.getByText("스토리 진행")).toBeDefined();
-    expect(screen.getByText("정보 관리")).toBeDefined();
-    expect(screen.getByText("읽기 대사")).toBeDefined();
-    expect(screen.getByText("등장인물 관리")).toBeDefined();
-    expect(screen.getByText("단서 관리")).toBeDefined();
-    expect(screen.getByText("게임 설계")).toBeDefined();
-    expect(screen.getByText("결말 관리")).toBeDefined();
-    expect(screen.getByText("장소 관리")).toBeDefined();
-    expect(screen.getByText("미디어 관리")).toBeDefined();
-    expect(screen.getByText("기본 설정")).toBeDefined();
-    expect(screen.getByText("고급 설정")).toBeDefined();
+    expect(screen.getByText('스토리 진행')).toBeDefined();
+    expect(screen.getByText('정보 관리')).toBeDefined();
+    expect(screen.getByText('읽기 대사')).toBeDefined();
+    expect(screen.getByText('등장인물 관리')).toBeDefined();
+    expect(screen.getByText('단서 관리')).toBeDefined();
+    expect(screen.getByText('게임 설계')).toBeDefined();
+    expect(screen.getByText('결말 관리')).toBeDefined();
+    expect(screen.getByText('장소 관리')).toBeDefined();
+    expect(screen.getByText('미디어 관리')).toBeDefined();
+    expect(screen.getByText('기본 설정')).toBeDefined();
+    expect(screen.queryByText('템플릿')).toBeNull();
+    expect(screen.getByText('고급 설정')).toBeDefined();
   });
 
-  it("미디어 탭은 voice_chat 모듈 없이도 표시된다", () => {
-    render(<EditorTabNav activeModules={["text_chat"]} />);
-    expect(screen.getByText("미디어 관리")).toBeDefined();
+  it('미디어 탭은 voice_chat 모듈 없이도 표시된다', () => {
+    render(<EditorTabNav activeModules={['text_chat']} />);
+    expect(screen.getByText('미디어 관리')).toBeDefined();
   });
 
-  it("직접 URL로 열린 미디어 탭은 기본 노출 탭으로 유지된다", () => {
-    mockActiveTab.current = "media";
+  it('직접 URL로 열린 미디어 탭은 기본 노출 탭으로 유지된다', () => {
+    mockActiveTab.current = 'media';
     render(<EditorTabNav activeModules={[]} forcedVisibleTab="media" />);
 
-    expect(screen.getByText("미디어 관리")).toBeDefined();
-    expect(mockSetActiveTab).not.toHaveBeenCalledWith("storyMap");
+    expect(screen.getByText('미디어 관리')).toBeDefined();
+    expect(mockSetActiveTab).not.toHaveBeenCalledWith('storyMap');
   });
 
-  it("현재 미디어 탭은 모듈이 없어도 숨겨지지 않는다", () => {
-    mockActiveTab.current = "media";
+  it('현재 미디어 탭은 모듈이 없어도 숨겨지지 않는다', () => {
+    mockActiveTab.current = 'media';
     render(<EditorTabNav activeModules={[]} />);
 
-    expect(screen.getByText("미디어 관리")).toBeDefined();
+    expect(screen.getByText('미디어 관리')).toBeDefined();
   });
 
-  it("스토리 진행, 보조 관리, 설정 순서로 탭 우선순위를 유지한다", () => {
-    render(<EditorTabNav activeModules={["voice_chat"]} />);
+  it('스토리 진행, 보조 관리, 설정 순서로 탭 우선순위를 유지한다', () => {
+    render(<EditorTabNav activeModules={['voice_chat']} />);
 
-    const tabLabels = screen.getAllByRole("tab").map((tab) => tab.textContent);
+    const tabLabels = screen.getAllByRole('tab').map((tab) => tab.textContent);
     expect(tabLabels).toEqual([
-      "스토리 진행",
-      "정보 관리",
-      "읽기 대사",
-      "등장인물 관리",
-      "단서 관리",
-      "게임 설계",
-      "결말 관리",
-      "장소 관리",
-      "미디어 관리",
-      "기본 설정",
-      "템플릿",
-      "고급 설정",
+      '스토리 진행',
+      '정보 관리',
+      '읽기 대사',
+      '등장인물 관리',
+      '단서 관리',
+      '게임 설계',
+      '결말 관리',
+      '장소 관리',
+      '미디어 관리',
+      '기본 설정',
+      '고급 설정',
     ]);
   });
 
-  it("탭 클릭 시 제작자가 다시 열 수 있는 canonical URL로 이동한다", () => {
-    render(<EditorTabNav themeId="theme-1" activeModules={["voice_chat"]} />);
+  it('탭 클릭 시 제작자가 다시 열 수 있는 canonical URL로 이동한다', () => {
+    render(<EditorTabNav themeId="theme-1" activeModules={['voice_chat']} />);
 
-    fireEvent.click(screen.getByRole("tab", { name: /등장인물 관리/ }));
+    fireEvent.click(screen.getByRole('tab', { name: /등장인물 관리/ }));
 
-    expect(mockSetActiveTab).toHaveBeenCalledWith("characters");
-    expect(mockNavigate).toHaveBeenCalledWith("/editor/theme-1/characters");
+    expect(mockSetActiveTab).toHaveBeenCalledWith('characters');
+    expect(mockNavigate).toHaveBeenCalledWith('/editor/theme-1/characters');
   });
 
-  it("게임 설계 탭 클릭은 기본 설계 화면 URL로 이동한다", () => {
+  it('게임 설계 탭 클릭은 기본 설계 화면 URL로 이동한다', () => {
     render(<EditorTabNav themeId="theme-1" />);
 
-    fireEvent.click(screen.getByRole("tab", { name: /게임 설계/ }));
+    fireEvent.click(screen.getByRole('tab', { name: /게임 설계/ }));
 
-    expect(mockSetActiveTab).toHaveBeenCalledWith("design");
-    expect(mockNavigate).toHaveBeenCalledWith("/editor/theme-1/design");
+    expect(mockSetActiveTab).toHaveBeenCalledWith('design');
+    expect(mockNavigate).toHaveBeenCalledWith('/editor/theme-1/design');
   });
 
-  it("항상 표시되는 미디어 현재 탭은 스토리 진행 URL로 되돌리지 않는다", () => {
-    mockActiveTab.current = "media";
+  it('항상 표시되는 미디어 현재 탭은 스토리 진행 URL로 되돌리지 않는다', () => {
+    mockActiveTab.current = 'media';
     render(<EditorTabNav themeId="theme-1" activeModules={[]} />);
 
-    expect(screen.getByText("미디어 관리")).toBeDefined();
-    expect(mockNavigate).not.toHaveBeenCalledWith("/editor/theme-1");
+    expect(screen.getByText('미디어 관리')).toBeDefined();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/editor/theme-1');
   });
 });

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -5,63 +5,73 @@ import {
   Settings,
   Music,
   Code,
-  LayoutTemplate,
   Search,
   GitBranch,
   Info,
   MapPin,
   Drama,
-} from "lucide-react";
-import type { ThemeStatus } from "./api";
+} from 'lucide-react';
+import type { ThemeStatus } from './api';
 
 // ---------------------------------------------------------------------------
 // Editor Tabs
 // ---------------------------------------------------------------------------
 
 export const EDITOR_TABS = [
-  { key: "storyMap" as const, label: "스토리 진행", icon: GitBranch, always: true, group: "primary" },
-  { key: "info" as const, label: "정보 관리", icon: Info, always: true, group: "manage" },
-  { key: "story" as const, label: "읽기 대사", icon: BookOpen, always: true, group: "manage" },
-  { key: "characters" as const, label: "등장인물 관리", icon: Users, always: true, group: "manage" },
-  { key: "clues" as const, label: "단서 관리", icon: Search, always: true, group: "manage" },
-  { key: "design" as const, label: "게임 설계", icon: Settings, always: true, group: "manage" },
-  { key: "endings" as const, label: "결말 관리", icon: Drama, always: true, group: "manage" },
-  { key: "locations" as const, label: "장소 관리", icon: MapPin, always: true, group: "manage" },
-  { key: "media" as const, label: "미디어 관리", icon: Music, always: true, group: "manage" },
-  { key: "overview" as const, label: "기본 설정", icon: FileText, always: true, group: "settings" },
-  { key: "template" as const, label: "템플릿", icon: LayoutTemplate, always: true, group: "settings" },
-  { key: "advanced" as const, label: "고급 설정", icon: Code, always: true, group: "settings" },
+  {
+    key: 'storyMap' as const,
+    label: '스토리 진행',
+    icon: GitBranch,
+    always: true,
+    group: 'primary',
+  },
+  { key: 'info' as const, label: '정보 관리', icon: Info, always: true, group: 'manage' },
+  { key: 'story' as const, label: '읽기 대사', icon: BookOpen, always: true, group: 'manage' },
+  {
+    key: 'characters' as const,
+    label: '등장인물 관리',
+    icon: Users,
+    always: true,
+    group: 'manage',
+  },
+  { key: 'clues' as const, label: '단서 관리', icon: Search, always: true, group: 'manage' },
+  { key: 'design' as const, label: '게임 설계', icon: Settings, always: true, group: 'manage' },
+  { key: 'endings' as const, label: '결말 관리', icon: Drama, always: true, group: 'manage' },
+  { key: 'locations' as const, label: '장소 관리', icon: MapPin, always: true, group: 'manage' },
+  { key: 'media' as const, label: '미디어 관리', icon: Music, always: true, group: 'manage' },
+  { key: 'overview' as const, label: '기본 설정', icon: FileText, always: true, group: 'settings' },
+  { key: 'advanced' as const, label: '고급 설정', icon: Code, always: true, group: 'settings' },
 ] as const;
 
-export type EditorTab = (typeof EDITOR_TABS)[number]["key"];
+export type EditorTab = (typeof EDITOR_TABS)[number]['key'];
 
 // ---------------------------------------------------------------------------
 // Theme Status
 // ---------------------------------------------------------------------------
 
 export const STATUS_LABEL: Record<ThemeStatus, string> = {
-  DRAFT: "초안",
-  PENDING_REVIEW: "심사 대기",
-  PUBLISHED: "출판됨",
-  REJECTED: "반려됨",
-  UNPUBLISHED: "비공개",
-  SUSPENDED: "정지됨",
+  DRAFT: '초안',
+  PENDING_REVIEW: '심사 대기',
+  PUBLISHED: '출판됨',
+  REJECTED: '반려됨',
+  UNPUBLISHED: '비공개',
+  SUSPENDED: '정지됨',
 };
 
 export const STATUS_COLOR: Record<ThemeStatus, string> = {
-  DRAFT: "bg-slate-600 text-slate-200",
-  PENDING_REVIEW: "bg-amber-600 text-amber-100",
-  PUBLISHED: "bg-emerald-600 text-emerald-100",
-  REJECTED: "bg-red-600 text-red-100",
-  UNPUBLISHED: "bg-slate-500 text-slate-200",
-  SUSPENDED: "bg-red-800 text-red-200",
+  DRAFT: 'bg-slate-600 text-slate-200',
+  PENDING_REVIEW: 'bg-amber-600 text-amber-100',
+  PUBLISHED: 'bg-emerald-600 text-emerald-100',
+  REJECTED: 'bg-red-600 text-red-100',
+  UNPUBLISHED: 'bg-slate-500 text-slate-200',
+  SUSPENDED: 'bg-red-800 text-red-200',
 };
 
 // ---------------------------------------------------------------------------
 // Module Categories
 // ---------------------------------------------------------------------------
 
-export type ModuleCatalogVisibility = "optional" | "built_in";
+export type ModuleCatalogVisibility = 'optional' | 'built_in';
 
 export interface ModuleInfo {
   id: string;
@@ -80,69 +90,254 @@ export interface ModuleCategory {
 
 export const MODULE_CATEGORIES: ModuleCategory[] = [
   {
-    key: "core",
-    label: "코어",
+    key: 'core',
+    label: '코어',
     modules: [
-      { id: "connection", name: "접속 관리", description: "플레이어 접속/재접속 처리", supported: true, required: true },
-      { id: "room", name: "방 관리", description: "방 생성/참가/나가기", supported: true, required: true },
-      { id: "ready", name: "준비 상태", description: "게임 시작 전 레디 체크", supported: true, required: true },
-      { id: "clue_interaction", name: "단서 상호작용", description: "단서 열람/공유", supported: true, required: true },
+      {
+        id: 'connection',
+        name: '접속 관리',
+        description: '플레이어 접속/재접속 처리',
+        supported: true,
+        required: true,
+      },
+      {
+        id: 'room',
+        name: '방 관리',
+        description: '방 생성/참가/나가기',
+        supported: true,
+        required: true,
+      },
+      {
+        id: 'ready',
+        name: '준비 상태',
+        description: '게임 시작 전 레디 체크',
+        supported: true,
+        required: true,
+      },
+      {
+        id: 'clue_interaction',
+        name: '단서 상호작용',
+        description: '단서 열람/공유',
+        supported: true,
+        required: true,
+      },
     ],
   },
   {
-    key: "progression",
-    label: "진행",
+    key: 'progression',
+    label: '진행',
     modules: [
-      { id: "script_progression", name: "스크립트 진행", description: "순차적 페이즈 진행", supported: true, required: false, catalogVisibility: "built_in" },
-      { id: "hybrid_progression", name: "하이브리드 진행", description: "타이머+합의 기반 진행", supported: false, required: false },
-      { id: "event_progression", name: "이벤트 진행", description: "비선형 이벤트 그래프", supported: false, required: false },
-      { id: "skip_consensus", name: "스킵 합의", description: "페이즈 스킵 투표", supported: false, required: false },
-      { id: "gm_control", name: "GM 제어", description: "진행자 수동 제어", supported: false, required: false },
-      { id: "consensus_control", name: "합의 제어", description: "플레이어 합의 기반 제어", supported: false, required: false },
-      { id: "reading", name: "리딩", description: "대사 낭독 시스템", supported: true, required: false, catalogVisibility: "built_in" },
-      { id: "ending", name: "엔딩", description: "엔딩 분기/결과 처리", supported: true, required: false, catalogVisibility: "built_in" },
+      {
+        id: 'script_progression',
+        name: '스크립트 진행',
+        description: '순차적 페이즈 진행',
+        supported: true,
+        required: false,
+        catalogVisibility: 'built_in',
+      },
+      {
+        id: 'hybrid_progression',
+        name: '하이브리드 진행',
+        description: '타이머+합의 기반 진행',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'event_progression',
+        name: '이벤트 진행',
+        description: '비선형 이벤트 그래프',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'skip_consensus',
+        name: '스킵 합의',
+        description: '페이즈 스킵 투표',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'gm_control',
+        name: 'GM 제어',
+        description: '진행자 수동 제어',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'consensus_control',
+        name: '합의 제어',
+        description: '플레이어 합의 기반 제어',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'reading',
+        name: '리딩',
+        description: '대사 낭독 시스템',
+        supported: true,
+        required: false,
+        catalogVisibility: 'built_in',
+      },
+      {
+        id: 'ending',
+        name: '엔딩',
+        description: '엔딩 분기/결과 처리',
+        supported: true,
+        required: false,
+        catalogVisibility: 'built_in',
+      },
     ],
   },
   {
-    key: "communication",
-    label: "소통",
+    key: 'communication',
+    label: '소통',
     modules: [
-      { id: "text_chat", name: "텍스트 채팅", description: "전역 채팅 기능 활성화", supported: true, required: false },
-      { id: "whisper", name: "귓속말", description: "전역 1:1 비밀 메시지 기능", supported: true, required: false },
-      { id: "group_chat", name: "그룹 채팅", description: "전역 소그룹 채팅 기능", supported: true, required: false },
-      { id: "voice_chat", name: "음성 채팅", description: "실시간 음성 통화", supported: false, required: false },
-      { id: "spatial_voice", name: "공간 음성", description: "위치 기반 음성", supported: false, required: false },
+      {
+        id: 'text_chat',
+        name: '텍스트 채팅',
+        description: '전역 채팅 기능 활성화',
+        supported: true,
+        required: false,
+      },
+      {
+        id: 'whisper',
+        name: '귓속말',
+        description: '전역 1:1 비밀 메시지 기능',
+        supported: true,
+        required: false,
+      },
+      {
+        id: 'group_chat',
+        name: '그룹 채팅',
+        description: '전역 소그룹 채팅 기능',
+        supported: true,
+        required: false,
+      },
+      {
+        id: 'voice_chat',
+        name: '음성 채팅',
+        description: '실시간 음성 통화',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'spatial_voice',
+        name: '공간 음성',
+        description: '위치 기반 음성',
+        supported: false,
+        required: false,
+      },
     ],
   },
   {
-    key: "decision",
-    label: "결정",
+    key: 'decision',
+    label: '결정',
     modules: [
-      { id: "voting", name: "투표", description: "다수결 투표 시스템", supported: true, required: false },
-      { id: "accusation", name: "고발", description: "범인 지목/변호", supported: true, required: false },
-      { id: "hidden_mission", name: "히든 미션", description: "비밀 임무 시스템", supported: true, required: false, catalogVisibility: "built_in" },
+      {
+        id: 'voting',
+        name: '투표',
+        description: '다수결 투표 시스템',
+        supported: true,
+        required: false,
+      },
+      {
+        id: 'accusation',
+        name: '고발',
+        description: '범인 지목/변호',
+        supported: true,
+        required: false,
+      },
+      {
+        id: 'hidden_mission',
+        name: '히든 미션',
+        description: '비밀 임무 시스템',
+        supported: true,
+        required: false,
+        catalogVisibility: 'built_in',
+      },
     ],
   },
   {
-    key: "exploration",
-    label: "탐색",
+    key: 'exploration',
+    label: '탐색',
     modules: [
-      { id: "floor_exploration", name: "층 탐색", description: "건물 층별 탐색", supported: false, required: false },
-      { id: "room_exploration", name: "방 탐색", description: "방별 탐색", supported: false, required: false },
-      { id: "timed_exploration", name: "시간 제한 탐색", description: "제한 시간 내 탐색", supported: false, required: false },
-      { id: "location_clue", name: "장소 단서", description: "위치 기반 단서 발견", supported: false, required: false },
-      { id: "deck_investigation", name: "단서 조사", description: "조사권을 소비해 장소/장면 단서를 획득", supported: true, required: false },
+      {
+        id: 'floor_exploration',
+        name: '층 탐색',
+        description: '건물 층별 탐색',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'room_exploration',
+        name: '방 탐색',
+        description: '방별 탐색',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'timed_exploration',
+        name: '시간 제한 탐색',
+        description: '제한 시간 내 탐색',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'location_clue',
+        name: '장소 단서',
+        description: '위치 기반 단서 발견',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'deck_investigation',
+        name: '단서 조사',
+        description: '조사권을 소비해 장소/장면 단서를 획득',
+        supported: true,
+        required: false,
+      },
     ],
   },
   {
-    key: "clue_distribution",
-    label: "단서 배포",
+    key: 'clue_distribution',
+    label: '단서 배포',
     modules: [
-      { id: "conditional_clue", name: "조건부 단서", description: "조건 충족 시 단서 제공", supported: false, required: false },
-      { id: "starting_clue", name: "시작 단서", description: "게임 시작 시 배포", supported: true, required: false, catalogVisibility: "built_in" },
-      { id: "round_clue", name: "라운드 단서", description: "라운드별 단서 배포", supported: false, required: false },
-      { id: "timed_clue", name: "시간 단서", description: "시간 경과 시 배포", supported: false, required: false },
-      { id: "trade_clue", name: "단서 교환", description: "플레이어 간 단서 교환", supported: true, required: false },
+      {
+        id: 'conditional_clue',
+        name: '조건부 단서',
+        description: '조건 충족 시 단서 제공',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'starting_clue',
+        name: '시작 단서',
+        description: '게임 시작 시 배포',
+        supported: true,
+        required: false,
+        catalogVisibility: 'built_in',
+      },
+      {
+        id: 'round_clue',
+        name: '라운드 단서',
+        description: '라운드별 단서 배포',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'timed_clue',
+        name: '시간 단서',
+        description: '시간 경과 시 배포',
+        supported: false,
+        required: false,
+      },
+      {
+        id: 'trade_clue',
+        name: '단서 교환',
+        description: '플레이어 간 단서 교환',
+        supported: true,
+        required: false,
+      },
     ],
   },
 ];
@@ -151,13 +346,12 @@ export const MODULE_CATEGORIES: ModuleCategory[] = [
 // Required Module IDs (코어 카테고리 — 항상 활성화)
 // ---------------------------------------------------------------------------
 
-export const REQUIRED_MODULE_IDS = MODULE_CATEGORIES
-  .flatMap((c) => c.modules)
+export const REQUIRED_MODULE_IDS = MODULE_CATEGORIES.flatMap((c) => c.modules)
   .filter((m) => m.required)
   .map((m) => m.id);
 
 export function isSelectableModule(module: ModuleInfo): boolean {
-  return module.supported && !module.required && module.catalogVisibility !== "built_in";
+  return module.supported && !module.required && module.catalogVisibility !== 'built_in';
 }
 
 export const OPTIONAL_MODULE_CATEGORIES = MODULE_CATEGORIES.map((cat) => ({

--- a/apps/web/src/features/editor/routeSegments.ts
+++ b/apps/web/src/features/editor/routeSegments.ts
@@ -27,8 +27,8 @@ const EDITOR_ROUTE_TAB_MAP: Record<string, EditorTab> = {
   endings: 'endings',
   media: 'media',
   advanced: 'advanced',
-  templates: 'template',
-  template: 'template',
+  templates: 'overview',
+  template: 'overview',
 };
 
 const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
@@ -42,7 +42,6 @@ const EDITOR_TAB_ROUTE_SEGMENTS: Record<EditorTab, string | undefined> = {
   locations: 'locations',
   media: 'media',
   overview: 'overview',
-  template: 'template',
   advanced: 'advanced',
 };
 
@@ -56,8 +55,8 @@ export const EDITOR_ROUTE_MATRIX = [
   { path: '/editor/:id/clues', routeSegment: 'clues', editorTab: 'clues' },
   { path: '/editor/:id/relations', routeSegment: 'relations', editorTab: 'clues' },
   { path: '/editor/:id/overview', routeSegment: 'overview', editorTab: 'overview' },
-  { path: '/editor/:id/template', routeSegment: 'template', editorTab: 'template' },
-  { path: '/editor/:id/templates', routeSegment: 'templates', editorTab: 'template', alias: true },
+  { path: '/editor/:id/template', routeSegment: 'template', editorTab: 'overview', alias: true },
+  { path: '/editor/:id/templates', routeSegment: 'templates', editorTab: 'overview', alias: true },
   { path: '/editor/:id/advanced', routeSegment: 'advanced', editorTab: 'advanced' },
   {
     path: '/editor/:id/design/modules',

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -44,8 +44,13 @@ const routeMatrixCases = [
   ['직접 URL /editor/:id/relations', { id: 'theme-1', tab: 'relations' }, 'relations', 'clues'],
   ['직접 URL /editor/:id/media', { id: 'theme-1', tab: 'media' }, 'media', 'media'],
   ['직접 URL /editor/:id/overview', { id: 'theme-1', tab: 'overview' }, 'overview', 'overview'],
-  ['직접 URL /editor/:id/template', { id: 'theme-1', tab: 'template' }, 'template', 'template'],
-  ['alias URL /editor/:id/templates', { id: 'theme-1', tab: 'templates' }, 'templates', 'template'],
+  ['legacy URL /editor/:id/template', { id: 'theme-1', tab: 'template' }, 'template', 'overview'],
+  [
+    'legacy URL /editor/:id/templates',
+    { id: 'theme-1', tab: 'templates' },
+    'templates',
+    'overview',
+  ],
   ['직접 URL /editor/:id/advanced', { id: 'theme-1', tab: 'advanced' }, 'advanced', 'advanced'],
   ['직접 URL /editor/:id/design', { id: 'theme-1', tab: 'design' }, 'design', 'design'],
   [
@@ -74,7 +79,12 @@ const routeMatrixCases = [
   ],
   ['alias URL /editor/:id/modules', { id: 'theme-1', tab: 'modules' }, 'modules', 'design'],
   ['alias URL /editor/:id/flow', { id: 'theme-1', tab: 'flow' }, 'flow', 'storyMap'],
-  ['sample slug URL /editor/e2e-test-theme/flow', { id: 'e2e-test-theme', tab: 'flow' }, 'flow', 'storyMap'],
+  [
+    'sample slug URL /editor/e2e-test-theme/flow',
+    { id: 'e2e-test-theme', tab: 'flow' },
+    'flow',
+    'storyMap',
+  ],
   ['직접 URL /editor/:id/locations', { id: 'theme-1', tab: 'locations' }, 'locations', 'locations'],
   ['직접 URL /editor/:id/endings', { id: 'theme-1', tab: 'endings' }, 'endings', 'endings'],
 ] as const;
@@ -113,12 +123,14 @@ describe('EditorPage', () => {
       locationPathMock.mockReturnValue(
         expectedSegment === 'no-segment'
           ? `/editor/${params.id}`
-          : `/editor/${params.id}/${expectedSegment}`,
+          : `/editor/${params.id}/${expectedSegment}`
       );
 
       render(<EditorPage />);
 
-      expect(screen.getByText(new RegExp(`테마 에디터 ${params.id} ${expectedSegment}`))).toBeDefined();
+      expect(
+        screen.getByText(new RegExp(`테마 에디터 ${params.id} ${expectedSegment}`))
+      ).toBeDefined();
       expect(setActiveTabMock).toHaveBeenCalledWith(expectedTab);
     }
   );


### PR DESCRIPTION
## Summary
- 독립 `템플릿` 탭을 제거하고, 장르/프리셋/스키마 설정을 `기본 설정` 탭의 `게임 유형과 초기 프리셋` 섹션으로 통합했습니다.
- `/editor/:id/template`, `/editor/:id/templates` legacy URL은 깨지지 않게 `overview` 탭으로 매핑했습니다.
- 기본 설정의 프리셋 선택은 스토리 흐름 노드/장면을 즉시 덮어쓰지 않는다는 안내를 추가해, 실제 흐름 프리셋 적용 책임과 분리했습니다.

Closes #512

## Coverage Plan
- `OverviewTab.tsx`, `TemplateConfigTab.tsx`: `Editor.test.tsx`가 overview에서 `게임 유형과 초기 프리셋` 섹션 렌더링을 확인하고, `SchemaDrivenForm.test.tsx`가 장르/프리셋/스키마 폼 동작을 덮습니다.
- `constants.ts`, `EditorTabNav.tsx`: `EditorTabNav.test.tsx`가 `템플릿` 탭 제거와 탭 순서를 확인합니다.
- `routeSegments.ts`, `EditorPage.tsx`: `routeSegments.test.ts`와 `EditorPage.test.tsx`가 `template/templates -> overview` legacy route 매핑을 확인합니다.
- `TabContent.tsx`: 독립 template case 제거는 route/nav 테스트와 `pnpm --dir apps/web typecheck`로 계약을 확인했습니다.
- E2E는 추가하지 않았습니다. 사용자 데이터 저장 계약 변경 없이 에디터 IA/routing 단위 변경이며, focused UI/route test와 local quick가 주요 흐름을 덮습니다.

## Local validation
- `pnpm --dir apps/web test -- src/pages/__tests__/EditorPage.test.tsx src/features/editor/__tests__/routeSegments.test.ts src/features/editor/components/__tests__/EditorTabNav.test.tsx src/features/editor/components/__tests__/Editor.test.tsx src/features/editor/components/__tests__/SchemaDrivenForm.test.tsx` 통과: 5 files / 133 tests.
- `pnpm --dir apps/web typecheck` 통과.
- `scripts/mmp-local-ci.sh quick` 통과.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 템플릿 설정 섹션이 개요 탭에 통합되었습니다.

* **버그 수정**
  * 에디터 경로 라우팅이 개선되어 템플릿 관련 URL이 올바른 탭으로 매핑됩니다.

* **개선**
  * 에디터 탭 구조가 재정렬되어 더 일관된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->