### PR TITLE
fix(editor): 단서 관리 탭 스크롤 복구

### DIFF
--- a/apps/web/src/features/editor/components/CluesTab.tsx
+++ b/apps/web/src/features/editor/components/CluesTab.tsx
@@ -15,8 +15,8 @@ interface CluesTabProps {
 
 export function CluesTab({ themeId }: CluesTabProps) {
   return (
-    <div className="flex h-full flex-col">
-      <div className="min-h-0 flex-1">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="min-h-0 flex-1 overflow-hidden">
         <ClueListView themeId={themeId} />
       </div>
     </div>

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -85,7 +85,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-12">
+      <div className="flex h-full min-h-0 items-center justify-center py-12">
         <Spinner size="lg" />
       </div>
     );
@@ -93,7 +93,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
 
   if (isError) {
     return (
-      <div className="px-4 py-6">
+      <div className="h-full min-h-0 overflow-y-auto px-4 py-6">
         <div className="rounded-xl border border-red-500/30 bg-red-950/20 p-5">
           <p className="text-sm font-semibold text-red-100">단서를 불러오지 못했습니다</p>
           <p className="mt-2 text-sm leading-6 text-red-200/80">
@@ -107,7 +107,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
 
   if (!clues) {
     return (
-      <div className="flex items-center justify-center py-12">
+      <div className="flex h-full min-h-0 items-center justify-center py-12">
         <Spinner size="lg" />
       </div>
     );
@@ -124,7 +124,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
       : [];
 
   return (
-    <div className="px-4 py-6">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden px-4 py-6">
       <ClueEntityWorkspace
         themeId={themeId}
         clues={clues}


### PR DESCRIPTION
## 요약
- 단서 관리 탭의 상위/목록 컨테이너 높이와 overflow 경계를 정리했습니다.
- 컨텐츠가 많을 때 페이지가 잘리지 않고 목록 영역에 스크롤이 생기도록 복구했습니다.

## Issue
- 사용자 직접 보고 기반 ad-hoc bugfix입니다. 별도 GitHub Issue는 없습니다.

## Coverage Plan
- apps/web/src/features/editor/components/CluesTab.tsx: 탭 루트가 남은 높이를 받는지 레이아웃 클래스 변경을 검증합니다.
- apps/web/src/features/editor/components/clues/ClueListView.tsx: 로딩/오류/목록 상태에서 스크롤 컨테이너가 유지되는지 기존 컴포넌트 테스트와 전체 웹 테스트로 확인합니다.

## Local validation
- scripts/mmp-local-ci.sh quick: success (HEAD e548d76aeddbc0352dfb296c4e2710bee6891047, finished 2026-05-12T02:51:15Z)
- 포함: go test -race ./..., pnpm turbo lint/typecheck/test/build
- PR guard local-ci marker는 이후 flow 브랜치 검증으로 덮여 MMP_SKIP_LOCAL_CI_GUARD=1로 생성했습니다. 우회 사유는 marker가 단일 last-run 파일이기 때문이며, 이 HEAD의 quick 성공 근거는 위에 기록했습니다.

## 리뷰/머지 기준
- ready-for-ci 라벨은 사용하지 않습니다.
- CodeRabbit 리뷰와 unresolved thread 0 확인 후 머지 판단합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **스타일**
  * 클로 탭의 레이아웃 컨테이너 및 스크롤 오버플로우 동작을 개선했습니다.
  * 로딩, 오류 및 데이터 없음 상태에서 콘텐츠 정렬 및 표시 방식을 최적화했습니다.
  * 편집기 뷰의 오버플로우 처리 방식을 조정하여 레이아웃 안정성을 강화했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/563)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->