### PR TITLE
feat(editor): 수사 장면 맵 연동

### DIFF
--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -134,6 +134,7 @@ function InvestigationMapField({
   onFlush: () => void;
 }) {
   const selectedMapExists = !mapId || maps.some((map) => map.id === mapId);
+  const showMissingMapWarning = !isLoading && !selectedMapExists;
 
   return (
     <label className="flex flex-col gap-1">
@@ -160,7 +161,7 @@ function InvestigationMapField({
       <p className="text-[11px] leading-4 text-slate-500">
         이 수사 장면에서 플레이어에게 보여줄 장소 묶음입니다.
       </p>
-      {!selectedMapExists ? (
+      {showMissingMapWarning ? (
         <p className="rounded border border-amber-500/20 bg-amber-500/10 px-2 py-1.5 text-[11px] leading-4 text-amber-100">
           이전에 선택한 맵을 찾을 수 없습니다. 사용할 맵을 다시 선택해 주세요.
         </p>

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -1,6 +1,7 @@
 import type { Edge, Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useEditorMaps } from "../../editorMapApi";
 import { useUpdateFlowNode } from "../../flowApi";
 import type {
   FlowGraphResponse,
@@ -29,6 +30,7 @@ const SAVE_DEBOUNCE_MS = 1500;
 
 export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
+  const { data: maps = [], isLoading: mapsLoading } = useEditorMaps(themeId);
   const queryClient = useQueryClient();
   const data = node.data as FlowNodeData;
   const phaseType = normalizePhaseType(data.phase_type);
@@ -76,11 +78,20 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
         onFlush={flush}
       />
       {phaseType === "investigation" ? (
-        <InvestigationPhasePanel
-          duration={data.duration}
-          onChange={handleChange}
-          onFlush={flush}
-        />
+        <>
+          <InvestigationMapField
+            mapId={data.investigationMapId}
+            maps={maps}
+            isLoading={mapsLoading}
+            onChange={handleChange}
+            onFlush={flush}
+          />
+          <InvestigationPhasePanel
+            duration={data.duration}
+            onChange={handleChange}
+            onFlush={flush}
+          />
+        </>
       ) : null}
       {phaseType === "discussion" ? (
         <DiscussionPhasePanel
@@ -106,6 +117,55 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
         />
       ) : null}
     </div>
+  );
+}
+
+function InvestigationMapField({
+  mapId,
+  maps,
+  isLoading,
+  onChange,
+  onFlush,
+}: {
+  mapId?: string;
+  maps: Array<{ id: string; name: string }>;
+  isLoading: boolean;
+  onChange: (patch: Partial<FlowNodeData>) => void;
+  onFlush: () => void;
+}) {
+  const selectedMapExists = !mapId || maps.some((map) => map.id === mapId);
+
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px] text-slate-400">사용할 맵</span>
+      <select
+        value={mapId ?? ""}
+        disabled={isLoading || maps.length === 0}
+        aria-label="사용할 맵"
+        onChange={(event) =>
+          onChange({ investigationMapId: event.target.value || undefined })
+        }
+        onBlur={onFlush}
+        className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <option value="">
+          {maps.length === 0 ? "등록된 맵 없음" : "맵 선택"}
+        </option>
+        {maps.map((map) => (
+          <option key={map.id} value={map.id}>
+            {map.name}
+          </option>
+        ))}
+      </select>
+      <p className="text-[11px] leading-4 text-slate-500">
+        이 수사 장면에서 플레이어에게 보여줄 장소 묶음입니다.
+      </p>
+      {!selectedMapExists ? (
+        <p className="rounded border border-amber-500/20 bg-amber-500/10 px-2 py-1.5 text-[11px] leading-4 text-amber-100">
+          이전에 선택한 맵을 찾을 수 없습니다. 사용할 맵을 다시 선택해 주세요.
+        </p>
+      ) : null}
+    </label>
   );
 }
 

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -140,7 +140,7 @@ function InvestigationMapField({
       <span className="text-[11px] text-slate-400">사용할 맵</span>
       <select
         value={mapId ?? ""}
-        disabled={isLoading || maps.length === 0}
+        disabled={isLoading}
         aria-label="사용할 맵"
         onChange={(event) =>
           onChange({ investigationMapId: event.target.value || undefined })

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx
@@ -21,6 +21,10 @@ vi.mock("../../../flowApi", () => ({
   useUpdateFlowNode: () => useUpdateFlowNodeMock(),
 }));
 
+vi.mock("../../../editorMapApi", () => ({
+  useEditorMaps: () => ({ data: [], isLoading: false }),
+}));
+
 import { PhaseNodePanel } from "../PhaseNodePanel";
 import { flowKeys } from "../../../flowTypes";
 import type { FlowGraphResponse } from "../../../flowTypes";
@@ -161,7 +165,7 @@ describe("PhaseNodePanel debounce + onBlur flush", () => {
       />,
     );
 
-    const select = screen.getByRole("combobox");
+    const select = screen.getByLabelText("타입");
     fireEvent.change(select, { target: { value: "voting" } });
     fireEvent.blur(select);
     expect(mutateMock).toHaveBeenCalledTimes(1);

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -11,6 +11,30 @@ vi.mock("../../../flowApi", () => ({
   useUpdateFlowNode: () => ({ mutate: vi.fn() }),
 }));
 
+vi.mock("../../../editorMapApi", () => ({
+  useEditorMaps: () => ({
+    data: [
+      {
+        id: "map-1",
+        theme_id: "t1",
+        name: "저택 1층",
+        image_url: null,
+        sort_order: 1,
+        created_at: "2026-04-15T00:00:00Z",
+      },
+      {
+        id: "map-2",
+        theme_id: "t1",
+        name: "저택 2층",
+        image_url: null,
+        sort_order: 2,
+        created_at: "2026-04-15T00:00:00Z",
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
 vi.mock("../../../readingApi", () => ({
   useReadingSections: () => ({
     data: [{ id: "rs-1", name: "오프닝 낭독", lines: [{ Text: "시작" }] }],
@@ -49,7 +73,7 @@ const makeNode = (data: Record<string, unknown> = {}) => ({
 });
 
 describe("PhaseNodePanel type-specific fields", () => {
-  it("수사 장면은 기본 정보, 시간, 자동 진행 안내만 표시한다", () => {
+  it("수사 장면은 기본 정보, 시간, 맵 선택, 자동 진행 안내를 표시한다", () => {
     renderWithQC(
       <PhaseNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
     );
@@ -58,6 +82,7 @@ describe("PhaseNodePanel type-specific fields", () => {
     expect(screen.getByLabelText("라벨")).toBeDefined();
     expect(screen.getByLabelText("타입")).toBeDefined();
     expect(screen.getByLabelText("시간 (분)")).toBeDefined();
+    expect(screen.getByLabelText("사용할 맵")).toBeDefined();
     expect(screen.getByText(/다음 연결 장면으로 자동 진행/)).toBeDefined();
 
     expect(screen.queryByText("라운드 수")).toBeNull();
@@ -65,6 +90,20 @@ describe("PhaseNodePanel type-specific fields", () => {
     expect(screen.queryByText("토론방 설정")).toBeNull();
     expect(screen.queryByText("읽기 대사 배치")).toBeNull();
     expect(screen.queryByText("장면 시작 트리거")).toBeNull();
+  });
+
+  it("수사 장면에서 사용할 맵을 선택하면 investigationMapId를 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel node={makeNode({ investigationMapId: "map-1" })} themeId="t1" onUpdate={onUpdate} />,
+    );
+
+    const mapSelect = screen.getByLabelText("사용할 맵") as HTMLSelectElement;
+    expect(mapSelect.value).toBe("map-1");
+
+    fireEvent.change(mapSelect, { target: { value: "map-2" } });
+
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", { investigationMapId: "map-2" });
   });
 
   it("진행 시간은 음수를 0으로 보정하고 빈 값은 제거한다", () => {
@@ -101,6 +140,7 @@ describe("PhaseNodePanel type-specific fields", () => {
     );
 
     expect(screen.getByText("토론방 설정")).toBeDefined();
+    expect(screen.queryByLabelText("사용할 맵")).toBeNull();
     expect((screen.getByLabelText("전체토론방 이름") as HTMLInputElement).value).toBe("전체 토론");
     expect((screen.getByLabelText("밀담방 1 이름") as HTMLInputElement).value).toBe("비밀방");
     expect((screen.getByLabelText("최대 인원") as HTMLInputElement).value).toBe("3");

--- a/apps/web/src/features/editor/flowTypes.ts
+++ b/apps/web/src/features/editor/flowTypes.ts
@@ -42,6 +42,7 @@ export interface FlowNodeData {
   label?: string;
   phase_type?: string;
   duration?: number;
+  investigationMapId?: string;
   rounds?: number;
   description?: string;
   icon?: string;


### PR DESCRIPTION
## 요약
- 수사 장면 설정에 사용할 맵 선택 필드를 추가했습니다.
- 선택값은 flow node data의 `investigationMapId`로 저장됩니다.
- `PhaseNodePanel` 테스트에서 수사 장면 맵 선택/저장과 기존 debounce 동작을 검증했습니다.

## Issue
Refs #558

## Coverage Plan
- `PhaseNodePanel.tsx`: 수사 장면에서만 맵 선택 필드가 표시되고, 선택값이 `onUpdate` 흐름으로 저장되는지 검증합니다.
- `flowTypes.ts`: `investigationMapId` 필드 타입 추가는 `PhaseNodePanel` 테스트와 typecheck로 검증합니다.
- `PhaseNodePanelDebounce.test.tsx`: 기존 타입 select debounce/flush가 새 맵 select 추가 후에도 깨지지 않는지 검증합니다.

## Local validation
- `pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web build` 통과
- `scripts/mmp-local-ci.sh quick` 통과
  - web lint는 기존 warning 48개만 있고 error 0개
  - web Vitest 181 files / 1648 tests passed
  - web build 통과, 기존 Rollup barrel/chunk warning은 남아 있음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 조사(수사) 단계에서 사용할 맵을 선택하는 UI가 추가되었습니다. 로딩 중에는 선택기가 비활성화되며 등록된 맵이 없을 땐 빈 상태가 표시됩니다.
  * 선택된 맵은 단계 데이터에 저장(investigationMapId)되어 유지됩니다.

* **버그 수정 / 사용성**
  * 선택 필드에서 포커스를 벗어날 때(debounce) 변경사항이 플러시됩니다.
  * 선택된 맵이 목록에 없을 경우 경고가 표시됩니다.

* **테스트**
  * 맵 로드/선택, onBlur 디바운스 및 유효성 검사 동작에 대한 테스트가 추가·확장되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/561)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->