### PR TITLE
fix(editor): 결말 flow 저장 계약 보존

### DIFF
--- a/apps/server/internal/domain/flow/db_helpers.go
+++ b/apps/server/internal/domain/flow/db_helpers.go
@@ -30,10 +30,26 @@ func insertNode(ctx context.Context, q dbConn, themeID uuid.UUID, nodeType strin
 	return scanNode(row)
 }
 
+func insertNodeWithID(ctx context.Context, q dbConn, id, themeID uuid.UUID, nodeType string, data json.RawMessage, x, y float64) (*FlowNode, error) {
+	row := q.QueryRow(ctx,
+		`INSERT INTO flow_nodes (id, theme_id, type, data, position_x, position_y) VALUES ($1,$2,$3,$4,$5,$6) RETURNING *`,
+		id, themeID, nodeType, data, x, y,
+	)
+	return scanNode(row)
+}
+
 func insertEdge(ctx context.Context, q dbConn, themeID, srcID, tgtID uuid.UUID, condition json.RawMessage, label *string, sortOrder int32) (*FlowEdge, error) {
 	row := q.QueryRow(ctx,
 		`INSERT INTO flow_edges (theme_id, source_id, target_id, condition, label, sort_order) VALUES ($1,$2,$3,$4,$5,$6) RETURNING *`,
 		themeID, srcID, tgtID, condition, label, sortOrder,
+	)
+	return scanEdge(row)
+}
+
+func insertEdgeWithID(ctx context.Context, q dbConn, id, themeID, srcID, tgtID uuid.UUID, condition json.RawMessage, label *string, sortOrder int32) (*FlowEdge, error) {
+	row := q.QueryRow(ctx,
+		`INSERT INTO flow_edges (id, theme_id, source_id, target_id, condition, label, sort_order) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *`,
+		id, themeID, srcID, tgtID, condition, label, sortOrder,
 	)
 	return scanEdge(row)
 }

--- a/apps/server/internal/domain/flow/handler_extra_test.go
+++ b/apps/server/internal/domain/flow/handler_extra_test.go
@@ -52,7 +52,7 @@ func TestUpdateNode_Success(t *testing.T) {
 		},
 	}
 	r := newRouter(NewHandler(svc))
-	body, _ := json.Marshal(UpdateNodeRequest{Type: NodeTypePhase, PositionX: 100, PositionY: 200})
+	body, _ := json.Marshal(UpdateNodeRequest{Type: NodeTypePhase, PositionX: flowFloat64Ptr(100), PositionY: flowFloat64Ptr(200)})
 	req := withAuth(httptest.NewRequest(http.MethodPatch, "/themes/"+themeID.String()+"/flow/nodes/"+nodeID.String(), bytes.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/apps/server/internal/domain/flow/models.go
+++ b/apps/server/internal/domain/flow/models.go
@@ -82,8 +82,8 @@ type CreateNodeRequest struct {
 type UpdateNodeRequest struct {
 	Type      string          `json:"type"`
 	Data      json.RawMessage `json:"data"`
-	PositionX float64         `json:"position_x"`
-	PositionY float64         `json:"position_y"`
+	PositionX *float64        `json:"position_x"`
+	PositionY *float64        `json:"position_y"`
 }
 
 // CreateEdgeRequest creates a single new edge.

--- a/apps/server/internal/domain/flow/service.go
+++ b/apps/server/internal/domain/flow/service.go
@@ -74,30 +74,33 @@ func (s *serviceImpl) SaveFlow(ctx context.Context, creatorID, themeID uuid.UUID
 		return nil, apperror.Internal("failed to clear nodes")
 	}
 
-	// Insert nodes and build id map (client id → db id)
-	idMap := make(map[uuid.UUID]uuid.UUID, len(req.Nodes))
+	// Insert nodes using client-provided IDs when available. The editor keeps
+	// those IDs in local state and may PATCH a node immediately after autosave.
 	nodes := make([]FlowNode, 0, len(req.Nodes))
 	for _, n := range req.Nodes {
 		data := n.Data
 		if data == nil {
 			data = json.RawMessage(`{}`)
 		}
-		node, err := insertNode(ctx, tx, themeID, n.Type, data, n.PositionX, n.PositionY)
+		nodeID := uuid.New()
+		if n.ID != nil {
+			nodeID = *n.ID
+		}
+		node, err := insertNodeWithID(ctx, tx, nodeID, themeID, n.Type, data, n.PositionX, n.PositionY)
 		if err != nil {
 			return nil, err
 		}
 		nodes = append(nodes, *node)
-		if n.ID != nil {
-			idMap[*n.ID] = node.ID
-		}
 	}
 
-	// Insert edges (remap client ids)
+	// Insert edges after nodes so FK checks validate endpoints.
 	edges := make([]FlowEdge, 0, len(req.Edges))
 	for _, e := range req.Edges {
-		srcID := remapID(idMap, e.SourceID)
-		tgtID := remapID(idMap, e.TargetID)
-		edge, err := insertEdge(ctx, tx, themeID, srcID, tgtID, e.Condition, e.Label, e.SortOrder)
+		edgeID := uuid.New()
+		if e.ID != nil {
+			edgeID = *e.ID
+		}
+		edge, err := insertEdgeWithID(ctx, tx, edgeID, themeID, e.SourceID, e.TargetID, e.Condition, e.Label, e.SortOrder)
 		if err != nil {
 			return nil, err
 		}
@@ -139,16 +142,22 @@ func (s *serviceImpl) CreateNode(ctx context.Context, creatorID, themeID uuid.UU
 }
 
 func (s *serviceImpl) UpdateNode(ctx context.Context, creatorID, themeID, nodeID uuid.UUID, req UpdateNodeRequest) (*FlowNode, error) {
-	if err := ValidateNodeType(req.Type); err != nil {
-		return nil, err
+	if req.Type != "" {
+		if err := ValidateNodeType(req.Type); err != nil {
+			return nil, err
+		}
 	}
 	data := req.Data
-	if data == nil {
-		data = json.RawMessage(`{}`)
+	if len(data) == 0 {
+		data = nil
 	}
 	row := s.pool.QueryRow(ctx,
 		`UPDATE flow_nodes n
-		SET type=$2, data=$3, position_x=$4, position_y=$5, updated_at=now()
+		SET type = CASE WHEN $2 = '' THEN n.type ELSE $2 END,
+			data = COALESCE($3, n.data),
+			position_x = COALESCE($4, n.position_x),
+			position_y = COALESCE($5, n.position_y),
+			updated_at = now()
 		FROM themes t
 		WHERE n.id=$1 AND n.theme_id=$6 AND t.id=n.theme_id AND t.creator_id=$7
 		RETURNING n.*`,
@@ -360,11 +369,4 @@ func validateSaveRequest(req SaveFlowRequest) error {
 		edges[i] = FlowEdge{SourceID: e.SourceID, TargetID: e.TargetID}
 	}
 	return ValidateDAG(nodes, edges)
-}
-
-func remapID(m map[uuid.UUID]uuid.UUID, id uuid.UUID) uuid.UUID {
-	if newID, ok := m[id]; ok {
-		return newID
-	}
-	return id
 }

--- a/apps/server/internal/domain/flow/service.go
+++ b/apps/server/internal/domain/flow/service.go
@@ -355,16 +355,57 @@ func ensureEdgeEndpointsInTheme(ctx context.Context, q dbConn, themeID, sourceID
 
 func validateSaveRequest(req SaveFlowRequest) error {
 	nodes := make([]FlowNode, len(req.Nodes))
+	nodeIDs := make(map[uuid.UUID]struct{}, len(req.Nodes))
 	for i, n := range req.Nodes {
 		if err := ValidateNodeType(n.Type); err != nil {
 			return err
 		}
-		nodes[i] = FlowNode{ID: uuid.New(), Type: n.Type}
+		nodeID := uuid.New()
+		if n.ID != nil {
+			if *n.ID == uuid.Nil {
+				return apperror.Validation("flow node id is invalid", []apperror.FieldError{{
+					Field:   "nodes.id",
+					Message: "node id must be a valid UUID",
+					Code:    "invalid_uuid",
+				}})
+			}
+			nodeID = *n.ID
+		}
+		if _, exists := nodeIDs[nodeID]; exists {
+			return apperror.Validation("flow node id is duplicated", []apperror.FieldError{{
+				Field:   "nodes.id",
+				Message: "node ids must be unique",
+				Code:    "duplicate",
+			}})
+		}
+		nodeIDs[nodeID] = struct{}{}
+		nodes[i] = FlowNode{ID: nodeID, Type: n.Type}
 	}
 	edges := make([]FlowEdge, len(req.Edges))
 	for i, e := range req.Edges {
 		if err := ValidateEdgeCondition(e.Condition); err != nil {
 			return err
+		}
+		if e.SourceID == uuid.Nil || e.TargetID == uuid.Nil {
+			return apperror.Validation("flow edge endpoint is invalid", []apperror.FieldError{{
+				Field:   "edges.endpoint",
+				Message: "edge endpoints must be valid UUIDs",
+				Code:    "invalid_uuid",
+			}})
+		}
+		if _, ok := nodeIDs[e.SourceID]; !ok {
+			return apperror.Validation("flow edge source node was not found", []apperror.FieldError{{
+				Field:   "edges.source_id",
+				Message: "edge source_id must reference a node in the same flow",
+				Code:    "not_found",
+			}})
+		}
+		if _, ok := nodeIDs[e.TargetID]; !ok {
+			return apperror.Validation("flow edge target node was not found", []apperror.FieldError{{
+				Field:   "edges.target_id",
+				Message: "edge target_id must reference a node in the same flow",
+				Code:    "not_found",
+			}})
 		}
 		edges[i] = FlowEdge{SourceID: e.SourceID, TargetID: e.TargetID}
 	}

--- a/apps/server/internal/domain/flow/service_ownership_test.go
+++ b/apps/server/internal/domain/flow/service_ownership_test.go
@@ -75,8 +75,8 @@ func TestServiceFlowOwnership_RejectsDifferentCreatorMutations(t *testing.T) {
 	if _, err := svc.UpdateNode(ctx, otherCreatorID, themeID, startNode.ID, UpdateNodeRequest{
 		Type:      NodeTypeEnding,
 		Data:      json.RawMessage(`{"label":"탈취"}`),
-		PositionX: 999,
-		PositionY: 999,
+		PositionX: flowFloat64Ptr(999),
+		PositionY: flowFloat64Ptr(999),
 	}); err == nil {
 		t.Fatal("expected UpdateNode to reject a different creator")
 	} else {
@@ -159,8 +159,8 @@ func TestServiceFlowOwnership_RejectsCrossThemeEdgeEndpoints(t *testing.T) {
 	if _, err := svc.UpdateNode(ctx, creatorID, themeAID, nodeB.ID, UpdateNodeRequest{
 		Type:      NodeTypeEnding,
 		Data:      json.RawMessage(`{"label":"wrong theme"}`),
-		PositionX: 99,
-		PositionY: 99,
+		PositionX: flowFloat64Ptr(99),
+		PositionY: flowFloat64Ptr(99),
 	}); err == nil {
 		t.Fatal("expected UpdateNode to reject a node from a different theme")
 	} else {
@@ -227,7 +227,7 @@ func TestServiceFlowOwnership_RejectsCrossThemeEdgeEndpoints(t *testing.T) {
 	assertFlowNodeExists(t, pool, nodeA.ID)
 }
 
-func TestServiceFlowOwnership_SaveFlowOwnedGraph(t *testing.T) {
+func TestServiceFlowOwnership_SaveFlowOwnedGraphPreservesProvidedNodeIDs(t *testing.T) {
 	ctx := context.Background()
 	pool := setupFlowTestPool(t)
 	svc := NewService(pool, zerolog.Nop())
@@ -269,14 +269,14 @@ func TestServiceFlowOwnership_SaveFlowOwnedGraph(t *testing.T) {
 	for _, node := range graph.Nodes {
 		nodeIDs[node.ID] = struct{}{}
 	}
-	if _, ok := nodeIDs[graph.Edges[0].SourceID]; !ok {
-		t.Fatalf("edge source %s is not one of saved node IDs", graph.Edges[0].SourceID)
+	if _, ok := nodeIDs[clientStartID]; !ok {
+		t.Fatalf("saved nodes do not include provided start ID %s", clientStartID)
 	}
-	if _, ok := nodeIDs[graph.Edges[0].TargetID]; !ok {
-		t.Fatalf("edge target %s is not one of saved node IDs", graph.Edges[0].TargetID)
+	if _, ok := nodeIDs[clientPhaseID]; !ok {
+		t.Fatalf("saved nodes do not include provided phase ID %s", clientPhaseID)
 	}
-	if graph.Edges[0].SourceID == clientStartID || graph.Edges[0].TargetID == clientPhaseID {
-		t.Fatalf("edge endpoints were not remapped from client IDs")
+	if graph.Edges[0].SourceID != clientStartID || graph.Edges[0].TargetID != clientPhaseID {
+		t.Fatalf("edge endpoints = %s -> %s, want %s -> %s", graph.Edges[0].SourceID, graph.Edges[0].TargetID, clientStartID, clientPhaseID)
 	}
 
 	loaded, err := svc.GetFlow(ctx, creatorID, themeID)
@@ -285,6 +285,55 @@ func TestServiceFlowOwnership_SaveFlowOwnedGraph(t *testing.T) {
 	}
 	if len(loaded.Nodes) != 2 || len(loaded.Edges) != 1 {
 		t.Fatalf("loaded graph sizes = nodes %d edges %d, want 2/1", len(loaded.Nodes), len(loaded.Edges))
+	}
+
+	updated, err := svc.UpdateNode(ctx, creatorID, themeID, clientPhaseID, UpdateNodeRequest{
+		Data: json.RawMessage(`{"label":"수정된 조사"}`),
+	})
+	if err != nil {
+		t.Fatalf("UpdateNode with preserved ID: %v", err)
+	}
+	if updated.ID != clientPhaseID {
+		t.Fatalf("updated node ID = %s, want %s", updated.ID, clientPhaseID)
+	}
+}
+
+func TestServiceUpdateNode_PartialDataPatchPreservesTypeAndPosition(t *testing.T) {
+	ctx := context.Background()
+	pool := setupFlowTestPool(t)
+	svc := NewService(pool, zerolog.Nop())
+	creatorID := insertFlowTestUser(t, pool)
+	themeID := insertFlowTestTheme(t, pool, creatorID, json.RawMessage(`{}`))
+
+	node, err := svc.CreateNode(ctx, creatorID, themeID, CreateNodeRequest{
+		Type:      NodeTypeEnding,
+		Data:      json.RawMessage(`{"label":"새 결말"}`),
+		PositionX: 240,
+		PositionY: 360,
+	})
+	if err != nil {
+		t.Fatalf("CreateNode ending: %v", err)
+	}
+
+	updated, err := svc.UpdateNode(ctx, creatorID, themeID, node.ID, UpdateNodeRequest{
+		Data: json.RawMessage(`{"label":"진실","endingContent":"범인이 밝혀졌다."}`),
+	})
+	if err != nil {
+		t.Fatalf("UpdateNode partial data patch: %v", err)
+	}
+
+	if updated.Type != NodeTypeEnding {
+		t.Fatalf("updated type = %q, want %q", updated.Type, NodeTypeEnding)
+	}
+	if updated.PositionX != 240 || updated.PositionY != 360 {
+		t.Fatalf("updated position = (%v,%v), want (240,360)", updated.PositionX, updated.PositionY)
+	}
+	var data map[string]string
+	if err := json.Unmarshal(updated.Data, &data); err != nil {
+		t.Fatalf("unmarshal updated data: %v", err)
+	}
+	if data["label"] != "진실" || data["endingContent"] != "범인이 밝혀졌다." {
+		t.Fatalf("updated data = %#v", data)
 	}
 }
 
@@ -298,6 +347,10 @@ func validSaveFlowRequest() SaveFlowRequest {
 		}},
 		Edges: []FlowEdgeInput{},
 	}
+}
+
+func flowFloat64Ptr(value float64) *float64 {
+	return &value
 }
 
 func validFlowCondition() json.RawMessage {

--- a/apps/server/internal/domain/flow/service_ownership_test.go
+++ b/apps/server/internal/domain/flow/service_ownership_test.go
@@ -298,6 +298,71 @@ func TestServiceFlowOwnership_SaveFlowOwnedGraphPreservesProvidedNodeIDs(t *test
 	}
 }
 
+func TestServiceSaveFlow_RejectsEdgeEndpointOutsideSubmittedGraph(t *testing.T) {
+	ctx := context.Background()
+	pool := setupFlowTestPool(t)
+	svc := NewService(pool, zerolog.Nop())
+	creatorID := insertFlowTestUser(t, pool)
+	themeID := insertFlowTestTheme(t, pool, creatorID, json.RawMessage(`{}`))
+	startID := uuid.New()
+	unknownTargetID := uuid.New()
+
+	_, err := svc.SaveFlow(ctx, creatorID, themeID, SaveFlowRequest{
+		Nodes: []FlowNodeInput{{
+			ID:        &startID,
+			Type:      NodeTypeStart,
+			PositionX: 0,
+			PositionY: 0,
+		}},
+		Edges: []FlowEdgeInput{{
+			SourceID: startID,
+			TargetID: unknownTargetID,
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected SaveFlow to reject an edge target outside the submitted graph")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected app error, got %T", err)
+	}
+	if appErr.Code != apperror.ErrValidation {
+		t.Fatalf("error code = %q, want %q", appErr.Code, apperror.ErrValidation)
+	}
+}
+
+func TestServiceSaveFlow_RejectsNilEdgeEndpoint(t *testing.T) {
+	ctx := context.Background()
+	pool := setupFlowTestPool(t)
+	svc := NewService(pool, zerolog.Nop())
+	creatorID := insertFlowTestUser(t, pool)
+	themeID := insertFlowTestTheme(t, pool, creatorID, json.RawMessage(`{}`))
+	startID := uuid.New()
+
+	_, err := svc.SaveFlow(ctx, creatorID, themeID, SaveFlowRequest{
+		Nodes: []FlowNodeInput{{
+			ID:        &startID,
+			Type:      NodeTypeStart,
+			PositionX: 0,
+			PositionY: 0,
+		}},
+		Edges: []FlowEdgeInput{{
+			SourceID: startID,
+			TargetID: uuid.Nil,
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected SaveFlow to reject a nil edge endpoint")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected app error, got %T", err)
+	}
+	if appErr.Code != apperror.ErrValidation {
+		t.Fatalf("error code = %q, want %q", appErr.Code, apperror.ErrValidation)
+	}
+}
+
 func TestServiceUpdateNode_PartialDataPatchPreservesTypeAndPosition(t *testing.T) {
 	ctx := context.Background()
 	pool := setupFlowTestPool(t)


### PR DESCRIPTION
## 요약
- 결말 저장 실패 원인이던 flow node PATCH 계약을 부분 업데이트로 보정합니다.
- SaveFlow가 클라이언트가 가진 node/edge id를 유지하도록 저장 경로를 보강합니다.
- 기존 노드 위치/데이터가 누락 payload 때문에 초기화되지 않도록 회귀 테스트를 추가했습니다.

## Issue
- 사용자 직접 보고 기반 ad-hoc bugfix입니다. 별도 GitHub Issue는 없습니다.

## Coverage Plan
- apps/server/internal/domain/flow/models.go: position 좌표를 optional field로 검증합니다.
- apps/server/internal/domain/flow/service.go: partial UpdateNode와 SaveFlow id 보존 회귀를 서버 테스트로 검증합니다.
- apps/server/internal/domain/flow/db_helpers.go: 기존 id 삽입 helper는 flow service 테스트 경로로 검증합니다.

## Local validation
- scripts/mmp-local-ci.sh quick: success (HEAD b246fec5aabe992294c2902b5900b6875c76347a, finished 2026-05-12T02:59:34Z)
- 포함: go test -race ./..., pnpm turbo lint/typecheck/test/build

## 리뷰/머지 기준
- ready-for-ci 라벨은 사용하지 않습니다.
- CodeRabbit 리뷰와 unresolved thread 0 확인 후 머지 판단합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 노드 및 엣지 생성 시 사용자 지정 ID 사용 지원
* **개선 사항**
  * 노드 위치 정보의 선택적 업데이트 지원 (X 또는 Y만 업데이트 가능)
  * 부분 업데이트 시 기존 타입·데이터·위치 보존
  * 플로우 저장 시 클라이언트가 제공한 노드 ID 유지
* **버그 수정 / 검증 강화**
  * 제출된 그래프 외부 또는 빈(UUID.Nil) 엣지 대상 거부 검사 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/562)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->