### PR TITLE
test(web): 전역 stub cleanup 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { FlowNodeData } from "../../../flowTypes";
-import { InformationDeliveryPanel } from "../InformationDeliveryPanel";
-import { DELIVER_INFORMATION_ACTION } from "../phaseEditorAdapter";
-import { GRANT_CLUE_ACTION } from "../../../entities/shared/actionAdapter";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { FlowNodeData } from '../../../flowTypes';
+import { InformationDeliveryPanel } from '../InformationDeliveryPanel';
+import { DELIVER_INFORMATION_ACTION } from '../phaseEditorAdapter';
+import { GRANT_CLUE_ACTION } from '../../../entities/shared/actionAdapter';
 
 const { useEditorCharactersMock, useEditorCluesMock, useStoryInfosMock } = vi.hoisted(() => ({
   useEditorCharactersMock: vi.fn(),
@@ -11,66 +11,70 @@ const { useEditorCharactersMock, useEditorCluesMock, useStoryInfosMock } = vi.ho
   useStoryInfosMock: vi.fn(),
 }));
 
-vi.mock("../../../api", () => ({
+vi.mock('../../../api', () => ({
   useEditorCharacters: () => useEditorCharactersMock(),
   useEditorClues: () => useEditorCluesMock(),
 }));
 
-vi.mock("../../../storyInfoApi", () => ({
+vi.mock('../../../storyInfoApi', () => ({
   useStoryInfos: () => useStoryInfosMock(),
 }));
 
-vi.stubGlobal("crypto", { randomUUID: () => "delivery-new" });
+vi.stubGlobal('crypto', { randomUUID: () => 'delivery-new' });
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
 
 const characters = [
-  { id: "char-1", name: "탐정 A" },
-  { id: "char-2", name: "용의자 B" },
+  { id: 'char-1', name: '탐정 A' },
+  { id: 'char-2', name: '용의자 B' },
 ];
 
 const storyInfos = [
   {
-    id: "info-1",
-    themeId: "theme-1",
-    title: "숨겨진 단서",
-    body: "모두가 확인해야 하는 공개 정보",
+    id: 'info-1',
+    themeId: 'theme-1',
+    title: '숨겨진 단서',
+    body: '모두가 확인해야 하는 공개 정보',
     imageMediaId: null,
     relatedCharacterIds: [],
     relatedClueIds: [],
     relatedLocationIds: [],
     sortOrder: 0,
     version: 1,
-    createdAt: "2026-05-06T00:00:00Z",
-    updatedAt: "2026-05-06T00:00:00Z",
+    createdAt: '2026-05-06T00:00:00Z',
+    updatedAt: '2026-05-06T00:00:00Z',
   },
   {
-    id: "info-2",
-    themeId: "theme-1",
-    title: "비밀 통로",
-    body: "서재 뒤쪽에 통로가 있다",
-    imageMediaId: "media-1",
+    id: 'info-2',
+    themeId: 'theme-1',
+    title: '비밀 통로',
+    body: '서재 뒤쪽에 통로가 있다',
+    imageMediaId: 'media-1',
     relatedCharacterIds: [],
     relatedClueIds: [],
     relatedLocationIds: [],
     sortOrder: 1,
     version: 1,
-    createdAt: "2026-05-06T00:00:00Z",
-    updatedAt: "2026-05-06T00:00:00Z",
+    createdAt: '2026-05-06T00:00:00Z',
+    updatedAt: '2026-05-06T00:00:00Z',
   },
 ];
 
 const clues = [
   {
-    id: "clue-1",
-    theme_id: "theme-1",
+    id: 'clue-1',
+    theme_id: 'theme-1',
     location_id: null,
-    name: "혈흔",
-    description: "현장에서 발견된 흔적",
+    name: '혈흔',
+    description: '현장에서 발견된 흔적',
     image_url: null,
     image_media_id: null,
     is_common: false,
     level: 1,
     sort_order: 0,
-    created_at: "2026-05-06T00:00:00Z",
+    created_at: '2026-05-06T00:00:00Z',
     is_usable: false,
     use_effect: null,
     use_target: null,
@@ -79,17 +83,17 @@ const clues = [
     hide_round: null,
   },
   {
-    id: "clue-2",
-    theme_id: "theme-1",
+    id: 'clue-2',
+    theme_id: 'theme-1',
     location_id: null,
-    name: "비밀 편지",
-    description: "봉인된 편지",
+    name: '비밀 편지',
+    description: '봉인된 편지',
     image_url: null,
     image_media_id: null,
     is_common: false,
     level: 1,
     sort_order: 1,
-    created_at: "2026-05-06T00:00:00Z",
+    created_at: '2026-05-06T00:00:00Z',
     is_usable: false,
     use_effect: null,
     use_target: null,
@@ -125,30 +129,30 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("InformationDeliveryPanel", () => {
-  it("모든 페이즈에서 캐릭터별 장면 진입 효과 설정을 추가할 수 있다", () => {
+describe('InformationDeliveryPanel', () => {
+  it('모든 페이즈에서 캐릭터별 장면 진입 효과 설정을 추가할 수 있다', () => {
     const onChange = vi.fn();
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={onChange} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "캐릭터별 대상 추가" }));
+    fireEvent.click(screen.getByRole('button', { name: '캐릭터별 대상 추가' }));
 
-    expect(screen.getByText("받을 캐릭터를 선택하세요 · 정보 0개 · 단서 0개")).toBeDefined();
+    expect(screen.getByText('받을 캐릭터를 선택하세요 · 정보 0개 · 단서 0개')).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 
-  it("캐릭터, 공개 정보, 단서를 검색하고 선택/삭제할 수 있다", () => {
+  it('캐릭터, 공개 정보, 단서를 검색하고 선택/삭제할 수 있다', () => {
     const onChange = vi.fn();
     const phaseData: FlowNodeData = {
       onEnter: [
         {
-          id: "info",
+          id: 'info',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character" },
-                story_info_ids: ["info-1"],
+                id: 'd1',
+                target: { type: 'character' },
+                story_info_ids: ['info-1'],
               },
             ],
           },
@@ -156,25 +160,27 @@ describe("InformationDeliveryPanel", () => {
       ],
     };
 
-    render(<InformationDeliveryPanel themeId="theme-1" phaseData={phaseData} onChange={onChange} />);
+    render(
+      <InformationDeliveryPanel themeId="theme-1" phaseData={phaseData} onChange={onChange} />
+    );
 
-    fireEvent.change(screen.getByPlaceholderText("이름으로 찾기"), {
-      target: { value: "용의자" },
+    fireEvent.change(screen.getByPlaceholderText('이름으로 찾기'), {
+      target: { value: '용의자' },
     });
-    fireEvent.click(screen.getByRole("button", { name: /용의자 B/ }));
+    fireEvent.click(screen.getByRole('button', { name: /용의자 B/ }));
 
     expect(onChange).toHaveBeenLastCalledWith({
       onEnter: [
         {
-          id: "info",
+          id: 'info',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-2" },
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-2' },
                 reading_section_ids: [],
-                story_info_ids: ["info-1"],
+                story_info_ids: ['info-1'],
               },
             ],
           },
@@ -182,23 +188,23 @@ describe("InformationDeliveryPanel", () => {
       ],
     });
 
-    fireEvent.change(screen.getByPlaceholderText("정보 제목으로 찾기"), {
-      target: { value: "비밀" },
+    fireEvent.change(screen.getByPlaceholderText('정보 제목으로 찾기'), {
+      target: { value: '비밀' },
     });
-    fireEvent.click(screen.getByRole("button", { name: /비밀 통로/ }));
+    fireEvent.click(screen.getByRole('button', { name: /비밀 통로/ }));
 
     expect(onChange).toHaveBeenLastCalledWith({
       onEnter: [
         {
-          id: "info",
+          id: 'info',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-2" },
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-2' },
                 reading_section_ids: [],
-                story_info_ids: ["info-1", "info-2"],
+                story_info_ids: ['info-1', 'info-2'],
               },
             ],
           },
@@ -206,36 +212,36 @@ describe("InformationDeliveryPanel", () => {
       ],
     });
 
-    fireEvent.change(screen.getByPlaceholderText("단서 이름으로 찾기"), {
-      target: { value: "편지" },
+    fireEvent.change(screen.getByPlaceholderText('단서 이름으로 찾기'), {
+      target: { value: '편지' },
     });
-    fireEvent.click(screen.getByRole("button", { name: /비밀 편지/ }));
+    fireEvent.click(screen.getByRole('button', { name: /비밀 편지/ }));
 
     expect(onChange).toHaveBeenLastCalledWith({
       onEnter: [
         {
-          id: "info",
+          id: 'info',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-2" },
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-2' },
                 reading_section_ids: [],
-                story_info_ids: ["info-1", "info-2"],
+                story_info_ids: ['info-1', 'info-2'],
               },
             ],
           },
         },
         {
-          id: "delivery-new",
+          id: 'delivery-new',
           type: GRANT_CLUE_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-2" },
-                clue_ids: ["clue-2"],
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-2' },
+                clue_ids: ['clue-2'],
               },
             ],
           },
@@ -243,12 +249,11 @@ describe("InformationDeliveryPanel", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "진입 효과 1 삭제" }));
+    fireEvent.click(screen.getByRole('button', { name: '진입 효과 1 삭제' }));
     expect(onChange).toHaveBeenLastCalledWith({ onEnter: [] });
   });
 
-
-  it("캐릭터 또는 정보 조회 실패를 빈 상태와 구분하고 재시도할 수 있다", () => {
+  it('캐릭터 또는 정보 조회 실패를 빈 상태와 구분하고 재시도할 수 있다', () => {
     const refetchCharacters = vi.fn();
     const refetchStoryInfos = vi.fn();
     useEditorCharactersMock.mockReturnValue({
@@ -272,14 +277,16 @@ describe("InformationDeliveryPanel", () => {
 
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
-    expect(screen.getByText("장면 진입 효과에 필요한 캐릭터, 정보, 단서 목록을 불러오지 못했습니다.")).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { name: "다시 불러오기" }));
+    expect(
+      screen.getByText('장면 진입 효과에 필요한 캐릭터, 정보, 단서 목록을 불러오지 못했습니다.')
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: '다시 불러오기' }));
 
     expect(refetchCharacters).toHaveBeenCalledTimes(1);
     expect(refetchStoryInfos).toHaveBeenCalledTimes(1);
   });
 
-  it("옵션 목록이 비어도 저장된 장면 진입 효과는 계속 표시한다", () => {
+  it('옵션 목록이 비어도 저장된 장면 진입 효과는 계속 표시한다', () => {
     useStoryInfosMock.mockReturnValue({
       data: [],
       isLoading: false,
@@ -296,14 +303,14 @@ describe("InformationDeliveryPanel", () => {
     const phaseData: FlowNodeData = {
       onEnter: [
         {
-          id: "info",
+          id: 'info',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-1" },
-                story_info_ids: ["missing-info"],
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-1' },
+                story_info_ids: ['missing-info'],
               },
             ],
           },
@@ -313,23 +320,23 @@ describe("InformationDeliveryPanel", () => {
 
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={phaseData} onChange={vi.fn()} />);
 
-    expect(screen.getByText("탐정 A · 정보 1개 · 단서 0개")).toBeDefined();
+    expect(screen.getByText('탐정 A · 정보 1개 · 단서 0개')).toBeDefined();
     expect(screen.queryByText(/연결할 정보나 단서가 없습니다/)).toBeNull();
   });
 
-  it("phaseData onEnter 변경이 들어오면 저장된 장면 연결 설정을 다시 반영한다", () => {
+  it('phaseData onEnter 변경이 들어오면 저장된 장면 연결 설정을 다시 반영한다', () => {
     const firstPhaseData: FlowNodeData = {
       onEnter: [
         {
-          id: "info",
+          id: 'info',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-1" },
-                reading_section_ids: ["rs-1"],
-                story_info_ids: ["info-1"],
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-1' },
+                reading_section_ids: ['rs-1'],
+                story_info_ids: ['info-1'],
               },
             ],
           },
@@ -339,14 +346,14 @@ describe("InformationDeliveryPanel", () => {
     const nextPhaseData: FlowNodeData = {
       onEnter: [
         {
-          id: "info",
+          id: 'info',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d2",
-                target: { type: "character", character_id: "char-2" },
-                reading_section_ids: ["rs-2"],
+                id: 'd2',
+                target: { type: 'character', character_id: 'char-2' },
+                reading_section_ids: ['rs-2'],
                 story_info_ids: [],
               },
             ],
@@ -356,17 +363,18 @@ describe("InformationDeliveryPanel", () => {
     };
 
     const { rerender } = render(
-      <InformationDeliveryPanel themeId="theme-1" phaseData={firstPhaseData} onChange={vi.fn()} />,
+      <InformationDeliveryPanel themeId="theme-1" phaseData={firstPhaseData} onChange={vi.fn()} />
     );
-    expect(screen.getByText("탐정 A · 정보 1개 · 단서 0개")).toBeDefined();
+    expect(screen.getByText('탐정 A · 정보 1개 · 단서 0개')).toBeDefined();
 
-    rerender(<InformationDeliveryPanel themeId="theme-1" phaseData={nextPhaseData} onChange={vi.fn()} />);
+    rerender(
+      <InformationDeliveryPanel themeId="theme-1" phaseData={nextPhaseData} onChange={vi.fn()} />
+    );
 
-    expect(screen.queryByText("용의자 B · 정보 0개 · 단서 0개")).toBeNull();
+    expect(screen.queryByText('용의자 B · 정보 0개 · 단서 0개')).toBeNull();
   });
 
-
-  it("캐릭터가 없으면 캐릭터별 대상 추가를 비활성화하고 안내한다", () => {
+  it('캐릭터가 없으면 캐릭터별 대상 추가를 비활성화하고 안내한다', () => {
     useEditorCharactersMock.mockReturnValue({
       data: [],
       isLoading: false,
@@ -376,23 +384,29 @@ describe("InformationDeliveryPanel", () => {
 
     render(<InformationDeliveryPanel themeId="theme-1" phaseData={{}} onChange={vi.fn()} />);
 
-    expect((screen.getByRole("button", { name: "캐릭터별 대상 추가" }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText("아직 장면 진입 효과 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어에게 적용할 효과를 연결해 주세요.")).toBeDefined();
+    expect(
+      (screen.getByRole('button', { name: '캐릭터별 대상 추가' }) as HTMLButtonElement).disabled
+    ).toBe(true);
+    expect(
+      screen.getByText(
+        '아직 장면 진입 효과 대상이 없습니다. 전체 대상 추가를 눌러 모든 플레이어에게 적용할 효과를 연결해 주세요.'
+      )
+    ).toBeDefined();
   });
 
-  it("모든 페이즈에서 모든 플레이어 공통 전달을 추가할 수 있다", () => {
+  it('모든 페이즈에서 모든 플레이어 공통 전달을 추가할 수 있다', () => {
     const onChange = vi.fn();
     render(
       <InformationDeliveryPanel
         themeId="theme-1"
-        phaseData={{ phase_type: "investigation" }}
+        phaseData={{ phase_type: 'investigation' }}
         onChange={onChange}
-      />,
+      />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "전체 대상 추가" }));
+    fireEvent.click(screen.getByRole('button', { name: '전체 대상 추가' }));
 
-    expect(screen.getByText("모든 플레이어 · 정보 0개 · 단서 0개")).toBeDefined();
+    expect(screen.getByText('모든 플레이어 · 정보 0개 · 단서 0개')).toBeDefined();
     expect(onChange).toHaveBeenCalledWith({ onEnter: [] });
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts
@@ -1,32 +1,36 @@
-import { describe, expect, it, vi } from "vitest";
-import type { FlowNodeData } from "../../../flowTypes";
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import type { FlowNodeData } from '../../../flowTypes';
 import {
   DELIVER_INFORMATION_ACTION,
   flowNodeToInformationDeliveries,
   informationDeliveriesToFlowNodePatch,
-} from "../phaseEditorAdapter";
+} from '../phaseEditorAdapter';
 
-vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
+vi.stubGlobal('crypto', { randomUUID: () => 'generated-id' });
 
-describe("phaseEditorAdapter", () => {
-  it("API flow node의 정보 공개 action을 제작자용 ViewModel로 변환한다", () => {
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('phaseEditorAdapter', () => {
+  it('API flow node의 정보 공개 action을 제작자용 ViewModel로 변환한다', () => {
     const data: FlowNodeData = {
       onEnter: [
-        { id: "a1", type: "broadcast", params: { message: "시작" } },
+        { id: 'a1', type: 'broadcast', params: { message: '시작' } },
         {
-          id: "info-1",
+          id: 'info-1',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-1" },
-                reading_section_ids: ["rs-1", "rs-2", "rs-1"],
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-1' },
+                reading_section_ids: ['rs-1', 'rs-2', 'rs-1'],
               },
               {
-                id: "d2",
-                target: { type: "all_players" },
-                reading_section_ids: ["rs-common"],
+                id: 'd2',
+                target: { type: 'all_players' },
+                reading_section_ids: ['rs-common'],
               },
             ],
           },
@@ -36,57 +40,57 @@ describe("phaseEditorAdapter", () => {
 
     expect(flowNodeToInformationDeliveries(data)).toEqual([
       {
-        id: "d1",
-        recipientType: "character",
-        characterId: "char-1",
-        readingSectionIds: ["rs-1", "rs-2"],
+        id: 'd1',
+        recipientType: 'character',
+        characterId: 'char-1',
+        readingSectionIds: ['rs-1', 'rs-2'],
         storyInfoIds: [],
       },
       {
-        id: "d2",
-        recipientType: "all_players",
-        readingSectionIds: ["rs-common"],
+        id: 'd2',
+        recipientType: 'all_players',
+        readingSectionIds: ['rs-common'],
         storyInfoIds: [],
       },
     ]);
   });
 
-  it("정보 공개 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다", () => {
+  it('정보 공개 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다', () => {
     const data: FlowNodeData = {
       onEnter: [
-        { id: "legacy", type: "deliver_information", params: { deliveries: [] } },
-        { id: "bgm", type: "play_bgm", params: { mediaId: "bgm-1" } },
+        { id: 'legacy', type: 'deliver_information', params: { deliveries: [] } },
+        { id: 'bgm', type: 'play_bgm', params: { mediaId: 'bgm-1' } },
       ],
     };
 
     const patch = informationDeliveriesToFlowNodePatch(data, [
       {
-        id: "draft",
-        recipientType: "character",
+        id: 'draft',
+        recipientType: 'character',
         readingSectionIds: [],
         storyInfoIds: [],
       },
       {
-        id: "d1",
-        recipientType: "character",
-        characterId: "char-1",
-        readingSectionIds: ["rs-1", "rs-2", "rs-1"],
-        storyInfoIds: ["info-1", "info-1"],
+        id: 'd1',
+        recipientType: 'character',
+        characterId: 'char-1',
+        readingSectionIds: ['rs-1', 'rs-2', 'rs-1'],
+        storyInfoIds: ['info-1', 'info-1'],
       },
     ]);
 
     expect(patch.onEnter).toEqual([
-      { id: "bgm", type: "play_bgm", params: { mediaId: "bgm-1" } },
+      { id: 'bgm', type: 'play_bgm', params: { mediaId: 'bgm-1' } },
       {
-        id: "legacy",
+        id: 'legacy',
         type: DELIVER_INFORMATION_ACTION,
         params: {
           deliveries: [
             {
-              id: "d1",
-              target: { type: "character", character_id: "char-1" },
-              reading_section_ids: ["rs-1", "rs-2"],
-              story_info_ids: ["info-1"],
+              id: 'd1',
+              target: { type: 'character', character_id: 'char-1' },
+              reading_section_ids: ['rs-1', 'rs-2'],
+              story_info_ids: ['info-1'],
             },
           ],
         },
@@ -94,55 +98,56 @@ describe("phaseEditorAdapter", () => {
     ]);
   });
 
-  it("마지막 공개 설정을 삭제하면 정보 공개 action만 제거하고 다른 action은 유지한다", () => {
+  it('마지막 공개 설정을 삭제하면 정보 공개 action만 제거하고 다른 action은 유지한다', () => {
     const data: FlowNodeData = {
       onEnter: [
-        { id: "info", type: DELIVER_INFORMATION_ACTION, params: { deliveries: [] } },
-        { id: "chat", type: "enable_chat" },
+        { id: 'info', type: DELIVER_INFORMATION_ACTION, params: { deliveries: [] } },
+        { id: 'chat', type: 'enable_chat' },
       ],
     };
 
     expect(informationDeliveriesToFlowNodePatch(data, [])).toEqual({
-      onEnter: [{ id: "chat", type: "enable_chat" }],
+      onEnter: [{ id: 'chat', type: 'enable_chat' }],
     });
   });
 
-  it("미완성 공개 설정은 저장 payload에서 제외한다", () => {
-    const data: FlowNodeData = { onEnter: [{ id: "chat", type: "enable_chat" }] };
+  it('미완성 공개 설정은 저장 payload에서 제외한다', () => {
+    const data: FlowNodeData = { onEnter: [{ id: 'chat', type: 'enable_chat' }] };
 
     expect(
       informationDeliveriesToFlowNodePatch(data, [
-        { id: "empty", recipientType: "character", readingSectionIds: [], storyInfoIds: [] },
-        { id: "no-character", recipientType: "character", readingSectionIds: ["rs-1"], storyInfoIds: [] },
-        { id: "no-section", recipientType: "all_players", readingSectionIds: [], storyInfoIds: [] },
-      ]),
-    ).toEqual({ onEnter: [{ id: "chat", type: "enable_chat" }] });
+        { id: 'empty', recipientType: 'character', readingSectionIds: [], storyInfoIds: [] },
+        {
+          id: 'no-character',
+          recipientType: 'character',
+          readingSectionIds: ['rs-1'],
+          storyInfoIds: [],
+        },
+        { id: 'no-section', recipientType: 'all_players', readingSectionIds: [], storyInfoIds: [] },
+      ])
+    ).toEqual({ onEnter: [{ id: 'chat', type: 'enable_chat' }] });
   });
 
-
-  it("모든 페이즈에서 all_players 공개 설정을 저장한다", () => {
+  it('모든 페이즈에서 all_players 공개 설정을 저장한다', () => {
     expect(
-      informationDeliveriesToFlowNodePatch(
-        { phase_type: "investigation" },
-        [
-          {
-            id: "all",
-            recipientType: "all_players",
-            readingSectionIds: ["rs-common"],
-            storyInfoIds: [],
-          },
-        ],
-      ).onEnter,
+      informationDeliveriesToFlowNodePatch({ phase_type: 'investigation' }, [
+        {
+          id: 'all',
+          recipientType: 'all_players',
+          readingSectionIds: ['rs-common'],
+          storyInfoIds: [],
+        },
+      ]).onEnter
     ).toEqual([
       {
-        id: "generated-id",
+        id: 'generated-id',
         type: DELIVER_INFORMATION_ACTION,
         params: {
           deliveries: [
             {
-              id: "all",
-              target: { type: "all_players" },
-              reading_section_ids: ["rs-common"],
+              id: 'all',
+              target: { type: 'all_players' },
+              reading_section_ids: ['rs-common'],
               story_info_ids: [],
             },
           ],
@@ -150,5 +155,4 @@ describe("phaseEditorAdapter", () => {
       },
     ]);
   });
-
 });

--- a/apps/web/src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts
@@ -1,34 +1,38 @@
-import type { Edge } from "@xyflow/react";
-import { describe, expect, it, vi } from "vitest";
-import type { FlowNodeData } from "../../../flowTypes";
+import type { Edge } from '@xyflow/react';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import type { FlowNodeData } from '../../../flowTypes';
 import {
   DELIVER_INFORMATION_ACTION,
   flowNodeToInformationDeliveries,
   informationDeliveriesToFlowNodePatch,
   toPhaseEditorViewModel,
-} from "../phaseEntityAdapter";
+} from '../phaseEntityAdapter';
 
-vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
+vi.stubGlobal('crypto', { randomUUID: () => 'generated-id' });
 
-describe("phaseEntityAdapter", () => {
-  it("API flow node의 정보 공개 action을 제작자용 ViewModel로 변환한다", () => {
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('phaseEntityAdapter', () => {
+  it('API flow node의 정보 공개 action을 제작자용 ViewModel로 변환한다', () => {
     const data: FlowNodeData = {
       onEnter: [
-        { id: "a1", type: "broadcast", params: { message: "시작" } },
+        { id: 'a1', type: 'broadcast', params: { message: '시작' } },
         {
-          id: "info-1",
+          id: 'info-1',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "d1",
-                target: { type: "character", character_id: "char-1" },
-                reading_section_ids: ["rs-1", "rs-2", "rs-1"],
+                id: 'd1',
+                target: { type: 'character', character_id: 'char-1' },
+                reading_section_ids: ['rs-1', 'rs-2', 'rs-1'],
               },
               {
-                id: "d2",
-                target: { type: "all_players" },
-                reading_section_ids: ["rs-common"],
+                id: 'd2',
+                target: { type: 'all_players' },
+                reading_section_ids: ['rs-common'],
               },
             ],
           },
@@ -38,57 +42,57 @@ describe("phaseEntityAdapter", () => {
 
     expect(flowNodeToInformationDeliveries(data)).toEqual([
       {
-        id: "d1",
-        recipientType: "character",
-        characterId: "char-1",
-        readingSectionIds: ["rs-1", "rs-2"],
+        id: 'd1',
+        recipientType: 'character',
+        characterId: 'char-1',
+        readingSectionIds: ['rs-1', 'rs-2'],
         storyInfoIds: [],
       },
       {
-        id: "d2",
-        recipientType: "all_players",
-        readingSectionIds: ["rs-common"],
+        id: 'd2',
+        recipientType: 'all_players',
+        readingSectionIds: ['rs-common'],
         storyInfoIds: [],
       },
     ]);
   });
 
-  it("정보 공개 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다", () => {
+  it('정보 공개 ViewModel을 기존 onEnter action과 함께 round-trip 저장 payload로 되돌린다', () => {
     const data: FlowNodeData = {
       onEnter: [
-        { id: "legacy", type: "deliver_information", params: { deliveries: [] } },
-        { id: "bgm", type: "play_bgm", params: { mediaId: "bgm-1" } },
+        { id: 'legacy', type: 'deliver_information', params: { deliveries: [] } },
+        { id: 'bgm', type: 'play_bgm', params: { mediaId: 'bgm-1' } },
       ],
     };
 
     const patch = informationDeliveriesToFlowNodePatch(data, [
       {
-        id: "draft",
-        recipientType: "character",
+        id: 'draft',
+        recipientType: 'character',
         readingSectionIds: [],
         storyInfoIds: [],
       },
       {
-        id: "d1",
-        recipientType: "character",
-        characterId: "char-1",
-        readingSectionIds: ["rs-1", "rs-2", "rs-1"],
-        storyInfoIds: ["info-1", "info-1"],
+        id: 'd1',
+        recipientType: 'character',
+        characterId: 'char-1',
+        readingSectionIds: ['rs-1', 'rs-2', 'rs-1'],
+        storyInfoIds: ['info-1', 'info-1'],
       },
     ]);
 
     expect(patch.onEnter).toEqual([
-      { id: "bgm", type: "play_bgm", params: { mediaId: "bgm-1" } },
+      { id: 'bgm', type: 'play_bgm', params: { mediaId: 'bgm-1' } },
       {
-        id: "legacy",
+        id: 'legacy',
         type: DELIVER_INFORMATION_ACTION,
         params: {
           deliveries: [
             {
-              id: "d1",
-              target: { type: "character", character_id: "char-1" },
-              reading_section_ids: ["rs-1", "rs-2"],
-              story_info_ids: ["info-1"],
+              id: 'd1',
+              target: { type: 'character', character_id: 'char-1' },
+              reading_section_ids: ['rs-1', 'rs-2'],
+              story_info_ids: ['info-1'],
             },
           ],
         },
@@ -96,42 +100,39 @@ describe("phaseEntityAdapter", () => {
     ]);
   });
 
-  it("마지막 공개 설정을 삭제하면 정보 공개 action만 제거하고 다른 action은 유지한다", () => {
+  it('마지막 공개 설정을 삭제하면 정보 공개 action만 제거하고 다른 action은 유지한다', () => {
     const data: FlowNodeData = {
       onEnter: [
-        { id: "info", type: DELIVER_INFORMATION_ACTION, params: { deliveries: [] } },
-        { id: "chat", type: "enable_chat" },
+        { id: 'info', type: DELIVER_INFORMATION_ACTION, params: { deliveries: [] } },
+        { id: 'chat', type: 'enable_chat' },
       ],
     };
 
     expect(informationDeliveriesToFlowNodePatch(data, [])).toEqual({
-      onEnter: [{ id: "chat", type: "enable_chat" }],
+      onEnter: [{ id: 'chat', type: 'enable_chat' }],
     });
   });
 
-  it("모든 페이즈에서 all_players 공개 설정을 저장한다", () => {
+  it('모든 페이즈에서 all_players 공개 설정을 저장한다', () => {
     expect(
-      informationDeliveriesToFlowNodePatch(
-        { phase_type: "investigation" },
-        [
-          {
-            id: "all",
-            recipientType: "all_players",
-            readingSectionIds: ["rs-common"],
-            storyInfoIds: [],
-          },
-        ],
-      ).onEnter,
+      informationDeliveriesToFlowNodePatch({ phase_type: 'investigation' }, [
+        {
+          id: 'all',
+          recipientType: 'all_players',
+          readingSectionIds: ['rs-common'],
+          storyInfoIds: [],
+        },
+      ]).onEnter
     ).toEqual([
       {
-        id: "generated-id",
+        id: 'generated-id',
         type: DELIVER_INFORMATION_ACTION,
         params: {
           deliveries: [
             {
-              id: "all",
-              target: { type: "all_players" },
-              reading_section_ids: ["rs-common"],
+              id: 'all',
+              target: { type: 'all_players' },
+              reading_section_ids: ['rs-common'],
               story_info_ids: [],
             },
           ],
@@ -140,64 +141,71 @@ describe("phaseEntityAdapter", () => {
     ]);
   });
 
-  it("페이즈 설정과 연결 상태를 제작자용 요약 ViewModel로 변환한다", () => {
+  it('페이즈 설정과 연결 상태를 제작자용 요약 ViewModel로 변환한다', () => {
     const data: FlowNodeData = {
-      label: "1차 조사",
-      phase_type: "investigation",
+      label: '1차 조사',
+      phase_type: 'investigation',
       duration: 25,
       rounds: 3,
       autoAdvance: true,
       warningAt: 120,
       onEnter: [
-        { type: "play_bgm" },
+        { type: 'play_bgm' },
         {
           type: DELIVER_INFORMATION_ACTION,
-          params: { deliveries: [{ target: { type: "character", character_id: "char-1" }, reading_section_ids: ["rs-1"] }] },
+          params: {
+            deliveries: [
+              {
+                target: { type: 'character', character_id: 'char-1' },
+                reading_section_ids: ['rs-1'],
+              },
+            ],
+          },
         },
       ],
-      onExit: [{ type: "disable_chat" }],
+      onExit: [{ type: 'disable_chat' }],
     };
     const edges: Edge[] = [
-      { id: "e1", source: "phase-1", target: "phase-2" },
+      { id: 'e1', source: 'phase-1', target: 'phase-2' },
       {
-        id: "e2",
-        source: "phase-1",
-        target: "ending-1",
+        id: 'e2',
+        source: 'phase-1',
+        target: 'ending-1',
         data: {
           condition: {
-            id: "group-1",
-            operator: "AND",
+            id: 'group-1',
+            operator: 'AND',
             rules: [
               {
-                id: "rule-1",
-                variable: "custom_flag",
-                target_flag_key: "route_open",
-                comparator: "=",
-                value: "true",
+                id: 'rule-1',
+                variable: 'custom_flag',
+                target_flag_key: 'route_open',
+                comparator: '=',
+                value: 'true',
               },
             ],
           },
         },
       },
       {
-        id: "e3",
-        source: "phase-1",
-        target: "ending-2",
-        data: { condition: { type: "has_clue", clueId: "clue-1" } },
+        id: 'e3',
+        source: 'phase-1',
+        target: 'ending-2',
+        data: { condition: { type: 'has_clue', clueId: 'clue-1' } },
       },
     ];
 
     expect(toPhaseEditorViewModel(data, edges)).toMatchObject({
-      title: "1차 조사",
-      phaseTypeLabel: "수사",
-      durationLabel: "25분",
-      roundLabel: "3라운드",
-      autoAdvanceLabel: "자동 진행",
-      warningLabel: "120초 전에 경고",
+      title: '1차 조사',
+      phaseTypeLabel: '수사',
+      durationLabel: '25분',
+      roundLabel: '3라운드',
+      autoAdvanceLabel: '자동 진행',
+      warningLabel: '120초 전에 경고',
       informationDeliveryCount: 1,
-      enterActionLabels: ["BGM 재생"],
-      exitActionLabels: ["채팅 닫기"],
-      defaultTransitionLabel: "기본 이동 2개",
+      enterActionLabels: ['BGM 재생'],
+      exitActionLabels: ['채팅 닫기'],
+      defaultTransitionLabel: '기본 이동 2개',
       conditionalTransitionCount: 1,
     });
   });

--- a/apps/web/src/features/editor/entities/shared/__tests__/informationDeliveryAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/informationDeliveryAdapter.test.ts
@@ -1,75 +1,76 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from 'vitest';
 import {
   DELIVER_INFORMATION_ACTION,
   flowNodeToInformationDeliveries,
   informationDeliveriesToFlowNodePatch,
-} from "../informationDeliveryAdapter";
+} from '../informationDeliveryAdapter';
 
-vi.stubGlobal("crypto", { randomUUID: () => "generated-id" });
+vi.stubGlobal('crypto', { randomUUID: () => 'generated-id' });
 
-describe("informationDeliveryAdapter", () => {
-  it("legacy/current 정보 공개 payload를 같은 ViewModel로 정규화한다", () => {
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('informationDeliveryAdapter', () => {
+  it('legacy/current 정보 공개 payload를 같은 ViewModel로 정규화한다', () => {
     expect(
       flowNodeToInformationDeliveries({
         onEnter: [
           {
-            type: "deliver_information",
+            type: 'deliver_information',
             params: {
               deliveries: [
                 {
-                  id: "d1",
-                  recipient_type: "character",
-                  character_id: "char-1",
-                  readingSectionIds: ["rs-1", "rs-1"],
-                  storyInfoIds: ["info-1", "info-1"],
+                  id: 'd1',
+                  recipient_type: 'character',
+                  character_id: 'char-1',
+                  readingSectionIds: ['rs-1', 'rs-1'],
+                  storyInfoIds: ['info-1', 'info-1'],
                 },
               ],
             },
           },
         ],
-      }),
+      })
     ).toEqual([
       {
-        id: "d1",
-        recipientType: "character",
-        characterId: "char-1",
-        readingSectionIds: ["rs-1"],
-        storyInfoIds: ["info-1"],
+        id: 'd1',
+        recipientType: 'character',
+        characterId: 'char-1',
+        readingSectionIds: ['rs-1'],
+        storyInfoIds: ['info-1'],
       },
     ]);
   });
 
-  it("완성된 공개 설정을 모든 페이즈에서 current payload로 저장한다", () => {
+  it('완성된 공개 설정을 모든 페이즈에서 current payload로 저장한다', () => {
     expect(
-      informationDeliveriesToFlowNodePatch(
-        { phase_type: "investigation" },
-        [
-          {
-            id: "empty",
-            recipientType: "character",
-            readingSectionIds: [],
-            storyInfoIds: [],
-          },
-          {
-            id: "all",
-            recipientType: "all_players",
-            readingSectionIds: ["rs-1"],
-            storyInfoIds: ["info-1"],
-          },
-        ],
-      ),
+      informationDeliveriesToFlowNodePatch({ phase_type: 'investigation' }, [
+        {
+          id: 'empty',
+          recipientType: 'character',
+          readingSectionIds: [],
+          storyInfoIds: [],
+        },
+        {
+          id: 'all',
+          recipientType: 'all_players',
+          readingSectionIds: ['rs-1'],
+          storyInfoIds: ['info-1'],
+        },
+      ])
     ).toEqual({
       onEnter: [
         {
-          id: "generated-id",
+          id: 'generated-id',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "all",
-                target: { type: "all_players" },
-                reading_section_ids: ["rs-1"],
-                story_info_ids: ["info-1"],
+                id: 'all',
+                target: { type: 'all_players' },
+                reading_section_ids: ['rs-1'],
+                story_info_ids: ['info-1'],
               },
             ],
           },
@@ -78,32 +79,29 @@ describe("informationDeliveryAdapter", () => {
     });
   });
 
-  it("정보 카드만 연결한 공개 설정도 완성된 payload로 저장한다", () => {
+  it('정보 카드만 연결한 공개 설정도 완성된 payload로 저장한다', () => {
     expect(
-      informationDeliveriesToFlowNodePatch(
-        { phase_type: "story_progression" },
-        [
-          {
-            id: "info-only",
-            recipientType: "character",
-            characterId: "char-1",
-            readingSectionIds: [],
-            storyInfoIds: ["info-1", "info-1"],
-          },
-        ],
-      ),
+      informationDeliveriesToFlowNodePatch({ phase_type: 'story_progression' }, [
+        {
+          id: 'info-only',
+          recipientType: 'character',
+          characterId: 'char-1',
+          readingSectionIds: [],
+          storyInfoIds: ['info-1', 'info-1'],
+        },
+      ])
     ).toEqual({
       onEnter: [
         {
-          id: "generated-id",
+          id: 'generated-id',
           type: DELIVER_INFORMATION_ACTION,
           params: {
             deliveries: [
               {
-                id: "info-only",
-                target: { type: "character", character_id: "char-1" },
+                id: 'info-only',
+                target: { type: 'character', character_id: 'char-1' },
                 reading_section_ids: [],
-                story_info_ids: ["info-1"],
+                story_info_ids: ['info-1'],
               },
             ],
           },

--- a/apps/web/src/features/payment/components/__tests__/PaymentModal.test.tsx
+++ b/apps/web/src/features/payment/components/__tests__/PaymentModal.test.tsx
@@ -1,15 +1,11 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { afterAll, describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const {
-  createPaymentMutateAsync,
-  confirmPaymentMutateAsync,
-  toastSuccess,
-} = vi.hoisted(() => ({
+const { createPaymentMutateAsync, confirmPaymentMutateAsync, toastSuccess } = vi.hoisted(() => ({
   createPaymentMutateAsync: vi.fn(),
   confirmPaymentMutateAsync: vi.fn(),
   toastSuccess: vi.fn(),
@@ -19,7 +15,7 @@ const {
 // Mock: sonner
 // ---------------------------------------------------------------------------
 
-vi.mock("sonner", () => ({
+vi.mock('sonner', () => ({
   toast: { success: toastSuccess, error: vi.fn() },
 }));
 
@@ -27,7 +23,7 @@ vi.mock("sonner", () => ({
 // Mock: @/features/payment/api
 // ---------------------------------------------------------------------------
 
-vi.mock("@/features/payment/api", () => ({
+vi.mock('@/features/payment/api', () => ({
   useCreatePayment: () => ({ mutateAsync: createPaymentMutateAsync }),
   useConfirmPayment: () => ({ mutateAsync: confirmPaymentMutateAsync }),
 }));
@@ -36,24 +32,24 @@ vi.mock("@/features/payment/api", () => ({
 // Mock: crypto.randomUUID
 // ---------------------------------------------------------------------------
 
-vi.stubGlobal("crypto", {
-  randomUUID: () => "test-uuid-1234",
+vi.stubGlobal('crypto', {
+  randomUUID: () => 'test-uuid-1234',
 });
 
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { PaymentModal } from "../PaymentModal";
+import { PaymentModal } from '../PaymentModal';
 
 // ---------------------------------------------------------------------------
 // Mock data
 // ---------------------------------------------------------------------------
 
 const mockPkg = {
-  id: "pkg-2",
-  platform: "WEB" as const,
-  name: "프리미엄 팩",
+  id: 'pkg-2',
+  platform: 'WEB' as const,
+  name: '프리미엄 팩',
   price_krw: 30000,
   base_coins: 300,
   bonus_coins: 50,
@@ -71,54 +67,52 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("PaymentModal", () => {
-  it("선택된 패키지 정보를 표시한다", () => {
-    render(
-      <PaymentModal pkg={mockPkg} isOpen={true} onClose={onCloseMock} />,
-    );
+describe('PaymentModal', () => {
+  it('선택된 패키지 정보를 표시한다', () => {
+    render(<PaymentModal pkg={mockPkg} isOpen={true} onClose={onCloseMock} />);
 
-    expect(screen.getByText("프리미엄 팩")).toBeDefined();
-    expect(screen.getByText("350 코인")).toBeDefined();
-    expect(screen.getByText("30,000원")).toBeDefined();
-    expect(screen.getByText("결제하기")).toBeDefined();
+    expect(screen.getByText('프리미엄 팩')).toBeDefined();
+    expect(screen.getByText('350 코인')).toBeDefined();
+    expect(screen.getByText('30,000원')).toBeDefined();
+    expect(screen.getByText('결제하기')).toBeDefined();
   });
 
-  it("결제 처리 중 로딩을 표시한다", async () => {
+  it('결제 처리 중 로딩을 표시한다', async () => {
     // createPayment을 pending 상태로 유지
     createPaymentMutateAsync.mockReturnValue(new Promise(() => {}));
 
-    render(
-      <PaymentModal pkg={mockPkg} isOpen={true} onClose={onCloseMock} />,
-    );
+    render(<PaymentModal pkg={mockPkg} isOpen={true} onClose={onCloseMock} />);
 
-    fireEvent.click(screen.getByText("결제하기"));
+    fireEvent.click(screen.getByText('결제하기'));
 
     await waitFor(() => {
-      expect(screen.getByText("결제 처리 중...")).toBeDefined();
+      expect(screen.getByText('결제 처리 중...')).toBeDefined();
     });
   });
 
-  it("결제 확인 후 성공 메시지를 표시한다", async () => {
+  it('결제 확인 후 성공 메시지를 표시한다', async () => {
     createPaymentMutateAsync.mockResolvedValue({
-      id: "pay-1",
-      payment_key: "key-1",
+      id: 'pay-1',
+      payment_key: 'key-1',
     });
-    confirmPaymentMutateAsync.mockResolvedValue({ id: "pay-1" });
+    confirmPaymentMutateAsync.mockResolvedValue({ id: 'pay-1' });
 
-    render(
-      <PaymentModal pkg={mockPkg} isOpen={true} onClose={onCloseMock} />,
-    );
+    render(<PaymentModal pkg={mockPkg} isOpen={true} onClose={onCloseMock} />);
 
-    fireEvent.click(screen.getByText("결제하기"));
+    fireEvent.click(screen.getByText('결제하기'));
 
     await waitFor(() => {
-      expect(screen.getByText("결제가 완료되었습니다!")).toBeDefined();
+      expect(screen.getByText('결제가 완료되었습니다!')).toBeDefined();
     });
 
-    expect(toastSuccess).toHaveBeenCalledWith("350 코인이 충전되었습니다!");
+    expect(toastSuccess).toHaveBeenCalledWith('350 코인이 충전되었습니다!');
   });
 });


### PR DESCRIPTION
## Summary
- `vi.stubGlobal("crypto", ...)`를 파일 상단에서 사용하는 테스트 5곳에 `afterAll(() => vi.unstubAllGlobals())` cleanup을 추가했습니다.
- 이미 파일별 cleanup이 있던 `localStorage`/`fetch` stub 테스트는 inventory만 확인하고 동작 변경 없이 유지했습니다.
- production code 변경 없이 테스트 전역 객체 오염 방지만 정리했습니다.

Closes #518

## Coverage Plan
- `PaymentModal.test.tsx`: crypto UUID stub cleanup 추가, 기존 payment modal 렌더/로딩/성공 테스트로 확인.
- `informationDeliveryAdapter.test.ts`, `phaseEntityAdapter.test.ts`, `phaseEditorAdapter.test.ts`: crypto UUID stub cleanup 추가, adapter round-trip 및 payload 생성 테스트로 확인.
- `InformationDeliveryPanel.test.tsx`: crypto UUID stub cleanup 추가, UI 추가/선택/삭제 및 조회 실패/재시도 테스트로 확인.
- Inventory 확인: `rg -n 'vi\.stubGlobal\(' apps/web/src -g '*.ts' -g '*.tsx'` 기준 모든 stubGlobal 사용 파일이 `vi.unstubAllGlobals()` cleanup을 갖는지 확인했습니다.
- E2E는 추가하지 않았습니다. 사용자 플로우 변경이 아닌 테스트 격리 정리이며, focused unit/component tests와 local quick로 검증했습니다.

## Local validation
- `pnpm --dir apps/web test -- src/features/payment/components/__tests__/PaymentModal.test.tsx src/features/editor/entities/shared/__tests__/informationDeliveryAdapter.test.ts src/features/editor/entities/phase/__tests__/phaseEntityAdapter.test.ts src/features/editor/components/design/__tests__/InformationDeliveryPanel.test.tsx src/features/editor/components/design/__tests__/phaseEditorAdapter.test.ts src/features/editor/entities/shared/__tests__/sceneEntryEffectAdapter.test.ts src/pages/__tests__/ReadingScriptMockPages.test.tsx src/features/editor/mockReadingBlocks.test.ts src/features/editor/__tests__/flowApi.msw.test.ts` 통과: 9 files / 40 tests.
- `pnpm --dir apps/web typecheck` 통과.
- `scripts/mmp-local-ci.sh quick` 통과.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 릴리스는 **내부 테스트 개선사항**만 포함하며, 사용자에게 보이는 기능 변화는 없습니다.

* **Tests**
  * 테스트 코드 스타일 및 구조 개선으로 일관성 강화
  * 테스트 설정 및 정리 로직 명시화
  * 다양한 시나리오에 대한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->