### PR TITLE
fix(editor): 미디어 관리 프리뷰와 WAV 업로드 개선

### DIFF
--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -256,6 +256,7 @@ func (s *mediaService) RequestUpload(ctx context.Context, creatorID, themeID uui
 
 	mediaID := uuid.New()
 	storageKey := fmt.Sprintf("themes/%s/media/%s%s", themeID.String(), mediaID.String(), ext)
+	duration := mediaUploadDurationParam(req.Type, req.Duration)
 
 	created, err := s.q.CreateMedia(ctx, db.CreateMediaParams{
 		ThemeID:    themeID,
@@ -264,7 +265,7 @@ func (s *mediaService) RequestUpload(ctx context.Context, creatorID, themeID uui
 		SourceType: SourceTypeFile,
 		Url:        pgtype.Text{},
 		StorageKey: pgtype.Text{String: storageKey, Valid: true},
-		Duration:   pgtype.Int4{},
+		Duration:   duration,
 		FileSize:   pgtype.Int8{Int64: req.FileSize, Valid: true},
 		MimeType:   pgtype.Text{String: req.MimeType, Valid: true},
 		Tags:       []string{},
@@ -293,6 +294,18 @@ func (s *mediaService) RequestUpload(ctx context.Context, creatorID, themeID uui
 		UploadURL: uploadURL,
 		ExpiresAt: time.Now().Add(expiry),
 	}, nil
+}
+
+func mediaUploadDurationParam(mediaType string, duration *int32) pgtype.Int4 {
+	if duration == nil || *duration < 0 {
+		return pgtype.Int4{}
+	}
+	switch mediaType {
+	case MediaTypeBGM, MediaTypeSFX, MediaTypeVoice, MediaTypeVideo:
+		return pgtype.Int4{Int32: *duration, Valid: true}
+	default:
+		return pgtype.Int4{}
+	}
 }
 
 // --- ConfirmUpload ---
@@ -456,8 +469,8 @@ func (s *mediaService) UpdateMedia(ctx context.Context, creatorID, mediaID uuid.
 		return nil, apperror.Internal("failed to get media")
 	}
 
-	if req.Type != media.Type {
-		return nil, apperror.New(apperror.ErrMediaInvalidType, 422, "media type cannot be changed")
+	if !canUpdateMediaType(media.Type, req.Type) {
+		return nil, apperror.New(apperror.ErrMediaInvalidType, 422, "media type cannot be changed outside the same media group")
 	}
 
 	tags := req.Tags
@@ -493,6 +506,28 @@ func (s *mediaService) UpdateMedia(ctx context.Context, creatorID, mediaID uuid.
 
 	resp := toMediaResponse(updated)
 	return &resp, nil
+}
+
+func canUpdateMediaType(current, next string) bool {
+	if current == next {
+		return true
+	}
+	return mediaTypeGroup(current) == "audio" && mediaTypeGroup(next) == "audio"
+}
+
+func mediaTypeGroup(mediaType string) string {
+	switch mediaType {
+	case MediaTypeBGM, MediaTypeSFX, MediaTypeVoice:
+		return "audio"
+	case MediaTypeVideo:
+		return "video"
+	case MediaTypeImage:
+		return "image"
+	case MediaTypeDocument:
+		return "document"
+	default:
+		return ""
+	}
 }
 
 // --- GetEditorMediaDownloadURL ---
@@ -718,7 +753,7 @@ func validateAudioMagicBytes(header []byte, declaredMime string) error {
 		if len(header) >= 4 && string(header[:4]) == "OggS" {
 			return nil
 		}
-	case "audio/wav":
+	case "audio/vnd.wave", "audio/wav", "audio/wave", "audio/x-wav":
 		if len(header) >= 12 && string(header[:4]) == "RIFF" && string(header[8:12]) == "WAVE" {
 			return nil
 		}

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -256,7 +256,10 @@ func (s *mediaService) RequestUpload(ctx context.Context, creatorID, themeID uui
 
 	mediaID := uuid.New()
 	storageKey := fmt.Sprintf("themes/%s/media/%s%s", themeID.String(), mediaID.String(), ext)
-	duration := mediaUploadDurationParam(req.Type, req.Duration)
+	duration, err := mediaUploadDurationParam(req.Type, req.Duration)
+	if err != nil {
+		return nil, err
+	}
 
 	created, err := s.q.CreateMedia(ctx, db.CreateMediaParams{
 		ThemeID:    themeID,
@@ -296,15 +299,22 @@ func (s *mediaService) RequestUpload(ctx context.Context, creatorID, themeID uui
 	}, nil
 }
 
-func mediaUploadDurationParam(mediaType string, duration *int32) pgtype.Int4 {
-	if duration == nil || *duration < 0 {
-		return pgtype.Int4{}
+func mediaUploadDurationParam(mediaType string, duration *int32) (pgtype.Int4, error) {
+	if duration == nil {
+		return pgtype.Int4{}, nil
+	}
+	if *duration < 0 {
+		return pgtype.Int4{}, apperror.Validation("media duration must be non-negative", []apperror.FieldError{{
+			Field:   "duration",
+			Message: "duration must be greater than or equal to 0",
+			Code:    "invalid_range",
+		}})
 	}
 	switch mediaType {
 	case MediaTypeBGM, MediaTypeSFX, MediaTypeVoice, MediaTypeVideo:
-		return pgtype.Int4{Int32: *duration, Valid: true}
+		return pgtype.Int4{Int32: *duration, Valid: true}, nil
 	default:
-		return pgtype.Int4{}
+		return pgtype.Int4{}, nil
 	}
 }
 

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -644,7 +644,25 @@ func assertMediaAppCode(t *testing.T, err error, want string) {
 	}
 }
 
-func TestMediaService_UpdateMedia_RejectsTypeChange(t *testing.T) {
+func TestMediaService_UpdateMedia_AllowsAudioTypeChange(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeBGM)
+
+	resp, err := svc.UpdateMedia(context.Background(), creatorID, mediaID, UpdateMediaRequest{
+		Name:      "relabel",
+		Type:      MediaTypeSFX,
+		Tags:      []string{},
+		SortOrder: 0,
+	})
+	if err != nil {
+		t.Fatalf("UpdateMedia audio type change: %v", err)
+	}
+	if resp.Type != MediaTypeSFX || q.media[mediaID].Type != MediaTypeSFX {
+		t.Fatalf("media type not changed to SFX: resp=%q stored=%q", resp.Type, q.media[mediaID].Type)
+	}
+}
+
+func TestMediaService_UpdateMedia_RejectsCrossGroupTypeChange(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	mediaID := seedMedia(q, themeID, MediaTypeBGM)
 
@@ -1900,6 +1918,28 @@ func TestMediaService_RequestUploadURL_ImageSuccess(t *testing.T) {
 	}
 }
 
+func TestMediaService_RequestUploadURL_AudioStoresDuration(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	duration := int32(125)
+
+	resp, err := svc.RequestUpload(context.Background(), creatorID, themeID, RequestMediaUploadRequest{
+		Name:     "opening.mp3",
+		Type:     MediaTypeBGM,
+		MimeType: "audio/mpeg",
+		FileSize: 1024,
+		Duration: &duration,
+	})
+	if err != nil {
+		t.Fatalf("RequestUpload BGM/mp3: %v", err)
+	}
+	created := q.media[resp.UploadID]
+	if !created.Duration.Valid || created.Duration.Int32 != duration {
+		t.Fatalf("expected audio duration %d, got %#v", duration, created.Duration)
+	}
+}
+
 func TestMediaService_ConfirmUpload_ImageMagicBytes(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	st := newFakeStorageProvider()
@@ -2576,6 +2616,7 @@ func TestUploadExtensionFor_ImageAndDocumentTypes(t *testing.T) {
 		{name: "jpeg image", mediaType: MediaTypeImage, mimeType: "image/jpeg", wantExt: ".jpg", wantOK: true},
 		{name: "webp image", mediaType: MediaTypeImage, mimeType: "image/webp", wantExt: ".webp", wantOK: true},
 		{name: "pdf document", mediaType: MediaTypeDocument, mimeType: "application/pdf", wantExt: ".pdf", wantOK: true},
+		{name: "wav alias audio", mediaType: MediaTypeBGM, mimeType: "audio/x-wav", wantExt: ".wav", wantOK: true},
 		{name: "unsupported image", mediaType: MediaTypeImage, mimeType: "image/gif", wantOK: false},
 	}
 	for _, tt := range tests {
@@ -2655,6 +2696,7 @@ func TestValidateAudioMagicBytes(t *testing.T) {
 		{"MP3 ID3 tag", []byte("ID3\x04\x00"), "audio/mpeg", false},
 		{"OGG valid", []byte("OggS\x00\x00\x00\x00"), "audio/ogg", false},
 		{"WAV valid", []byte("RIFF\x00\x00\x00\x00WAVEfmt "), "audio/wav", false},
+		{"WAV alias valid", []byte("RIFF\x00\x00\x00\x00WAVEfmt "), "audio/x-wav", false},
 		{"MIME mismatch (MP3 as OGG)", []byte{0xFF, 0xFB, 0x00}, "audio/ogg", true},
 		{"Invalid header for MP3", []byte{0x00, 0x00, 0x00}, "audio/mpeg", true},
 		{"WAV without WAVE marker", []byte("RIFF\x00\x00\x00\x00AVIf"), "audio/wav", true},

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -1940,6 +1940,31 @@ func TestMediaService_RequestUploadURL_AudioStoresDuration(t *testing.T) {
 	}
 }
 
+func TestMediaService_RequestUploadURL_RejectsNegativeDuration(t *testing.T) {
+	svc, _, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	duration := int32(-1)
+
+	_, err := svc.RequestUpload(context.Background(), creatorID, themeID, RequestMediaUploadRequest{
+		Name:     "opening.mp3",
+		Type:     MediaTypeBGM,
+		MimeType: "audio/mpeg",
+		FileSize: 1024,
+		Duration: &duration,
+	})
+	if err == nil {
+		t.Fatal("expected negative duration to be rejected")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected app error, got %T", err)
+	}
+	if appErr.Code != apperror.ErrValidation {
+		t.Fatalf("error code = %q, want %q", appErr.Code, apperror.ErrValidation)
+	}
+}
+
 func TestMediaService_ConfirmUpload_ImageMagicBytes(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	st := newFakeStorageProvider()
@@ -2616,7 +2641,10 @@ func TestUploadExtensionFor_ImageAndDocumentTypes(t *testing.T) {
 		{name: "jpeg image", mediaType: MediaTypeImage, mimeType: "image/jpeg", wantExt: ".jpg", wantOK: true},
 		{name: "webp image", mediaType: MediaTypeImage, mimeType: "image/webp", wantExt: ".webp", wantOK: true},
 		{name: "pdf document", mediaType: MediaTypeDocument, mimeType: "application/pdf", wantExt: ".pdf", wantOK: true},
-		{name: "wav alias audio", mediaType: MediaTypeBGM, mimeType: "audio/x-wav", wantExt: ".wav", wantOK: true},
+		{name: "wav audio", mediaType: MediaTypeBGM, mimeType: "audio/wav", wantExt: ".wav", wantOK: true},
+		{name: "wave audio", mediaType: MediaTypeBGM, mimeType: "audio/wave", wantExt: ".wav", wantOK: true},
+		{name: "x-wav audio", mediaType: MediaTypeBGM, mimeType: "audio/x-wav", wantExt: ".wav", wantOK: true},
+		{name: "vendor wave audio", mediaType: MediaTypeBGM, mimeType: "audio/vnd.wave", wantExt: ".wav", wantOK: true},
 		{name: "unsupported image", mediaType: MediaTypeImage, mimeType: "image/gif", wantOK: false},
 	}
 	for _, tt := range tests {

--- a/apps/server/internal/domain/editor/media_types.go
+++ b/apps/server/internal/domain/editor/media_types.go
@@ -26,9 +26,12 @@ const (
 
 // AllowedAudioMIMEs defines allowed MIME types for audio files.
 var AllowedAudioMIMEs = map[string]string{
-	"audio/mpeg": ".mp3",
-	"audio/ogg":  ".ogg",
-	"audio/wav":  ".wav",
+	"audio/mpeg":     ".mp3",
+	"audio/ogg":      ".ogg",
+	"audio/vnd.wave": ".wav",
+	"audio/wav":      ".wav",
+	"audio/wave":     ".wav",
+	"audio/x-wav":    ".wav",
 }
 
 // AllowedDocumentMIMEs defines allowed MIME types for document role sheets.
@@ -47,6 +50,7 @@ type RequestMediaUploadRequest struct {
 	Type       string     `json:"type" validate:"required,oneof=BGM SFX VOICE VIDEO DOCUMENT IMAGE"`
 	MimeType   string     `json:"mime_type" validate:"required"`
 	FileSize   int64      `json:"file_size" validate:"required,min=1"`
+	Duration   *int32     `json:"duration,omitempty" validate:"omitempty,min=0"`
 	CategoryID *uuid.UUID `json:"category_id,omitempty"`
 }
 

--- a/apps/web/src/features/editor/components/media/MediaCard.tsx
+++ b/apps/web/src/features/editor/components/media/MediaCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Pause, Play, Youtube } from "lucide-react";
-import type { MediaResponse } from "@/features/editor/mediaApi";
+import { useMediaDownloadUrl, type MediaResponse } from "@/features/editor/mediaApi";
 import {
   canPlayInlinePreview,
   getMediaThumbnailUrl,
@@ -36,6 +36,25 @@ function formatDuration(seconds?: number): string | null {
   return `${mm}:${ss.toString().padStart(2, "0")}`;
 }
 
+function getPreviewSurfaceClass(type: MediaResponse["type"]): string {
+  switch (type) {
+    case "BGM":
+      return "border-amber-500/25 bg-amber-500/10 text-amber-200";
+    case "SFX":
+      return "border-cyan-500/25 bg-cyan-500/10 text-cyan-200";
+    case "VOICE":
+      return "border-emerald-500/25 bg-emerald-500/10 text-emerald-200";
+    case "VIDEO":
+      return "border-rose-500/25 bg-rose-500/10 text-rose-200";
+    case "DOCUMENT":
+      return "border-violet-500/25 bg-violet-500/10 text-violet-200";
+    case "IMAGE":
+      return "border-teal-500/25 bg-teal-500/10 text-teal-200";
+    default:
+      return "border-slate-600/40 bg-slate-800/70 text-slate-200";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // MediaCard
 // ---------------------------------------------------------------------------
@@ -52,7 +71,16 @@ export function MediaCard({
 }: MediaCardProps) {
   const [thumbnailFailed, setThumbnailFailed] = useState(false);
   const isYouTube = media.source_type === "YOUTUBE";
-  const thumbnailUrl = getMediaThumbnailUrl(media);
+  const shouldLoadFileImagePreview =
+    media.type === "IMAGE" && media.source_type === "FILE" && !media.url;
+  const { data: fileImagePreview } = useMediaDownloadUrl(
+    shouldLoadFileImagePreview ? media.id : undefined,
+  );
+  const thumbnailUrl = getMediaThumbnailUrl({
+    ...media,
+    url: media.url ?? fileImagePreview?.url,
+  });
+  const shouldRenderImagePreview = media.type === "IMAGE" && thumbnailUrl && !thumbnailFailed;
   const duration = formatDuration(media.duration);
   const badgeClass = getMediaTypeBadgeClass(media.type);
   const badgeLabel = getMediaTypeBadgeLabel(media.type);
@@ -97,17 +125,25 @@ export function MediaCard({
       )}
 
       {/* Thumbnail */}
-      <div className="relative flex aspect-[4/3] min-h-28 items-center justify-center bg-slate-950/60">
-        {thumbnailUrl && !thumbnailFailed ? (
+      <div className="relative mx-auto mt-2 flex aspect-square w-24 items-center justify-center bg-slate-950/70 p-2 sm:w-28">
+        {shouldRenderImagePreview ? (
           <img
             src={thumbnailUrl}
             alt=""
-            className="h-full w-full object-cover"
+            className="h-full w-full object-contain"
             loading="lazy"
             onError={() => setThumbnailFailed(true)}
           />
         ) : (
-          <MediaTypeIcon type={media.type} />
+          <div
+            data-testid="media-preview-face"
+            className={`flex h-full w-full flex-col items-center justify-center gap-1 rounded-sm border ${getPreviewSurfaceClass(
+              media.type,
+            )}`}
+          >
+            <MediaTypeIcon type={media.type} />
+            <span className="text-[10px] font-semibold">{badgeLabel}</span>
+          </div>
         )}
 
         {/* YouTube overlay */}

--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -8,6 +8,7 @@ import {
   useUpdateMedia,
   type MediaReferenceInfo,
   type MediaResponse,
+  type MediaType,
   type UpdateMediaRequest,
 } from '@/features/editor/mediaApi';
 import { ApiHttpError } from '@/lib/api-error';
@@ -23,6 +24,9 @@ export interface MediaDetailProps {
   onClose: () => void;
 }
 
+const AUDIO_MEDIA_TYPES: MediaType[] = ['BGM', 'SFX', 'VOICE'];
+const PLAYABLE_MEDIA_TYPES: MediaType[] = ['BGM', 'SFX', 'VOICE', 'VIDEO'];
+
 // ---------------------------------------------------------------------------
 // MediaDetail
 // ---------------------------------------------------------------------------
@@ -32,9 +36,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const [tagsText, setTagsText] = useState((media.tags ?? []).join(', '));
   const [sortOrder, setSortOrder] = useState<number>(media.sort_order);
   const [categoryId, setCategoryId] = useState<string>(media.category_id ?? '');
-  const [duration, setDuration] = useState<string>(
-    media.duration != null ? String(media.duration) : ''
-  );
+  const [mediaType, setMediaType] = useState<MediaType>(media.type);
   const [referenceWarning, setReferenceWarning] = useState<MediaReferenceInfo[] | null>(null);
   const [replaceOpen, setReplaceOpen] = useState(false);
 
@@ -44,10 +46,10 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
     setTagsText((media.tags ?? []).join(', '));
     setSortOrder(media.sort_order);
     setCategoryId(media.category_id ?? '');
-    setDuration(media.duration != null ? String(media.duration) : '');
+    setMediaType(media.type);
     setReferenceWarning(null);
     setReplaceOpen(false);
-  }, [media.id, media.name, media.tags, media.sort_order, media.category_id, media.duration]);
+  }, [media.id, media.name, media.tags, media.sort_order, media.category_id, media.type]);
 
   const updateMutation = useUpdateMedia(themeId);
   const deleteMutation = useDeleteMedia(themeId);
@@ -55,6 +57,10 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const { data: deletePreview, isLoading: deletePreviewLoading } = useMediaDeletePreview(media.id);
   const references = deletePreview?.references ?? [];
   const canReplaceFile = media.source_type === 'FILE' && media.type !== 'VIDEO';
+  const typeOptions = getEditableMediaTypeOptions(media.type);
+  const canChangeMediaType = typeOptions.length > 1;
+  const canShowDuration = PLAYABLE_MEDIA_TYPES.includes(mediaType);
+  const showCategorySelect = categories.length > 0 || Boolean(media.category_id);
 
   const handleSave = () => {
     const trimmedName = name.trim();
@@ -66,18 +72,12 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
       .split(',')
       .map((t) => t.trim())
       .filter(Boolean);
-    const durationNum = duration.trim() ? Number(duration) : undefined;
-    if (durationNum != null && (!Number.isFinite(durationNum) || durationNum < 0)) {
-      toast.error('길이는 0 이상 숫자여야 합니다');
-      return;
-    }
     const patch: UpdateMediaRequest = {
       name: trimmedName,
-      type: media.type,
+      type: mediaType,
       sort_order: sortOrder,
       tags,
-      category_id: categoryId || undefined,
-      ...(durationNum != null ? { duration: durationNum } : {}),
+      ...(showCategorySelect ? { category_id: categoryId || undefined } : {}),
     };
     updateMutation.mutate(
       { id: media.id, patch },
@@ -150,41 +150,51 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
           />
         </label>
 
-        <div className="grid grid-cols-2 gap-3">
-          <label className="flex flex-col gap-1">
-            <span className="text-[10px] font-mono uppercase tracking-widest text-slate-600">
-              카테고리
-            </span>
-            <select
-              value={categoryId}
-              onChange={(e) => setCategoryId(e.target.value)}
-              className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-            >
-              <option value="">전체</option>
-              {categories.map((category) => (
-                <option key={category.id} value={category.id}>
-                  {category.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-[10px] font-mono uppercase tracking-widest text-slate-600">
-              길이 (초)
-            </span>
-            <input
-              type="number"
-              min={0}
-              step="0.1"
-              value={duration}
-              onChange={(e) => setDuration(e.target.value)}
-              className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
-            />
-          </label>
-        </div>
+        {(showCategorySelect || canChangeMediaType) && (
+          <div className="grid grid-cols-2 gap-3">
+            {showCategorySelect && (
+              <label className="flex flex-col gap-1">
+                <span className="text-[10px] font-mono uppercase tracking-widest text-slate-600">
+                  카테고리
+                </span>
+                <select
+                  value={categoryId}
+                  onChange={(e) => setCategoryId(e.target.value)}
+                  className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+                >
+                  <option value="">전체</option>
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            {canChangeMediaType && (
+              <label className="flex flex-col gap-1">
+                <span className="text-[10px] font-mono uppercase tracking-widest text-slate-600">
+                  분류
+                </span>
+                <select
+                  value={mediaType}
+                  onChange={(e) => setMediaType(e.target.value as MediaType)}
+                  className="h-8 rounded-sm border border-slate-700 bg-slate-950 px-2 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+                >
+                  {typeOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {mediaTypeLabel(option)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+          </div>
+        )}
 
         <dl className="grid gap-2 rounded-sm border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs">
-          <MediaInfoRow label="분류" value={mediaTypeLabel(media.type)} />
+          {!canChangeMediaType && <MediaInfoRow label="분류" value={mediaTypeLabel(media.type)} />}
+          {canShowDuration && <MediaInfoRow label="길이" value={formatDurationInfo(media.duration)} />}
           <MediaInfoRow label="출처" value={mediaSourceLabel(media.source_type)} />
           {media.mime_type && <MediaInfoRow label="파일 형식" value={mimeTypeLabel(media.mime_type)} />}
           {media.file_size != null && (
@@ -337,6 +347,26 @@ function mediaTypeLabel(type: MediaResponse['type']): string {
   }
 }
 
+function getEditableMediaTypeOptions(type: MediaType): MediaType[] {
+  if (AUDIO_MEDIA_TYPES.includes(type)) {
+    return AUDIO_MEDIA_TYPES;
+  }
+  return [type];
+}
+
+function formatDurationInfo(duration: number | undefined): string {
+  if (duration == null || !Number.isFinite(duration) || duration < 0) {
+    return '자동 확인 안 됨';
+  }
+  const totalSeconds = Math.round(duration);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}초`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}분 ${seconds}초` : `${minutes}분`;
+}
+
 function mediaSourceLabel(source: MediaResponse['source_type']): string {
   switch (source) {
     case 'FILE':
@@ -352,6 +382,9 @@ function mimeTypeLabel(mimeType: string): string {
   const labels: Record<string, string> = {
     'audio/mpeg': 'MP3',
     'audio/wav': 'WAV',
+    'audio/x-wav': 'WAV',
+    'audio/wave': 'WAV',
+    'audio/vnd.wave': 'WAV',
     'audio/ogg': 'OGG',
     'image/jpeg': 'JPEG',
     'image/png': 'PNG',

--- a/apps/web/src/features/editor/components/media/MediaReplaceModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaReplaceModal.tsx
@@ -27,10 +27,12 @@ interface MediaReplaceModalProps {
 }
 
 const MAX_SIZE = 20 * 1024 * 1024;
+const WAV_MIME = ["audio/wav", "audio/x-wav", "audio/wave", "audio/vnd.wave"];
+const AUDIO_MIME = ["audio/mpeg", ...WAV_MIME, "audio/ogg"];
 const MIME_BY_TYPE: Record<MediaType, string[]> = {
-  BGM: ["audio/mpeg", "audio/wav", "audio/ogg"],
-  SFX: ["audio/mpeg", "audio/wav", "audio/ogg"],
-  VOICE: ["audio/mpeg", "audio/wav", "audio/ogg"],
+  BGM: AUDIO_MIME,
+  SFX: AUDIO_MIME,
+  VOICE: AUDIO_MIME,
   IMAGE: ["image/jpeg", "image/png", "image/webp"],
   DOCUMENT: ["application/pdf"],
   VIDEO: [],
@@ -310,5 +312,22 @@ function formatFileSize(bytes: number): string {
 }
 
 function acceptedMimeTypesLabel(mimeTypes: string[]): string {
-  return mimeTypes.map((mime) => mime.split("/")[1]?.toUpperCase() ?? mime).join(", ");
+  return mimeTypes
+    .map((mime) => {
+      switch (mime) {
+        case "audio/mpeg":
+          return "MP3";
+        case "audio/ogg":
+          return "OGG";
+        case "audio/vnd.wave":
+        case "audio/wav":
+        case "audio/wave":
+        case "audio/x-wav":
+          return "WAV";
+        default:
+          return mime.split("/")[1]?.toUpperCase() ?? mime;
+      }
+    })
+    .filter((label, index, labels) => labels.indexOf(label) === index)
+    .join(", ");
 }

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -304,7 +304,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
             </div>
           ) : (
             <div
-              className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+              className="grid grid-cols-[repeat(auto-fill,minmax(10rem,12rem))] gap-3"
               role="list"
               aria-label="미디어 목록"
             >

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -304,7 +304,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
             </div>
           ) : (
             <div
-              className="grid grid-cols-[repeat(auto-fill,minmax(10rem,12rem))] gap-3"
+              className="grid max-w-[39rem] grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3"
               role="list"
               aria-label="미디어 목록"
             >

--- a/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
@@ -143,11 +143,11 @@ export function MediaUploadModal({
     setType(nextType);
     setDurationSeconds(null);
     setMetadataLoading(false);
+    const loadId = metadataLoadIdRef.current + 1;
+    metadataLoadIdRef.current = loadId;
     const defaultName = f.name.replace(/\.[^.]+$/, '');
     setName((prev) => (prev ? prev : defaultName));
     if (isPlayableUploadType(nextType)) {
-      const loadId = metadataLoadIdRef.current + 1;
-      metadataLoadIdRef.current = loadId;
       setMetadataLoading(true);
       extractMediaDurationSeconds(f).then((seconds) => {
         if (!isMountedRef.current || metadataLoadIdRef.current !== loadId) return;

--- a/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaUploadModal.tsx
@@ -32,7 +32,8 @@ export interface MediaUploadModalProps {
 }
 
 const MAX_SIZE = 20 * 1024 * 1024;
-const AUDIO_MIME = ['audio/mpeg', 'audio/wav', 'audio/ogg'];
+const WAV_MIME = ['audio/wav', 'audio/x-wav', 'audio/wave', 'audio/vnd.wave'];
+const AUDIO_MIME = ['audio/mpeg', ...WAV_MIME, 'audio/ogg'];
 const IMAGE_MIME = ['image/jpeg', 'image/png', 'image/webp'];
 const DOCUMENT_MIME = ['application/pdf'];
 const MIME_BY_TYPE: Record<MediaType, string[]> = {
@@ -70,6 +71,8 @@ export function MediaUploadModal({
   const [uploading, setUploading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [durationSeconds, setDurationSeconds] = useState<number | null>(null);
+  const [metadataLoading, setMetadataLoading] = useState(false);
 
   const requestUrlMutation = useRequestUploadUrl(themeId);
   const confirmMutation = useConfirmUpload(themeId);
@@ -91,6 +94,7 @@ export function MediaUploadModal({
 
   // Abort controller for the in-flight upload. Re-created per upload attempt.
   const controllerRef = useRef<AbortController | null>(null);
+  const metadataLoadIdRef = useRef(0);
   // Guards setState after unmount or abort.
   const isMountedRef = useRef(true);
 
@@ -114,6 +118,8 @@ export function MediaUploadModal({
       setType(uploadableTypes[0]?.value ?? 'BGM');
       setProgress(0);
       setError(null);
+      setDurationSeconds(null);
+      setMetadataLoading(false);
       setUploading(false);
       setIsDragging(false);
     }
@@ -135,8 +141,20 @@ export function MediaUploadModal({
     setError(null);
     setFile(f);
     setType(nextType);
+    setDurationSeconds(null);
+    setMetadataLoading(false);
     const defaultName = f.name.replace(/\.[^.]+$/, '');
     setName((prev) => (prev ? prev : defaultName));
+    if (isPlayableUploadType(nextType)) {
+      const loadId = metadataLoadIdRef.current + 1;
+      metadataLoadIdRef.current = loadId;
+      setMetadataLoading(true);
+      extractMediaDurationSeconds(f).then((seconds) => {
+        if (!isMountedRef.current || metadataLoadIdRef.current !== loadId) return;
+        setDurationSeconds(seconds);
+        setMetadataLoading(false);
+      });
+    }
   };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -179,6 +197,7 @@ export function MediaUploadModal({
         type,
         name: name || file.name,
         categoryId: categoryId ?? undefined,
+        duration: durationSeconds ?? undefined,
         requestUploadUrl: requestUrlMutation.mutateAsync,
         confirmUpload: confirmMutation.mutateAsync,
         onProgress: (p) => {
@@ -261,6 +280,11 @@ export function MediaUploadModal({
             <>
               <p className="text-sm text-slate-200">{file.name}</p>
               <p className="text-xs text-slate-400">{(file.size / 1024 / 1024).toFixed(2)} MB</p>
+              {isPlayableUploadType(type) && (
+                <p className="text-xs text-slate-500">
+                  길이 {metadataLoading ? '확인 중...' : formatDurationLabel(durationSeconds)}
+                </p>
+              )}
             </>
           ) : (
             <>
@@ -383,6 +407,52 @@ function inferUploadType(mimeType: string, allowedTypes: MediaType[]): MediaType
   return null;
 }
 
+function isPlayableUploadType(type: MediaType): boolean {
+  return type === 'BGM' || type === 'SFX' || type === 'VOICE' || type === 'VIDEO';
+}
+
+function extractMediaDurationSeconds(file: File): Promise<number | null> {
+  if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    const element = document.createElement(file.type.startsWith('video/') ? 'video' : 'audio');
+    const objectUrl = URL.createObjectURL(file);
+    let settled = false;
+
+    const cleanup = () => {
+      element.removeAttribute('src');
+      element.load();
+      URL.revokeObjectURL(objectUrl);
+    };
+    const finish = (duration: number | null) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      cleanup();
+      resolve(duration);
+    };
+    const timeout = window.setTimeout(() => finish(null), 2500);
+
+    element.preload = 'metadata';
+    element.onloadedmetadata = () => {
+      const duration = Number.isFinite(element.duration) ? Math.round(element.duration) : null;
+      finish(duration != null && duration >= 0 ? duration : null);
+    };
+    element.onerror = () => finish(null);
+    element.src = objectUrl;
+  });
+}
+
+function formatDurationLabel(duration: number | null): string {
+  if (duration == null) return '자동 확인 안 됨';
+  if (duration < 60) return `${duration}초`;
+  const minutes = Math.floor(duration / 60);
+  const seconds = duration % 60;
+  return seconds > 0 ? `${minutes}분 ${seconds}초` : `${minutes}분`;
+}
+
 function acceptedMimeTypesLabel(mimeTypes: string[]): string {
   return mimeTypes
     .map((mime) => {
@@ -390,6 +460,9 @@ function acceptedMimeTypesLabel(mimeTypes: string[]): string {
         case 'audio/mpeg':
           return 'MP3';
         case 'audio/wav':
+        case 'audio/x-wav':
+        case 'audio/wave':
+        case 'audio/vnd.wave':
           return 'WAV';
         case 'audio/ogg':
           return 'OGG';
@@ -405,5 +478,6 @@ function acceptedMimeTypesLabel(mimeTypes: string[]): string {
           return mime;
       }
     })
+    .filter((label, index, labels) => labels.indexOf(label) === index)
     .join(', ');
 }

--- a/apps/web/src/features/editor/components/media/__tests__/MediaCard.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaCard.test.tsx
@@ -1,8 +1,20 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MediaCard } from "../MediaCard";
 import type { MediaResponse } from "@/features/editor/mediaApi";
+
+const { useMediaDownloadUrlMock } = vi.hoisted(() => ({
+  useMediaDownloadUrlMock: vi.fn(),
+}));
+
+vi.mock("@/features/editor/mediaApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/editor/mediaApi")>();
+  return {
+    ...actual,
+    useMediaDownloadUrl: (mediaId?: string) => useMediaDownloadUrlMock(mediaId),
+  };
+});
 
 const baseMedia: MediaResponse = {
   id: "media-1",
@@ -18,6 +30,11 @@ const baseMedia: MediaResponse = {
   sort_order: 1,
   created_at: "2026-04-05T00:00:00Z",
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useMediaDownloadUrlMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+});
 
 afterEach(() => cleanup());
 
@@ -48,12 +65,39 @@ describe("MediaCard", () => {
     const image = document.querySelector("img") as HTMLImageElement;
     expect(image).not.toBeNull();
     expect(image.getAttribute("src")).toBe("https://example.com/clue.webp");
+    expect(image.className).toContain("object-contain");
+    expect(image.parentElement?.className).toContain("aspect-square");
+    expect(image.parentElement?.className).toContain("w-24");
 
     fireEvent.error(image);
     expect(screen.getByLabelText("이미지")).toBeDefined();
   });
 
-  it("영상과 문서는 깨진 이미지 없이 타입별 fallback 아이콘을 표시한다", () => {
+  it("업로드 이미지는 임시 다운로드 URL로 preview를 보여준다", () => {
+    useMediaDownloadUrlMock.mockReturnValue({
+      data: { url: "https://download.example/clue.webp", expires_at: "2026-05-12T00:15:00Z" },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderCard({
+      ...baseMedia,
+      id: "image-private-1",
+      name: "보관함 단서 사진",
+      type: "IMAGE",
+      url: undefined,
+      mime_type: "image/webp",
+    });
+
+    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith("image-private-1");
+
+    const image = document.querySelector("img") as HTMLImageElement;
+    expect(image).not.toBeNull();
+    expect(image.getAttribute("src")).toBe("https://download.example/clue.webp");
+    expect(image.className).toContain("object-contain");
+  });
+
+  it("비이미지 미디어는 같은 프리뷰 face 안에 타입별 아이콘을 표시한다", () => {
     const { rerender } = renderCard({
       ...baseMedia,
       id: "video-1",
@@ -63,7 +107,12 @@ describe("MediaCard", () => {
       mime_type: "video/mp4",
     });
 
+    expect(screen.getByTestId("media-preview-face")).toBeDefined();
+    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("aspect-square");
+    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("w-24");
     expect(screen.getByLabelText("영상")).toBeDefined();
+    expect(screen.getAllByText("영상").length).toBeGreaterThan(0);
+    expect(document.querySelector("img")).toBeNull();
     expect(screen.queryByRole("button", { name: "프리뷰 재생" })).toBeNull();
 
     rerender(
@@ -83,7 +132,10 @@ describe("MediaCard", () => {
       />,
     );
 
+    expect(screen.getByTestId("media-preview-face")).toBeDefined();
     expect(screen.getByLabelText("문서")).toBeDefined();
+    expect(screen.getAllByText("문서").length).toBeGreaterThan(0);
+    expect(document.querySelector("img")).toBeNull();
     expect(screen.queryByRole("button", { name: "프리뷰 재생" })).toBeNull();
   });
 
@@ -95,7 +147,7 @@ describe("MediaCard", () => {
     fireEvent.click(playButton);
 
     expect(onPreviewToggle).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("배경음악")).toBeDefined();
+    expect(screen.getAllByText("배경음악").length).toBeGreaterThan(0);
     expect(screen.getByText("2:05")).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -199,7 +199,7 @@ describe('MediaTab', () => {
 
     render(<MediaTab themeId="theme-1" />);
     expect(screen.getByRole('list', { name: '미디어 목록' }).className).toContain(
-      'grid-cols-[repeat(auto-fill,minmax(10rem,12rem))]',
+      'lg:grid-cols-3',
     );
     expect(screen.getByText('오프닝 BGM')).toBeDefined();
     expect(screen.getByText('문 닫는 소리')).toBeDefined();

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -11,6 +11,7 @@ const {
   useCreateMediaCategoryMock,
   useDeleteMediaCategoryMock,
   useMediaDeletePreviewMock,
+  useMediaDownloadUrlMock,
   useUpdateMediaMock,
   useDeleteMediaMock,
   useRequestReplacementUploadMock,
@@ -26,6 +27,7 @@ const {
   useCreateMediaCategoryMock: vi.fn(),
   useDeleteMediaCategoryMock: vi.fn(),
   useMediaDeletePreviewMock: vi.fn(),
+  useMediaDownloadUrlMock: vi.fn(),
   useUpdateMediaMock: vi.fn(),
   useDeleteMediaMock: vi.fn(),
   useRequestReplacementUploadMock: vi.fn(),
@@ -43,6 +45,7 @@ vi.mock('@/features/editor/mediaApi', () => ({
   useCreateMediaCategory: () => useCreateMediaCategoryMock(),
   useDeleteMediaCategory: () => useDeleteMediaCategoryMock(),
   useMediaDeletePreview: (...args: unknown[]) => useMediaDeletePreviewMock(...args),
+  useMediaDownloadUrl: (...args: unknown[]) => useMediaDownloadUrlMock(...args),
   useUpdateMedia: () => useUpdateMediaMock(),
   useDeleteMedia: () => useDeleteMediaMock(),
   useRequestReplacementUpload: () => useRequestReplacementUploadMock(),
@@ -145,6 +148,7 @@ beforeEach(() => {
   useCreateMediaCategoryMock.mockReturnValue(mutationStub());
   useDeleteMediaCategoryMock.mockReturnValue(mutationStub());
   useMediaDeletePreviewMock.mockReturnValue({ data: { references: [] }, isLoading: false });
+  useMediaDownloadUrlMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
   useUpdateMediaMock.mockReturnValue(mutationStub());
   useDeleteMediaMock.mockReturnValue(mutationStub());
   useRequestReplacementUploadMock.mockReturnValue(mutationStub());
@@ -194,6 +198,9 @@ describe('MediaTab', () => {
     });
 
     render(<MediaTab themeId="theme-1" />);
+    expect(screen.getByRole('list', { name: '미디어 목록' }).className).toContain(
+      'grid-cols-[repeat(auto-fill,minmax(10rem,12rem))]',
+    );
     expect(screen.getByText('오프닝 BGM')).toBeDefined();
     expect(screen.getByText('문 닫는 소리')).toBeDefined();
     // Type badges render creator-facing labels on cards.
@@ -340,6 +347,9 @@ describe('MediaTab', () => {
     expect(screen.getByDisplayValue('오프닝 BGM')).toBeDefined();
     expect(screen.getByText('분류')).toBeDefined();
     expect(screen.getAllByText('배경음악').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByLabelText('길이 (초)')).toBeNull();
+    expect(screen.getByText('길이')).toBeDefined();
+    expect(screen.getByText('2분 5초')).toBeDefined();
     expect(screen.getByText('출처')).toBeDefined();
     expect(screen.getByText('직접 업로드')).toBeDefined();
     expect(screen.getByText('파일 형식')).toBeDefined();
@@ -352,6 +362,69 @@ describe('MediaTab', () => {
     expect(screen.queryByText('size: 1234567 B')).toBeNull();
     expect(screen.getByText('아직 연결된 제작 요소가 없습니다.')).toBeDefined();
     expect(screen.getByRole('button', { name: '교체' })).toBeDefined();
+  });
+
+  it('오디오 미디어는 같은 오디오 묶음 안에서만 분류를 바꿔 저장한다', () => {
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+    const mutate = vi.fn();
+    useUpdateMediaMock.mockReturnValue({
+      mutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+
+    render(<MediaTab themeId="theme-1" />);
+
+    fireEvent.click(screen.getByText('오프닝 BGM').closest("[role='button']")!);
+    fireEvent.change(screen.getByLabelText('분류'), { target: { value: 'VOICE' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      {
+        id: 'media-1',
+        patch: expect.objectContaining({
+          name: '오프닝 BGM',
+          type: 'VOICE',
+          sort_order: 1,
+        }),
+      },
+      expect.any(Object)
+    );
+    expect(mutate.mock.calls[0][0].patch).not.toHaveProperty('duration');
+  });
+
+  it('이미지 상세에는 길이와 분류 변경 입력을 표시하지 않는다', () => {
+    useMediaListMock.mockReturnValue({
+      data: [
+        {
+          id: 'media-image',
+          theme_id: 'theme-1',
+          name: '현장 사진',
+          type: 'IMAGE',
+          source_type: 'FILE',
+          duration: undefined,
+          file_size: 2048,
+          mime_type: 'image/png',
+          tags: [],
+          sort_order: 1,
+          created_at: '2026-04-05T00:00:00Z',
+        } satisfies MediaResponse,
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<MediaTab themeId="theme-1" />);
+
+    fireEvent.click(screen.getByText('현장 사진').closest("[role='button']")!);
+
+    expect(screen.queryByLabelText('길이 (초)')).toBeNull();
+    expect(screen.queryByLabelText('분류')).toBeNull();
+    expect(screen.getAllByText('이미지').length).toBeGreaterThanOrEqual(1);
   });
 
   it('상세 패널은 삭제 전 사용 위치와 파일 교체 모달을 보여준다', () => {

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -125,6 +125,17 @@ describe('MediaUploadModal', () => {
     expect(screen.getByRole('alert').textContent).toContain('지원하지 않는 파일 형식입니다');
   });
 
+  it('accepts browser WAV alias MIME types', () => {
+    renderModal(true);
+    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+    const file = makeFile('effect.wav', 1024, 'audio/x-wav');
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByText('effect.wav')).toBeTruthy();
+    expect((screen.getByLabelText('유형') as HTMLSelectElement).value).toBe('BGM');
+  });
+
   it('type select works', () => {
     renderModal(true);
     const input = screen.getByTestId('media-upload-input') as HTMLInputElement;

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -125,16 +125,19 @@ describe('MediaUploadModal', () => {
     expect(screen.getByRole('alert').textContent).toContain('지원하지 않는 파일 형식입니다');
   });
 
-  it('accepts browser WAV alias MIME types', () => {
-    renderModal(true);
-    const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
-    const file = makeFile('effect.wav', 1024, 'audio/x-wav');
-    fireEvent.change(input, { target: { files: [file] } });
+  it.each(['audio/wav', 'audio/wave', 'audio/x-wav', 'audio/vnd.wave'])(
+    'accepts browser WAV alias MIME type %s',
+    (mimeType) => {
+      renderModal(true);
+      const input = screen.getByTestId('media-upload-input') as HTMLInputElement;
+      const file = makeFile('effect.wav', 1024, mimeType);
+      fireEvent.change(input, { target: { files: [file] } });
 
-    expect(screen.queryByRole('alert')).toBeNull();
-    expect(screen.getByText('effect.wav')).toBeTruthy();
-    expect((screen.getByLabelText('유형') as HTMLSelectElement).value).toBe('BGM');
-  });
+      expect(screen.queryByRole('alert')).toBeNull();
+      expect(screen.getByText('effect.wav')).toBeTruthy();
+      expect((screen.getByLabelText('유형') as HTMLSelectElement).value).toBe('BGM');
+    },
+  );
 
   it('type select works', () => {
     renderModal(true);

--- a/apps/web/src/features/editor/mediaApi.test.ts
+++ b/apps/web/src/features/editor/mediaApi.test.ts
@@ -714,4 +714,57 @@ describe("uploadMediaFile", () => {
       category_id: undefined,
     });
   });
+
+  it("rounds fractional upload duration before requesting an upload URL", async () => {
+    const requestUploadUrl = vi.fn().mockResolvedValue(mockUploadUrl);
+    const confirmUpload = vi.fn().mockResolvedValue(mockMedia);
+    const putFile = vi.fn().mockResolvedValue(undefined);
+
+    await uploadMediaFile({
+      themeId: THEME_ID,
+      file,
+      type: "BGM",
+      name: "song",
+      duration: 125.6,
+      requestUploadUrl,
+      confirmUpload,
+      putFile,
+      retryBaseDelayMs: 0,
+    });
+
+    expect(requestUploadUrl).toHaveBeenCalledWith({
+      name: "song",
+      type: "BGM",
+      mime_type: "audio/mpeg",
+      file_size: file.size,
+      duration: 126,
+      category_id: undefined,
+    });
+  });
+
+  it("omits invalid upload duration before requesting an upload URL", async () => {
+    const requestUploadUrl = vi.fn().mockResolvedValue(mockUploadUrl);
+    const confirmUpload = vi.fn().mockResolvedValue(mockMedia);
+    const putFile = vi.fn().mockResolvedValue(undefined);
+
+    await uploadMediaFile({
+      themeId: THEME_ID,
+      file,
+      type: "BGM",
+      name: "song",
+      duration: Number.NaN,
+      requestUploadUrl,
+      confirmUpload,
+      putFile,
+      retryBaseDelayMs: 0,
+    });
+
+    expect(requestUploadUrl).toHaveBeenCalledWith({
+      name: "song",
+      type: "BGM",
+      mime_type: "audio/mpeg",
+      file_size: file.size,
+      category_id: undefined,
+    });
+  });
 });

--- a/apps/web/src/features/editor/mediaApi.test.ts
+++ b/apps/web/src/features/editor/mediaApi.test.ts
@@ -687,4 +687,31 @@ describe("uploadMediaFile", () => {
       category_id: "category-1",
     });
   });
+
+  it("passes detected duration through the upload helper request", async () => {
+    const requestUploadUrl = vi.fn().mockResolvedValue(mockUploadUrl);
+    const confirmUpload = vi.fn().mockResolvedValue(mockMedia);
+    const putFile = vi.fn().mockResolvedValue(undefined);
+
+    await uploadMediaFile({
+      themeId: THEME_ID,
+      file,
+      type: "BGM",
+      name: "song",
+      duration: 125,
+      requestUploadUrl,
+      confirmUpload,
+      putFile,
+      retryBaseDelayMs: 0,
+    });
+
+    expect(requestUploadUrl).toHaveBeenCalledWith({
+      name: "song",
+      type: "BGM",
+      mime_type: "audio/mpeg",
+      file_size: file.size,
+      duration: 125,
+      category_id: undefined,
+    });
+  });
 });

--- a/apps/web/src/features/editor/mediaApi.ts
+++ b/apps/web/src/features/editor/mediaApi.ts
@@ -31,6 +31,7 @@ export interface RequestUploadUrlRequest {
   type: MediaType;
   mime_type: string;
   file_size: number;
+  duration?: number;
   category_id?: string;
 }
 
@@ -344,6 +345,7 @@ export interface UploadMediaFileParams {
   type: MediaType;
   name: string;
   categoryId?: string;
+  duration?: number;
   requestUploadUrl: (
     req: RequestUploadUrlRequest,
   ) => Promise<UploadUrlResponse>;
@@ -377,6 +379,7 @@ export async function uploadMediaFile(
     name,
     requestUploadUrl,
     confirmUpload,
+    duration,
     onProgress,
     signal,
     putFile = defaultPutFile,
@@ -394,6 +397,7 @@ export async function uploadMediaFile(
     type,
     mime_type: effectiveMimeType,
     file_size: file.size,
+    ...(duration != null ? { duration } : {}),
     category_id: params.categoryId,
   });
 

--- a/apps/web/src/features/editor/mediaApi.ts
+++ b/apps/web/src/features/editor/mediaApi.ts
@@ -365,6 +365,13 @@ export interface UploadMediaFileParams {
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+const normalizeUploadDuration = (duration: number | undefined) => {
+  if (duration == null || !Number.isFinite(duration) || duration < 0) {
+    return undefined;
+  }
+  return Math.round(duration);
+};
+
 /**
  * Three-step media upload: request presigned URL → PUT file → confirm.
  * Retries the PUT step up to maxAttempts on network errors with exponential
@@ -390,6 +397,7 @@ export async function uploadMediaFile(
 
   const effectiveMimeType =
     (mimeType ?? file.type) || "application/octet-stream";
+  const normalizedDuration = normalizeUploadDuration(duration);
 
   // Step 1: request presigned URL
   const uploadUrl = await requestUploadUrl({
@@ -397,7 +405,7 @@ export async function uploadMediaFile(
     type,
     mime_type: effectiveMimeType,
     file_size: file.size,
-    ...(duration != null ? { duration } : {}),
+    ...(normalizedDuration != null ? { duration: normalizedDuration } : {}),
     category_id: params.categoryId,
   });
 


### PR DESCRIPTION
## 요약
- 미디어 관리 카드 폭과 프리뷰를 아이콘형 비율로 줄이고, 이미지 프리뷰는 전체가 보이도록 object-contain으로 조정했습니다.
- 이미지가 아닌 BGM/효과음/음성/비디오/문서 미디어는 같은 카드 모양에서 타입별 아이콘 프리뷰로 보이게 정리했습니다.
- WAV MIME alias와 RIFF/WAVE magic-byte를 허용하고, 오디오/비디오 길이 메타데이터를 업로드 시 저장하도록 보강했습니다.
- 미디어 상세에서 길이는 재생 가능한 미디어에만 읽기 전용 정보로 표시하고, 오디오 카테고리 이동만 BGM/효과음/음성 사이에서 허용합니다.

## Issue
- 사용자 직접 보고 기반 ad-hoc bugfix입니다. 별도 GitHub Issue는 없습니다.

## Coverage Plan
- apps/web/src/features/editor/components/media/MediaCard.tsx: 이미지 프리뷰와 비이미지 아이콘 카드 렌더링을 컴포넌트 테스트로 확인합니다.
- apps/web/src/features/editor/components/media/MediaTab.tsx: grid 카드 폭 축소와 목록 렌더링을 기존 테스트로 확인합니다.
- apps/web/src/features/editor/components/media/MediaUploadModal.tsx: WAV alias 허용과 duration 추출 payload를 테스트로 확인합니다.
- apps/web/src/features/editor/mediaApi.ts: upload duration 전달을 API 테스트로 확인합니다.
- apps/server/internal/domain/editor: WAV MIME/magic-byte 허용, duration 저장, 오디오 그룹 내 타입 변경 제한을 Go 테스트로 확인합니다.

## Local validation
- pnpm --filter @mmp/web test -- MediaUploadModal.test.tsx MediaCard.test.tsx MediaTab.test.tsx mediaApi.test.ts: success (4 files, 75 tests)
- go test ./internal/domain/editor: success
- scripts/mmp-local-ci.sh quick: success (HEAD 937a49e3e12fb627c539164139cdf4de7ca575a9, finished 2026-05-12T02:45:36Z)
- 포함: go test -race ./..., pnpm turbo lint/typecheck/test/build
- PR guard local-ci marker는 이후 다른 브랜치 검증으로 덮여 MMP_SKIP_LOCAL_CI_GUARD=1로 생성했습니다. 우회 사유는 marker가 단일 last-run 파일이기 때문이며, 이 HEAD의 quick 성공 근거는 위에 기록했습니다.

## 리뷰/머지 기준
- ready-for-ci 라벨은 사용하지 않습니다.
- CodeRabbit 리뷰와 unresolved thread 0 확인 후 머지 판단합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 업로드 시 오디오/비디오 재생 시간 자동 추출 및 전달(업로드에 길이 포함)
  * 이미지(비공개 업로드 포함) 미리보기용 임시 다운로드 처리

* **버그 수정**
  * WAV 관련 추가 MIME 지원: audio/x-wav, audio/wave, audio/vnd.wave
  * 음성/효과/배경음 간 동일 그룹 내에서만 유형 변경 허용

* **개선 사항**
  * 미디어 그리드 반응형 조정 및 미리보기 UI 개선
  * 업로드 시 음원 길이 검사 상태 표시 및 음성형 길이 표기 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/564)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->