### PR TITLE
fix(editor): 장면 복제/삭제 버튼을 상단에 표시

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -620,7 +620,7 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
 
     await node.click();
     page.once('dialog', (dialog) => dialog.accept());
-    await page.getByRole('button', { name: '선택 항목 삭제' }).click();
+    await page.getByRole('button', { name: '장면 삭제' }).click();
     await expect.poll(() => state.flowDeleteNodeCalls).toBeGreaterThanOrEqual(1);
   });
 

--- a/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
@@ -46,9 +46,36 @@ export function NodeDetailPanel({
   const isStart = node.type === "start";
   const canEditConnections =
     node.type === "start" || node.type === "phase";
+  const canUseSceneActions = node.type === "phase";
 
   return (
     <div className="min-h-full">
+      {canUseSceneActions && (
+        <div className="sticky top-0 z-10 space-y-2 border-b border-slate-800 bg-slate-900 p-3 shadow-[0_8px_20px_rgba(15,23,42,0.35)]">
+          {onDuplicate && (
+            <button
+              type="button"
+              onClick={() => onDuplicate(node.id)}
+              className="flex w-full items-center justify-center gap-1.5 rounded border border-slate-700 bg-slate-950 px-3 py-2 text-xs font-semibold text-slate-200 transition-colors hover:border-amber-500/60 hover:text-amber-200"
+            >
+              <Copy className="h-3.5 w-3.5" />
+              장면 복제
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              if (!window.confirm("이 장면을 삭제할까요? 연결된 선도 함께 삭제됩니다.")) return;
+              onDelete(node.id);
+            }}
+            className="flex w-full items-center justify-center gap-1.5 rounded border border-red-800 bg-red-950/30 px-3 py-2 text-xs font-semibold text-red-300 transition-colors hover:border-red-600 hover:bg-red-900/30"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            장면 삭제
+          </button>
+        </div>
+      )}
+
       {/* Panel content */}
       <div>
         {isStart ? (
@@ -78,32 +105,6 @@ export function NodeDetailPanel({
         />
       )}
 
-      {/* Delete button — start 노드 제외 */}
-      {!isStart && (
-        <div className="space-y-2 border-t border-slate-800 p-3">
-          {node.type === "phase" && onDuplicate && (
-            <button
-              type="button"
-              onClick={() => onDuplicate(node.id)}
-              className="flex w-full items-center justify-center gap-1.5 rounded border border-slate-700 bg-slate-950 px-3 py-1.5 text-xs text-slate-200 transition-colors hover:border-amber-500/60 hover:text-amber-200"
-            >
-              <Copy className="h-3.5 w-3.5" />
-              장면 복제
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => {
-              if (!window.confirm("이 장면을 삭제할까요? 연결된 선도 함께 삭제됩니다.")) return;
-              onDelete(node.id);
-            }}
-            className="flex w-full items-center justify-center gap-1.5 rounded border border-red-800 bg-red-950/30 px-3 py-1.5 text-xs text-red-400 transition-colors hover:border-red-600 hover:bg-red-900/30"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            선택 항목 삭제
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
@@ -84,7 +84,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.queryByText("선택 항목 삭제")).toBeNull();
+    expect(screen.queryByText("장면 삭제")).toBeNull();
   });
 
   it("start 노드에서도 다음 장면 연결을 편집할 수 있다", () => {
@@ -134,7 +134,7 @@ describe("NodeDetailPanel", () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText("선택 항목 삭제")).toBeDefined();
+    expect(screen.getByText("장면 삭제")).toBeDefined();
   });
 
   it("삭제 버튼 클릭 시 onDelete가 노드 id와 함께 호출된다", () => {
@@ -148,7 +148,7 @@ describe("NodeDetailPanel", () => {
         onDelete={onDelete}
       />,
     );
-    fireEvent.click(screen.getByText("선택 항목 삭제"));
+    fireEvent.click(screen.getByText("장면 삭제"));
     expect(window.confirm).toHaveBeenCalledWith("이 장면을 삭제할까요? 연결된 선도 함께 삭제됩니다.");
     expect(onDelete).toHaveBeenCalledWith("node-1");
   });
@@ -165,7 +165,7 @@ describe("NodeDetailPanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("선택 항목 삭제"));
+    fireEvent.click(screen.getByText("장면 삭제"));
 
     expect(onDelete).not.toHaveBeenCalled();
   });
@@ -185,6 +185,35 @@ describe("NodeDetailPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "장면 복제" }));
 
     expect(onDuplicate).toHaveBeenCalledWith("node-1");
+  });
+
+  it("장면 액션은 다음 장면 연결보다 먼저 보여준다", () => {
+    render(
+      <NodeDetailPanel
+        node={storyNodes[0]}
+        themeId="t1"
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        nodes={storyNodes}
+        edges={[]}
+        onConnectNodes={vi.fn()}
+        onDeleteEdge={vi.fn()}
+      />,
+    );
+
+    const duplicateButton = screen.getByRole("button", { name: "장면 복제" });
+    const deleteButton = screen.getByRole("button", { name: "장면 삭제" });
+    const nextSceneLabel = screen.getByText("다음 장면 연결");
+
+    expect(
+      duplicateButton.compareDocumentPosition(nextSceneLabel) &
+        globalThis.Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      deleteButton.compareDocumentPosition(nextSceneLabel) &
+        globalThis.Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("선택한 장면에서 다음 장면을 버튼으로 연결할 수 있다", () => {


### PR DESCRIPTION
Refs #568

## 요약

- 스토리 진행 장면 선택 패널에서 장면 복제 / 장면 삭제 버튼을 오른쪽 패널 최상단 sticky 액션 영역으로 이동했습니다.
- 삭제 버튼 문구를 선택 항목 삭제에서 장면 삭제로 바꿔 기능을 바로 알아볼 수 있게 했습니다.
- 다음 장면 연결 섹션보다 장면 액션이 먼저 렌더링되도록 회귀 테스트를 추가했습니다.

## Coverage Plan

- NodeDetailPanel.test.tsx: phase 장면의 장면 삭제 버튼, 삭제 confirm, 복제 버튼, 액션 영역이 다음 장면 연결보다 먼저 보이는지 검증했습니다.
- editor-golden-path.spec.ts [7B]: mocked E2E 삭제 버튼 이름을 장면 삭제로 갱신해 복제/삭제 흐름을 검증했습니다.

## Local validation

- pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx: passed
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium -g "\\[7B\\]": passed
- pnpm --filter @mmp/web typecheck: passed
- pnpm --filter @mmp/web lint: passed with existing warnings only
- scripts/mmp-local-ci.sh quick: passed, head f998c2b1d75b5322b705559c2f530af1115eff83

## 확인

- cmux surface:7에서 기존 버튼이 하단에 있어 발견성이 떨어지는 상태를 DOM snapshot으로 확인했습니다.
- 이후 surface는 로그인 화면으로 돌아가 직접 시각 재확인은 못 했지만, dev server는 localhost:3000에서 HTTP 200 응답 중입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 에디터 패널의 장면 삭제 및 복제 버튼이 상단 고정 액션 바로 이동하여 더 빠르게 접근 가능
  * 단계별 노드의 작업 버튼이 개선된 UI 레이아웃으로 정렬되어 사용성 향상

* **테스트**
  * 에디터 기능 및 UI 순서 검증 테스트 강화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/570)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->