### PR TITLE
fix: Codex 사용자 프롬프트 훅 출력 정규화

### DIFF
--- a/.codex/scripts/mmp-keyword-router.py
+++ b/.codex/scripts/mmp-keyword-router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import re
 import sys
+import json
 
 
 def _configure_utf8_stdio() -> None:
@@ -113,23 +114,40 @@ def main() -> None:
   _configure_utf8_stdio()
 
   user_input = sys.stdin.read()
-  text = _normalize(user_input)
+  try:
+    payload = json.loads(user_input) if user_input.strip() else {}
+  except json.JSONDecodeError:
+    payload = {}
+
+  prompt = payload.get("prompt") if isinstance(payload, dict) else None
+  text = _normalize(prompt if isinstance(prompt, str) else user_input)
   if not text:
     print("", end="")
     return
 
   action = detect(text)
   if not action:
-    print(user_input, end="")
+    print("", end="")
     return
 
   issue = _find_issue(text)
   hint = _render(action, issue)
   if not hint:
-    print(user_input, end="")
+    print("", end="")
     return
 
-  print(f"{user_input}\n\n{hint}", end="")
+  print(
+    json.dumps(
+      {
+        "hookSpecificOutput": {
+          "hookEventName": "UserPromptSubmit",
+          "additionalContext": hint,
+        }
+      },
+      ensure_ascii=False,
+    ),
+    end="",
+  )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- Codex UserPromptSubmit 훅 라우터가 힌트가 없을 때 빈 출력만 내도록 정리
- 힌트가 있을 때만 hookSpecificOutput.additionalContext JSON을 출력하도록 변경

## Coverage Plan
- `.codex/scripts/mmp-keyword-router.py`: 일반 입력, MMP 키워드 입력, issue token 추출, UserPromptSubmit JSON 출력 경로를 smoke test로 확인

## Local validation
- `python3 -m py_compile .codex/scripts/mmp-keyword-router.py` 통과
- `git diff --check origin/main...HEAD` 통과
- `.codex/scripts/mmp-workflow-hook-smoke-test.sh` 통과

## CI policy
- no ready-for-ci
- workflow_dispatch 미실행
- 운영 훅 스크립트 단일 파일 변경이라 issue seed는 `MMP_WORKFLOW_INTERVIEW_STRICT=0`로 우회

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 빈 입력 값 및 형식 오류 처리 안정성 개선

* **Refactor**
  * 입력/출력 형식을 JSON 기반으로 표준화하여 시스템 호환성 및 데이터 처리 효율성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->