### PR TITLE
fix: Chrome 로그인 자동완성 힌트 개선

### DIFF
--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -124,14 +124,14 @@ function LoginPage() {
             type="email"
             placeholder="이메일"
             aria-label="이메일"
-            autoComplete="email"
+            autoComplete="username"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
             className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 text-sm text-slate-100 placeholder-slate-500 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-900"
           />
           <input
-            id="password"
+            id={mode === "register" ? "new-password" : "current-password"}
             name="password"
             type="password"
             placeholder="비밀번호"

--- a/apps/web/src/features/auth/__tests__/LoginPage.test.tsx
+++ b/apps/web/src/features/auth/__tests__/LoginPage.test.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
 });
 
 describe("LoginPage", () => {
-  it("uses browser password-manager autocomplete hints on login fields", () => {
+  it("uses Chrome password-manager autocomplete hints on login fields", () => {
     render(
       <MemoryRouter>
         <LoginPage />
@@ -20,7 +20,8 @@ describe("LoginPage", () => {
     const password = screen.getByLabelText("비밀번호");
 
     expect(email.getAttribute("name")).toBe("email");
-    expect(email.getAttribute("autocomplete")).toBe("email");
+    expect(email.getAttribute("autocomplete")).toBe("username");
+    expect(password.getAttribute("id")).toBe("current-password");
     expect(password.getAttribute("name")).toBe("password");
     expect(password.getAttribute("autocomplete")).toBe("current-password");
   });
@@ -35,6 +36,8 @@ describe("LoginPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "계정이 없으신가요? 회원가입" }));
 
     expect(screen.getByLabelText("닉네임").getAttribute("autocomplete")).toBe("nickname");
-    expect(screen.getByLabelText("비밀번호").getAttribute("autocomplete")).toBe("new-password");
+    const password = screen.getByLabelText("비밀번호");
+    expect(password.getAttribute("id")).toBe("new-password");
+    expect(password.getAttribute("autocomplete")).toBe("new-password");
   });
 });


### PR DESCRIPTION
## 요약
- 로그인 이메일 입력을 Chrome Password Manager가 계정 식별자로 인식하기 쉽게 `autocomplete="username"`으로 변경했습니다.
- 로그인/회원가입 모드에 따라 password input id를 `current-password` / `new-password`로 분리했습니다.
- 인증 API payload는 그대로 `name="password"`를 유지해 백엔드 계약은 바꾸지 않았습니다.

## Coverage Plan
- `LoginPage.tsx`: 로그인/회원가입 모드별 autocomplete/id 속성을 `LoginPage.test.tsx`에서 검증합니다.
- 브라우저 렌더링: `/login` 실제 DOM에서 form/email/password 속성을 확인했습니다.
- 인증 유지 흐름: 로그인 후 refresh token 저장, 새 페이지 진입 시 `/auth/refresh`와 `/auth/me` 재사용을 확인했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/features/auth/__tests__/LoginPage.test.tsx`
- `pnpm --filter @mmp/web typecheck`
- `scripts/mmp-local-ci.sh quick`
- Dev smoke: `/login` DOM 속성 확인, 로그인 후 refresh 재사용 확인

## CI policy
- `ready-for-ci` 라벨과 workflow_dispatch는 실행하지 않았습니다.
- 기본 PR 처리는 로컬 focused validation과 CodeRabbit 확인 기준으로 진행합니다.