### PR TITLE
fix(editor): 장면 연결 edge UUID 저장 보정

### DIFF
--- a/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
@@ -93,6 +93,20 @@ describe("toSaveRequest", () => {
     expect(req.edges[0].id).toMatch(UUID_RE);
   });
 
+  it("React Flow 임시 edge id 보정값은 같은 세션에서 안정적으로 유지한다", () => {
+    const rfNode = toReactFlowNode(baseNode);
+    const rfEdge = {
+      ...toReactFlowEdge(baseEdge),
+      id: "xy-edge__node-1-node-2-stable",
+    };
+
+    const first = toSaveRequest([rfNode], [rfEdge]);
+    const second = toSaveRequest([rfNode], [rfEdge]);
+
+    expect(first.edges[0].id).toMatch(UUID_RE);
+    expect(second.edges[0].id).toBe(first.edges[0].id);
+  });
+
   it("완성된 조건만 저장 요청에 포함한다", () => {
     const rfNode = toReactFlowNode(baseNode);
     const rfEdge = {

--- a/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { toReactFlowNode, toReactFlowEdge, toSaveRequest } from "../flowConverters";
 import type { FlowNodeResponse, FlowEdgeResponse } from "../../flowTypes";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 const baseNode: FlowNodeResponse = {
   id: "node-1",
   theme_id: "theme-1",
@@ -78,6 +80,17 @@ describe("toSaveRequest", () => {
     expect(req.edges[0].source_id).toBe("node-1");
     expect(req.edges[0].target_id).toBe("node-2");
     expect(req.edges[0].sort_order).toBe(0);
+  });
+
+  it("React Flow 임시 edge id는 서버 저장 가능한 UUID로 보정한다", () => {
+    const rfNode = toReactFlowNode(baseNode);
+    const rfEdge = {
+      ...toReactFlowEdge(baseEdge),
+      id: "xy-edge__node-1-node-2",
+    };
+    const req = toSaveRequest([rfNode], [rfEdge]);
+
+    expect(req.edges[0].id).toMatch(UUID_RE);
   });
 
   it("완성된 조건만 저장 요청에 포함한다", () => {

--- a/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/flowConverters.test.ts
@@ -95,13 +95,13 @@ describe("toSaveRequest", () => {
 
   it("React Flow 임시 edge id 보정값은 같은 세션에서 안정적으로 유지한다", () => {
     const rfNode = toReactFlowNode(baseNode);
-    const rfEdge = {
+    const makeRfEdge = () => ({
       ...toReactFlowEdge(baseEdge),
       id: "xy-edge__node-1-node-2-stable",
-    };
+    });
 
-    const first = toSaveRequest([rfNode], [rfEdge]);
-    const second = toSaveRequest([rfNode], [rfEdge]);
+    const first = toSaveRequest([rfNode], [makeRfEdge()]);
+    const second = toSaveRequest([rfNode], [makeRfEdge()]);
 
     expect(first.edges[0].id).toMatch(UUID_RE);
     expect(second.edges[0].id).toBe(first.edges[0].id);

--- a/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
@@ -55,6 +55,8 @@ function latestSavedGraph() {
   return calls[calls.length - 1][0];
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 describe('useFlowData', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -148,6 +150,33 @@ describe('useFlowData', () => {
 
     expect(latestSavedGraph().edges).toHaveLength(2);
     expect(latestSavedGraph().edges[1]).toMatchObject({ source_id: 'n2', target_id: 'n1' });
+  });
+
+  it('onConnect가 서버 저장 가능한 UUID edge id를 생성한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.onConnect({
+        source: 'n2',
+        target: 'n1',
+        sourceHandle: null,
+        targetHandle: null,
+      });
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(latestSavedGraph().edges[1].id).toMatch(UUID_RE);
+  });
+
+  it('connectNodes가 서버 저장 가능한 UUID edge id를 생성한다', () => {
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.connectNodes('n2', 'n1');
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(latestSavedGraph().edges[1].id).toMatch(UUID_RE);
   });
 
   it('node 삭제 성공 시 연결된 edge도 ref와 저장 payload에서 제거한다', () => {

--- a/apps/web/src/features/editor/hooks/flowConverters.ts
+++ b/apps/web/src/features/editor/hooks/flowConverters.ts
@@ -6,6 +6,8 @@ import type {
 } from "../flowTypes";
 import { isCompleteConditionGroupRecord } from "../components/design/condition/conditionTypes";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 // ---------------------------------------------------------------------------
 // Converters: server ↔ ReactFlow
 // ---------------------------------------------------------------------------
@@ -39,7 +41,7 @@ export function toSaveRequest(nodes: Node[], edges: Edge[]): SaveFlowRequest {
       position_y: n.position.y,
     })),
     edges: edges.map((e, i) => ({
-      id: e.id,
+      id: toPersistableEdgeId(e.id),
       source_id: e.source,
       target_id: e.target,
       condition: toPersistedCondition(e.data),
@@ -47,6 +49,10 @@ export function toSaveRequest(nodes: Node[], edges: Edge[]): SaveFlowRequest {
       sort_order: i,
     })),
   };
+}
+
+function toPersistableEdgeId(id: string): string {
+  return UUID_RE.test(id) ? id : crypto.randomUUID();
 }
 
 function toPersistedCondition(data: Edge["data"]): Record<string, unknown> | null {

--- a/apps/web/src/features/editor/hooks/flowConverters.ts
+++ b/apps/web/src/features/editor/hooks/flowConverters.ts
@@ -7,6 +7,7 @@ import type {
 import { isCompleteConditionGroupRecord } from "../components/design/condition/conditionTypes";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const nonUuidEdgeIdMap = new Map<string, string>();
 
 // ---------------------------------------------------------------------------
 // Converters: server ↔ ReactFlow
@@ -52,7 +53,16 @@ export function toSaveRequest(nodes: Node[], edges: Edge[]): SaveFlowRequest {
 }
 
 function toPersistableEdgeId(id: string): string {
-  return UUID_RE.test(id) ? id : crypto.randomUUID();
+  if (UUID_RE.test(id)) {
+    return id;
+  }
+  const cached = nonUuidEdgeIdMap.get(id);
+  if (cached) {
+    return cached;
+  }
+  const next = crypto.randomUUID();
+  nonUuidEdgeIdMap.set(id, next);
+  return next;
 }
 
 function toPersistedCondition(data: Edge["data"]): Record<string, unknown> | null {

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -19,6 +19,10 @@ import { createDefaultTemplate } from './flowDefaults';
 import { useEdgeCondition } from './useEdgeCondition';
 import { useApplyPreset } from './useApplyPreset';
 
+function createFlowEdgeId(): string {
+  return crypto.randomUUID();
+}
+
 export function useFlowData(themeId: string) {
   const { data, isLoading, isError, error, refetch } = useFlowGraph(themeId);
   const saveFlow = useSaveFlow(themeId);
@@ -112,7 +116,7 @@ export function useFlowData(themeId: string) {
   );
   const onConnect: OnConnect = useCallback(
     (connection) => {
-      const next = addEdge(connection, edgesRef.current);
+      const next = addEdge({ id: createFlowEdgeId(), ...connection }, edgesRef.current);
       setEdgesAndRef(next);
       autoSave(nodesRef.current, next);
     },
@@ -121,7 +125,10 @@ export function useFlowData(themeId: string) {
 
   const connectNodes = useCallback(
     (sourceId: string, targetId: string) => {
-      const next = addEdge({ source: sourceId, target: targetId, type: 'condition' }, edgesRef.current);
+      const next = addEdge(
+        { id: createFlowEdgeId(), source: sourceId, target: targetId, type: 'condition' },
+        edgesRef.current
+      );
       setEdgesAndRef(next);
       autoSave(nodesRef.current, next);
     },


### PR DESCRIPTION
## 요약
- React Flow가 만든 임시 edge id를 서버 저장 가능한 UUID로 보정합니다.
- onConnect/connectNodes 신규 연결 id를 UUID로 생성합니다.
- 저장 변환 단계에서도 비-UUID edge id를 UUID로 방어 보정합니다.

## Coverage Plan
- apps/web/src/features/editor/hooks/useFlowData.ts: onConnect/connectNodes가 UUID edge id를 생성하는 회귀 테스트로 검증했습니다.
- apps/web/src/features/editor/hooks/flowConverters.ts: React Flow 임시 edge id가 저장 요청에서 UUID로 보정되는 회귀 테스트로 검증했습니다.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/hooks/__tests__/useFlowData.test.ts src/features/editor/hooks/__tests__/flowConverters.test.ts (18 passed)
- pnpm --filter @mmp/web typecheck
- scripts/mmp-local-ci.sh quick (success, head dd107c36d9feb7502a3d172e53e1b8b02c6967dc)

## 비고
- 긴급 로컬 재현 버그픽스라 별도 Issue 없이 진행했습니다.
- ready-for-ci 라벨과 workflow_dispatch는 사용하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 플로우 에디터의 임시 엣지 ID가 서버에 저장될 때 UUID 형식의 안정적 식별자로 변환되도록 개선했습니다.
  * 새로 생성되는 엣지에 일관된 UUID 기반 ID가 할당되어 동일 세션 내 반복 저장 시 ID가 안정적으로 유지됩니다.

* **테스트**
  * 엣지 ID 검증 및 UUID 생성/재사용 동작을 검증하는 테스트 케이스를 추가했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/565)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->