### PR TITLE
fix(web): 플레이어킬 설정 저장과 장면 옵션 노출 복구

### DIFF
--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -56,7 +56,7 @@ export function PhaseNodePanel({
   const playerKillEnabled = readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID);
   const playerKillConfig = readPlayerKillConfig(configJson);
   const sceneKillEnabled = playerKillConfig.allowedSceneIds.includes(node.id);
-  const isStorySceneNode = node.type === "phase" && phaseType === "story_progression";
+  const isPhaseSceneNode = node.type === "phase";
 
   const debouncer = useDebouncedMutation<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
@@ -89,7 +89,7 @@ export function PhaseNodePanel({
   };
 
   const handleSceneKillToggle = (enabled: boolean) => {
-    if (!theme || updateConfig.isPending || !isStorySceneNode) return;
+    if (!theme || updateConfig.isPending || !isPhaseSceneNode) return;
     const nextConfig = writePlayerKillSceneEnabled(configJson, node.id, enabled);
     updateConfig.mutate({ ...nextConfig, version: theme.version });
   };
@@ -113,7 +113,7 @@ export function PhaseNodePanel({
         onChange={handleChange}
         onFlush={flush}
       />
-      {isStorySceneNode && playerKillEnabled ? (
+      {isPhaseSceneNode && playerKillEnabled ? (
         <label className="flex items-start gap-2 rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-100">
           <input
             type="checkbox"

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -125,7 +125,7 @@ describe("PhaseNodePanel type-specific fields", () => {
     );
   });
 
-  it("스토리 진행 페이즈가 아니면 장면별 살해 가능 체크를 숨긴다", () => {
+  it("플레이어킬 모듈이 켜져 있으면 수사 장면에도 살해 가능 체크를 표시한다", () => {
     renderWithQC(
       <PhaseNodePanel
         node={makeNode({ phase_type: "investigation" })}
@@ -151,7 +151,7 @@ describe("PhaseNodePanel type-specific fields", () => {
       },
     );
 
-    expect(screen.queryByLabelText("살해 가능 장면")).toBeNull();
+    expect(screen.getByLabelText("살해 가능 장면")).toBeDefined();
   });
 
   it("수사 장면은 기본 정보, 시간, 맵 선택, 자동 진행 안내를 표시한다", () => {

--- a/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
+++ b/apps/web/src/features/editor/utils/__tests__/configShape.test.ts
@@ -413,6 +413,48 @@ describe('configShape', () => {
     });
   });
 
+  it('strips legacy killChancePercent from clue item effects when normalizing config for save', () => {
+    const next = normalizeConfigForSave({
+      modules: {
+        player_kill: {
+          enabled: true,
+          config: { muteOnKilled: true },
+        },
+        clue_interaction: {
+          enabled: true,
+          config: {
+            itemEffects: {
+              'clue-1': {
+                effect: 'kill',
+                target: 'player',
+                consume: true,
+                killChancePercent: 10,
+              },
+              'clue-2': {
+                effect: 'peek',
+                customFutureField: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(readModuleConfig(next, 'clue_interaction')).toEqual({
+      itemEffects: {
+        'clue-1': {
+          effect: 'kill',
+          target: 'player',
+          consume: true,
+        },
+        'clue-2': {
+          effect: 'peek',
+          customFutureField: true,
+        },
+      },
+    });
+  });
+
   it('reads and writes player kill module config through canonical modules', () => {
     const base = {
       modules: {

--- a/apps/web/src/features/editor/utils/configShape.ts
+++ b/apps/web/src/features/editor/utils/configShape.ts
@@ -162,6 +162,7 @@ function stripKnownClueEffectFields(value: unknown): EditorConfig {
   delete next.grantClueIds;
   delete next.attackPower;
   delete next.defensePower;
+  delete next.killChancePercent;
   return next;
 }
 
@@ -237,6 +238,30 @@ export function readModuleConfig(
 function stripLegacyConfigKeys(configJson: EditorConfig): EditorConfig {
   const next: EditorConfig = { ...configJson };
   for (const key of LEGACY_KEYS) delete next[key];
+
+  const modules = isRecord(next.modules) ? { ...next.modules } : {};
+  const clueInteraction = isRecord(modules[CLUE_INTERACTION_MODULE_ID])
+    ? { ...(modules[CLUE_INTERACTION_MODULE_ID] as ModuleEntry) }
+    : null;
+  const clueInteractionConfig = isRecord(clueInteraction?.config)
+    ? { ...(clueInteraction.config as EditorConfig) }
+    : null;
+  const itemEffects = isRecord(clueInteractionConfig?.[CLUE_ITEM_EFFECTS_KEY])
+    ? { ...(clueInteractionConfig[CLUE_ITEM_EFFECTS_KEY] as EditorConfig) }
+    : null;
+
+  if (clueInteraction && clueInteractionConfig && itemEffects) {
+    for (const [clueId, rawEffect] of Object.entries(itemEffects)) {
+      if (!isRecord(rawEffect) || !hasOwnKey(rawEffect, 'killChancePercent')) continue;
+      const nextEffect = { ...rawEffect };
+      delete nextEffect.killChancePercent;
+      itemEffects[clueId] = nextEffect;
+    }
+    clueInteractionConfig[CLUE_ITEM_EFFECTS_KEY] = itemEffects;
+    clueInteraction.config = clueInteractionConfig;
+    modules[CLUE_INTERACTION_MODULE_ID] = clueInteraction;
+    next.modules = modules;
+  }
 
   const rawLocations = next.locations;
   if (Array.isArray(rawLocations)) {


### PR DESCRIPTION
## 요약
- 게임 설계 저장 전 legacy `killChancePercent`를 제거해 backend config validation 400을 막았습니다.
- 플레이어킬이 켜진 모든 phase 장면에서 `살해 가능` 옵션을 표시하도록 조정했습니다.
- 관련 이력: Refs #582, PR #583 후속 회귀 보정입니다.

## Coverage Plan
- `apps/web/src/features/editor/utils/configShape.ts`: 저장 정규화가 legacy clue item effect의 `killChancePercent`를 제거하고 다른 future field는 보존하는지 unit test로 검증.
- `apps/web/src/features/editor/components/design/PhaseNodePanel.tsx`: investigation phase에서도 장면별 `살해 가능` 체크가 렌더링되는지 component test로 검증.
- backend 코드는 변경하지 않고, 실제 backend validation은 cmux 저장 요청과 container log로 확인했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- configShape PhaseNodePanelExtended` 통과.
- `pnpm --filter @mmp/web typecheck` 통과.
- `scripts/mmp-local-ci.sh quick` 통과: head `6868bec775dae43a73390f7394026fb85dd6a5d3`, finished `2026-05-16T14:39:55Z`.

## Browser/backend evidence
- cmux `surface:3`에서 게임 설계의 `살해 판정 방식` 변경 저장 확인.
- backend log: `PUT /api/v1/editor/themes/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/config` status `200`, request_id `b842c34e2c4ef543b160e8867c6084eb`.
- DB 확인: 기존 clue item effect에서 `killChancePercent` 제거 후 `{effect,target,consume}`만 유지.
- 스토리 진행 탭에서 `1라운드` phase 선택 시 `살해 가능` 옵션 표시 확인.

## Deferred / Follow-up
- 없음. 이번 PR은 저장 오류와 장면 옵션 노출 회귀를 함께 닫는 좁은 수정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 모든 페이즈 유형에서 플레이어 킬(장면 살해) 기능을 사용할 수 있도록 확대되었습니다.

* **버그 수정**
  * 레거시 필드 정리: 단서 상호작용에서 불필요한 레거시 데이터를 제거하여 데이터 무결성을 개선했습니다.

* **테스트**
  * 모든 페이즈 유형에서의 기능 동작 및 레거시 데이터 정리 검증 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->