### PR TITLE
feat(ending): 복수 답변 all/any 결말 조건 연결

### DIFF
--- a/apps/server/internal/module/decision/ending_branch/module_test.go
+++ b/apps/server/internal/module/decision/ending_branch/module_test.go
@@ -325,6 +325,80 @@ func TestModule_ReactTo_ThresholdRuleReturnsAnswerSummary(t *testing.T) {
 	assert.Equal(t, float64(1), counts["B"])
 }
 
+func TestModule_ReactTo_EvaluatesMultiAnswerAllAnyRules(t *testing.T) {
+	t.Run("all requires every configured choice to pass threshold", func(t *testing.T) {
+		m := NewModule()
+		cfg := json.RawMessage(`{
+			"questions": [
+				{"id": "q1", "text": "확보한 증거는?", "type": "multi", "choices": ["장갑","시계","편지"], "impact": "branch"}
+			],
+			"matrix": [
+				{"id":"all-evidence","priority": 1, "conditions": {"and": [
+					{"in": ["장갑", {"var":"answers.q1.choices"}]},
+					{"in": ["시계", {"var":"answers.q1.choices"}]}
+				]}, "ending": "진실"},
+				{"id":"any-evidence","priority": 2, "conditions": {"or": [
+					{"in": ["장갑", {"var":"answers.q1.choices"}]},
+					{"in": ["편지", {"var":"answers.q1.choices"}]}
+				]}, "ending": "단서부족"}
+			],
+			"defaultEnding": "미해결",
+			"multiVoteThreshold": 0.5
+		}`)
+		require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{}, cfg))
+		playerA := uuid.New()
+		playerB := uuid.New()
+		require.NoError(t, m.HandleMessage(context.Background(), playerA, "submit_answer", json.RawMessage(`{"question_id":"q1","choices":["장갑","시계"]}`)))
+		require.NoError(t, m.HandleMessage(context.Background(), playerB, "submit_answer", json.RawMessage(`{"question_id":"q1","choices":["장갑","편지"]}`)))
+
+		require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+		raw, err := m.BuildState()
+		require.NoError(t, err)
+		var state map[string]any
+		require.NoError(t, json.Unmarshal(raw, &state))
+		result := state["result"].(map[string]any)
+		assert.Equal(t, "진실", result["selectedEnding"])
+		assert.Equal(t, "all-evidence", result["matchedRuleId"])
+	})
+
+	t.Run("any matches when one configured choice passes threshold", func(t *testing.T) {
+		m := NewModule()
+		cfg := json.RawMessage(`{
+			"questions": [
+				{"id": "q1", "text": "확보한 증거는?", "type": "multi", "choices": ["장갑","시계","편지"], "impact": "branch"}
+			],
+			"matrix": [
+				{"id":"all-evidence","priority": 1, "conditions": {"and": [
+					{"in": ["시계", {"var":"answers.q1.choices"}]},
+					{"in": ["편지", {"var":"answers.q1.choices"}]}
+				]}, "ending": "진실"},
+				{"id":"any-evidence","priority": 2, "conditions": {"or": [
+					{"in": ["장갑", {"var":"answers.q1.choices"}]},
+					{"in": ["편지", {"var":"answers.q1.choices"}]}
+				]}, "ending": "단서부족"}
+			],
+			"defaultEnding": "미해결",
+			"multiVoteThreshold": 0.5
+		}`)
+		require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{}, cfg))
+		playerA := uuid.New()
+		playerB := uuid.New()
+		require.NoError(t, m.HandleMessage(context.Background(), playerA, "submit_answer", json.RawMessage(`{"question_id":"q1","choices":["장갑"]}`)))
+		require.NoError(t, m.HandleMessage(context.Background(), playerB, "submit_answer", json.RawMessage(`{"question_id":"q1","choices":["장갑"]}`)))
+
+		require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+		raw, err := m.BuildState()
+		require.NoError(t, err)
+		var state map[string]any
+		require.NoError(t, json.Unmarshal(raw, &state))
+		result := state["result"].(map[string]any)
+		assert.Equal(t, "단서부족", result["selectedEnding"])
+		assert.Equal(t, "any-evidence", result["matchedRuleId"])
+	})
+}
+
 func TestModule_ReactTo_FallbackWhenNoRuleMatches(t *testing.T) {
 	m := NewModule()
 	cfg := json.RawMessage(`{

--- a/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
@@ -145,6 +145,16 @@ function MatrixRuleRow({ draft, rowIndex, endingNodes, branchQuestions, onChange
   const selectedQuestion = parsed
     ? branchQuestions.find((question) => question.id === parsed.questionId)
     : undefined;
+  const choiceText = parsed?.choices?.length
+    ? parsed.choices.join(", ")
+    : parsed?.choice;
+  const aggregationText = parsed?.aggregation === "winning"
+    ? " 이 가장 많이 선택되면 "
+    : parsed?.aggregation === "all"
+      ? " 이 모두 기준 이상 선택되면 "
+      : parsed?.aggregation === "any"
+        ? " 중 하나라도 기준 이상 선택되면 "
+        : " 이 기준 이상 선택되면 ";
   return (
     <article className="rounded-xl border border-slate-800 bg-slate-900/70 p-3">
       <div className="flex items-center justify-between gap-3">
@@ -161,8 +171,8 @@ function MatrixRuleRow({ draft, rowIndex, endingNodes, branchQuestions, onChange
       <p className="mt-3 rounded-xl border border-slate-800 bg-slate-950 p-3 text-sm leading-6 text-slate-300">
         <span className="font-semibold text-slate-100">{selectedQuestion?.text || "질문 선택 필요"}</span>
         {" 에서 "}
-        <span className="font-semibold text-amber-100">{parsed?.choice || "선택지 선택 필요"}</span>
-        {parsed?.aggregation === "winning" ? " 이 가장 많이 선택되면 " : " 이 기준 이상 선택되면 "}
+        <span className="font-semibold text-amber-100">{choiceText || "선택지 선택 필요"}</span>
+        {aggregationText}
         <span className="font-semibold text-emerald-100">{endingName(endingNodes.find((node) => node.id === row.ending) ?? { id: "", type: "ending", position: { x: 0, y: 0 }, data: {} } as Node)}</span>
         {" 결말을 보여줍니다."}
       </p>
@@ -189,9 +199,16 @@ function EndingConditionModal({
   const firstQuestion = branchQuestions[0];
   const [questionId, setQuestionId] = useState(parsed?.questionId ?? firstQuestion?.id ?? "");
   const selectedQuestion = branchQuestions.find((question) => question.id === questionId);
-  const [choice, setChoice] = useState(parsed?.choice ?? selectedQuestion?.choices[0] ?? "");
-  const [aggregation, setAggregation] = useState<"threshold" | "winning">(parsed?.aggregation ?? "threshold");
+  const [selectedChoices, setSelectedChoices] = useState<string[]>(
+    parsed?.choices?.length ? parsed.choices : selectedQuestion?.choices[0] ? [selectedQuestion.choices[0]] : [],
+  );
+  const [aggregation, setAggregation] = useState<"threshold" | "winning" | "all" | "any">(
+    selectedQuestion?.type === "multi"
+      ? parsed?.aggregation === "all" ? "all" : "any"
+      : parsed?.aggregation === "winning" ? "winning" : "threshold",
+  );
   const [endingId, setEndingId] = useState(initialRow?.ending ?? draft.defaultEnding ?? endingNodes[0]?.id ?? "");
+  const isMultiQuestion = selectedQuestion?.type === "multi";
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -204,22 +221,43 @@ function EndingConditionModal({
 
   const preview = useMemo(() => {
     const questionText = selectedQuestion?.text.trim() || "질문";
+    const choiceText = selectedChoices.length > 0 ? selectedChoices.join(", ") : "선택지";
     const ending = endingName(endingNodes.find((node) => node.id === endingId) ?? { id: "", type: "ending", position: { x: 0, y: 0 }, data: {} } as Node);
-    return `${questionText}에서 '${choice || "선택지"}' 답변이 ${aggregation === "winning" ? "가장 많으면" : "설정 비율 이상이면"} '${ending}' 결말로 보냅니다.`;
-  }, [aggregation, choice, endingId, endingNodes, selectedQuestion]);
+    const ruleText = aggregation === "winning"
+      ? "가장 많으면"
+      : aggregation === "all"
+        ? "모두 설정 비율 이상이면"
+        : aggregation === "any"
+          ? "하나라도 설정 비율 이상이면"
+          : "설정 비율 이상이면";
+    return `${questionText}에서 '${choiceText}' 답변이 ${ruleText} '${ending}' 결말로 보냅니다.`;
+  }, [aggregation, endingId, endingNodes, selectedChoices, selectedQuestion]);
 
   const handleQuestionChange = (nextQuestionId: string) => {
     const nextQuestion = branchQuestions.find((question) => question.id === nextQuestionId);
     setQuestionId(nextQuestionId);
-    setChoice(nextQuestion?.choices[0] ?? "");
-    setAggregation("threshold");
+    setSelectedChoices(nextQuestion?.choices[0] ? [nextQuestion.choices[0]] : []);
+    setAggregation(nextQuestion?.type === "multi" ? "any" : "threshold");
+  };
+
+  const toggleChoice = (choice: string) => {
+    setSelectedChoices((current) => (
+      current.includes(choice)
+        ? current.filter((item) => item !== choice)
+        : [...current, choice]
+    ));
   };
 
   const handleSubmit = () => {
-    if (!selectedQuestion || !choice || !endingId) return;
+    if (!selectedQuestion || selectedChoices.length === 0 || !endingId) return;
     const base = initialRow ?? createEndingBranchMatrixRow(draft, endingId);
     onSave({
-      ...updateMatrixCondition(base, selectedQuestion.id, choice, aggregation),
+      ...updateMatrixCondition(
+        base,
+        selectedQuestion.id,
+        isMultiQuestion ? selectedChoices : selectedChoices[0],
+        isMultiQuestion ? aggregation === "all" ? "all" : "any" : aggregation,
+      ),
       ending: endingId,
     });
   };
@@ -243,17 +281,48 @@ function EndingConditionModal({
               {branchQuestions.map((question) => <option key={question.id} value={question.id}>{question.text || "질문 내용 필요"}</option>)}
             </select>
           </label>
-          <label className="block">
-            <span className="text-xs font-medium text-slate-400">답변</span>
-            <select value={choice} onChange={(event) => setChoice(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
-              {(selectedQuestion?.choices ?? []).map((item) => <option key={item} value={item}>{item}</option>)}
-            </select>
-          </label>
+          {isMultiQuestion ? (
+            <div>
+              <span className="text-xs font-medium text-slate-400">답변</span>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {(selectedQuestion?.choices ?? []).map((item) => {
+                  const selected = selectedChoices.includes(item);
+                  return (
+                    <button
+                      key={item}
+                      type="button"
+                      onClick={() => toggleChoice(item)}
+                      className={`rounded-full border px-3 py-2 text-xs font-medium transition ${selected ? "border-amber-400 bg-amber-400/15 text-amber-100" : "border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500"}`}
+                      aria-pressed={selected}
+                    >
+                      {item}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : (
+            <label className="block">
+              <span className="text-xs font-medium text-slate-400">답변</span>
+              <select value={selectedChoices[0] ?? ""} onChange={(event) => setSelectedChoices(event.target.value ? [event.target.value] : [])} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
+                {(selectedQuestion?.choices ?? []).map((item) => <option key={item} value={item}>{item}</option>)}
+              </select>
+            </label>
+          )}
           <label className="block">
             <span className="text-xs font-medium text-slate-400">집계 기준</span>
-            <select value={aggregation} onChange={(event) => setAggregation(event.target.value === "winning" ? "winning" : "threshold")} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
-              <option value="threshold">과반수 / 설정 비율 이상</option>
-              <option value="winning">가장 많이 선택</option>
+            <select value={aggregation} onChange={(event) => setAggregation(event.target.value === "winning" ? "winning" : event.target.value === "all" ? "all" : event.target.value === "any" ? "any" : "threshold")} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
+              {isMultiQuestion ? (
+                <>
+                  <option value="any">하나라도 정답</option>
+                  <option value="all">모두 정답</option>
+                </>
+              ) : (
+                <>
+                  <option value="threshold">과반수 / 설정 비율 이상</option>
+                  <option value="winning">가장 많이 선택</option>
+                </>
+              )}
             </select>
           </label>
           <label className="block">
@@ -266,7 +335,7 @@ function EndingConditionModal({
         </div>
         <div className="mt-5 flex justify-end gap-2">
           <button type="button" onClick={onClose} className="min-h-11 rounded-xl border border-slate-700 px-4 text-sm text-slate-200 hover:bg-slate-800">취소</button>
-          <button type="button" onClick={handleSubmit} disabled={!selectedQuestion || !choice || !endingId} className="min-h-11 rounded-xl border border-amber-500/60 bg-amber-500/15 px-4 text-sm font-medium text-amber-100 hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-50">조건 저장</button>
+          <button type="button" onClick={handleSubmit} disabled={!selectedQuestion || selectedChoices.length === 0 || !endingId} className="min-h-11 rounded-xl border border-amber-500/60 bg-amber-500/15 px-4 text-sm font-medium text-amber-100 hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-50">조건 저장</button>
         </div>
       </section>
     </div>

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -443,4 +443,64 @@ describe("EndingEntitySubTab", () => {
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
     );
   });
+
+  it("복수 선택 질문은 모두 정답 기준 결말 규칙을 저장한다", () => {
+    renderWithClient(
+      <EndingEntitySubTab
+        themeId="theme-1"
+        theme={{
+          ...theme,
+          config_json: {
+            modules: {
+              ending_branch: {
+                enabled: true,
+                config: {
+                  questions: [{
+                    id: "q1",
+                    text: "확보한 증거는?",
+                    type: "multi",
+                    choices: ["피 묻은 장갑", "부서진 시계", "찢어진 편지"],
+                    impact: "branch",
+                    respondents: "all",
+                  }],
+                  matrix: [{ priority: 1, ending: "ending-1", condition: { in: ["피 묻은 장갑", { var: "answers.q1.choices" }] } }],
+                  defaultEnding: "ending-2",
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+    openEndingManagement();
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.click(screen.getByRole("button", { name: "부서진 시계" }));
+    fireEvent.change(screen.getByLabelText("집계 기준"), { target: { value: "all" } });
+    fireEvent.click(screen.getByRole("button", { name: "조건 저장" }));
+    fireEvent.click(screen.getByRole("button", { name: "판정 설정 저장" }));
+
+    expect(configMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modules: expect.objectContaining({
+          ending_branch: expect.objectContaining({
+            config: expect.objectContaining({
+              matrix: [
+                expect.objectContaining({
+                  ending: "ending-1",
+                  conditions: {
+                    and: [
+                      { in: ["피 묻은 장갑", { var: "answers.q1.choices" }] },
+                      { in: ["부서진 시계", { var: "answers.q1.choices" }] },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
 });

--- a/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { Node } from "@xyflow/react";
 import {
   buildChoiceCondition,
+  buildAllChoicesCondition,
+  buildAnyChoicesCondition,
   buildWinningChoiceCondition,
   createEndingBranchMatrixRow,
   createEndingBranchQuestion,
@@ -71,7 +73,7 @@ describe("endingBranchAdapter", () => {
     }, [endingNode("end-truth", "진실"), endingNode("end-fail", "미해결")]);
 
     expect(viewModel.questions[0]).toMatchObject({ label: "누가 진범인가?", typeLabel: "하나 선택", impactLabel: "결말 분기" });
-    expect(viewModel.matrix[0]).toMatchObject({ questionId: "q1", choice: "하윤", aggregation: "threshold", endingName: "진실" });
+    expect(viewModel.matrix[0]).toMatchObject({ questionId: "q1", choice: "하윤", choices: ["하윤"], aggregation: "threshold", endingName: "진실" });
     expect(viewModel.defaultEndingName).toBe("미해결");
     expect(viewModel.thresholdPercent).toBe(50);
     expect(viewModel.warnings).toEqual([]);
@@ -166,7 +168,7 @@ describe("endingBranchAdapter", () => {
   it("선택지 조건을 JSONLogic으로 숨겨 저장하고 다시 읽는다", () => {
     const condition = buildChoiceCondition("q1", "비밀 편지 획득");
     expect(condition).toEqual({ in: ["비밀 편지 획득", { var: "answers.q1.choices" }] });
-    expect(readChoiceCondition(condition)).toEqual({ questionId: "q1", choice: "비밀 편지 획득", aggregation: "threshold" });
+    expect(readChoiceCondition(condition)).toEqual({ questionId: "q1", choice: "비밀 편지 획득", choices: ["비밀 편지 획득"], aggregation: "threshold" });
     expect(updateMatrixCondition({ priority: 1, ending: "end-1", condition: {} }, "q2", "A").condition)
       .toEqual({ in: ["A", { var: "answers.q2.choices" }] });
   });
@@ -175,9 +177,46 @@ describe("endingBranchAdapter", () => {
     const condition = buildWinningChoiceCondition("q1", "하윤");
 
     expect(condition).toEqual({ "==": [{ var: "answers.q1.winning" }, "하윤"] });
-    expect(readChoiceCondition(condition)).toEqual({ questionId: "q1", choice: "하윤", aggregation: "winning" });
+    expect(readChoiceCondition(condition)).toEqual({ questionId: "q1", choice: "하윤", choices: ["하윤"], aggregation: "winning" });
     expect(updateMatrixCondition({ priority: 1, ending: "end-1", condition: {} }, "q2", "B", "winning").condition)
       .toEqual({ "==": [{ var: "answers.q2.winning" }, "B"] });
+  });
+
+  it("복수 답변 all/any 조건을 JSONLogic and/or로 저장하고 다시 읽는다", () => {
+    const allCondition = buildAllChoicesCondition("q1", ["증거 A", "증거 B", "증거 A"]);
+    const anyCondition = buildAnyChoicesCondition("q1", ["증거 A", "증거 C"]);
+
+    expect(allCondition).toEqual({
+      and: [
+        { in: ["증거 A", { var: "answers.q1.choices" }] },
+        { in: ["증거 B", { var: "answers.q1.choices" }] },
+      ],
+    });
+    expect(anyCondition).toEqual({
+      or: [
+        { in: ["증거 A", { var: "answers.q1.choices" }] },
+        { in: ["증거 C", { var: "answers.q1.choices" }] },
+      ],
+    });
+    expect(readChoiceCondition(allCondition)).toEqual({
+      questionId: "q1",
+      choice: "증거 A",
+      choices: ["증거 A", "증거 B"],
+      aggregation: "all",
+    });
+    expect(readChoiceCondition(anyCondition)).toEqual({
+      questionId: "q1",
+      choice: "증거 A",
+      choices: ["증거 A", "증거 C"],
+      aggregation: "any",
+    });
+    expect(updateMatrixCondition({ priority: 1, ending: "end-1", condition: {} }, "q2", ["A", "B"], "all").condition)
+      .toEqual({
+        and: [
+          { in: ["A", { var: "answers.q2.choices" }] },
+          { in: ["B", { var: "answers.q2.choices" }] },
+        ],
+      });
   });
 
   it("새 질문과 규칙의 기본값은 제작자가 바로 수정 가능한 형태다", () => {
@@ -186,6 +225,6 @@ describe("endingBranchAdapter", () => {
 
     expect(question).toMatchObject({ id: "ending-question-1234-1", choices: ["선택지 1", "선택지 2"], respondents: "all", target: { type: "all_players" } });
     expect(row).toMatchObject({ priority: 1, ending: "end-1" });
-    expect(readChoiceCondition(row.condition)).toEqual({ questionId: question.id, choice: "선택지 1", aggregation: "threshold" });
+    expect(readChoiceCondition(row.condition)).toEqual({ questionId: question.id, choice: "선택지 1", choices: ["선택지 1"], aggregation: "threshold" });
   });
 });

--- a/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
@@ -10,7 +10,7 @@ export const ENDING_BRANCH_MODULE_ID = "ending_branch";
 
 export type EndingBranchQuestionType = "single" | "multi";
 export type EndingBranchQuestionImpact = "branch" | "score";
-export type EndingBranchAggregation = "threshold" | "winning";
+export type EndingBranchAggregation = "threshold" | "winning" | "all" | "any";
 export type EndingBranchQuestionTarget =
   | { type: "all_players" }
   | { type: "specific_players"; characterIds: string[] };
@@ -52,6 +52,7 @@ export interface EndingBranchMatrixDraft {
   priority: number;
   questionId: string | null;
   choice: string | null;
+  choices: string[];
   aggregation: EndingBranchAggregation;
   endingId: string;
   endingName: string;
@@ -231,38 +232,82 @@ export function buildWinningChoiceCondition(questionId: string, choice: string):
   return { "==": [{ var: `answers.${questionId}.winning` }, choice] };
 }
 
+function uniqueChoices(choices: string[]): string[] {
+  return Array.from(new Set(choices.map((choice) => choice.trim()).filter(Boolean)));
+}
+
+function thresholdChoiceCondition(questionId: string, choice: string): EditorConfig {
+  return buildChoiceCondition(questionId, choice);
+}
+
+export function buildAllChoicesCondition(questionId: string, choices: string[]): EditorConfig {
+  return { and: uniqueChoices(choices).map((choice) => thresholdChoiceCondition(questionId, choice)) };
+}
+
+export function buildAnyChoicesCondition(questionId: string, choices: string[]): EditorConfig {
+  return { or: uniqueChoices(choices).map((choice) => thresholdChoiceCondition(questionId, choice)) };
+}
+
 export function updateMatrixCondition(
   row: EndingBranchMatrixRow,
   questionId: string,
-  choice: string,
+  choice: string | string[],
   aggregation: EndingBranchAggregation = readChoiceCondition(row.condition)?.aggregation ?? "threshold",
 ): EndingBranchMatrixRow {
+  const choices = Array.isArray(choice) ? uniqueChoices(choice) : uniqueChoices([choice]);
+  const firstChoice = choices[0] ?? "";
   return {
     ...row,
     condition: aggregation === "winning"
-      ? buildWinningChoiceCondition(questionId, choice)
-      : buildChoiceCondition(questionId, choice),
+      ? buildWinningChoiceCondition(questionId, firstChoice)
+      : aggregation === "all"
+        ? buildAllChoicesCondition(questionId, choices)
+        : aggregation === "any"
+          ? buildAnyChoicesCondition(questionId, choices)
+          : buildChoiceCondition(questionId, firstChoice),
   };
 }
 
 export function readChoiceCondition(
   condition: EditorConfig,
-): { questionId: string; choice: string; aggregation: EndingBranchAggregation } | null {
+): { questionId: string; choice: string; choices: string[]; aggregation: EndingBranchAggregation } | null {
   const raw = condition.in;
   if (Array.isArray(raw) && raw.length >= 2) {
     const [choice, source] = raw;
     if (typeof choice === "string" && isRecord(source) && typeof source.var === "string") {
       const match = source.var.match(/^answers\.(.+)\.choices$/);
-      if (match) return { questionId: match[1], choice, aggregation: "threshold" };
+      if (match) return { questionId: match[1], choice, choices: [choice], aggregation: "threshold" };
     }
   }
 
   const equals = condition["=="];
-  if (!Array.isArray(equals) || equals.length < 2) return null;
-  const [source, choice] = equals;
-  if (!isRecord(source) || typeof source.var !== "string" || typeof choice !== "string") return null;
-  const match = source.var.match(/^answers\.(.+)\.winning$/);
-  return match ? { questionId: match[1], choice, aggregation: "winning" } : null;
+  if (Array.isArray(equals) && equals.length >= 2) {
+    const [source, choice] = equals;
+    if (!isRecord(source) || typeof source.var !== "string" || typeof choice !== "string") return null;
+    const match = source.var.match(/^answers\.(.+)\.winning$/);
+    return match ? { questionId: match[1], choice, choices: [choice], aggregation: "winning" } : null;
+  }
+
+  return readCompositeChoiceCondition(condition.and, "all")
+    ?? readCompositeChoiceCondition(condition.or, "any");
+}
+
+function readCompositeChoiceCondition(
+  value: unknown,
+  aggregation: "all" | "any",
+): { questionId: string; choice: string; choices: string[]; aggregation: EndingBranchAggregation } | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const parsed = value
+    .map((item) => isRecord(item) ? readChoiceCondition(item) : null)
+    .filter((item): item is NonNullable<ReturnType<typeof readChoiceCondition>> => Boolean(item));
+  if (parsed.length !== value.length) return null;
+  const questionId = parsed[0]?.questionId;
+  if (!questionId || parsed.some((item) => item.questionId !== questionId || item.aggregation !== "threshold")) {
+    return null;
+  }
+  const choices = uniqueChoices(parsed.map((item) => item.choice));
+  if (choices.length === 0) return null;
+  return { questionId, choice: choices[0], choices, aggregation };
 }
 
 function endingNameById(nodes: Node[]): Map<string, string> {
@@ -311,6 +356,7 @@ export function toEndingBranchEditorViewModel(
       priority: row.priority,
       questionId: question?.id ?? null,
       choice,
+      choices: parsed?.choices.filter((item) => question?.choices.includes(item)) ?? [],
       aggregation: parsed?.aggregation ?? "threshold",
       endingId: row.ending,
       endingName: names.get(row.ending) ?? "결말 선택 필요",
@@ -344,7 +390,7 @@ function buildEndingBranchWarnings(config: EndingBranchConfig, endingNodes: Node
   for (const row of config.matrix) {
     if (!endingIds.has(row.ending)) warnings.push("결말 규칙 중 도착 결말이 비어 있습니다.");
     const parsed = readChoiceCondition(row.condition);
-    if (!parsed || !parsed.choice.trim()) warnings.push("결말 규칙 중 질문/선택지 조건이 비어 있습니다.");
+    if (!parsed || !parsed.choices.some((choice) => choice.trim())) warnings.push("결말 규칙 중 질문/선택지 조건이 비어 있습니다.");
   }
   return Array.from(new Set(warnings));
 }


### PR DESCRIPTION
## 요약
- ending_branch matrix가 복수 답변 all/any 조건을 JSONLogic and/or로 저장하고 해석하게 확장했습니다.
- EndingConditionModal에서 multi 질문은 여러 답변 chip과 모두 정답/하나라도 정답 기준을 저장합니다.
- 기존 threshold/winning 단일 조건 호환을 유지했습니다.

## Coverage Plan
- Backend runtime: apps/server/internal/module/decision/ending_branch/module_test.go에서 all/any 조건의 실제 outcome 선택을 검증했습니다.
- Frontend adapter: apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts의 all/any JSONLogic 생성과 역파싱을 단위 테스트로 검증했습니다.
- Frontend UI: apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx에서 multi 질문 chip 선택과 all 저장 흐름을 컴포넌트 테스트로 검증했습니다.
- E2E 대체: 이번 변경은 기존 결말 설정 화면 내부의 조건 저장/해석 로직 확장이며, backend module test + frontend adapter/component focused test + local-ci quick으로 사용자 흐름 주요 분기를 덮었습니다.

## Local validation
- `go test ./internal/module/decision/ending_branch` 통과
- `pnpm --filter @mmp/web test -- src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx` 통과 (2 files / 24 tests)
- `pnpm --filter @mmp/web typecheck` 통과
- `git diff --check` 통과
- `scripts/mmp-local-ci.sh quick` 통과: mode=quick, head=007477a49300c736a9c6fdd986731ecb75f89c97, finished_at=2026-05-08T08:17:35Z

Closes #525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 엔딩 분기 조건에서 복수 선택 문항 지원 추가
  * 조건 생성 시 새로운 통합 옵션('모두'/'하나라도') 추가

* **테스트**
  * 복수 선택 규칙 평가 검증 테스트 추가
  * 다중 선택 조건 처리 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->