### PR TITLE
feat(editor): 장소관리 UI 재설계

### DIFF
--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -9,6 +9,7 @@ import { EditorTabNav } from "./EditorTabNav";
 import { TabContent } from "./TabContent";
 import { ValidationPanel } from "./ValidationPanel";
 import { STATUS_LABEL } from "@/features/editor/constants";
+import type { EditorTab } from "@/features/editor/constants";
 import type { DesignWarning } from "@/features/editor/validation";
 import type { SaveStatus } from "@/features/editor/hooks/useAutoSave";
 import { readEnabledModuleIds } from "@/features/editor/utils/configShape";
@@ -52,11 +53,12 @@ export function EditorLayout({
     () => readEnabledModuleIds(theme.config_json),
     [theme.config_json],
   );
-  const usesInternalScroll = activeTab === "storyMap" || activeTab === "characters";
   const routeTab = useMemo(
     () => (routeSegment ? readEditorTabFromRouteSegment(routeSegment) : undefined),
     [routeSegment],
   );
+  const effectiveTab = routeTab ?? activeTab;
+  const usesInternalScroll = INTERNAL_SCROLL_TABS.has(effectiveTab);
 
   const handleValidate = () => {
     if (onValidate) {
@@ -79,7 +81,7 @@ export function EditorLayout({
   }, [onSave]);
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-slate-950 text-slate-100">
+    <div className="fixed inset-0 flex flex-col overflow-hidden bg-slate-950 text-slate-100">
       {/* ── Top bar ── */}
       <header className="sticky top-0 z-50 flex h-12 shrink-0 items-center gap-2 border-b border-slate-800 bg-slate-900 px-2 sm:gap-3 sm:px-3">
         <button
@@ -173,3 +175,15 @@ export function EditorLayout({
     </div>
   );
 }
+
+const INTERNAL_SCROLL_TABS = new Set<EditorTab>([
+  "storyMap",
+  "info",
+  "characters",
+  "clues",
+  "design",
+  "questions",
+  "endings",
+  "locations",
+  "media",
+]);

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -153,8 +153,8 @@ export function EditorLayout({
       {/* ── Content ── */}
       <div
         role="tabpanel"
-        id={`tabpanel-${activeTab}`}
-        aria-labelledby={`tab-${activeTab}`}
+        id={`tabpanel-${effectiveTab}`}
+        aria-labelledby={`tab-${effectiveTab}`}
         className={usesInternalScroll ? "min-h-0 flex-1 overflow-hidden" : "flex-1 overflow-y-auto"}
       >
         <Suspense
@@ -165,7 +165,7 @@ export function EditorLayout({
           }
         >
           <TabContent
-            tab={activeTab}
+            tab={effectiveTab}
             theme={theme}
             themeId={themeId}
             routeSegment={routeSegment}

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -178,14 +178,17 @@ describe('EditorLayout', () => {
     expect(screen.getByText('탭 콘텐츠')).toBeDefined();
   });
 
-  it('캐릭터 탭은 내부 편집 화면이 스크롤을 맡도록 탭 패널을 고정한다', () => {
-    mockActiveTab.current = 'characters';
+  it.each(['characters', 'info', 'clues', 'design', 'questions', 'endings', 'locations', 'media'])(
+    '%s 탭은 내부 편집 화면이 스크롤을 맡도록 탭 패널을 고정한다',
+    (tab) => {
+      mockActiveTab.current = tab;
 
-    render(<EditorLayout theme={baseTheme} themeId="theme-1" />);
+      render(<EditorLayout theme={baseTheme} themeId="theme-1" />);
 
-    const tabPanel = screen.getByRole('tabpanel');
-    expect(tabPanel.id).toBe('tabpanel-characters');
-    expect(tabPanel.className).toContain('min-h-0');
-    expect(tabPanel.className).toContain('overflow-hidden');
-  });
+      const tabPanel = screen.getByRole('tabpanel');
+      expect(tabPanel.id).toBe(`tabpanel-${tab}`);
+      expect(tabPanel.className).toContain('min-h-0');
+      expect(tabPanel.className).toContain('overflow-hidden');
+    }
+  );
 });

--- a/apps/web/src/features/editor/components/design/InvestigationCostSelector.tsx
+++ b/apps/web/src/features/editor/components/design/InvestigationCostSelector.tsx
@@ -31,6 +31,7 @@ export function InvestigationCostSelector({
   const fallbackTokenId = tokens[0]?.id ?? 'investigation-token';
   const selectedTokenId = cost.mode === 'token' ? cost.tokenId : fallbackTokenId;
   const selectedCost = cost.mode === 'token' ? cost.tokenCost : 1;
+  const hasTokens = tokens.length > 0;
 
   return (
     <div className="mt-2 rounded-md border border-slate-800 bg-slate-950/80 p-2">
@@ -44,60 +45,54 @@ export function InvestigationCostSelector({
         </span>
       </div>
 
-      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(8rem,0.8fr)_5rem]">
-        <button
-          type="button"
+      <label className="flex min-h-9 items-center gap-2 rounded-md border border-slate-800 bg-slate-900/70 px-2 py-1.5 text-xs text-slate-300">
+        <input
+          type="checkbox"
+          checked={cost.mode === 'free'}
           disabled={disabled}
-          aria-pressed={cost.mode === 'free'}
-          aria-label={`${clueName} 무료 조사로 설정`}
-          onClick={() => onChange({ mode: 'free' })}
-          className={`rounded-md border px-2 py-1.5 text-xs transition disabled:opacity-50 ${
-            cost.mode === 'free'
-              ? 'border-emerald-400/50 bg-emerald-500/10 text-emerald-200'
-              : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-300'
-          }`}
-        >
-          무료
-        </button>
+          aria-label={`${clueName} 무료 조사`}
+          onChange={(event) =>
+            onChange(
+              event.target.checked
+                ? { mode: 'free' }
+                : { mode: 'token', tokenId: selectedTokenId, tokenCost: selectedCost },
+            )
+          }
+          className="h-4 w-4 rounded border-slate-700 bg-slate-950 text-emerald-400 focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+        />
+        <span className="font-medium text-slate-200">무료 조사</span>
+        <span className="text-[10px] text-slate-600">
+          체크하면 조사권 없이 바로 조사할 수 있습니다.
+        </span>
+      </label>
 
-        <label className="min-w-0">
-          <span className="sr-only">{clueName} 조사권 종류</span>
-          <select
-            value={selectedTokenId}
-            disabled={disabled}
-            aria-label={`${clueName} 조사권 종류`}
-            onChange={(event) =>
-              onChange({ mode: 'token', tokenId: event.target.value, tokenCost: selectedCost })
-            }
-            className="w-full rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 disabled:opacity-50"
-          >
-            {tokens.map((token) => (
-              <option key={token.id} value={token.id}>
-                {token.iconLabel} {token.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label>
-          <span className="sr-only">{clueName} 조사권 소비량</span>
-          <input
-            type="number"
-            min={1}
-            value={selectedCost}
-            disabled={disabled}
-            aria-label={`${clueName} 조사권 소비량`}
-            onChange={(event) =>
-              onChange({
-                mode: 'token',
-                tokenId: selectedTokenId,
-                tokenCost: normalizeCost(event.target.value),
-              })
-            }
-            className="w-full rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 disabled:opacity-50"
-          />
-        </label>
-      </div>
+      {cost.mode === 'token' ? (
+        <div className="mt-2">
+          <label className="block max-w-28">
+            <span className="mb-1 block text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+              소비량
+            </span>
+            <input
+              type="number"
+              min={1}
+              value={selectedCost}
+              disabled={disabled || !hasTokens}
+              aria-label={`${clueName} 조사권 소비량`}
+              onChange={(event) =>
+                onChange({
+                  mode: 'token',
+                  tokenId: selectedTokenId,
+                  tokenCost: normalizeCost(event.target.value),
+                })
+              }
+              className="w-full rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 disabled:opacity-50"
+            />
+          </label>
+          <p className="mt-1.5 text-[10px] text-slate-600">
+            모듈 탭의 기본 조사권 설정을 사용합니다.
+          </p>
+        </div>
+      ) : null}
       <div className="mt-1.5 flex flex-wrap items-center justify-between gap-2 text-[10px] text-slate-600">
         <span>조사권 이름과 시작 수량은 모듈 탭의 조사권 설정에서 관리합니다.</span>
         <a

--- a/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
@@ -37,8 +37,8 @@ export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessP
           restricted_characters: stringifyLocationRestrictedCharacterIds(next),
           image_url: location.image_url,
           sort_order: location.sort_order,
-          from_round: location.from_round ?? null,
-          until_round: location.until_round ?? null,
+          appearance_scene_id: location.appearance_scene_id ?? null,
+          hide_scene_id: location.hide_scene_id ?? null,
         },
       },
       { onError: () => toast.error('접근 제한 저장에 실패했습니다') }

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { Check, MapPin, Package, Plus, Search } from 'lucide-react';
+import { Check, MapPin, Package, Plus, Search, X } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import type { EditorThemeResponse, LocationResponse, ClueResponse } from '@/features/editor/api';
 import { editorKeys, useEditorClues, useUpdateConfigJson } from '@/features/editor/api';
 import {
+  readAllLocationDiscoveries,
   readLocationDiscoveries,
   writeLocationDiscoveries,
   type LocationDiscoveryConfig,
@@ -53,6 +54,7 @@ export function LocationClueAssignPanel({
   const updateConfig = useUpdateConfigJson(themeId);
   const queryClient = useQueryClient();
   const [query, setQuery] = useState('');
+  const [activeClueId, setActiveClueId] = useState<string | null>(null);
 
   const discoveries = useMemo(
     () => readLocationDiscoveries(theme.config_json, location.id),
@@ -66,9 +68,19 @@ export function LocationClueAssignPanel({
     () => discoveries.map((discovery) => discovery.clueId),
     [discoveries]
   );
+  const globallyAssignedClueIds = useMemo(
+    () =>
+      new Set(
+        readAllLocationDiscoveries(theme.config_json)
+          .filter((discovery) => discovery.locationId !== location.id)
+          .map((discovery) => discovery.clueId)
+      ),
+    [location.id, theme.config_json]
+  );
   const assignedSet = useMemo(() => new Set(assignedIds), [assignedIds]);
   const clueById = useMemo(() => new Map(clues.map((clue) => [clue.id, clue])), [clues]);
   const selectedClues = clues.filter((clue) => assignedSet.has(clue.id));
+  const activeClue = selectedClues.find((clue) => clue.id === activeClueId) ?? selectedClues[0] ?? null;
   const visibleClues = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return clues;
@@ -107,20 +119,43 @@ export function LocationClueAssignPanel({
   }
 
   function addClue(clueId: string) {
-    if (assignedSet.has(clueId)) return;
-    commit([
+    if (assignedSet.has(clueId)) {
+      setActiveClueId(clueId);
+      return;
+    }
+    if (globallyAssignedClueIds.has(clueId)) {
+      toast.error('이미 다른 장소에 배치된 단서입니다');
+      return;
+    }
+    const clue = clueById.get(clueId);
+    const nextDiscoveries = [
       ...discoveries,
       { locationId: location.id, clueId, requiredClueIds: [], oncePerPlayer: true },
-    ]);
+    ];
+    const nextDeckDraft = clue
+      ? writeLocationClueInvestigationCost(investigationDraft, {
+          locationId: location.id,
+          locationName: location.name,
+          clueId,
+          clueName: clue.name,
+          requiredClueIds: [],
+          cost: {
+            mode: 'token',
+            tokenId: investigationDraft.tokens[0]?.id ?? 'investigation-token',
+            tokenCost: 1,
+          },
+        })
+      : investigationDraft;
+    setActiveClueId(clueId);
+    commit(nextDiscoveries, nextDeckDraft);
   }
 
   function removeClue(clueId: string) {
-    const cost = readLocationClueInvestigationCost(investigationDraft, location.id, clueId);
+    const nextDiscoveries = discoveries.filter((discovery) => discovery.clueId !== clueId);
+    setActiveClueId((current) => (current === clueId ? null : current));
     commit(
-      discoveries.filter((discovery) => discovery.clueId !== clueId),
-      cost.mode === 'token'
-        ? removeLocationClueInvestigationCost(investigationDraft, location.id, clueId)
-        : undefined
+      nextDiscoveries,
+      removeLocationClueInvestigationCost(investigationDraft, location.id, clueId)
     );
   }
 
@@ -243,8 +278,11 @@ export function LocationClueAssignPanel({
                     key={clue.id}
                     clue={clue}
                     selected={assignedSet.has(clue.id)}
+                    active={activeClue?.id === clue.id}
+                    unavailable={globallyAssignedClueIds.has(clue.id)}
                     disabled={updateConfig.isPending}
-                    onAdd={addClue}
+                    onSelect={addClue}
+                    onRemove={removeClue}
                   />
                 ))
               )}
@@ -253,37 +291,35 @@ export function LocationClueAssignPanel({
           <section className="rounded-lg border border-amber-500/20 bg-amber-950/10 p-2.5">
             <div className="mb-2 flex items-center justify-between gap-2">
               <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
-                조사 결과
+                조사 설정
               </p>
-              <span className="text-[10px] text-slate-600">플레이어당 1회</span>
+              <span className="text-[10px] text-slate-600">
+                {activeClue ? activeClue.name : '선택 없음'}
+              </span>
             </div>
-            {selectedClues.length === 0 ? (
+            {!activeClue ? (
               <p className="rounded-md border border-dashed border-slate-800 px-2.5 py-5 text-center text-xs text-slate-600">
                 아직 배정된 단서가 없습니다. 좌측 목록에서 조사 시 발견할 단서를 클릭하세요.
               </p>
             ) : (
-              <div className="space-y-2">
-                {selectedClues.map((clue) => (
-                  <LocationSelectedClueItem
-                    key={clue.id}
-                    clue={clue}
-                    discovery={discoveries.find((item) => item.clueId === clue.id)}
-                    availableClues={clues.filter((candidate) => candidate.id !== clue.id)}
-                    clueById={clueById}
-                    tokens={investigationDraft.tokens}
-                    cost={readLocationClueInvestigationCost(
-                      investigationDraft,
-                      location.id,
-                      clue.id
-                    )}
-                    disabled={updateConfig.isPending}
-                    manageHref={`/editor/${themeId}/design/modules`}
-                    onRemove={removeClue}
-                    onToggleRequired={toggleRequiredClue}
-                    onCostChange={updateInvestigationCost}
-                  />
-                ))}
-              </div>
+              <LocationSelectedClueItem
+                key={activeClue.id}
+                clue={activeClue}
+                discovery={discoveries.find((item) => item.clueId === activeClue.id)}
+                availableClues={clues.filter((candidate) => candidate.id !== activeClue.id)}
+                clueById={clueById}
+                tokens={investigationDraft.tokens}
+                cost={readLocationClueInvestigationCost(
+                  investigationDraft,
+                  location.id,
+                  activeClue.id
+                )}
+                disabled={updateConfig.isPending}
+                manageHref={`/editor/${themeId}/design/modules`}
+                onRemove={removeClue}
+                onToggleRequired={toggleRequiredClue}
+                onCostChange={updateInvestigationCost}
+              />
             )}
           </section>
         </div>
@@ -295,33 +331,70 @@ export function LocationClueAssignPanel({
 function ClueOption({
   clue,
   selected,
+  active,
+  unavailable,
   disabled,
-  onAdd,
+  onSelect,
+  onRemove,
 }: {
   clue: ClueResponse;
   selected: boolean;
+  active: boolean;
+  unavailable: boolean;
   disabled: boolean;
-  onAdd: (id: string) => void;
+  onSelect: (id: string) => void;
+  onRemove: (id: string) => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={() => onAdd(clue.id)}
-      disabled={disabled || selected}
-      aria-label={`${clue.name} 추가`}
-      className="group flex w-full items-center gap-3 rounded-md border border-transparent px-2 py-2 text-left transition hover:border-amber-500/30 hover:bg-slate-800/80 disabled:cursor-default disabled:border-amber-500/10 disabled:bg-amber-950/10"
+    <div
+      className={`group flex w-full items-center gap-3 rounded-md border px-2 py-2 text-left transition hover:border-amber-500/30 hover:bg-slate-800/80 disabled:cursor-default disabled:border-slate-800 disabled:bg-slate-950/40 ${
+        active
+          ? 'border-amber-400/50 bg-amber-500/10'
+          : selected
+            ? 'border-amber-500/20 bg-amber-950/10'
+            : 'border-transparent'
+      }`}
     >
-      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-800 text-[10px] font-semibold text-amber-400">
-        {roundLabel(clue)}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-medium text-slate-200">{clue.name}</span>
-        <span className="mt-0.5 block truncate text-xs text-slate-500">{clueMeta(clue)}</span>
-      </span>
-      <span className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-slate-700 px-2 text-[10px] font-semibold text-slate-500 group-hover:border-amber-500 group-hover:text-amber-300 group-disabled:border-amber-500/20 group-disabled:text-amber-300/70">
-        {selected ? <Check className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
-      </span>
-    </button>
+      <button
+        type="button"
+        onClick={() => onSelect(clue.id)}
+        disabled={disabled || unavailable}
+        aria-label={selected ? `${clue.name} 설정 열기` : `${clue.name} 추가`}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left disabled:cursor-default"
+      >
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-800 text-[10px] font-semibold text-amber-400">
+          {roundLabel(clue)}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-slate-200">{clue.name}</span>
+          <span className="mt-0.5 block truncate text-xs text-slate-500">{clueMeta(clue)}</span>
+        </span>
+        <span className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-slate-700 px-2 text-[10px] font-semibold text-slate-500 group-hover:border-amber-500 group-hover:text-amber-300">
+          {selected ? (
+            <>
+              <Check className="mr-1 h-3.5 w-3.5" />
+              선택됨
+            </>
+          ) : unavailable ? (
+            '배치됨'
+          ) : (
+            <Plus className="h-3.5 w-3.5" />
+          )}
+        </span>
+      </button>
+      {selected ? (
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label={`${clue.name} 해제`}
+          onClick={() => onRemove(clue.id)}
+          className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-red-500/20 px-2 text-[10px] font-semibold text-red-300 transition hover:border-red-400/50 hover:bg-red-500/10 disabled:opacity-50"
+        >
+          <X className="mr-1 h-3 w-3" />
+          해제
+        </button>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -93,8 +93,17 @@ export function LocationClueAssignPanel({
     );
   }, [clues, query]);
 
-  function commit(next: LocationDiscoveryConfig[], deckDraft?: typeof investigationDraft) {
-    const locationConfig = writeLocationDiscoveries(theme.config_json, location.id, next);
+  function readLatestConfigJson() {
+    return queryClient.getQueryData<EditorThemeResponse>(editorKeys.theme(themeId))?.config_json
+      ?? theme.config_json;
+  }
+
+  function commit(
+    next: LocationDiscoveryConfig[],
+    deckDraft?: typeof investigationDraft,
+    baseConfig = theme.config_json,
+  ) {
+    const locationConfig = writeLocationDiscoveries(baseConfig, location.id, next);
     const nextConfig = deckDraft
       ? writeDeckInvestigationConfig(locationConfig, deckDraft)
       : locationConfig;
@@ -119,35 +128,47 @@ export function LocationClueAssignPanel({
   }
 
   function addClue(clueId: string) {
-    if (assignedSet.has(clueId)) {
+    const baseConfig = readLatestConfigJson();
+    const currentDiscoveries = readLocationDiscoveries(baseConfig, location.id);
+    const currentInvestigationDraft = readDeckInvestigationConfig(baseConfig);
+    const currentAssignedSet = new Set(currentDiscoveries.map((discovery) => discovery.clueId));
+    const currentGloballyAssignedClueIds = new Set(
+      readAllLocationDiscoveries(baseConfig)
+        .filter((discovery) => discovery.locationId !== location.id)
+        .map((discovery) => discovery.clueId)
+    );
+
+    if (currentAssignedSet.has(clueId)) {
       setActiveClueId(clueId);
       return;
     }
-    if (globallyAssignedClueIds.has(clueId)) {
+    if (currentGloballyAssignedClueIds.has(clueId)) {
       toast.error('이미 다른 장소에 배치된 단서입니다');
       return;
     }
     const clue = clueById.get(clueId);
     const nextDiscoveries = [
-      ...discoveries,
+      ...currentDiscoveries,
       { locationId: location.id, clueId, requiredClueIds: [], oncePerPlayer: true },
     ];
     const nextDeckDraft = clue
-      ? writeLocationClueInvestigationCost(investigationDraft, {
+      ? writeLocationClueInvestigationCost(currentInvestigationDraft, {
           locationId: location.id,
           locationName: location.name,
           clueId,
           clueName: clue.name,
           requiredClueIds: [],
-          cost: {
-            mode: 'token',
-            tokenId: investigationDraft.tokens[0]?.id ?? 'investigation-token',
-            tokenCost: 1,
-          },
+          cost: currentInvestigationDraft.tokens[0]
+            ? {
+                mode: 'token',
+                tokenId: currentInvestigationDraft.tokens[0].id,
+                tokenCost: 1,
+              }
+            : { mode: 'free' },
         })
-      : investigationDraft;
+      : currentInvestigationDraft;
     setActiveClueId(clueId);
-    commit(nextDiscoveries, nextDeckDraft);
+    commit(nextDiscoveries, nextDeckDraft, baseConfig);
   }
 
   function removeClue(clueId: string) {

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
-import { Info, MapPin, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { GripVertical, MapPin, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import type { EditorThemeResponse, MapResponse, LocationResponse } from '@/features/editor/api';
-import { useUpdateConfigJson, useUpdateLocation } from '@/features/editor/api';
-import { EntityTriggerPlacementCard } from '@/features/editor/components/triggers/EntityTriggerPlacementCard';
-import { readLocationClueIds } from '@/features/editor/editorTypes';
-import type { EditorConfig } from '@/features/editor/utils/configShape';
+import { useEditorClues, useUpdateConfigJson, useUpdateLocation } from '@/features/editor/api';
+import { SceneSelectField } from '@/features/editor/components/SceneSelectField';
 import {
-  buildLocationParentOptions,
-  toLocationEditorViewModel,
-} from '@/features/editor/entities/location/locationEntityAdapter';
+  type LocationDiscoveryConfig,
+  readLocationClueIds,
+  readLocationDiscoveries,
+  readLocationInvestigationSettings,
+  writeLocationDiscoveries,
+} from '@/features/editor/editorTypes';
+import type { ProgressNodeRevealOption } from '@/features/editor/entities/reveal/revealTimingOptions';
+import { toLocationEditorViewModel } from '@/features/editor/entities/location/locationEntityAdapter';
 import { readLocationMeta } from '@/features/editor/utils/entityMeta';
 import { AddNameInput } from './AddNameInput';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
@@ -23,6 +26,7 @@ interface LocationDetailPanelProps {
   selectedMap: MapResponse | null;
   selectedLocation: LocationResponse | null;
   mapLocations: LocationResponse[];
+  sceneOptions?: ProgressNodeRevealOption[];
   addingLocation: boolean;
   isCreatingLocation: boolean;
   onStartAdd: () => void;
@@ -32,23 +36,10 @@ interface LocationDetailPanelProps {
   onDeleteLocation: (locationId: string) => void;
 }
 
-function parseRound(raw: string): number | null | undefined {
-  const trimmed = raw.trim();
-  if (trimmed === '') return null;
-  const n = Number(trimmed);
-  if (!Number.isFinite(n) || n < 1) return undefined;
-  return Math.floor(n);
-}
-
-function roundToInput(value: number | null | undefined) {
-  return value == null ? '' : String(value);
-}
-
 interface LocationBasicDraft {
   name: string;
   publicDescription: string;
   entryMessage: string;
-  parentLocationId: string;
 }
 
 export function LocationDetailPanel({
@@ -57,6 +48,7 @@ export function LocationDetailPanel({
   selectedMap,
   selectedLocation,
   mapLocations,
+  sceneOptions = [],
   addingLocation,
   isCreatingLocation,
   onStartAdd,
@@ -123,6 +115,7 @@ export function LocationDetailPanel({
           map={selectedMap}
           location={location}
           mapLocations={mapLocations}
+          sceneOptions={sceneOptions}
         />
       )}
     />
@@ -134,40 +127,44 @@ function SelectedLocationDetail({
   map,
   location,
   mapLocations,
+  sceneOptions,
 }: {
   themeId: string;
   theme: EditorThemeResponse;
   map: MapResponse;
   location: LocationResponse;
   mapLocations: LocationResponse[];
+  sceneOptions: ProgressNodeRevealOption[];
 }) {
   const updateLocation = useUpdateLocation(themeId);
   const updateConfig = useUpdateConfigJson(themeId);
-  const [fromRoundInput, setFromRoundInput] = useState(roundToInput(location.from_round));
-  const [untilRoundInput, setUntilRoundInput] = useState(roundToInput(location.until_round));
-  const [visibilityMode, setVisibilityMode] = useState<VisibilityMode>(
-    getVisibilityMode(roundToInput(location.from_round), roundToInput(location.until_round))
-  );
+  const { data: clues } = useEditorClues(themeId);
+  const [appearanceSceneId, setAppearanceSceneId] = useState(location.appearance_scene_id ?? null);
+  const [hideSceneId, setHideSceneId] = useState(location.hide_scene_id ?? null);
   const locationMeta = useMemo(
     () => readLocationMeta(theme.config_json, location.id),
     [theme.config_json, location.id]
-  );
-  const locationMetaById = useMemo(
-    () =>
-      Object.fromEntries(
-        mapLocations.map((item) => [item.id, readLocationMeta(theme.config_json, item.id)])
-      ),
-    [mapLocations, theme.config_json]
   );
   const [basicDraft, setBasicDraft] = useState({
     name: location.name,
     publicDescription: location.public_description ?? locationMeta.publicDescription ?? '',
     entryMessage: location.entry_message ?? locationMeta.entryMessage ?? '',
-    parentLocationId: location.parent_location_id ?? locationMeta.parentLocationId ?? '',
   });
   const assignedCount = useMemo(
     () => readLocationClueIds(theme.config_json, location.id).length,
     [theme.config_json, location.id]
+  );
+  const discoveries = useMemo(
+    () => readLocationDiscoveries(theme.config_json, location.id),
+    [theme.config_json, location.id]
+  );
+  const investigationSettings = useMemo(
+    () => readLocationInvestigationSettings(theme.config_json),
+    [theme.config_json]
+  );
+  const clueNameById = useMemo(
+    () => new Map((clues ?? []).map((clue) => [clue.id, clue.name])),
+    [clues]
   );
   const viewModel = toLocationEditorViewModel(location, {
     clueCount: assignedCount,
@@ -175,31 +172,22 @@ function SelectedLocationDetail({
     locationMeta,
     allLocations: mapLocations,
   });
-  const parentOptions = useMemo(
-    () => buildLocationParentOptions(location.id, mapLocations, locationMetaById),
-    [location.id, locationMetaById, mapLocations]
-  );
 
   useEffect(() => {
-    setFromRoundInput(roundToInput(location.from_round));
-    setUntilRoundInput(roundToInput(location.until_round));
-    setVisibilityMode(
-      getVisibilityMode(roundToInput(location.from_round), roundToInput(location.until_round))
-    );
+    setAppearanceSceneId(location.appearance_scene_id ?? null);
+    setHideSceneId(location.hide_scene_id ?? null);
     setBasicDraft({
       name: location.name,
       publicDescription: location.public_description ?? locationMeta.publicDescription ?? '',
       entryMessage: location.entry_message ?? locationMeta.entryMessage ?? '',
-      parentLocationId: location.parent_location_id ?? locationMeta.parentLocationId ?? '',
     });
   }, [
     location.id,
     location.name,
-    location.from_round,
-    location.until_round,
+    location.appearance_scene_id,
+    location.hide_scene_id,
     location.public_description,
     location.entry_message,
-    location.parent_location_id,
     locationMeta,
   ]);
 
@@ -207,26 +195,14 @@ function SelectedLocationDetail({
     patch: Partial<LocationResponse>,
     options: { onSuccess?: () => void; onErrorMessage?: string } = {}
   ) {
-    const currentFrom = parseRound(fromRoundInput);
-    const currentUntil = parseRound(untilRoundInput);
-    const nextFrom =
-      patch.from_round !== undefined
-        ? patch.from_round
-        : currentFrom === undefined
-          ? (location.from_round ?? null)
-          : currentFrom;
-    const nextUntil =
-      patch.until_round !== undefined
-        ? patch.until_round
-        : currentUntil === undefined
-          ? (location.until_round ?? null)
-          : currentUntil;
-    if (nextFrom != null && nextUntil != null && nextFrom > nextUntil) {
-      toast.error('등장 라운드는 퇴장 라운드보다 클 수 없습니다');
-      setFromRoundInput(roundToInput(location.from_round));
-      setUntilRoundInput(roundToInput(location.until_round));
-      return;
-    }
+    const nextAppearanceSceneId =
+      patch.appearance_scene_id !== undefined
+        ? (patch.appearance_scene_id ?? null)
+        : (appearanceSceneId ?? location.appearance_scene_id ?? null);
+    const nextHideSceneId =
+      patch.hide_scene_id !== undefined
+        ? (patch.hide_scene_id ?? null)
+        : (hideSceneId ?? location.hide_scene_id ?? null);
     const nextImageUrl = Object.prototype.hasOwnProperty.call(patch, 'image_url')
       ? (patch.image_url ?? null)
       : location.image_url;
@@ -237,10 +213,10 @@ function SelectedLocationDetail({
       image_url: nextImageUrl,
       public_description: patch.public_description ?? location.public_description ?? null,
       entry_message: patch.entry_message ?? location.entry_message ?? null,
-      parent_location_id: patch.parent_location_id ?? location.parent_location_id ?? null,
+      parent_location_id: null,
       sort_order: patch.sort_order ?? location.sort_order,
-      from_round: nextFrom,
-      until_round: nextUntil,
+      appearance_scene_id: nextAppearanceSceneId,
+      hide_scene_id: nextHideSceneId,
       ...(hasImageMediaPatch ? { image_media_id: patch.image_media_id ?? null } : {}),
     };
     updateLocation.mutate(
@@ -255,13 +231,6 @@ function SelectedLocationDetail({
     );
   }
 
-  function saveTriggerConfig(nextConfig: EditorConfig) {
-    updateConfig.mutate(nextConfig, {
-      onSuccess: () => toast.success('장소 트리거가 저장되었습니다'),
-      onError: () => toast.error('장소 트리거 저장에 실패했습니다'),
-    });
-  }
-
   function saveBasicInfo() {
     const nextName = basicDraft.name.trim();
     if (!nextName) {
@@ -269,19 +238,29 @@ function SelectedLocationDetail({
       return;
     }
 
-    const nextParentId = basicDraft.parentLocationId || null;
     saveLocation(
       {
         name: nextName,
         public_description: basicDraft.publicDescription.trim() || null,
         entry_message: basicDraft.entryMessage.trim() || null,
-        parent_location_id: nextParentId,
       },
       {
         onSuccess: () => toast.success('장소 기본 정보가 저장되었습니다'),
         onErrorMessage: '장소 기본 정보 저장에 실패했습니다',
       }
     );
+  }
+
+  function saveDiscoveryOrder(nextDiscoveries: LocationDiscoveryConfig[]) {
+    const nextConfig = writeLocationDiscoveries(
+      theme.config_json,
+      location.id,
+      nextDiscoveries.map((discovery, index) => ({ ...discovery, order: index }))
+    );
+    updateConfig.mutate(nextConfig, {
+      onSuccess: () => toast.success('장소 단서 순서가 저장되었습니다'),
+      onError: () => toast.error('장소 단서 순서 저장에 실패했습니다'),
+    });
   }
 
   return (
@@ -294,10 +273,7 @@ function SelectedLocationDetail({
             </p>
             <h3 className="mt-1 text-xl font-semibold text-slate-100">{viewModel.name}</h3>
             <p className="mt-1 text-xs text-slate-500">
-              트리 경로: {map.name} /{' '}
-              {viewModel.parentLabel === '최상위 장소'
-                ? location.name
-                : `${viewModel.parentLabel} / ${location.name}`}
+              소속 맵: {map.name}
             </p>
             <p className="mt-1 text-xs text-slate-400">{viewModel.roundLabel}</p>
           </div>
@@ -319,42 +295,40 @@ function SelectedLocationDetail({
               draft={basicDraft}
               onDraftChange={setBasicDraft}
               onSave={saveBasicInfo}
-              isSaving={updateLocation.isPending || updateConfig.isPending}
+              isSaving={updateLocation.isPending}
             />
-            <LocationStructureFields
+            <SceneVisibilityFields
               location={location}
-              mapName={map.name}
-              parentLabel={viewModel.parentLabel}
-              parentOptions={parentOptions}
-              selectedParentId={basicDraft.parentLocationId}
-              onParentChange={(parentLocationId) =>
-                setBasicDraft((current) => ({ ...current, parentLocationId }))
-              }
-            />
-            <RoundFields
-              location={location}
-              fromRoundInput={fromRoundInput}
-              untilRoundInput={untilRoundInput}
-              setFromRoundInput={setFromRoundInput}
-              setUntilRoundInput={setUntilRoundInput}
-              visibilityMode={visibilityMode}
-              setVisibilityMode={setVisibilityMode}
+              sceneOptions={sceneOptions}
+              appearanceSceneId={appearanceSceneId}
+              hideSceneId={hideSceneId}
+              setAppearanceSceneId={setAppearanceSceneId}
+              setHideSceneId={setHideSceneId}
               onCommit={saveLocation}
+            />
+            <LocationInvestigationStructurePanel
+              location={location}
+              settings={investigationSettings}
+              discoveries={discoveries}
+              clueNameById={clueNameById}
+              isSaving={updateConfig.isPending}
+              onReorder={saveDiscoveryOrder}
+            />
+            <LocationValidationPanel
+              location={location}
+              settings={investigationSettings}
+              discoveries={discoveries}
             />
           </div>
         </div>
       </section>
-      <EntityTriggerPlacementCard
-        themeId={themeId}
-        entityKind="location"
-        entityId={location.id}
-        entityName={location.name}
-        configJson={theme.config_json}
-        onConfigChange={saveTriggerConfig}
-        isSaving={updateConfig.isPending}
-      />
       <LocationAccessPolicyPanel themeId={themeId} location={location} />
-      <LocationClueAssignPanel themeId={themeId} theme={theme} location={location} />
+      <LocationClueAssignPanel
+        themeId={themeId}
+        theme={theme}
+        location={location}
+        allClues={clues}
+      />
     </div>
   );
 }
@@ -432,189 +406,220 @@ function LocationBasicInfoFields({
   );
 }
 
-function LocationStructureFields({
+function SceneVisibilityFields({
   location,
-  mapName,
-  parentLabel,
-  parentOptions,
-  selectedParentId,
-  onParentChange,
-}: {
-  location: LocationResponse;
-  mapName: string;
-  parentLabel: string;
-  parentOptions: Array<{ id: string; label: string; depth: number }>;
-  selectedParentId: string;
-  onParentChange: (parentLocationId: string) => void;
-}) {
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-      <div className="mb-2 flex items-center gap-1.5 font-semibold text-slate-300">
-        <Info className="h-3.5 w-3.5 text-amber-400" />
-        장소 구조
-      </div>
-      <label className="text-xs text-slate-500">
-        부모 장소
-        <select
-          aria-label={`${location.name} 부모 장소`}
-          value={selectedParentId}
-          onChange={(event) => onParentChange(event.target.value)}
-          className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-        >
-          <option value="">최상위 장소</option>
-          {parentOptions.map((option) => (
-            <option key={option.id} value={option.id}>
-              {`${'· '.repeat(option.depth)}${option.label}`}
-            </option>
-          ))}
-        </select>
-      </label>
-      <p className="mt-2 text-xs leading-5 text-slate-500">
-        현재 경로: {mapName} /{' '}
-        {parentLabel === '최상위 장소' ? location.name : `${parentLabel} / ${location.name}`}
-      </p>
-    </div>
-  );
-}
-
-function RoundFields({
-  location,
-  fromRoundInput,
-  untilRoundInput,
-  setFromRoundInput,
-  setUntilRoundInput,
-  visibilityMode,
-  setVisibilityMode,
+  sceneOptions,
+  appearanceSceneId,
+  hideSceneId,
+  setAppearanceSceneId,
+  setHideSceneId,
   onCommit,
 }: {
   location: LocationResponse;
-  fromRoundInput: string;
-  untilRoundInput: string;
-  setFromRoundInput: (value: string) => void;
-  setUntilRoundInput: (value: string) => void;
-  visibilityMode: VisibilityMode;
-  setVisibilityMode: (value: VisibilityMode) => void;
+  sceneOptions: ProgressNodeRevealOption[];
+  appearanceSceneId: string | null;
+  hideSceneId: string | null;
+  setAppearanceSceneId: (value: string | null) => void;
+  setHideSceneId: (value: string | null) => void;
   onCommit: (patch: Partial<LocationResponse>) => void;
 }) {
-  function commitVisibility(nextFrom: string, nextUntil: string) {
-    const parsedFrom = parseRound(nextFrom);
-    const parsedUntil = parseRound(nextUntil);
-    if (parsedFrom === undefined || parsedUntil === undefined) {
-      toast.error('라운드는 1 이상의 숫자로 입력해 주세요');
-      setFromRoundInput(roundToInput(location.from_round));
-      setUntilRoundInput(roundToInput(location.until_round));
-      return;
-    }
-    onCommit({ from_round: parsedFrom, until_round: parsedUntil });
+  const sceneDraftRef = useRef({ appearanceSceneId, hideSceneId });
+
+  useEffect(() => {
+    sceneDraftRef.current = { appearanceSceneId, hideSceneId };
+  }, [appearanceSceneId, hideSceneId]);
+
+  function changeAppearance(sceneId: string | null) {
+    setAppearanceSceneId(sceneId);
+    sceneDraftRef.current = { ...sceneDraftRef.current, appearanceSceneId: sceneId };
+    onCommit({
+      appearance_scene_id: sceneDraftRef.current.appearanceSceneId,
+      hide_scene_id: sceneDraftRef.current.hideSceneId,
+    });
   }
 
-  function commitRound(kind: 'from_round' | 'until_round', raw: string) {
-    const nextFrom = kind === 'from_round' ? raw : fromRoundInput;
-    const nextUntil = kind === 'until_round' ? raw : untilRoundInput;
-    const parsed = parseRound(raw);
-    if (parsed === undefined) {
-      toast.error('라운드는 1 이상의 숫자로 입력해 주세요');
-      if (kind === 'from_round') setFromRoundInput(roundToInput(location.from_round));
-      else setUntilRoundInput(roundToInput(location.until_round));
-      return;
-    }
-    commitVisibility(nextFrom, nextUntil);
-  }
-
-  function selectMode(nextMode: VisibilityMode) {
-    setVisibilityMode(nextMode);
-    if (nextMode === 'always') {
-      setFromRoundInput('');
-      setUntilRoundInput('');
-      onCommit({ from_round: null, until_round: null });
-      return;
-    }
-    const fallbackFrom = fromRoundInput || '1';
-    const fallbackUntil = untilRoundInput || fallbackFrom;
-    if (nextMode === 'from') {
-      setFromRoundInput(fallbackFrom);
-      setUntilRoundInput('');
-      commitVisibility(fallbackFrom, '');
-    } else if (nextMode === 'until') {
-      setFromRoundInput('');
-      setUntilRoundInput(fallbackUntil);
-      commitVisibility('', fallbackUntil);
-    } else {
-      setFromRoundInput(fallbackFrom);
-      setUntilRoundInput(fallbackUntil);
-      commitVisibility(fallbackFrom, fallbackUntil);
-    }
+  function changeHide(sceneId: string | null) {
+    setHideSceneId(sceneId);
+    sceneDraftRef.current = { ...sceneDraftRef.current, hideSceneId: sceneId };
+    onCommit({
+      appearance_scene_id: sceneDraftRef.current.appearanceSceneId,
+      hide_scene_id: sceneDraftRef.current.hideSceneId,
+    });
   }
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-      <p className="mb-2 text-xs font-semibold text-slate-300">공개 시점</p>
-      <div className="grid gap-2 sm:grid-cols-2">
-        {[
-          ['always', '처음부터 끝까지'],
-          ['from', '특정 라운드부터'],
-          ['until', '특정 라운드까지'],
-          ['range', '특정 구간만'],
-        ].map(([value, label]) => (
-          <button
-            key={value}
-            type="button"
-            onClick={() => selectMode(value as 'always' | 'from' | 'until' | 'range')}
-            className={`rounded-md border px-3 py-2 text-left text-xs transition ${
-              visibilityMode === value
-                ? 'border-amber-500/60 bg-amber-500/10 text-amber-100'
-                : 'border-slate-700 bg-slate-950 text-slate-400 hover:border-slate-600'
-            }`}
-          >
-            {label}
-          </button>
-        ))}
+      <p className="mb-2 text-xs font-semibold text-slate-300">공개 장면</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <SceneSelectField
+          label={`${location.name} 출현 장면`}
+          selectedId={appearanceSceneId}
+          options={sceneOptions}
+          onChange={changeAppearance}
+          emptyLabel="처음부터 공개"
+        />
+        <SceneSelectField
+          label={`${location.name} 숨김 장면`}
+          selectedId={hideSceneId}
+          options={sceneOptions}
+          onChange={changeHide}
+          emptyLabel="마지막 장면까지"
+        />
       </div>
-      {visibilityMode !== 'always' ? (
-        <div className="mt-3 grid gap-2 sm:grid-cols-2">
-          {visibilityMode === 'from' || visibilityMode === 'range' ? (
-            <label className="text-xs text-slate-500">
-              시작 라운드
-              <input
-                type="number"
-                min={1}
-                aria-label={`${location.name} 시작 라운드`}
-                value={fromRoundInput}
-                onChange={(e) => setFromRoundInput(e.target.value)}
-                onBlur={() => commitRound('from_round', fromRoundInput)}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-              />
-            </label>
-          ) : null}
-          {visibilityMode === 'until' || visibilityMode === 'range' ? (
-            <label className="text-xs text-slate-500">
-              종료 라운드
-              <input
-                type="number"
-                min={1}
-                aria-label={`${location.name} 종료 라운드`}
-                value={untilRoundInput}
-                onChange={(e) => setUntilRoundInput(e.target.value)}
-                onBlur={() => commitRound('until_round', untilRoundInput)}
-                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-              />
-            </label>
-          ) : null}
-        </div>
-      ) : null}
     </div>
   );
 }
 
-type VisibilityMode = 'always' | 'from' | 'until' | 'range';
+function LocationInvestigationStructurePanel({
+  location,
+  settings,
+  discoveries,
+  clueNameById,
+  isSaving,
+  onReorder,
+}: {
+  location: LocationResponse;
+  settings: ReturnType<typeof readLocationInvestigationSettings>;
+  discoveries: ReturnType<typeof readLocationDiscoveries>;
+  clueNameById: Map<string, string>;
+  isSaving: boolean;
+  onReorder: (discoveries: LocationDiscoveryConfig[]) => void;
+}) {
+  const [draggingClueId, setDraggingClueId] = useState<string | null>(null);
+  const sortedDiscoveries = discoveries
+    .map((discovery, index) => ({ discovery, index }))
+    .sort((a, b) => {
+      const left = typeof a.discovery.order === 'number' ? a.discovery.order : 9999;
+      const right = typeof b.discovery.order === 'number' ? b.discovery.order : 9999;
+      return left === right ? a.index - b.index : left - right;
+    })
+    .map(({ discovery }) => discovery);
 
-function getVisibilityMode(fromRoundInput: string, untilRoundInput: string): VisibilityMode {
-  const hasFrom = fromRoundInput.trim() !== '';
-  const hasUntil = untilRoundInput.trim() !== '';
-  if (hasFrom && hasUntil) return 'range';
-  if (hasFrom) return 'from';
-  if (hasUntil) return 'until';
-  return 'always';
+  function moveDiscovery(sourceClueId: string, targetClueId: string) {
+    if (sourceClueId === targetClueId || isSaving) return;
+    const sourceIndex = sortedDiscoveries.findIndex((discovery) => discovery.clueId === sourceClueId);
+    const targetIndex = sortedDiscoveries.findIndex((discovery) => discovery.clueId === targetClueId);
+    if (sourceIndex < 0 || targetIndex < 0) return;
+    const next = [...sortedDiscoveries];
+    const [moved] = next.splice(sourceIndex, 1);
+    next.splice(targetIndex, 0, moved);
+    onReorder(next);
+  }
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-3">
+        <p className="text-xs font-semibold text-slate-200">
+          {settings.investigationMode === 'list' ? '장소 단서 목록' : '장소 덱 단서'}
+        </p>
+        <p className="mt-1 text-xs leading-5 text-slate-500">
+          {settings.investigationMode === 'list'
+            ? `${location.name}에 배치한 단서를 플레이어가 목록에서 확인하고 획득하는 방식입니다.`
+            : `${location.name}에 추가한 단서를 ${
+                settings.deckOrder === 'random' ? '랜덤' : '설정 순서'
+              }으로 한 장씩 획득하는 방식입니다.`}
+        </p>
+      </div>
+      {sortedDiscoveries.length > 0 ? (
+        <ol className="space-y-2">
+          {sortedDiscoveries.map((discovery, index) => (
+            <li
+              key={`${discovery.locationId}:${discovery.clueId}`}
+              draggable={!isSaving}
+              onDragStart={(event) => {
+                setDraggingClueId(discovery.clueId);
+                const dataTransfer = event.dataTransfer as DataTransfer | undefined;
+                if (dataTransfer) {
+                  dataTransfer.effectAllowed = 'move';
+                  dataTransfer.setData('text/plain', discovery.clueId);
+                }
+              }}
+              onDragEnter={(event) => {
+                event.preventDefault();
+              }}
+              onDragOver={(event) => {
+                event.preventDefault();
+                const dataTransfer = event.dataTransfer as DataTransfer | undefined;
+                if (dataTransfer) dataTransfer.dropEffect = 'move';
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                const sourceClueId =
+                  draggingClueId ||
+                  (event.dataTransfer as DataTransfer | undefined)?.getData('text/plain');
+                setDraggingClueId(null);
+                if (sourceClueId) moveDiscovery(sourceClueId, discovery.clueId);
+              }}
+              onDragEnd={() => setDraggingClueId(null)}
+              aria-label={`${clueNameById.get(discovery.clueId) ?? '알 수 없는 단서'} 순서 이동`}
+              className={`flex items-center gap-3 rounded-md border px-3 py-2 transition ${
+                draggingClueId === discovery.clueId
+                  ? 'border-amber-400/50 bg-amber-500/10 opacity-70'
+                  : 'border-slate-800 bg-slate-950'
+              } ${isSaving ? 'cursor-wait opacity-60' : 'cursor-grab active:cursor-grabbing'}`}
+            >
+              <GripVertical className="h-4 w-4 shrink-0 text-slate-600" aria-hidden="true" />
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/10 text-xs font-semibold text-amber-200">
+                {index + 1}
+              </span>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-slate-200">
+                  {clueNameById.get(discovery.clueId) ?? '알 수 없는 단서'}
+                </p>
+                <p className="text-xs text-slate-500">
+                  {settings.investigationMode === 'list'
+                    ? '장소 배치 단서'
+                    : settings.deckOrder === 'random'
+                      ? '랜덤 후보 카드'
+                      : '순차 획득 카드'}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="rounded-md border border-dashed border-slate-800 px-3 py-4 text-xs leading-5 text-slate-500">
+          아직 배치된 단서가 없습니다. 아래 단서 배치에서 단서를 추가하면 이 장소에서
+          획득할 수 있습니다.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function LocationValidationPanel({
+  location,
+  discoveries,
+}: {
+  location: LocationResponse;
+  discoveries: ReturnType<typeof readLocationDiscoveries>;
+}) {
+  const messages: string[] = [];
+  if (!location.appearance_scene_id) messages.push('출현 장면 미선택: 게임 시작부터 공개됩니다.');
+  if (!location.hide_scene_id) messages.push('숨김 장면 미선택: 마지막 장면까지 공개됩니다.');
+  if (discoveries.length === 0) messages.push('이 장소에서 획득할 단서가 아직 없습니다.');
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-950/70 p-3">
+      <p className="text-xs font-semibold text-slate-200">장소 검수</p>
+      <div className="mt-2 space-y-1">
+        {messages.length > 0 ? (
+          messages.map((message) => (
+            <p
+              key={message}
+              className="rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-100"
+            >
+              {message}
+            </p>
+          ))
+        ) : (
+          <p className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-100">
+            공개 시점과 단서 배치가 기본 조건을 만족합니다.
+          </p>
+        )}
+      </div>
+    </section>
+  );
 }
 
 function LocationEmptyState({ message, compact = false }: { message: string; compact?: boolean }) {

--- a/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
+++ b/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
@@ -10,6 +10,7 @@ interface LocationImageMediaFieldProps {
   pickerTitle?: string;
   emptyLabel?: string;
   legacyMessage?: string;
+  compact?: boolean;
   imageMediaId?: string | null;
   legacyImageUrl?: string | null;
   onSelect: (media: MediaResponse) => void;
@@ -22,6 +23,7 @@ export function LocationImageMediaField({
   pickerTitle = '장소 이미지 선택',
   emptyLabel = '미디어 이미지 선택',
   legacyMessage = '기존 직접 업로드 이미지가 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다.',
+  compact = false,
   imageMediaId,
   legacyImageUrl,
   onSelect,
@@ -32,8 +34,14 @@ export function LocationImageMediaField({
   const selectedImage = images.find((media) => media.id === imageMediaId) ?? null;
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-      <div className="mb-2 flex items-center justify-between gap-2">
+    <div
+      className={
+        compact
+          ? 'rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2'
+          : 'rounded-lg border border-slate-800 bg-slate-900/70 p-3'
+      }
+    >
+      <div className={compact ? 'flex items-center justify-between gap-3' : 'mb-2 flex items-center justify-between gap-2'}>
         <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-300">
           <Image className="h-3.5 w-3.5 text-amber-400" />
           {label}
@@ -54,7 +62,11 @@ export function LocationImageMediaField({
         <button
           type="button"
           onClick={() => setPickerOpen(true)}
-          className="flex w-full items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-left text-sm text-amber-100 hover:bg-amber-500/15"
+          className={
+            compact
+              ? 'flex min-w-0 items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-left text-xs text-amber-100 hover:bg-amber-500/15'
+              : 'flex w-full items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-left text-sm text-amber-100 hover:bg-amber-500/15'
+          }
         >
           <span className="truncate">{selectedImage?.name ?? '선택된 이미지'}</span>
           <span className="shrink-0 text-xs text-amber-200/70">교체</span>
@@ -63,7 +75,11 @@ export function LocationImageMediaField({
         <button
           type="button"
           onClick={() => setPickerOpen(true)}
-          className="flex aspect-[16/10] w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200"
+          className={
+            compact
+              ? 'shrink-0 rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-1.5 text-xs text-slate-400 hover:border-amber-500/50 hover:text-slate-200'
+              : 'flex aspect-[16/10] w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200'
+          }
         >
           {emptyLabel}
         </button>

--- a/apps/web/src/features/editor/components/design/LocationRow.tsx
+++ b/apps/web/src/features/editor/components/design/LocationRow.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from 'react';
 import { MapPin, Trash2 } from 'lucide-react';
-import { toast } from 'sonner';
 import type { LocationResponse } from '@/features/editor/api';
-import { useUpdateLocation } from '@/features/editor/api';
+import { formatLocationRoundLabel } from '@/features/editor/entities/location/locationEntityAdapter';
 
 // ---------------------------------------------------------------------------
 // LocationRow — name + inline round schedule editor + delete.
@@ -17,62 +15,8 @@ interface LocationRowProps {
   onDelete: (id: string) => void;
 }
 
-function parseRound(raw: string): number | null {
-  const trimmed = raw.trim();
-  if (trimmed === '') return null;
-  const n = Number(trimmed);
-  if (!Number.isFinite(n) || n < 1) return null;
-  return Math.floor(n);
-}
-
 export function LocationRow({ themeId, location, onDelete }: LocationRowProps) {
-  const updateLocation = useUpdateLocation(themeId);
-
-  const [fromRound, setFromRound] = useState<number | null>(
-    location.from_round ?? null,
-  );
-  const [untilRound, setUntilRound] = useState<number | null>(
-    location.until_round ?? null,
-  );
-
-  // Keep local state in sync when server data refreshes (e.g. after PATCH).
-  useEffect(() => {
-    setFromRound(location.from_round ?? null);
-    setUntilRound(location.until_round ?? null);
-  }, [location.from_round, location.until_round]);
-
-  function commitRounds(nextFrom: number | null, nextUntil: number | null) {
-    if (
-      nextFrom === (location.from_round ?? null) &&
-      nextUntil === (location.until_round ?? null)
-    ) {
-      return;
-    }
-    if (nextFrom != null && nextUntil != null && nextFrom > nextUntil) {
-      toast.error('등장 라운드는 퇴장 라운드보다 클 수 없습니다');
-      setFromRound(location.from_round ?? null);
-      setUntilRound(location.until_round ?? null);
-      return;
-    }
-    updateLocation.mutate(
-      {
-        locationId: location.id,
-        body: {
-          name: location.name,
-          sort_order: location.sort_order,
-          from_round: nextFrom,
-          until_round: nextUntil,
-        },
-      },
-      {
-        onError: () => {
-          toast.error('라운드 저장에 실패했습니다');
-          setFromRound(location.from_round ?? null);
-          setUntilRound(location.until_round ?? null);
-        },
-      },
-    );
-  }
+  void themeId;
 
   return (
     <div className="group flex items-center gap-2 rounded-sm border border-slate-800 bg-slate-900 px-3 py-2 hover:border-slate-700">
@@ -80,51 +24,7 @@ export function LocationRow({ themeId, location, onDelete }: LocationRowProps) {
       <span className="flex-1 truncate text-xs font-medium text-slate-300">
         {location.name}
       </span>
-      <div className="flex items-center gap-1 text-[10px] text-slate-500">
-        <label
-          htmlFor={`location-${location.id}-from`}
-          className="sr-only"
-        >
-          {location.name} 등장 라운드
-        </label>
-        <input
-          id={`location-${location.id}-from`}
-          type="number"
-          min={1}
-          step={1}
-          placeholder="시작"
-          aria-label={`${location.name} 등장 라운드`}
-          value={fromRound ?? ''}
-          onChange={(e) => setFromRound(parseRound(e.target.value))}
-          onBlur={() => commitRounds(fromRound, untilRound)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
-          }}
-          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
-        />
-        <span>~</span>
-        <label
-          htmlFor={`location-${location.id}-until`}
-          className="sr-only"
-        >
-          {location.name} 퇴장 라운드
-        </label>
-        <input
-          id={`location-${location.id}-until`}
-          type="number"
-          min={1}
-          step={1}
-          placeholder="끝"
-          aria-label={`${location.name} 퇴장 라운드`}
-          value={untilRound ?? ''}
-          onChange={(e) => setUntilRound(parseRound(e.target.value))}
-          onBlur={() => commitRounds(fromRound, untilRound)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
-          }}
-          className="w-14 rounded-sm border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-center text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
-        />
-      </div>
+      <span className="shrink-0 text-[10px] text-slate-500">{formatLocationRoundLabel(location)}</span>
       <button
         type="button"
         onClick={() => onDelete(location.id)}

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { Map, Plus, Trash2 } from 'lucide-react';
 import { Spinner } from '@/shared/components/ui/Spinner';
@@ -7,14 +7,14 @@ import {
   useEditorMaps,
   useCreateMap,
   useDeleteMap,
-  useUpdateMap,
   useEditorLocations,
   useCreateLocation,
   useDeleteLocation,
 } from '@/features/editor/api';
+import { useFlowGraph } from '@/features/editor/flowApi';
+import { buildProgressNodeRevealOptions } from '@/features/editor/entities/reveal/revealTimingOptions';
 import { AddNameInput } from './AddNameInput';
 import { LocationDetailPanel } from './LocationDetailPanel';
-import { LocationImageMediaField } from './LocationImageMediaField';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -32,9 +32,9 @@ interface LocationsSubTabProps {
 export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   const { data: maps, isLoading: mapsLoading } = useEditorMaps(themeId);
   const { data: locations, isLoading: locsLoading } = useEditorLocations(themeId);
+  const { data: flowGraph } = useFlowGraph(themeId);
   const createMap = useCreateMap(themeId);
   const deleteMap = useDeleteMap(themeId);
-  const updateMap = useUpdateMap(themeId);
   const createLocation = useCreateLocation(themeId);
   const deleteLocation = useDeleteLocation(themeId);
 
@@ -48,7 +48,17 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   const mapLocations = locations?.filter((l) => l.map_id === effectiveSelectedMapId) ?? [];
   const selectedLocation =
     mapLocations.find((l) => l.id === selectedLocationId) ?? mapLocations[0] ?? null;
-
+  const sceneOptions = useMemo(
+    () =>
+      buildProgressNodeRevealOptions(
+        flowGraph?.nodes,
+        locations?.flatMap((location) => [
+          location.appearance_scene_id ?? null,
+          location.hide_scene_id ?? null,
+        ]) ?? []
+      ),
+    [flowGraph?.nodes, locations]
+  );
   function handleAddMap(name: string) {
     createMap.mutate(
       { name },
@@ -111,139 +121,43 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
-      {/* ── Map list (full-width on mobile, 240px on md+) ── */}
-      <aside className="shrink-0 border-b border-slate-800 bg-slate-950 py-2 md:min-h-0 md:w-60 md:overflow-y-auto md:border-b-0 md:border-r">
-        <div className="flex items-center justify-between px-3 pb-2">
-          <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">
-            맵
-          </span>
-          <button
-            type="button"
-            onClick={() => setAddingMap(true)}
-            aria-label="맵 추가"
-            className="rounded-sm p-0.5 text-slate-600 hover:bg-slate-800 hover:text-amber-400 transition-colors"
-          >
-            <Plus className="h-3.5 w-3.5" />
-          </button>
-        </div>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-950/40">
+      <div className="border-b border-slate-800 bg-slate-950/80 px-5 py-3">
+        <LocationMapToolbar
+          maps={maps ?? []}
+          selectedMap={selectedMap}
+          effectiveSelectedMapId={effectiveSelectedMapId}
+          addingMap={addingMap}
+          isCreatingMap={createMap.isPending}
+          isDeletingMap={deleteMap.isPending}
+          onSelectMap={(mapId) => {
+            setSelectedMapId(mapId);
+            setSelectedLocationId(null);
+          }}
+          onStartAddMap={() => setAddingMap(true)}
+          onCancelAddMap={() => setAddingMap(false)}
+          onAddMap={handleAddMap}
+          onDeleteSelectedMap={() => {
+            if (!selectedMap) return;
+            if (
+              window.confirm(
+                `${selectedMap.name} 맵을 삭제할까요? 하위 장소 편집 흐름도 함께 영향을 받습니다.`
+              )
+            ) {
+              handleDeleteMap(selectedMap.id);
+            }
+          }}
+        />
+      </div>
 
-        {addingMap && (
-          <AddNameInput
-            placeholder="맵 이름"
-            onAdd={handleAddMap}
-            onCancel={() => setAddingMap(false)}
-            isPending={createMap.isPending}
-          />
-        )}
-
-        {!maps || maps.length === 0 ? (
-          <div className="px-3 py-4 text-center">
-            <Map className="mx-auto mb-1.5 h-5 w-5 text-slate-800" />
-            <p className="text-[10px] font-mono uppercase tracking-widest text-slate-700">
-              맵 없음
-            </p>
-          </div>
-        ) : (
-          maps.map((map) => {
-            const isSelected = effectiveSelectedMapId === map.id;
-            return (
-              <div
-                key={map.id}
-                className={`group flex w-full items-center gap-1 border-l-2 px-2 py-1.5 transition-colors ${
-                  isSelected
-                    ? 'border-amber-500 bg-slate-900 text-slate-200'
-                    : 'border-transparent text-slate-500 hover:bg-slate-900/50 hover:text-slate-300'
-                }`}
-              >
-                <button
-                  type="button"
-                  aria-pressed={isSelected}
-                  onClick={() => {
-                    setSelectedMapId(map.id);
-                    setSelectedLocationId(null);
-                  }}
-                  className="flex min-h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-                >
-                  <Map className="h-3.5 w-3.5 shrink-0" />
-                  <span className="flex-1 truncate text-xs font-medium">{map.name}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    if (
-                      window.confirm(
-                        `${map.name} 맵을 삭제할까요? 하위 장소 편집 흐름도 함께 영향을 받습니다.`
-                      )
-                    ) {
-                      handleDeleteMap(map.id);
-                    }
-                  }}
-                  aria-label={`${map.name} 삭제`}
-                  className="shrink-0 rounded-md p-2 text-slate-600 transition hover:bg-red-950/40 hover:text-red-300 md:text-slate-700 md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100"
-                >
-                  <Trash2 className="h-3 w-3" />
-                </button>
-              </div>
-            );
-          })
-        )}
-      </aside>
-
-      {/* ── Location detail ── */}
-      <div className="min-h-0 flex-1 px-5 py-5 md:overflow-y-auto">
-        {selectedMap ? (
-          <div className="mb-4 rounded-lg border border-slate-800 bg-slate-950/70 p-4">
-            <div className="mb-3">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-amber-300/80">
-                토론방 배경
-              </p>
-              <h3 className="mt-1 text-base font-semibold text-slate-100">{selectedMap.name}</h3>
-            </div>
-            <LocationImageMediaField
-              themeId={themeId}
-              label="지도 이미지"
-              pickerTitle="지도 이미지 선택"
-              emptyLabel="미디어에서 지도 선택"
-              legacyMessage="기존 지도 이미지 URL이 있습니다. 미디어 관리 이미지로 교체하면 이후 한 곳에서 관리할 수 있습니다."
-              imageMediaId={selectedMap.image_media_id}
-              legacyImageUrl={selectedMap.image_url}
-              onSelect={(media) =>
-                updateMap.mutate(
-                  {
-                    mapId: selectedMap.id,
-                    body: {
-                      name: selectedMap.name,
-                      image_url: null,
-                      image_media_id: media.id,
-                      sort_order: selectedMap.sort_order,
-                    },
-                  },
-                  { onError: () => toast.error('지도 이미지 저장에 실패했습니다') }
-                )
-              }
-              onClear={() =>
-                updateMap.mutate(
-                  {
-                    mapId: selectedMap.id,
-                    body: {
-                      name: selectedMap.name,
-                      image_media_id: null,
-                      sort_order: selectedMap.sort_order,
-                    },
-                  },
-                  { onError: () => toast.error('지도 이미지 저장에 실패했습니다') }
-                )
-              }
-            />
-          </div>
-        ) : null}
+      <div className="min-h-0 flex-1 overflow-hidden px-5 py-5">
         <LocationDetailPanel
           themeId={themeId}
           theme={theme}
           selectedMap={selectedMap}
           selectedLocation={selectedLocation}
           mapLocations={mapLocations}
+          sceneOptions={sceneOptions}
           addingLocation={addingLocation}
           isCreatingLocation={createLocation.isPending}
           onStartAdd={() => setAddingLocation(true)}
@@ -254,5 +168,93 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
         />
       </div>
     </div>
+  );
+}
+
+function LocationMapToolbar({
+  maps,
+  selectedMap,
+  effectiveSelectedMapId,
+  addingMap,
+  isCreatingMap,
+  isDeletingMap,
+  onSelectMap,
+  onStartAddMap,
+  onCancelAddMap,
+  onAddMap,
+  onDeleteSelectedMap,
+}: {
+  maps: NonNullable<ReturnType<typeof useEditorMaps>['data']>;
+  selectedMap: NonNullable<ReturnType<typeof useEditorMaps>['data']>[number] | null;
+  effectiveSelectedMapId: string | null;
+  addingMap: boolean;
+  isCreatingMap: boolean;
+  isDeletingMap: boolean;
+  onSelectMap: (mapId: string) => void;
+  onStartAddMap: () => void;
+  onCancelAddMap: () => void;
+  onAddMap: (name: string) => void;
+  onDeleteSelectedMap: () => void;
+}) {
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-2 text-xs font-semibold text-slate-300">
+          <Map className="h-3.5 w-3.5 text-amber-400" />
+          맵
+        </div>
+        {maps.length > 0 ? (
+          <select
+            aria-label="맵 선택"
+            value={effectiveSelectedMapId ?? ''}
+            onChange={(event) => onSelectMap(event.target.value)}
+            className="h-9 min-w-0 rounded-md border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 sm:w-64"
+          >
+            {maps.map((map) => (
+              <option key={map.id} value={map.id}>
+                {map.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="rounded-md border border-dashed border-slate-700 px-3 py-2 text-xs text-slate-500">
+            맵 없음
+          </span>
+        )}
+      </div>
+
+      {addingMap ? (
+        <div className="min-w-0 sm:w-72">
+          <AddNameInput
+            placeholder="맵 이름"
+            onAdd={onAddMap}
+            onCancel={onCancelAddMap}
+            isPending={isCreatingMap}
+          />
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onStartAddMap}
+            aria-label="맵 추가"
+            className="inline-flex h-9 items-center gap-1.5 rounded-md border border-slate-700 px-3 text-xs font-medium text-slate-300 transition hover:border-amber-500/50 hover:text-amber-100"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            맵 추가
+          </button>
+          <button
+            type="button"
+            onClick={onDeleteSelectedMap}
+            disabled={!selectedMap || isDeletingMap}
+            aria-label={selectedMap ? `${selectedMap.name} 삭제` : '맵 삭제'}
+            className="inline-flex h-9 items-center gap-1.5 rounded-md border border-slate-800 px-3 text-xs font-medium text-slate-500 transition hover:border-red-500/40 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            삭제
+          </button>
+        </div>
+      )}
+    </section>
   );
 }

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -17,9 +17,13 @@ import {
 import { InvestigationTokenSettingsPanel } from './InvestigationTokenSettingsPanel';
 import {
   readEnabledModuleIds,
+  readLocationInvestigationSettings,
   readModuleConfig,
+  writeLocationInvestigationSettings,
   writeModuleConfigPath,
   writeModuleEnabled,
+  type LocationDeckOrder,
+  type LocationInvestigationMode,
 } from '@/features/editor/utils/configShape';
 
 // ---------------------------------------------------------------------------
@@ -30,6 +34,8 @@ interface ModulesSubTabProps {
   themeId: string;
   theme: EditorThemeResponse;
 }
+
+const LOCATION_MODULE_ID = 'location';
 
 // ---------------------------------------------------------------------------
 // ModulesSubTab — card + toggle UI (optional modules only)
@@ -180,6 +186,24 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
     [activeConfig, mutateConfig, updateConfig.isPending]
   );
 
+  const handleLocationInvestigationChange = useCallback(
+    (settings: {
+      investigationMode: LocationInvestigationMode;
+      deckOrder: LocationDeckOrder;
+    }) => {
+      if (updateConfig.isPending) {
+        return;
+      }
+
+      mutateConfig(
+        writeLocationInvestigationSettings(activeConfig, settings),
+        '장소 탐색 설정이 저장되었습니다',
+        '장소 탐색 설정 저장에 실패했습니다'
+      );
+    },
+    [activeConfig, mutateConfig, updateConfig.isPending]
+  );
+
   const schemaMap = useMemo((): Record<string, TemplateSchema | null> => {
     if (!moduleSchemasResp?.schemas) return {};
     const result: Record<string, TemplateSchema | null> = {};
@@ -266,8 +290,19 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
                       />
                     )}
 
+                    {isEnabled && mod.id === LOCATION_MODULE_ID && (
+                      <LocationInvestigationModePanel
+                        settings={readLocationInvestigationSettings(activeConfig)}
+                        isSaving={updateConfig.isPending}
+                        onChange={handleLocationInvestigationChange}
+                      />
+                    )}
+
                     {/* Inline config form when enabled and schema exists */}
-                    {isEnabled && mod.id !== DECK_INVESTIGATION_MODULE_ID && schema && (
+                    {isEnabled &&
+                      mod.id !== DECK_INVESTIGATION_MODULE_ID &&
+                      mod.id !== LOCATION_MODULE_ID &&
+                      schema && (
                       <div className="border-t border-slate-700 px-3 py-3">
                         <SchemaDrivenForm
                           schema={schema}
@@ -283,6 +318,83 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
           </section>
         );
       })}
+    </div>
+  );
+}
+
+function LocationInvestigationModePanel({
+  settings,
+  isSaving,
+  onChange,
+}: {
+  settings: {
+    investigationMode: LocationInvestigationMode;
+    deckOrder: LocationDeckOrder;
+  };
+  isSaving: boolean;
+  onChange: (settings: {
+    investigationMode: LocationInvestigationMode;
+    deckOrder: LocationDeckOrder;
+  }) => void;
+}) {
+  const modes: Array<{ value: LocationInvestigationMode; label: string; description: string }> = [
+    {
+      value: 'list',
+      label: '리스트형',
+      description: '세부 항목별 단서를 제작자가 정한 목록으로 보여줍니다.',
+    },
+    {
+      value: 'deck',
+      label: '덱형',
+      description: '장소에 쌓인 단서를 한 번에 하나씩 뽑아 획득합니다.',
+    },
+  ];
+  const orders: Array<{ value: LocationDeckOrder; label: string }> = [
+    { value: 'fixed', label: '설정 순서' },
+    { value: 'random', label: '랜덤' },
+  ];
+
+  return (
+    <div className="border-t border-slate-700 px-3 py-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        {modes.map((mode) => (
+          <button
+            key={mode.value}
+            type="button"
+            disabled={isSaving}
+            onClick={() => onChange({ ...settings, investigationMode: mode.value })}
+            className={`rounded-md border px-3 py-2 text-left transition ${
+              settings.investigationMode === mode.value
+                ? 'border-amber-500/60 bg-amber-500/10 text-amber-100'
+                : 'border-slate-700 bg-slate-950 text-slate-400 hover:border-slate-600'
+            }`}
+          >
+            <span className="block text-xs font-semibold">{mode.label}</span>
+            <span className="mt-1 block text-[10px] leading-4 text-slate-500">
+              {mode.description}
+            </span>
+          </button>
+        ))}
+      </div>
+      {settings.investigationMode === 'deck' ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {orders.map((order) => (
+            <button
+              key={order.value}
+              type="button"
+              disabled={isSaving}
+              onClick={() => onChange({ ...settings, deckOrder: order.value })}
+              className={`rounded-md border px-3 py-1.5 text-xs font-medium transition ${
+                settings.deckOrder === order.value
+                  ? 'border-amber-500/60 bg-amber-500/10 text-amber-100'
+                  : 'border-slate-700 bg-slate-950 text-slate-400 hover:border-slate-600'
+              }`}
+            >
+              {order.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx
@@ -60,8 +60,8 @@ const location: LocationResponse = {
   description: '낡은 서재',
   restricted_characters: 'char-1',
   image_url: '/images/study.webp',
-  from_round: 1,
-  until_round: 3,
+  appearance_scene_id: 'scene-1',
+  hide_scene_id: 'scene-3',
   sort_order: 7,
   created_at: '2026-05-02T00:00:00Z',
 };
@@ -98,8 +98,8 @@ describe('LocationAccessPolicyPanel', () => {
         restricted_characters: 'char-1,char-2',
         image_url: '/images/study.webp',
         sort_order: 7,
-        from_round: 1,
-        until_round: 3,
+        appearance_scene_id: 'scene-1',
+        hide_scene_id: 'scene-3',
       },
     });
   });

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -158,10 +158,10 @@ describe('LocationClueAssignPanel', () => {
       ...baseTheme,
       config_json: { locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }] },
     };
-    renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
-    expect((screen.getByLabelText('단검 추가') as HTMLButtonElement).disabled).toBe(true);
+  renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
+    expect(screen.getByLabelText('단검 설정 열기')).toBeDefined();
     expect((screen.getByLabelText('편지 추가') as HTMLButtonElement).disabled).toBe(false);
-    expect(screen.getByLabelText('단검 제거')).toBeDefined();
+    expect(screen.getByLabelText('단검 해제')).toBeDefined();
   });
 
   it('배정되지 않은 clue 클릭 시 clueIds에 추가되어 mutate가 호출된다', () => {
@@ -202,7 +202,7 @@ describe('LocationClueAssignPanel', () => {
       },
     };
     renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
-    fireEvent.click(screen.getByLabelText('단검 제거'));
+    fireEvent.click(screen.getByLabelText('단검 해제'));
     expect(mutateMock).toHaveBeenCalledOnce();
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
     const locs = config.locations as Array<{
@@ -293,7 +293,7 @@ describe('LocationClueAssignPanel', () => {
     };
     renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
 
-    expect(screen.getByText('무료 조사')).toBeDefined();
+    expect((screen.getByLabelText('단검 무료 조사') as HTMLInputElement).checked).toBe(false);
     expect(screen.getByRole('link', { name: '조사권 관리' }).getAttribute('href')).toBe(
       '/editor/theme-1/design/modules'
     );
@@ -326,7 +326,7 @@ describe('LocationClueAssignPanel', () => {
     });
   });
 
-  it('장소 단서 조사 비용을 무료로 바꾸면 연결된 비용 deck을 제거한다', () => {
+  it('장소 단서 조사 비용을 무료로 바꾸면 연결된 비용 deck을 무료 비용으로 저장한다', () => {
     const theme: EditorThemeResponse = {
       ...baseTheme,
       config_json: {
@@ -364,14 +364,18 @@ describe('LocationClueAssignPanel', () => {
     renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
 
     expect(screen.getByText('권 기본 조사권 2개 필요')).toBeDefined();
-    fireEvent.click(screen.getByLabelText('단검 무료 조사로 설정'));
+    fireEvent.click(screen.getByLabelText('단검 무료 조사'));
 
     expect(mutateMock).toHaveBeenCalledOnce();
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
     const modules = config.modules as {
-      deck_investigation: { config: { decks: unknown[] } };
+      deck_investigation: { config: { decks: Array<{ tokenCost: number; tokenId: string }> } };
     };
-    expect(modules.deck_investigation.config.decks).toEqual([]);
+    expect(modules.deck_investigation.config.decks[0]).toMatchObject({
+      id: 'location-clue-loc-1-clue-1',
+      tokenId: 'basic-token',
+      tokenCost: 0,
+    });
   });
 
   it('이미 선택된 필요 단서를 다시 클릭하면 requiredClueIds에서 해제된다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.media.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.media.test.tsx
@@ -2,53 +2,14 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import {
   mockLocations,
-  mockMaps,
-  mutateMock,
   renderLocationsSubTab,
   setupDefaultMocks,
   updateLocationMutateMock,
   useEditorLocationsMock,
-  useEditorMapsMock,
 } from './locationsSubTabTestUtils';
 
 describe('LocationsSubTab 장소 이미지 미디어 참조', () => {
   beforeEach(setupDefaultMocks);
-
-  it('IMAGE 미디어를 지도 이미지 참조로 저장한다', () => {
-    renderLocationsSubTab();
-
-    fireEvent.click(screen.getByText('미디어에서 지도 선택'));
-    expect(screen.getByText('filter:IMAGE')).toBeDefined();
-    fireEvent.click(screen.getByText('저택 사진 선택'));
-
-    expect(mutateMock).toHaveBeenCalledOnce();
-    const [payload] = mutateMock.mock.calls[0] as [
-      { mapId: string; body: Record<string, unknown> },
-    ];
-    expect(payload.mapId).toBe('map-1');
-    expect(payload.body.image_media_id).toBe('image-1');
-    expect(payload.body.image_url).toBeNull();
-    expect(payload.body.name).toBe('저택 1층');
-  });
-
-  it('선택된 지도 이미지 참조를 제거할 수 있다', () => {
-    useEditorMapsMock.mockReturnValue({
-      data: [{ ...mockMaps[0], image_media_id: 'image-1' }, ...mockMaps.slice(1)],
-      isLoading: false,
-    });
-
-    renderLocationsSubTab();
-
-    expect(screen.getByText('저택 사진')).toBeDefined();
-    fireEvent.click(screen.getAllByText('제거')[0]);
-
-    expect(mutateMock).toHaveBeenCalledOnce();
-    const [payload] = mutateMock.mock.calls[0] as [
-      { mapId: string; body: Record<string, unknown> },
-    ];
-    expect(payload.mapId).toBe('map-1');
-    expect(payload.body.image_media_id).toBeNull();
-  });
 
   it('IMAGE 미디어만 선택해 장소 이미지 참조로 저장한다', () => {
     renderLocationsSubTab();

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.rounds.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.rounds.test.tsx
@@ -4,66 +4,51 @@ import {
   mockLocations,
   renderLocationsSubTab,
   setupDefaultMocks,
-  toastError,
   updateLocationMutateMock,
   useEditorLocationsMock,
 } from './locationsSubTabTestUtils';
 
-describe('LocationsSubTab 라운드 공개 시점', () => {
+describe('LocationsSubTab 장면 공개 시점', () => {
   beforeEach(setupDefaultMocks);
 
-  it('공개 시점을 제작자용 선택지로 표시한다', () => {
+  it('장소 공개 장면 선택지를 표시한다', () => {
     renderLocationsSubTab();
-    expect(screen.getByText('공개 시점')).toBeDefined();
+    expect(screen.getByText('공개 장면')).toBeDefined();
     expect(screen.getAllByText('처음부터 끝까지').length).toBeGreaterThan(0);
-    expect(screen.getByText('특정 라운드부터')).toBeDefined();
+    expect(screen.getByLabelText('거실 출현 장면')).toBeDefined();
+    expect(screen.getByLabelText('거실 숨김 장면')).toBeDefined();
   });
 
-  it('시작 라운드 값 입력 후 blur 하면 useUpdateLocation.mutate 가 호출된다', () => {
+  it('출현 장면을 선택하면 useUpdateLocation.mutate 가 호출된다', () => {
     renderLocationsSubTab();
-    fireEvent.click(screen.getByText('특정 라운드부터'));
     updateLocationMutateMock.mockClear();
-    const fromInput = screen.getByLabelText('거실 시작 라운드') as HTMLInputElement;
-    fireEvent.change(fromInput, { target: { value: '2' } });
-    fireEvent.blur(fromInput);
+    fireEvent.change(screen.getByLabelText('거실 출현 장면'), { target: { value: 'scene-1' } });
     expect(updateLocationMutateMock).toHaveBeenCalledOnce();
     const [payload] = updateLocationMutateMock.mock.calls[0] as [
       { locationId: string; body: Record<string, unknown> },
     ];
     expect(payload.locationId).toBe('loc-1');
-    expect(payload.body.from_round).toBe(2);
+    expect(payload.body.appearance_scene_id).toBe('scene-1');
+    expect(payload.body.hide_scene_id).toBeNull();
     expect(payload.body.name).toBe('거실');
   });
 
-  it('등장 > 퇴장 조합은 에러 토스트 후 저장되지 않는다', () => {
-    renderLocationsSubTab();
-    fireEvent.click(screen.getByText('특정 구간만'));
-    updateLocationMutateMock.mockClear();
-    const fromInput = screen.getByLabelText('거실 시작 라운드') as HTMLInputElement;
-    const untilInput = screen.getByLabelText('거실 종료 라운드') as HTMLInputElement;
-    fireEvent.change(untilInput, { target: { value: '2' } });
-    fireEvent.blur(untilInput);
-    updateLocationMutateMock.mockClear();
-    fireEvent.change(fromInput, { target: { value: '5' } });
-    fireEvent.blur(fromInput);
-    expect(updateLocationMutateMock).not.toHaveBeenCalled();
-    expect(toastError).toHaveBeenCalledWith('등장 라운드는 퇴장 라운드보다 클 수 없습니다');
-  });
-
-  it('값을 비우면 from_round 가 null 로 저장된다', () => {
+  it('숨김 장면을 선택하면 기존 출현 장면과 함께 저장한다', () => {
     useEditorLocationsMock.mockReturnValue({
-      data: [{ ...mockLocations[0], from_round: 2, until_round: 5 }, ...mockLocations.slice(1)],
+      data: [
+        { ...mockLocations[0], appearance_scene_id: 'scene-1', hide_scene_id: null },
+        ...mockLocations.slice(1),
+      ],
       isLoading: false,
     });
     renderLocationsSubTab();
-    const fromInput = screen.getByLabelText('거실 시작 라운드') as HTMLInputElement;
-    fireEvent.change(fromInput, { target: { value: '' } });
-    fireEvent.blur(fromInput);
+    updateLocationMutateMock.mockClear();
+    fireEvent.change(screen.getByLabelText('거실 숨김 장면'), { target: { value: 'scene-1' } });
     expect(updateLocationMutateMock).toHaveBeenCalledOnce();
     const [payload] = updateLocationMutateMock.mock.calls[0] as [
       { body: Record<string, unknown> },
     ];
-    expect(payload.body.from_round).toBeNull();
-    expect(payload.body.until_round).toBe(5);
+    expect(payload.body.appearance_scene_id).toBe('scene-1');
+    expect(payload.body.hide_scene_id).toBe('scene-1');
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -9,6 +9,8 @@ import {
   useEditorMapsMock,
   useMediaListMock,
 } from './locationsSubTabTestUtils';
+import { writeLocationDiscoveries } from '@/features/editor/editorTypes';
+import { mockTheme } from './locationsSubTabTestUtils';
 
 describe('LocationsSubTab', () => {
   describe('로딩 상태', () => {
@@ -29,8 +31,10 @@ describe('LocationsSubTab', () => {
 
     it('맵 이름들을 렌더링한다', () => {
       const { container } = renderLocationsSubTab();
-      expect(container.firstElementChild?.className).toContain('overflow-y-auto');
-      expect(container.firstElementChild?.className).toContain('md:overflow-hidden');
+      expect(container.firstElementChild?.className).toContain('overflow-hidden');
+      expect(container.firstElementChild?.className).toContain('bg-slate-950/40');
+      expect(screen.getByRole('combobox', { name: '맵 선택' })).toBeDefined();
+      expect(screen.queryByText('맵은 조사 단계가 아니라 장소들을 묶는 배치 컨테이너입니다.')).toBeNull();
       expect(screen.getAllByText('저택 1층').length).toBeGreaterThan(0);
       expect(screen.getByText('저택 2층')).toBeDefined();
     });
@@ -101,6 +105,25 @@ describe('LocationsSubTab', () => {
       expect(screen.getAllByText('거실').length).toBeGreaterThan(0);
     });
 
+    it('장소 상세에서 하위장소 설정을 표시하지 않는다', () => {
+      renderLocationsSubTab();
+
+      expect(screen.queryByText('장소 구조')).toBeNull();
+      expect(screen.queryByText('부모 장소')).toBeNull();
+      expect(screen.queryByText(/하위 조사 항목/)).toBeNull();
+      expect(screen.queryByText(/2단계/)).toBeNull();
+      expect(screen.getByText('소속 맵: 저택 1층')).toBeDefined();
+    });
+
+    it('장소 상세에서 장소 트리거 UI를 표시하지 않는다', () => {
+      renderLocationsSubTab();
+
+      expect(screen.queryByText('진행 연결')).toBeNull();
+      expect(screen.queryByText('장소 트리거')).toBeNull();
+      expect(screen.queryByRole('button', { name: '트리거 추가' })).toBeNull();
+      expect(screen.queryByRole('button', { name: '트리거 저장' })).toBeNull();
+    });
+
     it('맵 선택 시 공통 엔티티 Shell로 해당 맵의 장소만 표시한다', () => {
       renderLocationsSubTab();
       expect(screen.getByRole('region', { name: '장소 목록' })).toBeDefined();
@@ -114,7 +137,7 @@ describe('LocationsSubTab', () => {
     it('다른 맵을 선택하면 해당 맵의 장소 workspace로 전환한다', () => {
       renderLocationsSubTab();
 
-      fireEvent.click(screen.getByRole('button', { name: '저택 2층' }));
+      fireEvent.change(screen.getByRole('combobox', { name: '맵 선택' }), { target: { value: 'map-2' } });
 
       expect(screen.getByRole('region', { name: '장소 목록' })).toBeDefined();
       expect(screen.getAllByText('침실').length).toBeGreaterThan(0);
@@ -126,6 +149,15 @@ describe('LocationsSubTab', () => {
       useEditorLocationsMock.mockReturnValue({ data: [], isLoading: false });
       renderLocationsSubTab();
       expect(screen.getByText('장소 없음')).toBeDefined();
+    });
+
+    it('장소가 없는 맵에서도 장소 추가 입력을 표시한다', () => {
+      useEditorLocationsMock.mockReturnValue({ data: [], isLoading: false });
+      renderLocationsSubTab();
+
+      fireEvent.click(screen.getByRole('button', { name: '장소 추가' }));
+
+      expect(screen.getByPlaceholderText('장소 이름')).toBeDefined();
     });
   });
 
@@ -184,6 +216,78 @@ describe('LocationsSubTab', () => {
         id: 'loc-1',
         locationClueConfig: { clueIds: ['clue-1'] },
       });
+    });
+
+    it('배정된 단서는 해제할 수 있고 선택한 단서 하나의 조사 설정만 표시한다', () => {
+      const config = writeLocationDiscoveries(null, 'loc-1', [
+        { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: [], oncePerPlayer: true },
+      ]);
+      renderLocationsSubTab({ ...mockTheme, config_json: config });
+
+      expect(screen.getByText('조사 설정')).toBeDefined();
+      expect(screen.queryByText('조사 결과')).toBeNull();
+      expect((screen.getByLabelText('단검 무료 조사') as HTMLInputElement).checked).toBe(false);
+      expect(screen.queryByLabelText('단검 조사권 종류')).toBeNull();
+      expect(screen.getByLabelText('단검 조사권 소비량')).toBeDefined();
+
+      fireEvent.click(screen.getByRole('button', { name: '단검 해제' }));
+      expect(updateConfigMutateMock).toHaveBeenCalledOnce();
+    });
+
+    it('무료 조사를 체크하면 조사권 필드 대신 무료 비용 설정을 저장한다', () => {
+      const config = writeLocationDiscoveries(null, 'loc-1', [
+        { locationId: 'loc-1', clueId: 'clue-1', requiredClueIds: [], oncePerPlayer: true },
+      ]);
+      renderLocationsSubTab({ ...mockTheme, config_json: config });
+
+      fireEvent.click(screen.getByLabelText('단검 무료 조사'));
+
+      expect(updateConfigMutateMock).toHaveBeenCalledOnce();
+      const [nextConfig] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
+      const modules = nextConfig.modules as {
+        deck_investigation: { config: { decks: Array<{ tokenCost: number }> } };
+      };
+      const deckConfig = modules.deck_investigation.config;
+      expect(deckConfig.decks[0]?.tokenCost).toBe(0);
+    });
+
+    it('장소 덱 단서를 드래그앤드롭으로 재정렬하면 순서를 저장한다', () => {
+      const config = writeLocationDiscoveries(null, 'loc-1', [
+        {
+          locationId: 'loc-1',
+          clueId: 'clue-1',
+          requiredClueIds: [],
+          oncePerPlayer: true,
+          order: 0,
+        },
+        {
+          locationId: 'loc-1',
+          clueId: 'clue-2',
+          requiredClueIds: [],
+          oncePerPlayer: true,
+          order: 1,
+        },
+      ]);
+      renderLocationsSubTab({ ...mockTheme, config_json: config });
+
+      fireEvent.dragStart(screen.getByLabelText('단검 순서 이동'));
+      fireEvent.dragEnter(screen.getByLabelText('서류 순서 이동'));
+      fireEvent.drop(screen.getByLabelText('서류 순서 이동'));
+
+      expect(updateConfigMutateMock).toHaveBeenCalledOnce();
+      const [nextConfig] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
+      const modules = nextConfig.modules as {
+        location: {
+          config: {
+            discoveries: Array<{ clueId: string; order?: number }>;
+          };
+        };
+      };
+      const reordered = modules.location.config.discoveries.filter((item) => item.locationId === 'loc-1');
+      expect(reordered.map((item) => [item.clueId, item.order])).toEqual([
+        ['clue-2', 0],
+        ['clue-1', 1],
+      ]);
     });
 
     it('맵이 없으면 단서 배정 picker 가 표시되지 않는다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestData.ts
+++ b/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestData.ts
@@ -84,6 +84,22 @@ export const mockClues = [
     use_target: null,
     use_consumed: false,
   },
+  {
+    id: 'clue-2',
+    theme_id: 'theme-1',
+    location_id: null,
+    name: '서류',
+    description: null,
+    image_url: null,
+    is_common: false,
+    level: 1,
+    sort_order: 1,
+    created_at: '2026-04-13T00:00:00Z',
+    is_usable: false,
+    use_effect: null,
+    use_target: null,
+    use_consumed: false,
+  },
 ];
 
 export const mockCharacters = [

--- a/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestUtils.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestUtils.tsx
@@ -114,6 +114,7 @@ vi.mock('@tanstack/react-query', async () => {
 });
 
 import { LocationsSubTab } from '../LocationsSubTab';
+import type { EditorThemeResponse } from '@/features/editor/api';
 import {
   mockCharacters as fixtureCharacters,
   mockClues as fixtureClues,
@@ -172,8 +173,8 @@ export function setupDefaultMocks() {
   });
 }
 
-export function renderLocationsSubTab() {
-  return render(<LocationsSubTab themeId="theme-1" theme={fixtureTheme} />);
+export function renderLocationsSubTab(theme: EditorThemeResponse = fixtureTheme as EditorThemeResponse) {
+  return render(<LocationsSubTab themeId="theme-1" theme={theme} />);
 }
 
 afterEach(() => {

--- a/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
+++ b/apps/web/src/features/editor/components/story-map/EditorEntityLibrary.tsx
@@ -81,8 +81,8 @@ function mapLocations(locations: LocationResponse[] = []): StoryLibraryEntity[] 
     kind: "location",
     title: location.name,
     detail:
-      location.from_round != null || location.until_round != null
-        ? "공개 구간 있음"
+      location.appearance_scene_id != null || location.hide_scene_id != null
+        ? "공개 장면 있음"
         : "상시 사용 가능",
     section: "장소",
     connectable: true,

--- a/apps/web/src/features/editor/components/story-map/__tests__/EditorEntityLibrary.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/EditorEntityLibrary.test.tsx
@@ -48,7 +48,7 @@ beforeEach(() => {
     isError: false,
   });
   useEditorLocationsMock.mockReturnValue({
-    data: [{ id: "loc-1", name: "응접실", from_round: 0, until_round: null }],
+    data: [{ id: "loc-1", name: "응접실", appearance_scene_id: "scene-1", hide_scene_id: null }],
     isLoading: false,
     isError: false,
   });
@@ -68,7 +68,7 @@ describe("EditorEntityLibrary", () => {
     expect(screen.getByText("찢어진 초대장")).toBeDefined();
     expect(screen.getByText("피 묻은 장갑")).toBeDefined();
     expect(screen.getByText("응접실")).toBeDefined();
-    expect(screen.getByText("공개 구간 있음")).toBeDefined();
+    expect(screen.getByText("공개 장면 있음")).toBeDefined();
     expect(screen.getByText("오프닝 음악")).toBeDefined();
     expect(screen.getByText("조사권")).toBeDefined();
     expect(screen.getByText("토론방")).toBeDefined();

--- a/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/StoryMapWorkspace.test.tsx
@@ -50,7 +50,7 @@ describe("StoryMapWorkspace", () => {
       isError: false,
     });
     useEditorLocationsMock.mockReturnValue({
-      data: [{ id: "loc-1", name: "응접실", from_round: 1, until_round: 2 }],
+      data: [{ id: "loc-1", name: "응접실", appearance_scene_id: "scene-1", hide_scene_id: "scene-2" }],
       isLoading: false,
       isError: false,
     });

--- a/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
@@ -295,7 +295,11 @@ describe('deckInvestigationAdapter', () => {
     });
 
     expect(removeLocationClueInvestigationCost(paid, 'loc-1', 'clue-1').decks).toEqual([]);
-    expect(readLocationClueInvestigationCost(paid, 'loc-1', 'missing')).toEqual({ mode: 'free' });
+    expect(readLocationClueInvestigationCost(paid, 'loc-1', 'missing')).toEqual({
+      mode: 'token',
+      tokenId: 'investigation-token',
+      tokenCost: 1,
+    });
     expect(formatInvestigationCostLabel({ mode: 'free' }, paid.tokens)).toBe('무료 조사');
   });
 

--- a/apps/web/src/features/editor/entities/deckInvestigation/locationClueInvestigationCost.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/locationClueInvestigationCost.ts
@@ -30,7 +30,8 @@ export function readLocationClueInvestigationCost(
   clueId: string,
 ): InvestigationCostDraft {
   const deck = draft.decks.find((item) => item.id === buildLocationClueDeckId(locationId, clueId));
-  if (!deck || deck.tokenCost <= 0) return { mode: 'free' };
+  if (!deck) return { mode: 'token', tokenId: draft.tokens[0]?.id ?? DEFAULT_TOKEN_ID, tokenCost: 1 };
+  if (deck.tokenCost <= 0) return { mode: 'free' };
   return { mode: 'token', tokenId: deck.tokenId, tokenCost: deck.tokenCost };
 }
 
@@ -46,13 +47,9 @@ export function writeLocationClueInvestigationCost(
   },
 ): DeckInvestigationConfigDraft {
   const deckId = buildLocationClueDeckId(params.locationId, params.clueId);
-  if (params.cost.mode === 'free') {
-    return { ...draft, decks: draft.decks.filter((deck) => deck.id !== deckId) };
-  }
-
   const fallbackTokenId = draft.tokens[0]?.id ?? DEFAULT_TOKEN_ID;
-  const tokenId = params.cost.tokenId || fallbackTokenId;
-  const tokenCost = Math.max(1, Math.floor(params.cost.tokenCost));
+  const tokenId = params.cost.mode === 'token' ? params.cost.tokenId || fallbackTokenId : fallbackTokenId;
+  const tokenCost = params.cost.mode === 'token' ? Math.max(1, Math.floor(params.cost.tokenCost)) : 0;
   const existingDeck = draft.decks.find((deck) => deck.id === deckId);
   const nextDeck = {
     ...createInvestigationDeckDraft(draft.decks.length, tokenId),

--- a/apps/web/src/features/editor/entities/deckInvestigation/locationClueInvestigationCost.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/locationClueInvestigationCost.ts
@@ -48,7 +48,9 @@ export function writeLocationClueInvestigationCost(
 ): DeckInvestigationConfigDraft {
   const deckId = buildLocationClueDeckId(params.locationId, params.clueId);
   const fallbackTokenId = draft.tokens[0]?.id ?? DEFAULT_TOKEN_ID;
-  const tokenId = params.cost.mode === 'token' ? params.cost.tokenId || fallbackTokenId : fallbackTokenId;
+  const tokenId = params.cost.mode === 'token'
+    ? params.cost.tokenId || fallbackTokenId
+    : draft.tokens[0]?.id ?? '';
   const tokenCost = params.cost.mode === 'token' ? Math.max(1, Math.floor(params.cost.tokenCost)) : 0;
   const existingDeck = draft.decks.find((deck) => deck.id === deckId);
   const nextDeck = {

--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
@@ -45,10 +45,10 @@ describe('EntityEditorShell', () => {
     expect(screen.getByLabelText('검수 슬롯').textContent).toContain('첫 단서 검수');
     expect(screen.getByText('2개의 단서')).toBeDefined();
     expect(container.firstElementChild?.className).toContain('min-h-0');
-    expect(container.firstElementChild?.className).toContain('lg:overflow-hidden');
+    expect(container.firstElementChild?.className).toContain('overflow-y-auto');
   });
 
-  it('데스크톱에서는 목록과 상세 패널이 각자 스크롤 책임을 가진다', () => {
+  it('데스크톱에서는 Shell 하나만 스크롤 책임을 가진다', () => {
     renderShell();
 
     const list = screen.getByRole('region', { name: '단서 목록' });
@@ -61,9 +61,8 @@ describe('EntityEditorShell', () => {
     expect(list.className).toContain('min-h-0');
     expect(list.className).toContain('shrink-0');
     expect(detail.className).toContain('shrink-0');
-    expect(listScroller?.className).toContain('lg:flex-1');
-    expect(listScroller?.className).toContain('lg:overflow-y-auto');
-    expect(detail.className).toContain('lg:overflow-y-auto');
+    expect(listScroller).toBeUndefined();
+    expect(detail.className).not.toContain('lg:overflow-y-auto');
   });
 
   it('검색어에 맞는 항목만 보여준다', () => {

--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
@@ -71,12 +71,17 @@ export function EntityEditorShell<TItem>({
             <Plus className="h-4 w-4" />{actionLabel}
           </button>
         )}
+        {listAccessory && (
+          <div className="mx-auto mt-4 w-full max-w-sm text-left">
+            {listAccessory}
+          </div>
+        )}
       </div>
     );
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto lg:grid lg:grid-cols-[minmax(14rem,0.72fr)_minmax(0,1.9fr)] lg:overflow-hidden">
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto lg:grid lg:grid-cols-[minmax(14rem,0.72fr)_minmax(0,1.9fr)]">
       <section
         aria-label={`${title} 목록`}
         className="flex min-h-0 shrink-0 flex-col rounded-xl border border-slate-800 bg-slate-950/70 p-3"
@@ -109,7 +114,7 @@ export function EntityEditorShell<TItem>({
             className="w-full rounded-lg border border-slate-800 bg-slate-900 py-2.5 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
           />
         </label>
-        <div className="min-h-0 space-y-2 pr-1 lg:flex-1 lg:overflow-y-auto">
+        <div className="space-y-2 pr-1">
           {visibleItems.length === 0 ? (
             <p className="rounded-lg border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
               검색 결과가 없습니다.
@@ -135,7 +140,7 @@ export function EntityEditorShell<TItem>({
 
       {selected && (
         <section
-          className="min-h-0 shrink-0 overflow-y-visible lg:overflow-y-auto lg:pr-2"
+          className="min-h-0 shrink-0 overflow-y-visible lg:pr-2"
           aria-label={`${title} 상세 영역`}
         >
           <div className="space-y-4 pb-4">


### PR DESCRIPTION
## 요약
- 장소관리 탭을 맵 바 + 장소 설정 패널 중심 UI로 정리했습니다.
- 지도 이미지/장소 트리거/하위장소 설정처럼 현재 설계와 맞지 않는 UI를 제거했습니다.
- 단서 선택/해제, 선택 단서별 조사 설정, 무료 조사 토글, 덱 단서 순서 조정 UI를 개선했습니다.
- 에디터 레이아웃 이중 스크롤 회귀와 관련 shell/story-map 표시를 정리했습니다.

## Coverage Plan
- Location UI: `LocationsSubTab`, `LocationDetailPanel`, `LocationClueAssignPanel`, `LocationAccessPolicyPanel`, `InvestigationCostSelector`.
- Shell/Layout: `EditorLayout`, `EntityEditorShell`의 scroll/slot 동작.
- Story-map references: location entity library labels/placement smoke coverage.
- Deck investigation cost: location clue cost adapter와 무료/유료 비용 표시 경로.

## Local validation
- `pnpm --filter @mmp/web exec vitest run src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.media.test.tsx` 성공: 3 files, 31 tests.
- `scripts/mmp-local-ci.sh quick` 성공: Go tests, web lint, typecheck, Vitest 181 files/1647 tests, build.

## Notes
- 진행플로우 수사 장면의 맵 선택 UI는 별도 PR로 분리합니다.

Refs #558


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 위치 공개 시점을 라운드 기반에서 장면(appearance/hide) 기반으로 변경
  * 모듈 설정에서 위치 조사 모드 선택 가능(조사 모드 및 덱 순서)
  * 위치 상세 편집에서 활성 단서 편집 집중(하이라이트 및 선택 전용 패널)

* **Bug Fixes**
  * 조사 비용을 무료로 전환해도 관련 덱/항목이 유지되도록 수정

* **UI/UX Improvements**
  * 편집 레이아웃의 스크롤·뷰포트 동작 개선
  * 위치 목록·상세 UI 단순화 및 조사 비용 선택 인터페이스 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/560)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->