### PR TITLE
feat(web): 공개 시점 선택을 진행 데이터와 연결

### DIFF
--- a/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
@@ -8,6 +8,7 @@ import {
   writeCluePolicy,
   type EditorConfig,
 } from '@/features/editor/utils/configShape';
+import type { RoundRevealOption } from '@/features/editor/entities/reveal/revealTimingOptions';
 
 interface ClueBasicInfoCardProps {
   themeId: string;
@@ -15,6 +16,7 @@ interface ClueBasicInfoCardProps {
   configJson: EditorConfig | null | undefined;
   isSaving?: boolean;
   isConfigSaving?: boolean;
+  roundOptions?: RoundRevealOption[];
   onSave: (clueId: string, body: UpdateClueRequest) => void;
   onConfigChange: (nextConfig: EditorConfig) => void;
   onDelete: (clue: ClueResponse) => void;
@@ -92,6 +94,7 @@ export function ClueBasicInfoCard({
   configJson,
   isSaving = false,
   isConfigSaving = false,
+  roundOptions = DEFAULT_CLUE_ROUND_OPTIONS,
   onSave,
   onConfigChange,
   onDelete,
@@ -301,14 +304,11 @@ export function ClueBasicInfoCard({
               className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
             >
               <option value="start">처음부터</option>
-              <option value="round:1">1라운드 시작</option>
-              <option value="round:2">2라운드 시작</option>
-              <option value="round:3">3라운드 시작</option>
-              <option value="round:4">4라운드 시작</option>
-              <option value="round:5">5라운드 시작</option>
-              {draft.revealRound != null && draft.revealRound > 5 && (
-                <option value={`round:${draft.revealRound}`}>{draft.revealRound}라운드 시작</option>
-              )}
+              {roundOptions.map((option) => (
+                <option key={option.value} value={`round:${option.value}`}>
+                  {option.label} 시작
+                </option>
+              ))}
             </select>
           </label>
           <label className="text-sm font-medium text-slate-300">
@@ -319,14 +319,11 @@ export function ClueBasicInfoCard({
               className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
             >
               <option value="end">끝까지</option>
-              <option value="round:1">1라운드 종료</option>
-              <option value="round:2">2라운드 종료</option>
-              <option value="round:3">3라운드 종료</option>
-              <option value="round:4">4라운드 종료</option>
-              <option value="round:5">5라운드 종료</option>
-              {draft.hideRound != null && draft.hideRound > 5 && (
-                <option value={`round:${draft.hideRound}`}>{draft.hideRound}라운드 종료</option>
-              )}
+              {roundOptions.map((option) => (
+                <option key={option.value} value={`round:${option.value}`}>
+                  {option.label} 종료
+                </option>
+              ))}
             </select>
           </label>
         </div>
@@ -360,3 +357,8 @@ function InfoBlock({ title, value }: { title: string; value: string }) {
     </div>
   );
 }
+
+const DEFAULT_CLUE_ROUND_OPTIONS = Array.from({ length: 5 }, (_, index) => {
+  const round = index + 1;
+  return { value: round, label: `${round}라운드` };
+});

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -5,6 +5,7 @@ import type {
   LocationResponse,
   UpdateClueRequest,
 } from '@/features/editor/api';
+import type { FlowNodeResponse } from '@/features/editor/flowTypes';
 import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import {
@@ -17,11 +18,13 @@ import {
 } from '@/features/editor/entities/clue/clueEntityAdapter';
 import { ClueRuntimeEffectCard } from './ClueRuntimeEffectCard';
 import { ClueBasicInfoCard } from './ClueBasicInfoCard';
+import { buildRoundRevealOptions } from '@/features/editor/entities/reveal/revealTimingOptions';
 
 interface ClueEntityWorkspaceProps {
   themeId?: string;
   clues: ClueResponse[];
   configJson: EditorConfig | null | undefined;
+  flowNodes?: FlowNodeResponse[];
   locations: LocationResponse[];
   characters: EditorCharacterResponse[];
   onCreate: () => void;
@@ -36,6 +39,7 @@ export function ClueEntityWorkspace({
   themeId,
   clues,
   configJson,
+  flowNodes,
   locations,
   characters,
   onCreate,
@@ -49,6 +53,13 @@ export function ClueEntityWorkspace({
   const usageMap = useMemo(
     () => buildClueUsageMap({ configJson, clues, locations, characters }),
     [configJson, clues, locations, characters]
+  );
+  const roundOptions = useMemo(
+    () => buildRoundRevealOptions(
+      flowNodes,
+      clues.flatMap((clue) => [clue.reveal_round, clue.hide_round]),
+    ),
+    [flowNodes, clues],
   );
 
   return (
@@ -70,6 +81,7 @@ export function ClueEntityWorkspace({
             configJson={configJson}
             isSaving={isClueSaving}
             isConfigSaving={isConfigSaving}
+            roundOptions={roundOptions}
             onSave={onUpdate}
             onConfigChange={onConfigChange}
             onDelete={onDelete}

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -18,6 +18,7 @@ import type { EditorConfig } from '@/features/editor/utils/configShape';
 import { buildClueUsageMap, type EntityReference } from '@/features/editor/utils/entityReferences';
 import { ClueForm } from '../ClueForm';
 import { ClueEntityWorkspace } from './ClueEntityWorkspace';
+import { useFlowGraph } from '@/features/editor/flowApi';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -36,6 +37,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
   const { data: theme } = useEditorTheme(themeId);
   const { data: locations = [] } = useEditorLocations(themeId);
   const { data: characters = [] } = useEditorCharacters(themeId);
+  const { data: flowGraph } = useFlowGraph(themeId);
   const deleteClue = useDeleteClue(themeId);
   const updateClue = useUpdateClue(themeId);
   const updateConfig = useUpdateConfigJson(themeId);
@@ -127,6 +129,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
         themeId={themeId}
         clues={clues}
         configJson={theme?.config_json}
+        flowNodes={flowGraph?.nodes}
         locations={locations}
         characters={characters}
         onCreate={handleCreate}

--- a/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAliasRulesEditor.tsx
@@ -3,11 +3,18 @@ import type { CharacterAliasRule } from '@/features/editor/api';
 import { groupToRecord, type ConditionGroup } from './condition/conditionTypes';
 import { normalizeCharacterAliasRules } from '@/features/editor/entities/character/characterEditorAdapter';
 import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
+import type {
+  ProgressNodeRevealOption,
+  RoundRevealOption,
+} from '@/features/editor/entities/reveal/revealTimingOptions';
 
 interface CharacterAliasRulesEditorProps {
   themeId: string;
   characterName: string;
   rules: CharacterAliasRule[];
+  characterOptions?: unknown;
+  roundOptions?: RoundRevealOption[];
+  nodeOptions?: ProgressNodeRevealOption[];
   disabled: boolean;
   onChange: (rules: CharacterAliasRule[]) => void;
   onSave: (rules: CharacterAliasRule[]) => void;
@@ -18,6 +25,8 @@ interface CharacterAliasRuleItemProps {
   rule: CharacterAliasRule;
   index: number;
   characterName: string;
+  roundOptions: RoundRevealOption[];
+  nodeOptions: ProgressNodeRevealOption[];
   disabled: boolean;
   onUpdate: (index: number, patch: Partial<CharacterAliasRule>) => void;
   onRemove: (index: number) => void;
@@ -27,6 +36,8 @@ export function CharacterAliasRulesEditor({
   themeId,
   characterName,
   rules,
+  roundOptions = DEFAULT_ALIAS_ROUND_OPTIONS,
+  nodeOptions = DEFAULT_ALIAS_NODE_OPTIONS,
   disabled,
   onChange,
   onSave,
@@ -106,6 +117,8 @@ export function CharacterAliasRulesEditor({
             rule={rule}
             index={index}
             characterName={characterName}
+            roundOptions={roundOptions}
+            nodeOptions={nodeOptions}
             disabled={disabled}
             onUpdate={updateRule}
             onRemove={removeRule}
@@ -135,6 +148,8 @@ function CharacterAliasRuleItem({
   rule,
   index,
   characterName,
+  roundOptions,
+  nodeOptions,
   disabled,
   onUpdate,
   onRemove,
@@ -229,17 +244,21 @@ function CharacterAliasRuleItem({
       {selectedPreset === 'round_start' ? (
         <label className="mt-2 block text-[11px] text-slate-400">
           표시 라운드
-          <input
-            type="number"
-            min={1}
-            value={presetValue.round}
+          <select
+            value={String(presetValue.round)}
             disabled={disabled}
             onChange={(event) => {
               const round = normalizePositiveNumber(event.currentTarget.value);
               onUpdate(index, { condition: groupToRecord(createAliasPresetCondition('round_start', { ...presetValue, round })) });
             }}
             className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
-          />
+          >
+            {roundOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label} 시작
+              </option>
+            ))}
+          </select>
         </label>
       ) : null}
       {selectedPreset === 'node_reached' ? (
@@ -253,7 +272,7 @@ function CharacterAliasRuleItem({
             }}
             className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs text-slate-200 disabled:opacity-60"
           >
-            {ALIAS_NODE_OPTIONS.map((option) => (
+            {nodeOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -335,7 +354,12 @@ const ALIAS_PRESETS: Array<{ value: AliasPreset; label: string; flagKey?: string
   { value: 'custom', label: '기존 고급 조건 유지' },
 ];
 
-const ALIAS_NODE_OPTIONS = [
+const DEFAULT_ALIAS_ROUND_OPTIONS = Array.from({ length: 5 }, (_, index) => {
+  const round = index + 1;
+  return { value: round, label: `${round}라운드` };
+});
+
+const DEFAULT_ALIAS_NODE_OPTIONS = [
   { value: 'intro_finished', label: '자기소개 종료' },
   { value: 'round_summary', label: '라운드 정리' },
   { value: 'voting_started', label: '투표 시작' },
@@ -348,7 +372,7 @@ interface AliasPresetValue {
 
 function createAliasPresetCondition(
   preset: Exclude<AliasPreset, 'custom'>,
-  value: AliasPresetValue = { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value },
+  value: AliasPresetValue = { round: 1, nodeId: DEFAULT_ALIAS_NODE_OPTIONS[0].value },
 ): ConditionGroup {
   const option = ALIAS_PRESETS.find((item) => item.value === preset);
   return {
@@ -382,18 +406,18 @@ function inferAliasPreset(raw: CharacterAliasRule['condition']): AliasPreset {
 
 function inferAliasPresetValue(raw: CharacterAliasRule['condition']): AliasPresetValue {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value };
+    return { round: 1, nodeId: DEFAULT_ALIAS_NODE_OPTIONS[0].value };
   }
   const rules = (raw as { rules?: unknown }).rules;
   if (!Array.isArray(rules) || rules.length !== 1) {
-    return { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value };
+    return { round: 1, nodeId: DEFAULT_ALIAS_NODE_OPTIONS[0].value };
   }
   const rule = rules[0] as { target_flag_key?: unknown; value?: unknown };
   if (rule.target_flag_key === 'round_started' && typeof rule.value === 'string') {
-    return { round: normalizePositiveNumber(rule.value), nodeId: ALIAS_NODE_OPTIONS[0].value };
+    return { round: normalizePositiveNumber(rule.value), nodeId: DEFAULT_ALIAS_NODE_OPTIONS[0].value };
   }
   if (rule.target_flag_key === 'story_node_reached' && typeof rule.value === 'string') {
-    return { round: 1, nodeId: rule.value || ALIAS_NODE_OPTIONS[0].value };
+    return { round: 1, nodeId: rule.value || DEFAULT_ALIAS_NODE_OPTIONS[0].value };
   }
-  return { round: 1, nodeId: ALIAS_NODE_OPTIONS[0].value };
+  return { round: 1, nodeId: DEFAULT_ALIAS_NODE_OPTIONS[0].value };
 }

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from "react";
 import { Edit3, Trash2 } from "lucide-react";
 import type { CharacterAliasRule, EditorCharacterResponse, EditorThemeResponse, MysteryRole } from "@/features/editor/api";
 import { useEditorCharacters, useEditorClues, useUpdateCharacter } from "@/features/editor/api";
+import { useFlowGraph } from "@/features/editor/flowApi";
 import { useCharacterConfigDebounce } from "@/features/editor/hooks/useCharacterConfigDebounce";
 import { CharacterDetailPanel } from "./CharacterDetailPanel";
 import { EntityEditorShell } from "@/features/editor/entities/shell/EntityEditorShell";
@@ -23,6 +24,10 @@ import {
   writeCharacterMissionMap,
   type Mission,
 } from "@/features/editor/entities/mission/missionAdapter";
+import {
+  buildProgressNodeRevealOptions,
+  buildRoundRevealOptions,
+} from "@/features/editor/entities/reveal/revealTimingOptions";
 
 interface CharacterAssignPanelProps {
   themeId: string;
@@ -41,6 +46,7 @@ export function CharacterAssignPanel({
 }: CharacterAssignPanelProps) {
   const { data: characters, isLoading: charsLoading } = useEditorCharacters(themeId);
   const { data: clues } = useEditorClues(themeId);
+  const { data: flowGraph } = useFlowGraph(themeId);
   const updateCharacter = useUpdateCharacter(themeId);
   const [selectedCharId, setSelectedCharId] = useState<string | null>(null);
   const activeCharId = characters?.some((char) => char.id === selectedCharId)
@@ -55,6 +61,34 @@ export function CharacterAssignPanel({
   const characterMissions = useMemo((): Record<string, Mission[]> => {
     return readCharacterMissionMap(theme.config_json);
   }, [theme.config_json]);
+  const missionList = useMemo(
+    () => Object.values(characterMissions).flat(),
+    [characterMissions],
+  );
+  const aliasRules = useMemo(
+    () => (characters ?? []).flatMap((character) => character.alias_rules ?? []),
+    [characters],
+  );
+  const revealRoundOptions = useMemo(
+    () => buildRoundRevealOptions(
+      flowGraph?.nodes,
+      [
+        ...missionList.map((mission) => mission.revealRound),
+        ...aliasRules.map((rule) => readAliasRoundValue(rule.condition)),
+      ],
+    ),
+    [flowGraph?.nodes, missionList, aliasRules],
+  );
+  const revealNodeOptions = useMemo(
+    () => buildProgressNodeRevealOptions(
+      flowGraph?.nodes,
+      [
+        ...missionList.map((mission) => mission.revealNodeId),
+        ...aliasRules.map((rule) => readAliasNodeValue(rule.condition)),
+      ],
+    ),
+    [flowGraph?.nodes, missionList, aliasRules],
+  );
 
   const { saveConfig, flush } = useCharacterConfigDebounce(themeId, theme.config_json);
 
@@ -244,6 +278,8 @@ export function CharacterAssignPanel({
             clues={clues}
             charClueIds={characterClues[char.id] ?? []}
             charMissions={characterMissions[char.id] ?? []}
+            revealRoundOptions={revealRoundOptions}
+            revealNodeOptions={revealNodeOptions}
             onClueToggle={(clueId, checked) => handleClueToggleForChar(char.id, clueId, checked)}
             onAddMission={() => handleAddMissionForChar(char.id)}
             onChangeMission={(missionId, field, value) => handleMissionChangeForChar(char.id, missionId, field, value)}
@@ -269,4 +305,27 @@ export function CharacterAssignPanel({
       />
     </div>
   );
+}
+
+function readAliasRoundValue(condition: unknown): number | null {
+  const rule = readSingleCustomFlagRule(condition);
+  if (rule?.target_flag_key !== "round_started" || typeof rule.value !== "string") return null;
+  const round = Number(rule.value);
+  if (!Number.isFinite(round) || round < 1) return null;
+  return Math.trunc(round);
+}
+
+function readAliasNodeValue(condition: unknown): string | null {
+  const rule = readSingleCustomFlagRule(condition);
+  if (rule?.target_flag_key !== "story_node_reached" || typeof rule.value !== "string") return null;
+  return rule.value.trim() || null;
+}
+
+function readSingleCustomFlagRule(condition: unknown): { target_flag_key?: unknown; value?: unknown } | null {
+  if (!condition || typeof condition !== "object" || Array.isArray(condition)) return null;
+  const rules = (condition as { rules?: unknown }).rules;
+  if (!Array.isArray(rules) || rules.length !== 1) return null;
+  const rule = rules[0] as { variable?: unknown; comparator?: unknown; target_flag_key?: unknown; value?: unknown };
+  if (rule.variable !== "custom_flag" || rule.comparator !== "=") return null;
+  return rule;
 }

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -15,6 +15,10 @@ import {
   normalizeCharacterAliasRules,
   toCharacterEditorViewModel,
 } from '@/features/editor/entities/character/characterEditorAdapter';
+import type {
+  ProgressNodeRevealOption,
+  RoundRevealOption,
+} from '@/features/editor/entities/reveal/revealTimingOptions';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -52,6 +56,8 @@ interface CharacterDetailPanelProps {
   clues: ClueItem[] | undefined;
   charClueIds: string[];
   charMissions: Mission[];
+  revealRoundOptions?: RoundRevealOption[];
+  revealNodeOptions?: ProgressNodeRevealOption[];
   onClueToggle: (clueId: string, checked: boolean) => void;
   onAddMission: () => void;
   onChangeMission: (missionId: string, field: keyof Mission, value: string | number) => void;
@@ -73,6 +79,8 @@ export function CharacterDetailPanel({
   clues,
   charClueIds,
   charMissions,
+  revealRoundOptions,
+  revealNodeOptions,
   onClueToggle,
   onAddMission,
   onChangeMission,
@@ -252,6 +260,8 @@ export function CharacterDetailPanel({
                   themeId={themeId}
                   characterName={selectedChar.name}
                   rules={aliasDrafts}
+                  roundOptions={revealRoundOptions}
+                  nodeOptions={revealNodeOptions}
                   disabled={!onAliasRulesSave}
                   onChange={setAliasDrafts}
                   onSave={(rules) => {
@@ -296,6 +306,8 @@ export function CharacterDetailPanel({
                 missions={charMissions}
                 characters={characters}
                 clues={clues ?? []}
+                roundOptions={revealRoundOptions}
+                nodeOptions={revealNodeOptions}
                 onAdd={onAddMission}
                 onChange={onChangeMission}
                 onDelete={onDeleteMission}

--- a/apps/web/src/features/editor/components/design/MissionEditor.tsx
+++ b/apps/web/src/features/editor/components/design/MissionEditor.tsx
@@ -3,12 +3,15 @@ import { MissionTypeFields } from './MissionTypeFields';
 import {
   MISSION_TYPES,
   MISSION_REVEAL_OPTIONS,
-  MISSION_REVEAL_NODE_OPTIONS,
   toMissionViewModel,
   type Mission,
   type MissionEditorCharacter,
   type MissionEditorClue,
 } from '../../entities/mission/missionAdapter';
+import type {
+  ProgressNodeRevealOption,
+  RoundRevealOption,
+} from '@/features/editor/entities/reveal/revealTimingOptions';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -20,6 +23,8 @@ interface MissionEditorProps {
   missions: Mission[];
   characters?: MissionEditorCharacter[];
   clues?: MissionEditorClue[];
+  roundOptions?: RoundRevealOption[];
+  nodeOptions?: ProgressNodeRevealOption[];
   onAdd: () => void;
   onChange: (missionId: string, field: keyof Mission, value: string | number) => void;
   onDelete: (missionId: string) => void;
@@ -33,6 +38,8 @@ export function MissionEditor({
   missions,
   characters = [],
   clues = [],
+  roundOptions = DEFAULT_MISSION_ROUND_OPTIONS,
+  nodeOptions = DEFAULT_MISSION_NODE_OPTIONS,
   onAdd,
   onChange,
   onDelete,
@@ -58,6 +65,8 @@ export function MissionEditor({
               mission={mission}
               characters={characters}
               clues={clues}
+              roundOptions={roundOptions}
+              nodeOptions={nodeOptions}
               onChange={onChange}
               onDelete={onDelete}
             />
@@ -74,12 +83,16 @@ function MissionCard({
   mission,
   characters,
   clues,
+  roundOptions,
+  nodeOptions,
   onChange,
   onDelete,
 }: {
   mission: Mission;
   characters: MissionEditorCharacter[];
   clues: MissionEditorClue[];
+  roundOptions: RoundRevealOption[];
+  nodeOptions: ProgressNodeRevealOption[];
   onChange: (missionId: string, field: keyof Mission, value: string | number) => void;
   onDelete: (missionId: string) => void;
 }) {
@@ -145,26 +158,33 @@ function MissionCard({
         </label>
       </div>
       {mission.visibleFrom === 'round_start' ? (
-        <label className="mb-2 flex max-w-xs items-center gap-2 text-xs text-slate-500">
-          <span>시작 라운드:</span>
-          <input
-            type="number"
-            min={1}
-            value={mission.revealRound ?? 1}
+        <label className="mb-2 block text-xs text-slate-500">
+          시작 라운드
+          <select
+            value={String(mission.revealRound ?? 1)}
             onChange={(e) => onChange(mission.id, 'revealRound', Number(e.target.value))}
-            className="w-20 rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
-          />
+            className="mt-1 w-full rounded bg-slate-800 px-2 py-1 text-xs text-slate-300"
+          >
+            {roundOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label} 시작
+              </option>
+            ))}
+          </select>
         </label>
       ) : null}
       {mission.visibleFrom === 'node_reached' ? (
         <label className="mb-2 block text-xs text-slate-500">
           진행 노드
           <select
-            value={mission.revealNodeId ?? MISSION_REVEAL_NODE_OPTIONS[0].value}
+            value={mission.revealNodeId ?? nodeOptions[0]?.value ?? ''}
             onChange={(e) => onChange(mission.id, 'revealNodeId', e.target.value)}
             className="mt-1 w-full rounded bg-slate-800 px-2 py-1 text-xs text-slate-300 placeholder-slate-600"
           >
-            {MISSION_REVEAL_NODE_OPTIONS.map((option) => (
+            {nodeOptions.length === 0 ? (
+              <option value="">진행 장면 없음</option>
+            ) : null}
+            {nodeOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -191,3 +211,14 @@ function MissionCard({
     </div>
   );
 }
+
+const DEFAULT_MISSION_ROUND_OPTIONS = Array.from({ length: 5 }, (_, index) => {
+  const round = index + 1;
+  return { value: round, label: `${round}라운드` };
+});
+
+const DEFAULT_MISSION_NODE_OPTIONS = [
+  { value: 'intro_finished', label: '자기소개 종료' },
+  { value: 'round_summary', label: '라운드 정리' },
+  { value: 'voting_started', label: '투표 시작' },
+];

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx
@@ -3,6 +3,10 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CharacterAliasRulesEditor } from '../CharacterAliasRulesEditor';
 import type { CharacterAliasRule } from '@/features/editor/api';
+import type {
+  ProgressNodeRevealOption,
+  RoundRevealOption,
+} from '@/features/editor/entities/reveal/revealTimingOptions';
 
 vi.mock('@/features/editor/components/media/MediaPicker', () => ({
   MediaPicker: ({
@@ -34,6 +38,8 @@ const characterOptions = [{ id: 'char-1', name: '홍길동' }];
 function renderEditor(overrides: Partial<{
   rules: CharacterAliasRule[];
   disabled: boolean;
+  roundOptions: RoundRevealOption[];
+  nodeOptions: ProgressNodeRevealOption[];
   onChange: (rules: CharacterAliasRule[]) => void;
   onSave: (rules: CharacterAliasRule[]) => void;
 }> = {}) {
@@ -45,6 +51,8 @@ function renderEditor(overrides: Partial<{
       characterName="홍길동"
       rules={overrides.rules ?? []}
       characterOptions={characterOptions}
+      roundOptions={overrides.roundOptions}
+      nodeOptions={overrides.nodeOptions}
       disabled={overrides.disabled ?? false}
       onChange={onChange}
       onSave={onSave}
@@ -53,7 +61,14 @@ function renderEditor(overrides: Partial<{
   return { onChange, onSave };
 }
 
-function renderStatefulEditor(initialRules: CharacterAliasRule[], onSave = vi.fn()) {
+function renderStatefulEditor(
+  initialRules: CharacterAliasRule[],
+  onSave = vi.fn(),
+  options: {
+    roundOptions?: RoundRevealOption[];
+    nodeOptions?: ProgressNodeRevealOption[];
+  } = {},
+) {
   function Harness() {
     const [rules, setRules] = useState(initialRules);
     return (
@@ -62,6 +77,8 @@ function renderStatefulEditor(initialRules: CharacterAliasRule[], onSave = vi.fn
         characterName="홍길동"
         rules={rules}
         characterOptions={characterOptions}
+        roundOptions={options.roundOptions}
+        nodeOptions={options.nodeOptions}
         disabled={false}
         onChange={setRules}
         onSave={onSave}
@@ -201,6 +218,43 @@ describe('CharacterAliasRulesEditor', () => {
     expect(onSave).toHaveBeenLastCalledWith([expect.objectContaining({
       condition: expect.objectContaining({
         rules: [expect.objectContaining({ target_flag_key: 'story_node_reached', value: 'voting_started' })],
+      }),
+    })]);
+  });
+
+  it('실제 flow 후보로 별칭 진행 노드를 선택한다', () => {
+    const onSave = vi.fn();
+    const rules: CharacterAliasRule[] = [{
+      id: 'alias-1',
+      label: '장면 공개',
+      display_name: '현장 목격자',
+      priority: 1,
+      condition: {
+        id: 'group-1',
+        operator: 'AND',
+        rules: [{
+          id: 'rule-1',
+          variable: 'custom_flag',
+          target_flag_key: 'story_node_reached',
+          comparator: '=',
+          value: 'scene-2',
+        }],
+      },
+    }];
+
+    renderStatefulEditor(rules, onSave, {
+      nodeOptions: [
+        { value: 'scene-1', label: '오프닝 (장면)' },
+        { value: 'scene-2', label: '현장 조사 (장면)' },
+      ],
+    });
+
+    expect(screen.getByRole('option', { name: '현장 조사 (장면)' })).toBeDefined();
+    expect(screen.queryByRole('option', { name: '투표 시작' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: '플레이 중 표시 저장' }));
+    expect(onSave).toHaveBeenCalledWith([expect.objectContaining({
+      condition: expect.objectContaining({
+        rules: [expect.objectContaining({ target_flag_key: 'story_node_reached', value: 'scene-2' })],
       }),
     })]);
   });

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -57,6 +57,17 @@ vi.mock('@/features/editor/api', () => ({
   useUpdateCharacter: () => ({ mutate: updateCharacterMutateMock, isPending: updateCharacterPendingMock.value }),
 }));
 
+vi.mock('@/features/editor/flowApi', () => ({
+  useFlowGraph: () => ({
+    data: {
+      nodes: [
+        { id: 'scene-1', type: 'phase', data: { label: '오프닝', rounds: 2 } },
+        { id: 'scene-2', type: 'phase', data: { label: '현장 조사', rounds: 3 } },
+      ],
+    },
+  }),
+}));
+
 vi.mock('@/features/editor/mediaApi', () => ({
   uploadMediaFile: uploadMediaFileMock,
   useRequestUploadUrl: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/MissionEditor.test.tsx
@@ -145,7 +145,7 @@ describe('MissionEditor', () => {
 
     fireEvent.change(screen.getByLabelText('미션 공개 시점'), { target: { value: 'node_reached' } });
     expect(onChange).toHaveBeenCalledWith('mission-1', 'visibleFrom', 'node_reached');
-    fireEvent.change(screen.getByLabelText('시작 라운드:'), { target: { value: '3' } });
+    fireEvent.change(screen.getByLabelText('시작 라운드'), { target: { value: '3' } });
     expect(onChange).toHaveBeenCalledWith('mission-1', 'revealRound', 3);
 
     rerender(
@@ -158,6 +158,25 @@ describe('MissionEditor', () => {
     );
     fireEvent.change(screen.getByLabelText('진행 노드'), { target: { value: 'voting_started' } });
     expect(onChange).toHaveBeenCalledWith('mission-1', 'revealNodeId', 'voting_started');
+  });
+
+  it('실제 flow/round 후보를 공개 시점 selector에 사용한다', () => {
+    render(
+      <MissionEditor
+        missions={[baseMission({ visibleFrom: 'node_reached', revealNodeId: 'scene-2' })]}
+        roundOptions={[{ value: 1, label: '1라운드' }, { value: 2, label: '2라운드' }]}
+        nodeOptions={[
+          { value: 'scene-1', label: '오프닝 (장면)' },
+          { value: 'scene-2', label: '현장 조사 (장면)' },
+        ]}
+        onAdd={noop}
+        onChange={noop}
+        onDelete={noop}
+      />,
+    );
+
+    expect(screen.getByRole('option', { name: '현장 조사 (장면)' })).toBeDefined();
+    expect(screen.queryByRole('option', { name: '투표 시작' })).toBeNull();
   });
 
   it('MISSION_TYPES에 kill/possess/secret/protect가 포함된다', () => {

--- a/apps/web/src/features/editor/entities/reveal/__tests__/revealTimingOptions.test.ts
+++ b/apps/web/src/features/editor/entities/reveal/__tests__/revealTimingOptions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { FlowNodeResponse } from "../../../flowTypes";
+import {
+  buildProgressNodeRevealOptions,
+  buildRoundRevealOptions,
+} from "../revealTimingOptions";
+
+function node(
+  id: string,
+  type: FlowNodeResponse["type"],
+  label: string | undefined,
+  rounds?: number,
+): FlowNodeResponse {
+  return {
+    id,
+    theme_id: "theme-1",
+    type,
+    data: {
+      ...(label ? { label } : {}),
+      ...(rounds ? { rounds } : {}),
+    },
+    position_x: 0,
+    position_y: 0,
+    created_at: "2026-05-08T00:00:00Z",
+    updated_at: "2026-05-08T00:00:00Z",
+  };
+}
+
+describe("revealTimingOptions", () => {
+  it("flow phase rounds에서 라운드 후보를 만들고 기존 저장 라운드를 보존한다", () => {
+    const options = buildRoundRevealOptions(
+      [
+        node("start", "start", "시작"),
+        node("phase-1", "phase", "프롤로그", 2),
+        node("phase-2", "phase", "조사", 4),
+      ],
+      [7],
+    );
+
+    expect(options.map((option) => option.value)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(options[3]).toEqual({ value: 4, label: "4라운드" });
+  });
+
+  it("flow node label과 id를 진행 노드 후보로 만들고 legacy raw id를 복원한다", () => {
+    const options = buildProgressNodeRevealOptions(
+      [
+        node("start", "start", "시작"),
+        node("phase-1", "phase", "현장 조사"),
+        node("branch-1", "branch", "증언 분기"),
+        node("ending-1", "ending", "진엔딩"),
+      ],
+      ["legacy-node"],
+    );
+
+    expect(options).toEqual([
+      { value: "phase-1", label: "현장 조사 (장면)" },
+      { value: "branch-1", label: "증언 분기 (분기)" },
+      { value: "ending-1", label: "진엔딩 (결말)" },
+      { value: "legacy-node", label: "기존 저장값 (legacy-node)" },
+    ]);
+  });
+});

--- a/apps/web/src/features/editor/entities/reveal/revealTimingOptions.ts
+++ b/apps/web/src/features/editor/entities/reveal/revealTimingOptions.ts
@@ -1,0 +1,71 @@
+import type { FlowNodeResponse } from "../../flowTypes";
+
+export interface RoundRevealOption {
+  value: number;
+  label: string;
+}
+
+export interface ProgressNodeRevealOption {
+  value: string;
+  label: string;
+}
+
+const FALLBACK_ROUND_COUNT = 5;
+
+const FLOW_NODE_TYPE_LABELS: Record<FlowNodeResponse["type"], string> = {
+  start: "시작",
+  phase: "장면",
+  branch: "분기",
+  ending: "결말",
+};
+
+export function buildRoundRevealOptions(
+  nodes: FlowNodeResponse[] | undefined,
+  currentValues: Array<number | null | undefined> = [],
+): RoundRevealOption[] {
+  const configuredMaxRound = Math.max(
+    0,
+    ...(nodes ?? [])
+      .map((node) => node.data.rounds)
+      .filter((rounds): rounds is number => Number.isFinite(rounds) && rounds > 0)
+      .map((rounds) => Math.trunc(rounds)),
+  );
+  const currentMaxRound = Math.max(
+    0,
+    ...currentValues
+      .filter((round): round is number => Number.isFinite(round) && round > 0)
+      .map((round) => Math.trunc(round)),
+  );
+  const maxRound = Math.max(configuredMaxRound || FALLBACK_ROUND_COUNT, currentMaxRound);
+
+  return Array.from({ length: maxRound }, (_, index) => {
+    const round = index + 1;
+    return { value: round, label: `${round}라운드` };
+  });
+}
+
+export function buildProgressNodeRevealOptions(
+  nodes: FlowNodeResponse[] | undefined,
+  currentValues: Array<string | null | undefined> = [],
+): ProgressNodeRevealOption[] {
+  const options = (nodes ?? [])
+    .filter((node) => node.type !== "start")
+    .map((node, index) => ({
+      value: node.id,
+      label: formatFlowNodeLabel(node, index),
+    }));
+
+  const knownIds = new Set(options.map((option) => option.value));
+  const legacyOptions = currentValues
+    .map((value) => value?.trim())
+    .filter((value): value is string => !!value && !knownIds.has(value))
+    .map((value) => ({ value, label: `기존 저장값 (${value})` }));
+
+  return [...options, ...legacyOptions];
+}
+
+function formatFlowNodeLabel(node: FlowNodeResponse, index: number): string {
+  const label = node.data.label?.trim();
+  if (label) return `${label} (${FLOW_NODE_TYPE_LABELS[node.type]})`;
+  return `${FLOW_NODE_TYPE_LABELS[node.type]} ${index + 1}`;
+}


### PR DESCRIPTION
## 요약
- 공개 시점 selector가 실제 flow phase/branch/ending node와 phase round 설정에서 후보를 만들도록 공용 adapter를 추가했습니다.
- 캐릭터 별칭, 히든 미션, 단서 공개/숨김 시점이 같은 round/node 후보를 쓰도록 연결했습니다.
- 기존 저장값이 현재 flow 후보에 없어도 `기존 저장값 (...)` 옵션으로 복원되게 했습니다.

Closes #522

## Coverage Plan
- `entities/reveal/revealTimingOptions.ts`: flow node/round 후보 생성과 legacy raw id 보존을 unit test로 검증했습니다.
- `CharacterAssignPanel` / `CharacterAliasRulesEditor`: 실제 flow 후보가 별칭과 미션 selector로 전달되는지 component test로 검증했습니다.
- `MissionEditor`: node/round selector가 props 후보를 쓰고 저장 callback을 유지하는지 component test로 검증했습니다.
- `ClueListView` / `ClueEntityWorkspace` / `ClueBasicInfoCard`: flow graph에서 round 후보를 받아 단서 공개/숨김 selector에 전달하는 흐름을 기존 CluesTab/Workspace 테스트와 local CI로 검증했습니다.

## Local validation
- `git diff --check` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web test -- src/features/editor/entities/reveal/__tests__/revealTimingOptions.test.ts src/features/editor/components/design/__tests__/MissionEditor.test.tsx src/features/editor/components/design/__tests__/CharacterAliasRulesEditor.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/components/__tests__/CluesTab.test.tsx` 통과, 6 files / 69 tests
- `scripts/mmp-local-ci.sh quick` 통과, 최종 HEAD `1547ff5a169977f62546a48ef5c605f15a4770e2`

## E2E
- 새 route나 저장 API 계약을 추가하지 않은 selector 후보 연결입니다. UI 분기와 round-trip은 component/unit test로 검증했고, `quick`의 web build/test로 대체했습니다.

## CI policy
- 기본 PR 처리 정책에 따라 `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 단서, 캐릭터, 미션의 공개 시점 설정에서 라운드 및 진행 노드 기반 선택 옵션이 동적으로 구성됩니다.
  * 공개 시점 지정 시 드롭다운 선택으로 더 편리하게 설정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->