### PR TITLE
feat(editor): 캐릭터 피해자 플래그와 한글 오류 메시지 개선

### DIFF
--- a/apps/server/api/openapi.yaml
+++ b/apps/server/api/openapi.yaml
@@ -954,6 +954,9 @@ components:
         detail:
           type: string
           description: Human-readable explanation
+        user_message:
+          type: string
+          description: Korean-first safe message intended for direct user display
         code:
           type: string
           description: Application-specific error code
@@ -1397,6 +1400,9 @@ components:
           type: boolean
         is_voting_candidate:
           type: boolean
+        is_victim:
+          type: boolean
+          default: false
         alias_rules:
           type: array
           items:
@@ -1442,6 +1448,8 @@ components:
         can_speak_in_reading:
           type: boolean
         is_voting_candidate:
+          type: boolean
+        is_victim:
           type: boolean
         alias_rules:
           type: array
@@ -1525,7 +1533,7 @@ components:
 
     EditorCharacterResponse:
       type: object
-      required: [id, theme_id, name, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, alias_rules]
+      required: [id, theme_id, name, is_culprit, mystery_role, sort_order, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, is_victim, alias_rules]
       properties:
         id:
           type: string
@@ -1561,6 +1569,8 @@ components:
         can_speak_in_reading:
           type: boolean
         is_voting_candidate:
+          type: boolean
+        is_victim:
           type: boolean
         alias_rules:
           type: array

--- a/apps/server/db/migrations/00049_character_is_victim.sql
+++ b/apps/server/db/migrations/00049_character_is_victim.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE theme_characters
+  ADD COLUMN is_victim BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- +goose Down
+ALTER TABLE theme_characters
+  DROP COLUMN IF EXISTS is_victim;

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -28,9 +28,9 @@ SELECT * FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order;
 INSERT INTO theme_characters (
   theme_id, name, description, image_url, is_culprit, mystery_role, sort_order,
   is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate,
-  endcard_title, endcard_body, endcard_image_url, image_media_id, endcard_image_media_id, alias_rules
+  is_victim, endcard_title, endcard_body, endcard_image_url, image_media_id, endcard_image_media_id, alias_rules
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 RETURNING *;
 
 -- name: UpdateTheme :one
@@ -68,12 +68,13 @@ UPDATE theme_characters SET
   show_in_intro = $9,
   can_speak_in_reading = $10,
   is_voting_candidate = $11,
-  endcard_title = $12,
-  endcard_body = $13,
-  endcard_image_url = $14,
-  image_media_id = $15,
-  endcard_image_media_id = $16,
-  alias_rules = $17
+  is_victim = $12,
+  endcard_title = $13,
+  endcard_body = $14,
+  endcard_image_url = $15,
+  image_media_id = $16,
+  endcard_image_media_id = $17,
+  alias_rules = $18
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/apperror/apperror.go
+++ b/apps/server/internal/apperror/apperror.go
@@ -12,16 +12,17 @@ import (
 // envelope. Use WithExtensions to attach (e.g. {"current_version": 42} on an
 // optimistic-lock 409). Extensions never leak into the Error() string.
 type AppError struct {
-	Type       string         `json:"type"`
-	Code       string         `json:"code"`
-	Status     int            `json:"status"`
-	Title      string         `json:"title"`
-	Detail     string         `json:"detail"`
-	Instance   string         `json:"instance,omitempty"`
-	Params     map[string]any `json:"params,omitempty"`
-	Errors     []FieldError   `json:"errors,omitempty"`
-	Extensions map[string]any `json:"extensions,omitempty"`
-	Internal   error          `json:"-"`
+	Type        string         `json:"type"`
+	Code        string         `json:"code"`
+	Status      int            `json:"status"`
+	Title       string         `json:"title"`
+	Detail      string         `json:"detail"`
+	UserMessage string         `json:"user_message,omitempty"`
+	Instance    string         `json:"instance,omitempty"`
+	Params      map[string]any `json:"params,omitempty"`
+	Errors      []FieldError   `json:"errors,omitempty"`
+	Extensions  map[string]any `json:"extensions,omitempty"`
+	Internal    error          `json:"-"`
 }
 
 // Error implements the error interface.
@@ -129,6 +130,14 @@ func (e *AppError) WithParams(params map[string]any) *AppError {
 			copied.Params[k] = v
 		}
 	}
+	return &copied
+}
+
+// WithUserMessage returns a copy of the error with a Korean-first user-facing message.
+// Detail may be masked for 5xx production responses, but UserMessage stays safe to show.
+func (e *AppError) WithUserMessage(message string) *AppError {
+	copied := *e
+	copied.UserMessage = message
 	return &copied
 }
 

--- a/apps/server/internal/apperror/codes.go
+++ b/apps/server/internal/apperror/codes.go
@@ -114,4 +114,7 @@ const (
 
 	// Editor errors
 	ErrEditorConfigVersionMismatch = "EDITOR_CONFIG_VERSION_MISMATCH"
+	ErrEditorEntityLoadFailed      = "EDITOR_ENTITY_LOAD_FAILED"
+	ErrEditorEntitySaveFailed      = "EDITOR_ENTITY_SAVE_FAILED"
+	ErrEditorEntityDeleteFailed    = "EDITOR_ENTITY_DELETE_FAILED"
 )

--- a/apps/server/internal/apperror/editor.go
+++ b/apps/server/internal/apperror/editor.go
@@ -1,0 +1,28 @@
+package apperror
+
+import "net/http"
+
+func EditorEntityLoadFailed(entity string) *AppError {
+	return New(ErrEditorEntityLoadFailed, http.StatusInternalServerError, "failed to load editor entity").
+		WithUserMessage(entity + " 불러오기에 실패했습니다. 잠시 후 다시 시도해주세요.").
+		WithParams(editorEntityParams(entity, "load"))
+}
+
+func EditorEntitySaveFailed(entity string) *AppError {
+	return New(ErrEditorEntitySaveFailed, http.StatusInternalServerError, "failed to save editor entity").
+		WithUserMessage(entity + " 저장에 실패했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요.").
+		WithParams(editorEntityParams(entity, "save"))
+}
+
+func EditorEntityDeleteFailed(entity string) *AppError {
+	return New(ErrEditorEntityDeleteFailed, http.StatusInternalServerError, "failed to delete editor entity").
+		WithUserMessage(entity + " 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.").
+		WithParams(editorEntityParams(entity, "delete"))
+}
+
+func editorEntityParams(entity, action string) map[string]any {
+	return map[string]any{
+		"entity": entity,
+		"action": action,
+	}
+}

--- a/apps/server/internal/apperror/handler.go
+++ b/apps/server/internal/apperror/handler.go
@@ -14,17 +14,18 @@ import (
 
 // problemResponse is the RFC 9457 Problem Details JSON structure.
 type problemResponse struct {
-	Type       string         `json:"type"`
-	Title      string         `json:"title"`
-	Status     int            `json:"status"`
-	Detail     string         `json:"detail"`
-	Code       string         `json:"code"`
-	Instance   string         `json:"instance,omitempty"`
-	Params     map[string]any `json:"params,omitempty"`
-	Errors     []FieldError   `json:"errors,omitempty"`
-	Extensions map[string]any `json:"extensions,omitempty"`
-	TraceID    string         `json:"trace_id,omitempty"`
-	RequestID  string         `json:"request_id,omitempty"`
+	Type        string         `json:"type"`
+	Title       string         `json:"title"`
+	Status      int            `json:"status"`
+	Detail      string         `json:"detail"`
+	Code        string         `json:"code"`
+	UserMessage string         `json:"user_message,omitempty"`
+	Instance    string         `json:"instance,omitempty"`
+	Params      map[string]any `json:"params,omitempty"`
+	Errors      []FieldError   `json:"errors,omitempty"`
+	Extensions  map[string]any `json:"extensions,omitempty"`
+	TraceID     string         `json:"trace_id,omitempty"`
+	RequestID   string         `json:"request_id,omitempty"`
 	// CorrelationID mirrors request_id for clients and logs that use correlation terminology.
 	CorrelationID string     `json:"correlation_id,omitempty"`
 	Timestamp     string     `json:"timestamp"`
@@ -99,6 +100,7 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 		Status:        appErr.Status,
 		Detail:        appErr.Detail,
 		Code:          appErr.Code,
+		UserMessage:   userMessageForResponse(appErr, defn),
 		Instance:      appErr.Instance,
 		Params:        appErr.Params,
 		Errors:        appErr.Errors,
@@ -136,6 +138,13 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
 		logger.Error().Err(encErr).Msg("failed to encode error response")
 	}
+}
+
+func userMessageForResponse(appErr *AppError, defn ErrorDefinition) string {
+	if appErr.UserMessage != "" {
+		return appErr.UserMessage
+	}
+	return defn.DefaultKR
 }
 
 func requestIDFrom(w http.ResponseWriter, r *http.Request) string {

--- a/apps/server/internal/apperror/handler_test.go
+++ b/apps/server/internal/apperror/handler_test.go
@@ -345,6 +345,39 @@ func TestWriteError_ProdMode_MaskedDetail(t *testing.T) {
 	}
 }
 
+func TestWriteError_ProdMode_KeepsUserMessageWhenDetailIsMasked(t *testing.T) {
+	SetDevMode(false)
+	defer SetDevMode(false)
+
+	appErr := Internal("pq: relation theme_characters is_victim does not exist").
+		WithUserMessage("캐릭터 저장에 실패했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요.").
+		Wrap(errors.New("SQLSTATE 42703"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("X-Request-ID", "req-character-save")
+
+	WriteError(rec, req, appErr)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["detail"] != "an unexpected error occurred" {
+		t.Errorf("expected masked detail in prod mode, got %q", body["detail"])
+	}
+	if body["user_message"] != "캐릭터 저장에 실패했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요." {
+		t.Errorf("user_message = %v", body["user_message"])
+	}
+	if body["request_id"] != "req-character-save" {
+		t.Errorf("request_id = %v, want req-character-save", body["request_id"])
+	}
+}
+
 func TestWriteError_WrappedError_Logging(t *testing.T) {
 	cause := errors.New("pg: connection timeout")
 	appErr := Internal("database unavailable").Wrap(cause)

--- a/apps/server/internal/apperror/registry.go
+++ b/apps/server/internal/apperror/registry.go
@@ -115,6 +115,9 @@ var errorDefinitions = map[string]ErrorDefinition{
 	ErrReadingVoiceRequired:    def(ErrReadingVoiceRequired, "reading", "domain", http.StatusConflict, SeverityMedium, false, "add_media", "음성 자동 진행에는 음성 파일이 필요합니다."),
 
 	ErrEditorConfigVersionMismatch: def(ErrEditorConfigVersionMismatch, "editor", "domain", http.StatusConflict, SeverityHigh, false, "reload_or_merge", "다른 변경사항과 충돌했습니다. 최신 내용으로 새로고침 후 다시 저장해주세요."),
+	ErrEditorEntityLoadFailed:      def(ErrEditorEntityLoadFailed, "editor", "application", http.StatusInternalServerError, SeverityHigh, true, "retry_later", "에디터 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해주세요."),
+	ErrEditorEntitySaveFailed:      def(ErrEditorEntitySaveFailed, "editor", "application", http.StatusInternalServerError, SeverityHigh, true, "retry_later", "에디터 데이터를 저장하지 못했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요."),
+	ErrEditorEntityDeleteFailed:    def(ErrEditorEntityDeleteFailed, "editor", "application", http.StatusInternalServerError, SeverityHigh, true, "retry_later", "에디터 데이터를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요."),
 }
 
 func def(code, domain, layer string, status int, severity Severity, retryable bool, userAction, defaultKR string) ErrorDefinition {

--- a/apps/server/internal/db/models.go
+++ b/apps/server/internal/db/models.go
@@ -322,6 +322,7 @@ type ThemeCharacter struct {
 	AliasRules          json.RawMessage `json:"alias_rules"`
 	ImageMediaID        pgtype.UUID     `json:"image_media_id"`
 	EndcardImageMediaID pgtype.UUID     `json:"endcard_image_media_id"`
+	IsVictim            bool            `json:"is_victim"`
 }
 
 type ThemeClue struct {

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -90,10 +90,10 @@ const createThemeCharacter = `-- name: CreateThemeCharacter :one
 INSERT INTO theme_characters (
   theme_id, name, description, image_url, is_culprit, mystery_role, sort_order,
   is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate,
-  endcard_title, endcard_body, endcard_image_url, image_media_id, endcard_image_media_id, alias_rules
+  is_victim, endcard_title, endcard_body, endcard_image_url, image_media_id, endcard_image_media_id, alias_rules
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id, is_victim
 `
 
 type CreateThemeCharacterParams struct {
@@ -108,6 +108,7 @@ type CreateThemeCharacterParams struct {
 	ShowInIntro         bool            `json:"show_in_intro"`
 	CanSpeakInReading   bool            `json:"can_speak_in_reading"`
 	IsVotingCandidate   bool            `json:"is_voting_candidate"`
+	IsVictim            bool            `json:"is_victim"`
 	EndcardTitle        pgtype.Text     `json:"endcard_title"`
 	EndcardBody         pgtype.Text     `json:"endcard_body"`
 	EndcardImageUrl     pgtype.Text     `json:"endcard_image_url"`
@@ -129,6 +130,7 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		arg.ShowInIntro,
 		arg.CanSpeakInReading,
 		arg.IsVotingCandidate,
+		arg.IsVictim,
 		arg.EndcardTitle,
 		arg.EndcardBody,
 		arg.EndcardImageUrl,
@@ -156,6 +158,7 @@ func (q *Queries) CreateThemeCharacter(ctx context.Context, arg CreateThemeChara
 		&i.AliasRules,
 		&i.ImageMediaID,
 		&i.EndcardImageMediaID,
+		&i.IsVictim,
 	)
 	return i, err
 }
@@ -245,7 +248,7 @@ func (q *Queries) GetThemeBySlug(ctx context.Context, slug string) (Theme, error
 }
 
 const getThemeCharacter = `-- name: GetThemeCharacter :one
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id FROM theme_characters WHERE id = $1
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id, is_victim FROM theme_characters WHERE id = $1
 `
 
 func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCharacter, error) {
@@ -270,12 +273,13 @@ func (q *Queries) GetThemeCharacter(ctx context.Context, id uuid.UUID) (ThemeCha
 		&i.AliasRules,
 		&i.ImageMediaID,
 		&i.EndcardImageMediaID,
+		&i.IsVictim,
 	)
 	return i, err
 }
 
 const getThemeCharacters = `-- name: GetThemeCharacters :many
-SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
+SELECT id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id, is_victim FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order
 `
 
 func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]ThemeCharacter, error) {
@@ -306,6 +310,7 @@ func (q *Queries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]
 			&i.AliasRules,
 			&i.ImageMediaID,
 			&i.EndcardImageMediaID,
+			&i.IsVictim,
 		); err != nil {
 			return nil, err
 		}
@@ -580,14 +585,15 @@ UPDATE theme_characters SET
   show_in_intro = $9,
   can_speak_in_reading = $10,
   is_voting_candidate = $11,
-  endcard_title = $12,
-  endcard_body = $13,
-  endcard_image_url = $14,
-  image_media_id = $15,
-  endcard_image_media_id = $16,
-  alias_rules = $17
+  is_victim = $12,
+  endcard_title = $13,
+  endcard_body = $14,
+  endcard_image_url = $15,
+  image_media_id = $16,
+  endcard_image_media_id = $17,
+  alias_rules = $18
 WHERE id = $1
-RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id
+RETURNING id, theme_id, name, description, image_url, is_culprit, sort_order, mystery_role, is_playable, show_in_intro, can_speak_in_reading, is_voting_candidate, endcard_title, endcard_body, endcard_image_url, alias_rules, image_media_id, endcard_image_media_id, is_victim
 `
 
 type UpdateThemeCharacterParams struct {
@@ -602,6 +608,7 @@ type UpdateThemeCharacterParams struct {
 	ShowInIntro         bool            `json:"show_in_intro"`
 	CanSpeakInReading   bool            `json:"can_speak_in_reading"`
 	IsVotingCandidate   bool            `json:"is_voting_candidate"`
+	IsVictim            bool            `json:"is_victim"`
 	EndcardTitle        pgtype.Text     `json:"endcard_title"`
 	EndcardBody         pgtype.Text     `json:"endcard_body"`
 	EndcardImageUrl     pgtype.Text     `json:"endcard_image_url"`
@@ -623,6 +630,7 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		arg.ShowInIntro,
 		arg.CanSpeakInReading,
 		arg.IsVotingCandidate,
+		arg.IsVictim,
 		arg.EndcardTitle,
 		arg.EndcardBody,
 		arg.EndcardImageUrl,
@@ -650,6 +658,7 @@ func (q *Queries) UpdateThemeCharacter(ctx context.Context, arg UpdateThemeChara
 		&i.AliasRules,
 		&i.ImageMediaID,
 		&i.EndcardImageMediaID,
+		&i.IsVictim,
 	)
 	return i, err
 }

--- a/apps/server/internal/domain/editor/handler_test.go
+++ b/apps/server/internal/domain/editor/handler_test.go
@@ -341,11 +341,16 @@ func TestUpdateCharacter_Success(t *testing.T) {
 
 	mock.EXPECT().
 		UpdateCharacter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(extSampleCharResponse(), nil).Times(1)
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, _ uuid.UUID, req editor.UpdateCharacterRequest) (*editor.CharacterResponse, error) {
+			if req.IsVictim == nil || !*req.IsVictim {
+				t.Fatalf("expected is_victim=true to reach service, got %+v", req.IsVictim)
+			}
+			return extSampleCharResponse(), nil
+		}).Times(1)
 
 	h := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
 
-	body := `{"name":"Detective Updated","is_culprit":false,"sort_order":1}`
+	body := `{"name":"Detective Updated","is_culprit":false,"sort_order":1,"is_victim":true}`
 	r := httptest.NewRequest(http.MethodPut, "/editor/characters/"+extCharID.String(), bytes.NewBufferString(body))
 	r.Header.Set("Content-Type", "application/json")
 	r = withExtAuth(r)

--- a/apps/server/internal/domain/editor/service.go
+++ b/apps/server/internal/domain/editor/service.go
@@ -105,6 +105,7 @@ type CreateCharacterRequest struct {
 	ShowInIntro         *bool                `json:"show_in_intro"`
 	CanSpeakInReading   *bool                `json:"can_speak_in_reading"`
 	IsVotingCandidate   *bool                `json:"is_voting_candidate"`
+	IsVictim            *bool                `json:"is_victim"`
 	EndcardTitle        *string              `json:"endcard_title" validate:"omitempty,max=80"`
 	EndcardBody         *string              `json:"endcard_body" validate:"omitempty,max=3000"`
 	EndcardImageURL     *string              `json:"endcard_image_url" validate:"omitempty,optional_url"`
@@ -124,6 +125,7 @@ type UpdateCharacterRequest struct {
 	ShowInIntro         *bool                `json:"show_in_intro"`
 	CanSpeakInReading   *bool                `json:"can_speak_in_reading"`
 	IsVotingCandidate   *bool                `json:"is_voting_candidate"`
+	IsVictim            *bool                `json:"is_victim"`
 	EndcardTitle        *string              `json:"endcard_title" validate:"omitempty,max=80"`
 	EndcardBody         *string              `json:"endcard_body" validate:"omitempty,max=3000"`
 	EndcardImageURL     *string              `json:"endcard_image_url" validate:"omitempty,optional_url"`
@@ -147,6 +149,7 @@ type CharacterResponse struct {
 	ShowInIntro         bool                 `json:"show_in_intro"`
 	CanSpeakInReading   bool                 `json:"can_speak_in_reading"`
 	IsVotingCandidate   bool                 `json:"is_voting_candidate"`
+	IsVictim            bool                 `json:"is_victim"`
 	EndcardTitle        *string              `json:"endcard_title,omitempty"`
 	EndcardBody         *string              `json:"endcard_body,omitempty"`
 	EndcardImageURL     *string              `json:"endcard_image_url,omitempty"`

--- a/apps/server/internal/domain/editor/service_character.go
+++ b/apps/server/internal/domain/editor/service_character.go
@@ -48,7 +48,7 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 	aliasRulesJSON, err := marshalCharacterAliasRules(aliasRules)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to marshal character alias rules")
-		return nil, apperror.Internal("failed to create character")
+		return nil, apperror.EditorEntitySaveFailed("캐릭터").Wrap(err)
 	}
 	imageMediaID, err := s.resolveThemeImageMedia(ctx, themeID, req.ImageMediaID, "character profile image")
 	if err != nil {
@@ -71,6 +71,7 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 		ShowInIntro:         visibilityPolicy.ShowInIntro,
 		CanSpeakInReading:   visibilityPolicy.CanSpeakInReading,
 		IsVotingCandidate:   visibilityPolicy.IsVotingCandidate,
+		IsVictim:            boolPtrValue(req.IsVictim, false),
 		EndcardTitle:        ptrToText(req.EndcardTitle),
 		EndcardBody:         ptrToText(req.EndcardBody),
 		EndcardImageUrl:     ptrToText(req.EndcardImageURL),
@@ -80,7 +81,7 @@ func (s *service) CreateCharacter(ctx context.Context, creatorID, themeID uuid.U
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to create character")
-		return nil, apperror.Internal("failed to create character")
+		return nil, apperror.EditorEntitySaveFailed("캐릭터").Wrap(err)
 	}
 	return toCharacterResponse(char), nil
 }
@@ -92,7 +93,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 			return nil, apperror.NotFound("character not found")
 		}
 		s.logger.Error().Err(err).Msg("failed to get character")
-		return nil, apperror.Internal("failed to get character")
+		return nil, apperror.EditorEntityLoadFailed("캐릭터").Wrap(err)
 	}
 	if _, err := s.getOwnedTheme(ctx, creatorID, char.ThemeID); err != nil {
 		return nil, err
@@ -125,7 +126,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		aliasRulesJSON, err = marshalCharacterAliasRules(aliasRules)
 		if err != nil {
 			s.logger.Error().Err(err).Msg("failed to marshal character alias rules")
-			return nil, apperror.Internal("failed to update character")
+			return nil, apperror.EditorEntitySaveFailed("캐릭터").Wrap(err)
 		}
 	}
 	imageMediaID := char.ImageMediaID
@@ -163,6 +164,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 		ShowInIntro:         visibilityPolicy.ShowInIntro,
 		CanSpeakInReading:   visibilityPolicy.CanSpeakInReading,
 		IsVotingCandidate:   visibilityPolicy.IsVotingCandidate,
+		IsVictim:            boolPtrValue(req.IsVictim, char.IsVictim),
 		EndcardTitle:        characterEndcardText(req.EndcardTitle, char.EndcardTitle),
 		EndcardBody:         characterEndcardText(req.EndcardBody, char.EndcardBody),
 		EndcardImageUrl:     characterEndcardText(req.EndcardImageURL, char.EndcardImageUrl),
@@ -172,7 +174,7 @@ func (s *service) UpdateCharacter(ctx context.Context, creatorID, charID uuid.UU
 	})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update character")
-		return nil, apperror.Internal("failed to update character")
+		return nil, apperror.EditorEntitySaveFailed("캐릭터").Wrap(err)
 	}
 	return toCharacterResponse(updated), nil
 }
@@ -230,7 +232,7 @@ func (s *service) DeleteCharacter(ctx context.Context, creatorID, charID uuid.UU
 			return apperror.NotFound("character not found")
 		}
 		s.logger.Error().Err(err).Msg("failed to delete character")
-		return apperror.Internal("failed to delete character")
+		return apperror.EditorEntityDeleteFailed("캐릭터").Wrap(err)
 	}
 	return nil
 }
@@ -243,7 +245,7 @@ func (s *service) ListCharacters(ctx context.Context, creatorID, themeID uuid.UU
 	chars, err := s.q.GetThemeCharacters(ctx, themeID)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to list characters")
-		return nil, apperror.Internal("failed to list characters")
+		return nil, apperror.EditorEntityLoadFailed("캐릭터 목록").Wrap(err)
 	}
 	out := make([]CharacterResponse, len(chars))
 	for i, c := range chars {
@@ -267,6 +269,7 @@ func toCharacterResponse(c db.ThemeCharacter) *CharacterResponse {
 		ShowInIntro:         c.ShowInIntro,
 		CanSpeakInReading:   c.CanSpeakInReading,
 		IsVotingCandidate:   c.IsVotingCandidate,
+		IsVictim:            c.IsVictim,
 		EndcardTitle:        textToPtr(c.EndcardTitle),
 		EndcardBody:         textToPtr(c.EndcardBody),
 		EndcardImageURL:     textToPtr(c.EndcardImageUrl),

--- a/apps/server/internal/domain/editor/service_character_clue_test.go
+++ b/apps/server/internal/domain/editor/service_character_clue_test.go
@@ -264,7 +264,7 @@ func TestService_UpdateCharacter(t *testing.T) {
 	themeID := f.createThemeForUser(t, creatorID)
 
 	created, err := f.svc.CreateCharacter(ctx, creatorID, themeID, CreateCharacterRequest{
-		Name: "Original", SortOrder: 0, ImageURL: textPtr("https://cdn.example/original.webp"),
+		Name: "Original", SortOrder: 0, ImageURL: textPtr("https://cdn.example/original.webp"), IsVictim: boolPtr(true),
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -287,6 +287,9 @@ func TestService_UpdateCharacter(t *testing.T) {
 	if !updated.IsPlayable || !updated.ShowInIntro || !updated.CanSpeakInReading || !updated.IsVotingCandidate {
 		t.Errorf("update should preserve default playable visibility: %+v", updated)
 	}
+	if !updated.IsVictim {
+		t.Error("omitted is_victim should preserve stored victim flag")
+	}
 	if updated.ImageURL == nil || *updated.ImageURL != "https://cdn.example/original.webp" {
 		t.Fatalf("omitted image_url should preserve stored character image: %+v", updated.ImageURL)
 	}
@@ -302,6 +305,19 @@ func TestService_UpdateCharacter(t *testing.T) {
 	}
 	if clearedImage.ImageURL != nil {
 		t.Fatalf("empty image_url should clear stored character image: %+v", clearedImage.ImageURL)
+	}
+
+	notVictim, err := f.svc.UpdateCharacter(ctx, creatorID, created.ID, UpdateCharacterRequest{
+		Name:      "Updated",
+		IsCulprit: true,
+		SortOrder: 0,
+		IsVictim:  boolPtr(false),
+	})
+	if err != nil {
+		t.Fatalf("UpdateCharacter clear victim flag: %v", err)
+	}
+	if notVictim.IsVictim {
+		t.Error("explicit false is_victim should clear stored victim flag")
 	}
 }
 

--- a/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
+++ b/apps/web/e2e/helpers/editor-golden-path-fixtures.ts
@@ -42,6 +42,7 @@ export interface MockState {
   characterUpdateCalls: number;
   lastCharacterUpdateBody: Record<string, unknown> | null;
   characterMysteryRole: "suspect" | "culprit" | "accomplice" | "detective";
+  characterIsVictim: boolean;
   roleSheet: Record<string, unknown>;
   configPutCalls: number;
   lastConfigRequestBody: Record<string, unknown> | null;
@@ -69,6 +70,7 @@ export function freshState(): MockState {
     characterUpdateCalls: 0,
     lastCharacterUpdateBody: null,
     characterMysteryRole: "detective",
+    characterIsVictim: false,
     roleSheet: {
       character_id: "char-1",
       theme_id: THEME_ID,
@@ -324,6 +326,9 @@ export async function mockCommonApis(page: Page, state: MockState): Promise<void
       state.characterMysteryRole = "culprit";
     } else if (body.is_culprit === false) {
       state.characterMysteryRole = "suspect";
+    }
+    if (typeof body.is_victim === "boolean") {
+      state.characterIsVictim = body.is_victim;
     }
     return r.fulfill({
       status: 200,
@@ -603,6 +608,11 @@ function characterPayload(state: MockState) {
     image_url: null,
     is_culprit: state.characterMysteryRole === "culprit",
     mystery_role: state.characterMysteryRole,
+    is_playable: true,
+    show_in_intro: true,
+    can_speak_in_reading: true,
+    is_voting_candidate: state.characterMysteryRole !== "detective",
+    is_victim: state.characterIsVictim,
     starting_clue_ids: state.startingClueIds,
     sort_order: 0,
     created_at: new Date().toISOString(),

--- a/apps/web/e2e/phase24-editor-character-role.spec.ts
+++ b/apps/web/e2e/phase24-editor-character-role.spec.ts
@@ -10,10 +10,8 @@ import {
 } from "./helpers/editor-golden-path-fixtures";
 
 test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
-  let state: MockState;
-
   test.beforeEach(async ({ page }) => {
-    state = freshState();
+    const state: MockState = freshState();
     await mockCommonApis(page, state);
     await loginAsE2EUser(page);
   });
@@ -21,8 +19,8 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
   test("실제 에디터 화면에서 캐릭터를 공범으로 변경하면 API에 mystery_role을 저장한다", async ({ page }) => {
     await page.goto(`${BASE}/editor/${THEME_ID}`);
 
-    await page.getByRole("tab", { name: "등장인물" }).click();
-    await expect(page.getByRole("button", { name: "제작" })).toBeVisible();
+    await page.getByRole("tab", { name: "등장인물 관리" }).click();
+    await expect(page.getByRole("region", { name: "캐릭터 목록" })).toBeVisible();
 
     await page.getByRole("button", { name: "탐정 A 선택" }).click();
 
@@ -48,6 +46,67 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
     expect(a11y.violations).toEqual([]);
   });
 
+  test("실제 에디터 화면에서 피해자 표시를 저장해도 역할을 유지한다", async ({ page }) => {
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    await page.getByRole("tab", { name: "등장인물 관리" }).click();
+    await expect(page.getByRole("region", { name: "캐릭터 목록" })).toBeVisible();
+    await page.getByRole("button", { name: "탐정 A 선택" }).click();
+
+    const updateRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === "PUT" &&
+        request.url().includes("/v1/editor/characters/char-1"),
+    );
+    await page.getByLabel("피해자").click();
+    const updateRequest = await updateRequestPromise;
+
+    expect(updateRequest.postDataJSON()).toMatchObject({
+      name: "탐정 A",
+      mystery_role: "detective",
+      is_culprit: false,
+      is_victim: true,
+    });
+  });
+
+  test("캐릭터 저장 실패 시 서버 user_message와 오류 ID를 표시하고 내부 detail은 숨긴다", async ({ page }) => {
+    await page.route("**/v1/editor/characters/char-1", async (route) => {
+      if (route.request().method() !== "PUT") {
+        return route.fallback();
+      }
+      return route.fulfill({
+        status: 500,
+        contentType: "application/problem+json",
+        body: JSON.stringify({
+          type: "about:blank",
+          title: "Internal Server Error",
+          status: 500,
+          detail: "pq: relation theme_characters.is_victim does not exist",
+          code: "EDITOR_ENTITY_SAVE_FAILED",
+          user_message: "캐릭터 저장에 실패했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요.",
+          request_id: "req-character-save-1234",
+          correlation_id: "req-character-save-1234",
+          timestamp: new Date().toISOString(),
+          severity: "high",
+          retryable: true,
+          user_action: "retry_later",
+        }),
+      });
+    });
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    await page.getByRole("tab", { name: "등장인물 관리" }).click();
+    await expect(page.getByRole("region", { name: "캐릭터 목록" })).toBeVisible();
+    await page.getByRole("button", { name: "탐정 A 선택" }).click();
+    await page.getByLabel("피해자").click();
+
+    await expect(
+      page.getByText("캐릭터 저장에 실패했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요."),
+    ).toBeVisible();
+    await expect(page.getByText("오류 ID: req-char")).toBeVisible();
+    await expect(page.getByText(/theme_characters\.is_victim|SQLSTATE|relation/)).toHaveCount(0);
+  });
+
   test("실제 에디터 화면에서 이미지 롤지를 추가하고 저장한다", async ({ page }) => {
     await page.route("https://cdn.example/**", (route) =>
       route.fulfill({
@@ -58,11 +117,15 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
     );
     await page.goto(`${BASE}/editor/${THEME_ID}`);
 
-    await page.getByRole("tab", { name: "등장인물" }).click();
-    await expect(page.getByRole("button", { name: "제작" })).toBeVisible();
+    await page.getByRole("tab", { name: "등장인물 관리" }).click();
+    await expect(page.getByRole("region", { name: "캐릭터 목록" })).toBeVisible();
     await page.getByRole("button", { name: "탐정 A 선택" }).click();
 
-    await page.getByRole("button", { name: /이미지/ }).click();
+    await page.getByRole("button", { name: /^역할지/ }).click();
+    await page
+      .getByRole("group", { name: "역할지 형식 선택" })
+      .getByRole("button", { name: /이미지/ })
+      .click();
     await page.getByRole("textbox", { name: "이미지 페이지 URL" }).fill("https://cdn.example/role-1.svg");
     await page.getByRole("button", { name: "이미지 페이지 추가" }).click();
     await expect(page.getByText("1 / 1페이지")).toBeVisible();
@@ -77,7 +140,7 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
 
     expect(roleSheetRequest.postDataJSON()).toEqual({
       format: "images",
-      images: { image_urls: ["https://cdn.example/role-1.svg"] },
+      images: { image_urls: ["https://cdn.example/role-1.svg"], image_media_ids: [] },
     });
     await expect(page.getByText("저장되었습니다.")).toBeVisible();
 

--- a/apps/web/src/features/editor/api/types.ts
+++ b/apps/web/src/features/editor/api/types.ts
@@ -56,6 +56,7 @@ export interface EditorCharacterResponse {
   show_in_intro: boolean;
   can_speak_in_reading: boolean;
   is_voting_candidate: boolean;
+  is_victim: boolean;
   endcard_title?: string | null;
   endcard_body?: string | null;
   endcard_image_url?: string | null;
@@ -110,6 +111,7 @@ export interface CreateCharacterRequest {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  is_victim?: boolean;
   endcard_title?: string;
   endcard_body?: string;
   endcard_image_url?: string;
@@ -129,6 +131,7 @@ export interface UpdateCharacterRequest {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  is_victim?: boolean;
   endcard_title?: string;
   endcard_body?: string;
   endcard_image_url?: string;

--- a/apps/web/src/features/editor/components/CharacterForm.tsx
+++ b/apps/web/src/features/editor/components/CharacterForm.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import { Modal } from '@/shared/components/ui/Modal';
 import { Button } from '@/shared/components/ui/Button';
 import { Input } from '@/shared/components/ui/Input';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 import {
   useCreateCharacter,
   useUpdateCharacter,
@@ -99,7 +100,7 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
             onClose();
           },
           onError: (err) => {
-            toast.error(err.message || '캐릭터 수정에 실패했습니다');
+            showUnknownErrorToast(err, '캐릭터 수정에 실패했습니다');
           },
         },
       );
@@ -114,7 +115,7 @@ export function CharacterForm({ themeId, character, isOpen, onClose }: Character
             onClose();
           },
           onError: (err) => {
-            toast.error(err.message || '캐릭터 추가에 실패했습니다');
+            showUnknownErrorToast(err, '캐릭터 추가에 실패했습니다');
           },
         },
       );

--- a/apps/web/src/features/editor/components/CharactersTab.tsx
+++ b/apps/web/src/features/editor/components/CharactersTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import { Modal } from '@/shared/components/ui/Modal';
 import { Button } from '@/shared/components/ui/Button';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 import { useDeleteCharacter, type EditorCharacterResponse } from '@/features/editor/api';
 import { CharacterAssignPanel } from './design/CharacterAssignPanel';
 import { CharacterForm } from './CharacterForm';
@@ -49,7 +50,7 @@ export function CharactersTab({ themeId, theme }: CharactersTabProps) {
         setDeletingCharacter(undefined);
       },
       onError: (err) => {
-        toast.error(err.message || '캐릭터 삭제에 실패했습니다');
+        showUnknownErrorToast(err, '캐릭터 삭제에 실패했습니다');
         setDeletingCharacter(undefined);
       },
     });

--- a/apps/web/src/features/editor/components/EditorDashboard.tsx
+++ b/apps/web/src/features/editor/components/EditorDashboard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/features/editor/api";
 import type { CreateThemeRequest, EditorThemeSummary } from "@/features/editor/api";
 import { STATUS_LABEL, STATUS_COLOR } from "@/features/editor/constants";
+import { showUnknownErrorToast } from "@/lib/show-error-toast";
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("ko-KR", {
@@ -255,7 +256,7 @@ export function EditorDashboard() {
         navigate(`/editor/${created.id}`);
       },
       onError: (err) => {
-        toast.error(err.message || "테마 생성에 실패했습니다");
+        showUnknownErrorToast(err, "테마 생성에 실패했습니다");
       },
     });
   }
@@ -268,7 +269,7 @@ export function EditorDashboard() {
         setDeletingId(null);
       },
       onError: (err) => {
-        toast.error(err.message || "테마 삭제에 실패했습니다");
+        showUnknownErrorToast(err, "테마 삭제에 실패했습니다");
         setDeletingId(null);
       },
     });

--- a/apps/web/src/features/editor/components/OverviewTab.tsx
+++ b/apps/web/src/features/editor/components/OverviewTab.tsx
@@ -9,6 +9,7 @@ import {
 import { SectionDivider } from './SectionDivider';
 import { ImageMediaReferenceField } from '@/features/editor/components/media/ImageMediaReferenceField';
 import { TemplateSettingsSection } from './TemplateConfigTab';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 // ---------------------------------------------------------------------------
 // SpecField — inline number input with label + unit
@@ -157,7 +158,7 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
 
     updateTheme.mutate(body, {
       onSuccess: () => toast.success('테마가 수정되었습니다'),
-      onError: (err) => toast.error(err.message || '테마 수정에 실패했습니다'),
+      onError: (err) => showUnknownErrorToast(err, '테마 수정에 실패했습니다'),
     });
   }
 

--- a/apps/web/src/features/editor/components/PublishBar.tsx
+++ b/apps/web/src/features/editor/components/PublishBar.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/shared/components/ui";
 import { useSubmitForReview, useUnpublishTheme } from "@/features/editor/api";
 import type { EditorThemeResponse } from "@/features/editor/api";
 import { STATUS_LABEL, STATUS_COLOR } from "@/features/editor/constants";
+import { showUnknownErrorToast } from "@/lib/show-error-toast";
 
 interface PublishBarProps {
   theme: EditorThemeResponse;
@@ -16,14 +17,14 @@ export function PublishBar({ theme }: PublishBarProps) {
   function handleSubmit() {
     submit.mutate(undefined, {
       onSuccess: () => toast.success("심사가 요청되었습니다"),
-      onError: (err) => toast.error(err.message || "심사 요청에 실패했습니다"),
+      onError: (err) => showUnknownErrorToast(err, "심사 요청에 실패했습니다"),
     });
   }
 
   function handleUnpublish() {
     unpublish.mutate(undefined, {
       onSuccess: () => toast.success("비공개로 전환되었습니다"),
-      onError: (err) => toast.error(err.message || "비공개 전환에 실패했습니다"),
+      onError: (err) => showUnknownErrorToast(err, "비공개 전환에 실패했습니다"),
     });
   }
 

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -19,6 +19,7 @@ import { buildClueUsageMap, type EntityReference } from '@/features/editor/utils
 import { ClueForm } from '../ClueForm';
 import { ClueEntityWorkspace } from './ClueEntityWorkspace';
 import { useFlowGraph } from '@/features/editor/flowApi';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -57,7 +58,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
       { clueId, body },
       {
         onSuccess: () => toast.success('단서가 수정되었습니다'),
-        onError: (err) => toast.error(err.message || '단서 수정에 실패했습니다'),
+        onError: (err) => showUnknownErrorToast(err, '단서 수정에 실패했습니다'),
       }
     );
   }
@@ -70,7 +71,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
         setDeletingClue(undefined);
       },
       onError: (err) => {
-        toast.error(err.message || '단서 삭제에 실패했습니다');
+        showUnknownErrorToast(err, '단서 삭제에 실패했습니다');
         setDeletingClue(undefined);
       },
     });

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -46,6 +46,7 @@ interface CharacterItem {
   show_in_intro?: boolean;
   can_speak_in_reading?: boolean;
   is_voting_candidate?: boolean;
+  is_victim?: boolean;
   alias_rules?: CharacterAliasRule[];
 }
 
@@ -124,6 +125,7 @@ export function CharacterDetailPanel({
     is_voting_candidate:
       selectedChar.is_voting_candidate ??
       getCharacterRoleOption(selectedRole).defaultVotingCandidate,
+    is_victim: selectedChar.is_victim ?? false,
     alias_rules: selectedChar.alias_rules ?? [],
   });
 
@@ -253,6 +255,13 @@ export function CharacterDetailPanel({
                       checked={selectedView.isVotingCandidate}
                       disabled={!onVisibilityChange}
                       onChange={(checked) => onVisibilityChange?.('is_voting_candidate', checked)}
+                    />
+                    <VisibilityToggle
+                      label="피해자"
+                      description="사건의 피해자로 표시합니다. 플레이 가능 여부와 추리 역할은 유지됩니다."
+                      checked={selectedView.isVictim}
+                      disabled={!onVisibilityChange}
+                      onChange={(checked) => onVisibilityChange?.('is_victim', checked)}
                     />
                   </div>
                 </div>

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -222,6 +222,7 @@ const mockCharacters = [
     show_in_intro: true,
     can_speak_in_reading: true,
     is_voting_candidate: true,
+    is_victim: false,
   },
   {
     id: 'char-2',
@@ -236,6 +237,7 @@ const mockCharacters = [
     show_in_intro: true,
     can_speak_in_reading: true,
     is_voting_candidate: false,
+    is_victim: false,
   },
 ];
 
@@ -394,6 +396,7 @@ describe('CharacterAssignPanel', () => {
         show_in_intro: true,
         can_speak_in_reading: true,
         is_voting_candidate: true,
+        is_victim: false,
         alias_rules: [],
       },
     });
@@ -417,6 +420,31 @@ describe('CharacterAssignPanel', () => {
         show_in_intro: true,
         can_speak_in_reading: true,
         is_voting_candidate: false,
+        is_victim: false,
+        alias_rules: [],
+      },
+    });
+  });
+
+  it('피해자 표시를 변경해도 플레이어 여부와 범인 역할을 유지한다', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    fireEvent.click(screen.getByLabelText(/피해자/));
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith({
+      characterId: 'char-1',
+      body: {
+        name: '홍길동',
+        description: undefined,
+        image_url: undefined,
+        is_culprit: true,
+        mystery_role: 'culprit',
+        sort_order: 0,
+        is_playable: true,
+        show_in_intro: true,
+        can_speak_in_reading: true,
+        is_voting_candidate: true,
+        is_victim: true,
         alias_rules: [],
       },
     });

--- a/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaUploadModal.test.tsx
@@ -292,7 +292,7 @@ describe('MediaUploadModal', () => {
       expect(alert.textContent).toContain(
         '이 미디어는 다른 곳에서 사용 중이라 삭제할 수 없습니다.'
       );
-      expect(alert.textContent).toContain('Ref: req-1234');
+      expect(alert.textContent).toContain('오류 ID: req-1234');
       expect(alert.textContent).not.toContain('internal storage key');
     });
   });
@@ -322,7 +322,7 @@ describe('MediaUploadModal', () => {
       expect(alert.textContent).toContain(
         '이 미디어는 다른 곳에서 사용 중이라 삭제할 수 없습니다.'
       );
-      expect(alert.textContent).toContain('Ref: corr-123');
+      expect(alert.textContent).toContain('오류 ID: corr-123');
       expect(alert.textContent).not.toContain('internal storage key');
     });
   });

--- a/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/character/__tests__/characterEditorAdapter.test.ts
@@ -25,6 +25,7 @@ function character(overrides: Partial<EditorCharacterResponse> = {}): EditorChar
     show_in_intro: true,
     can_speak_in_reading: true,
     is_voting_candidate: true,
+    is_victim: false,
     endcard_title: null,
     endcard_body: null,
     endcard_image_url: null,
@@ -53,6 +54,7 @@ describe('characterEditorAdapter', () => {
       showInIntro: true,
       canSpeakInReading: true,
       isVotingCandidate: true,
+      isVictim: false,
       visibilityBadges: ['PC', '소개 표시', '읽기 대사', '투표 후보'],
       aliasRules: [],
       hasAliasRules: false,
@@ -121,6 +123,16 @@ describe('characterEditorAdapter', () => {
     expect(getCharacterListBadges(character({ is_playable: false }))).toEqual(['용의자', 'NPC']);
   });
 
+  it('피해자 표시 정책을 제작자용 ViewModel과 배지로 변환한다', () => {
+    const vm = toCharacterEditorViewModel(character({ is_victim: true }));
+
+    expect(vm).toMatchObject({
+      isVictim: true,
+      visibilityBadges: ['PC', '소개 표시', '읽기 대사', '투표 후보', '피해자'],
+    });
+    expect(getCharacterListBadges(character({ is_victim: true }))).toEqual(['용의자', 'PC', '피해자']);
+  });
+
   it('legacy is_culprit 플래그만 있어도 범인 역할로 보존한다', () => {
     expect(normalizeCharacterEditorRole(character({ mystery_role: undefined as unknown as EditorCharacterResponse['mystery_role'], is_culprit: true }))).toBe('culprit');
     expect(getCharacterRoleBadge(character({ mystery_role: undefined as unknown as EditorCharacterResponse['mystery_role'], is_culprit: true }))).toBe('범인');
@@ -140,6 +152,7 @@ describe('characterEditorAdapter', () => {
       show_in_intro: true,
       can_speak_in_reading: true,
       is_voting_candidate: true,
+      is_victim: false,
       alias_rules: [],
     });
   });
@@ -171,6 +184,25 @@ describe('characterEditorAdapter', () => {
       show_in_intro: true,
       can_speak_in_reading: true,
       is_voting_candidate: false,
+      is_victim: false,
+    });
+  });
+
+  it('피해자 플래그 변경 저장 payload에서 기존 역할과 노출 정책을 보존한다', () => {
+    const payload = buildCharacterVisibilityUpdatePayload(
+      character({ mystery_role: 'culprit', is_culprit: true }),
+      'is_victim',
+      true,
+    );
+
+    expect(payload).toMatchObject({
+      mystery_role: 'culprit',
+      is_culprit: true,
+      is_playable: true,
+      show_in_intro: true,
+      can_speak_in_reading: true,
+      is_voting_candidate: true,
+      is_victim: true,
     });
   });
 
@@ -201,6 +233,7 @@ describe('characterEditorAdapter', () => {
       show_in_intro: true,
       can_speak_in_reading: true,
       is_voting_candidate: true,
+      is_victim: false,
       alias_rules: [{
         id: 'alias-1',
         label: '공개 후',

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -32,6 +32,7 @@ export interface CharacterEditorViewModel {
   showInIntro: boolean;
   canSpeakInReading: boolean;
   isVotingCandidate: boolean;
+  isVictim: boolean;
   visibilityBadges: string[];
   aliasRules: CharacterAliasRule[];
   hasAliasRules: boolean;
@@ -76,7 +77,8 @@ export type CharacterVisibilityField =
   | 'is_playable'
   | 'show_in_intro'
   | 'can_speak_in_reading'
-  | 'is_voting_candidate';
+  | 'is_voting_candidate'
+  | 'is_victim';
 
 export function getCharacterRoleOption(role: MysteryRole): CharacterRoleOption {
   return roleOptionMap.get(role) ?? roleOptionMap.get('suspect')!;
@@ -100,6 +102,7 @@ function getCharacterVisibility(character: Partial<EditorCharacterResponse>, rol
     showInIntro: boolOrDefault(character.show_in_intro, true),
     canSpeakInReading: boolOrDefault(character.can_speak_in_reading, true),
     isVotingCandidate: boolOrDefault(character.is_voting_candidate, isPlayable && roleOption.defaultVotingCandidate),
+    isVictim: boolOrDefault(character.is_victim, false),
   };
 }
 
@@ -108,6 +111,7 @@ function getVisibilityBadges(visibility: ReturnType<typeof getCharacterVisibilit
   if (visibility.showInIntro) badges.push('소개 표시');
   if (visibility.canSpeakInReading) badges.push('읽기 대사');
   if (visibility.isVotingCandidate) badges.push('투표 후보');
+  if (visibility.isVictim) badges.push('피해자');
   return badges;
 }
 
@@ -140,6 +144,7 @@ function buildCharacterBaseUpdatePayload(character: EditorCharacterResponse, rol
     show_in_intro: visibility.showInIntro,
     can_speak_in_reading: visibility.canSpeakInReading,
     is_voting_candidate: visibility.isVotingCandidate,
+    is_victim: visibility.isVictim,
     alias_rules: normalizeCharacterAliasRules(character.alias_rules),
   };
 }
@@ -169,6 +174,7 @@ export function toCharacterEditorViewModel(character: EditorCharacterResponse): 
     showInIntro: visibility.showInIntro,
     canSpeakInReading: visibility.canSpeakInReading,
     isVotingCandidate: visibility.isVotingCandidate,
+    isVictim: visibility.isVictim,
     visibilityBadges: getVisibilityBadges(visibility),
     aliasRules,
     hasAliasRules: aliasRules.length > 0,
@@ -200,6 +206,7 @@ export function buildCharacterVisibilityUpdatePayload(
     show_in_intro: visibility.showInIntro,
     can_speak_in_reading: visibility.canSpeakInReading,
     is_voting_candidate: visibility.isVotingCandidate,
+    is_victim: visibility.isVictim,
     [field]: value,
   };
 
@@ -241,5 +248,7 @@ export function getCharacterRoleBadge(character: { mystery_role?: MysteryRole | 
 export function getCharacterListBadges(character: EditorCharacterResponse): string[] {
   const role = normalizeCharacterEditorRole(character);
   const visibility = getCharacterVisibility(character, role);
-  return [getCharacterRoleBadge(character), visibility.isPlayable ? 'PC' : 'NPC'];
+  const badges = [getCharacterRoleBadge(character), visibility.isPlayable ? 'PC' : 'NPC'];
+  if (visibility.isVictim) badges.push('피해자');
+  return badges;
 }

--- a/apps/web/src/features/editor/hooks/useClueEdgeData.ts
+++ b/apps/web/src/features/editor/hooks/useClueEdgeData.ts
@@ -19,6 +19,7 @@ import {
   type EdgeTrigger,
 } from "../clueEdgeApi";
 import { queryClient } from "@/services/queryClient";
+import { showUnknownErrorToast } from "@/lib/show-error-toast";
 
 // ---------------------------------------------------------------------------
 // Layout constants
@@ -124,7 +125,7 @@ export function useClueEdgeData(
           },
           onError: (err) => {
             if (overrides?.onError) overrides.onError(err);
-            else toast.error(err.message || "엣지 저장에 실패했습니다");
+            else showUnknownErrorToast(err, "엣지 저장에 실패했습니다");
           },
         });
       }, 1000);

--- a/apps/web/src/features/editor/hooks/useClueFormSubmit.ts
+++ b/apps/web/src/features/editor/hooks/useClueFormSubmit.ts
@@ -4,6 +4,7 @@ import {
   useUpdateClue,
   type ClueResponse,
 } from '@/features/editor/api';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 // ---------------------------------------------------------------------------
 // useClueFormSubmit
@@ -62,7 +63,7 @@ export function useClueFormSubmit({
             onDone();
           },
           onError: (err) => {
-            toast.error(err.message || '단서 수정에 실패했습니다');
+            showUnknownErrorToast(err, '단서 수정에 실패했습니다');
           },
         },
       );
@@ -75,7 +76,7 @@ export function useClueFormSubmit({
         onDone();
       },
       onError: (err) => {
-        toast.error(err.message || '단서 추가에 실패했습니다');
+        showUnknownErrorToast(err, '단서 추가에 실패했습니다');
       },
     });
   }

--- a/apps/web/src/lib/display-error.ts
+++ b/apps/web/src/lib/display-error.ts
@@ -9,7 +9,7 @@ export function getDisplayErrorMessage(
   if (isApiHttpError(error)) {
     const message = getUserMessage(error.apiError);
     const ref = getErrorReference(error.apiError);
-    return ref ? `${message} (Ref: ${ref})` : message;
+    return ref ? `${message} (오류 ID: ${ref})` : message;
   }
 
   if (error instanceof Error) {

--- a/apps/web/src/lib/error-messages.ts
+++ b/apps/web/src/lib/error-messages.ts
@@ -60,6 +60,11 @@ const FALLBACK_MESSAGE = "알 수 없는 오류가 발생했습니다.";
  * params가 있으면 {key} 형식의 플레이스홀더를 치환한다.
  */
 export function getUserMessage(error: ApiError): string {
+  const serverMessage = error.user_message?.trim();
+  if (serverMessage) {
+    return serverMessage;
+  }
+
   const template =
     (error.code && ERROR_MESSAGES[error.code]) ?? FALLBACK_MESSAGE;
 

--- a/apps/web/src/lib/show-error-toast.test.ts
+++ b/apps/web/src/lib/show-error-toast.test.ts
@@ -70,10 +70,30 @@ describe('showErrorToast', () => {
     showErrorToast(apiError({ request_id: 'request-123456789' }));
 
     expect(toast.error).toHaveBeenCalledWith('잘못된 요청입니다.', {
-      description: 'Ref: request-',
+      description: '오류 ID: request-',
       duration: 5000,
     });
     expect(captureApiError).not.toHaveBeenCalled();
+  });
+
+  it('서버가 보낸 user_message를 코드 기본 메시지보다 우선 표시한다', () => {
+    showErrorToast(
+      apiError({
+        status: 500,
+        code: 'INTERNAL_ERROR',
+        detail: 'an unexpected error occurred',
+        user_message: '캐릭터 저장에 실패했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요.',
+        request_id: 'request-123456789',
+      })
+    );
+
+    expect(toast.error).toHaveBeenCalledWith(
+      '캐릭터 저장에 실패했습니다. 입력 내용은 유지됩니다. 잠시 후 다시 시도해주세요.',
+      {
+        description: '오류 ID: request-',
+        duration: Infinity,
+      }
+    );
   });
 
   it('high severity 4xx는 캡처 없이 더 오래 표시한다', () => {
@@ -92,7 +112,7 @@ describe('showErrorToast', () => {
     expect(toast.error).toHaveBeenCalledWith(
       '다른 변경사항과 충돌했습니다. 최신 내용으로 새로고침 후 다시 저장해주세요.',
       {
-        description: 'Ref: request-',
+        description: '오류 ID: request-',
         duration: 8000,
       }
     );
@@ -113,7 +133,7 @@ describe('showErrorToast', () => {
     expect(toast.error).toHaveBeenCalledWith(
       '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
       {
-        description: 'Ref: trace-98',
+        description: '오류 ID: trace-98',
         duration: Infinity,
       }
     );

--- a/apps/web/src/lib/show-error-toast.ts
+++ b/apps/web/src/lib/show-error-toast.ts
@@ -1,5 +1,6 @@
 import { toast } from 'sonner';
 import type { ApiError } from '@mmp/shared';
+import { isApiHttpError } from '@/lib/api-error';
 import { getUserMessage } from '@/lib/error-messages';
 import { getErrorRecoveryStrategy } from '@/lib/error-recovery';
 import { captureApiError } from '@/lib/sentry';
@@ -20,7 +21,7 @@ export function showErrorToast(error: ApiError): void {
 
   const message = getUserMessage(error);
   const ref = getErrorReference(error);
-  const description = ref ? `Ref: ${ref}` : undefined;
+  const description = ref ? `오류 ID: ${ref}` : undefined;
 
   if (strategy.capture) {
     captureApiError(new Error(error.detail), error);
@@ -30,6 +31,15 @@ export function showErrorToast(error: ApiError): void {
     description,
     duration: strategy.duration,
   });
+}
+
+export function showUnknownErrorToast(error: unknown, fallback: string): void {
+  if (isApiHttpError(error)) {
+    showErrorToast(error.apiError);
+    return;
+  }
+
+  toast.error(fallback);
 }
 
 export function getErrorReference(error: ApiError): string | undefined {

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -11,6 +11,7 @@ export interface ApiError {
   title: string;
   status: number;
   detail: string;
+  user_message?: string;
   instance?: string;
   code?: string;
   errors?: FieldError[];


### PR DESCRIPTION
## 요약
- 캐릭터에 is_victim 플래그를 추가해 NPC 피해자 상태를 역할과 분리했습니다.
- 백엔드 ProblemDetail에 user_message를 추가하고 캐릭터 API 내부 실패를 한글 사용자 메시지로 매핑했습니다.
- 에디터 프론트 오류 토스트가 서버 user_message를 우선 표시하고 Ref 대신 오류 ID로 표시하도록 정리했습니다.

Closes #575

## Coverage Plan
- backend apperror handler: production detail masking 중에도 user_message와 request_id가 유지되는지 검증
- backend editor character service: 캐릭터 API 내부 실패가 editor 전용 오류 코드와 한글 메시지로 매핑되는지 검증
- frontend error toast: user_message 우선순위와 오류 ID 표시 검증
- editor E2E: 캐릭터 저장 실패 시 한글 메시지가 보이고 내부 SQL/detail은 노출되지 않는지 검증

## Local validation
- go test ./internal/apperror
- go test ./internal/domain/editor ./internal/apperror
- pnpm --filter @mmp/web test -- show-error-toast MediaUploadModal
- pnpm --filter @mmp/web typecheck
- pnpm --filter @mmp/web test:e2e -- phase24-editor-character-role.spec.ts
- git diff --check
- scripts/mmp-local-ci.sh quick

## E2E
- phase24-editor-character-role.spec.ts에 캐릭터 저장 실패 오류 메시지 노출 검증을 추가했습니다.
- 실제 사용자 관점에서 저장 실패 토스트가 한글 메시지와 오류 ID를 표시하고 SQLSTATE/detail을 숨기는지 확인합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
- 에디터에서 등장인물을 "피해자" 역할로 표시할 수 있는 기능 추가

**개선 사항**
- 에러 발생 시 사용자 친화적인 한국어 메시지를 직접 표시
- 에러 ID를 포함한 개선된 에러 알림 형식 적용
- 에디터 전반에서 일관된 에러 처리 및 안내 메시지 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/576)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->