### PR TITLE
fix(auth): 로그인 저장 힌트 추가

### DIFF
--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -101,11 +101,15 @@ function LoginPage() {
         </div>
 
         {/* 이메일/비밀번호 폼 */}
-        <form onSubmit={handleSubmit} className="mb-6 flex flex-col gap-3">
+        <form onSubmit={handleSubmit} autoComplete="on" className="mb-6 flex flex-col gap-3">
           {mode === "register" && (
             <input
+              id="nickname"
+              name="nickname"
               type="text"
               placeholder="닉네임"
+              aria-label="닉네임"
+              autoComplete="nickname"
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
               required
@@ -115,16 +119,24 @@ function LoginPage() {
             />
           )}
           <input
+            id="email"
+            name="email"
             type="email"
             placeholder="이메일"
+            aria-label="이메일"
+            autoComplete="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
             className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           <input
+            id="password"
+            name="password"
             type="password"
             placeholder="비밀번호"
+            aria-label="비밀번호"
+            autoComplete={mode === "register" ? "new-password" : "current-password"}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required

--- a/apps/web/src/features/auth/__tests__/LoginPage.test.tsx
+++ b/apps/web/src/features/auth/__tests__/LoginPage.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import LoginPage from "../LoginPage";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LoginPage", () => {
+  it("uses browser password-manager autocomplete hints on login fields", () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    const email = screen.getByLabelText("이메일");
+    const password = screen.getByLabelText("비밀번호");
+
+    expect(email.getAttribute("name")).toBe("email");
+    expect(email.getAttribute("autocomplete")).toBe("email");
+    expect(password.getAttribute("name")).toBe("password");
+    expect(password.getAttribute("autocomplete")).toBe("current-password");
+  });
+
+  it("switches password autocomplete to new-password on register mode", () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "계정이 없으신가요? 회원가입" }));
+
+    expect(screen.getByLabelText("닉네임").getAttribute("autocomplete")).toBe("nickname");
+    expect(screen.getByLabelText("비밀번호").getAttribute("autocomplete")).toBe("new-password");
+  });
+});


### PR DESCRIPTION
## 요약
- 로그인 이메일 입력에 username/email 자동완성 힌트를 추가했습니다.
- 비밀번호 입력에 current-password 자동완성 힌트를 추가했습니다.
- 브라우저 비밀번호 관리자와 이메일 저장 기능이 정상적으로 동작할 수 있게 입력 name/id를 명확히 했습니다.

## Coverage Plan
- 변경 파일: apps/web/src/features/auth/LoginPage.tsx
- 테스트: apps/web/src/features/auth/__tests__/LoginPage.test.tsx에서 이메일/비밀번호 자동완성 속성 검증
- 로컬 품질 게이트: scripts/mmp-local-ci.sh quick

## Local validation
- scripts/mmp-local-ci.sh quick
- 결과: success
- marker HEAD: 1f5854e6d1f81201f18745ca4c9175b25ccf8040

## 영향
- 런타임 인증 API 변경 없음
- 사용자 브라우저의 이메일/비밀번호 저장 UI에 필요한 힌트만 보강

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 폼의 접근성 개선으로 사용자 입력 편의성 증대
  * 브라우저 비밀번호 관리자 자동완성 지원 추가

* **테스트**
  * 자동완성 기능 동작 검증 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/553)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->