### PR TITLE
fix(editor): 이스케이프된 마크다운 저장값 렌더링 복원

### DIFF
--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -30,6 +30,7 @@ import {
   mediaTypeToEmbedType,
   type MediaEmbedAttributes,
 } from './mediaEmbedMarkdown';
+import { normalizeLegacyEscapedMarkdown } from './legacyMarkdown';
 
 export function RichContentEditor({
   themeId,
@@ -59,6 +60,7 @@ export function RichContentEditor({
   onBlurCapture?: (relatedTarget: EventTarget | null) => void;
 }) {
   const editorRef = useRef<MDXEditorMethods>(null);
+  const normalizedMarkdown = useMemo(() => normalizeLegacyEscapedMarkdown(markdown), [markdown]);
   const [replacementTarget, setReplacementTarget] = useState<MediaEmbedAttributes | null>(null);
   const { data: media = [] } = useMediaList(themeId);
   const plugins = useMemo(
@@ -101,7 +103,7 @@ export function RichContentEditor({
         replacementTarget.align,
         replacementTarget.width,
       ).trim();
-      onChange(replaceMediaEmbed(markdown, replacementTarget, snippet));
+      onChange(replaceMediaEmbed(normalizedMarkdown, replacementTarget, snippet));
       setReplacementTarget(null);
       onClosePicker();
       return;
@@ -137,7 +139,7 @@ export function RichContentEditor({
       <div className="mmp-rich-content-surface">
         <MDXEditor
           ref={editorRef}
-          markdown={markdown}
+          markdown={normalizedMarkdown}
           onChange={onChange}
           plugins={plugins}
           className="mmp-mdx-editor"

--- a/apps/web/src/features/editor/components/content/RichContentViewer.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentViewer.tsx
@@ -3,6 +3,7 @@ import { marked } from 'marked';
 
 import { useMediaList } from '@/features/editor/mediaApi';
 import { MediaEmbedDisplay } from './MediaEmbedDisplay';
+import { normalizeLegacyEscapedMarkdown } from './legacyMarkdown';
 import { readMediaEmbedAttributesFromSource } from './mediaEmbedMarkdown';
 
 type RichContentPart =
@@ -33,7 +34,8 @@ export function RichContentViewer({
 }
 
 function MarkdownFragment({ markdown }: { markdown: string }) {
-  const html = DOMPurify.sanitize(marked.parse(markdown, { async: false }) as string);
+  const normalizedMarkdown = normalizeLegacyEscapedMarkdown(markdown);
+  const html = DOMPurify.sanitize(marked.parse(normalizedMarkdown, { async: false }) as string);
   if (!html.trim()) return null;
   return (
     <div

--- a/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
@@ -47,4 +47,52 @@ describe('RichContentViewer', () => {
       expect.not.stringContaining('> *2008년'),
     );
   });
+
+  it('renders legacy escaped markdown markers as formatted content', () => {
+    useMediaListMock.mockReturnValue({ data: [] });
+
+    const { container } = render(
+      <RichContentViewer
+        themeId="theme-1"
+        markdown={[
+          '\\> \\*2008년 7월 28일 저녁, 비가 내리는 명우 홀리데이 호텔 2층 식당.\\*',
+          '',
+          '\\---',
+          '',
+          '\\*\\*고동(顾东):\\*\\* 송 사장님',
+        ].join('\n')}
+      />,
+    );
+
+    expect(container.querySelector('blockquote')).not.toBeNull();
+    expect(container.querySelector('blockquote em')?.textContent).toBe(
+      '2008년 7월 28일 저녁, 비가 내리는 명우 홀리데이 호텔 2층 식당.',
+    );
+    expect(container.querySelector('hr')).not.toBeNull();
+    expect(screen.getByText('고동(顾东):')).toHaveProperty('tagName', 'STRONG');
+    expect(container).toHaveProperty(
+      'textContent',
+      expect.not.stringContaining('\\> \\*2008년'),
+    );
+  });
+
+  it('preserves escaped formatting markers inside fenced code blocks', () => {
+    useMediaListMock.mockReturnValue({ data: [] });
+
+    const { container } = render(
+      <RichContentViewer
+        themeId="theme-1"
+        markdown={[
+          '\\> \\*2008년 7월 28일 저녁\\*',
+          '',
+          '```',
+          '\\*literal\\*',
+          '```',
+        ].join('\n')}
+      />,
+    );
+
+    expect(container.querySelector('blockquote em')?.textContent).toBe('2008년 7월 28일 저녁');
+    expect(container.querySelector('code')?.textContent?.trim()).toBe('\\*literal\\*');
+  });
 });

--- a/apps/web/src/features/editor/components/content/legacyMarkdown.ts
+++ b/apps/web/src/features/editor/components/content/legacyMarkdown.ts
@@ -1,0 +1,28 @@
+export function normalizeLegacyEscapedMarkdown(markdown: string) {
+  if (!hasLegacyEscapedMarkdown(markdown)) return markdown;
+
+  let inFence = false;
+  return markdown
+    .split('\n')
+    .map((line) => {
+      if (/^\s*(```|~~~)/.test(line)) {
+        inFence = !inFence;
+        return line;
+      }
+
+      if (inFence) return line;
+
+      return line
+        .replace(/^\\(?=>\s)/, '')
+        .replace(/^\\(?=#{1,6}\s)/, '')
+        .replace(/^\\(?=---\s*$)/, '')
+        .replace(/^\\(?=[-*+]\s)/, '')
+        .replace(/^\\(?=\d+\.\s)/, '')
+        .replace(/\\([*_`~])/g, '$1');
+    })
+    .join('\n');
+}
+
+function hasLegacyEscapedMarkdown(markdown: string) {
+  return /(^|\n)\\(?:>\s|#{1,6}\s|---\s*$|[-*+]\s|\d+\.\s)/m.test(markdown) || /\\[*_`~]/.test(markdown);
+}

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -9,6 +9,7 @@ import {
   type StoryInfoResponse,
 } from '@/features/editor/storyInfoApi';
 import type { MediaType } from '@/features/editor/mediaApi';
+import { normalizeLegacyEscapedMarkdown } from '@/features/editor/components/content/legacyMarkdown';
 import { ConfirmDialog, Spinner } from '@/shared/components/ui';
 import { InfoBodyPreview } from './InfoBodyPreview';
 import { InfoMarkdownEditor } from './InfoMarkdownEditor';
@@ -130,8 +131,8 @@ export function InfoTab({ themeId }: InfoTabProps) {
 }
 
 function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoResponse }) {
-  const [draft, setDraft] = useState(() => ({ ...info }));
-  const [baseline, setBaseline] = useState(() => ({ ...info }));
+  const [draft, setDraft] = useState(() => toEditableInfo(info));
+  const [baseline, setBaseline] = useState(() => toEditableInfo(info));
   const [embedPickerType, setEmbedPickerType] = useState<MediaType | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(() => !hasDisplayableBody(info));
@@ -140,8 +141,9 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   const deleteInfo = useDeleteStoryInfo(themeId);
 
   useEffect(() => {
-    setDraft({ ...info });
-    setBaseline({ ...info });
+    const editableInfo = toEditableInfo(info);
+    setDraft(editableInfo);
+    setBaseline(editableInfo);
     setEmbedPickerType(null);
     setError(null);
     setIsEditing(!hasDisplayableBody(info));
@@ -177,8 +179,9 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
           version: draft.version,
         },
       });
-      setDraft({ ...saved });
-      setBaseline({ ...saved });
+      const editableSaved = toEditableInfo(saved);
+      setDraft(editableSaved);
+      setBaseline(editableSaved);
       setIsEditing(!hasDisplayableBody(saved));
     } catch (err) {
       setError(errorMessage(err, '저장에 실패했습니다'));
@@ -292,6 +295,10 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
       {deleteDialog}
     </>
   );
+}
+
+function toEditableInfo(info: StoryInfoResponse) {
+  return { ...info, body: normalizeLegacyEscapedMarkdown(info.body) };
 }
 
 function hasDisplayableBody(info: StoryInfoResponse) {

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -285,6 +285,26 @@ describe('InfoTab', () => {
     expect(getInfoBodyEditor()).toHaveProperty('value', '처음 공개되는 정보');
   });
 
+  it('opens legacy escaped markdown in edit mode as editable markdown', () => {
+    useStoryInfosMock.mockReturnValue({
+      data: [
+        {
+          ...baseInfo,
+          body: '\\> \\*2008년 7월 28일 저녁\\*',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<InfoTab themeId="theme-1" />);
+
+    enterInfoEditMode();
+
+    expect(getInfoBodyEditor()).toHaveProperty('value', '> *2008년 7월 28일 저녁*');
+  });
+
   it('opens the editor first when the selected story info has no body', () => {
     useStoryInfosMock.mockReturnValue({
       data: [{ ...baseInfo, body: '' }],
@@ -447,6 +467,38 @@ describe('InfoTab', () => {
         body: expect.stringContaining('<MediaEmbed mediaId="video-2" type="video" align="center" width="medium" />'),
       }),
     });
+  });
+
+  it('replaces media embeds from normalized legacy markdown content', async () => {
+    useStoryInfosMock.mockReturnValue({
+      data: [
+        {
+          ...baseInfo,
+          body: [
+            '\\> \\*2008년 7월 28일 저녁\\*',
+            '<MediaEmbed mediaId="video-1" type="video" align="center" width="medium" />',
+          ].join('\n'),
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<InfoTab themeId="theme-1" />);
+
+    enterInfoEditMode();
+    const editorSurface = screen.getByTestId('mdx-editor-surface');
+    fireEvent.click(within(editorSurface).getByRole('button', { name: 'CCTV 교체' }));
+    fireEvent.click(screen.getByRole('button', { name: 'CCTV 후속 선택' }));
+
+    expect(getInfoBodyEditor()).toHaveProperty(
+      'value',
+      [
+        '> *2008년 7월 28일 저녁*',
+        '<MediaEmbed mediaId="video-2" type="video" align="center" width="medium" />',
+      ].join('\n')
+    );
   });
 
   it('does not mark legacy image or reference metadata as editable changes', async () => {


### PR DESCRIPTION
## 요약
- 기존 편집기에서 저장된 이스케이프 마크다운 표식을 보기/편집 진입 시 정상 마크다운으로 보정합니다.
- 정보 preview와 RichContentEditor 초기값 모두 같은 보정 함수를 통과하게 했습니다.
- 저장 경로도 보정된 본문 기준으로 유지되게 했습니다.

## Coverage Plan
- legacyMarkdown: 이스케이프된 blockquote/emphasis/divider/strong 표식이 보정되는 경로를 viewer/info 동작 테스트로 검증합니다.
- RichContentViewer: 기존 저장값의 백슬래시 처리된 인용/강조/구분선/굵게 표식이 실제 blockquote/em/hr/strong으로 렌더링되는지 검증합니다.
- InfoTab/RichContentEditor: 정보 수정 진입 시 이스케이프된 본문이 편집 가능한 마크다운 원문으로 들어오는지 검증합니다.
- Browser smoke: localhost:3000에서 mocked editor info 응답으로 preview/editor DOM에 blockquote/em/hr/strong이 생기는지 확인했습니다.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/components/content/__tests__/RichContentViewer.test.tsx src/features/editor/components/info/__tests__/InfoTab.test.tsx PASS (2 files / 16 tests)
- pnpm --filter @mmp/web typecheck PASS
- pnpm --filter @mmp/web lint PASS (기존 warning 48개, error 0)
- scripts/mmp-local-ci.sh quick PASS (.git/mmp-local-ci/last-run.json, head cbe7ad7f704ab8a54f78124aaad2e7bba5eb2ee1)
- Direct browser verification: preview/editor both rendered escaped markdown as blockquote/em/hr/strong on localhost:3000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 레거시 이스케이프 마크다운을 자동 정규화하는 처리 추가 및 에디터/뷰어에 적용

* **버그 수정**
  * 이스케이프된 마크다운 마커(인용구, 강조, 구분선 등)가 올바르게 해석되어 렌더링됨
  * 미디어 임베드 교체 로직이 정규화된 마크다운을 기반으로 동작

* **테스트**
  * 레거시 마크다운 정규화와 렌더링 동작을 검증하는 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/574)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->