### PR TITLE
fix: 플레이어킬 모듈 상태에 따라 단서 살해 요청 표시

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -184,6 +184,21 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     expect(JSON.stringify(state.lastConfigRequestBody)).not.toContain('module_configs');
   });
 
+  test('[2D] 플레이어킬 모듈 상태에 따라 단서 살해 요청 효과를 숨기거나 보여준다', async ({ page }) => {
+    state.configJson = { modules: { player_kill: { enabled: false, config: {} } } };
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
+    await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
+    await page.getByLabel('사용 가능한 아이템').check();
+    await expect(page.getByRole('button', { name: '살해 요청' })).toHaveCount(0);
+
+    state.configJson = { modules: { player_kill: { enabled: true, config: {} } } };
+    await page.reload();
+    await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
+    await page.getByLabel('사용 가능한 아이템').check();
+    await expect(page.getByRole('button', { name: '살해 요청' })).toBeVisible();
+  });
+
   test('[2B] 직접 URL은 올바른 제작 탭과 서브탭을 연다', async ({ page }) => {
     await page.goto(`${BASE}/editor/${THEME_ID}`);
     await expect(page.getByRole('tab', { name: '스토리 진행', selected: true })).toBeVisible({

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
@@ -240,7 +240,7 @@ describe('ClueEntityWorkspace', () => {
       <ClueEntityWorkspace
         themeId="theme-1"
         clues={[clue({ id: 'clue-1' })]}
-        configJson={{}}
+        configJson={{ modules: { player_kill: { enabled: true, config: {} } } }}
         flowNodes={flowNodes}
         locations={[]}
         characters={[]}
@@ -270,5 +270,37 @@ describe('ClueEntityWorkspace', () => {
       target: 'player',
       killChancePercent: 35,
     });
+  });
+
+  it('플레이어킬 모듈 상태에 따라 살해 요청 효과를 숨기거나 보여준다', () => {
+    const baseProps = {
+      themeId: 'theme-1',
+      clues: [clue({ id: 'clue-1' })],
+      flowNodes,
+      locations: [],
+      characters: [],
+      onCreate: vi.fn(),
+      onUpdate: vi.fn(),
+      onDelete: vi.fn(),
+    };
+
+    const { rerender } = render(
+      <ClueEntityWorkspace
+        {...baseProps}
+        configJson={{ modules: { player_kill: { enabled: false, config: {} } } }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
+    expect(screen.queryByRole('button', { name: '살해 요청' })).toBeNull();
+
+    rerender(
+      <ClueEntityWorkspace
+        {...baseProps}
+        configJson={{ modules: { player_kill: { enabled: true, config: {} } } }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: '살해 요청' })).toBeDefined();
   });
 });

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -7,7 +7,11 @@ import type {
   UpdateClueRequest,
 } from '@/features/editor/api';
 import type { FlowNodeResponse } from '@/features/editor/flowTypes';
-import type { EditorConfig } from '@/features/editor/utils/configShape';
+import {
+  PLAYER_KILL_MODULE_ID,
+  readEnabledModuleIds,
+  type EditorConfig,
+} from '@/features/editor/utils/configShape';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import {
   buildClueUsageMap,
@@ -84,6 +88,10 @@ export function ClueEntityWorkspace({
       ]),
     ),
     [flowNodes, clues],
+  );
+  const isPlayerKillEnabled = useMemo(
+    () => readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID),
+    [configJson],
   );
   const isSaving = Boolean(isClueSaving || isConfigSaving);
   const hasDetailChanges = basicInfoState.dirty || runtimeEffectState.dirty;
@@ -169,6 +177,7 @@ export function ClueEntityWorkspace({
             clue={clue}
             clues={clues}
             configJson={configJson}
+            isPlayerKillEnabled={isPlayerKillEnabled}
             onDraftStateChange={handleRuntimeEffectStateChange}
           />
         </div>

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
@@ -62,6 +62,7 @@ describe('ClueRuntimeEffectCard', () => {
         clue={clues[0]}
         clues={clues}
         configJson={configJson}
+        isPlayerKillEnabled={true}
       />,
     );
 
@@ -97,6 +98,7 @@ describe('ClueRuntimeEffectCard', () => {
         clue={clues[0]}
         clues={clues}
         configJson={{}}
+        isPlayerKillEnabled={true}
       />,
     );
 
@@ -147,6 +149,7 @@ describe('ClueRuntimeEffectCard', () => {
         clue={clues[0]}
         clues={clues}
         configJson={configJson}
+        isPlayerKillEnabled={true}
       />,
     );
 
@@ -172,6 +175,7 @@ describe('ClueRuntimeEffectCard', () => {
         clue={clues[0]}
         clues={clues}
         configJson={{}}
+        isPlayerKillEnabled={true}
       />,
     );
 
@@ -197,6 +201,7 @@ describe('ClueRuntimeEffectCard', () => {
         clue={clues[0]}
         clues={clues}
         configJson={{}}
+        isPlayerKillEnabled={true}
       />,
     );
 
@@ -216,6 +221,7 @@ describe('ClueRuntimeEffectCard', () => {
         clue={clues[0]}
         clues={clues}
         configJson={{}}
+        isPlayerKillEnabled={true}
       />,
     );
 
@@ -235,6 +241,48 @@ describe('ClueRuntimeEffectCard', () => {
       condition: { kind: 'password', value: 'knife' },
       killChancePercent: 35,
     });
+  });
+
+  it('플레이어킬 모듈이 꺼져 있으면 살해 요청 효과를 숨긴다', () => {
+    render(
+      <ClueRuntimeEffectCard
+        clue={clues[0]}
+        clues={clues}
+        configJson={{}}
+        isPlayerKillEnabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
+
+    expect(screen.queryByRole('button', { name: '살해 요청' })).toBeNull();
+    expect(screen.queryByLabelText('살해확률 (%)')).toBeNull();
+  });
+
+  it('저장된 살해 요청 효과가 있어도 플레이어킬 모듈이 꺼져 있으면 살해 설정을 숨긴다', () => {
+    render(
+      <ClueRuntimeEffectCard
+        clue={clues[0]}
+        clues={clues}
+        configJson={{
+          modules: {
+            clue_interaction: {
+              enabled: true,
+              config: {
+                itemEffects: {
+                  'clue-1': { effect: 'kill', target: 'player', killChancePercent: 35 },
+                },
+              },
+            },
+          },
+        }}
+        isPlayerKillEnabled={false}
+      />,
+    );
+
+    expect(screen.getByLabelText('사용 가능한 아이템')).toHaveProperty('checked', true);
+    expect(screen.queryByRole('button', { name: '살해 요청' })).toBeNull();
+    expect(screen.queryByLabelText('살해확률 (%)')).toBeNull();
   });
 
   it('사용 가능한 아이템을 끄면 저장된 효과를 제거한다', () => {
@@ -262,6 +310,7 @@ describe('ClueRuntimeEffectCard', () => {
         clue={clues[0]}
         clues={clues}
         configJson={configJson}
+        isPlayerKillEnabled={true}
       />,
     );
 

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
@@ -15,6 +15,7 @@ interface ClueRuntimeEffectCardProps {
   clue: ClueResponse;
   clues: ClueResponse[];
   configJson: EditorConfig | null | undefined;
+  isPlayerKillEnabled: boolean;
   onDraftStateChange?: (state: ClueRuntimeEffectDraftState) => void;
 }
 
@@ -203,6 +204,7 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
   clue,
   clues,
   configJson,
+  isPlayerKillEnabled,
   onDraftStateChange,
 }, ref) {
   const savedEffect = useMemo(
@@ -315,7 +317,9 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
             <EffectChoice mode="grant" current={draft.mode} label="새 단서 지급" icon={<Gift className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'grant' })} />
             <EffectChoice mode="peek" current={draft.mode} label="단서 훔쳐보기" icon={<Search className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'peek' })} />
             <EffectChoice mode="steal" current={draft.mode} label="단서 가져오기" icon={<Shuffle className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'steal' })} />
-            <EffectChoice mode="kill" current={draft.mode} label="살해 요청" icon={<TriangleAlert className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'kill' })} />
+            {isPlayerKillEnabled && (
+              <EffectChoice mode="kill" current={draft.mode} label="살해 요청" icon={<TriangleAlert className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'kill' })} />
+            )}
           </fieldset>
 
           <label className="flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-sm text-slate-300">
@@ -393,7 +397,7 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
             />
           )}
 
-          {draft.mode === 'kill' && (
+          {draft.mode === 'kill' && isPlayerKillEnabled && (
             <div className="space-y-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-3">
               <p className="text-sm leading-6 text-red-100">
                 대상 플레이어의 생존 상태를 런타임에서 사망으로 변경합니다.

--- a/docs/superpowers/plans/2026-05-16-player-kill-clue-effect-visibility.md
+++ b/docs/superpowers/plans/2026-05-16-player-kill-clue-effect-visibility.md
@@ -1,0 +1,230 @@
+# Player Kill Clue Effect Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `player_kill` 모듈이 꺼져 있으면 단서관리의 `살해 요청` 효과 선택지를 숨기고, 다시 켜면 선택지가 다시 보이게 한다.
+
+**Architecture:** `configJson.modules.player_kill.enabled`는 이미 캐릭터 상세에서 `살해 가능` 표시 조건으로 쓰인다. 같은 파생값을 단서 상세 컨테이너인 `ClueEntityWorkspace`에서 계산해 `ClueRuntimeEffectCard`에 전달하고, 카드 컴포넌트는 해당 prop으로 kill 효과 버튼과 확률 입력 표시만 제어한다. 저장된 kill 효과 데이터는 모듈 off 시 삭제하지 않아, 모듈을 다시 켰을 때 기존 제작 설정을 복구할 수 있게 둔다.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, MMP editor config helpers.
+
+---
+
+### Task 1: Regression Tests
+
+**Files:**
+- Modify: `apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx`
+- Modify: `apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx`
+
+- [x] **Step 1: Write failing component tests**
+
+Add two assertions to `ClueRuntimeEffectCard.test.tsx`: one for `isPlayerKillEnabled={false}` hiding kill UI, one for `true` preserving the existing kill flow.
+
+```tsx
+it('플레이어킬 모듈이 꺼져 있으면 살해 요청 효과를 숨긴다', () => {
+  render(
+    <ClueRuntimeEffectCard
+      clue={clues[0]}
+      clues={clues}
+      configJson={{}}
+      isPlayerKillEnabled={false}
+    />,
+  );
+
+  fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
+
+  expect(screen.queryByRole('button', { name: '살해 요청' })).toBeNull();
+  expect(screen.queryByLabelText('살해확률 (%)')).toBeNull();
+});
+```
+
+Update the existing kill-save test render call to include:
+
+```tsx
+isPlayerKillEnabled={true}
+```
+
+Add an integration-level assertion to `ClueEntityWorkspace.test.tsx` so the workspace proves it derives the flag from config:
+
+```tsx
+it('플레이어킬 모듈 상태에 따라 살해 요청 효과를 숨기거나 보여준다', () => {
+  const baseProps = {
+    themeId: 'theme-1',
+    clues: [clue({ id: 'clue-1' })],
+    flowNodes,
+    locations: [],
+    characters: [],
+    onCreate: vi.fn(),
+    onUpdate: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  const { rerender } = render(
+    <ClueEntityWorkspace
+      {...baseProps}
+      configJson={{ modules: { player_kill: { enabled: false, config: {} } } }}
+    />,
+  );
+  fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
+  expect(screen.queryByRole('button', { name: '살해 요청' })).toBeNull();
+
+  rerender(
+    <ClueEntityWorkspace
+      {...baseProps}
+      configJson={{ modules: { player_kill: { enabled: true, config: {} } } }}
+    />,
+  );
+  fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
+  expect(screen.getByRole('button', { name: '살해 요청' })).toBeDefined();
+});
+```
+
+- [x] **Step 2: Run RED verification**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+```
+
+Expected: FAIL because `ClueRuntimeEffectCardProps` does not yet define `isPlayerKillEnabled`, and/or `살해 요청` is still visible when the module is disabled.
+
+### Task 2: Visibility Wiring
+
+**Files:**
+- Modify: `apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx`
+- Modify: `apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx`
+
+- [x] **Step 1: Add a prop to the runtime effect card**
+
+In `ClueRuntimeEffectCardProps`, add:
+
+```ts
+isPlayerKillEnabled: boolean;
+```
+
+In the component parameter list, read the prop:
+
+```ts
+isPlayerKillEnabled,
+```
+
+Render the kill option only when enabled:
+
+```tsx
+{isPlayerKillEnabled && (
+  <EffectChoice mode="kill" current={draft.mode} label="살해 요청" icon={<TriangleAlert className="h-4 w-4" />} onSelect={() => updateDraft({ mode: 'kill' })} />
+)}
+```
+
+Guard the kill detail block with `draft.mode === 'kill' && isPlayerKillEnabled`. Existing saved kill data can still hydrate the draft internally, but the creator cannot see or edit kill-specific controls while the module is off.
+
+- [x] **Step 2: Derive player kill status in the workspace**
+
+In `ClueEntityWorkspace.tsx`, import:
+
+```ts
+readEnabledModuleIds,
+PLAYER_KILL_MODULE_ID,
+```
+
+from `@/features/editor/utils/configShape`.
+
+Add:
+
+```ts
+const isPlayerKillEnabled = useMemo(
+  () => readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID),
+  [configJson],
+);
+```
+
+Pass the flag:
+
+```tsx
+<ClueRuntimeEffectCard
+  ref={runtimeEffectRef}
+  clue={clue}
+  clues={clues}
+  configJson={configJson}
+  isPlayerKillEnabled={isPlayerKillEnabled}
+  onDraftStateChange={handleRuntimeEffectStateChange}
+/>
+```
+
+- [x] **Step 3: Update existing test call sites**
+
+Every direct test render of `ClueRuntimeEffectCard` must pass `isPlayerKillEnabled`. Use `true` for existing tests that are unrelated to player-kill visibility, except the new hidden-state regression test.
+
+- [x] **Step 4: Run GREEN verification**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+```
+
+Expected: PASS.
+
+### Task 3: Focused Validation
+
+**Files:**
+- Modify: `apps/web/e2e/editor-golden-path.spec.ts`
+
+- [x] **Step 1: Add mocked E2E route coverage**
+
+Add a Playwright test to `apps/web/e2e/editor-golden-path.spec.ts` that opens `/editor/${THEME_ID}/clues` with `player_kill.enabled=false`, checks that `살해 요청` is absent after `사용 가능한 아이템` is checked, reloads with `player_kill.enabled=true`, then checks that `살해 요청` is visible.
+
+```ts
+test('[2D] 플레이어킬 모듈 상태에 따라 단서 살해 요청 효과를 숨기거나 보여준다', async ({ page }) => {
+  state.configJson = { modules: { player_kill: { enabled: false, config: {} } } };
+
+  await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
+  await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
+  await page.getByLabel('사용 가능한 아이템').check();
+  await expect(page.getByRole('button', { name: '살해 요청' })).toHaveCount(0);
+
+  state.configJson = { modules: { player_kill: { enabled: true, config: {} } } };
+  await page.reload();
+  await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
+  await page.getByLabel('사용 가능한 아이템').check();
+  await expect(page.getByRole('button', { name: '살해 요청' })).toBeVisible();
+});
+```
+
+- [x] **Step 2: Run the wider focused suite**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/utils/__tests__/configShape.test.ts
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run the targeted E2E test**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium -g "플레이어킬 모듈 상태"
+```
+
+Expected: PASS on Chromium.
+
+- [x] **Step 4: Check diff and working tree**
+
+Run:
+
+```bash
+git diff --stat
+git status --short --branch
+```
+
+Expected: only the plan file and scoped frontend test/component files changed.
+
+### Self-Review
+
+- [x] Spec coverage: off state hides `살해 요청`, on state shows it again, saved config is not destructively removed.
+- [x] Placeholder scan: no `TBD`, broad TODO, or unspecified test step remains.
+- [x] Type consistency: `isPlayerKillEnabled` is required where `ClueRuntimeEffectCard` is rendered.


### PR DESCRIPTION
## 요약

- `player_kill` 모듈이 꺼져 있으면 단서 관리의 `살해 요청` 효과 선택지를 숨깁니다.
- 모듈을 다시 켜면 같은 단서 상세에서 `살해 요청` 선택지가 다시 표시됩니다.
- 저장된 kill 효과 데이터는 삭제하지 않고, 모듈 off 상태에서는 살해 설정 UI만 숨깁니다.
- 작업계획: `docs/superpowers/plans/2026-05-16-player-kill-clue-effect-visibility.md`

Closes #580

## Coverage Plan

- `ClueRuntimeEffectCard.test.tsx`: player_kill off 상태에서 `살해 요청`/`살해확률 (%)` 숨김, 저장된 kill 효과가 있어도 off 상태 UI 숨김 검증
- `ClueEntityWorkspace.test.tsx`: `configJson.modules.player_kill.enabled`에서 파생된 값으로 단서 효과 UI가 hide/show 되는지 검증
- `editor-golden-path.spec.ts`: mocked E2E로 `/editor/:themeId/clues`에서 player_kill off/on 전환 시 `살해 요청` 표시 상태 검증
- `typecheck`: 새 required prop 전파와 타입 안정성 확인

## Local validation

- `scripts/mmp-local-ci.sh quick` ✅ success at `486722749d2d0f81ca22ebcbe16cf99b1fc0821d`
- `pnpm --filter @mmp/web test -- src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/utils/__tests__/configShape.test.ts` ✅ 33 tests passed
- `pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium -g "플레이어킬 모듈 상태"` ✅ 1 passed
- `pnpm --filter @mmp/web typecheck` ✅ passed

## 참고

- 처음 `test:e2e -- ...` 형태로 실행했을 때 Playwright 인자 전달 문제로 전체 `editor-golden-path`가 실행됐고, 신규 `[2D]` 테스트는 통과했지만 기존 오래된 E2E 6개가 별도 실패했습니다. 이후 올바른 targeted E2E 명령으로 신규 케이스만 재검증했습니다.
