### PR TITLE
feat(location): 장소 공개 설명 런타임 계약 승격

### DIFF
--- a/apps/server/db/migrations/00044_location_text_contract.sql
+++ b/apps/server/db/migrations/00044_location_text_contract.sql
@@ -1,0 +1,58 @@
+-- +goose Up
+
+ALTER TABLE theme_locations
+  ADD COLUMN public_description TEXT,
+  ADD COLUMN entry_message TEXT,
+  ADD COLUMN parent_location_id UUID REFERENCES theme_locations(id) ON DELETE SET NULL;
+
+WITH meta AS (
+  SELECT
+    t.id AS theme_id,
+    entry.key::uuid AS location_id,
+    entry.value AS value
+  FROM themes t
+  CROSS JOIN LATERAL jsonb_each(t.config_json -> 'locationMeta') AS entry(key, value)
+  WHERE jsonb_typeof(t.config_json -> 'locationMeta') = 'object'
+    AND entry.key ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+),
+normalized AS (
+  SELECT
+    m.theme_id,
+    m.location_id,
+    NULLIF(m.value ->> 'publicDescription', '') AS public_description,
+    NULLIF(m.value ->> 'entryMessage', '') AS entry_message,
+    CASE
+      WHEN (m.value ->> 'parentLocationId') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        THEN (m.value ->> 'parentLocationId')::uuid
+      ELSE NULL
+    END AS candidate_parent_location_id
+  FROM meta m
+)
+UPDATE theme_locations l
+SET
+  public_description = n.public_description,
+  entry_message = n.entry_message,
+  parent_location_id = CASE
+    WHEN p.id IS NOT NULL AND p.id <> l.id THEN p.id
+    ELSE NULL
+  END
+FROM normalized n
+LEFT JOIN theme_locations p
+  ON p.id = n.candidate_parent_location_id
+ AND p.theme_id = n.theme_id
+ AND p.map_id = (SELECT map_id FROM theme_locations WHERE id = n.location_id)
+WHERE l.id = n.location_id
+  AND l.theme_id = n.theme_id;
+
+CREATE INDEX idx_theme_locations_parent
+  ON theme_locations(parent_location_id)
+  WHERE parent_location_id IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_theme_locations_parent;
+
+ALTER TABLE theme_locations
+  DROP COLUMN IF EXISTS parent_location_id,
+  DROP COLUMN IF EXISTS entry_message,
+  DROP COLUMN IF EXISTS public_description;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -38,13 +38,13 @@ SELECT * FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
 SELECT * FROM theme_locations WHERE id = $1;
 
 -- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 RETURNING *;
 
 -- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8, public_description = $9, entry_message = $10, parent_location_id = $11
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -111,9 +111,9 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 }
 
 const createLocation = `-- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id
 `
 
 type CreateLocationParams struct {
@@ -126,6 +126,9 @@ type CreateLocationParams struct {
 	UntilRound           pgtype.Int4 `json:"until_round"`
 	ImageUrl             pgtype.Text `json:"image_url"`
 	ImageMediaID         pgtype.UUID `json:"image_media_id"`
+	PublicDescription    pgtype.Text `json:"public_description"`
+	EntryMessage         pgtype.Text `json:"entry_message"`
+	ParentLocationID     pgtype.UUID `json:"parent_location_id"`
 }
 
 func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) (ThemeLocation, error) {
@@ -139,6 +142,9 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		arg.UntilRound,
 		arg.ImageUrl,
 		arg.ImageMediaID,
+		arg.PublicDescription,
+		arg.EntryMessage,
+		arg.ParentLocationID,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -153,6 +159,9 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		&i.UntilRound,
 		&i.ImageUrl,
 		&i.ImageMediaID,
+		&i.PublicDescription,
+		&i.EntryMessage,
+		&i.ParentLocationID,
 	)
 	return i, err
 }
@@ -379,7 +388,7 @@ func (q *Queries) GetContent(ctx context.Context, arg GetContentParams) (ThemeCo
 }
 
 const getLocation = `-- name: GetLocation :one
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id FROM theme_locations WHERE id = $1
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE id = $1
 `
 
 func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation, error) {
@@ -397,12 +406,15 @@ func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation,
 		&i.UntilRound,
 		&i.ImageUrl,
 		&i.ImageMediaID,
+		&i.PublicDescription,
+		&i.EntryMessage,
+		&i.ParentLocationID,
 	)
 	return i, err
 }
 
 const getLocationWithOwner = `-- name: GetLocationWithOwner :one
-SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round, l.image_url, l.image_media_id FROM theme_locations l
+SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round, l.image_url, l.image_media_id, l.public_description, l.entry_message, l.parent_location_id FROM theme_locations l
 JOIN themes t ON l.theme_id = t.id
 WHERE l.id = $1 AND t.creator_id = $2
 `
@@ -427,6 +439,9 @@ func (q *Queries) GetLocationWithOwner(ctx context.Context, arg GetLocationWithO
 		&i.UntilRound,
 		&i.ImageUrl,
 		&i.ImageMediaID,
+		&i.PublicDescription,
+		&i.EntryMessage,
+		&i.ParentLocationID,
 	)
 	return i, err
 }
@@ -600,7 +615,7 @@ func (q *Queries) ListContentsByTheme(ctx context.Context, themeID uuid.UUID) ([
 
 const listLocationsByMap = `-- name: ListLocationsByMap :many
 
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -627,6 +642,9 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 			&i.UntilRound,
 			&i.ImageUrl,
 			&i.ImageMediaID,
+			&i.PublicDescription,
+			&i.EntryMessage,
+			&i.ParentLocationID,
 		); err != nil {
 			return nil, err
 		}
@@ -639,7 +657,7 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 }
 
 const listLocationsByTheme = `-- name: ListLocationsByTheme :many
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeLocation, error) {
@@ -663,6 +681,9 @@ func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) (
 			&i.UntilRound,
 			&i.ImageUrl,
 			&i.ImageMediaID,
+			&i.PublicDescription,
+			&i.EntryMessage,
+			&i.ParentLocationID,
 		); err != nil {
 			return nil, err
 		}
@@ -778,9 +799,9 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 
 const updateLocation = `-- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8
+SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8, public_description = $9, entry_message = $10, parent_location_id = $11
 WHERE id = $1
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id
 `
 
 type UpdateLocationParams struct {
@@ -792,6 +813,9 @@ type UpdateLocationParams struct {
 	UntilRound           pgtype.Int4 `json:"until_round"`
 	ImageUrl             pgtype.Text `json:"image_url"`
 	ImageMediaID         pgtype.UUID `json:"image_media_id"`
+	PublicDescription    pgtype.Text `json:"public_description"`
+	EntryMessage         pgtype.Text `json:"entry_message"`
+	ParentLocationID     pgtype.UUID `json:"parent_location_id"`
 }
 
 func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) (ThemeLocation, error) {
@@ -804,6 +828,9 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		arg.UntilRound,
 		arg.ImageUrl,
 		arg.ImageMediaID,
+		arg.PublicDescription,
+		arg.EntryMessage,
+		arg.ParentLocationID,
 	)
 	var i ThemeLocation
 	err := row.Scan(
@@ -818,6 +845,9 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		&i.UntilRound,
 		&i.ImageUrl,
 		&i.ImageMediaID,
+		&i.PublicDescription,
+		&i.EntryMessage,
+		&i.ParentLocationID,
 	)
 	return i, err
 }

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -363,6 +363,9 @@ type ThemeLocation struct {
 	UntilRound           pgtype.Int4 `json:"until_round"`
 	ImageUrl             pgtype.Text `json:"image_url"`
 	ImageMediaID         pgtype.UUID `json:"image_media_id"`
+	PublicDescription    pgtype.Text `json:"public_description"`
+	EntryMessage         pgtype.Text `json:"entry_message"`
+	ParentLocationID     pgtype.UUID `json:"parent_location_id"`
 }
 
 type ThemeMap struct {

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -33,6 +33,7 @@ const (
 	MaxMapsPerTheme    = 20
 	MaxLocationsPerMap = 50
 	MaxCluesPerTheme   = 500
+	MaxLocationTextLen = 2000
 )
 
 // --- Request / Response types ---

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -141,6 +142,12 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if _, err := s.getOwnedTheme(ctx, creatorID, themeID); err != nil {
 		return nil, err
 	}
+	if err := validateLocationText("public_description", req.PublicDescription); err != nil {
+		return nil, err
+	}
+	if err := validateLocationText("entry_message", req.EntryMessage); err != nil {
+		return nil, err
+	}
 	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, themeID, req.RestrictedCharacters, req.FromRound, req.UntilRound)
 	if err != nil {
 		return nil, err
@@ -223,10 +230,16 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 	}
 	publicDescription := l.PublicDescription
 	if req.PublicDescription.Set {
+		if err := validateLocationText("public_description", req.PublicDescription.Value); err != nil {
+			return nil, err
+		}
 		publicDescription = ptrToText(req.PublicDescription.Value)
 	}
 	entryMessage := l.EntryMessage
 	if req.EntryMessage.Set {
+		if err := validateLocationText("entry_message", req.EntryMessage.Value); err != nil {
+			return nil, err
+		}
 		entryMessage = ptrToText(req.EntryMessage.Value)
 	}
 	parentLocationID := l.ParentLocationID
@@ -255,6 +268,13 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 	}
 	resp := toLocationResponse(updated)
 	return &resp, nil
+}
+
+func validateLocationText(field string, value *string) error {
+	if value != nil && utf8.RuneCountInString(*value) > MaxLocationTextLen {
+		return apperror.BadRequest(fmt.Sprintf("%s is too long", field))
+	}
+	return nil
 }
 
 func (s *service) resolveLocationParent(ctx context.Context, themeID, mapID, currentLocationID uuid.UUID, parentLocationID *uuid.UUID) (pgtype.UUID, error) {

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -166,6 +166,10 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if err != nil {
 		return nil, err
 	}
+	parentLocationID, err := s.resolveLocationParent(ctx, themeID, mapID, uuid.Nil, req.ParentLocationID)
+	if err != nil {
+		return nil, err
+	}
 	loc, err := s.q.CreateLocation(ctx, db.CreateLocationParams{
 		ThemeID:              themeID,
 		MapID:                mapID,
@@ -176,6 +180,9 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
 		ImageUrl:             ptrToText(req.ImageURL),
 		ImageMediaID:         imageMediaID,
+		PublicDescription:    ptrToText(req.PublicDescription),
+		EntryMessage:         ptrToText(req.EntryMessage),
+		ParentLocationID:     parentLocationID,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create location")
@@ -214,6 +221,21 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 			return nil, err
 		}
 	}
+	publicDescription := l.PublicDescription
+	if req.PublicDescription.Set {
+		publicDescription = ptrToText(req.PublicDescription.Value)
+	}
+	entryMessage := l.EntryMessage
+	if req.EntryMessage.Set {
+		entryMessage = ptrToText(req.EntryMessage.Value)
+	}
+	parentLocationID := l.ParentLocationID
+	if req.ParentLocationID.Set {
+		parentLocationID, err = s.resolveLocationParent(ctx, l.ThemeID, l.MapID, l.ID, req.ParentLocationID.Value)
+		if err != nil {
+			return nil, err
+		}
+	}
 	updated, err := s.q.UpdateLocation(ctx, db.UpdateLocationParams{
 		ID:                   l.ID,
 		Name:                 req.Name,
@@ -223,6 +245,9 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
 		ImageUrl:             imageURL,
 		ImageMediaID:         imageMediaID,
+		PublicDescription:    publicDescription,
+		EntryMessage:         entryMessage,
+		ParentLocationID:     parentLocationID,
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update location")
@@ -230,6 +255,44 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 	}
 	resp := toLocationResponse(updated)
 	return &resp, nil
+}
+
+func (s *service) resolveLocationParent(ctx context.Context, themeID, mapID, currentLocationID uuid.UUID, parentLocationID *uuid.UUID) (pgtype.UUID, error) {
+	if parentLocationID == nil {
+		return pgtype.UUID{}, nil
+	}
+	if currentLocationID != uuid.Nil && *parentLocationID == currentLocationID {
+		return pgtype.UUID{}, apperror.BadRequest("location cannot be its own parent")
+	}
+	locations, err := s.q.ListLocationsByTheme(ctx, themeID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to list locations for parent validation")
+		return pgtype.UUID{}, apperror.Internal("failed to validate location parent")
+	}
+	parentByID := make(map[uuid.UUID]uuid.UUID, len(locations))
+	parentFound := false
+	for _, location := range locations {
+		if location.ID == *parentLocationID && location.MapID == mapID {
+			parentFound = true
+		}
+		if location.MapID == mapID && location.ParentLocationID.Valid {
+			parentByID[location.ID] = uuid.UUID(location.ParentLocationID.Bytes)
+		}
+	}
+	if !parentFound {
+		return pgtype.UUID{}, apperror.BadRequest("parent location must belong to the same map")
+	}
+	for next, seen := *parentLocationID, map[uuid.UUID]bool{}; next != uuid.Nil; {
+		if currentLocationID != uuid.Nil && next == currentLocationID {
+			return pgtype.UUID{}, apperror.BadRequest("location parent cycle is not allowed")
+		}
+		if seen[next] {
+			return pgtype.UUID{}, apperror.BadRequest("location parent cycle is not allowed")
+		}
+		seen[next] = true
+		next = parentByID[next]
+	}
+	return uuidPtrToPgtype(parentLocationID), nil
 }
 
 func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID uuid.UUID, restrictedCharacters *string, fromRound, untilRound *int32) (LocationAccessPolicy, error) {
@@ -371,6 +434,9 @@ func toLocationResponse(l db.ThemeLocation) LocationResponse {
 		RestrictedCharacters: textToPtr(l.RestrictedCharacters),
 		ImageURL:             textToPtr(l.ImageUrl),
 		ImageMediaID:         pgtypeUUIDToPtr(l.ImageMediaID),
+		PublicDescription:    textToPtr(l.PublicDescription),
+		EntryMessage:         textToPtr(l.EntryMessage),
+		ParentLocationID:     pgtypeUUIDToPtr(l.ParentLocationID),
 		SortOrder:            l.SortOrder,
 		CreatedAt:            l.CreatedAt,
 		FromRound:            pgtypeInt4ToPtr(l.FromRound),

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -246,6 +246,105 @@ func TestService_LocationImageMediaReference(t *testing.T) {
 	}
 }
 
+func TestService_LocationTextContractAndParentValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	mapResp, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "지도"})
+	if err != nil {
+		t.Fatalf("CreateMap: %v", err)
+	}
+	otherMapResp, err := f.svc.CreateMap(ctx, creatorID, otherThemeID, CreateMapRequest{Name: "다른 지도"})
+	if err != nil {
+		t.Fatalf("CreateMap other: %v", err)
+	}
+	sameThemeOtherMap, err := f.svc.CreateMap(ctx, creatorID, themeID, CreateMapRequest{Name: "별관 지도"})
+	if err != nil {
+		t.Fatalf("CreateMap same theme other map: %v", err)
+	}
+	parent, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "저택"})
+	if err != nil {
+		t.Fatalf("CreateLocation parent: %v", err)
+	}
+	otherParent, err := f.svc.CreateLocation(ctx, creatorID, otherThemeID, otherMapResp.ID, CreateLocationRequest{Name: "다른 저택"})
+	if err != nil {
+		t.Fatalf("CreateLocation other parent: %v", err)
+	}
+	crossMapParent, err := f.svc.CreateLocation(ctx, creatorID, themeID, sameThemeOtherMap.ID, CreateLocationRequest{Name: "별관"})
+	if err != nil {
+		t.Fatalf("CreateLocation cross map parent: %v", err)
+	}
+
+	publicDescription := "누구나 볼 수 있는 응접실 설명"
+	entryMessage := "문을 열자 오래된 나무 냄새가 난다."
+	child, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{
+		Name:              "응접실",
+		PublicDescription: &publicDescription,
+		EntryMessage:      &entryMessage,
+		ParentLocationID:  &parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateLocation child: %v", err)
+	}
+	if child.PublicDescription == nil || *child.PublicDescription != publicDescription {
+		t.Fatalf("PublicDescription = %v, want %q", child.PublicDescription, publicDescription)
+	}
+	if child.EntryMessage == nil || *child.EntryMessage != entryMessage {
+		t.Fatalf("EntryMessage = %v, want %q", child.EntryMessage, entryMessage)
+	}
+	if child.ParentLocationID == nil || *child.ParentLocationID != parent.ID {
+		t.Fatalf("ParentLocationID = %v, want %s", child.ParentLocationID, parent.ID)
+	}
+
+	nextDescription := "수정된 설명"
+	updated, err := f.svc.UpdateLocation(ctx, creatorID, child.ID, UpdateLocationRequest{
+		Name:              child.Name,
+		SortOrder:         child.SortOrder,
+		PublicDescription: OptionalString{Set: true, Value: &nextDescription},
+		EntryMessage:      OptionalString{Set: true},
+		ParentLocationID:  OptionalUUID{Set: true},
+	})
+	if err != nil {
+		t.Fatalf("UpdateLocation clear nullable text/parent: %v", err)
+	}
+	if updated.PublicDescription == nil || *updated.PublicDescription != nextDescription {
+		t.Fatalf("updated PublicDescription = %v, want %q", updated.PublicDescription, nextDescription)
+	}
+	if updated.EntryMessage != nil {
+		t.Fatalf("updated EntryMessage = %v, want nil", updated.EntryMessage)
+	}
+	if updated.ParentLocationID != nil {
+		t.Fatalf("updated ParentLocationID = %v, want nil", updated.ParentLocationID)
+	}
+
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, child.ID, UpdateLocationRequest{
+		Name:             child.Name,
+		SortOrder:        child.SortOrder,
+		ParentLocationID: OptionalUUID{Set: true, Value: &child.ID},
+	}); !isBadRequest(err) {
+		t.Fatalf("UpdateLocation self parent error = %T %v, want bad request", err, err)
+	}
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, child.ID, UpdateLocationRequest{
+		Name:             child.Name,
+		SortOrder:        child.SortOrder,
+		ParentLocationID: OptionalUUID{Set: true, Value: &otherParent.ID},
+	}); !isBadRequest(err) {
+		t.Fatalf("UpdateLocation other theme parent error = %T %v, want bad request", err, err)
+	}
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, child.ID, UpdateLocationRequest{
+		Name:             child.Name,
+		SortOrder:        child.SortOrder,
+		ParentLocationID: OptionalUUID{Set: true, Value: &crossMapParent.ID},
+	}); !isBadRequest(err) {
+		t.Fatalf("UpdateLocation cross map parent error = %T %v, want bad request", err, err)
+	}
+}
+
 func TestService_MapImageMediaReference(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -320,6 +321,22 @@ func TestService_LocationTextContractAndParentValidation(t *testing.T) {
 	}
 	if updated.ParentLocationID != nil {
 		t.Fatalf("updated ParentLocationID = %v, want nil", updated.ParentLocationID)
+	}
+
+	overlongText := strings.Repeat("가", MaxLocationTextLen+1)
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, child.ID, UpdateLocationRequest{
+		Name:              child.Name,
+		SortOrder:         child.SortOrder,
+		PublicDescription: OptionalString{Set: true, Value: &overlongText},
+	}); !isBadRequest(err) {
+		t.Fatalf("UpdateLocation overlong public_description error = %T %v, want bad request", err, err)
+	}
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, child.ID, UpdateLocationRequest{
+		Name:         child.Name,
+		SortOrder:    child.SortOrder,
+		EntryMessage: OptionalString{Set: true, Value: &overlongText},
+	}); !isBadRequest(err) {
+		t.Fatalf("UpdateLocation overlong entry_message error = %T %v, want bad request", err, err)
 	}
 
 	if _, err := f.svc.UpdateLocation(ctx, creatorID, child.ID, UpdateLocationRequest{

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -30,6 +30,25 @@ func (o *OptionalUUID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type OptionalString struct {
+	Set   bool
+	Value *string
+}
+
+func (o *OptionalString) UnmarshalJSON(data []byte) error {
+	o.Set = true
+	if string(data) == "null" {
+		o.Value = nil
+		return nil
+	}
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	o.Value = &raw
+	return nil
+}
+
 // --- Map types ---
 
 type CreateMapRequest struct {
@@ -63,19 +82,25 @@ type CreateLocationRequest struct {
 	RestrictedCharacters *string    `json:"restricted_characters"`
 	ImageURL             *string    `json:"image_url" validate:"omitempty,url"`
 	ImageMediaID         *uuid.UUID `json:"image_media_id"`
+	PublicDescription    *string    `json:"public_description" validate:"omitempty,max=2000"`
+	EntryMessage         *string    `json:"entry_message" validate:"omitempty,max=2000"`
+	ParentLocationID     *uuid.UUID `json:"parent_location_id"`
 	SortOrder            int32      `json:"sort_order" validate:"min=0"`
 	FromRound            *int32     `json:"from_round" validate:"omitempty,min=1"`
 	UntilRound           *int32     `json:"until_round" validate:"omitempty,min=1"`
 }
 
 type UpdateLocationRequest struct {
-	Name                 string       `json:"name" validate:"required,min=1,max=100"`
-	RestrictedCharacters *string      `json:"restricted_characters"`
-	ImageURL             *string      `json:"image_url" validate:"omitempty,url"`
-	ImageMediaID         OptionalUUID `json:"image_media_id"`
-	SortOrder            int32        `json:"sort_order" validate:"min=0"`
-	FromRound            *int32       `json:"from_round" validate:"omitempty,min=1"`
-	UntilRound           *int32       `json:"until_round" validate:"omitempty,min=1"`
+	Name                 string         `json:"name" validate:"required,min=1,max=100"`
+	RestrictedCharacters *string        `json:"restricted_characters"`
+	ImageURL             *string        `json:"image_url" validate:"omitempty,url"`
+	ImageMediaID         OptionalUUID   `json:"image_media_id"`
+	PublicDescription    OptionalString `json:"public_description"`
+	EntryMessage         OptionalString `json:"entry_message"`
+	ParentLocationID     OptionalUUID   `json:"parent_location_id"`
+	SortOrder            int32          `json:"sort_order" validate:"min=0"`
+	FromRound            *int32         `json:"from_round" validate:"omitempty,min=1"`
+	UntilRound           *int32         `json:"until_round" validate:"omitempty,min=1"`
 }
 
 type LocationResponse struct {
@@ -86,6 +111,9 @@ type LocationResponse struct {
 	RestrictedCharacters *string    `json:"restricted_characters,omitempty"`
 	ImageURL             *string    `json:"image_url,omitempty"`
 	ImageMediaID         *uuid.UUID `json:"image_media_id,omitempty"`
+	PublicDescription    *string    `json:"public_description,omitempty"`
+	EntryMessage         *string    `json:"entry_message,omitempty"`
+	ParentLocationID     *uuid.UUID `json:"parent_location_id,omitempty"`
 	SortOrder            int32      `json:"sort_order"`
 	CreatedAt            time.Time  `json:"created_at"`
 	FromRound            *int32     `json:"from_round,omitempty"`

--- a/apps/server/internal/module/crime_scene/location.go
+++ b/apps/server/internal/module/crime_scene/location.go
@@ -19,10 +19,23 @@ func init() {
 
 // LocationDef describes a single location in the crime scene.
 type LocationDef struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	AccessRules []string `json:"accessRules"`
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	Description       string   `json:"description"`
+	PublicDescription string   `json:"publicDescription,omitempty"`
+	EntryMessage      string   `json:"entryMessage,omitempty"`
+	ParentLocationID  string   `json:"parentLocationId,omitempty"`
+	AccessRules       []string `json:"accessRules"`
+}
+
+// LocationPublicState is the player-facing location metadata safe to include in
+// reconnect state and movement events.
+type LocationPublicState struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	PublicDescription string `json:"publicDescription,omitempty"`
+	EntryMessage      string `json:"entryMessage,omitempty"`
+	ParentLocationID  string `json:"parentLocationId,omitempty"`
 }
 
 // LocationClueDiscovery defines a runtime-owned clue discovery candidate for a
@@ -173,8 +186,10 @@ func (m *LocationModule) handleMove(_ context.Context, playerID uuid.UUID, paylo
 	m.deps.EventBus.Publish(engine.Event{
 		Type: "location.moved",
 		Payload: map[string]any{
-			"playerID":   playerID,
-			"locationID": p.LocationID,
+			"playerID":     playerID,
+			"locationID":   p.LocationID,
+			"location":     toLocationPublicState(m.locationSet[p.LocationID]),
+			"entryMessage": m.locationSet[p.LocationID].EntryMessage,
 		},
 	})
 	return nil
@@ -272,9 +287,10 @@ func playerHasDiscoveredClue(clues []string, clueID string) bool {
 
 // locationState is the serialisable snapshot of location positions and history.
 type locationState struct {
-	Positions       map[string]string   `json:"positions"`
-	History         map[string][]string `json:"history"`
-	DiscoveredClues map[string][]string `json:"discoveredClues"`
+	Positions       map[string]string     `json:"positions"`
+	History         map[string][]string   `json:"history"`
+	DiscoveredClues map[string][]string   `json:"discoveredClues"`
+	Locations       []LocationPublicState `json:"locations,omitempty"`
 }
 
 func (m *LocationModule) snapshot() locationState {
@@ -294,7 +310,26 @@ func (m *LocationModule) snapshot() locationState {
 		copy(cp, clueIDs)
 		discoveredClues[pid.String()] = cp
 	}
-	return locationState{Positions: positions, History: history, DiscoveredClues: discoveredClues}
+	locations := make([]LocationPublicState, 0, len(m.config.Locations))
+	for _, location := range m.config.Locations {
+		locations = append(locations, toLocationPublicState(location))
+	}
+	return locationState{
+		Positions:       positions,
+		History:         history,
+		DiscoveredClues: discoveredClues,
+		Locations:       locations,
+	}
+}
+
+func toLocationPublicState(location LocationDef) LocationPublicState {
+	return LocationPublicState{
+		ID:                location.ID,
+		Name:              location.Name,
+		PublicDescription: location.PublicDescription,
+		EntryMessage:      location.EntryMessage,
+		ParentLocationID:  location.ParentLocationID,
+	}
 }
 
 // BuildState returns the module's current state for client sync.

--- a/apps/server/internal/module/crime_scene/location_test.go
+++ b/apps/server/internal/module/crime_scene/location_test.go
@@ -101,6 +101,53 @@ func TestLocationModule_HandleMessage_Move(t *testing.T) {
 	m.mu.RUnlock()
 }
 
+func TestLocationModule_MovePublishesLocationTextContract(t *testing.T) {
+	m := NewLocationModule()
+	deps := newTestDeps()
+	config := json.RawMessage(`{
+		"locations": [
+			{
+				"id": "library",
+				"name": "Library",
+				"description": "Book room",
+				"publicDescription": "먼지 쌓인 책장이 보인다.",
+				"entryMessage": "낡은 종이 냄새가 난다.",
+				"parentLocationId": "mansion"
+			},
+			{"id": "mansion", "name": "Mansion", "description": "Old mansion"}
+		]
+	}`)
+	if err := m.Init(context.Background(), deps, config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	playerID := uuid.New()
+	var moved engine.Event
+	deps.EventBus.Subscribe("location.moved", func(e engine.Event) { moved = e })
+
+	if err := m.HandleMessage(context.Background(), playerID, "move", json.RawMessage(`{"location_id":"library"}`)); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	payload := moved.Payload.(map[string]any)
+	if payload["entryMessage"] != "낡은 종이 냄새가 난다." {
+		t.Fatalf("entryMessage = %v", payload["entryMessage"])
+	}
+	location := payload["location"].(LocationPublicState)
+	if location.PublicDescription != "먼지 쌓인 책장이 보인다." {
+		t.Fatalf("PublicDescription = %q", location.PublicDescription)
+	}
+	if location.ParentLocationID != "mansion" {
+		t.Fatalf("ParentLocationID = %q", location.ParentLocationID)
+	}
+
+	raw, err := m.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"publicDescription":"먼지 쌓인 책장이 보인다."`)) {
+		t.Fatalf("BuildState missing publicDescription: %s", string(raw))
+	}
+}
+
 func TestLocationModule_HandleMessage_Move_UnknownLocation(t *testing.T) {
 	m := NewLocationModule()
 	if err := m.Init(context.Background(), newTestDeps(), locationCfg()); err != nil {

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -199,6 +199,9 @@ export interface LocationResponse {
   restricted_characters: string | null;
   image_url: string | null;
   image_media_id?: string | null;
+  public_description?: string | null;
+  entry_message?: string | null;
+  parent_location_id?: string | null;
   sort_order: number;
   created_at: string;
   from_round?: number | null;

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -10,7 +10,7 @@ import {
   buildLocationParentOptions,
   toLocationEditorViewModel,
 } from '@/features/editor/entities/location/locationEntityAdapter';
-import { readLocationMeta, writeLocationMeta } from '@/features/editor/utils/entityMeta';
+import { readLocationMeta } from '@/features/editor/utils/entityMeta';
 import { AddNameInput } from './AddNameInput';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import { LocationAccessPolicyPanel } from './LocationAccessPolicyPanel';
@@ -161,9 +161,9 @@ function SelectedLocationDetail({
   );
   const [basicDraft, setBasicDraft] = useState({
     name: location.name,
-    publicDescription: locationMeta.publicDescription ?? '',
-    entryMessage: locationMeta.entryMessage ?? '',
-    parentLocationId: locationMeta.parentLocationId ?? '',
+    publicDescription: location.public_description ?? locationMeta.publicDescription ?? '',
+    entryMessage: location.entry_message ?? locationMeta.entryMessage ?? '',
+    parentLocationId: location.parent_location_id ?? locationMeta.parentLocationId ?? '',
   });
   const assignedCount = useMemo(
     () => readLocationClueIds(theme.config_json, location.id).length,
@@ -188,11 +188,20 @@ function SelectedLocationDetail({
     );
     setBasicDraft({
       name: location.name,
-      publicDescription: locationMeta.publicDescription ?? '',
-      entryMessage: locationMeta.entryMessage ?? '',
-      parentLocationId: locationMeta.parentLocationId ?? '',
+      publicDescription: location.public_description ?? locationMeta.publicDescription ?? '',
+      entryMessage: location.entry_message ?? locationMeta.entryMessage ?? '',
+      parentLocationId: location.parent_location_id ?? locationMeta.parentLocationId ?? '',
     });
-  }, [location.id, location.name, location.from_round, location.until_round, locationMeta]);
+  }, [
+    location.id,
+    location.name,
+    location.from_round,
+    location.until_round,
+    location.public_description,
+    location.entry_message,
+    location.parent_location_id,
+    locationMeta,
+  ]);
 
   function saveLocation(
     patch: Partial<LocationResponse>,
@@ -226,6 +235,9 @@ function SelectedLocationDetail({
       name: patch.name ?? location.name,
       restricted_characters: patch.restricted_characters ?? location.restricted_characters,
       image_url: nextImageUrl,
+      public_description: patch.public_description ?? location.public_description ?? null,
+      entry_message: patch.entry_message ?? location.entry_message ?? null,
+      parent_location_id: patch.parent_location_id ?? location.parent_location_id ?? null,
       sort_order: patch.sort_order ?? location.sort_order,
       from_round: nextFrom,
       until_round: nextUntil,
@@ -259,21 +271,14 @@ function SelectedLocationDetail({
 
     const nextParentId = basicDraft.parentLocationId || null;
     saveLocation(
-      { name: nextName },
       {
-        onSuccess: () => {
-          updateConfig.mutate(
-            writeLocationMeta(theme.config_json, location.id, {
-              publicDescription: basicDraft.publicDescription.trim(),
-              entryMessage: basicDraft.entryMessage.trim(),
-              parentLocationId: nextParentId,
-            }),
-            {
-              onSuccess: () => toast.success('장소 기본 정보가 저장되었습니다'),
-              onError: () => toast.error('장소 기본 정보 저장에 실패했습니다'),
-            }
-          );
-        },
+        name: nextName,
+        public_description: basicDraft.publicDescription.trim() || null,
+        entry_message: basicDraft.entryMessage.trim() || null,
+        parent_location_id: nextParentId,
+      },
+      {
+        onSuccess: () => toast.success('장소 기본 정보가 저장되었습니다'),
         onErrorMessage: '장소 기본 정보 저장에 실패했습니다',
       }
     );

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -444,7 +444,7 @@ describe('LocationsSubTab', () => {
   describe('장소 기본 정보', () => {
     beforeEach(setupDefaultMocks);
 
-    it('공개 설명, 진입 메시지, 부모 장소를 locationMeta 기반으로 편집한다', () => {
+    it('공개 설명, 진입 메시지, 부모 장소를 Location API payload로 저장한다', () => {
       useEditorLocationsMock.mockReturnValue({
         data: [{ ...mockLocations[0], name: '거실' }, ...mockLocations.slice(1)],
         isLoading: false,
@@ -469,7 +469,12 @@ describe('LocationsSubTab', () => {
       expect(updateLocationMutateMock).toHaveBeenCalledWith(
         expect.objectContaining({
           locationId: 'loc-1',
-          body: expect.objectContaining({ name: '응접실' }),
+          body: expect.objectContaining({
+            name: '응접실',
+            public_description: '손님들이 모이는 공간',
+            entry_message: '낡은 시계 소리가 들린다.',
+            parent_location_id: 'loc-2',
+          }),
         }),
         expect.any(Object)
       );
@@ -478,14 +483,8 @@ describe('LocationsSubTab', () => {
         { onSuccess?: () => void },
       ];
       updateLocationOptions.onSuccess?.();
-      const [config] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
-      expect(config.locationMeta).toMatchObject({
-        'loc-1': {
-          publicDescription: '손님들이 모이는 공간',
-          entryMessage: '낡은 시계 소리가 들린다.',
-          parentLocationId: 'loc-2',
-        },
-      });
+      expect(updateConfigMutateMock).not.toHaveBeenCalled();
+      expect(toastSuccess).toHaveBeenCalledWith('장소 기본 정보가 저장되었습니다');
     });
   });
 

--- a/apps/web/src/features/editor/editorMapApi.ts
+++ b/apps/web/src/features/editor/editorMapApi.ts
@@ -17,20 +17,24 @@ export interface UpdateMapRequest {
 
 export interface CreateLocationRequest {
   name: string;
-  description?: string;
   restricted_characters?: string | null;
   image_url?: string | null;
   image_media_id?: string | null;
+  public_description?: string | null;
+  entry_message?: string | null;
+  parent_location_id?: string | null;
   from_round?: number | null;
   until_round?: number | null;
 }
 
 export interface UpdateLocationRequest {
   name?: string;
-  description?: string;
   restricted_characters?: string | null;
   image_url?: string | null;
   image_media_id?: string | null;
+  public_description?: string | null;
+  entry_message?: string | null;
+  parent_location_id?: string | null;
   sort_order?: number;
   from_round?: number | null;
   until_round?: number | null;

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -134,6 +134,22 @@ describe('locationEntityAdapter', () => {
     ).toEqual([{ id: 'loc-4', label: '정원', depth: 0 }]);
   });
 
+  it('부모 장소 후보 계산도 API parent_location_id를 locationMeta보다 우선한다', () => {
+    const locations = [
+      location({ id: 'loc-1', name: '저택' }),
+      location({ id: 'loc-2', name: '1층', parent_location_id: 'loc-1' }),
+      location({ id: 'loc-3', name: '서재', parent_location_id: 'loc-2' }),
+      location({ id: 'loc-4', name: '정원' }),
+    ];
+
+    expect(
+      buildLocationParentOptions('loc-1', locations, {
+        'loc-2': { parentLocationId: null },
+        'loc-3': { parentLocationId: null },
+      })
+    ).toEqual([{ id: 'loc-4', label: '정원', depth: 0 }]);
+  });
+
   it('restricted character CSV를 trim/dedupe한다', () => {
     expect(parseLocationRestrictedCharacterIds(' char-1, char-2, char-1, ')).toEqual([
       'char-1',

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -80,20 +80,42 @@ describe('locationEntityAdapter', () => {
     });
   });
 
-  it('locationMeta를 제작자용 공개 설명과 부모 요약으로 변환한다', () => {
-    const vm = toLocationEditorViewModel(location(), {
-      locationMeta: {
-        publicDescription: '모든 플레이어에게 보이는 설명',
-        entryMessage: '차가운 바람이 분다.',
-        parentLocationId: 'loc-parent',
-      },
-      allLocations: [location({ id: 'loc-parent', name: '저택 1층' })],
-    });
+  it('API 필드를 제작자용 공개 설명과 부모 요약으로 변환한다', () => {
+    const vm = toLocationEditorViewModel(
+      location({
+        public_description: '모든 플레이어에게 보이는 설명',
+        entry_message: '차가운 바람이 분다.',
+        parent_location_id: 'loc-parent',
+      }),
+      {
+        locationMeta: {
+          publicDescription: 'legacy 설명',
+          entryMessage: 'legacy 진입',
+          parentLocationId: 'legacy-parent',
+        },
+        allLocations: [location({ id: 'loc-parent', name: '저택 1층' })],
+      }
+    );
 
     expect(vm.publicDescription).toBe('모든 플레이어에게 보이는 설명');
     expect(vm.entryMessage).toBe('차가운 바람이 분다.');
     expect(vm.parentLocationId).toBe('loc-parent');
     expect(vm.parentLabel).toBe('저택 1층');
+  });
+
+  it('신규 API 필드가 비어 있으면 locationMeta fallback을 사용한다', () => {
+    const vm = toLocationEditorViewModel(location(), {
+      locationMeta: {
+        publicDescription: '기존 설명',
+        entryMessage: '기존 진입',
+        parentLocationId: 'loc-parent',
+      },
+      allLocations: [location({ id: 'loc-parent', name: '저택 1층' })],
+    });
+
+    expect(vm.publicDescription).toBe('기존 설명');
+    expect(vm.entryMessage).toBe('기존 진입');
+    expect(vm.parentLocationId).toBe('loc-parent');
   });
 
   it('부모 장소 후보에서 자기 자신과 자손을 제외한다', () => {

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -37,7 +37,7 @@ export function toLocationEditorViewModel(
   const clueCount = options.clueCount ?? 0;
   const parentLocationId = normalizeParentLocationId(
     location.id,
-    options.locationMeta?.parentLocationId
+    location.parent_location_id ?? options.locationMeta?.parentLocationId
   );
   const parentLocation = options.allLocations?.find((item) => item.id === parentLocationId);
   return {
@@ -50,8 +50,10 @@ export function toLocationEditorViewModel(
       location.restricted_characters,
       options.characters ?? []
     ),
-    publicDescription: normalizeMetaText(options.locationMeta?.publicDescription),
-    entryMessage: normalizeMetaText(options.locationMeta?.entryMessage),
+    publicDescription: normalizeMetaText(
+      location.public_description ?? options.locationMeta?.publicDescription
+    ),
+    entryMessage: normalizeMetaText(location.entry_message ?? options.locationMeta?.entryMessage),
     parentLocationId,
     parentLabel: parentLocation?.name ?? '최상위 장소',
     clueCountLabel: `단서 조사 ${clueCount}개`,

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -35,10 +35,7 @@ export function toLocationEditorViewModel(
   } = {}
 ): LocationEditorViewModel {
   const clueCount = options.clueCount ?? 0;
-  const parentLocationId = normalizeParentLocationId(
-    location.id,
-    location.parent_location_id ?? options.locationMeta?.parentLocationId
-  );
+  const parentLocationId = resolveLocationParentId(location, options.locationMeta);
   const parentLocation = options.allLocations?.find((item) => item.id === parentLocationId);
   return {
     id: location.id,
@@ -135,6 +132,16 @@ function normalizeParentLocationId(
   return trimmed;
 }
 
+function resolveLocationParentId(
+  location: LocationResponse,
+  locationMeta?: LocationMeta
+): string | null {
+  return normalizeParentLocationId(
+    location.id,
+    location.parent_location_id ?? locationMeta?.parentLocationId
+  );
+}
+
 function collectDescendantLocationIds(
   currentLocationId: string,
   locations: LocationResponse[],
@@ -146,10 +153,7 @@ function collectDescendantLocationIds(
     changed = false;
     for (const location of locations) {
       if (descendants.has(location.id)) continue;
-      const parentId = normalizeParentLocationId(
-        location.id,
-        metaByLocationId[location.id]?.parentLocationId
-      );
+      const parentId = resolveLocationParentId(location, metaByLocationId[location.id]);
       if (parentId === currentLocationId || (parentId != null && descendants.has(parentId))) {
         descendants.add(location.id);
         changed = true;
@@ -169,10 +173,7 @@ function getLocationDepth(
   seen.add(locationId);
   const location = locations.find((item) => item.id === locationId);
   if (!location) return 0;
-  const parentId = normalizeParentLocationId(
-    location.id,
-    metaByLocationId[location.id]?.parentLocationId
-  );
+  const parentId = resolveLocationParentId(location, metaByLocationId[location.id]);
   if (!parentId) return 0;
   return 1 + getLocationDepth(parentId, locations, metaByLocationId, seen);
 }


### PR DESCRIPTION
## 요약
- theme_locations에 public_description, entry_message, parent_location_id 계약을 추가하고 기존 locationMeta 값을 migration으로 흡수
- Location API create/update/response와 editor 저장 흐름을 신규 필드 기준으로 전환
- runtime location module이 공개 위치 정보와 진입 메시지를 player-facing state/event로 노출하되 내부 description/accessRules는 제외

## Coverage Plan
- DB/API: migration + sqlc + service create/update/parent validation을 apps/server/internal/domain/editor/service_location_policy_test.go에서 검증
- Runtime: apps/server/internal/module/crime_scene/location_test.go에서 movement event와 BuildState 공개 필드 검증
- Frontend adapter/UI: locationEntityAdapter + LocationsSubTab focused tests로 API 필드 우선 읽기와 저장 payload 검증
- E2E 대체: 저장/API/runtime 계약 변경은 backend service/module + frontend adapter/component tests와 local-ci quick으로 검증

## Local validation
- `cd apps/server && go test ./internal/module/crime_scene ./internal/domain/editor` 통과
- `pnpm --filter @mmp/web test -- src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx` 통과 (2 files / 36 tests)
- `pnpm --filter @mmp/web typecheck` 통과
- `git diff --check` 통과
- `scripts/mmp-local-ci.sh quick` 통과: mode=quick, head=268c2ebf72f54ea7276c07bb4b1ca1be7a80aeb2, finished_at=2026-05-08T08:38:18Z

Closes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 장소에 공개 설명(public_description)과 입장 메시지(entry_message)를 추가했습니다.
  * 장소 계층(parent_location_id)을 지정할 수 있어 부모-자식 구조로 관리할 수 있습니다.
  * 에디터 UI에서 설명·메시지·부모 관계를 직접 편집하고 저장할 수 있습니다.

* **Behavior / Validation**
  * 길이 제한(최대 2000자)과 부모 유효성(자기참조/맵·테마 일치 등)을 검사합니다.

* **Data**
  * 기존 메타에서 새 필드로 데이터를 마이그레이션했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->