### PR TITLE
단서 공격력/방어력 기반 살해 판정으로 전환

### DIFF
--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -92,6 +92,11 @@ type playerKillCharacterRef struct {
 	id    string
 }
 
+type playerKillSceneRef struct {
+	index int
+	id    string
+}
+
 func extractLocationDiscoveryRefs(cfg map[string]any) ([]locationDiscoveryRef, error) {
 	modules, ok := cfg["modules"].(map[string]any)
 	if !ok {
@@ -453,7 +458,7 @@ func validateClueInteractionConfigShape(cfg map[string]any) error {
 
 func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 	for key := range effect {
-		if key != "effect" && key != "target" && key != "consume" && key != "descriptionText" && key != "revealText" && key != "grantClueIds" && key != "killChancePercent" && key != "condition" && key != "password" && key != "trigger" {
+		if key != "effect" && key != "target" && key != "consume" && key != "descriptionText" && key != "revealText" && key != "grantClueIds" && key != "attackPower" && key != "defensePower" && key != "condition" && key != "password" && key != "trigger" {
 			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].%s is not supported", clueID, key)
 		}
 	}
@@ -480,16 +485,22 @@ func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].consume must be boolean", clueID)
 		}
 	}
-	if rawChance, exists := effect["killChancePercent"]; exists {
-		chance, ok := rawChance.(float64)
+	if rawAttack, exists := effect["attackPower"]; exists {
+		attack, ok := rawAttack.(float64)
 		if !ok {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].killChancePercent must be a number", clueID)
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].attackPower must be a number", clueID)
 		}
-		if chance < 0 || chance > 100 {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].killChancePercent must be between 0 and 100", clueID)
+		if attack < 0 {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].attackPower must be non-negative", clueID)
 		}
-		if kind != "kill" {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].killChancePercent is only supported for kill", clueID)
+	}
+	if rawDefense, exists := effect["defensePower"]; exists {
+		defense, ok := rawDefense.(float64)
+		if !ok {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].defensePower must be a number", clueID)
+		}
+		if defense < 0 {
+			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].defensePower must be non-negative", clueID)
 		}
 	}
 	if kind == "description_change" {
@@ -572,6 +583,33 @@ func validatePlayerKillConfigShape(cfg map[string]any) error {
 			return fmt.Errorf("config_json: modules.player_kill.config.muteOnKilled must be boolean")
 		}
 	}
+	if rawMode, exists := moduleConfig["killResolutionMode"]; exists {
+		mode, ok := rawMode.(string)
+		if !ok {
+			return fmt.Errorf("config_json: modules.player_kill.config.killResolutionMode must be a string")
+		}
+		if mode != "" && mode != "all_weapons_vs_all_armor" && mode != "best_weapon_vs_all_armor" && mode != "best_weapon_vs_best_armor" {
+			return fmt.Errorf("config_json: modules.player_kill.config.killResolutionMode is not supported")
+		}
+	}
+	if rawSceneIDs, exists := moduleConfig["allowedSceneIds"]; exists {
+		if rawSceneIDs == nil {
+			return fmt.Errorf("config_json: modules.player_kill.config.allowedSceneIds cannot be null")
+		}
+		sceneIDs, ok := rawSceneIDs.([]any)
+		if !ok {
+			return fmt.Errorf("config_json: modules.player_kill.config.allowedSceneIds must be an array")
+		}
+		for _, rawSceneID := range sceneIDs {
+			sceneID, ok := rawSceneID.(string)
+			if !ok {
+				return fmt.Errorf("config_json: modules.player_kill.config.allowedSceneIds must contain strings")
+			}
+			if _, err := uuid.Parse(sceneID); err != nil {
+				return fmt.Errorf("config_json: modules.player_kill.config.allowedSceneIds has invalid scene id %q", sceneID)
+			}
+		}
+	}
 	return nil
 }
 
@@ -625,32 +663,109 @@ func extractPlayerKillCharacterRefs(raw json.RawMessage) ([]playerKillCharacterR
 	return refs, nil
 }
 
+func extractPlayerKillSceneRefs(raw json.RawMessage) ([]playerKillSceneRef, error) {
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("config_json: invalid JSON: %w", err)
+	}
+	modules, ok := cfg["modules"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	rawModule, exists := modules["player_kill"]
+	if !exists {
+		return nil, nil
+	}
+	module, ok := rawModule.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("config_json: modules.player_kill must be an object")
+	}
+	moduleConfigRaw, exists := module["config"]
+	if !exists {
+		return nil, nil
+	}
+	if moduleConfigRaw == nil {
+		return nil, fmt.Errorf("config_json: modules.player_kill.config cannot be null")
+	}
+	moduleConfig, ok := moduleConfigRaw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("config_json: modules.player_kill.config must be an object")
+	}
+	rawIDs, exists := moduleConfig["allowedSceneIds"]
+	if !exists {
+		return nil, nil
+	}
+	if rawIDs == nil {
+		return nil, fmt.Errorf("config_json: modules.player_kill.config.allowedSceneIds cannot be null")
+	}
+	ids, ok := rawIDs.([]any)
+	if !ok {
+		return nil, fmt.Errorf("config_json: modules.player_kill.config.allowedSceneIds must be an array")
+	}
+	refs := make([]playerKillSceneRef, 0, len(ids))
+	for i, rawID := range ids {
+		sceneID, ok := rawID.(string)
+		if !ok {
+			return nil, fmt.Errorf("config_json: modules.player_kill.config.allowedSceneIds must contain strings")
+		}
+		refs = append(refs, playerKillSceneRef{index: i, id: sceneID})
+	}
+	return refs, nil
+}
+
 func (s *service) validatePlayerKillConfigReferences(ctx context.Context, q *db.Queries, themeID uuid.UUID, raw json.RawMessage) error {
-	refs, err := extractPlayerKillCharacterRefs(raw)
+	characterRefs, err := extractPlayerKillCharacterRefs(raw)
 	if err != nil {
 		return apperror.BadRequest(err.Error())
 	}
-	if len(refs) == 0 {
-		return nil
-	}
-
-	characters, err := q.GetThemeCharacters(ctx, themeID)
+	sceneRefs, err := extractPlayerKillSceneRefs(raw)
 	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to validate player_kill characters")
-		return apperror.Internal("failed to validate player_kill references")
-	}
-	characterIDs := make(map[string]struct{}, len(characters))
-	for _, character := range characters {
-		characterIDs[character.ID.String()] = struct{}{}
+		return apperror.BadRequest(err.Error())
 	}
 
-	for _, ref := range refs {
-		parsedID, err := uuid.Parse(ref.id)
+	if len(characterRefs) > 0 {
+		characters, err := q.GetThemeCharacters(ctx, themeID)
 		if err != nil {
-			return apperror.BadRequest(fmt.Sprintf("config_json: modules.player_kill.config.killableCharacterIds[%d] must be a valid character id", ref.index))
+			s.logger.Error().Err(err).Msg("failed to validate player_kill characters")
+			return apperror.Internal("failed to validate player_kill references")
 		}
-		if _, ok := characterIDs[parsedID.String()]; !ok {
-			return apperror.BadRequest(fmt.Sprintf("config_json: modules.player_kill.config.killableCharacterIds[%d] must belong to this theme", ref.index))
+		characterIDs := make(map[string]struct{}, len(characters))
+		for _, character := range characters {
+			characterIDs[character.ID.String()] = struct{}{}
+		}
+
+		for _, ref := range characterRefs {
+			parsedID, err := uuid.Parse(ref.id)
+			if err != nil {
+				return apperror.BadRequest(fmt.Sprintf("config_json: modules.player_kill.config.killableCharacterIds[%d] must be a valid character id", ref.index))
+			}
+			if _, ok := characterIDs[parsedID.String()]; !ok {
+				return apperror.BadRequest(fmt.Sprintf("config_json: modules.player_kill.config.killableCharacterIds[%d] must belong to this theme", ref.index))
+			}
+		}
+	}
+
+	if len(sceneRefs) > 0 {
+		nodes, err := q.ListFlowNodesByTheme(ctx, themeID)
+		if err != nil {
+			s.logger.Error().Err(err).Msg("failed to validate player_kill scenes")
+			return apperror.Internal("failed to validate player_kill references")
+		}
+		phaseNodeIDs := make(map[string]struct{}, len(nodes))
+		for _, node := range nodes {
+			if node.Type == "phase" {
+				phaseNodeIDs[node.ID.String()] = struct{}{}
+			}
+		}
+
+		for _, ref := range sceneRefs {
+			parsedID, err := uuid.Parse(ref.id)
+			if err != nil {
+				return apperror.BadRequest(fmt.Sprintf("config_json: modules.player_kill.config.allowedSceneIds[%d] must be a valid scene id", ref.index))
+			}
+			if _, ok := phaseNodeIDs[parsedID.String()]; !ok {
+				return apperror.BadRequest(fmt.Sprintf("config_json: modules.player_kill.config.allowedSceneIds[%d] must belong to this theme as a phase flow node", ref.index))
+			}
 		}
 	}
 	return nil

--- a/apps/server/internal/domain/editor/service_config.go
+++ b/apps/server/internal/domain/editor/service_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/google/uuid"
@@ -486,21 +487,13 @@ func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 		}
 	}
 	if rawAttack, exists := effect["attackPower"]; exists {
-		attack, ok := rawAttack.(float64)
-		if !ok {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].attackPower must be a number", clueID)
-		}
-		if attack < 0 {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].attackPower must be non-negative", clueID)
+		if err := validateClueItemEffectPower(clueID, "attackPower", rawAttack); err != nil {
+			return err
 		}
 	}
 	if rawDefense, exists := effect["defensePower"]; exists {
-		defense, ok := rawDefense.(float64)
-		if !ok {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].defensePower must be a number", clueID)
-		}
-		if defense < 0 {
-			return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].defensePower must be non-negative", clueID)
+		if err := validateClueItemEffectPower(clueID, "defensePower", rawDefense); err != nil {
+			return err
 		}
 	}
 	if kind == "description_change" {
@@ -529,6 +522,20 @@ func validateClueItemEffectShape(clueID string, effect map[string]any) error {
 				return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].grantClueIds has invalid clue id %q", clueID, grantClueID)
 			}
 		}
+	}
+	return nil
+}
+
+func validateClueItemEffectPower(clueID string, field string, rawValue any) error {
+	value, ok := rawValue.(float64)
+	if !ok {
+		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].%s must be a number", clueID, field)
+	}
+	if value != math.Trunc(value) {
+		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].%s must be an integer", clueID, field)
+	}
+	if value < 0 {
+		return fmt.Errorf("config_json: clue_interaction.itemEffects[%s].%s must be non-negative", clueID, field)
 	}
 	return nil
 }

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -755,6 +755,18 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			want: "attackPower must be non-negative",
 		},
 		{
+			name: "attack power must be integer",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "kill", "target": "player", "attackPower": 1.5}}}
+					}
+				}
+			}`, clueID)),
+			want: "attackPower must be an integer",
+		},
+		{
 			name: "defense power must be number",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {
@@ -765,6 +777,18 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 				}
 			}`, clueID)),
 			want: "defensePower must be a number",
+		},
+		{
+			name: "defense power must be integer",
+			input: json.RawMessage(fmt.Sprintf(`{
+				"modules": {
+					"clue_interaction": {
+						"enabled": true,
+						"config": {"itemEffects": {"%s": {"effect": "peek", "target": "player", "defensePower": 2.25}}}
+					}
+				}
+			}`, clueID)),
+			want: "defensePower must be an integer",
 		},
 		{
 			name: "description change requires text",

--- a/apps/server/internal/domain/editor/service_config_test.go
+++ b/apps/server/internal/domain/editor/service_config_test.go
@@ -479,7 +479,8 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 						"%s": {
 							"effect": "kill",
 							"target": "player",
-							"killChancePercent": 35
+							"attackPower": 3,
+							"defensePower": 1
 						}
 					},
 					"cluePolicies": {
@@ -730,40 +731,40 @@ func TestUpdateConfigJson_ValidatesClueInteractionItemEffects(t *testing.T) {
 			want: "is not supported",
 		},
 		{
-			name: "kill chance must be number",
+			name: "attack power must be number",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {
 					"clue_interaction": {
 						"enabled": true,
-						"config": {"itemEffects": {"%s": {"effect": "kill", "target": "player", "killChancePercent": "high"}}}
+						"config": {"itemEffects": {"%s": {"effect": "kill", "target": "player", "attackPower": "high"}}}
 					}
 				}
 			}`, clueID)),
-			want: "killChancePercent must be a number",
+			want: "attackPower must be a number",
 		},
 		{
-			name: "kill chance must be percent range",
+			name: "attack power must be non-negative",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {
 					"clue_interaction": {
 						"enabled": true,
-						"config": {"itemEffects": {"%s": {"effect": "kill", "target": "player", "killChancePercent": 101}}}
+						"config": {"itemEffects": {"%s": {"effect": "kill", "target": "player", "attackPower": -1}}}
 					}
 				}
 			}`, clueID)),
-			want: "killChancePercent must be between 0 and 100",
+			want: "attackPower must be non-negative",
 		},
 		{
-			name: "kill chance is kill-only",
+			name: "defense power must be number",
 			input: json.RawMessage(fmt.Sprintf(`{
 				"modules": {
 					"clue_interaction": {
 						"enabled": true,
-						"config": {"itemEffects": {"%s": {"effect": "peek", "target": "player", "killChancePercent": 35}}}
+						"config": {"itemEffects": {"%s": {"effect": "peek", "target": "player", "defensePower": "high"}}}
 					}
 				}
 			}`, clueID)),
-			want: "killChancePercent is only supported for kill",
+			want: "defensePower must be a number",
 		},
 		{
 			name: "description change requires text",
@@ -835,6 +836,7 @@ func TestUpdateConfigJson_ValidatesPlayerKillModuleConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateCharacter: %v", err)
 	}
+	phaseID := insertEditorFlowNode(t, f.pool, themeID, "phase")
 
 	valid := json.RawMessage(fmt.Sprintf(`{
 		"modules": {
@@ -842,11 +844,13 @@ func TestUpdateConfigJson_ValidatesPlayerKillModuleConfig(t *testing.T) {
 				"enabled": true,
 				"config": {
 					"killableCharacterIds": ["%s"],
-					"muteOnKilled": true
+					"muteOnKilled": true,
+					"killResolutionMode": "best_weapon_vs_all_armor",
+					"allowedSceneIds": ["%s"]
 				}
 			}
 		}
-	}`, character.ID))
+	}`, character.ID, phaseID))
 	if _, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, valid); err != nil {
 		t.Fatalf("valid player_kill config must save: %v", err)
 	}
@@ -890,6 +894,27 @@ func TestUpdateConfigJson_ValidatesPlayerKillModuleConfig(t *testing.T) {
 				"modules": {"player_kill": {"enabled": true, "config": {"muteOnKilled": "yes"}}}
 			}`),
 			want: "muteOnKilled must be boolean",
+		},
+		{
+			name: "resolution mode must be supported",
+			input: json.RawMessage(`{
+				"modules": {"player_kill": {"enabled": true, "config": {"killResolutionMode": "coin_flip"}}}
+			}`),
+			want: "killResolutionMode is not supported",
+		},
+		{
+			name: "allowed scene ids must be array",
+			input: json.RawMessage(`{
+				"modules": {"player_kill": {"enabled": true, "config": {"allowedSceneIds": "phase-1"}}}
+			}`),
+			want: "allowedSceneIds must be an array",
+		},
+		{
+			name: "allowed scene ids must be uuids",
+			input: json.RawMessage(`{
+				"modules": {"player_kill": {"enabled": true, "config": {"allowedSceneIds": ["phase-1"]}}}
+			}`),
+			want: "allowedSceneIds has invalid scene id",
 		},
 	}
 	for _, tc := range cases {
@@ -942,6 +967,40 @@ func TestUpdateConfigJson_RejectsPlayerKillCharacterOutsideTheme(t *testing.T) {
 		t.Fatalf("expected BAD_REQUEST, got %s", appErr.Code)
 	}
 	if !strings.Contains(appErr.Detail, "killableCharacterIds[0] must belong to this theme") {
+		t.Fatalf("unexpected error detail: %s", appErr.Detail)
+	}
+}
+
+func TestUpdateConfigJson_RejectsPlayerKillSceneOutsideTheme(t *testing.T) {
+	f := setupFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID := f.createThemeForUser(t, creatorID)
+	otherThemeID := f.createThemeForUser(t, creatorID)
+	foreignPhaseID := insertEditorFlowNode(t, f.pool, otherThemeID, "phase")
+
+	config := json.RawMessage(fmt.Sprintf(`{
+		"modules": {
+			"player_kill": {
+				"enabled": true,
+				"config": {
+					"allowedSceneIds": ["%s"]
+				}
+			}
+		}
+	}`, foreignPhaseID))
+	_, err := f.svc.UpdateConfigJson(ctx, creatorID, themeID, config)
+	if err == nil {
+		t.Fatal("expected player_kill scene reference validation error, got nil")
+	}
+	var appErr *apperror.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *apperror.AppError, got %T", err)
+	}
+	if appErr.Code != apperror.ErrBadRequest {
+		t.Fatalf("expected BAD_REQUEST, got %s", appErr.Code)
+	}
+	if !strings.Contains(appErr.Detail, "allowedSceneIds[0] must belong to this theme as a phase flow node") {
 		t.Fatalf("unexpected error detail: %s", appErr.Detail)
 	}
 }

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -135,6 +135,9 @@ func (m *ClueInteractionModule) OnPhaseEnter(_ context.Context, phase engine.Pha
 }
 
 func (m *ClueInteractionModule) OnPhaseExit(_ context.Context, _ engine.Phase) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.currentPhaseID = ""
 	return nil
 }
 
@@ -408,8 +411,8 @@ func (m *ClueInteractionModule) Schema() json.RawMessage {
 						"descriptionText": map[string]any{"type": "string"},
 						"revealText":      map[string]any{"type": "string"},
 						"grantClueIds":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-						"attackPower":     map[string]any{"type": "number", "minimum": 0},
-						"defensePower":    map[string]any{"type": "number", "minimum": 0},
+						"attackPower":     map[string]any{"type": "integer", "minimum": 0},
+						"defensePower":    map[string]any{"type": "integer", "minimum": 0},
 					},
 					"required":             []string{"effect"},
 					"additionalProperties": false,

--- a/apps/server/internal/module/core/clue_interaction.go
+++ b/apps/server/internal/module/core/clue_interaction.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -63,14 +62,13 @@ type ClueInteractionModule struct {
 	itemTimeout         *time.Timer
 	appliedGrantIDs     map[string]struct{}
 	playerKillConfig    PlayerKillConfig
-	killRoll            func() int
+	playerKillEnabled   bool
+	currentPhaseID      string
 }
 
 // NewClueInteractionModule creates a new ClueInteractionModule instance.
 func NewClueInteractionModule() *ClueInteractionModule {
-	return &ClueInteractionModule{
-		killRoll: func() int { return rand.Intn(100) + 1 },
-	}
+	return &ClueInteractionModule{}
 }
 
 func (m *ClueInteractionModule) Name() string { return "clue_interaction" }
@@ -80,9 +78,6 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 	defer m.mu.Unlock()
 
 	m.deps = deps
-	if m.killRoll == nil {
-		m.killRoll = func() int { return rand.Intn(100) + 1 }
-	}
 	m.playerDrawCounts = make(map[uuid.UUID]int)
 	m.acquiredClues = make(map[uuid.UUID][]string)
 	m.targetCodeClues = make(map[string][]string)
@@ -120,13 +115,26 @@ func (m *ClueInteractionModule) Init(_ context.Context, deps engine.ModuleDeps, 
 		return err
 	}
 	m.playerKillConfig = PlayerKillConfig{}
+	m.playerKillEnabled = false
 	if rawConfig, ok := deps.ModuleConfigs[playerKillModuleName]; ok && len(rawConfig) > 0 {
+		m.playerKillEnabled = true
 		if err := json.Unmarshal(rawConfig, &m.playerKillConfig); err != nil {
 			return fmt.Errorf("clue_interaction: invalid player_kill config: %w", err)
 		}
 	}
 
 	m.currentClueLevel = m.config.InitialClueLevel
+	return nil
+}
+
+func (m *ClueInteractionModule) OnPhaseEnter(_ context.Context, phase engine.Phase) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.currentPhaseID = string(phase)
+	return nil
+}
+
+func (m *ClueInteractionModule) OnPhaseExit(_ context.Context, _ engine.Phase) error {
 	return nil
 }
 
@@ -394,13 +402,14 @@ func (m *ClueInteractionModule) Schema() json.RawMessage {
 				"additionalProperties": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
-						"effect":            map[string]any{"type": "string", "enum": []string{"description_change", "peek", "steal", "reveal", "grant_clue", "kill"}},
-						"target":            map[string]any{"type": "string", "enum": []string{"player", "self"}},
-						"consume":           map[string]any{"type": "boolean", "default": false},
-						"descriptionText":   map[string]any{"type": "string"},
-						"revealText":        map[string]any{"type": "string"},
-						"grantClueIds":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-						"killChancePercent": map[string]any{"type": "number", "minimum": 0, "maximum": 100},
+						"effect":          map[string]any{"type": "string", "enum": []string{"description_change", "peek", "steal", "reveal", "grant_clue", "kill"}},
+						"target":          map[string]any{"type": "string", "enum": []string{"player", "self"}},
+						"consume":         map[string]any{"type": "boolean", "default": false},
+						"descriptionText": map[string]any{"type": "string"},
+						"revealText":      map[string]any{"type": "string"},
+						"grantClueIds":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+						"attackPower":     map[string]any{"type": "number", "minimum": 0},
+						"defensePower":    map[string]any{"type": "number", "minimum": 0},
 					},
 					"required":             []string{"effect"},
 					"additionalProperties": false,
@@ -575,6 +584,7 @@ func (m *ClueInteractionModule) configForPlayerState() ClueInteractionConfig {
 var (
 	_ engine.Module            = (*ClueInteractionModule)(nil)
 	_ engine.PhaseReactor      = (*ClueInteractionModule)(nil)
+	_ engine.PhaseHookModule   = (*ClueInteractionModule)(nil)
 	_ engine.ConfigSchema      = (*ClueInteractionModule)(nil)
 	_ engine.GameEventHandler  = (*ClueInteractionModule)(nil)
 	_ engine.PlayerAwareModule = (*ClueInteractionModule)(nil)

--- a/apps/server/internal/module/core/clue_interaction_test.go
+++ b/apps/server/internal/module/core/clue_interaction_test.go
@@ -501,8 +501,14 @@ func TestClueInteractionModule_Schema(t *testing.T) {
 	if !hasKill {
 		t.Fatal("expected itemEffects.effect enum to include kill")
 	}
-	if _, exists := effectProps["killChancePercent"]; !exists {
-		t.Fatal("expected itemEffects.killChancePercent schema")
+	if _, exists := effectProps["attackPower"]; !exists {
+		t.Fatal("expected itemEffects.attackPower schema")
+	}
+	if _, exists := effectProps["defensePower"]; !exists {
+		t.Fatal("expected itemEffects.defensePower schema")
+	}
+	if _, exists := effectProps["killChancePercent"]; exists {
+		t.Fatal("did not expect itemEffects.killChancePercent schema")
 	}
 }
 

--- a/apps/server/internal/module/core/clue_interaction_test.go
+++ b/apps/server/internal/module/core/clue_interaction_test.go
@@ -501,11 +501,19 @@ func TestClueInteractionModule_Schema(t *testing.T) {
 	if !hasKill {
 		t.Fatal("expected itemEffects.effect enum to include kill")
 	}
-	if _, exists := effectProps["attackPower"]; !exists {
+	attackPower, exists := effectProps["attackPower"].(map[string]any)
+	if !exists {
 		t.Fatal("expected itemEffects.attackPower schema")
 	}
-	if _, exists := effectProps["defensePower"]; !exists {
+	if attackPower["type"] != "integer" {
+		t.Fatalf("expected attackPower to be integer schema, got %#v", attackPower["type"])
+	}
+	defensePower, exists := effectProps["defensePower"].(map[string]any)
+	if !exists {
 		t.Fatal("expected itemEffects.defensePower schema")
+	}
+	if defensePower["type"] != "integer" {
+		t.Fatalf("expected defensePower to be integer schema, got %#v", defensePower["type"])
 	}
 	if _, exists := effectProps["killChancePercent"]; exists {
 		t.Fatal("did not expect itemEffects.killChancePercent schema")

--- a/apps/server/internal/module/core/clue_item_effects.go
+++ b/apps/server/internal/module/core/clue_item_effects.go
@@ -23,13 +23,14 @@ const (
 // Editor labels are mapped to this contract by adapters; the engine executes
 // only this typed shape and never trusts client-side labels as runtime truth.
 type ClueItemEffectConfig struct {
-	Effect            string   `json:"effect"`
-	Target            string   `json:"target,omitempty"`
-	Consume           bool     `json:"consume"`
-	DescriptionText   string   `json:"descriptionText,omitempty"`
-	RevealText        string   `json:"revealText,omitempty"`
-	GrantClueIDs      []string `json:"grantClueIds,omitempty"`
-	KillChancePercent *int     `json:"killChancePercent,omitempty"`
+	Effect          string   `json:"effect"`
+	Target          string   `json:"target,omitempty"`
+	Consume         bool     `json:"consume"`
+	DescriptionText string   `json:"descriptionText,omitempty"`
+	RevealText      string   `json:"revealText,omitempty"`
+	GrantClueIDs    []string `json:"grantClueIds,omitempty"`
+	AttackPower     int      `json:"attackPower,omitempty"`
+	DefensePower    int      `json:"defensePower,omitempty"`
 }
 
 type itemUsePayload struct {
@@ -207,13 +208,11 @@ func validateSingleClueItemEffectConfig(clueID string, cfg ClueItemEffectConfig)
 	if cfg.Effect == clueEffectKill && cfg.Target != "player" {
 		return fmt.Errorf("clue_interaction: kill requires player target")
 	}
-	if cfg.KillChancePercent != nil {
-		if cfg.Effect != clueEffectKill {
-			return fmt.Errorf("clue_interaction: killChancePercent is only supported for kill")
-		}
-		if *cfg.KillChancePercent < 0 || *cfg.KillChancePercent > 100 {
-			return fmt.Errorf("clue_interaction: killChancePercent must be between 0 and 100")
-		}
+	if cfg.AttackPower < 0 {
+		return fmt.Errorf("clue_interaction: attackPower must be non-negative")
+	}
+	if cfg.DefensePower < 0 {
+		return fmt.Errorf("clue_interaction: defensePower must be non-negative")
 	}
 	return nil
 }
@@ -365,19 +364,21 @@ func (m *ClueInteractionModule) handleKillEffect(ctx context.Context, playerID u
 	if err := m.validateKillableTarget(ctx, targetPlayerID); err != nil {
 		return err
 	}
-	cfg := m.config.ItemEffects[clueID.String()]
-	chance := 100
-	if cfg.KillChancePercent != nil {
-		chance = *cfg.KillChancePercent
+	result, err := m.resolveKillPower(ctx, playerID, targetPlayerID)
+	if err != nil {
+		return err
 	}
-	if chance <= 0 || m.killRoll() > chance {
+	if !result.Allowed {
 		m.deps.EventBus.Publish(engine.Event{
 			Type: "clue.kill_failed",
 			Payload: map[string]any{
-				"playerId":          playerID.String(),
-				"targetPlayerId":    targetPlayerID.String(),
-				"clueId":            clueID.String(),
-				"killChancePercent": chance,
+				"playerId":             playerID.String(),
+				"targetPlayerId":       targetPlayerID.String(),
+				"clueId":               clueID.String(),
+				"reason":               result.Reason,
+				"killResolutionMode":   result.Mode,
+				"resolvedAttackPower":  result.AttackPower,
+				"resolvedDefensePower": result.DefensePower,
 			},
 		})
 		return nil
@@ -397,12 +398,125 @@ func (m *ClueInteractionModule) handleKillEffect(ctx context.Context, playerID u
 	m.deps.EventBus.Publish(engine.Event{
 		Type: "clue.kill_requested",
 		Payload: map[string]any{
-			"playerId":       playerID.String(),
-			"targetPlayerId": targetPlayerID.String(),
-			"clueId":         clueID.String(),
+			"playerId":             playerID.String(),
+			"targetPlayerId":       targetPlayerID.String(),
+			"clueId":               clueID.String(),
+			"killResolutionMode":   result.Mode,
+			"resolvedAttackPower":  result.AttackPower,
+			"resolvedDefensePower": result.DefensePower,
 		},
 	})
 	return nil
+}
+
+type killPowerResult struct {
+	Allowed      bool
+	Reason       string
+	Mode         string
+	AttackPower  int
+	DefensePower int
+}
+
+func (m *ClueInteractionModule) resolveKillPower(ctx context.Context, attackerID uuid.UUID, targetID uuid.UUID) (killPowerResult, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	mode := m.playerKillConfig.KillResolutionMode
+	if mode == "" {
+		mode = KillResolutionAllWeaponsVsAllArmor
+	}
+	result := killPowerResult{Mode: mode}
+	if m.playerKillEnabled && !m.currentSceneAllowsKillLocked() {
+		result.Reason = "scene_not_allowed"
+		return result, nil
+	}
+
+	weapons := m.playerPowerValuesLocked(ctx, attackerID, true)
+	armor := m.playerPowerValuesLocked(ctx, targetID, false)
+	result.AttackPower = resolveAttackPower(mode, weapons)
+	result.DefensePower = resolveDefensePower(mode, armor)
+	result.Allowed = result.AttackPower > result.DefensePower
+	if !result.Allowed {
+		result.Reason = "attack_not_greater_than_defense"
+	}
+	return result, nil
+}
+
+func (m *ClueInteractionModule) currentSceneAllowsKillLocked() bool {
+	if len(m.playerKillConfig.AllowedSceneIDs) == 0 {
+		return false
+	}
+	for _, sceneID := range m.playerKillConfig.AllowedSceneIDs {
+		if sceneID == m.currentPhaseID {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveAttackPower(mode string, values []int) int {
+	switch mode {
+	case KillResolutionBestWeaponVsAllArmor, KillResolutionBestWeaponVsBestArmor:
+		return maxPower(values)
+	default:
+		return sumPower(values)
+	}
+}
+
+func resolveDefensePower(mode string, values []int) int {
+	switch mode {
+	case KillResolutionBestWeaponVsBestArmor:
+		return maxPower(values)
+	default:
+		return sumPower(values)
+	}
+}
+
+func sumPower(values []int) int {
+	total := 0
+	for _, value := range values {
+		total += value
+	}
+	return total
+}
+
+func maxPower(values []int) int {
+	max := 0
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}
+
+func (m *ClueInteractionModule) playerPowerValuesLocked(ctx context.Context, playerID uuid.UUID, attack bool) []int {
+	clueIDs := m.playerInventoryCluesLocked(ctx, playerID)
+	values := make([]int, 0, len(clueIDs))
+	for _, clueID := range clueIDs {
+		cfg, ok := m.config.ItemEffects[clueID]
+		if !ok {
+			continue
+		}
+		value := cfg.DefensePower
+		if attack {
+			value = cfg.AttackPower
+		}
+		if value > 0 {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func (m *ClueInteractionModule) playerInventoryCluesLocked(ctx context.Context, playerID uuid.UUID) []string {
+	clues := mergeClueList(m.acquiredClues[playerID], m.allPlayerClues)
+	if m.deps.PlayerInfoProvider != nil {
+		if info, ok := m.deps.PlayerInfoProvider.PlayerRuntimeInfo(ctx, playerID); ok {
+			clues = mergeClueList(clues, m.targetCodeClues[info.TargetCode])
+		}
+	}
+	return mergeClueList(clues, m.targetCodeClues[playerID.String()])
 }
 
 func (m *ClueInteractionModule) validateKillableTarget(ctx context.Context, targetPlayerID uuid.UUID) error {

--- a/apps/server/internal/module/core/clue_item_effects.go
+++ b/apps/server/internal/module/core/clue_item_effects.go
@@ -154,7 +154,7 @@ func (m *ClueInteractionModule) resolveItemUse(ctx context.Context, state ItemUs
 		return resolveErr
 	}
 
-	m.finishItemUse(state)
+	m.finishItemUse(ctx, state)
 	m.deps.EventBus.Publish(engine.Event{
 		Type: "clue.item_resolved",
 		Payload: map[string]any{
@@ -426,7 +426,7 @@ func (m *ClueInteractionModule) resolveKillPower(ctx context.Context, attackerID
 		mode = KillResolutionAllWeaponsVsAllArmor
 	}
 	result := killPowerResult{Mode: mode}
-	if m.playerKillEnabled && !m.currentSceneAllowsKillLocked() {
+	if !m.playerKillEnabled || !m.currentSceneAllowsKillLocked() {
 		result.Reason = "scene_not_allowed"
 		return result, nil
 	}
@@ -583,7 +583,7 @@ func (m *ClueInteractionModule) publishItemDeclared(playerID uuid.UUID, clueID u
 	})
 }
 
-func (m *ClueInteractionModule) finishItemUse(state ItemUseState) {
+func (m *ClueInteractionModule) finishItemUse(ctx context.Context, state ItemUseState) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.activeItemUse != nil && m.activeItemUse.ClueID == state.ClueID {
@@ -595,7 +595,7 @@ func (m *ClueInteractionModule) finishItemUse(state ItemUseState) {
 	}
 	m.usedItems[state.UserID] = append(m.usedItems[state.UserID], state.ClueID)
 	if state.Consume {
-		m.removePlayerClueLocked(state.UserID, state.ClueID.String())
+		m.removeConsumedClueLocked(ctx, state.UserID, state.ClueID.String())
 	}
 }
 
@@ -641,11 +641,36 @@ func (m *ClueInteractionModule) isProtectedClue(clueID string) bool {
 }
 
 func (m *ClueInteractionModule) removePlayerClueLocked(playerID uuid.UUID, clueID string) {
-	clues := m.acquiredClues[playerID]
-	for i, ownedID := range clues {
-		if ownedID == clueID {
-			m.acquiredClues[playerID] = append(clues[:i], clues[i+1:]...)
-			return
+	m.acquiredClues[playerID] = removeClueID(m.acquiredClues[playerID], clueID)
+}
+
+func (m *ClueInteractionModule) removeConsumedClueLocked(ctx context.Context, playerID uuid.UUID, clueID string) {
+	m.removePlayerClueLocked(playerID, clueID)
+	m.allPlayerClues = removeClueID(m.allPlayerClues, clueID)
+
+	playerKey := playerID.String()
+	m.targetCodeClues[playerKey] = removeClueID(m.targetCodeClues[playerKey], clueID)
+	if len(m.targetCodeClues[playerKey]) == 0 {
+		delete(m.targetCodeClues, playerKey)
+	}
+
+	if m.deps.PlayerInfoProvider == nil {
+		return
+	}
+	if info, ok := m.deps.PlayerInfoProvider.PlayerRuntimeInfo(ctx, playerID); ok {
+		m.targetCodeClues[info.TargetCode] = removeClueID(m.targetCodeClues[info.TargetCode], clueID)
+		if len(m.targetCodeClues[info.TargetCode]) == 0 {
+			delete(m.targetCodeClues, info.TargetCode)
 		}
 	}
+}
+
+func removeClueID(clues []string, clueID string) []string {
+	out := clues[:0]
+	for _, ownedID := range clues {
+		if ownedID != clueID {
+			out = append(out, ownedID)
+		}
+	}
+	return out
 }

--- a/apps/server/internal/module/core/clue_item_effects_test.go
+++ b/apps/server/internal/module/core/clue_item_effects_test.go
@@ -74,6 +74,10 @@ func TestClueInteractionModule_ConfiguredKillRequestsPlayerStatusChange(t *testi
 	status := enginemocks.NewMockPlayerStatusController(ctrl)
 	deps := newTestDeps()
 	deps.PlayerStatusController = status
+	sceneID := uuid.NewString()
+	deps.ModuleConfigs = map[string]json.RawMessage{
+		"player_kill": json.RawMessage(fmt.Sprintf(`{"allowedSceneIds":["%s"]}`, sceneID)),
+	}
 	m := NewClueInteractionModule()
 	playerID := uuid.New()
 	targetID := uuid.New()
@@ -83,6 +87,9 @@ func TestClueInteractionModule_ConfiguredKillRequestsPlayerStatusChange(t *testi
 	}})
 	if err := m.Init(context.Background(), deps, cfg); err != nil {
 		t.Fatalf("Init: %v", err)
+	}
+	if err := m.OnPhaseEnter(context.Background(), engine.Phase(sceneID)); err != nil {
+		t.Fatalf("OnPhaseEnter: %v", err)
 	}
 	m.mu.Lock()
 	m.acquiredClues[playerID] = []string{clueID.String()}
@@ -137,6 +144,10 @@ func TestClueInteractionModule_ConfiguredKillUsesPowerBeforeStatusChange(t *test
 	status := enginemocks.NewMockPlayerStatusController(ctrl)
 	deps := newTestDeps()
 	deps.PlayerStatusController = status
+	sceneID := uuid.NewString()
+	deps.ModuleConfigs = map[string]json.RawMessage{
+		"player_kill": json.RawMessage(fmt.Sprintf(`{"allowedSceneIds":["%s"]}`, sceneID)),
+	}
 	m := NewClueInteractionModule()
 	playerID := uuid.New()
 	targetID := uuid.New()
@@ -148,6 +159,9 @@ func TestClueInteractionModule_ConfiguredKillUsesPowerBeforeStatusChange(t *test
 	}})
 	if err := m.Init(context.Background(), deps, cfg); err != nil {
 		t.Fatalf("Init: %v", err)
+	}
+	if err := m.OnPhaseEnter(context.Background(), engine.Phase(sceneID)); err != nil {
+		t.Fatalf("OnPhaseEnter: %v", err)
 	}
 	m.mu.Lock()
 	m.acquiredClues[playerID] = []string{clueID.String()}
@@ -226,6 +240,10 @@ func TestClueInteractionModule_ConfiguredKillDoesNotResolveWhenStatusChangeFails
 	status := enginemocks.NewMockPlayerStatusController(ctrl)
 	deps := newTestDeps()
 	deps.PlayerStatusController = status
+	sceneID := uuid.NewString()
+	deps.ModuleConfigs = map[string]json.RawMessage{
+		"player_kill": json.RawMessage(fmt.Sprintf(`{"allowedSceneIds":["%s"]}`, sceneID)),
+	}
 	m := NewClueInteractionModule()
 	playerID := uuid.New()
 	targetID := uuid.New()
@@ -235,6 +253,9 @@ func TestClueInteractionModule_ConfiguredKillDoesNotResolveWhenStatusChangeFails
 	}})
 	if err := m.Init(context.Background(), deps, cfg); err != nil {
 		t.Fatalf("Init: %v", err)
+	}
+	if err := m.OnPhaseEnter(context.Background(), engine.Phase(sceneID)); err != nil {
+		t.Fatalf("OnPhaseEnter: %v", err)
 	}
 	m.mu.Lock()
 	m.acquiredClues[playerID] = []string{clueID.String()}
@@ -301,6 +322,110 @@ func TestClueInteractionModule_ConfiguredGrantClueIsIdempotent(t *testing.T) {
 	}
 	if acquiredEvents != 1 {
 		t.Fatalf("expected one clue.acquired event, got %d", acquiredEvents)
+	}
+}
+
+func TestClueInteractionModule_ConfiguredKillFailsWhenPlayerKillDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	status := enginemocks.NewMockPlayerStatusController(ctrl)
+	deps := newTestDeps()
+	deps.PlayerStatusController = status
+	m := NewClueInteractionModule()
+	playerID := uuid.New()
+	targetID := uuid.New()
+	clueID := uuid.New()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true, AttackPower: 10},
+	}})
+	if err := m.Init(context.Background(), deps, cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := m.OnPhaseEnter(context.Background(), engine.Phase(uuid.NewString())); err != nil {
+		t.Fatalf("OnPhaseEnter: %v", err)
+	}
+	m.mu.Lock()
+	m.acquiredClues[playerID] = []string{clueID.String()}
+	m.mu.Unlock()
+
+	var failedEvent bool
+	deps.EventBus.Subscribe("clue.kill_failed", func(e engine.Event) {
+		payload := e.Payload.(map[string]any)
+		failedEvent = payload["reason"] == "scene_not_allowed" &&
+			payload["resolvedAttackPower"] == 0 &&
+			payload["resolvedDefensePower"] == 0
+	})
+
+	payload, _ := json.Marshal(itemUsePayload{ClueID: clueID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", payload); err != nil {
+		t.Fatalf("clue:use kill: %v", err)
+	}
+	targetPayload, _ := json.Marshal(itemUseTargetPayload{TargetPlayerID: targetID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use_target", targetPayload); err != nil {
+		t.Fatalf("disabled kill should resolve as failed use: %v", err)
+	}
+	if !failedEvent {
+		t.Fatal("expected disabled player_kill to publish clue.kill_failed")
+	}
+}
+
+func TestClueInteractionModule_ConsumedTargetCodeDefenseIsNotCountedForKill(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	status := enginemocks.NewMockPlayerStatusController(ctrl)
+	deps := newTestDeps()
+	deps.PlayerStatusController = status
+	sceneID := uuid.NewString()
+	targetCode := uuid.NewString()
+	deps.ModuleConfigs = map[string]json.RawMessage{
+		"player_kill": json.RawMessage(fmt.Sprintf(`{"allowedSceneIds":["%s"]}`, sceneID)),
+	}
+	playerID := uuid.New()
+	targetID := uuid.New()
+	deps.PlayerInfoProvider = clueGrantTestProvider{players: map[uuid.UUID]engine.PlayerRuntimeInfo{
+		playerID: {PlayerID: playerID, TargetCode: uuid.NewString(), IsAlive: true},
+		targetID: {PlayerID: targetID, TargetCode: targetCode, IsAlive: true},
+	}}
+	m := NewClueInteractionModule()
+	weaponID := uuid.New()
+	armorID := uuid.New()
+	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
+		weaponID.String(): {Effect: clueEffectKill, Target: "player", Consume: false, AttackPower: 1},
+		armorID.String():  {Effect: clueEffectReveal, Target: "self", Consume: true, RevealText: "방어구 소모", DefensePower: 2},
+	}})
+	if err := m.Init(context.Background(), deps, cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := m.OnPhaseEnter(context.Background(), engine.Phase(sceneID)); err != nil {
+		t.Fatalf("OnPhaseEnter: %v", err)
+	}
+	m.mu.Lock()
+	m.acquiredClues[playerID] = []string{weaponID.String()}
+	m.acquiredClues[targetID] = []string{armorID.String()}
+	m.targetCodeClues[targetCode] = []string{armorID.String()}
+	m.mu.Unlock()
+
+	consumePayload, _ := json.Marshal(itemUsePayload{ClueID: armorID.String()})
+	if err := m.HandleMessage(context.Background(), targetID, "clue:use", consumePayload); err != nil {
+		t.Fatalf("consume armor: %v", err)
+	}
+
+	var action engine.PlayerStatusAction
+	status.EXPECT().
+		ApplyPlayerStatus(gomock.Any(), gomock.AssignableToTypeOf(engine.PlayerStatusAction{})).
+		DoAndReturn(func(_ context.Context, got engine.PlayerStatusAction) (engine.PlayerRuntimeInfo, error) {
+			action = got
+			return engine.PlayerRuntimeInfo{PlayerID: got.TargetID, IsAlive: got.IsAlive}, nil
+		})
+
+	killPayload, _ := json.Marshal(itemUsePayload{ClueID: weaponID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use", killPayload); err != nil {
+		t.Fatalf("clue:use kill: %v", err)
+	}
+	targetPayload, _ := json.Marshal(itemUseTargetPayload{TargetPlayerID: targetID.String()})
+	if err := m.HandleMessage(context.Background(), playerID, "clue:use_target", targetPayload); err != nil {
+		t.Fatalf("clue:use_target kill: %v", err)
+	}
+	if action.TargetID != targetID || action.IsAlive {
+		t.Fatalf("expected kill after consumed armor was removed, got %+v", action)
 	}
 }
 

--- a/apps/server/internal/module/core/clue_item_effects_test.go
+++ b/apps/server/internal/module/core/clue_item_effects_test.go
@@ -79,7 +79,7 @@ func TestClueInteractionModule_ConfiguredKillRequestsPlayerStatusChange(t *testi
 	targetID := uuid.New()
 	clueID := uuid.New()
 	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
-		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true},
+		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true, AttackPower: 1},
 	}})
 	if err := m.Init(context.Background(), deps, cfg); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -132,25 +132,26 @@ func TestClueInteractionModule_ConfiguredKillRequestsPlayerStatusChange(t *testi
 	m.mu.RUnlock()
 }
 
-func TestClueInteractionModule_ConfiguredKillUsesChanceBeforeStatusChange(t *testing.T) {
+func TestClueInteractionModule_ConfiguredKillUsesPowerBeforeStatusChange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	status := enginemocks.NewMockPlayerStatusController(ctrl)
 	deps := newTestDeps()
 	deps.PlayerStatusController = status
 	m := NewClueInteractionModule()
-	m.killRoll = func() int { return 90 }
 	playerID := uuid.New()
 	targetID := uuid.New()
 	clueID := uuid.New()
-	chance := 35
+	armorID := uuid.New()
 	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
-		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true, KillChancePercent: &chance},
+		clueID.String():  {Effect: clueEffectKill, Target: "player", Consume: true, AttackPower: 2},
+		armorID.String(): {Effect: clueEffectReveal, Target: "self", RevealText: "방어구", DefensePower: 2},
 	}})
 	if err := m.Init(context.Background(), deps, cfg); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
 	m.mu.Lock()
 	m.acquiredClues[playerID] = []string{clueID.String()}
+	m.acquiredClues[targetID] = []string{armorID.String()}
 	m.mu.Unlock()
 
 	var failedEvent bool
@@ -159,7 +160,9 @@ func TestClueInteractionModule_ConfiguredKillUsesChanceBeforeStatusChange(t *tes
 		failedEvent = payload["playerId"] == playerID.String() &&
 			payload["targetPlayerId"] == targetID.String() &&
 			payload["clueId"] == clueID.String() &&
-			payload["killChancePercent"] == chance
+			payload["reason"] == "attack_not_greater_than_defense" &&
+			payload["resolvedAttackPower"] == 2 &&
+			payload["resolvedDefensePower"] == 2
 	})
 
 	payload, _ := json.Marshal(itemUsePayload{ClueID: clueID.String()})
@@ -168,7 +171,7 @@ func TestClueInteractionModule_ConfiguredKillUsesChanceBeforeStatusChange(t *tes
 	}
 	targetPayload, _ := json.Marshal(itemUseTargetPayload{TargetPlayerID: targetID.String()})
 	if err := m.HandleMessage(context.Background(), playerID, "clue:use_target", targetPayload); err != nil {
-		t.Fatalf("failed chance should still resolve item use: %v", err)
+		t.Fatalf("failed power should still resolve item use: %v", err)
 	}
 
 	if !failedEvent {
@@ -177,7 +180,7 @@ func TestClueInteractionModule_ConfiguredKillUsesChanceBeforeStatusChange(t *tes
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if m.playerHasClueLocked(playerID, clueID.String()) {
-		t.Fatal("failed chance should consume configured consumable kill clue")
+		t.Fatal("failed power should consume configured consumable kill clue")
 	}
 }
 
@@ -199,7 +202,7 @@ func TestClueInteractionModule_ConfiguredKillRejectsNonKillableTarget(t *testing
 	m := NewClueInteractionModule()
 	clueID := uuid.New()
 	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
-		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true},
+		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true, AttackPower: 1},
 	}})
 	if err := m.Init(context.Background(), deps, cfg); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -228,7 +231,7 @@ func TestClueInteractionModule_ConfiguredKillDoesNotResolveWhenStatusChangeFails
 	targetID := uuid.New()
 	clueID := uuid.New()
 	cfg, _ := json.Marshal(ClueInteractionConfig{ItemEffects: map[string]ClueItemEffectConfig{
-		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true},
+		clueID.String(): {Effect: clueEffectKill, Target: "player", Consume: true, AttackPower: 1},
 	}})
 	if err := m.Init(context.Background(), deps, cfg); err != nil {
 		t.Fatalf("Init: %v", err)

--- a/apps/server/internal/module/core/player_kill.go
+++ b/apps/server/internal/module/core/player_kill.go
@@ -11,6 +11,12 @@ import (
 
 const playerKillModuleName = "player_kill"
 
+const (
+	KillResolutionAllWeaponsVsAllArmor  = "all_weapons_vs_all_armor"
+	KillResolutionBestWeaponVsAllArmor  = "best_weapon_vs_all_armor"
+	KillResolutionBestWeaponVsBestArmor = "best_weapon_vs_best_armor"
+)
+
 func init() {
 	engine.Register(playerKillModuleName, func() engine.Module { return NewPlayerKillModule() })
 }
@@ -18,6 +24,8 @@ func init() {
 type PlayerKillConfig struct {
 	KillableCharacterIDs []string `json:"killableCharacterIds,omitempty"`
 	MuteOnKilled         bool     `json:"muteOnKilled"`
+	KillResolutionMode   string   `json:"killResolutionMode,omitempty"`
+	AllowedSceneIDs      []string `json:"allowedSceneIds,omitempty"`
 }
 
 type PlayerKillModule struct {

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
@@ -256,7 +256,7 @@ describe('ClueEntityWorkspace', () => {
     });
     fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
     fireEvent.click(screen.getByRole('button', { name: '살해 요청' }));
-    fireEvent.change(screen.getByLabelText('살해확률 (%)'), { target: { value: '35' } });
+    fireEvent.change(screen.getByLabelText('공격력'), { target: { value: '3' } });
     fireEvent.click(screen.getByRole('button', { name: '단서 저장' }));
 
     expect(onUpdate).toHaveBeenCalledWith(
@@ -268,7 +268,7 @@ describe('ClueEntityWorkspace', () => {
     expect(readClueItemEffect(savedConfig, 'clue-1')).toMatchObject({
       effect: 'kill',
       target: 'player',
-      killChancePercent: 35,
+      attackPower: 3,
     });
   });
 

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
@@ -192,6 +192,37 @@ describe('ClueRuntimeEffectCard', () => {
     expect(readClueItemEffect(saved, 'clue-1')).not.toHaveProperty('condition');
   });
 
+  it('살해 요청이 아닌 보유 단서에도 공격력과 방어력을 저장한다', () => {
+    const ref = createRef<ClueRuntimeEffectCardHandle>();
+
+    render(
+      <ClueRuntimeEffectCard
+        ref={ref}
+        clue={clues[0]}
+        clues={clues}
+        configJson={{}}
+        isPlayerKillEnabled={true}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
+    fireEvent.click(screen.getByRole('button', { name: '정보 공개' }));
+    fireEvent.change(screen.getByLabelText('공개할 정보'), {
+      target: { value: '방패에 새겨진 문양이 드러납니다.' },
+    });
+    fireEvent.change(screen.getByLabelText('공격력'), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText('방어력'), { target: { value: '5' } });
+
+    const saved = ref.current?.getSaveRequest().writeConfig({}) as EditorConfig;
+    expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
+      effect: 'reveal',
+      target: 'self',
+      revealText: '방패에 새겨진 문양이 드러납니다.',
+      attackPower: 2,
+      defensePower: 5,
+    });
+  });
+
   it('암호 사용을 켠 뒤 암호가 비어 있으면 저장을 막는다', () => {
     const ref = createRef<ClueRuntimeEffectCardHandle>();
 
@@ -231,15 +262,17 @@ describe('ClueRuntimeEffectCard', () => {
     fireEvent.click(screen.getByRole('button', { name: '살해 요청' }));
 
     expect(screen.getByText(/생존 상태를 런타임에서 사망으로 변경/)).toBeDefined();
-    expect(screen.getByLabelText('살해확률 (%)')).toHaveProperty('value', '100');
-    fireEvent.change(screen.getByLabelText('살해확률 (%)'), { target: { value: '35' } });
+    expect(screen.getByLabelText('공격력')).toHaveProperty('value', '0');
+    fireEvent.change(screen.getByLabelText('공격력'), { target: { value: '3' } });
+    fireEvent.change(screen.getByLabelText('방어력'), { target: { value: '1' } });
 
     const saved = ref.current?.getSaveRequest().writeConfig({}) as EditorConfig;
     expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({
       effect: 'kill',
       target: 'player',
       condition: { kind: 'password', value: 'knife' },
-      killChancePercent: 35,
+      attackPower: 3,
+      defensePower: 1,
     });
   });
 
@@ -256,7 +289,7 @@ describe('ClueRuntimeEffectCard', () => {
     fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
 
     expect(screen.queryByRole('button', { name: '살해 요청' })).toBeNull();
-    expect(screen.queryByLabelText('살해확률 (%)')).toBeNull();
+    expect(screen.queryByLabelText('공격력')).toBeNull();
   });
 
   it('저장된 살해 요청 효과가 있어도 플레이어킬 모듈이 꺼져 있으면 살해 설정을 숨긴다', () => {
@@ -270,7 +303,7 @@ describe('ClueRuntimeEffectCard', () => {
               enabled: true,
               config: {
                 itemEffects: {
-                  'clue-1': { effect: 'kill', target: 'player', killChancePercent: 35 },
+                  'clue-1': { effect: 'kill', target: 'player', attackPower: 3 },
                 },
               },
             },
@@ -282,7 +315,7 @@ describe('ClueRuntimeEffectCard', () => {
 
     expect(screen.getByLabelText('사용 가능한 아이템')).toHaveProperty('checked', true);
     expect(screen.queryByRole('button', { name: '살해 요청' })).toBeNull();
-    expect(screen.queryByLabelText('살해확률 (%)')).toBeNull();
+    expect(screen.queryByLabelText('공격력')).toBeNull();
   });
 
   it('사용 가능한 아이템을 끄면 저장된 효과를 제거한다', () => {

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
@@ -27,7 +27,8 @@ interface DraftState {
   descriptionText: string;
   revealText: string;
   grantClueIds: string[];
-  killChancePercent: number;
+  attackPower: number;
+  defensePower: number;
   consume: boolean;
 }
 
@@ -65,7 +66,8 @@ function draftFromConfig(config: ClueItemEffectConfig | null): DraftState {
     usesPassword: password.trim().length > 0,
     password,
     consume: config?.consume === true,
-    killChancePercent: normalizePercent(config?.killChancePercent ?? 100),
+    attackPower: normalizePower(config?.attackPower ?? 0),
+    defensePower: normalizePower(config?.defensePower ?? 0),
   };
 
   if (config?.effect === 'description_change') {
@@ -113,14 +115,15 @@ function draftFromConfig(config: ClueItemEffectConfig | null): DraftState {
     descriptionText: '',
     revealText: '',
     grantClueIds: [],
-    killChancePercent: 100,
+    attackPower: 0,
+    defensePower: 0,
     consume: false,
   };
 }
 
-function normalizePercent(value: number): number {
-  if (!Number.isFinite(value)) return 100;
-  return Math.min(100, Math.max(0, Math.round(value)));
+function normalizePower(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.round(value));
 }
 
 function passwordCondition(draft: DraftState): EditorConfig & {
@@ -133,6 +136,15 @@ function passwordCondition(draft: DraftState): EditorConfig & {
   };
 }
 
+function powerConfig(draft: DraftState): Pick<ClueItemEffectConfig, 'attackPower' | 'defensePower'> {
+  const attackPower = normalizePower(draft.attackPower);
+  const defensePower = normalizePower(draft.defensePower);
+  return {
+    ...(attackPower > 0 ? { attackPower } : {}),
+    ...(defensePower > 0 ? { defensePower } : {}),
+  };
+}
+
 function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
   if (!draft.isUsableItem) return null;
   if (draft.mode === 'description') {
@@ -140,6 +152,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
       effect: 'description_change',
       target: 'self',
       ...passwordCondition(draft),
+      ...powerConfig(draft),
       descriptionText: draft.descriptionText.trim(),
       consume: draft.consume,
     };
@@ -149,6 +162,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
       effect: 'reveal',
       target: 'self',
       ...passwordCondition(draft),
+      ...powerConfig(draft),
       revealText: draft.revealText.trim(),
       consume: draft.consume,
     };
@@ -158,6 +172,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
       effect: 'grant_clue',
       target: 'self',
       ...passwordCondition(draft),
+      ...powerConfig(draft),
       grantClueIds: draft.grantClueIds,
       consume: draft.consume,
     };
@@ -167,6 +182,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
       effect: 'peek',
       target: 'player',
       ...passwordCondition(draft),
+      ...powerConfig(draft),
       consume: draft.consume,
     };
   }
@@ -175,7 +191,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
       effect: 'kill',
       target: 'player',
       ...passwordCondition(draft),
-      killChancePercent: normalizePercent(draft.killChancePercent),
+      ...powerConfig(draft),
       consume: draft.consume,
     };
   }
@@ -183,6 +199,7 @@ function toEffectConfig(draft: DraftState): ClueItemEffectConfig | null {
     effect: 'steal',
     target: 'player',
     ...passwordCondition(draft),
+    ...powerConfig(draft),
     consume: draft.consume,
   };
 }
@@ -398,23 +415,30 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
           )}
 
           {draft.mode === 'kill' && isPlayerKillEnabled && (
-            <div className="space-y-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-3">
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-3">
               <p className="text-sm leading-6 text-red-100">
                 대상 플레이어의 생존 상태를 런타임에서 사망으로 변경합니다.
               </p>
-              <div className="flex max-w-xs flex-col gap-1.5">
-                <label htmlFor="clue-runtime-kill-chance" className="text-sm font-semibold text-red-100">
-                  살해확률 (%)
-                </label>
-                <input
-                  id="clue-runtime-kill-chance"
-                  type="number"
-                  min={0}
-                  max={100}
-                  step={1}
-                  value={draft.killChancePercent}
-                  onChange={(e) => updateDraft({ killChancePercent: normalizePercent(Number(e.target.value)) })}
-                  className="w-full rounded-lg border border-red-500/40 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/50"
+            </div>
+          )}
+
+          {isPlayerKillEnabled && (
+            <div className="space-y-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-3">
+              <p className="text-sm leading-6 text-red-100">
+                살해 판정에 사용할 단서 수치입니다. 공격력은 공격자 보유 단서, 방어력은 대상 보유 단서에서 계산됩니다.
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <PowerField
+                  id="clue-runtime-attack-power"
+                  label="공격력"
+                  value={draft.attackPower}
+                  onChange={(attackPower) => updateDraft({ attackPower })}
+                />
+                <PowerField
+                  id="clue-runtime-defense-power"
+                  label="방어력"
+                  value={draft.defensePower}
+                  onChange={(defensePower) => updateDraft({ defensePower })}
                 />
               </div>
             </div>
@@ -469,6 +493,35 @@ function EffectChoice({
       {icon}
       {label}
     </button>
+  );
+}
+
+function PowerField({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="text-sm font-semibold text-red-100">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        min={0}
+        step={1}
+        value={value}
+        onChange={(e) => onChange(normalizePower(Number(e.target.value)))}
+        className="w-full rounded-lg border border-red-500/40 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/50"
+      />
+    </div>
   );
 }
 

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -359,8 +359,56 @@ function PlayerKillSettingsPanel({
   isSaving: boolean;
   onChange: (settings: PlayerKillConfig) => void;
 }) {
+  const modes: Array<{ value: PlayerKillConfig['killResolutionMode']; label: string; description: string }> = [
+    {
+      value: 'all_weapons_vs_all_armor',
+      label: '무기 모두 vs 방어구 모두',
+      description: '공격자의 모든 공격 단서 합계와 대상의 모든 방어 단서 합계를 비교합니다.',
+    },
+    {
+      value: 'best_weapon_vs_all_armor',
+      label: '최고 무기 1개 vs 방어구 모두',
+      description: '공격자의 가장 강한 공격 단서 1개와 대상의 모든 방어 단서 합계를 비교합니다.',
+    },
+    {
+      value: 'best_weapon_vs_best_armor',
+      label: '최고 무기 1개 vs 최고 방어구 1개',
+      description: '공격자의 최고 공격력 1개와 대상의 최고 방어력 1개를 비교합니다.',
+    },
+  ];
   return (
-    <div className="border-t border-slate-700 px-3 py-3">
+    <div className="space-y-3 border-t border-slate-700 px-3 py-3">
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-semibold text-slate-200">살해 판정 방식</legend>
+        <div className="grid gap-2 lg:grid-cols-3">
+          {modes.map((mode) => (
+            <label
+              key={mode.value}
+              className={`flex min-h-24 cursor-pointer gap-2 rounded-md border px-3 py-2 text-left ${
+                settings.killResolutionMode === mode.value
+                  ? 'border-red-400 bg-red-500/10'
+                  : 'border-slate-700 bg-slate-950'
+              }`}
+            >
+              <input
+                type="radio"
+                name="killResolutionMode"
+                aria-label={mode.label}
+                checked={settings.killResolutionMode === mode.value}
+                disabled={isSaving}
+                onChange={() => onChange({ ...settings, killResolutionMode: mode.value })}
+                className="mt-0.5 h-4 w-4 border-slate-700 bg-slate-900 text-red-500 focus:ring-red-500"
+              />
+              <span>
+                <span className="block text-xs font-semibold text-slate-100">{mode.label}</span>
+                <span className="mt-1 block text-[10px] leading-4 text-slate-500">
+                  {mode.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
       <label
         className="flex min-h-14 items-center gap-3 rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-left"
         title="살해된 플레이어가 음성채팅에서 말하지 못하게 막습니다."

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -56,6 +56,7 @@ export function PhaseNodePanel({
   const playerKillEnabled = readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID);
   const playerKillConfig = readPlayerKillConfig(configJson);
   const sceneKillEnabled = playerKillConfig.allowedSceneIds.includes(node.id);
+  const isStorySceneNode = node.type === "phase" && phaseType === "story_progression";
 
   const debouncer = useDebouncedMutation<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
@@ -88,7 +89,7 @@ export function PhaseNodePanel({
   };
 
   const handleSceneKillToggle = (enabled: boolean) => {
-    if (!theme || updateConfig.isPending) return;
+    if (!theme || updateConfig.isPending || !isStorySceneNode) return;
     const nextConfig = writePlayerKillSceneEnabled(configJson, node.id, enabled);
     updateConfig.mutate({ ...nextConfig, version: theme.version });
   };
@@ -112,7 +113,7 @@ export function PhaseNodePanel({
         onChange={handleChange}
         onFlush={flush}
       />
-      {node.type === "phase" && playerKillEnabled ? (
+      {isStorySceneNode && playerKillEnabled ? (
         <label className="flex items-start gap-2 rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-100">
           <input
             type="checkbox"

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -3,7 +3,10 @@ import type { Edge, Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useEditorMaps } from "../../editorMapApi";
+import { useUpdateConfigJson } from "../../editorConfigApi";
 import { useUpdateFlowNode } from "../../flowApi";
+import type { EditorThemeResponse } from "../../api";
+import { editorKeys } from "../../api";
 import type {
   FlowGraphResponse,
   FlowNodeData,
@@ -18,6 +21,12 @@ import { InvestigationPhasePanel } from "./InvestigationPhasePanel";
 import { DiscussionPhasePanel } from "./DiscussionPhasePanel";
 import { VotingQuestionPhasePanel } from "./VotingQuestionPhasePanel";
 import { ReadingPhasePanel } from "./ReadingPhasePanel";
+import {
+  PLAYER_KILL_MODULE_ID,
+  readEnabledModuleIds,
+  readPlayerKillConfig,
+  writePlayerKillSceneEnabled,
+} from "../../utils/configShape";
 
 interface PhaseNodePanelProps {
   node: Node;
@@ -37,10 +46,16 @@ export function PhaseNodePanel({
   headerActions,
 }: PhaseNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
+  const updateConfig = useUpdateConfigJson(themeId);
   const { data: maps = [], isLoading: mapsLoading } = useEditorMaps(themeId);
   const queryClient = useQueryClient();
   const data = node.data as FlowNodeData;
   const phaseType = normalizePhaseType(data.phase_type);
+  const theme = queryClient.getQueryData<EditorThemeResponse>(editorKeys.theme(themeId));
+  const configJson = theme?.config_json ?? {};
+  const playerKillEnabled = readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID);
+  const playerKillConfig = readPlayerKillConfig(configJson);
+  const sceneKillEnabled = playerKillConfig.allowedSceneIds.includes(node.id);
 
   const debouncer = useDebouncedMutation<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
@@ -72,6 +87,12 @@ export function PhaseNodePanel({
     );
   };
 
+  const handleSceneKillToggle = (enabled: boolean) => {
+    if (!theme || updateConfig.isPending) return;
+    const nextConfig = writePlayerKillSceneEnabled(configJson, node.id, enabled);
+    updateConfig.mutate({ ...nextConfig, version: theme.version });
+  };
+
   return (
     <div className="flex flex-col gap-3 p-4">
       <div className="flex items-center justify-between gap-2">
@@ -91,6 +112,24 @@ export function PhaseNodePanel({
         onChange={handleChange}
         onFlush={flush}
       />
+      {node.type === "phase" && playerKillEnabled ? (
+        <label className="flex items-start gap-2 rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-100">
+          <input
+            type="checkbox"
+            aria-label="살해 가능 장면"
+            checked={sceneKillEnabled}
+            disabled={updateConfig.isPending}
+            onChange={(event) => handleSceneKillToggle(event.currentTarget.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-red-500/40 bg-slate-950 text-red-500 focus:ring-red-500"
+          />
+          <span>
+            <span className="block font-semibold">살해 가능</span>
+            <span className="mt-1 block leading-4 text-red-100/70">
+              이 장면에서만 플레이어킬 단서 사용이 사망 판정까지 진행됩니다.
+            </span>
+          </span>
+        </label>
+      ) : null}
       {phaseType === "investigation" ? (
         <>
           <InvestigationMapField

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -87,7 +87,11 @@ const makeNode = (data: Record<string, unknown> = {}) => ({
 describe("PhaseNodePanel type-specific fields", () => {
   it("플레이어킬 모듈이 켜져 있으면 장면별 살해 가능 체크를 저장한다", () => {
     renderWithQC(
-      <PhaseNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+      <PhaseNodePanel
+        node={makeNode({ phase_type: "story_progression" })}
+        themeId="t1"
+        onUpdate={vi.fn()}
+      />,
       {
         id: "t1",
         version: 7,
@@ -119,6 +123,35 @@ describe("PhaseNodePanel type-specific fields", () => {
         }),
       }),
     );
+  });
+
+  it("스토리 진행 페이즈가 아니면 장면별 살해 가능 체크를 숨긴다", () => {
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({ phase_type: "investigation" })}
+        themeId="t1"
+        onUpdate={vi.fn()}
+      />,
+      {
+        id: "t1",
+        version: 7,
+        config_json: {
+          modules: {
+            player_kill: {
+              enabled: true,
+              config: {
+                killableCharacterIds: [],
+                muteOnKilled: false,
+                killResolutionMode: "all_weapons_vs_all_armor",
+                allowedSceneIds: [],
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(screen.queryByLabelText("살해 가능 장면")).toBeNull();
   });
 
   it("수사 장면은 기본 정보, 시간, 맵 선택, 자동 진행 안내를 표시한다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -2,6 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactElement } from "react";
+import { editorKeys } from "../../../api";
+
+const { configMutateMock } = vi.hoisted(() => ({
+  configMutateMock: vi.fn(),
+}));
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -9,6 +14,10 @@ vi.mock("sonner", () => ({
 
 vi.mock("../../../flowApi", () => ({
   useUpdateFlowNode: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("../../../editorConfigApi", () => ({
+  useUpdateConfigJson: () => ({ mutate: configMutateMock, isPending: false }),
 }));
 
 vi.mock("../../../editorMapApi", () => ({
@@ -58,10 +67,13 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function renderWithQC(ui: ReactElement) {
+function renderWithQC(ui: ReactElement, seedTheme?: Record<string, unknown>) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+  if (seedTheme) {
+    qc.setQueryData(editorKeys.theme("t1"), seedTheme);
+  }
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
@@ -73,6 +85,42 @@ const makeNode = (data: Record<string, unknown> = {}) => ({
 });
 
 describe("PhaseNodePanel type-specific fields", () => {
+  it("플레이어킬 모듈이 켜져 있으면 장면별 살해 가능 체크를 저장한다", () => {
+    renderWithQC(
+      <PhaseNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+      {
+        id: "t1",
+        version: 7,
+        config_json: {
+          modules: {
+            player_kill: {
+              enabled: true,
+              config: {
+                killableCharacterIds: [],
+                muteOnKilled: false,
+                killResolutionMode: "all_weapons_vs_all_armor",
+                allowedSceneIds: [],
+              },
+            },
+          },
+        },
+      },
+    );
+
+    fireEvent.click(screen.getByLabelText("살해 가능 장면"));
+
+    expect(configMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 7,
+        modules: expect.objectContaining({
+          player_kill: expect.objectContaining({
+            config: expect.objectContaining({ allowedSceneIds: ["node-1"] }),
+          }),
+        }),
+      }),
+    );
+  });
+
   it("수사 장면은 기본 정보, 시간, 맵 선택, 자동 진행 안내를 표시한다", () => {
     renderWithQC(
       <PhaseNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -22,6 +22,7 @@ import {
   writeModuleEnabled,
   writePlayerKillCharacterEnabled,
   writePlayerKillConfig,
+  writePlayerKillSceneEnabled,
 } from '../configShape';
 
 describe('configShape', () => {
@@ -394,19 +395,21 @@ describe('configShape', () => {
     });
   });
 
-  it('writes kill chance on clue runtime kill effects', () => {
+  it('writes attack and defense power on clue runtime kill effects', () => {
     const next = writeClueItemEffect({}, 'clue-1', {
       effect: 'kill',
       target: 'player',
       consume: true,
-      killChancePercent: 35,
+      attackPower: 3,
+      defensePower: 1,
     });
 
     expect(readClueItemEffect(next, 'clue-1')).toEqual({
       effect: 'kill',
       target: 'player',
       consume: true,
-      killChancePercent: 35,
+      attackPower: 3,
+      defensePower: 1,
     });
   });
 
@@ -423,28 +426,41 @@ describe('configShape', () => {
     expect(readPlayerKillConfig(base)).toEqual({
       killableCharacterIds: ['char-1'],
       muteOnKilled: true,
+      killResolutionMode: 'all_weapons_vs_all_armor',
+      allowedSceneIds: [],
     });
 
     const withChar = writePlayerKillCharacterEnabled(base, 'char-2', true);
     expect(readPlayerKillConfig(withChar)).toEqual({
       killableCharacterIds: ['char-1', 'char-2'],
       muteOnKilled: true,
+      killResolutionMode: 'all_weapons_vs_all_armor',
+      allowedSceneIds: [],
     });
 
     const withoutChar = writePlayerKillCharacterEnabled(withChar, 'char-1', false);
     expect(readPlayerKillConfig(withoutChar)).toEqual({
       killableCharacterIds: ['char-2'],
       muteOnKilled: true,
+      killResolutionMode: 'all_weapons_vs_all_armor',
+      allowedSceneIds: [],
     });
 
     const withMuteOff = writePlayerKillConfig(withoutChar, {
       killableCharacterIds: ['char-2'],
       muteOnKilled: false,
+      killResolutionMode: 'best_weapon_vs_all_armor',
+      allowedSceneIds: ['scene-1'],
     });
     expect(readModuleConfig(withMuteOff, 'player_kill')).toEqual({
       killableCharacterIds: ['char-2'],
       muteOnKilled: false,
+      killResolutionMode: 'best_weapon_vs_all_armor',
+      allowedSceneIds: ['scene-1'],
     });
+
+    const withScene = writePlayerKillSceneEnabled(withMuteOff, 'scene-2', true);
+    expect(readPlayerKillConfig(withScene).allowedSceneIds).toEqual(['scene-1', 'scene-2']);
   });
 
   it('does not create clue interaction config when deleting a missing runtime effect', () => {

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -51,7 +51,8 @@ export interface ClueItemEffectConfig extends EditorConfig {
   descriptionText?: string;
   revealText?: string;
   grantClueIds?: string[];
-  killChancePercent?: number;
+  attackPower?: number;
+  defensePower?: number;
 }
 
 export interface CluePolicyConfig extends EditorConfig {
@@ -62,7 +63,16 @@ export interface CluePolicyConfig extends EditorConfig {
 export interface PlayerKillConfig extends EditorConfig {
   killableCharacterIds: string[];
   muteOnKilled: boolean;
+  killResolutionMode: KillResolutionMode;
+  allowedSceneIds: string[];
 }
+
+export type KillResolutionMode =
+  | 'all_weapons_vs_all_armor'
+  | 'best_weapon_vs_all_armor'
+  | 'best_weapon_vs_best_armor';
+
+export const DEFAULT_KILL_RESOLUTION_MODE: KillResolutionMode = 'all_weapons_vs_all_armor';
 
 const LEGACY_KEYS = ['module_configs', 'clue_placement', 'character_clues'] as const;
 const CLUE_INTERACTION_MODULE_ID = 'clue_interaction';
@@ -111,9 +121,8 @@ function readClueItemEffectConfig(value: unknown): ClueItemEffectConfig | null {
   const descriptionText = typeof value.descriptionText === 'string' ? value.descriptionText : undefined;
   const revealText = typeof value.revealText === 'string' ? value.revealText : undefined;
   const grantClueIds = stringList(value.grantClueIds);
-  const killChancePercent = typeof value.killChancePercent === 'number' && Number.isFinite(value.killChancePercent)
-    ? Math.min(100, Math.max(0, Math.round(value.killChancePercent)))
-    : undefined;
+  const attackPower = normalizePower(value.attackPower);
+  const defensePower = normalizePower(value.defensePower);
 
   return {
     ...value,
@@ -123,8 +132,15 @@ function readClueItemEffectConfig(value: unknown): ClueItemEffectConfig | null {
     ...(descriptionText !== undefined ? { descriptionText } : {}),
     ...(revealText !== undefined ? { revealText } : {}),
     ...(grantClueIds.length > 0 ? { grantClueIds } : {}),
-    ...(killChancePercent !== undefined ? { killChancePercent } : {}),
+    ...(attackPower !== undefined ? { attackPower } : {}),
+    ...(defensePower !== undefined ? { defensePower } : {}),
   };
+}
+
+function normalizePower(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.round(value))
+    : undefined;
 }
 
 function readRawClueItemEffects(
@@ -144,7 +160,8 @@ function stripKnownClueEffectFields(value: unknown): EditorConfig {
   delete next.descriptionText;
   delete next.revealText;
   delete next.grantClueIds;
-  delete next.killChancePercent;
+  delete next.attackPower;
+  delete next.defensePower;
   return next;
 }
 
@@ -273,11 +290,24 @@ export function readPlayerKillConfig(
   configJson: EditorConfig | null | undefined
 ): PlayerKillConfig {
   const config = readModuleConfig(configJson, PLAYER_KILL_MODULE_ID);
+  const killResolutionMode = isKillResolutionMode(config.killResolutionMode)
+    ? config.killResolutionMode
+    : DEFAULT_KILL_RESOLUTION_MODE;
   return {
     ...config,
     killableCharacterIds: uniqueStrings(stringList(config.killableCharacterIds)),
     muteOnKilled: config.muteOnKilled === true,
+    killResolutionMode,
+    allowedSceneIds: uniqueStrings(stringList(config.allowedSceneIds)),
   };
+}
+
+function isKillResolutionMode(value: unknown): value is KillResolutionMode {
+  return (
+    value === 'all_weapons_vs_all_armor' ||
+    value === 'best_weapon_vs_all_armor' ||
+    value === 'best_weapon_vs_best_armor'
+  );
 }
 
 export function writePlayerKillConfig(
@@ -290,6 +320,25 @@ export function writePlayerKillConfig(
     ...config,
     killableCharacterIds: uniqueStrings(config.killableCharacterIds),
     muteOnKilled: config.muteOnKilled === true,
+    killResolutionMode: isKillResolutionMode(config.killResolutionMode)
+      ? config.killResolutionMode
+      : DEFAULT_KILL_RESOLUTION_MODE,
+    allowedSceneIds: uniqueStrings(config.allowedSceneIds),
+  });
+}
+
+export function writePlayerKillSceneEnabled(
+  configJson: EditorConfig | null | undefined,
+  sceneId: string,
+  enabled: boolean
+): EditorConfig {
+  const current = readPlayerKillConfig(configJson);
+  const allowedSceneIds = enabled
+    ? uniqueStrings([...current.allowedSceneIds, sceneId])
+    : current.allowedSceneIds.filter((id) => id !== sceneId);
+  return writePlayerKillConfig(configJson, {
+    ...current,
+    allowedSceneIds,
   });
 }
 

--- a/docs/plans/2026-05-16-player-kill-power-resolution-plan.md
+++ b/docs/plans/2026-05-16-player-kill-power-resolution-plan.md
@@ -123,7 +123,7 @@
 
 - [x] `go test ./internal/module/core ./internal/domain/editor`
 - [x] `pnpm --filter @mmp/web test -- ClueRuntimeEffectCard configShape ModulesSubTab`
-- [ ] 필요 시 `scripts/mmp-local-ci.sh quick`
+- [x] `scripts/mmp-local-ci.sh quick`
 
 ## PR 묶음 제안
 

--- a/docs/plans/2026-05-16-player-kill-power-resolution-plan.md
+++ b/docs/plans/2026-05-16-player-kill-power-resolution-plan.md
@@ -1,0 +1,135 @@
+# Player Kill Power Resolution Plan
+
+- GitHub Issue: #582
+- Seed: `seed_f41eca0ce689`
+
+## 목표
+
+- `player_kill` 살해 판정을 `killChancePercent` 확률 방식에서 단서별 공격력/방어력 비교 방식으로 전환한다.
+- 제작자는 게임설계에서 살해 판정 방식을 고르고, 스토리진행 장면별로 살해 가능 여부를 체크할 수 있다.
+- 런타임은 현재 인벤토리에 남아 있는 단서와 현재 장면만 기준으로 살해 성공/실패를 판정한다.
+
+## 고정 결정
+
+- `killChancePercent`는 UI, 저장 계약, validation, runtime 판정에서 제거한다.
+- 기존 `killChancePercent` 값은 `attackPower`로 자동 변환하지 않는다.
+- 공격 후보는 공격자가 현재 인벤토리에 가진 `attackPower > 0` 단서다.
+- 방어 후보는 대상 플레이어가 현재 인벤토리에 가진 `defensePower > 0` 단서다.
+- 사용되어 소모된 단서, 현재 인벤토리에 없는 단서, 공개만 되었지만 보유 중이 아닌 단서는 계산하지 않는다.
+- 살해 성공 조건은 항상 `resolvedAttackPower > resolvedDefensePower`다. 같으면 실패다.
+- 체크된 장면에서만 살해 가능하다. 체크된 장면이 없으면 살해 불가로 본다.
+
+## 판정 방식
+
+- `all_weapons_vs_all_armor`: 무기 모두 vs 방어구 모두
+  - 공격자 인벤토리의 모든 공격 단서 합계와 대상 인벤토리의 모든 방어 단서 합계를 비교한다.
+- `best_weapon_vs_all_armor`: 최고 무기 1개 vs 방어구 모두
+  - 공격자 인벤토리의 최고 공격력 1개와 대상 인벤토리의 모든 방어 단서 합계를 비교한다.
+- `best_weapon_vs_best_armor`: 최고 무기 1개 vs 최고 방어구 1개
+  - 공격자 인벤토리의 최고 공격력 1개와 대상 인벤토리의 최고 방어력 1개를 비교한다.
+
+## 작업 범위
+
+- [x] `modules.player_kill.config`에 판정 방식과 허용 장면 목록을 추가한다.
+- [x] `modules.clue_interaction.config.itemEffects[clueId]`에서 `killChancePercent`를 제거하고 `attackPower`, `defensePower`를 지원한다.
+- [x] 단서 런타임 효과 UI에서 살해확률 입력을 제거하고 공격력/방어력 입력을 제공한다.
+- [x] 게임설계의 살해 모드 설정 UI에 판정 방식 선택을 추가한다.
+- [x] 스토리진행 장면 설정 UI에 `살해 가능` 체크박스를 추가하고 `allowedSceneIds`에 저장한다.
+- [x] 런타임 살해 처리에서 현재 장면 허용 여부를 먼저 확인한 뒤 공격/방어 수치 판정을 수행한다.
+- [x] 살해 실패 이벤트 payload에 실패 이유와 계산값을 포함해 디버깅 가능하게 한다.
+- [x] 기존 `killChancePercent` 테스트를 제거하거나 새 수치 판정 테스트로 대체한다.
+
+## 제외
+
+- [ ] 확률 기반 살해 판정 유지
+- [ ] 기존 `killChancePercent` 값을 공격력으로 자동 마이그레이션
+- [ ] 인벤토리에 없는 단서, 소모된 단서, 단순 공개 단서의 공격/방어 반영
+- [ ] 별도 장착 시스템 구현
+
+## 완료 조건
+
+- [x] 사용자는 게임설계에서 세 가지 살해 판정 방식 중 하나를 선택할 수 있다.
+- [x] 사용자는 스토리진행 탭의 각 장면에서 살해 가능 여부를 체크할 수 있다.
+- [x] 사용자는 단서별 공격력/방어력을 설정할 수 있다.
+- [x] 런타임은 현재 장면이 허용되지 않으면 살해를 실패시킨다.
+- [x] 런타임은 선택한 판정 방식에 따라 현재 인벤토리의 공격/방어 단서만 계산한다.
+- [x] `killChancePercent`는 새 저장 payload와 런타임 schema에 남지 않는다.
+- [x] focused backend/frontend tests가 주요 성공/실패 경로를 덮는다.
+
+## Coverage Plan
+
+- Backend runtime
+  - [x] `apps/server/internal/module/core/clue_item_effects_test.go`
+    - 장면 미허용 실패
+    - 세 가지 판정 방식 성공/실패
+    - 인벤토리에 없는 공격/방어 단서 제외
+    - `attackPower == defensePower` 실패
+  - [x] `apps/server/internal/module/core/clue_interaction_test.go`
+    - schema에서 `attackPower`, `defensePower`, 새 판정 필드 확인
+    - `killChancePercent` 제거 확인
+- Backend config validation
+  - [x] `apps/server/internal/domain/editor/service_config_test.go`
+    - `attackPower`/`defensePower` numeric validation
+    - `player_kill.config.killResolutionMode` enum validation
+    - `player_kill.config.allowedSceneIds` shape validation
+    - `killChancePercent` rejected or stripped policy 확인
+- Frontend adapter/UI
+  - [x] `apps/web/src/features/editor/utils/__tests__/configShape.test.ts`
+    - player kill mode, allowed scene IDs, attack/defense read/write
+  - [x] `apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx`
+    - 살해확률 입력 제거
+    - 공격력/방어력 저장
+  - [x] `apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx`
+    - 판정 방식 선택 저장
+  - [x] flow/phase panel 테스트
+    - 장면별 `살해 가능` 체크 저장
+
+## 병렬 작업 설계
+
+### 병렬 가능 작업
+
+- [ ] Backend lane: config validation, runtime 판정, Go tests
+- [ ] Frontend lane: configShape adapter, clue UI, game-design UI, flow scene UI
+- [ ] Test review lane: 변경 파일별 focused test 누락 확인
+
+### 파일/모듈 소유권
+
+- Backend lane
+  - `apps/server/internal/module/core/clue_item_effects.go`
+  - `apps/server/internal/module/core/clue_interaction.go`
+  - `apps/server/internal/module/core/player_kill.go`
+  - `apps/server/internal/domain/editor/service_config.go`
+  - 관련 Go tests
+- Frontend lane
+  - `apps/web/src/features/editor/utils/configShape.ts`
+  - `apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx`
+  - `apps/web/src/features/editor/components/design/ModulesSubTab.tsx`
+  - `apps/web/src/features/editor/components/design/PhaseNodePanel.tsx`
+  - `apps/web/src/features/editor/flowTypes.ts`
+  - 관련 Vitest tests
+
+### 병렬 금지/주의 영역
+
+- 공유 계약인 `ClueItemEffectConfig`, `PlayerKillConfig`, config validation은 한 번에 취합한다.
+- `killChancePercent` 제거는 backend/frontend/test를 동시에 맞춰야 하므로 중간 커밋에서 깨진 상태로 PR을 만들지 않는다.
+- PR 생성, label, merge는 메인 Codex가 맡는다.
+
+### 취합 방식
+
+- Sub-agent를 사용할 경우 결과는 `발견 / 수행 / 판단 / 미해결`로 압축한다.
+- 이번 세션에서는 사용자가 별도 병렬 sub-agent 실행을 명시하지 않았으므로 메인 Codex가 순차 구현한다.
+
+## 검증 계획
+
+- [x] `go test ./internal/module/core ./internal/domain/editor`
+- [x] `pnpm --filter @mmp/web test -- ClueRuntimeEffectCard configShape ModulesSubTab`
+- [ ] 필요 시 `scripts/mmp-local-ci.sh quick`
+
+## PR 묶음 제안
+
+- 단일 PR 권장.
+- 이유: 저장 계약, 에디터 UI, 런타임 판정이 서로 강하게 연결되어 분리하면 중간 PR이 깨진 계약을 남길 가능성이 높다.
+
+## 브레인스토밍 필요 여부
+
+- [x] 완료. `ooo interview`로 판정 방식, 후보 단서 범위, 레거시 제거, 장면 게이트 요구가 확정됐다.


### PR DESCRIPTION
## 요약
- `killChancePercent` 확률 판정을 제거하고 단서별 `attackPower` / `defensePower` 기반 판정으로 전환했습니다.
- 게임설계의 플레이어 살해 설정에서 세 가지 판정 방식(`all_weapons_vs_all_armor`, `best_weapon_vs_all_armor`, `best_weapon_vs_best_armor`)을 선택할 수 있게 했습니다.
- 스토리진행 phase 장면별 `살해 가능 장면` 체크를 `player_kill.config.allowedSceneIds`에 저장하고, 런타임에서 해당 장면에서만 살해 판정이 진행되도록 했습니다.
- 공격/방어 후보는 현재 인벤토리에 남아 있는 단서만 계산하며, 저장 검증에서 `allowedSceneIds`가 현재 테마의 phase node인지 확인합니다.

Closes #582

## Coverage Plan
- Backend runtime: `apps/server/internal/module/core/clue_item_effects_test.go`에서 공격/방어력 비교, 같으면 실패, 현재 인벤토리 기준 계산, 장면 미허용 실패 경로를 검증했습니다.
- Backend schema/config: `apps/server/internal/module/core/clue_interaction_test.go`, `apps/server/internal/domain/editor/service_config_test.go`에서 `killChancePercent` 제거, `attackPower`/`defensePower`, `killResolutionMode`, `allowedSceneIds` shape/reference validation을 검증했습니다.
- Frontend adapter/UI: `configShape.test.ts`, `ClueRuntimeEffectCard.test.tsx`, `ClueEntityWorkspace.test.tsx`, `ModulesSubTab.test.tsx`, `PhaseNodePanelExtended.test.tsx`에서 단서 수치 저장, 판정 방식 선택, 장면 체크 저장을 검증했습니다.

## Local validation
- `go test ./internal/module/core ./internal/domain/editor` 통과
- `pnpm --filter @mmp/web test -- ClueRuntimeEffectCard configShape ClueEntityWorkspace ModulesSubTab PhaseNodePanelExtended` 통과: 6 files, 65 tests
- `pnpm --filter @mmp/web typecheck` 통과
- `scripts/mmp-local-ci.sh quick` 통과: marker head `c4cdc5e3570d4b828f00ff760389743e3e1fa942`, status `success`

## 메모
- `ready-for-ci` 라벨과 GitHub Actions 수동 실행은 사용하지 않았습니다.
- 첫 번째 local-ci 시도는 host macOS `node_modules`와 Linux local-ci 컨테이너의 Rollup optional dependency가 달라 실패했고, 컨테이너 내부 install을 허용해 재실행 후 통과했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 플레이어 제거 기능의 판정 모드를 선택할 수 있게 추가
  * 장면별 제거 가능 여부를 설정할 수 있게 추가
  * 단서 효과에서 공격력/방어력 시스템 도입

* **Documentation**
  * 판정 방식 변경에 대한 개발 계획 문서 추가

* **Refactor**
  * 단서 효과 설정 구조 업데이트
  * 제거 기능 판정 로직 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

