### PR TITLE
장면 액션을 장면 설정 제목 줄에 배치

### DIFF
--- a/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
@@ -46,36 +46,39 @@ export function NodeDetailPanel({
   const isStart = node.type === "start";
   const canEditConnections =
     node.type === "start" || node.type === "phase";
-  const canUseSceneActions = node.type === "phase";
+  const phaseActions =
+    node.type === "phase" ? (
+      <>
+        {onDuplicate ? (
+          <button
+            type="button"
+            aria-label="장면 복제"
+            title="장면 복제"
+            onClick={() => onDuplicate(node.id)}
+            className="inline-flex h-7 items-center gap-1 rounded border border-amber-500/50 bg-amber-500/10 px-2 text-[11px] font-semibold text-amber-100 transition-colors hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+          >
+            <Copy className="h-3.5 w-3.5" />
+            장면 복제
+          </button>
+        ) : null}
+        <button
+          type="button"
+          aria-label="장면 삭제"
+          title="장면 삭제"
+          onClick={() => {
+            if (!window.confirm("이 장면을 삭제할까요? 연결된 선도 함께 삭제됩니다.")) return;
+            onDelete(node.id);
+          }}
+          className="inline-flex h-7 items-center gap-1 rounded border border-red-500/50 bg-red-500/10 px-2 text-[11px] font-semibold text-red-200 transition-colors hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/60"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          장면 삭제
+        </button>
+      </>
+    ) : undefined;
 
   return (
     <div className="min-h-full">
-      {canUseSceneActions && (
-        <div className="sticky top-0 z-10 space-y-2 border-b border-slate-800 bg-slate-900 p-3 shadow-[0_8px_20px_rgba(15,23,42,0.35)]">
-          {onDuplicate && (
-            <button
-              type="button"
-              onClick={() => onDuplicate(node.id)}
-              className="flex w-full items-center justify-center gap-1.5 rounded border border-slate-700 bg-slate-950 px-3 py-2 text-xs font-semibold text-slate-200 transition-colors hover:border-amber-500/60 hover:text-amber-200"
-            >
-              <Copy className="h-3.5 w-3.5" />
-              장면 복제
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => {
-              if (!window.confirm("이 장면을 삭제할까요? 연결된 선도 함께 삭제됩니다.")) return;
-              onDelete(node.id);
-            }}
-            className="flex w-full items-center justify-center gap-1.5 rounded border border-red-800 bg-red-950/30 px-3 py-2 text-xs font-semibold text-red-300 transition-colors hover:border-red-600 hover:bg-red-900/30"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            장면 삭제
-          </button>
-        </div>
-      )}
-
       {/* Panel content */}
       <div>
         {isStart ? (
@@ -85,7 +88,13 @@ export function NodeDetailPanel({
             </span>
           </div>
         ) : node.type === "phase" ? (
-          <PhaseNodePanel node={node} themeId={themeId} onUpdate={onUpdate} edges={edges} />
+          <PhaseNodePanel
+            node={node}
+            themeId={themeId}
+            onUpdate={onUpdate}
+            edges={edges}
+            headerActions={phaseActions}
+          />
         ) : (
           <div className="flex h-full items-center justify-center p-4">
             <span className="text-xs text-slate-500">

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { Edge, Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -23,12 +24,18 @@ interface PhaseNodePanelProps {
   themeId: string;
   onUpdate: (id: string, data: Partial<FlowNodeData>) => void;
   edges?: Edge[];
+  headerActions?: ReactNode;
 }
 
 /** Debounce window for flow-node saves (W2 PR-5: 500→1500ms). */
 const SAVE_DEBOUNCE_MS = 1500;
 
-export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps) {
+export function PhaseNodePanel({
+  node,
+  themeId,
+  onUpdate,
+  headerActions,
+}: PhaseNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
   const { data: maps = [], isLoading: mapsLoading } = useEditorMaps(themeId);
   const queryClient = useQueryClient();
@@ -67,9 +74,16 @@ export function PhaseNodePanel({ node, themeId, onUpdate }: PhaseNodePanelProps)
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-        장면 설정
-      </h3>
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+          장면 설정
+        </h3>
+        {headerActions ? (
+          <div className="flex shrink-0 items-center gap-1.5">
+            {headerActions}
+          </div>
+        ) : null}
+      </div>
 
       <PhasePanelBasicInfo
         label={data.label}

--- a/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
@@ -1,13 +1,21 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import type { Edge, Node } from "@xyflow/react";
+import type { ReactNode } from "react";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
 vi.mock("../PhaseNodePanel", () => ({
-  PhaseNodePanel: () => <div>장면 설정</div>,
+  PhaseNodePanel: ({ headerActions }: { headerActions?: ReactNode }) => (
+    <div>
+      <div data-testid="scene-settings-header">
+        <span>장면 설정</span>
+        {headerActions}
+      </div>
+    </div>
+  ),
 }));
 
 // ---------------------------------------------------------------------------
@@ -187,7 +195,7 @@ describe("NodeDetailPanel", () => {
     expect(onDuplicate).toHaveBeenCalledWith("node-1");
   });
 
-  it("장면 액션은 다음 장면 연결보다 먼저 보여준다", () => {
+  it("장면 액션은 장면 설정 제목 줄에 보여준다", () => {
     render(
       <NodeDetailPanel
         node={storyNodes[0]}
@@ -202,18 +210,12 @@ describe("NodeDetailPanel", () => {
       />,
     );
 
+    const header = screen.getByTestId("scene-settings-header");
     const duplicateButton = screen.getByRole("button", { name: "장면 복제" });
     const deleteButton = screen.getByRole("button", { name: "장면 삭제" });
-    const nextSceneLabel = screen.getByText("다음 장면 연결");
 
-    expect(
-      duplicateButton.compareDocumentPosition(nextSceneLabel) &
-        globalThis.Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      deleteButton.compareDocumentPosition(nextSceneLabel) &
-        globalThis.Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+    expect(header.contains(duplicateButton)).toBe(true);
+    expect(header.contains(deleteButton)).toBe(true);
   });
 
   it("선택한 장면에서 다음 장면을 버튼으로 연결할 수 있다", () => {


### PR DESCRIPTION
## 요약
- 장면 복제/삭제 버튼을 오른쪽 패널 상단의 큰 영역에서 제거했습니다.
- `장면 설정` 제목 줄 오른쪽에 작은 버튼으로 배치했습니다.
- 버튼 동작은 `NodeDetailPanel`에 유지하고 `PhaseNodePanel`은 제목 줄 위치만 제공합니다.

## Coverage Plan
- `NodeDetailPanel`: phase 노드에서 복제/삭제 버튼이 `장면 설정` 제목 줄 안에 렌더링되는지 검증
- `PhaseNodePanel`: `headerActions` 슬롯으로 제목 줄 오른쪽 배치만 담당

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx`
- `pnpm --filter @mmp/web typecheck`
- `scripts/mmp-local-ci.sh quick`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 편집기 인터페이스에서 장면 액션 버튼(복제/삭제)의 위치를 재정렬했습니다. 이제 장면 설정 헤더 내에 통합되어 있습니다.
  * 컴포넌트 구조를 최적화하여 더 나은 유지보수성을 제공합니다.

* **테스트**
  * 새로운 컴포넌트 구조를 반영하도록 테스트 코드를 업데이트했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/571)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->