### PR TITLE
fix(editor): 공용 확인창으로 confirm 대체

### DIFF
--- a/apps/web/src/features/editor/components/design/FlowCanvas.tsx
+++ b/apps/web/src/features/editor/components/design/FlowCanvas.tsx
@@ -11,6 +11,7 @@ import {
 import '@xyflow/react/dist/style.css';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { ConfirmDialog } from '@/shared/components/ui';
 import { useFlowData } from '../../hooks/useFlowData';
 import { useFlowConnections } from '../../hooks/useFlowConnections';
 import { FlowToolbar } from './FlowToolbar';
@@ -53,6 +54,7 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
   const [showOrderReview, setShowOrderReview] = useState(false);
   const [highlightId, setHighlightId] = useState<string | null>(null);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
+  const [pendingDeleteEdgeId, setPendingDeleteEdgeId] = useState<string | null>(null);
 
   const {
     nodes,
@@ -116,6 +118,10 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
   const selectedEdge = useMemo(
     () => flowEdges.find((edge) => edge.id === selectedEdgeId) ?? null,
     [flowEdges, selectedEdgeId]
+  );
+  const pendingDeleteEdge = useMemo(
+    () => flowEdges.find((edge) => edge.id === pendingDeleteEdgeId) ?? null,
+    [flowEdges, pendingDeleteEdgeId]
   );
 
   const handleAddScene = useCallback(
@@ -256,11 +262,7 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
                   </div>
                   <button
                     type="button"
-                    onClick={() => {
-                      if (!window.confirm('선 연결을 끊을까요? 이 작업은 즉시 저장됩니다.')) return;
-                      deleteEdge(selectedEdge.id);
-                      setSelectedEdgeId(null);
-                    }}
+                    onClick={() => setPendingDeleteEdgeId(selectedEdge.id)}
                     className="w-full rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-200 transition hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/60"
                   >
                     연결 끊기
@@ -299,6 +301,20 @@ export function FlowCanvas({ themeId, onSelectedNodeChange }: FlowCanvasProps) {
           )}
         </div>
       </div>
+      <ConfirmDialog
+        isOpen={pendingDeleteEdge != null}
+        title="선 연결을 끊을까요?"
+        description="이 작업은 즉시 저장됩니다."
+        confirmLabel="연결 끊기"
+        tone="danger"
+        onCancel={() => setPendingDeleteEdgeId(null)}
+        onConfirm={() => {
+          if (!pendingDeleteEdge) return;
+          deleteEdge(pendingDeleteEdge.id);
+          setSelectedEdgeId(null);
+          setPendingDeleteEdgeId(null);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/FlowToolbar.tsx
+++ b/apps/web/src/features/editor/components/design/FlowToolbar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { Plus, Save, ChevronDown, LayoutTemplate, Play } from "lucide-react";
+import { ConfirmDialog } from "@/shared/components/ui";
 import { FLOW_PRESETS, createPresetFlow } from "../../hooks/flowPresets";
 import type { Node, Edge } from "@xyflow/react";
 
@@ -31,7 +32,15 @@ export function FlowToolbar({
   isOrderReviewing,
 }: FlowToolbarProps) {
   const [presetOpen, setPresetOpen] = useState(false);
+  const [pendingPresetId, setPendingPresetId] = useState<string | null>(null);
   const presetRef = useRef<HTMLDivElement>(null);
+  const pendingPreset = FLOW_PRESETS.find((preset) => preset.id === pendingPresetId) ?? null;
+
+  function applyPresetFromTemplate(preset: (typeof FLOW_PRESETS)[number]) {
+    const flow = createPresetFlow(preset);
+    onApplyPreset?.(flow.nodes, flow.edges);
+    setPresetOpen(false);
+  }
 
   // Close dropdowns on outside click
   useEffect(() => {
@@ -75,10 +84,12 @@ export function FlowToolbar({
                   key={preset.id}
                   type="button"
                   onClick={() => {
-                    if (hasNodes && !window.confirm("기존 흐름이 대체됩니다. 계속할까요?")) return;
-                    const flow = createPresetFlow(preset);
-                    onApplyPreset(flow.nodes, flow.edges);
-                    setPresetOpen(false);
+                    if (hasNodes) {
+                      setPendingPresetId(preset.id);
+                      setPresetOpen(false);
+                      return;
+                    }
+                    applyPresetFromTemplate(preset);
                   }}
                   className="flex w-full flex-col px-3 py-2 text-left transition-colors hover:bg-slate-700"
                 >
@@ -123,6 +134,19 @@ export function FlowToolbar({
         <Save className="h-3.5 w-3.5" />
         {isSaving ? "저장 중..." : "저장"}
       </button>
+      <ConfirmDialog
+        isOpen={pendingPreset != null}
+        title="기존 흐름을 대체할까요?"
+        description="현재 장면 흐름이 프리셋으로 바뀝니다."
+        confirmLabel="프리셋 적용"
+        tone="warning"
+        onCancel={() => setPendingPresetId(null)}
+        onConfirm={() => {
+          if (!pendingPreset) return;
+          applyPresetFromTemplate(pendingPreset);
+          setPendingPresetId(null);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/InvestigationTokenSettingsPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InvestigationTokenSettingsPanel.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
+import { ConfirmDialog } from '@/shared/components/ui';
 import type {
   DeckInvestigationConfigDraft,
   InvestigationTokenDraft,
@@ -35,9 +37,15 @@ export function InvestigationTokenSettingsPanel({
   isSaving,
   onChange,
 }: InvestigationTokenSettingsPanelProps) {
+  const [pendingDeleteTokenId, setPendingDeleteTokenId] = useState<string | null>(null);
   const tokens = draft.tokens.length > 0 ? draft.tokens : [
     { id: 'investigation-token', name: '조사권', iconLabel: '권', defaultAmount: 0 },
   ];
+  const pendingDeleteToken =
+    tokens.find((token) => token.id === pendingDeleteTokenId) ?? null;
+  const affectedDeckCount = pendingDeleteToken
+    ? draft.decks.filter((deck) => deck.tokenId === pendingDeleteToken.id).length
+    : 0;
 
   function updateToken(tokenId: string, patch: Partial<InvestigationTokenDraft>) {
     onChange({
@@ -73,16 +81,6 @@ export function InvestigationTokenSettingsPanel({
         deck.tokenId === tokenId ? { ...deck, tokenId: fallbackTokenId } : deck,
       ),
     });
-  }
-
-  function confirmAndRemoveToken(token: InvestigationTokenDraft) {
-    const affectedDeckCount = draft.decks.filter((deck) => deck.tokenId === token.id).length;
-    const confirmed = window.confirm(
-      `조사권 "${token.name}"을(를) 삭제할까요?\n` +
-        `연결된 단서 조사 덱 ${affectedDeckCount}개는 다른 조사권으로 자동 변경됩니다.`,
-    );
-    if (!confirmed) return;
-    removeToken(token.id);
   }
 
   return (
@@ -159,7 +157,7 @@ export function InvestigationTokenSettingsPanel({
 
             <button
               type="button"
-              onClick={() => confirmAndRemoveToken(token)}
+              onClick={() => setPendingDeleteTokenId(token.id)}
               disabled={isSaving || tokens.length <= 1}
               aria-label={`${token.name} 조사권 삭제`}
               className="self-end rounded p-2 text-slate-500 transition hover:bg-red-950/40 hover:text-red-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60 disabled:cursor-not-allowed disabled:opacity-40"
@@ -169,6 +167,19 @@ export function InvestigationTokenSettingsPanel({
           </div>
         ))}
       </div>
+      <ConfirmDialog
+        isOpen={pendingDeleteToken != null}
+        title="조사권을 삭제할까요?"
+        description={`조사권 "${pendingDeleteToken?.name ?? '선택한 조사권'}"을(를) 삭제합니다.\n연결된 단서 조사 덱 ${affectedDeckCount}개는 다른 조사권으로 자동 변경됩니다.`}
+        confirmLabel="조사권 삭제"
+        tone="danger"
+        onCancel={() => setPendingDeleteTokenId(null)}
+        onConfirm={() => {
+          if (!pendingDeleteToken) return;
+          removeToken(pendingDeleteToken.id);
+          setPendingDeleteTokenId(null);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -16,6 +16,7 @@ import { toLocationEditorViewModel } from '@/features/editor/entities/location/l
 import { readLocationMeta } from '@/features/editor/utils/entityMeta';
 import { AddNameInput } from './AddNameInput';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
+import { ConfirmDialog } from '@/shared/components/ui';
 import { LocationAccessPolicyPanel } from './LocationAccessPolicyPanel';
 import { LocationClueAssignPanel } from './LocationClueAssignPanel';
 import { LocationImageMediaField } from './LocationImageMediaField';
@@ -57,68 +58,83 @@ export function LocationDetailPanel({
   onSelectLocation,
   onDeleteLocation,
 }: LocationDetailPanelProps) {
+  const [pendingDeleteLocation, setPendingDeleteLocation] =
+    useState<LocationResponse | null>(null);
+
   if (!selectedMap) return <LocationEmptyState message="좌측에서 맵을 선택하세요" />;
 
   return (
-    <EntityEditorShell
-      title="장소"
-      items={mapLocations}
-      selectedId={selectedLocation?.id}
-      onSelect={onSelectLocation}
-      onCreate={onStartAdd}
-      createLabel="장소 추가"
-      emptyMessage="장소 없음"
-      emptyDescription="이 맵에 배치할 장소를 추가하세요."
-      listAccessory={
-        addingLocation ? (
-          <div className="mb-3 rounded-md border border-amber-500/30 bg-slate-900 p-2">
-            <AddNameInput
-              placeholder="장소 이름"
-              onAdd={onAddLocation}
-              onCancel={onCancelAdd}
-              isPending={isCreatingLocation}
-            />
-          </div>
-        ) : null
-      }
-      getItemId={(location) => location.id}
-      getItemTitle={(location) => location.name}
-      getItemDescription={(location) =>
-        toLocationEditorViewModel(location, {
-          clueCount: readLocationClueIds(theme.config_json, location.id).length,
-          mapName: selectedMap.name,
-        }).roundLabel
-      }
-      getItemBadges={(location) =>
-        toLocationEditorViewModel(location, {
-          clueCount: readLocationClueIds(theme.config_json, location.id).length,
-          mapName: selectedMap.name,
-        }).badges
-      }
-      renderItemActions={(location) => (
-        <button
-          type="button"
-          onClick={() => {
-            if (window.confirm(`${location.name} 장소를 삭제할까요?`))
-              onDeleteLocation(location.id);
-          }}
-          aria-label={`${location.name} 삭제`}
-          className="rounded-md p-2 text-slate-700 opacity-100 transition hover:bg-red-950/40 hover:text-red-300 md:opacity-0 md:group-hover:opacity-100"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
-      )}
-      renderDetail={(location) => (
-        <SelectedLocationDetail
-          themeId={themeId}
-          theme={theme}
-          map={selectedMap}
-          location={location}
-          mapLocations={mapLocations}
-          sceneOptions={sceneOptions}
-        />
-      )}
-    />
+    <>
+      <EntityEditorShell
+        title="장소"
+        items={mapLocations}
+        selectedId={selectedLocation?.id}
+        onSelect={onSelectLocation}
+        onCreate={onStartAdd}
+        createLabel="장소 추가"
+        emptyMessage="장소 없음"
+        emptyDescription="이 맵에 배치할 장소를 추가하세요."
+        listAccessory={
+          addingLocation ? (
+            <div className="mb-3 rounded-md border border-amber-500/30 bg-slate-900 p-2">
+              <AddNameInput
+                placeholder="장소 이름"
+                onAdd={onAddLocation}
+                onCancel={onCancelAdd}
+                isPending={isCreatingLocation}
+              />
+            </div>
+          ) : null
+        }
+        getItemId={(location) => location.id}
+        getItemTitle={(location) => location.name}
+        getItemDescription={(location) =>
+          toLocationEditorViewModel(location, {
+            clueCount: readLocationClueIds(theme.config_json, location.id).length,
+            mapName: selectedMap.name,
+          }).roundLabel
+        }
+        getItemBadges={(location) =>
+          toLocationEditorViewModel(location, {
+            clueCount: readLocationClueIds(theme.config_json, location.id).length,
+            mapName: selectedMap.name,
+          }).badges
+        }
+        renderItemActions={(location) => (
+          <button
+            type="button"
+            onClick={() => setPendingDeleteLocation(location)}
+            aria-label={`${location.name} 삭제`}
+            className="rounded-md p-2 text-slate-700 opacity-100 transition hover:bg-red-950/40 hover:text-red-300 md:opacity-0 md:group-hover:opacity-100"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+        renderDetail={(location) => (
+          <SelectedLocationDetail
+            themeId={themeId}
+            theme={theme}
+            map={selectedMap}
+            location={location}
+            mapLocations={mapLocations}
+            sceneOptions={sceneOptions}
+          />
+        )}
+      />
+      <ConfirmDialog
+        isOpen={pendingDeleteLocation != null}
+        title="장소를 삭제할까요?"
+        description={`${pendingDeleteLocation?.name ?? '선택한 장소'} 장소를 삭제합니다.`}
+        confirmLabel="장소 삭제"
+        tone="danger"
+        onCancel={() => setPendingDeleteLocation(null)}
+        onConfirm={() => {
+          if (!pendingDeleteLocation) return;
+          onDeleteLocation(pendingDeleteLocation.id);
+          setPendingDeleteLocation(null);
+        }}
+      />
+    </>
   );
 }
 function SelectedLocationDetail({

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { Map, Plus, Trash2 } from 'lucide-react';
+import { ConfirmDialog } from '@/shared/components/ui';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import type { EditorThemeResponse } from '@/features/editor/api';
 import {
@@ -42,9 +43,11 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   const [selectedLocationId, setSelectedLocationId] = useState<string | null>(null);
   const [addingMap, setAddingMap] = useState(false);
   const [addingLocation, setAddingLocation] = useState(false);
+  const [pendingDeleteMapId, setPendingDeleteMapId] = useState<string | null>(null);
 
   const effectiveSelectedMapId = selectedMapId ?? maps?.[0]?.id ?? null;
   const selectedMap = maps?.find((m) => m.id === effectiveSelectedMapId) ?? null;
+  const pendingDeleteMap = maps?.find((m) => m.id === pendingDeleteMapId) ?? null;
   const mapLocations = locations?.filter((l) => l.map_id === effectiveSelectedMapId) ?? [];
   const selectedLocation =
     mapLocations.find((l) => l.id === selectedLocationId) ?? mapLocations[0] ?? null;
@@ -139,13 +142,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           onAddMap={handleAddMap}
           onDeleteSelectedMap={() => {
             if (!selectedMap) return;
-            if (
-              window.confirm(
-                `${selectedMap.name} 맵을 삭제할까요? 하위 장소 편집 흐름도 함께 영향을 받습니다.`
-              )
-            ) {
-              handleDeleteMap(selectedMap.id);
-            }
+            setPendingDeleteMapId(selectedMap.id);
           }}
         />
       </div>
@@ -167,6 +164,20 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           onDeleteLocation={handleDeleteLocation}
         />
       </div>
+      <ConfirmDialog
+        isOpen={pendingDeleteMap != null}
+        title="맵을 삭제할까요?"
+        description={`${pendingDeleteMap?.name ?? '선택한 맵'} 맵과 하위 장소 편집 흐름도 함께 영향을 받습니다.`}
+        confirmLabel="맵 삭제"
+        isConfirming={deleteMap.isPending}
+        tone="danger"
+        onCancel={() => setPendingDeleteMapId(null)}
+        onConfirm={() => {
+          if (!pendingDeleteMap) return;
+          handleDeleteMap(pendingDeleteMap.id);
+          setPendingDeleteMapId(null);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/NodeDetailPanel.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Copy, Trash2 } from "lucide-react";
 import type { Node, Edge } from "@xyflow/react";
+import { ConfirmDialog } from "@/shared/components/ui";
 import { PhaseNodePanel } from "./PhaseNodePanel";
 import { NodeConnectionPanel } from "./NodeConnectionPanel";
 import type { FlowNodeData } from "../../flowTypes";
@@ -35,6 +37,8 @@ export function NodeDetailPanel({
   onConnectNodes,
   onDeleteEdge,
 }: NodeDetailPanelProps) {
+  const [pendingDeleteNodeId, setPendingDeleteNodeId] = useState<string | null>(null);
+
   if (!node) {
     return (
       <div className="flex h-full items-center justify-center p-4">
@@ -65,10 +69,7 @@ export function NodeDetailPanel({
           type="button"
           aria-label="장면 삭제"
           title="장면 삭제"
-          onClick={() => {
-            if (!window.confirm("이 장면을 삭제할까요? 연결된 선도 함께 삭제됩니다.")) return;
-            onDelete(node.id);
-          }}
+          onClick={() => setPendingDeleteNodeId(node.id)}
           className="inline-flex h-7 items-center gap-1 rounded border border-red-500/50 bg-red-500/10 px-2 text-[11px] font-semibold text-red-200 transition-colors hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/60"
         >
           <Trash2 className="h-3.5 w-3.5" />
@@ -114,6 +115,19 @@ export function NodeDetailPanel({
         />
       )}
 
+      <ConfirmDialog
+        isOpen={pendingDeleteNodeId != null}
+        title="장면을 삭제할까요?"
+        description="연결된 선도 함께 삭제됩니다."
+        confirmLabel="장면 삭제"
+        tone="danger"
+        onCancel={() => setPendingDeleteNodeId(null)}
+        onConfirm={() => {
+          if (!pendingDeleteNodeId) return;
+          onDelete(pendingDeleteNodeId);
+          setPendingDeleteNodeId(null);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/FlowCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -238,7 +238,6 @@ describe('FlowCanvas', () => {
 
   it('ending 노드만 남은 그래프도 프리셋 적용 전에 덮어쓰기 확인을 요구한다', () => {
     const applyPreset = vi.fn();
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
     useFlowDataMock.mockReturnValue({
       nodes: [
         {
@@ -271,7 +270,9 @@ describe('FlowCanvas', () => {
     fireEvent.click(screen.getByRole('button', { name: '프리셋' }));
     fireEvent.click(screen.getByText('클래식 머더미스터리'));
 
-    expect(confirmSpy).toHaveBeenCalledWith('기존 흐름이 대체됩니다. 계속할까요?');
+    const dialog = screen.getByRole('dialog', { name: '기존 흐름을 대체할까요?' });
+    expect(within(dialog).getByText('현재 장면 흐름이 프리셋으로 바뀝니다.')).toBeDefined();
+    fireEvent.click(within(dialog).getByRole('button', { name: '취소' }));
     expect(applyPreset).not.toHaveBeenCalled();
   });
 
@@ -326,7 +327,6 @@ describe('FlowCanvas', () => {
 
   it('선택한 연결선을 버튼으로 끊을 수 있다', () => {
     const deleteEdge = vi.fn();
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     useFlowDataMock.mockReturnValue({
       nodes: [
         {
@@ -365,13 +365,14 @@ describe('FlowCanvas', () => {
     expect(screen.getByText('오프닝 -> 조사')).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: '연결 끊기' }));
-    expect(window.confirm).toHaveBeenCalledWith('선 연결을 끊을까요? 이 작업은 즉시 저장됩니다.');
+    const dialog = screen.getByRole('dialog', { name: '선 연결을 끊을까요?' });
+    expect(within(dialog).getByText('이 작업은 즉시 저장됩니다.')).toBeDefined();
+    fireEvent.click(within(dialog).getByRole('button', { name: '연결 끊기' }));
     expect(deleteEdge).toHaveBeenCalledWith('e-p1-p2');
   });
 
   it('연결선 삭제 확인을 취소하면 연결을 유지한다', () => {
     const deleteEdge = vi.fn();
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
     useFlowDataMock.mockReturnValue({
       nodes: [
         { id: 'p1', type: 'phase', position: { x: 0, y: 0 }, data: { label: '오프닝' } },
@@ -398,6 +399,11 @@ describe('FlowCanvas', () => {
     render(<FlowCanvas themeId="theme-1" />);
     fireEvent.click(screen.getByRole('button', { name: 'e-p1-p2 선택' }));
     fireEvent.click(screen.getByRole('button', { name: '연결 끊기' }));
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: '선 연결을 끊을까요?' })).getByRole('button', {
+        name: '취소',
+      }),
+    );
 
     expect(deleteEdge).not.toHaveBeenCalled();
   });

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { screen, fireEvent, within } from '@testing-library/react';
 import {
   mutateMock,
   renderLocationsSubTab,
@@ -89,9 +89,11 @@ describe('LocationsSubTab', () => {
     });
 
     it('맵 삭제 버튼 클릭 시 mutate가 호출된다', () => {
-      vi.spyOn(window, 'confirm').mockReturnValue(true);
       renderLocationsSubTab();
       fireEvent.click(screen.getByLabelText('저택 1층 삭제'));
+      const dialog = screen.getByRole('dialog', { name: '맵을 삭제할까요?' });
+      expect(within(dialog).getByText(/저택 1층 맵과 하위 장소 편집 흐름도/)).toBeDefined();
+      fireEvent.click(within(dialog).getByRole('button', { name: '맵 삭제' }));
       expect(mutateMock).toHaveBeenCalledWith('map-1', expect.any(Object));
     });
   });

--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.deckInvestigation.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.deckInvestigation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 
 const { mutateMock, useUpdateConfigJsonMock, useModuleSchemasMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
@@ -168,7 +168,6 @@ describe('ModulesSubTab deck investigation settings', () => {
   });
 
   it('사용 중인 조사권 삭제 시 단서 조사 덱을 남은 조사권으로 이동한다', () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     const themeWithDeckInvestigation: EditorThemeResponse = {
       ...baseTheme,
       config_json: {
@@ -218,10 +217,10 @@ describe('ModulesSubTab deck investigation settings', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '추가 조사권 조사권 삭제' }));
 
-    expect(confirmSpy).toHaveBeenCalledWith(
-      '조사권 "추가 조사권"을(를) 삭제할까요?\n' +
-        '연결된 단서 조사 덱 1개는 다른 조사권으로 자동 변경됩니다.',
-    );
+    const dialog = screen.getByRole('dialog', { name: '조사권을 삭제할까요?' });
+    expect(within(dialog).getByText(/조사권 "추가 조사권"을\(를\) 삭제합니다/)).toBeDefined();
+    expect(within(dialog).getByText(/연결된 단서 조사 덱 1개/)).toBeDefined();
+    fireEvent.click(within(dialog).getByRole('button', { name: '조사권 삭제' }));
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
     expect(config.modules).toMatchObject({
@@ -235,7 +234,6 @@ describe('ModulesSubTab deck investigation settings', () => {
   });
 
   it('조사권 삭제 확인을 취소하면 저장하지 않는다', () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
     const themeWithDeckInvestigation: EditorThemeResponse = {
       ...baseTheme,
       config_json: {
@@ -268,9 +266,12 @@ describe('ModulesSubTab deck investigation settings', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '추가 조사권 조사권 삭제' }));
 
-    expect(confirmSpy).toHaveBeenCalledWith(
-      '조사권 "추가 조사권"을(를) 삭제할까요?\n' +
-        '연결된 단서 조사 덱 0개는 다른 조사권으로 자동 변경됩니다.',
+    const dialog = screen.getByRole('dialog', { name: '조사권을 삭제할까요?' });
+    expect(within(dialog).getByText(/연결된 단서 조사 덱 0개/)).toBeDefined();
+    fireEvent.click(
+      within(dialog).getByRole('button', {
+        name: '취소',
+      }),
     );
     expect(mutateMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
 import type { Edge, Node } from "@xyflow/react";
 import type { ReactNode } from "react";
 
@@ -147,7 +147,6 @@ describe("NodeDetailPanel", () => {
 
   it("삭제 버튼 클릭 시 onDelete가 노드 id와 함께 호출된다", () => {
     const onDelete = vi.fn();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
     render(
       <NodeDetailPanel
         node={makeNode("phase")}
@@ -157,13 +156,14 @@ describe("NodeDetailPanel", () => {
       />,
     );
     fireEvent.click(screen.getByText("장면 삭제"));
-    expect(window.confirm).toHaveBeenCalledWith("이 장면을 삭제할까요? 연결된 선도 함께 삭제됩니다.");
+    const dialog = screen.getByRole("dialog", { name: "장면을 삭제할까요?" });
+    expect(within(dialog).getByText("연결된 선도 함께 삭제됩니다.")).toBeDefined();
+    fireEvent.click(within(dialog).getByRole("button", { name: "장면 삭제" }));
     expect(onDelete).toHaveBeenCalledWith("node-1");
   });
 
   it("삭제 확인을 취소하면 onDelete를 호출하지 않는다", () => {
     const onDelete = vi.fn();
-    vi.spyOn(window, "confirm").mockReturnValue(false);
     render(
       <NodeDetailPanel
         node={makeNode("phase")}
@@ -174,6 +174,12 @@ describe("NodeDetailPanel", () => {
     );
 
     fireEvent.click(screen.getByText("장면 삭제"));
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "장면을 삭제할까요?" })).getByRole(
+        "button",
+        { name: "취소" },
+      ),
+    );
 
     expect(onDelete).not.toHaveBeenCalled();
   });

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -9,7 +9,7 @@ import {
   type StoryInfoResponse,
 } from '@/features/editor/storyInfoApi';
 import type { MediaType } from '@/features/editor/mediaApi';
-import { Spinner } from '@/shared/components/ui';
+import { ConfirmDialog, Spinner } from '@/shared/components/ui';
 import { InfoBodyPreview } from './InfoBodyPreview';
 import { InfoMarkdownEditor } from './InfoMarkdownEditor';
 
@@ -135,6 +135,7 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   const [embedPickerType, setEmbedPickerType] = useState<MediaType | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(() => !hasDisplayableBody(info));
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const updateInfo = useUpdateStoryInfo(themeId);
   const deleteInfo = useDeleteStoryInfo(themeId);
 
@@ -144,6 +145,7 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
     setEmbedPickerType(null);
     setError(null);
     setIsEditing(!hasDisplayableBody(info));
+    setDeleteDialogOpen(false);
   }, [info]);
 
   useEffect(() => {
@@ -184,91 +186,111 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   }
 
   async function handleDelete() {
-    if (!window.confirm(`"${info.title}" 정보를 삭제하시겠습니까?`)) return;
     try {
       await deleteInfo.mutateAsync(info.id);
+      setDeleteDialogOpen(false);
     } catch (err) {
       setError(errorMessage(err, '삭제에 실패했습니다'));
+      setDeleteDialogOpen(false);
     }
   }
 
+  const deleteDialog = (
+    <ConfirmDialog
+      isOpen={deleteDialogOpen}
+      title="정보를 삭제할까요?"
+      description={`"${info.title}" 정보를 삭제합니다.`}
+      confirmLabel="정보 삭제"
+      isConfirming={deleteInfo.isPending}
+      tone="danger"
+      onCancel={() => setDeleteDialogOpen(false)}
+      onConfirm={() => void handleDelete()}
+    />
+  );
+
   if (!isEditing) {
     return (
-      <InfoBodyPreview
-        themeId={themeId}
-        info={baseline}
-        error={error}
-        deletePending={deleteInfo.isPending}
-        onEdit={() => setIsEditing(true)}
-        onDelete={() => void handleDelete()}
-      />
+      <>
+        <InfoBodyPreview
+          themeId={themeId}
+          info={baseline}
+          error={error}
+          deletePending={deleteInfo.isPending}
+          onEdit={() => setIsEditing(true)}
+          onDelete={() => setDeleteDialogOpen(true)}
+        />
+        {deleteDialog}
+      </>
     );
   }
 
   return (
-    <section className="min-h-full">
-      <div className="space-y-4 rounded border border-slate-800 bg-slate-950 p-4">
-        {error && (
-          <div
-            className="flex items-start justify-between gap-3 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200"
-            role="alert"
-          >
-            <span>{error}</span>
+    <>
+      <section className="min-h-full">
+        <div className="space-y-4 rounded border border-slate-800 bg-slate-950 p-4">
+          {error && (
+            <div
+              className="flex items-start justify-between gap-3 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200"
+              role="alert"
+            >
+              <span>{error}</span>
+              <button
+                type="button"
+                aria-label="오류 메시지 닫기"
+                onClick={() => setError(null)}
+                className="shrink-0 rounded p-0.5 text-rose-200 hover:bg-rose-500/20"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )}
+
+          <label className="block text-xs text-slate-400">
+            제목
+            <input
+              aria-label="정보 제목"
+              value={draft.title}
+              onChange={(event) => updateDraft({ title: event.target.value })}
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+            />
+          </label>
+
+          <div className="space-y-1">
+            <span className="block text-xs text-slate-400">본문</span>
+            <InfoMarkdownEditor
+              themeId={themeId}
+              markdown={draft.body}
+              onChange={(body) => updateDraft({ body })}
+              pickerType={embedPickerType}
+              onOpenPicker={setEmbedPickerType}
+              onClosePicker={() => setEmbedPickerType(null)}
+            />
+          </div>
+
+          <div className="flex items-center justify-between border-t border-slate-800 pt-3">
             <button
               type="button"
-              aria-label="오류 메시지 닫기"
-              onClick={() => setError(null)}
-              className="shrink-0 rounded p-0.5 text-rose-200 hover:bg-rose-500/20"
+              onClick={() => setDeleteDialogOpen(true)}
+              disabled={deleteInfo.isPending}
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-rose-400 hover:bg-rose-500/10"
             >
-              <X className="h-3.5 w-3.5" />
+              <Trash2 className="h-3 w-3" />
+              정보 삭제
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!isDirty || updateInfo.isPending}
+              className="flex items-center gap-1 rounded bg-amber-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-amber-400 disabled:bg-slate-700 disabled:text-slate-500"
+            >
+              <Save className="h-4 w-4" />
+              {updateInfo.isPending ? '저장 중...' : '저장'}
             </button>
           </div>
-        )}
-
-        <label className="block text-xs text-slate-400">
-          제목
-          <input
-            aria-label="정보 제목"
-            value={draft.title}
-            onChange={(event) => updateDraft({ title: event.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
-          />
-        </label>
-
-        <div className="space-y-1">
-          <span className="block text-xs text-slate-400">본문</span>
-          <InfoMarkdownEditor
-            themeId={themeId}
-            markdown={draft.body}
-            onChange={(body) => updateDraft({ body })}
-            pickerType={embedPickerType}
-            onOpenPicker={setEmbedPickerType}
-            onClosePicker={() => setEmbedPickerType(null)}
-          />
         </div>
-
-        <div className="flex items-center justify-between border-t border-slate-800 pt-3">
-          <button
-            type="button"
-            onClick={() => void handleDelete()}
-            disabled={deleteInfo.isPending}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-rose-400 hover:bg-rose-500/10"
-          >
-            <Trash2 className="h-3 w-3" />
-            정보 삭제
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleSave()}
-            disabled={!isDirty || updateInfo.isPending}
-            className="flex items-center gap-1 rounded bg-amber-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-amber-400 disabled:bg-slate-700 disabled:text-slate-500"
-          >
-            <Save className="h-4 w-4" />
-            {updateInfo.isPending ? '저장 중...' : '저장'}
-          </button>
-        </div>
-      </div>
-    </section>
+      </section>
+      {deleteDialog}
+    </>
   );
 }
 

--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -12,6 +12,7 @@ import {
   type UpdateMediaRequest,
 } from '@/features/editor/mediaApi';
 import { ApiHttpError } from '@/lib/api-error';
+import { ConfirmDialog } from '@/shared/components/ui';
 import { MediaReplaceModal } from './MediaReplaceModal';
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const [mediaType, setMediaType] = useState<MediaType>(media.type);
   const [referenceWarning, setReferenceWarning] = useState<MediaReferenceInfo[] | null>(null);
   const [replaceOpen, setReplaceOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   // Reset local state when selected media changes
   useEffect(() => {
@@ -49,6 +51,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
     setMediaType(media.type);
     setReferenceWarning(null);
     setReplaceOpen(false);
+    setDeleteDialogOpen(false);
   }, [media.id, media.name, media.tags, media.sort_order, media.category_id, media.type]);
 
   const updateMutation = useUpdateMedia(themeId);
@@ -90,15 +93,13 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
 
   const handleDelete = async () => {
     setReferenceWarning(null);
-    if (typeof window !== 'undefined') {
-      const ok = window.confirm(`"${media.name}"을(를) 삭제하시겠습니까?`);
-      if (!ok) return;
-    }
     try {
       await deleteMutation.mutateAsync(media.id);
+      setDeleteDialogOpen(false);
       toast.success('미디어가 삭제되었습니다');
       onClose();
     } catch (err) {
+      setDeleteDialogOpen(false);
       if (err instanceof ApiHttpError && err.apiError.code === 'MEDIA_REFERENCE_IN_USE') {
         const refs = err.apiError.params?.references as MediaReferenceInfo[] | undefined;
         setReferenceWarning(refs?.length ? refs : []);
@@ -236,7 +237,7 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
       <div className="mt-auto flex items-center justify-between gap-2 pt-3">
         <button
           type="button"
-          onClick={handleDelete}
+          onClick={() => setDeleteDialogOpen(true)}
           disabled={deleteMutation.isPending}
           className="flex h-8 items-center gap-1.5 rounded-sm border border-rose-800 px-3 text-xs font-medium text-rose-400 transition-colors hover:border-rose-500 hover:text-rose-300 disabled:cursor-not-allowed disabled:opacity-40"
         >
@@ -271,6 +272,16 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
         themeId={themeId}
         media={media}
         onReplaced={() => toast.success('파일을 교체했습니다')}
+      />
+      <ConfirmDialog
+        isOpen={deleteDialogOpen}
+        title="미디어를 삭제할까요?"
+        description={`"${media.name}" 미디어를 삭제합니다. 사용 중이면 삭제되지 않고 위치가 표시됩니다.`}
+        confirmLabel="미디어 삭제"
+        isConfirming={deleteMutation.isPending}
+        tone="danger"
+        onCancel={() => setDeleteDialogOpen(false)}
+        onConfirm={() => void handleDelete()}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { AlertTriangle, CheckCircle2, ListChecks, Trash2, XCircle } from "lucide-react";
 import { toast } from "sonner";
-import { Spinner } from "@/shared/components/ui";
-import { Modal } from "@/shared/components/ui";
+import { ConfirmDialog, Modal, Spinner } from "@/shared/components/ui";
 import {
   useCreateMediaCategory,
   useDeleteMedia,
@@ -55,6 +54,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteResult, setDeleteResult] = useState<BulkDeleteResult | null>(null);
   const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [pendingDeleteCategoryId, setPendingDeleteCategoryId] = useState<string | null>(null);
   // Modal state.
   const [uploadOpen, setUploadOpen] = useState(false);
   const [youtubeOpen, setYoutubeOpen] = useState(false);
@@ -84,6 +84,8 @@ export function MediaTab({ themeId }: MediaTabProps) {
   }, [mediaList, searchQuery]);
   const selected = media.find((m) => m.id === selectedId) ?? null;
   const bulkSelectedMedia = media.filter((m) => selectedIds.has(m.id));
+  const pendingDeleteCategory =
+    categories.find((item) => item.id === pendingDeleteCategoryId) ?? null;
 
   const { playingId, toggle: togglePreview, stop: stopPreview } = usePreviewPlayer();
 
@@ -155,16 +157,20 @@ export function MediaTab({ themeId }: MediaTabProps) {
 
   const handleDeleteCategory = () => {
     if (!categoryId) return;
-    const category = categories.find((item) => item.id === categoryId);
-    const ok = window.confirm(
-      `"${category?.name ?? "선택한 카테고리"}" 카테고리를 삭제하시겠습니까? 연결된 미디어는 전체 카테고리로 이동합니다.`,
-    );
-    if (!ok) return;
-    deleteCategoryMutation.mutate(categoryId, {
+    setPendingDeleteCategoryId(categoryId);
+  };
+
+  const handleConfirmDeleteCategory = () => {
+    if (!pendingDeleteCategoryId) return;
+    deleteCategoryMutation.mutate(pendingDeleteCategoryId, {
       onSuccess: () => {
         setCategoryId(null);
         setSelectedId(null);
+        setPendingDeleteCategoryId(null);
         stopPreview();
+      },
+      onError: () => {
+        setPendingDeleteCategoryId(null);
       },
     });
   };
@@ -355,6 +361,16 @@ export function MediaTab({ themeId }: MediaTabProps) {
         deleting={bulkDeleting}
         onClose={handleCloseBulkDelete}
         onConfirm={handleConfirmBulkDelete}
+      />
+      <ConfirmDialog
+        isOpen={pendingDeleteCategory != null}
+        title="카테고리를 삭제할까요?"
+        description={`"${pendingDeleteCategory?.name ?? '선택한 카테고리'}" 카테고리를 삭제합니다. 연결된 미디어는 전체 카테고리로 이동합니다.`}
+        confirmLabel="카테고리 삭제"
+        isConfirming={deleteCategoryMutation.isPending}
+        tone="danger"
+        onCancel={() => setPendingDeleteCategoryId(null)}
+        onConfirm={handleConfirmDeleteCategory}
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -261,20 +261,18 @@ describe('MediaTab', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     });
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-    try {
-      render(<MediaTab themeId="theme-1" />);
+    render(<MediaTab themeId="theme-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: '스크린', pressed: false }));
-      fireEvent.click(screen.getByRole('button', { name: /카테고리 삭제/ }));
+    fireEvent.click(screen.getByRole('button', { name: '스크린', pressed: false }));
+    fireEvent.click(screen.getByRole('button', { name: /카테고리 삭제/ }));
+    const dialog = screen.getByRole('dialog', { name: '카테고리를 삭제할까요?' });
+    expect(within(dialog).getByText(/"스크린" 카테고리를 삭제합니다/)).toBeDefined();
+    fireEvent.click(within(dialog).getByRole('button', { name: '카테고리 삭제' }));
 
-      expect(mutate).toHaveBeenCalledWith('category-screen', expect.any(Object));
-      const categoryGroup = screen.getByRole('group', { name: '미디어 카테고리 필터' });
-      expect(within(categoryGroup).getByRole('button', { name: '전체', pressed: true })).toBeDefined();
-    } finally {
-      confirmSpy.mockRestore();
-    }
+    expect(mutate).toHaveBeenCalledWith('category-screen', expect.any(Object));
+    const categoryGroup = screen.getByRole('group', { name: '미디어 카테고리 필터' });
+    expect(within(categoryGroup).getByRole('button', { name: '전체', pressed: true })).toBeDefined();
   });
 
   it('새 카테고리는 기존 sort_order 최댓값 다음 순서로 생성한다', () => {
@@ -680,7 +678,6 @@ describe('MediaTab', () => {
       isPending: false,
     };
     useDeleteMediaMock.mockReturnValue(deleteMutation);
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
     try {
@@ -689,6 +686,11 @@ describe('MediaTab', () => {
       const card = screen.getByText('오프닝 BGM').closest("[role='button']") as HTMLElement | null;
       fireEvent.click(card!);
       fireEvent.click(screen.getByRole('button', { name: '삭제' }));
+      fireEvent.click(
+        within(screen.getByRole('dialog', { name: '미디어를 삭제할까요?' })).getByRole('button', {
+          name: '미디어 삭제',
+        }),
+      );
 
       const warning = await screen.findByRole('alert');
       expect(warning.textContent).toContain('이 미디어는 아직 삭제할 수 없습니다.');
@@ -703,7 +705,6 @@ describe('MediaTab', () => {
       expect(toastSuccess).not.toHaveBeenCalled();
       expect(alertSpy).not.toHaveBeenCalled();
     } finally {
-      confirmSpy.mockRestore();
       alertSpy.mockRestore();
     }
   });

--- a/apps/web/src/shared/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/shared/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from './Button';
+import { Modal } from './Modal';
+
+export interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description: ReactNode;
+  confirmLabel: string;
+  cancelLabel?: string;
+  isConfirming?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  tone?: 'danger' | 'warning';
+}
+
+export function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = '취소',
+  isConfirming = false,
+  onCancel,
+  onConfirm,
+  tone = 'danger',
+}: ConfirmDialogProps) {
+  const iconClasses =
+    tone === 'danger'
+      ? 'border-red-500/30 bg-red-500/10 text-red-300'
+      : 'border-amber-500/30 bg-amber-500/10 text-amber-300';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={isConfirming ? () => undefined : onCancel}
+      title={title}
+      size="sm"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel} disabled={isConfirming}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={tone === 'danger' ? 'danger' : 'primary'}
+            onClick={onConfirm}
+            isLoading={isConfirming}
+            aria-label={confirmLabel}
+          >
+            {confirmLabel}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex gap-3 text-sm text-slate-300">
+        <div
+          className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border ${iconClasses}`}
+          aria-hidden="true"
+        >
+          <AlertTriangle className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 leading-6">
+          {typeof description === 'string' ? (
+            <p className="whitespace-pre-line">{description}</p>
+          ) : (
+            description
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/shared/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/apps/web/src/shared/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ConfirmDialog } from "../ConfirmDialog";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ConfirmDialog", () => {
+  it("제목과 설명, 취소/확인 버튼을 표시한다", () => {
+    render(
+      <ConfirmDialog
+        isOpen
+        title="장면을 삭제할까요?"
+        description="연결된 선도 함께 삭제됩니다."
+        confirmLabel="장면 삭제"
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "장면을 삭제할까요?" })).toBeDefined();
+    expect(screen.getByText("연결된 선도 함께 삭제됩니다.")).toBeDefined();
+    expect(screen.getByRole("button", { name: "취소" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "장면 삭제" })).toBeDefined();
+  });
+
+  it("취소와 확인 동작을 각각 호출한다", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen
+        title="연결을 끊을까요?"
+        description="이 작업은 즉시 저장됩니다."
+        confirmLabel="연결 끊기"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+    fireEvent.click(screen.getByRole("button", { name: "연결 끊기" }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("처리 중에는 확인 버튼을 비활성화한다", () => {
+    render(
+      <ConfirmDialog
+        isOpen
+        title="미디어를 삭제할까요?"
+        description="삭제 후에는 되돌릴 수 없습니다."
+        confirmLabel="삭제"
+        isConfirming
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "삭제" })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+});

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -10,6 +10,9 @@ export type { SelectProps } from './Select';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
 
+export { ConfirmDialog } from './ConfirmDialog';
+export type { ConfirmDialogProps } from './ConfirmDialog';
+
 export { Card } from './Card';
 export type { CardProps } from './Card';
 


### PR DESCRIPTION
## 요약
- 공용 ConfirmDialog를 추가했습니다.
- 에디터 삭제/덮어쓰기 확인 흐름의 window.confirm 사용을 제거했습니다.
- 관련 컴포넌트 테스트를 모달 확인 흐름으로 갱신했습니다.

## Coverage Plan
- ConfirmDialog: 렌더링, 취소/확인 콜백, 처리 중 비활성 상태를 테스트합니다.
- Flow/scene/location/map/media/info/token 삭제와 preset 덮어쓰기 흐름: 기존 컴포넌트 테스트를 공용 확인창 클릭 흐름으로 갱신했습니다.
- quick local CI: generated drift, server tests, web lint/typecheck/test/build를 확인합니다.

## Local validation
- pnpm --filter @mmp/web test -- src/shared/components/ui/__tests__/ConfirmDialog.test.tsx src/features/editor/components/design/__tests__/NodeDetailPanel.test.tsx src/features/editor/components/design/__tests__/FlowCanvas.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx src/features/editor/components/design/__tests__/ModulesSubTab.deckInvestigation.test.tsx src/features/editor/components/media/__tests__/MediaTab.test.tsx ✅
- pnpm --filter @mmp/web test -- src/features/editor/components/info/__tests__/InfoTab.test.tsx ✅
- pnpm --filter @mmp/web typecheck ✅
- pnpm --filter @mmp/web lint ✅ (0 errors, existing warnings only)
- scripts/mmp-local-ci.sh quick ✅

## Notes
- ready-for-ci 라벨과 workflow_dispatch는 사용하지 않았습니다.
- 독립 GitHub Issue 없이 사용자의 즉시 수정 요청 범위로 진행했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 삭제 확인 대화를 브라우저의 기본 확인 창에서 새로운 커스텀 대화 상자로 변경했습니다. 선 연결 끊기, 위치, 노드, 지도, 미디어 등 여러 삭제 기능에서 더 일관된 사용자 경험을 제공합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/572)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->