### PR TITLE
feat(editor): 장소 scene 공개 계약 추가

### DIFF
--- a/apps/server/db/migrations/00048_location_scene_visibility.sql
+++ b/apps/server/db/migrations/00048_location_scene_visibility.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- Scene-based visibility for editor locations.
+-- NULL appearance_scene_id means "visible from the beginning".
+-- NULL hide_scene_id means "visible until the final scene".
+
+ALTER TABLE theme_locations
+  ADD COLUMN appearance_scene_id UUID REFERENCES flow_nodes(id) ON DELETE SET NULL,
+  ADD COLUMN hide_scene_id UUID REFERENCES flow_nodes(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_theme_locations_appearance_scene
+  ON theme_locations(appearance_scene_id)
+  WHERE appearance_scene_id IS NOT NULL;
+
+CREATE INDEX idx_theme_locations_hide_scene
+  ON theme_locations(hide_scene_id)
+  WHERE hide_scene_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_theme_locations_hide_scene;
+DROP INDEX IF EXISTS idx_theme_locations_appearance_scene;
+
+ALTER TABLE theme_locations
+  DROP COLUMN IF EXISTS hide_scene_id,
+  DROP COLUMN IF EXISTS appearance_scene_id;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -29,24 +29,24 @@ SELECT count(*) FROM theme_maps WHERE theme_id = $1;
 -- ============================================================
 
 -- name: ListLocationsByMap :many
-SELECT * FROM theme_locations WHERE map_id = $1 ORDER BY sort_order;
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order;
 
 -- name: ListLocationsByTheme :many
-SELECT * FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
 
 -- name: GetLocation :one
-SELECT * FROM theme_locations WHERE id = $1;
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id FROM theme_locations WHERE id = $1;
 
 -- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id)
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-RETURNING *;
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id;
 
 -- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8, public_description = $9, entry_message = $10, parent_location_id = $11
+SET name = $2, restricted_characters = $3, sort_order = $4, appearance_scene_id = $5, hide_scene_id = $6, image_url = $7, image_media_id = $8, public_description = $9, entry_message = $10, parent_location_id = $11
 WHERE id = $1
-RETURNING *;
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id;
 
 -- name: DeleteLocation :exec
 DELETE FROM theme_locations WHERE id = $1;

--- a/apps/server/db/queries/editor.sql
+++ b/apps/server/db/queries/editor.sql
@@ -29,24 +29,24 @@ SELECT count(*) FROM theme_maps WHERE theme_id = $1;
 -- ============================================================
 
 -- name: ListLocationsByMap :many
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order;
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order;
 
 -- name: ListLocationsByTheme :many
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order;
 
 -- name: GetLocation :one
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id FROM theme_locations WHERE id = $1;
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE id = $1;
 
 -- name: CreateLocation :one
 INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id;
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id;
 
 -- name: UpdateLocation :one
 UPDATE theme_locations
 SET name = $2, restricted_characters = $3, sort_order = $4, appearance_scene_id = $5, hide_scene_id = $6, image_url = $7, image_media_id = $8, public_description = $9, entry_message = $10, parent_location_id = $11
 WHERE id = $1
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, image_url, image_media_id, public_description, entry_message, parent_location_id, appearance_scene_id, hide_scene_id;
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id;
 
 -- name: DeleteLocation :exec
 DELETE FROM theme_locations WHERE id = $1;

--- a/apps/server/internal/db/editor.sql.go
+++ b/apps/server/internal/db/editor.sql.go
@@ -120,9 +120,9 @@ func (q *Queries) CreateClue(ctx context.Context, arg CreateClueParams) (ThemeCl
 }
 
 const createLocation = `-- name: CreateLocation :one
-INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id)
+INSERT INTO theme_locations (theme_id, map_id, name, restricted_characters, sort_order, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id
 `
 
 type CreateLocationParams struct {
@@ -131,8 +131,8 @@ type CreateLocationParams struct {
 	Name                 string      `json:"name"`
 	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
 	SortOrder            int32       `json:"sort_order"`
-	FromRound            pgtype.Int4 `json:"from_round"`
-	UntilRound           pgtype.Int4 `json:"until_round"`
+	AppearanceSceneID    pgtype.UUID `json:"appearance_scene_id"`
+	HideSceneID          pgtype.UUID `json:"hide_scene_id"`
 	ImageUrl             pgtype.Text `json:"image_url"`
 	ImageMediaID         pgtype.UUID `json:"image_media_id"`
 	PublicDescription    pgtype.Text `json:"public_description"`
@@ -147,8 +147,8 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		arg.Name,
 		arg.RestrictedCharacters,
 		arg.SortOrder,
-		arg.FromRound,
-		arg.UntilRound,
+		arg.AppearanceSceneID,
+		arg.HideSceneID,
 		arg.ImageUrl,
 		arg.ImageMediaID,
 		arg.PublicDescription,
@@ -164,8 +164,8 @@ func (q *Queries) CreateLocation(ctx context.Context, arg CreateLocationParams) 
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
-		&i.FromRound,
-		&i.UntilRound,
+		&i.AppearanceSceneID,
+		&i.HideSceneID,
 		&i.ImageUrl,
 		&i.ImageMediaID,
 		&i.PublicDescription,
@@ -403,7 +403,7 @@ func (q *Queries) GetContent(ctx context.Context, arg GetContentParams) (ThemeCo
 }
 
 const getLocation = `-- name: GetLocation :one
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE id = $1
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE id = $1
 `
 
 func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation, error) {
@@ -417,8 +417,8 @@ func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation,
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
-		&i.FromRound,
-		&i.UntilRound,
+		&i.AppearanceSceneID,
+		&i.HideSceneID,
 		&i.ImageUrl,
 		&i.ImageMediaID,
 		&i.PublicDescription,
@@ -429,7 +429,7 @@ func (q *Queries) GetLocation(ctx context.Context, id uuid.UUID) (ThemeLocation,
 }
 
 const getLocationWithOwner = `-- name: GetLocationWithOwner :one
-SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.from_round, l.until_round, l.image_url, l.image_media_id, l.public_description, l.entry_message, l.parent_location_id FROM theme_locations l
+SELECT l.id, l.theme_id, l.map_id, l.name, l.restricted_characters, l.sort_order, l.created_at, l.appearance_scene_id, l.hide_scene_id, l.image_url, l.image_media_id, l.public_description, l.entry_message, l.parent_location_id FROM theme_locations l
 JOIN themes t ON l.theme_id = t.id
 WHERE l.id = $1 AND t.creator_id = $2
 `
@@ -450,8 +450,8 @@ func (q *Queries) GetLocationWithOwner(ctx context.Context, arg GetLocationWithO
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
-		&i.FromRound,
-		&i.UntilRound,
+		&i.AppearanceSceneID,
+		&i.HideSceneID,
 		&i.ImageUrl,
 		&i.ImageMediaID,
 		&i.PublicDescription,
@@ -636,7 +636,7 @@ func (q *Queries) ListContentsByTheme(ctx context.Context, themeID uuid.UUID) ([
 
 const listLocationsByMap = `-- name: ListLocationsByMap :many
 
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE map_id = $1 ORDER BY sort_order
 `
 
 // ============================================================
@@ -659,8 +659,8 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 			&i.RestrictedCharacters,
 			&i.SortOrder,
 			&i.CreatedAt,
-			&i.FromRound,
-			&i.UntilRound,
+			&i.AppearanceSceneID,
+			&i.HideSceneID,
 			&i.ImageUrl,
 			&i.ImageMediaID,
 			&i.PublicDescription,
@@ -678,7 +678,7 @@ func (q *Queries) ListLocationsByMap(ctx context.Context, mapID uuid.UUID) ([]Th
 }
 
 const listLocationsByTheme = `-- name: ListLocationsByTheme :many
-SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id FROM theme_locations WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) ([]ThemeLocation, error) {
@@ -698,8 +698,8 @@ func (q *Queries) ListLocationsByTheme(ctx context.Context, themeID uuid.UUID) (
 			&i.RestrictedCharacters,
 			&i.SortOrder,
 			&i.CreatedAt,
-			&i.FromRound,
-			&i.UntilRound,
+			&i.AppearanceSceneID,
+			&i.HideSceneID,
 			&i.ImageUrl,
 			&i.ImageMediaID,
 			&i.PublicDescription,
@@ -829,9 +829,9 @@ func (q *Queries) UpdateClue(ctx context.Context, arg UpdateClueParams) (ThemeCl
 
 const updateLocation = `-- name: UpdateLocation :one
 UPDATE theme_locations
-SET name = $2, restricted_characters = $3, sort_order = $4, from_round = $5, until_round = $6, image_url = $7, image_media_id = $8, public_description = $9, entry_message = $10, parent_location_id = $11
+SET name = $2, restricted_characters = $3, sort_order = $4, appearance_scene_id = $5, hide_scene_id = $6, image_url = $7, image_media_id = $8, public_description = $9, entry_message = $10, parent_location_id = $11
 WHERE id = $1
-RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, from_round, until_round, image_url, image_media_id, public_description, entry_message, parent_location_id
+RETURNING id, theme_id, map_id, name, restricted_characters, sort_order, created_at, appearance_scene_id, hide_scene_id, image_url, image_media_id, public_description, entry_message, parent_location_id
 `
 
 type UpdateLocationParams struct {
@@ -839,8 +839,8 @@ type UpdateLocationParams struct {
 	Name                 string      `json:"name"`
 	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
 	SortOrder            int32       `json:"sort_order"`
-	FromRound            pgtype.Int4 `json:"from_round"`
-	UntilRound           pgtype.Int4 `json:"until_round"`
+	AppearanceSceneID    pgtype.UUID `json:"appearance_scene_id"`
+	HideSceneID          pgtype.UUID `json:"hide_scene_id"`
 	ImageUrl             pgtype.Text `json:"image_url"`
 	ImageMediaID         pgtype.UUID `json:"image_media_id"`
 	PublicDescription    pgtype.Text `json:"public_description"`
@@ -854,8 +854,8 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		arg.Name,
 		arg.RestrictedCharacters,
 		arg.SortOrder,
-		arg.FromRound,
-		arg.UntilRound,
+		arg.AppearanceSceneID,
+		arg.HideSceneID,
 		arg.ImageUrl,
 		arg.ImageMediaID,
 		arg.PublicDescription,
@@ -871,8 +871,8 @@ func (q *Queries) UpdateLocation(ctx context.Context, arg UpdateLocationParams) 
 		&i.RestrictedCharacters,
 		&i.SortOrder,
 		&i.CreatedAt,
-		&i.FromRound,
-		&i.UntilRound,
+		&i.AppearanceSceneID,
+		&i.HideSceneID,
 		&i.ImageUrl,
 		&i.ImageMediaID,
 		&i.PublicDescription,

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -363,8 +363,8 @@ type ThemeLocation struct {
 	RestrictedCharacters pgtype.Text `json:"restricted_characters"`
 	SortOrder            int32       `json:"sort_order"`
 	CreatedAt            time.Time   `json:"created_at"`
-	FromRound            pgtype.Int4 `json:"from_round"`
-	UntilRound           pgtype.Int4 `json:"until_round"`
+	AppearanceSceneID    pgtype.UUID `json:"appearance_scene_id"`
+	HideSceneID          pgtype.UUID `json:"hide_scene_id"`
 	ImageUrl             pgtype.Text `json:"image_url"`
 	ImageMediaID         pgtype.UUID `json:"image_media_id"`
 	PublicDescription    pgtype.Text `json:"public_description"`

--- a/apps/server/internal/domain/editor/image_service.go
+++ b/apps/server/internal/domain/editor/image_service.go
@@ -301,10 +301,13 @@ func (s *ImageService) ConfirmImageUpload(
 			Name:                 loc.Name,
 			RestrictedCharacters: loc.RestrictedCharacters,
 			SortOrder:            loc.SortOrder,
-			FromRound:            loc.FromRound,
-			UntilRound:           loc.UntilRound,
+			AppearanceSceneID:    loc.AppearanceSceneID,
+			HideSceneID:          loc.HideSceneID,
 			ImageUrl:             pgtype.Text{String: downloadURL, Valid: true},
 			ImageMediaID:         loc.ImageMediaID,
+			PublicDescription:    loc.PublicDescription,
+			EntryMessage:         loc.EntryMessage,
+			ParentLocationID:     loc.ParentLocationID,
 		})
 		if err != nil {
 			s.logger.Error().Err(err).Str("location_id", targetID.String()).Msg("failed to update location image_url")

--- a/apps/server/internal/domain/editor/image_service_test.go
+++ b/apps/server/internal/domain/editor/image_service_test.go
@@ -73,8 +73,12 @@ func TestConfirmImageUpload_PreservesExistingTargetFields(t *testing.T) {
 			uploadKey: "themes/11111111-1111-1111-1111-111111111111/locations/44444444-4444-4444-4444-444444444444/image.webp",
 			assert: func(t *testing.T, q *fakeImageQueries) {
 				arg := q.updateLocationArg
-				if arg.RestrictedCharacters.String != "char-a,char-b" || arg.FromRound.Int32 != 1 || arg.UntilRound.Int32 != 4 {
+				if arg.RestrictedCharacters.String != "char-a,char-b" {
 					t.Fatalf("location fields not preserved: %+v", arg)
+				}
+				if arg.AppearanceSceneID.Bytes != q.location.AppearanceSceneID.Bytes ||
+					arg.HideSceneID.Bytes != q.location.HideSceneID.Bytes {
+					t.Fatalf("location scene fields not preserved: %+v", arg)
 				}
 			},
 		},
@@ -132,7 +136,14 @@ func newFakeImageQueries(creatorID, themeID, charID, clueID, locationID uuid.UUI
 			RevealSceneID:     uuidValue("66666666-6666-6666-6666-666666666666"),
 			HideSceneID:       uuidValue("77777777-7777-7777-7777-777777777777"),
 		},
-		location: db.ThemeLocation{ID: locationID, ThemeID: themeID, Name: "서재", RestrictedCharacters: text("char-a,char-b"), FromRound: int4(1), UntilRound: int4(4)},
+		location: db.ThemeLocation{
+			ID:                   locationID,
+			ThemeID:              themeID,
+			Name:                 "서재",
+			RestrictedCharacters: text("char-a,char-b"),
+			AppearanceSceneID:    uuidValue("88888888-8888-8888-8888-888888888888"),
+			HideSceneID:          uuidValue("99999999-9999-9999-9999-999999999999"),
+		},
 	}
 }
 

--- a/apps/server/internal/domain/editor/round_validation_test.go
+++ b/apps/server/internal/domain/editor/round_validation_test.go
@@ -44,35 +44,3 @@ func TestValidateClueRoundOrder(t *testing.T) {
 		})
 	}
 }
-
-func TestValidateLocationRoundOrder(t *testing.T) {
-	cases := []struct {
-		name    string
-		from    *int32
-		until   *int32
-		wantErr bool
-	}{
-		{"both nil", nil, nil, false},
-		{"only from", p(1), nil, false},
-		{"only until", nil, p(4), false},
-		{"from < until", p(1), p(4), false},
-		{"from == until", p(2), p(2), false},
-		{"from > until", p(5), p(2), true},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateLocationRoundOrder(tc.from, tc.until)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				if !strings.Contains(err.Error(), "from_round") {
-					t.Fatalf("expected from_round in error, got %v", err)
-				}
-			} else if err != nil {
-				t.Fatalf("expected nil error, got %v", err)
-			}
-		})
-	}
-}

--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -108,6 +108,24 @@ func extractLocationDiscoveryRefs(cfg map[string]any) ([]locationDiscoveryRef, e
 	if !ok {
 		return nil, fmt.Errorf("config_json: modules.location.config must be an object")
 	}
+	if rawMode, exists := moduleConfig["investigationMode"]; exists {
+		if rawMode == nil {
+			return nil, fmt.Errorf("config_json: modules.location.config.investigationMode cannot be null")
+		}
+		mode, ok := rawMode.(string)
+		if !ok || (mode != "list" && mode != "deck") {
+			return nil, fmt.Errorf("config_json: modules.location.config.investigationMode must be list or deck")
+		}
+	}
+	if rawOrder, exists := moduleConfig["deckOrder"]; exists {
+		if rawOrder == nil {
+			return nil, fmt.Errorf("config_json: modules.location.config.deckOrder cannot be null")
+		}
+		order, ok := rawOrder.(string)
+		if !ok || (order != "fixed" && order != "random") {
+			return nil, fmt.Errorf("config_json: modules.location.config.deckOrder must be fixed or random")
+		}
+	}
 	rawDiscoveries, exists := moduleConfig["discoveries"]
 	if !exists {
 		return nil, nil
@@ -199,7 +217,12 @@ func (s *service) validateLocationDiscoveryReferences(ctx context.Context, q *db
 		clueIDs[clue.ID.String()] = struct{}{}
 	}
 
+	clueToLocation := make(map[string]string, len(refs))
 	for _, ref := range refs {
+		if previous, exists := clueToLocation[ref.clueID]; exists {
+			return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].clueId is already mapped to location %s", ref.index, previous))
+		}
+		clueToLocation[ref.clueID] = ref.locationID
 		parsedLocationID, err := uuid.Parse(ref.locationID)
 		if err != nil {
 			return apperror.BadRequest(fmt.Sprintf("config_json: modules.location.config.discoveries[%d].locationId must be a valid location id", ref.index))

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -216,13 +216,19 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		s.logger.Error().Err(err).Msg("failed to get location")
 		return nil, apperror.Internal("failed to get location")
 	}
-	appearanceSceneID, err := s.resolveLocationSceneReference(ctx, l.ThemeID, req.AppearanceSceneID, "appearance_scene_id")
-	if err != nil {
-		return nil, err
+	appearanceSceneID := l.AppearanceSceneID
+	if req.AppearanceSceneID.Set {
+		appearanceSceneID, err = s.resolveLocationSceneReference(ctx, l.ThemeID, req.AppearanceSceneID.Value, "appearance_scene_id")
+		if err != nil {
+			return nil, err
+		}
 	}
-	hideSceneID, err := s.resolveLocationSceneReference(ctx, l.ThemeID, req.HideSceneID, "hide_scene_id")
-	if err != nil {
-		return nil, err
+	hideSceneID := l.HideSceneID
+	if req.HideSceneID.Set {
+		hideSceneID, err = s.resolveLocationSceneReference(ctx, l.ThemeID, req.HideSceneID.Value, "hide_scene_id")
+		if err != nil {
+			return nil, err
+		}
 	}
 	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, l.ThemeID, req.RestrictedCharacters)
 	if err != nil {

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -148,7 +148,15 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 	if err := validateLocationText("entry_message", req.EntryMessage); err != nil {
 		return nil, err
 	}
-	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, themeID, req.RestrictedCharacters, req.FromRound, req.UntilRound)
+	appearanceSceneID, err := s.resolveLocationSceneReference(ctx, themeID, req.AppearanceSceneID, "appearance_scene_id")
+	if err != nil {
+		return nil, err
+	}
+	hideSceneID, err := s.resolveLocationSceneReference(ctx, themeID, req.HideSceneID, "hide_scene_id")
+	if err != nil {
+		return nil, err
+	}
+	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, themeID, req.RestrictedCharacters)
 	if err != nil {
 		return nil, err
 	}
@@ -183,8 +191,8 @@ func (s *service) CreateLocation(ctx context.Context, creatorID, themeID, mapID 
 		Name:                 req.Name,
 		RestrictedCharacters: ptrToText(accessPolicy.RestrictedCharacters),
 		SortOrder:            req.SortOrder,
-		FromRound:            int32PtrToPgtype(accessPolicy.FromRound),
-		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
+		AppearanceSceneID:    appearanceSceneID,
+		HideSceneID:          hideSceneID,
 		ImageUrl:             ptrToText(req.ImageURL),
 		ImageMediaID:         imageMediaID,
 		PublicDescription:    ptrToText(req.PublicDescription),
@@ -208,7 +216,15 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		s.logger.Error().Err(err).Msg("failed to get location")
 		return nil, apperror.Internal("failed to get location")
 	}
-	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, l.ThemeID, req.RestrictedCharacters, req.FromRound, req.UntilRound)
+	appearanceSceneID, err := s.resolveLocationSceneReference(ctx, l.ThemeID, req.AppearanceSceneID, "appearance_scene_id")
+	if err != nil {
+		return nil, err
+	}
+	hideSceneID, err := s.resolveLocationSceneReference(ctx, l.ThemeID, req.HideSceneID, "hide_scene_id")
+	if err != nil {
+		return nil, err
+	}
+	accessPolicy, err := s.buildLocationAccessPolicyForTheme(ctx, l.ThemeID, req.RestrictedCharacters)
 	if err != nil {
 		return nil, err
 	}
@@ -254,8 +270,8 @@ func (s *service) UpdateLocation(ctx context.Context, creatorID, locID uuid.UUID
 		Name:                 req.Name,
 		RestrictedCharacters: ptrToText(accessPolicy.RestrictedCharacters),
 		SortOrder:            req.SortOrder,
-		FromRound:            int32PtrToPgtype(accessPolicy.FromRound),
-		UntilRound:           int32PtrToPgtype(accessPolicy.UntilRound),
+		AppearanceSceneID:    appearanceSceneID,
+		HideSceneID:          hideSceneID,
 		ImageUrl:             imageURL,
 		ImageMediaID:         imageMediaID,
 		PublicDescription:    publicDescription,
@@ -294,6 +310,9 @@ func (s *service) resolveLocationParent(ctx context.Context, themeID, mapID, cur
 	for _, location := range locations {
 		if location.ID == *parentLocationID && location.MapID == mapID {
 			parentFound = true
+			if location.ParentLocationID.Valid {
+				return pgtype.UUID{}, apperror.BadRequest("sub-location cannot have child locations")
+			}
 		}
 		if location.MapID == mapID && location.ParentLocationID.Valid {
 			parentByID[location.ID] = uuid.UUID(location.ParentLocationID.Bytes)
@@ -315,11 +334,8 @@ func (s *service) resolveLocationParent(ctx context.Context, themeID, mapID, cur
 	return uuidPtrToPgtype(parentLocationID), nil
 }
 
-func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID uuid.UUID, restrictedCharacters *string, fromRound, untilRound *int32) (LocationAccessPolicy, error) {
-	accessPolicy, err := BuildLocationAccessPolicy(restrictedCharacters, fromRound, untilRound)
-	if err != nil {
-		return LocationAccessPolicy{}, err
-	}
+func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID uuid.UUID, restrictedCharacters *string) (LocationAccessPolicy, error) {
+	accessPolicy := BuildLocationAccessPolicy(restrictedCharacters)
 	if len(accessPolicy.RestrictedCharacterIDs) == 0 {
 		return accessPolicy, nil
 	}
@@ -345,6 +361,35 @@ func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID
 	return accessPolicy, nil
 }
 
+func uuidPtrToStringPtr(value *uuid.UUID) *string {
+	if value == nil {
+		return nil
+	}
+	text := value.String()
+	return &text
+}
+
+func (s *service) resolveLocationSceneReference(ctx context.Context, themeID uuid.UUID, sceneID *uuid.UUID, field string) (pgtype.UUID, error) {
+	if sceneID == nil {
+		return pgtype.UUID{}, nil
+	}
+	node, err := s.q.GetFlowNode(ctx, *sceneID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return pgtype.UUID{}, apperror.BadRequest(field + " must reference an existing scene")
+		}
+		s.logger.Error().Err(err).Str("field", field).Msg("failed to get location scene reference")
+		return pgtype.UUID{}, apperror.Internal("failed to get location scene reference")
+	}
+	if node.ThemeID != themeID {
+		return pgtype.UUID{}, apperror.BadRequest(field + " must belong to the same theme")
+	}
+	if node.Type == "start" || node.Type == "branch" {
+		return pgtype.UUID{}, apperror.BadRequest(field + " cannot reference start or branch nodes")
+	}
+	return uuidPtrToPgtype(sceneID), nil
+}
+
 func (s *service) resolveThemeImageMedia(ctx context.Context, themeID uuid.UUID, mediaID *uuid.UUID, purpose string) (pgtype.UUID, error) {
 	if mediaID == nil {
 		return pgtype.UUID{}, nil
@@ -361,14 +406,6 @@ func (s *service) resolveThemeImageMedia(ctx context.Context, themeID uuid.UUID,
 		return pgtype.UUID{}, apperror.New(apperror.ErrMediaNotInTheme, 400, "media has wrong type for "+purpose)
 	}
 	return pgtype.UUID{Bytes: *mediaID, Valid: true}, nil
-}
-
-// validateLocationRoundOrder enforces from_round <= until_round when both set.
-func validateLocationRoundOrder(from, until *int32) error {
-	if from != nil && until != nil && *from > *until {
-		return apperror.BadRequest("from_round must not be greater than until_round")
-	}
-	return nil
 }
 
 func (s *service) DeleteLocation(ctx context.Context, creatorID, locID uuid.UUID) error {
@@ -459,7 +496,7 @@ func toLocationResponse(l db.ThemeLocation) LocationResponse {
 		ParentLocationID:     pgtypeUUIDToPtr(l.ParentLocationID),
 		SortOrder:            l.SortOrder,
 		CreatedAt:            l.CreatedAt,
-		FromRound:            pgtypeInt4ToPtr(l.FromRound),
-		UntilRound:           pgtypeInt4ToPtr(l.UntilRound),
+		AppearanceSceneID:    pgtypeUUIDToPtr(l.AppearanceSceneID),
+		HideSceneID:          pgtypeUUIDToPtr(l.HideSceneID),
 	}
 }

--- a/apps/server/internal/domain/editor/service_location.go
+++ b/apps/server/internal/domain/editor/service_location.go
@@ -361,14 +361,6 @@ func (s *service) buildLocationAccessPolicyForTheme(ctx context.Context, themeID
 	return accessPolicy, nil
 }
 
-func uuidPtrToStringPtr(value *uuid.UUID) *string {
-	if value == nil {
-		return nil
-	}
-	text := value.String()
-	return &text
-}
-
 func (s *service) resolveLocationSceneReference(ctx context.Context, themeID uuid.UUID, sceneID *uuid.UUID, field string) (pgtype.UUID, error) {
 	if sceneID == nil {
 		return pgtype.UUID{}, nil

--- a/apps/server/internal/domain/editor/service_location_policy.go
+++ b/apps/server/internal/domain/editor/service_location_policy.go
@@ -7,15 +7,9 @@ import "strings"
 type LocationAccessPolicy struct {
 	RestrictedCharacterIDs []string
 	RestrictedCharacters   *string
-	FromRound              *int32
-	UntilRound             *int32
 }
 
-func BuildLocationAccessPolicy(restrictedCharacters *string, fromRound, untilRound *int32) (LocationAccessPolicy, error) {
-	if err := validateLocationRoundOrder(fromRound, untilRound); err != nil {
-		return LocationAccessPolicy{}, err
-	}
-
+func BuildLocationAccessPolicy(restrictedCharacters *string) LocationAccessPolicy {
 	ids := parseLocationRestrictedCharacterIDs(restrictedCharacters)
 	var normalized *string
 	if len(ids) > 0 {
@@ -25,29 +19,14 @@ func BuildLocationAccessPolicy(restrictedCharacters *string, fromRound, untilRou
 	return LocationAccessPolicy{
 		RestrictedCharacterIDs: ids,
 		RestrictedCharacters:   normalized,
-		FromRound:              fromRound,
-		UntilRound:             untilRound,
-	}, nil
+	}
 }
 
 func (p LocationAccessPolicy) IsPublic() bool {
 	return len(p.RestrictedCharacterIDs) == 0
 }
 
-func (p LocationAccessPolicy) IsVisibleInRound(round int32) bool {
-	if p.FromRound != nil && round < *p.FromRound {
-		return false
-	}
-	if p.UntilRound != nil && round > *p.UntilRound {
-		return false
-	}
-	return true
-}
-
-func (p LocationAccessPolicy) CanCharacterAccess(characterID string, round int32) bool {
-	if !p.IsVisibleInRound(round) {
-		return false
-	}
+func (p LocationAccessPolicy) CanCharacterAccess(characterID string) bool {
 	normalizedCharacterID := strings.TrimSpace(characterID)
 	if len(p.RestrictedCharacterIDs) > 0 && normalizedCharacterID == "" {
 		return false

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -160,8 +160,6 @@ func TestService_LocationRestrictedCharactersMustBelongToTheme(t *testing.T) {
 		Name:                 created.Name,
 		RestrictedCharacters: &invalidCSV,
 		SortOrder:            created.SortOrder,
-		AppearanceSceneID:    created.AppearanceSceneID,
-		HideSceneID:          created.HideSceneID,
 	}); !isBadRequest(err) {
 		t.Fatalf("UpdateLocation with other theme character error = %T %v, want bad request", err, err)
 	}

--- a/apps/server/internal/domain/editor/service_location_policy_test.go
+++ b/apps/server/internal/domain/editor/service_location_policy_test.go
@@ -14,17 +14,12 @@ import (
 	"github.com/mmp-platform/server/internal/db"
 )
 
-func int32Value(value int32) *int32 { return &value }
-
 func TestBuildLocationAccessPolicy(t *testing.T) {
 	t.Parallel()
 
 	t.Run("restricted character CSV를 trim/dedupe하고 저장용 문자열을 정규화한다", func(t *testing.T) {
 		t.Parallel()
-		policy, err := BuildLocationAccessPolicy(stringPtr(" char-1, char-2, char-1,  "), int32Value(2), int32Value(4))
-		if err != nil {
-			t.Fatalf("BuildLocationAccessPolicy returned error: %v", err)
-		}
+		policy := BuildLocationAccessPolicy(stringPtr(" char-1, char-2, char-1,  "))
 
 		if got, want := policy.RestrictedCharacterIDs, []string{"char-1", "char-2"}; !stringSlicesEqual(got, want) {
 			t.Fatalf("RestrictedCharacterIDs = %v, want %v", got, want)
@@ -39,10 +34,7 @@ func TestBuildLocationAccessPolicy(t *testing.T) {
 
 	t.Run("빈 제한값은 공개 장소로 해석한다", func(t *testing.T) {
 		t.Parallel()
-		policy, err := BuildLocationAccessPolicy(stringPtr(" , "), nil, nil)
-		if err != nil {
-			t.Fatalf("BuildLocationAccessPolicy returned error: %v", err)
-		}
+		policy := BuildLocationAccessPolicy(stringPtr(" , "))
 
 		if !policy.IsPublic() {
 			t.Fatal("empty restricted characters should be public")
@@ -52,42 +44,29 @@ func TestBuildLocationAccessPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("라운드 범위와 캐릭터 제한으로 접근 가능 여부를 판단한다", func(t *testing.T) {
+	t.Run("캐릭터 제한으로 접근 가능 여부를 판단한다", func(t *testing.T) {
 		t.Parallel()
-		policy, err := BuildLocationAccessPolicy(stringPtr("char-2"), int32Value(2), int32Value(4))
-		if err != nil {
-			t.Fatalf("BuildLocationAccessPolicy returned error: %v", err)
-		}
+		policy := BuildLocationAccessPolicy(stringPtr("char-2"))
 
 		cases := []struct {
 			name        string
 			characterID string
-			round       int32
 			want        bool
 		}{
-			{name: "before visible round", characterID: "char-1", round: 1, want: false},
-			{name: "allowed character in range", characterID: "char-1", round: 2, want: true},
-			{name: "missing character context on restricted location", characterID: " ", round: 2, want: false},
-			{name: "restricted character in range", characterID: "char-2", round: 3, want: false},
-			{name: "restricted character with whitespace in range", characterID: " char-2 ", round: 3, want: false},
-			{name: "after visible round", characterID: "char-1", round: 5, want: false},
+			{name: "allowed character", characterID: "char-1", want: true},
+			{name: "missing character context on restricted location", characterID: " ", want: false},
+			{name: "restricted character", characterID: "char-2", want: false},
+			{name: "restricted character with whitespace", characterID: " char-2 ", want: false},
 		}
 
 		for _, tc := range cases {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				if got := policy.CanCharacterAccess(tc.characterID, tc.round); got != tc.want {
-					t.Fatalf("CanCharacterAccess(%q, %d) = %v, want %v", tc.characterID, tc.round, got, tc.want)
+				if got := policy.CanCharacterAccess(tc.characterID); got != tc.want {
+					t.Fatalf("CanCharacterAccess(%q) = %v, want %v", tc.characterID, got, tc.want)
 				}
 			})
-		}
-	})
-
-	t.Run("from_round이 until_round보다 크면 거부한다", func(t *testing.T) {
-		t.Parallel()
-		if _, err := BuildLocationAccessPolicy(nil, int32Value(5), int32Value(3)); err == nil {
-			t.Fatal("expected invalid round order error")
 		}
 	})
 }
@@ -181,8 +160,8 @@ func TestService_LocationRestrictedCharactersMustBelongToTheme(t *testing.T) {
 		Name:                 created.Name,
 		RestrictedCharacters: &invalidCSV,
 		SortOrder:            created.SortOrder,
-		FromRound:            created.FromRound,
-		UntilRound:           created.UntilRound,
+		AppearanceSceneID:    created.AppearanceSceneID,
+		HideSceneID:          created.HideSceneID,
 	}); !isBadRequest(err) {
 		t.Fatalf("UpdateLocation with other theme character error = %T %v, want bad request", err, err)
 	}
@@ -300,6 +279,24 @@ func TestService_LocationTextContractAndParentValidation(t *testing.T) {
 	}
 	if child.ParentLocationID == nil || *child.ParentLocationID != parent.ID {
 		t.Fatalf("ParentLocationID = %v, want %s", child.ParentLocationID, parent.ID)
+	}
+	if _, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{
+		Name:             "응접실 서랍 속",
+		ParentLocationID: &child.ID,
+	}); !isBadRequest(err) {
+		t.Fatalf("CreateLocation grandchild parent error = %T %v, want bad request", err, err)
+	}
+
+	looseLocation, err := f.svc.CreateLocation(ctx, creatorID, themeID, mapResp.ID, CreateLocationRequest{Name: "복도"})
+	if err != nil {
+		t.Fatalf("CreateLocation loose location: %v", err)
+	}
+	if _, err := f.svc.UpdateLocation(ctx, creatorID, looseLocation.ID, UpdateLocationRequest{
+		Name:             looseLocation.Name,
+		SortOrder:        looseLocation.SortOrder,
+		ParentLocationID: OptionalUUID{Set: true, Value: &child.ID},
+	}); !isBadRequest(err) {
+		t.Fatalf("UpdateLocation grandchild parent error = %T %v, want bad request", err, err)
 	}
 
 	nextDescription := "수정된 설명"

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -86,8 +86,8 @@ type CreateLocationRequest struct {
 	EntryMessage         *string    `json:"entry_message" validate:"omitempty,max=2000"`
 	ParentLocationID     *uuid.UUID `json:"parent_location_id"`
 	SortOrder            int32      `json:"sort_order" validate:"min=0"`
-	FromRound            *int32     `json:"from_round" validate:"omitempty,min=1"`
-	UntilRound           *int32     `json:"until_round" validate:"omitempty,min=1"`
+	AppearanceSceneID    *uuid.UUID `json:"appearance_scene_id"`
+	HideSceneID          *uuid.UUID `json:"hide_scene_id"`
 }
 
 type UpdateLocationRequest struct {
@@ -99,8 +99,8 @@ type UpdateLocationRequest struct {
 	EntryMessage         OptionalString `json:"entry_message"`
 	ParentLocationID     OptionalUUID   `json:"parent_location_id"`
 	SortOrder            int32          `json:"sort_order" validate:"min=0"`
-	FromRound            *int32         `json:"from_round" validate:"omitempty,min=1"`
-	UntilRound           *int32         `json:"until_round" validate:"omitempty,min=1"`
+	AppearanceSceneID    *uuid.UUID     `json:"appearance_scene_id"`
+	HideSceneID          *uuid.UUID     `json:"hide_scene_id"`
 }
 
 type LocationResponse struct {
@@ -116,8 +116,8 @@ type LocationResponse struct {
 	ParentLocationID     *uuid.UUID `json:"parent_location_id,omitempty"`
 	SortOrder            int32      `json:"sort_order"`
 	CreatedAt            time.Time  `json:"created_at"`
-	FromRound            *int32     `json:"from_round,omitempty"`
-	UntilRound           *int32     `json:"until_round,omitempty"`
+	AppearanceSceneID    *uuid.UUID `json:"appearance_scene_id,omitempty"`
+	HideSceneID          *uuid.UUID `json:"hide_scene_id,omitempty"`
 }
 
 // --- Clue types ---

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -99,8 +99,8 @@ type UpdateLocationRequest struct {
 	EntryMessage         OptionalString `json:"entry_message"`
 	ParentLocationID     OptionalUUID   `json:"parent_location_id"`
 	SortOrder            int32          `json:"sort_order" validate:"min=0"`
-	AppearanceSceneID    *uuid.UUID     `json:"appearance_scene_id"`
-	HideSceneID          *uuid.UUID     `json:"hide_scene_id"`
+	AppearanceSceneID    OptionalUUID   `json:"appearance_scene_id"`
+	HideSceneID          OptionalUUID   `json:"hide_scene_id"`
 }
 
 type LocationResponse struct {

--- a/apps/server/internal/engine/module_types.go
+++ b/apps/server/internal/engine/module_types.go
@@ -23,7 +23,7 @@ type GameEvent struct {
 // CurrentRound (Phase 20 PR-5) is the game's monotonic round counter — it
 // starts at 1 when the engine starts and increments once per AdvancePhase
 // call. Modules consult this to filter clue/location visibility against
-// reveal_round/hide_round and from_round/until_round.
+// reveal_round/hide_round and scene-based visibility refs.
 type GameState struct {
 	SessionID    uuid.UUID                  `json:"sessionId"`
 	Phase        string                     `json:"phase"`

--- a/apps/server/internal/module/exploration/location_clue.go
+++ b/apps/server/internal/module/exploration/location_clue.go
@@ -12,6 +12,7 @@ import (
 
 func init() {
 	engine.Register("location_clue", func() engine.Module { return NewLocationClueModule() })
+	engine.Register("location", func() engine.Module { return NewLocationClueModule() })
 }
 
 // locationClueConfig holds the parsed configuration.

--- a/apps/server/internal/module/exploration/location_clue.go
+++ b/apps/server/internal/module/exploration/location_clue.go
@@ -12,7 +12,6 @@ import (
 
 func init() {
 	engine.Register("location_clue", func() engine.Module { return NewLocationClueModule() })
-	engine.Register("location", func() engine.Module { return NewLocationClueModule() })
 }
 
 // locationClueConfig holds the parsed configuration.

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -210,8 +210,8 @@ export interface LocationResponse {
   parent_location_id?: string | null;
   sort_order: number;
   created_at: string;
-  from_round?: number | null;
-  until_round?: number | null;
+  appearance_scene_id?: string | null;
+  hide_scene_id?: string | null;
 }
 
 export interface ClueResponse {

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx
@@ -13,7 +13,7 @@ import {
 describe('LocationsSubTab 장소 기본 정보', () => {
   beforeEach(setupDefaultMocks);
 
-  it('공개 설명, 진입 메시지, 부모 장소를 Location API payload로 저장한다', () => {
+  it('공개 설명과 진입 메시지를 Location API payload로 저장한다', () => {
     useEditorLocationsMock.mockReturnValue({
       data: [{ ...mockLocations[0], name: '거실' }, ...mockLocations.slice(1)],
       isLoading: false,
@@ -30,9 +30,6 @@ describe('LocationsSubTab 장소 기본 정보', () => {
     fireEvent.change(screen.getByLabelText('거실 진입 메시지'), {
       target: { value: '낡은 시계 소리가 들린다.' },
     });
-    fireEvent.change(screen.getByLabelText('거실 부모 장소'), {
-      target: { value: 'loc-2' },
-    });
     fireEvent.click(screen.getByText('저장'));
 
     expect(updateLocationMutateMock).toHaveBeenCalledWith(
@@ -42,7 +39,6 @@ describe('LocationsSubTab 장소 기본 정보', () => {
           name: '응접실',
           public_description: '손님들이 모이는 공간',
           entry_message: '낡은 시계 소리가 들린다.',
-          parent_location_id: 'loc-2',
         }),
       }),
       expect.any(Object)

--- a/apps/web/src/features/editor/constants.ts
+++ b/apps/web/src/features/editor/constants.ts
@@ -285,10 +285,10 @@ export const MODULE_CATEGORIES: ModuleCategory[] = [
         required: false,
       },
       {
-        id: 'location_clue',
-        name: '장소 단서',
-        description: '위치 기반 단서 발견',
-        supported: false,
+        id: 'location',
+        name: '장소 탐색',
+        description: '장소별 단서 발견 방식',
+        supported: true,
         required: false,
       },
       {

--- a/apps/web/src/features/editor/editorMapApi.ts
+++ b/apps/web/src/features/editor/editorMapApi.ts
@@ -23,8 +23,8 @@ export interface CreateLocationRequest {
   public_description?: string | null;
   entry_message?: string | null;
   parent_location_id?: string | null;
-  from_round?: number | null;
-  until_round?: number | null;
+  appearance_scene_id?: string | null;
+  hide_scene_id?: string | null;
 }
 
 export interface UpdateLocationRequest {
@@ -36,8 +36,8 @@ export interface UpdateLocationRequest {
   entry_message?: string | null;
   parent_location_id?: string | null;
   sort_order?: number;
-  from_round?: number | null;
-  until_round?: number | null;
+  appearance_scene_id?: string | null;
+  hide_scene_id?: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/editor/editorTypes.ts
+++ b/apps/web/src/features/editor/editorTypes.ts
@@ -13,7 +13,10 @@ export type EditorLocationsConfig = import('@/features/editor/utils/configShape'
 export {
   readLocationsConfig,
   readLocationDiscoveries,
+  readAllLocationDiscoveries,
   readLocationClueIds,
+  readLocationInvestigationSettings,
   writeLocationDiscoveries,
   writeLocationClueIds,
+  writeLocationInvestigationSettings,
 } from '@/features/editor/utils/configShape';

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -50,8 +50,8 @@ function location(overrides: Partial<LocationResponse> = {}): LocationResponse {
     image_url: null,
     sort_order: 0,
     created_at: '2026-05-03T00:00:00Z',
-    from_round: null,
-    until_round: null,
+    appearance_scene_id: null,
+    hide_scene_id: null,
     ...overrides,
   };
 }
@@ -62,8 +62,8 @@ describe('locationEntityAdapter', () => {
       location({
         restricted_characters: 'char-1',
         image_url: 'https://cdn.example/study.webp',
-        from_round: 2,
-        until_round: 4,
+        appearance_scene_id: 'scene-2',
+        hide_scene_id: 'scene-4',
       }),
       { characters, clueCount: 3, mapName: '저택 1층' }
     );
@@ -72,15 +72,15 @@ describe('locationEntityAdapter', () => {
       id: 'loc-1',
       name: '서재',
       imageUrl: 'https://cdn.example/study.webp',
-      roundLabel: 'R2~4',
+      roundLabel: '장면 구간 공개',
       accessLabel: '탐정 한나 접근 제한',
       clueCountLabel: '단서 조사 3개',
       clueShortLabel: '단서 3개',
-      badges: ['저택 1층', 'R2~4', '접근 제한 있음', '단서 3', '이미지 있음'],
+      badges: ['저택 1층', '장면 구간 공개', '접근 제한 있음', '단서 3', '이미지 있음'],
     });
   });
 
-  it('API 필드를 제작자용 공개 설명과 부모 요약으로 변환한다', () => {
+  it('API 필드를 제작자용 공개 설명으로 변환하고 부모 정보는 에디터에서 무시한다', () => {
     const vm = toLocationEditorViewModel(
       location({
         public_description: '모든 플레이어에게 보이는 설명',
@@ -99,8 +99,8 @@ describe('locationEntityAdapter', () => {
 
     expect(vm.publicDescription).toBe('모든 플레이어에게 보이는 설명');
     expect(vm.entryMessage).toBe('차가운 바람이 분다.');
-    expect(vm.parentLocationId).toBe('loc-parent');
-    expect(vm.parentLabel).toBe('저택 1층');
+    expect(vm.parentLocationId).toBeNull();
+    expect(vm.parentLabel).toBe('동등 장소');
   });
 
   it('신규 API 필드가 비어 있으면 locationMeta fallback을 사용한다', () => {
@@ -115,10 +115,10 @@ describe('locationEntityAdapter', () => {
 
     expect(vm.publicDescription).toBe('기존 설명');
     expect(vm.entryMessage).toBe('기존 진입');
-    expect(vm.parentLocationId).toBe('loc-parent');
+    expect(vm.parentLocationId).toBeNull();
   });
 
-  it('부모 장소 후보에서 자기 자신과 자손을 제외한다', () => {
+  it('부모 장소 후보를 제공하지 않는다', () => {
     const locations = [
       location({ id: 'loc-1', name: '저택' }),
       location({ id: 'loc-2', name: '1층' }),
@@ -131,10 +131,10 @@ describe('locationEntityAdapter', () => {
         'loc-2': { parentLocationId: 'loc-1' },
         'loc-3': { parentLocationId: 'loc-2' },
       })
-    ).toEqual([{ id: 'loc-4', label: '정원', depth: 0 }]);
+    ).toEqual([]);
   });
 
-  it('부모 장소 후보 계산도 API parent_location_id를 locationMeta보다 우선한다', () => {
+  it('API parent_location_id가 있어도 부모 장소 후보를 제공하지 않는다', () => {
     const locations = [
       location({ id: 'loc-1', name: '저택' }),
       location({ id: 'loc-2', name: '1층', parent_location_id: 'loc-1' }),
@@ -147,7 +147,7 @@ describe('locationEntityAdapter', () => {
         'loc-2': { parentLocationId: null },
         'loc-3': { parentLocationId: null },
       })
-    ).toEqual([{ id: 'loc-4', label: '정원', depth: 0 }]);
+    ).toEqual([]);
   });
 
   it('restricted character CSV를 trim/dedupe한다', () => {

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -1,5 +1,4 @@
 import type { EditorCharacterResponse, LocationResponse } from '@/features/editor/api/types';
-import { formatRoundRange } from '@/features/editor/utils/roundFormat';
 import type { LocationMeta } from '@/features/editor/utils/entityMeta';
 
 export interface LocationEditorViewModel {
@@ -35,8 +34,6 @@ export function toLocationEditorViewModel(
   } = {}
 ): LocationEditorViewModel {
   const clueCount = options.clueCount ?? 0;
-  const parentLocationId = resolveLocationParentId(location, options.locationMeta);
-  const parentLocation = options.allLocations?.find((item) => item.id === parentLocationId);
   return {
     id: location.id,
     name: location.name,
@@ -51,8 +48,8 @@ export function toLocationEditorViewModel(
       location.public_description ?? options.locationMeta?.publicDescription
     ),
     entryMessage: normalizeMetaText(location.entry_message ?? options.locationMeta?.entryMessage),
-    parentLocationId,
-    parentLabel: parentLocation?.name ?? '최상위 장소',
+    parentLocationId: null,
+    parentLabel: '동등 장소',
     clueCountLabel: `단서 조사 ${clueCount}개`,
     clueShortLabel: `단서 ${clueCount}개`,
     badges: buildLocationBadges(location, clueCount, options.mapName),
@@ -64,14 +61,10 @@ export function buildLocationParentOptions(
   locations: LocationResponse[],
   metaByLocationId: Record<string, LocationMeta | undefined> = {}
 ): LocationParentOption[] {
-  const blocked = collectDescendantLocationIds(currentLocationId, locations, metaByLocationId);
-  return locations
-    .filter((location) => location.id !== currentLocationId && !blocked.has(location.id))
-    .map((location) => ({
-      id: location.id,
-      label: location.name,
-      depth: getLocationDepth(location.id, locations, metaByLocationId, new Set<string>()),
-    }));
+  void currentLocationId;
+  void locations;
+  void metaByLocationId;
+  return [];
 }
 
 export function parseLocationRestrictedCharacterIds(value: string | null | undefined): string[] {
@@ -113,69 +106,16 @@ export function formatLocationAccessLabel(
 }
 
 export function formatLocationRoundLabel(
-  location: Pick<LocationResponse, 'from_round' | 'until_round'>
+  location: Pick<LocationResponse, 'appearance_scene_id' | 'hide_scene_id'>
 ): string {
-  return formatRoundRange(location.from_round, location.until_round) || '처음부터 끝까지';
+  if (!location.appearance_scene_id && !location.hide_scene_id) return '처음부터 끝까지';
+  if (location.appearance_scene_id && location.hide_scene_id) return '장면 구간 공개';
+  if (location.appearance_scene_id) return '선택 장면부터';
+  return '선택 장면까지';
 }
 
 function normalizeMetaText(value: unknown): string {
   return typeof value === 'string' ? value : '';
-}
-
-function normalizeParentLocationId(
-  currentLocationId: string,
-  parentLocationId: unknown
-): string | null {
-  if (typeof parentLocationId !== 'string') return null;
-  const trimmed = parentLocationId.trim();
-  if (!trimmed || trimmed === currentLocationId) return null;
-  return trimmed;
-}
-
-function resolveLocationParentId(
-  location: LocationResponse,
-  locationMeta?: LocationMeta
-): string | null {
-  return normalizeParentLocationId(
-    location.id,
-    location.parent_location_id ?? locationMeta?.parentLocationId
-  );
-}
-
-function collectDescendantLocationIds(
-  currentLocationId: string,
-  locations: LocationResponse[],
-  metaByLocationId: Record<string, LocationMeta | undefined>
-): Set<string> {
-  const descendants = new Set<string>();
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const location of locations) {
-      if (descendants.has(location.id)) continue;
-      const parentId = resolveLocationParentId(location, metaByLocationId[location.id]);
-      if (parentId === currentLocationId || (parentId != null && descendants.has(parentId))) {
-        descendants.add(location.id);
-        changed = true;
-      }
-    }
-  }
-  return descendants;
-}
-
-function getLocationDepth(
-  locationId: string,
-  locations: LocationResponse[],
-  metaByLocationId: Record<string, LocationMeta | undefined>,
-  seen: Set<string>
-): number {
-  if (seen.has(locationId)) return 0;
-  seen.add(locationId);
-  const location = locations.find((item) => item.id === locationId);
-  if (!location) return 0;
-  const parentId = resolveLocationParentId(location, metaByLocationId[location.id]);
-  if (!parentId) return 0;
-  return 1 + getLocationDepth(parentId, locations, metaByLocationId, seen);
 }
 
 export function buildLocationBadges(

--- a/apps/web/src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts
+++ b/apps/web/src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts
@@ -12,6 +12,8 @@ const baseLocation = {
   image_url: null,
   sort_order: 1,
   created_at: "2026-05-06T00:00:00Z",
+  appearance_scene_id: null,
+  hide_scene_id: null,
 } satisfies LocationResponse;
 
 const baseClue = {
@@ -32,46 +34,41 @@ const baseClue = {
 } satisfies ClueResponse;
 
 describe("buildRoundVisibilityPreview", () => {
-  it("장소와 단서의 공개 라운드를 라운드별 미리보기로 변환한다", () => {
+  it("장소는 장면 기준 공개 대상으로 유지하고 단서 공개 라운드를 미리보기로 변환한다", () => {
     const previews = buildRoundVisibilityPreview(
       [{ ...baseClue, reveal_round: 2, hide_round: 3 }],
-      [{ ...baseLocation, from_round: 1, until_round: 2 }],
+      [{ ...baseLocation, appearance_scene_id: "scene-1", hide_scene_id: "scene-2" }],
     );
 
     expect(previews).toHaveLength(3);
     expect(previews[0].label).toBe("1라운드");
     expect(previews[0].locations.map((item) => item.name)).toEqual(["응접실"]);
+    expect(previews[0].locations[0].scheduleLabel).toBe("장면 기준 공개");
     expect(previews[0].clues).toHaveLength(0);
     expect(previews[1].clues.map((item) => item.name)).toEqual(["찢어진 초대장"]);
-    expect(previews[2].locations).toHaveLength(0);
+    expect(previews[2].locations.map((item) => item.name)).toEqual(["응접실"]);
   });
 
-  it("단서가 보이는 라운드에 연결 장소가 숨겨져 있으면 제작자용 경고를 만든다", () => {
+  it("단서가 보이는 라운드에도 장소 라운드 숨김 경고를 만들지 않는다", () => {
     const previews = buildRoundVisibilityPreview(
       [{ ...baseClue, reveal_round: 3, hide_round: 3 }],
-      [{ ...baseLocation, from_round: 1, until_round: 2 }],
+      [baseLocation],
     );
 
-    expect(previews[2].warnings).toEqual([
-      {
-        id: "hidden-location:clue-1:3",
-        message: "찢어진 초대장 단서는 공개되지만 응접실 장소는 이 라운드에 보이지 않습니다.",
-      },
-    ]);
+    expect(previews[2].warnings).toEqual([]);
   });
 
-  it("잘못된 라운드 범위와 삭제된 장소 연결을 raw key 없이 설명한다", () => {
+  it("잘못된 단서 라운드 범위와 삭제된 장소 연결을 raw key 없이 설명한다", () => {
     const previews = buildRoundVisibilityPreview(
       [
         { ...baseClue, id: "bad-clue", name: "잘못된 단서", reveal_round: 5, hide_round: 2 },
         { ...baseClue, id: "lost-clue", name: "분실된 단서", location_id: "missing" },
       ],
-      [{ ...baseLocation, from_round: 3, until_round: 1 }],
+      [baseLocation],
       1,
     );
 
     const messages = previews[0].warnings.map((warning) => warning.message);
-    expect(messages).toContain("응접실 장소의 등장/퇴장 라운드가 서로 맞지 않습니다.");
     expect(messages).toContain("잘못된 단서 단서의 공개/사라짐 라운드가 서로 맞지 않습니다.");
     expect(messages).toContain("분실된 단서 단서가 삭제되었거나 찾을 수 없는 장소에 연결되어 있습니다.");
   });

--- a/apps/web/src/features/editor/entities/validation/roundVisibilityPreview.ts
+++ b/apps/web/src/features/editor/entities/validation/roundVisibilityPreview.ts
@@ -51,29 +51,17 @@ export function buildRoundVisibilityPreview(
   const maxRound = Math.max(
     minRounds,
     maxFiniteRound(clues.flatMap((clue) => [clue.reveal_round, clue.hide_round])),
-    maxFiniteRound(locations.flatMap((location) => [location.from_round, location.until_round])),
   );
   const locationById = new Map(locations.map((location) => [location.id, location]));
 
   return Array.from({ length: maxRound }, (_, index) => {
     const round = index + 1;
-    const visibleLocations = locations.filter((location) =>
-      isVisibleInRound(round, location.from_round, location.until_round),
-    );
+    const visibleLocations = locations;
     const visibleLocationIds = new Set(visibleLocations.map((location) => location.id));
     const visibleClues = clues.filter((clue) =>
       isVisibleInRound(round, clue.reveal_round, clue.hide_round),
     );
     const warnings: RoundVisibilityWarning[] = [];
-
-    for (const location of locations) {
-      if (hasInvalidRange(location.from_round, location.until_round)) {
-        warnings.push({
-          id: `location-range:${location.id}`,
-          message: `${location.name} 장소의 등장/퇴장 라운드가 서로 맞지 않습니다.`,
-        });
-      }
-    }
 
     for (const clue of clues) {
       if (hasInvalidRange(clue.reveal_round, clue.hide_round)) {
@@ -115,7 +103,8 @@ export function buildRoundVisibilityPreview(
       locations: visibleLocations.map((location) => ({
         id: location.id,
         name: location.name,
-        scheduleLabel: formatScheduleLabel(location.from_round, location.until_round),
+        scheduleLabel:
+          location.appearance_scene_id || location.hide_scene_id ? "장면 기준 공개" : "항상 공개",
       })),
       warnings,
     };

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -131,7 +131,7 @@ describe('configShape', () => {
       {
         locations: [
           { id: 'loc-1', name: '서재' },
-          { id: 'loc-2', name: '복도' },
+          { id: 'loc-2', name: '복도', locationClueConfig: { clueIds: [] } },
         ],
         modules: {
           location: {

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -166,7 +166,7 @@ describe('configShape', () => {
     ]);
     expect(next.locations).toEqual([
       { id: 'loc-1', name: '서재', locationClueConfig: { clueIds: ['clue-1'] } },
-      { id: 'loc-2', name: '복도' },
+      { id: 'loc-2', name: '복도', locationClueConfig: { clueIds: [] } },
     ]);
     expect(readModuleConfig(next, 'location')).toMatchObject({
       startingLocation: 'loc-1',

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -22,6 +22,18 @@ export interface LocationDiscoveryConfig extends EditorConfig {
   clueId: string;
   requiredClueIds: string[];
   oncePerPlayer: boolean;
+  slotId?: string;
+  subLocationId?: string;
+  order?: number;
+  label?: string;
+}
+
+export type LocationInvestigationMode = 'list' | 'deck';
+export type LocationDeckOrder = 'fixed' | 'random';
+
+export interface LocationInvestigationSettings {
+  investigationMode: LocationInvestigationMode;
+  deckOrder: LocationDeckOrder;
 }
 
 export type ClueItemEffectKind =
@@ -52,6 +64,8 @@ const CLUE_ITEM_EFFECTS_KEY = 'itemEffects';
 const CLUE_POLICIES_KEY = 'cluePolicies';
 const LOCATION_MODULE_ID = 'location';
 const LOCATION_DISCOVERIES_KEY = 'discoveries';
+const LOCATION_INVESTIGATION_MODE_KEY = 'investigationMode';
+const LOCATION_DECK_ORDER_KEY = 'deckOrder';
 
 function isRecord(value: unknown): value is EditorConfig {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -350,6 +364,28 @@ export function readLocationsConfig(configJson: EditorConfig | null | undefined)
   );
 }
 
+export function readLocationInvestigationSettings(
+  configJson: EditorConfig | null | undefined
+): LocationInvestigationSettings {
+  const moduleConfig = readModuleConfig(configJson, LOCATION_MODULE_ID);
+  const investigationMode =
+    moduleConfig[LOCATION_INVESTIGATION_MODE_KEY] === 'deck' ? 'deck' : 'list';
+  const deckOrder = moduleConfig[LOCATION_DECK_ORDER_KEY] === 'random' ? 'random' : 'fixed';
+  return { investigationMode, deckOrder };
+}
+
+export function writeLocationInvestigationSettings(
+  configJson: EditorConfig | null | undefined,
+  settings: LocationInvestigationSettings
+): EditorConfig {
+  const current = readModuleConfig(configJson, LOCATION_MODULE_ID);
+  return writeModuleConfig(configJson, LOCATION_MODULE_ID, {
+    ...current,
+    [LOCATION_INVESTIGATION_MODE_KEY]: settings.investigationMode,
+    [LOCATION_DECK_ORDER_KEY]: settings.deckOrder,
+  });
+}
+
 function readRawLocationDiscoveries(
   configJson: EditorConfig | null | undefined
 ): LocationDiscoveryConfig[] {
@@ -427,6 +463,28 @@ export function readLocationDiscoveries(
   }));
 }
 
+export function readAllLocationDiscoveries(
+  configJson: EditorConfig | null | undefined
+): LocationDiscoveryConfig[] {
+  const seen = new Set<string>();
+  const result: LocationDiscoveryConfig[] = [];
+  const pushUnique = (discovery: LocationDiscoveryConfig) => {
+    if (seen.has(discovery.clueId)) return;
+    seen.add(discovery.clueId);
+    result.push(discovery);
+  };
+
+  for (const discovery of readRawLocationDiscoveries(configJson)) {
+    pushUnique(discovery);
+  }
+  for (const location of readLocationsConfig(configJson)) {
+    for (const discovery of readLocationDiscoveries(configJson, location.id)) {
+      pushUnique(discovery);
+    }
+  }
+  return result;
+}
+
 function readLegacyLocationClueIds(
   configJson: EditorConfig | null | undefined,
   locationId: string
@@ -453,14 +511,25 @@ export function writeLocationClueIds(
   const locations = readLocationsConfig(next);
   const idx = locations.findIndex((loc) => loc.id === locationId);
   const cleanIds = Array.from(new Set(clueIds));
+  const assignedHere = new Set(cleanIds);
   const upsert = (loc: LocationConfig): LocationConfig => ({
     ...loc,
     locationClueConfig: { ...(loc.locationClueConfig ?? {}), clueIds: cleanIds },
   });
+  const withoutDuplicates = locations.map((loc, i) => {
+    if (i === idx) return upsert(loc);
+    const existingIds = readLegacyLocationClueIds(next, loc.id).filter(
+      (clueId) => !assignedHere.has(clueId)
+    );
+    return {
+      ...loc,
+      locationClueConfig: { ...(loc.locationClueConfig ?? {}), clueIds: existingIds },
+    };
+  });
   const nextLocations =
     idx >= 0
-      ? locations.map((loc, i) => (i === idx ? upsert(loc) : loc))
-      : [...locations, { id: locationId, locationClueConfig: { clueIds: cleanIds } }];
+      ? withoutDuplicates
+      : [...withoutDuplicates, { id: locationId, locationClueConfig: { clueIds: cleanIds } }];
   return { ...next, locations: nextLocations };
 }
 
@@ -516,8 +585,12 @@ export function writeLocationDiscoveries(
     cleanDiscoveries.map((discovery) => discovery.clueId)
   );
   const current = readModuleConfig(next, LOCATION_MODULE_ID);
+  const assignedHere = new Set(cleanDiscoveries.map((discovery) => discovery.clueId));
   const preservedRawDiscoveries = rawLocationDiscoveries(current[LOCATION_DISCOVERIES_KEY]).filter(
-    (raw) => !isRecord(raw) || raw.locationId !== locationId
+    (raw) =>
+      !isRecord(raw) ||
+      (raw.locationId !== locationId &&
+        (typeof raw.clueId !== 'string' || !assignedHere.has(raw.clueId)))
   );
   const preservedValidDiscoveries = preservedRawDiscoveries
     .map(validRawLocationDiscovery)
@@ -531,6 +604,7 @@ export function writeLocationDiscoveries(
           .map((discovery) => discovery.clueId)
       );
       return readLegacyLocationClueIds(next, loc.id)
+        .filter((clueId) => !assignedHere.has(clueId))
         .filter((clueId) => !existingClueIds.has(clueId))
         .map((clueId) => ({
           locationId: loc.id,


### PR DESCRIPTION
## 요약
- 장소 공개 시점을 round 기반에서 scene 기반 계약으로 확장했습니다.
- `theme_locations` scene visibility migration과 sqlc 모델/쿼리를 갱신했습니다.
- 서버 저장/검증/런타임 alias가 신규 `location` 설정과 기존 `location_clue` 설정을 함께 처리하도록 정리했습니다.
- 프론트 API 타입, location adapter, config shape, visibility preview를 scene 계약에 맞췄습니다.

## Coverage Plan
- Backend: editor location service, location policy validation, config validation, exploration module alias, engine module type alias.
- Frontend contract: API type, location entity adapter, round/scene visibility preview, config shape normalization.
- Migration: `00048_location_scene_visibility.sql` adds scene visibility columns without dropping legacy round columns.

## Local validation
- `scripts/mmp-local-ci.sh quick` 성공.
- Focused: `cd apps/server && go test ./internal/domain/editor ./internal/module/exploration ./internal/engine` 성공.
- Focused: `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts src/features/editor/entities/validation/__tests__/roundVisibilityPreview.test.ts` 성공.
- Focused: `pnpm --filter @mmp/web typecheck` 성공.

## Notes
- 장소관리 탭 UI 리빌드와 진행플로우 맵 선택 UI는 후속 PR로 분리합니다.

Refs #558


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 위치 공개 기준을 회차에서 장면 기반(노출 시작/종료 장면)으로 전환해 장면별 노출을 지원합니다.
  * 위치 조사 설정에 조사 방식(목록/카드) 및 카드 정렬(고정/무작위) 옵션을 추가했습니다.
  * 편집기 구성 읽기/쓰기 및 UI가 위치 탐색 모듈을 완전 지원하도록 확장했습니다.

* **변경/호환성**
  * 위치 접근 정책이 회차 기반에서 제한된 캐릭터 및 장면 기준으로 단순화되었습니다.
  * 부모/자식 위치 검증이 강화되어 서브-위치를 부모로 지정하는 것이 제한됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/559)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->