### PR TITLE
fix(editor): 마크다운 입력 즉시 서식 적용

### DIFF
--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -10,6 +10,7 @@ import {
   jsxPlugin,
   linkPlugin,
   listsPlugin,
+  markdownShortcutPlugin,
   quotePlugin,
   thematicBreakPlugin,
   toolbarPlugin,
@@ -86,6 +87,7 @@ export function RichContentEditor({
           </>
         ),
       }),
+      markdownShortcutPlugin(),
     ],
     [media, onOpenPicker],
   );

--- a/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { useMediaListMock } = vi.hoisted(() => ({
+  useMediaListMock: vi.fn(),
+}));
+
+vi.mock('@/features/editor/mediaApi', () => ({
+  useMediaList: (...args: unknown[]) => useMediaListMock(...args),
+}));
+
+import { RichContentViewer } from '../RichContentViewer';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('RichContentViewer', () => {
+  it('renders markdown blockquotes, emphasis, dividers, and strong text as formatted content', () => {
+    useMediaListMock.mockReturnValue({ data: [] });
+
+    const { container } = render(
+      <RichContentViewer
+        themeId="theme-1"
+        markdown={[
+          '> *2008년 7월 28일 저녁, 비가 내리는 명우 홀리데이 호텔 2층 식당.*',
+          '',
+          '> *7시 10분, 일행은 자리를 잡았다.*',
+          '',
+          '---',
+          '',
+          '**고동(顾东):** 송 사장님',
+        ].join('\n')}
+      />,
+    );
+
+    const blockquotes = container.querySelectorAll('blockquote');
+    expect(blockquotes).toHaveLength(2);
+    expect(blockquotes[0]?.querySelector('em')?.textContent).toBe(
+      '2008년 7월 28일 저녁, 비가 내리는 명우 홀리데이 호텔 2층 식당.',
+    );
+    expect(container.querySelector('hr')).not.toBeNull();
+    expect(screen.getByText('고동(顾东):')).toHaveProperty('tagName', 'STRONG');
+    expect(container).toHaveProperty(
+      'textContent',
+      expect.not.stringContaining('> *2008년'),
+    );
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -122,6 +122,7 @@ vi.mock('@mdxeditor/editor', () => ({
   listsPlugin: vi.fn(() => ({})),
   quotePlugin: vi.fn(() => ({})),
   linkPlugin: vi.fn(() => ({})),
+  markdownShortcutPlugin: vi.fn(() => ({ markdownShortcuts: true })),
   thematicBreakPlugin: vi.fn(() => ({})),
   toolbarPlugin: vi.fn(() => ({})),
   UndoRedo: () => null,

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -90,6 +90,7 @@ vi.mock("@mdxeditor/editor", () => ({
   listsPlugin: vi.fn(() => ({})),
   quotePlugin: vi.fn(() => ({})),
   linkPlugin: vi.fn(() => ({})),
+  markdownShortcutPlugin: vi.fn(() => ({ markdownShortcuts: true })),
   thematicBreakPlugin: vi.fn(() => ({})),
   toolbarPlugin: vi.fn(() => ({})),
   UndoRedo: () => null,

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -38,12 +38,16 @@ vi.mock('@mdxeditor/editor', () => ({
     {
       markdown: string;
       onChange: (markdown: string) => void;
-      plugins?: Array<{ jsxComponentDescriptors?: Array<{ name: string; Editor: ComponentType<{ mdastNode: { attributes: Array<{ name: string; value: string }> } }> }> }>;
+      plugins?: Array<{
+        markdownShortcuts?: boolean;
+        jsxComponentDescriptors?: Array<{ name: string; Editor: ComponentType<{ mdastNode: { attributes: Array<{ name: string; value: string }> } }> }>;
+      }>;
     }
   >(({ markdown, onChange, plugins = [] }, ref) => {
     useImperativeHandle(ref, () => ({
       insertMarkdown: (snippet: string) => onChange(`${markdown}${snippet}`),
     }));
+    const hasMarkdownShortcuts = plugins.some((plugin) => plugin.markdownShortcuts);
     const mediaEmbedDescriptor = plugins
       .flatMap((plugin) => plugin.jsxComponentDescriptors ?? [])
       .find((descriptor) => descriptor.name === 'MediaEmbed');
@@ -55,6 +59,9 @@ vi.mock('@mdxeditor/editor', () => ({
           value={markdown}
           onChange={(event) => onChange(event.target.value)}
         />
+        {hasMarkdownShortcuts && markdown.startsWith('> ') ? (
+          <blockquote>{markdown.slice(2)}</blockquote>
+        ) : null}
         {mediaEmbedDescriptor
           ? mediaEmbeds.map((match) => {
               const attrs = match[1] ?? '';
@@ -78,6 +85,7 @@ vi.mock('@mdxeditor/editor', () => ({
   listsPlugin: vi.fn(() => ({})),
   quotePlugin: vi.fn(() => ({})),
   linkPlugin: vi.fn(() => ({})),
+  markdownShortcutPlugin: vi.fn(() => ({ markdownShortcuts: true })),
   thematicBreakPlugin: vi.fn(() => ({})),
   toolbarPlugin: vi.fn(() => ({})),
   UndoRedo: () => null,
@@ -216,6 +224,16 @@ describe('InfoTab', () => {
     expect(screen.queryByText('관련 단서')).toBeNull();
     expect(screen.queryByText('관련 장소')).toBeNull();
     expect(screen.queryByRole('region', { name: '정보 카드 프리뷰' })).toBeNull();
+  });
+
+  it('shows typed markdown shortcuts as formatted content in the information editor', () => {
+    render(<InfoTab themeId="theme-1" />);
+
+    enterInfoEditMode();
+    fireEvent.change(getInfoBodyEditor(), { target: { value: '> 현장 기록' } });
+
+    const editor = screen.getByTestId('mdx-editor-surface');
+    expect(editor.querySelector('blockquote')).toHaveProperty('textContent', '현장 기록');
   });
 
   it('renders image media embeds in the read-only preview without a card caption', () => {


### PR DESCRIPTION
## 요약
- 공용 RichContentEditor에 MDXEditor markdownShortcutPlugin을 등록했습니다.
- 정보 본문 편집기에서 `>`, `**`, `---` 같은 마크다운 입력이 일반 텍스트로 저장되지 않고 서식 노드로 변환되도록 했습니다.
- 정보 preview의 마크다운 렌더링과 공용 편집기 plugin 등록 회귀 테스트를 추가했습니다.

## Coverage Plan
- RichContentEditor: 정보 편집기 진입 시 markdownShortcutPlugin 등록 여부를 InfoTab 테스트로 검증합니다.
- RichContentViewer: blockquote/emphasis/hr/strong 마크다운이 HTML 서식으로 렌더링되는지 검증합니다.
- 공용 RichContentEditor를 사용하는 역할지/결말 테스트 mock에 새 plugin export를 반영해 기존 흐름 회귀를 확인합니다.
- quick local CI: generated drift, server tests, web lint/typecheck/test/build를 확인합니다.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/content/__tests__/RichContentViewer.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx ✅
- pnpm --filter @mmp/web typecheck ✅
- pnpm --filter @mmp/web lint ✅ (0 errors, existing warnings only)
- git diff --check ✅
- scripts/mmp-local-ci.sh quick ✅

## Notes
- ready-for-ci 라벨과 workflow_dispatch는 사용하지 않았습니다.
- 기존에 이미 escape되어 저장된 데이터는 자동 보정하지 않았습니다. 이번 PR은 새 편집/수정 입력이 더 이상 escape된 일반 텍스트로 저장되지 않게 하는 범위입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리치 콘텐츠 에디터에 마크다운 단축키 기능을 추가했습니다.

* **테스트**
  * 콘텐츠 뷰어의 마크다운 렌더링 검증 테스트를 추가했습니다.
  * 정보 탭에서 마크다운 단축키 입력 시 블록인용 등 렌더링을 검증하는 테스트를 추가했습니다.
  * 여러 테스트 파일의 관련 모듈 목(mock)을 업데이트했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/573)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->