### PR TITLE
feat(runtime): 캐릭터 공개 시점 연결

### DIFF
--- a/apps/server/internal/engine/build_state_for_test.go
+++ b/apps/server/internal/engine/build_state_for_test.go
@@ -187,6 +187,94 @@ func TestPhaseEngine_BuildStateForIncludesResolvedRosterWithoutAliasRules(t *tes
 	}
 }
 
+func TestPhaseEngine_BuildStateForResolvesAliasPresetFromProgressContext(t *testing.T) {
+	playerID := uuid.New()
+	aliasName := "정체를 밝힌 목격자"
+	baseName := "홍길동"
+	pe, _ := newTestPhaseEngine(t, []Module{&stubCoreModule{name: "public_mod"}}, []PhaseDefinition{
+		{ID: "intro", Name: "자기소개"},
+		{ID: "investigation", Name: "조사"},
+		{ID: "voting_started", Name: "투표"},
+	})
+	pe.SetPlayerInfoProvider(rosterProviderStub{players: []PlayerRuntimeInfo{{
+		PlayerID:    playerID,
+		Nickname:    "참가자",
+		DisplayName: baseName,
+	}}})
+	pe.playerInfoProvider = progressRosterProvider{
+		rosterProviderStub: rosterProviderStub{players: []PlayerRuntimeInfo{{
+			PlayerID:    playerID,
+			Nickname:    "참가자",
+			DisplayName: baseName,
+		}}},
+		base: CharacterDisplayBase{
+			Name: baseName,
+			AliasRules: []CharacterAliasRule{{
+				ID:          "round-three",
+				DisplayName: &aliasName,
+				Priority:    1,
+				Condition:   aliasPresetCondition("round_started", "3"),
+			}},
+		},
+	}
+
+	ctx := context.Background()
+	if err := pe.Start(ctx, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop(ctx)
+
+	raw, err := pe.BuildStateFor(playerID)
+	if err != nil {
+		t.Fatalf("BuildStateFor round 1: %v", err)
+	}
+	if strings.Contains(string(raw), aliasName) {
+		t.Fatalf("alias should be hidden before round 3: %s", raw)
+	}
+
+	if _, err := pe.AdvancePhase(ctx); err != nil {
+		t.Fatalf("AdvancePhase round 2: %v", err)
+	}
+	if _, err := pe.AdvancePhase(ctx); err != nil {
+		t.Fatalf("AdvancePhase round 3: %v", err)
+	}
+	raw, err = pe.BuildStateFor(playerID)
+	if err != nil {
+		t.Fatalf("BuildStateFor round 3: %v", err)
+	}
+	if !strings.Contains(string(raw), aliasName) {
+		t.Fatalf("alias should be visible from round 3: %s", raw)
+	}
+}
+
+type progressRosterProvider struct {
+	rosterProviderStub
+	base CharacterDisplayBase
+}
+
+func (p progressRosterProvider) PlayerRuntimeRosterWithContext(_ context.Context, displayContext json.RawMessage) []PlayerRuntimeInfo {
+	players := p.PlayerRuntimeRoster(context.Background())
+	for i := range players {
+		display := ResolveCharacterDisplay(p.base, displayContext)
+		players[i].DisplayName = display.Name
+	}
+	return players
+}
+
+func aliasPresetCondition(flagKey, value string) json.RawMessage {
+	return json.RawMessage(`{
+		"id":"group-1",
+		"operator":"AND",
+		"rules":[{
+			"id":"rule-1",
+			"variable":"custom_flag",
+			"target_flag_key":"` + flagKey + `",
+			"comparator":"=",
+			"value":"` + value + `"
+		}]
+	}`)
+}
+
 func TestPhaseEngine_BuildStateForRosterSortsAndUsesNicknameFallback(t *testing.T) {
 	earlyID := uuid.New()
 	lateID := uuid.New()

--- a/apps/server/internal/engine/condition_contract.go
+++ b/apps/server/internal/engine/condition_contract.go
@@ -184,6 +184,9 @@ func conditionGroupLogic(group ConditionGroup) (any, error) {
 }
 
 func conditionRuleLogic(rule ConditionRule) (any, error) {
+	if logic, ok, err := specialCustomFlagLogic(rule); ok || err != nil {
+		return logic, err
+	}
 	pathBuilder, ok := conditionVariablePaths[rule.Variable]
 	if !ok {
 		return nil, fmt.Errorf("condition: rule %q has unsupported variable %q", rule.ID, rule.Variable)
@@ -200,6 +203,29 @@ func conditionRuleLogic(rule ConditionRule) (any, error) {
 		map[string]any{"var": path},
 		coerceConditionValue(rule.Value),
 	}}, nil
+}
+
+func specialCustomFlagLogic(rule ConditionRule) (any, bool, error) {
+	if rule.Variable != "custom_flag" || rule.Comparator != "=" {
+		return nil, false, nil
+	}
+	switch rule.TargetFlagKey {
+	case "round_started":
+		return map[string]any{">=": []any{
+			map[string]any{"var": "round"},
+			coerceConditionValue(rule.Value),
+		}}, true, nil
+	case "story_node_reached":
+		if rule.Value == "" {
+			return nil, true, fmt.Errorf("condition: rule %q requires story node id", rule.ID)
+		}
+		return map[string]any{">": []any{
+			map[string]any{"var": joinConditionPath("scenes", rule.Value, "visitCount")},
+			0,
+		}}, true, nil
+	default:
+		return nil, false, nil
+	}
 }
 
 func targetValue(rule ConditionRule) string {

--- a/apps/server/internal/engine/condition_contract_test.go
+++ b/apps/server/internal/engine/condition_contract_test.go
@@ -34,6 +34,69 @@ func TestConditionGroupToJSONLogic_EvaluatesSharedMMPShape(t *testing.T) {
 	}
 }
 
+func TestConditionGroupToJSONLogic_CustomFlagRevealPresetsUseRuntimeProgress(t *testing.T) {
+	t.Run("round_started means from that round onward", func(t *testing.T) {
+		raw := json.RawMessage(`{
+			"id":"g1",
+			"operator":"AND",
+			"rules":[{
+				"id":"r1",
+				"variable":"custom_flag",
+				"target_flag_key":"round_started",
+				"comparator":"=",
+				"value":"3"
+			}]
+		}`)
+		for _, tc := range []struct {
+			name string
+			ctx  json.RawMessage
+			want bool
+		}{
+			{name: "before round", ctx: json.RawMessage(`{"round":2}`), want: false},
+			{name: "at round", ctx: json.RawMessage(`{"round":3}`), want: true},
+			{name: "after round", ctx: json.RawMessage(`{"round":4}`), want: true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := EvaluateConditionGroup(raw, tc.ctx)
+				if err != nil {
+					t.Fatalf("EvaluateConditionGroup: %v", err)
+				}
+				if got.Bool != tc.want {
+					t.Fatalf("Bool = %v, want %v", got.Bool, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("story_node_reached uses visited scene count", func(t *testing.T) {
+		raw := json.RawMessage(`{
+			"id":"g1",
+			"operator":"AND",
+			"rules":[{
+				"id":"r1",
+				"variable":"custom_flag",
+				"target_flag_key":"story_node_reached",
+				"comparator":"=",
+				"value":"voting_started"
+			}]
+		}`)
+		got, err := EvaluateConditionGroup(raw, json.RawMessage(`{"scenes":{"voting_started":{"visitCount":1}}}`))
+		if err != nil {
+			t.Fatalf("EvaluateConditionGroup: %v", err)
+		}
+		if !got.Bool {
+			t.Fatalf("Bool = false, want true")
+		}
+		got, err = EvaluateConditionGroup(raw, json.RawMessage(`{"scenes":{"intro_finished":{"visitCount":1}}}`))
+		if err != nil {
+			t.Fatalf("EvaluateConditionGroup miss: %v", err)
+		}
+		if got.Bool {
+			t.Fatalf("Bool = true, want false")
+		}
+	})
+}
+
 func TestParseConditionGroup_RejectsInvalidContract(t *testing.T) {
 	tests := []struct {
 		name string

--- a/apps/server/internal/engine/phase_actions.go
+++ b/apps/server/internal/engine/phase_actions.go
@@ -19,6 +19,7 @@ func (e *PhaseEngine) enterCurrentPhase(ctx context.Context) error {
 	if err := e.dispatchDiscussionRoomPolicy(ctx, phase.DiscussionRoomPolicy); err != nil {
 		return err
 	}
+	e.recordPhaseVisit(phase.ID)
 	e.eventBus.Publish(Event{
 		Type:    "phase:entered",
 		Payload: e.CurrentPhase(),

--- a/apps/server/internal/engine/phase_engine.go
+++ b/apps/server/internal/engine/phase_engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -42,6 +43,7 @@ type PhaseEngine struct {
 	mediaResolver      MediaResolver
 	phases             []PhaseDefinition
 	sceneTransitions   []SceneTransition
+	sceneVisitCounts   map[string]int
 	current            int // index into phases, -1 = not started
 	currentRound       int32
 	started            bool
@@ -71,15 +73,16 @@ func NewPhaseEngine(
 	}
 
 	return &PhaseEngine{
-		sessionID: sessionID,
-		modules:   modules,
-		moduleMap: moduleMap,
-		eventBus:  bus,
-		audit:     audit,
-		logger:    logger,
-		phases:    phases,
-		current:   0,
-		started:   false,
+		sessionID:        sessionID,
+		modules:          modules,
+		moduleMap:        moduleMap,
+		eventBus:         bus,
+		audit:            audit,
+		logger:           logger,
+		phases:           phases,
+		sceneVisitCounts: make(map[string]int),
+		current:          0,
+		started:          false,
 	}
 }
 
@@ -373,7 +376,9 @@ func (e *PhaseEngine) BuildStateFor(playerID uuid.UUID) (json.RawMessage, error)
 		"sessionId": e.sessionID,
 		"phase":     e.CurrentPhase(),
 	}
-	if rosterProvider, ok := e.playerInfoProvider.(PlayerRuntimeRosterProvider); ok {
+	if rosterProvider, ok := e.playerInfoProvider.(PlayerRuntimeRosterContextProvider); ok {
+		state["players"] = playerRuntimeRosterPayload(rosterProvider.PlayerRuntimeRosterWithContext(context.Background(), e.PlayerDisplayContext()))
+	} else if rosterProvider, ok := e.playerInfoProvider.(PlayerRuntimeRosterProvider); ok {
 		state["players"] = playerRuntimeRosterPayload(rosterProvider.PlayerRuntimeRoster(context.Background()))
 	}
 
@@ -478,7 +483,71 @@ func (e *PhaseEngine) phaseInfo(idx int) *PhaseInfo {
 		ID:    string(p.ID),
 		Name:  p.Name,
 		Index: idx,
+		Round: e.currentRound,
 	}
+}
+
+func (e *PhaseEngine) recordPhaseVisit(phase Phase) {
+	if e.sceneVisitCounts == nil {
+		e.sceneVisitCounts = make(map[string]int)
+	}
+	e.sceneVisitCounts[string(phase)]++
+}
+
+// PlayerDisplayContext is the backend-owned condition context for character
+// alias presets. It keeps creator-authored "from round/node" presets tied to
+// actual engine progress instead of frontend-only labels.
+func (e *PhaseEngine) PlayerDisplayContext() json.RawMessage {
+	phase := e.CurrentPhase()
+	if phase == nil {
+		return json.RawMessage(`{"flags":{}}`)
+	}
+	firstIntro, lastIntro := e.introPhaseBounds()
+	introStarted := firstIntro >= 0 && e.current >= firstIntro
+	introFinished := lastIntro >= 0 && e.current > lastIntro
+
+	scenes := make(map[string]map[string]any, len(e.sceneVisitCounts))
+	for id, count := range e.sceneVisitCounts {
+		scenes[id] = map[string]any{"visitCount": count, "reached": count > 0}
+	}
+
+	payload := map[string]any{
+		"phase": phase.ID,
+		"round": e.currentRound,
+		"flags": map[string]any{
+			"game_started":       e.started && !e.stopped,
+			"intro_started":      introStarted,
+			"intro_finished":     introFinished,
+			"round_started":      e.currentRound,
+			"story_node_reached": phase.ID,
+		},
+		"scenes": scenes,
+	}
+	data, _ := json.Marshal(payload)
+	return data
+}
+
+func (e *PhaseEngine) introPhaseBounds() (int, int) {
+	first, last := -1, -1
+	for idx, phase := range e.phases {
+		if isIntroPhase(phase) {
+			if first == -1 {
+				first = idx
+			}
+			last = idx
+		}
+	}
+	return first, last
+}
+
+func isIntroPhase(phase PhaseDefinition) bool {
+	id := strings.ToLower(string(phase.ID))
+	name := strings.ToLower(phase.Name)
+	return strings.Contains(id, "intro") ||
+		strings.Contains(id, "introduction") ||
+		strings.Contains(name, "intro") ||
+		strings.Contains(name, "introduction") ||
+		strings.Contains(name, "자기소개")
 }
 
 func (e *PhaseEngine) moduleNames() []string {

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -50,6 +50,7 @@ type PhaseInfo struct {
 	Name     string          `json:"name"`
 	Type     string          `json:"type"`
 	Index    int             `json:"index"`
+	Round    int32           `json:"round"`
 	Duration int             `json:"duration"`
 	Elapsed  int             `json:"elapsed"`
 	State    json.RawMessage `json:"state,omitempty"`
@@ -235,6 +236,13 @@ type PlayerInfoProvider interface {
 // raw alias rules or spoiler fields must never be included.
 type PlayerRuntimeRosterProvider interface {
 	PlayerRuntimeRoster(ctx context.Context) []PlayerRuntimeInfo
+}
+
+// PlayerRuntimeRosterContextProvider resolves player display values against
+// the current backend progress context. It is used for character alias rules
+// whose conditions depend on phase, round, or visited story node state.
+type PlayerRuntimeRosterContextProvider interface {
+	PlayerRuntimeRosterWithContext(ctx context.Context, displayContext json.RawMessage) []PlayerRuntimeInfo
 }
 
 // ModuleDeps provides session-scoped dependencies to modules.

--- a/apps/server/internal/module/decision/hidden_mission/config.go
+++ b/apps/server/internal/module/decision/hidden_mission/config.go
@@ -21,6 +21,9 @@ type Mission struct {
 	TargetCharacterID string `json:"targetCharacterId,omitempty"`
 	TargetEndingID    string `json:"targetEndingId,omitempty"`
 	Condition         string `json:"condition,omitempty"`
+	VisibleFrom       string `json:"visibleFrom,omitempty"`
+	RevealRound       int32  `json:"revealRound,omitempty"`
+	RevealNodeID      string `json:"revealNodeId,omitempty"`
 	Completed         bool   `json:"completed"`
 }
 

--- a/apps/server/internal/module/decision/hidden_mission/events.go
+++ b/apps/server/internal/module/decision/hidden_mission/events.go
@@ -1,6 +1,8 @@
 package hidden_mission
 
 import (
+	"strings"
+
 	"github.com/google/uuid"
 	"github.com/mmp-platform/server/internal/engine"
 )
@@ -93,4 +95,41 @@ func (m *HiddenMissionModule) onClueTransferred(event engine.Event) {
 			m.completeMission(pid, mission.ID, "clue.transferred")
 		}
 	}
+}
+
+func (m *HiddenMissionModule) onPhaseEntered(event engine.Event) {
+	info, ok := event.Payload.(*engine.PhaseInfo)
+	if !ok || info == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.gameStarted = true
+	m.currentRound = info.Round
+	if m.currentRound == 0 {
+		m.currentRound = int32(info.Index + 1)
+	}
+	m.currentNodeID = info.ID
+	if m.visitedNodes == nil {
+		m.visitedNodes = make(map[string]bool)
+	}
+	if info.ID != "" {
+		m.visitedNodes[info.ID] = true
+	}
+	if isIntroPhaseInfo(info) {
+		m.introStarted = true
+	} else if m.introStarted {
+		m.introFinished = true
+	}
+}
+
+func isIntroPhaseInfo(info *engine.PhaseInfo) bool {
+	id := strings.ToLower(info.ID)
+	name := strings.ToLower(info.Name)
+	return strings.Contains(id, "intro") ||
+		strings.Contains(id, "introduction") ||
+		strings.Contains(name, "intro") ||
+		strings.Contains(name, "introduction") ||
+		strings.Contains(name, "자기소개")
 }

--- a/apps/server/internal/module/decision/hidden_mission/hidden_mission_test.go
+++ b/apps/server/internal/module/decision/hidden_mission/hidden_mission_test.go
@@ -447,6 +447,62 @@ func TestHiddenMissionModule_BuildState(t *testing.T) {
 	}
 }
 
+func TestHiddenMissionModule_BuildStateForFiltersMissionsByRevealTiming(t *testing.T) {
+	pid := uuid.New()
+	cfg := map[string]any{
+		"playerMissions": map[string]any{
+			pid.String(): []map[string]any{
+				{"id": "game", "type": "custom", "description": "게임 시작", "points": 1, "visibleFrom": "game_start"},
+				{"id": "round3", "type": "custom", "description": "3라운드", "points": 1, "visibleFrom": "round_start", "revealRound": 3},
+				{"id": "node", "type": "custom", "description": "투표", "points": 1, "visibleFrom": "node_reached", "revealNodeId": "voting_started"},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	m := initHiddenMissionModule(t, string(data))
+
+	m.onPhaseEntered(engine.Event{Type: "phase:entered", Payload: &engine.PhaseInfo{ID: "intro", Name: "자기소개", Index: 0, Round: 1}})
+	state := buildHiddenMissionStateFor(t, m, pid)
+	assertMissionIDs(t, state.PlayerMissions[pid], []string{"game"})
+
+	m.onPhaseEntered(engine.Event{Type: "phase:entered", Payload: &engine.PhaseInfo{ID: "investigation", Name: "조사", Index: 1, Round: 2}})
+	state = buildHiddenMissionStateFor(t, m, pid)
+	assertMissionIDs(t, state.PlayerMissions[pid], []string{"game"})
+
+	m.onPhaseEntered(engine.Event{Type: "phase:entered", Payload: &engine.PhaseInfo{ID: "round_three", Name: "3라운드", Index: 2, Round: 3}})
+	state = buildHiddenMissionStateFor(t, m, pid)
+	assertMissionIDs(t, state.PlayerMissions[pid], []string{"game", "round3"})
+
+	m.onPhaseEntered(engine.Event{Type: "phase:entered", Payload: &engine.PhaseInfo{ID: "voting_started", Name: "투표", Index: 3, Round: 4}})
+	state = buildHiddenMissionStateFor(t, m, pid)
+	assertMissionIDs(t, state.PlayerMissions[pid], []string{"game", "round3", "node"})
+}
+
+func buildHiddenMissionStateFor(t *testing.T, m *HiddenMissionModule, pid uuid.UUID) hiddenMissionState {
+	t.Helper()
+	raw, err := m.BuildStateFor(pid)
+	if err != nil {
+		t.Fatalf("BuildStateFor: %v", err)
+	}
+	var state hiddenMissionState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	return state
+}
+
+func assertMissionIDs(t *testing.T, missions []Mission, want []string) {
+	t.Helper()
+	if len(missions) != len(want) {
+		t.Fatalf("missions len = %d, want %d: %+v", len(missions), len(want), missions)
+	}
+	for i, mission := range missions {
+		if mission.ID != want[i] {
+			t.Fatalf("mission[%d] = %q, want %q; all=%+v", i, mission.ID, want[i], missions)
+		}
+	}
+}
+
 func TestHiddenMissionModule_Schema(t *testing.T) {
 	m := NewHiddenMissionModule()
 	schema := m.Schema()

--- a/apps/server/internal/module/decision/hidden_mission/module.go
+++ b/apps/server/internal/module/decision/hidden_mission/module.go
@@ -22,6 +22,12 @@ type HiddenMissionModule struct {
 	completedMissions map[uuid.UUID][]string // playerID → completed mission IDs
 	scores            map[uuid.UUID]int
 	subscriptionIDs   []int
+	gameStarted       bool
+	introStarted      bool
+	introFinished     bool
+	currentRound      int32
+	currentNodeID     string
+	visitedNodes      map[string]bool
 }
 
 // NewHiddenMissionModule creates a new HiddenMissionModule instance.
@@ -41,6 +47,7 @@ func (m *HiddenMissionModule) Init(_ context.Context, deps engine.ModuleDeps, co
 	m.playerMissions = make(map[uuid.UUID][]Mission)
 	m.completedMissions = make(map[uuid.UUID][]string)
 	m.scores = make(map[uuid.UUID]int)
+	m.visitedNodes = make(map[string]bool)
 
 	// Apply defaults.
 	m.config = HiddenMissionConfig{
@@ -96,6 +103,8 @@ func (m *HiddenMissionModule) Init(_ context.Context, deps engine.ModuleDeps, co
 		deps.EventBus.Subscribe("vote.cast", m.onVoteCast))
 	m.subscriptionIDs = append(m.subscriptionIDs,
 		deps.EventBus.Subscribe("clue.transferred", m.onClueTransferred))
+	m.subscriptionIDs = append(m.subscriptionIDs,
+		deps.EventBus.Subscribe("phase:entered", m.onPhaseEntered))
 
 	return nil
 }
@@ -113,6 +122,7 @@ func (m *HiddenMissionModule) Cleanup(_ context.Context) error {
 	m.playerMissions = nil
 	m.completedMissions = nil
 	m.scores = nil
+	m.visitedNodes = nil
 	return nil
 }
 

--- a/apps/server/internal/module/decision/hidden_mission/state.go
+++ b/apps/server/internal/module/decision/hidden_mission/state.go
@@ -51,10 +51,44 @@ func (m *HiddenMissionModule) BuildStateFor(playerID uuid.UUID) (json.RawMessage
 	}
 
 	if own, ok := m.playerMissions[playerID]; ok && len(own) > 0 {
-		state.PlayerMissions = map[uuid.UUID][]Mission{playerID: own}
+		visible := m.visibleMissions(own)
+		if len(visible) > 0 {
+			state.PlayerMissions = map[uuid.UUID][]Mission{playerID: visible}
+		}
 	}
 
 	return json.Marshal(state)
+}
+
+func (m *HiddenMissionModule) visibleMissions(missions []Mission) []Mission {
+	visible := make([]Mission, 0, len(missions))
+	for _, mission := range missions {
+		if m.isMissionVisible(mission) {
+			visible = append(visible, mission)
+		}
+	}
+	return visible
+}
+
+func (m *HiddenMissionModule) isMissionVisible(mission Mission) bool {
+	switch mission.VisibleFrom {
+	case "", "game_start":
+		return m.gameStarted
+	case "intro_start":
+		return m.introStarted
+	case "intro_end":
+		return m.introFinished
+	case "round_start":
+		round := mission.RevealRound
+		if round <= 0 {
+			round = 1
+		}
+		return m.currentRound >= round
+	case "node_reached":
+		return mission.RevealNodeID != "" && m.visitedNodes[mission.RevealNodeID]
+	default:
+		return m.gameStarted
+	}
 }
 
 // --- SerializableModule ---
@@ -64,6 +98,12 @@ type hiddenMissionSavedState struct {
 	PlayerMissions    map[string][]Mission `json:"playerMissions"`
 	CompletedMissions map[string][]string  `json:"completedMissions"`
 	Scores            map[string]int       `json:"scores"`
+	GameStarted       bool                 `json:"gameStarted,omitempty"`
+	IntroStarted      bool                 `json:"introStarted,omitempty"`
+	IntroFinished     bool                 `json:"introFinished,omitempty"`
+	CurrentRound      int32                `json:"currentRound,omitempty"`
+	CurrentNodeID     string               `json:"currentNodeId,omitempty"`
+	VisitedNodes      map[string]bool      `json:"visitedNodes,omitempty"`
 }
 
 // SaveState snapshots the module's persistable state.
@@ -89,6 +129,12 @@ func (m *HiddenMissionModule) SaveState(_ context.Context) (engine.GameState, er
 		PlayerMissions:    pm,
 		CompletedMissions: cm,
 		Scores:            sc,
+		GameStarted:       m.gameStarted,
+		IntroStarted:      m.introStarted,
+		IntroFinished:     m.introFinished,
+		CurrentRound:      m.currentRound,
+		CurrentNodeID:     m.currentNodeID,
+		VisitedNodes:      cloneStringBoolMap(m.visitedNodes),
 	})
 	if err != nil {
 		return engine.GameState{}, fmt.Errorf("hidden_mission: save state: %w", err)
@@ -138,5 +184,22 @@ func (m *HiddenMissionModule) RestoreState(_ context.Context, _ uuid.UUID, state
 	m.playerMissions = pm
 	m.completedMissions = cm
 	m.scores = sc
+	m.gameStarted = s.GameStarted
+	m.introStarted = s.IntroStarted
+	m.introFinished = s.IntroFinished
+	m.currentRound = s.CurrentRound
+	m.currentNodeID = s.CurrentNodeID
+	m.visitedNodes = cloneStringBoolMap(s.VisitedNodes)
 	return nil
+}
+
+func cloneStringBoolMap(src map[string]bool) map[string]bool {
+	if len(src) == 0 {
+		return map[string]bool{}
+	}
+	dst := make(map[string]bool, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }

--- a/apps/server/internal/session/starter.go
+++ b/apps/server/internal/session/starter.go
@@ -198,6 +198,7 @@ func startModularGame(
 
 type staticPlayerInfoProvider struct {
 	players       map[uuid.UUID]engine.PlayerRuntimeInfo
+	displayBases  map[uuid.UUID]engine.CharacterDisplayBase
 	targetCodeIDs map[string]uuid.UUID
 }
 
@@ -206,6 +207,7 @@ func newStaticPlayerInfoProvider(players []PlayerState) engine.PlayerInfoProvide
 		return nil
 	}
 	infos := make(map[uuid.UUID]engine.PlayerRuntimeInfo, len(players))
+	displayBases := make(map[uuid.UUID]engine.CharacterDisplayBase, len(players))
 	targetCodeIDs := make(map[string]uuid.UUID, len(players))
 	for _, player := range players {
 		isAlive := true
@@ -223,6 +225,7 @@ func newStaticPlayerInfoProvider(players []PlayerState) engine.PlayerInfoProvide
 			ConnectedAt: player.ConnectedAt,
 		}
 		if player.DisplayBase.Name != "" {
+			displayBases[player.PlayerID] = player.DisplayBase
 			display := engine.ResolveCharacterDisplay(player.DisplayBase, player.DisplayContext)
 			info := infos[player.PlayerID]
 			info.DisplayName = display.Name
@@ -234,7 +237,7 @@ func newStaticPlayerInfoProvider(players []PlayerState) engine.PlayerInfoProvide
 			targetCodeIDs[player.TargetCode] = player.PlayerID
 		}
 	}
-	return staticPlayerInfoProvider{players: infos, targetCodeIDs: targetCodeIDs}
+	return staticPlayerInfoProvider{players: infos, displayBases: displayBases, targetCodeIDs: targetCodeIDs}
 }
 
 func (p staticPlayerInfoProvider) ResolvePlayerID(_ context.Context, targetCode string) (uuid.UUID, bool) {
@@ -254,8 +257,23 @@ func (p staticPlayerInfoProvider) PlayerRuntimeInfo(_ context.Context, playerID 
 }
 
 func (p staticPlayerInfoProvider) PlayerRuntimeRoster(_ context.Context) []engine.PlayerRuntimeInfo {
+	return p.PlayerRuntimeRosterWithContext(context.Background(), nil)
+}
+
+func (p staticPlayerInfoProvider) PlayerRuntimeRosterWithContext(_ context.Context, displayContext json.RawMessage) []engine.PlayerRuntimeInfo {
 	players := make([]engine.PlayerRuntimeInfo, 0, len(p.players))
 	for _, player := range p.players {
+		if len(displayContext) > 0 && string(displayContext) != "null" {
+			base, ok := p.displayBases[player.PlayerID]
+			if !ok || base.Name == "" {
+				players = append(players, player)
+				continue
+			}
+			display := engine.ResolveCharacterDisplay(base, displayContext)
+			player.DisplayName = display.Name
+			player.DisplayIconURL = display.ImageURL
+			player.DisplayIconMediaID = display.ImageMediaID
+		}
 		players = append(players, player)
 	}
 	return players


### PR DESCRIPTION
## 요약
- 캐릭터 별칭 공개 프리셋을 backend engine 진행 상태로 평가하도록 연결했습니다.
- `round_started`는 지정 라운드부터 계속 true, `story_node_reached`는 scene 방문 기록 기준으로 동작하게 했습니다.
- `hidden_mission` runtime이 `visibleFrom` / `revealRound` / `revealNodeId`를 반영해 플레이어별 공개 미션만 내려주도록 했습니다.

Closes #520
Refs #533

## Coverage Plan
- `apps/server/internal/engine/*`: 라운드/스토리 노드 진행 상태가 character display condition에 들어가는지 unit test로 검증했습니다.
- `apps/server/internal/engine/condition_contract.go`: `round_started`, `story_node_reached` preset 변환을 unit test로 검증했습니다.
- `apps/server/internal/session/starter.go`: engine이 넘긴 progress context로 alias display가 재계산되는지 engine test에서 검증했습니다.
- `apps/server/internal/module/decision/hidden_mission/*`: 공개 시점별 hidden mission 필터링과 Save/Restore를 module test로 검증했습니다.

## Local validation
- `git diff --check` 통과
- `go test ./internal/engine ./internal/module/decision/hidden_mission ./internal/session -count=1` 통과
- `go test ./internal/domain/editor -run TestGetTheme_AppliesNormalizer -count=1` 통과
- `go test ./internal/engine ./internal/module/decision/hidden_mission ./internal/session ./internal/domain/editor -count=1` 통과
- `go test ./internal/auditlog -run TestStore_ConcurrentAppend_SeqUniqueness -count=1` 통과
- `go test ./internal/domain/flow -run TestServiceFlowOwnership_RejectsDifferentCreatorMutations -count=1` 통과
- `scripts/mmp-local-ci.sh quick`는 같은 HEAD에서 시도했지만 병렬 testcontainers 포트 조회 flake(`port "5432/tcp" not found`)로 실패했습니다. 실패한 테스트들은 단독 재시도에서 통과했고, flake 안정화는 #533으로 분리했습니다.

## Deferred / Follow-up
- #533: 병렬 testcontainers 포트 조회 flake 안정화

## CI policy
- 기본 PR 처리 정책에 따라 `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않습니다.
- 로컬 CI marker는 위 flake 때문에 `MMP_SKIP_LOCAL_CI_GUARD=1`로 우회했고, 대체 focused validation 근거를 위에 남겼습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 미션 공개 타이밍을 라운드 또는 스토리 진행 상황에 따라 설정할 수 있습니다.
  * 게임 진행 상황에 따른 동적 미션 표시 필터링이 추가되었습니다.

* **개선사항**
  * 게임 단계 진행 중 플레이어 정보 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->