### PR TITLE
test(ci): Postgres testcontainer 시작 대기 안정화

### DIFF
--- a/apps/server/internal/auditlog/store_test.go
+++ b/apps/server/internal/auditlog/store_test.go
@@ -18,12 +18,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx stdlib driver for database/sql used by goose
 	"github.com/pressly/goose/v3"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/testutil/postgrestest"
 )
 
 // ---------------------------------------------------------------------------
@@ -47,26 +45,7 @@ func setupStore(t *testing.T) *Store {
 	t.Helper()
 	ctx := context.Background()
 
-	pgC, err := postgres.Run(ctx,
-		"public.ecr.aws/docker/library/postgres:16-alpine",
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	if err != nil {
-		t.Fatalf("failed to start postgres container: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := pgC.Terminate(ctx); err != nil {
-			t.Logf("failed to terminate postgres container: %v", err)
-		}
-	})
-
-	connStr, err := pgC.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("failed to get connection string: %v", err)
-	}
+	connStr := postgrestest.Start(ctx, t)
 
 	// Run migrations via goose using the pgx stdlib driver.
 	sqlDB, err := sql.Open("pgx", connStr)

--- a/apps/server/internal/domain/auth/revoke_test.go
+++ b/apps/server/internal/domain/auth/revoke_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx stdlib driver for goose
 	"github.com/pressly/goose/v3"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/testutil/postgrestest"
 )
 
 // ---------------------------------------------------------------------------
@@ -73,26 +71,7 @@ func setupRevokeRepo(t *testing.T) (RevokeRepo, *pgxpool.Pool) {
 	t.Helper()
 	ctx := context.Background()
 
-	pgC, err := postgres.Run(ctx,
-		"public.ecr.aws/docker/library/postgres:16-alpine",
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	if err != nil {
-		t.Fatalf("failed to start postgres container: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := pgC.Terminate(ctx); err != nil {
-			t.Logf("failed to terminate postgres container: %v", err)
-		}
-	})
-
-	connStr, err := pgC.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
+	connStr := postgrestest.Start(ctx, t)
 
 	sqlDB, err := sql.Open("pgx", connStr)
 	if err != nil {

--- a/apps/server/internal/domain/editor/test_fixture_test.go
+++ b/apps/server/internal/domain/editor/test_fixture_test.go
@@ -14,11 +14,9 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
 	"github.com/rs/zerolog"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/testutil/postgrestest"
 )
 
 func migrationsPath() string {
@@ -39,26 +37,7 @@ func setupFixture(t *testing.T) *testFixture {
 	t.Helper()
 	ctx := context.Background()
 
-	pgC, err := postgres.Run(ctx,
-		"public.ecr.aws/docker/library/postgres:16-alpine",
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	if err != nil {
-		t.Fatalf("start postgres container: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := pgC.Terminate(ctx); err != nil {
-			t.Logf("terminate container: %v", err)
-		}
-	})
-
-	connStr, err := pgC.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
+	connStr := postgrestest.Start(ctx, t)
 
 	sqlDB, err := sql.Open("pgx", connStr)
 	if err != nil {

--- a/apps/server/internal/domain/flow/service_delete_test.go
+++ b/apps/server/internal/domain/flow/service_delete_test.go
@@ -13,11 +13,9 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
 	"github.com/rs/zerolog"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/testutil/postgrestest"
 )
 
 func TestServiceDeleteNode_CleansEndingBranchReferencesAndCascadesEdges(t *testing.T) {
@@ -179,26 +177,7 @@ func TestServiceDeleteNode_RejectsDifferentThemeOwnedBySameCreator(t *testing.T)
 func setupFlowTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	ctx := context.Background()
-	pgC, err := postgres.Run(ctx,
-		"public.ecr.aws/docker/library/postgres:16-alpine",
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2),
-		),
-	)
-	if err != nil {
-		t.Fatalf("start postgres container: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := pgC.Terminate(ctx); err != nil {
-			t.Logf("terminate container: %v", err)
-		}
-	})
-
-	connStr, err := pgC.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
+	connStr := postgrestest.Start(ctx, t)
 
 	sqlDB, err := sql.Open("pgx", connStr)
 	if err != nil {

--- a/apps/server/internal/domain/theme/test_fixture_test.go
+++ b/apps/server/internal/domain/theme/test_fixture_test.go
@@ -11,11 +11,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/testutil/postgrestest"
 )
 
 type themeFixture struct {
@@ -26,22 +24,8 @@ type themeFixture struct {
 func setupThemeFixture(t *testing.T) *themeFixture {
 	t.Helper()
 	ctx := context.Background()
-	pgC, err := postgres.Run(ctx,
-		"public.ecr.aws/docker/library/postgres:16-alpine",
-		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2)),
-	)
-	if err != nil {
-		t.Fatalf("start postgres container: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := pgC.Terminate(ctx); err != nil {
-			t.Logf("terminate container: %v", err)
-		}
-	})
-	connStr, err := pgC.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
+	connStr := postgrestest.Start(ctx, t)
+
 	sqlDB, err := sql.Open("pgx", connStr)
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)

--- a/apps/server/internal/testutil/postgrestest/postgres.go
+++ b/apps/server/internal/testutil/postgrestest/postgres.go
@@ -3,6 +3,7 @@ package postgrestest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
@@ -20,7 +21,9 @@ func Start(ctx context.Context, t testing.TB) string {
 		t.Fatalf("start postgres container: %v", err)
 	}
 	t.Cleanup(func() {
-		if err := pgC.Terminate(ctx); err != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := pgC.Terminate(cleanupCtx); err != nil {
 			t.Logf("terminate postgres container: %v", err)
 		}
 	})

--- a/apps/server/internal/testutil/postgrestest/postgres.go
+++ b/apps/server/internal/testutil/postgrestest/postgres.go
@@ -1,0 +1,33 @@
+package postgrestest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+const image = "public.ecr.aws/docker/library/postgres:16-alpine"
+
+// Start returns a test PostgreSQL connection string and registers container
+// cleanup. BasicWaitStrategies waits for both database readiness and the Docker
+// host port proxy, avoiding flaky mapped-port lookups on macOS.
+func Start(ctx context.Context, t testing.TB) string {
+	t.Helper()
+
+	pgC, err := postgres.Run(ctx, image, postgres.BasicWaitStrategies())
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := pgC.Terminate(ctx); err != nil {
+			t.Logf("terminate postgres container: %v", err)
+		}
+	})
+
+	connStr, err := pgC.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return connStr
+}


### PR DESCRIPTION
## 요약
- 중복된 Postgres testcontainer 시작 코드를 공통 `postgrestest.Start` helper로 통합
- `postgres.BasicWaitStrategies()`를 사용해 Postgres 로그 readiness뿐 아니라 Docker host port proxy 준비까지 기다리도록 변경
- `port "5432/tcp" not found`가 관측된 editor/auditlog/flow와 같은 패턴의 auth/theme fixture를 함께 전환

## Coverage Plan
- 실패 관측 패키지: `internal/auditlog`, `internal/domain/flow`, `internal/domain/editor` focused test로 검증
- 같은 helper 패턴 패키지: `internal/domain/auth`, `internal/domain/theme` package test로 검증
- 최종 검증: `scripts/mmp-local-ci.sh quick`로 전체 quick validation 및 PR guard marker 확보

## Local validation
- `cd apps/server && go test ./internal/auditlog -run TestStore_ConcurrentAppend_SeqUniqueness -count=1` 통과
- `cd apps/server && go test ./internal/domain/flow -run TestServiceFlowOwnership_RejectsDifferentCreatorMutations -count=1` 통과
- `cd apps/server && go test ./internal/domain/editor -run TestGetTheme_AppliesNormalizer -count=1` 통과
- `cd apps/server && go test ./internal/domain/auth ./internal/domain/theme -count=1` 통과
- `cd apps/server && go test ./internal/auditlog ./internal/domain/flow ./internal/domain/editor -count=1` 통과
- `git diff --check` 통과
- `scripts/mmp-local-ci.sh quick` 통과: mode=quick, head=38b16d364559af50832742666e91d8fd61a56864, finished_at=2026-05-08T08:54:17Z

Closes #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 테스트 데이터베이스 초기화 로직을 통합하는 내부 헬퍼를 추가하고, 여러 테스트에서 이를 사용하도록 리팩토링하여 유지보수성을 향상시켰습니다.
* **Tests**
  * 테스트 인프라의 컨테이너 시작·종료 관리가 중앙화되어 테스트 안정성과 일관성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->