### PR TITLE
단서 편집 자동저장과 장소 계층 배치 UI 개선

### DIFF
--- a/apps/server/internal/domain/editor/handler_test.go
+++ b/apps/server/internal/domain/editor/handler_test.go
@@ -25,6 +25,7 @@ var (
 	extCreatorID = uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 	extThemeID   = uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 	extCharID    = uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+	extClueID    = uuid.MustParse("dddddddd-dddd-dddd-dddd-dddddddddddd")
 	extNow       = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 )
 
@@ -67,6 +68,18 @@ func extSampleCharResponse() *editor.CharacterResponse {
 		Name:        "Detective",
 		Description: &desc,
 		IsCulprit:   false,
+		SortOrder:   0,
+	}
+}
+
+func extSampleClueResponse() *editor.ClueResponse {
+	desc := "A clue"
+	return &editor.ClueResponse{
+		ID:          extClueID,
+		ThemeID:     extThemeID,
+		Name:        "Clue",
+		Description: &desc,
+		Level:       1,
 		SortOrder:   0,
 	}
 }
@@ -416,6 +429,35 @@ func TestUpdateCharacter_AllowsEmptyImageURL(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	h.UpdateCharacter(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateClue_AllowsEmptyImageURL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockService(ctrl)
+
+	mock.EXPECT().
+		UpdateClue(gomock.Any(), gomock.Eq(extCreatorID), gomock.Eq(extClueID), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, _ uuid.UUID, req editor.UpdateClueRequest) (*editor.ClueResponse, error) {
+			if req.ImageURL == nil || *req.ImageURL != "" {
+				t.Fatalf("expected empty image URL to reach service, got %+v", req.ImageURL)
+			}
+			return extSampleClueResponse(), nil
+		}).Times(1)
+
+	h := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
+
+	body := `{"name":"Clue Updated","level":1,"sort_order":1,"is_common":false,"is_usable":false,"use_consumed":false,"image_url":""}`
+	r := httptest.NewRequest(http.MethodPut, "/editor/clues/"+extClueID.String(), bytes.NewBufferString(body))
+	r.Header.Set("Content-Type", "application/json")
+	r = withExtAuth(r)
+	r = extChiContext(r, map[string]string{"id": extClueID.String()})
+	w := httptest.NewRecorder()
+
+	h.UpdateClue(w, r)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())

--- a/apps/server/internal/domain/editor/types.go
+++ b/apps/server/internal/domain/editor/types.go
@@ -126,7 +126,7 @@ type CreateClueRequest struct {
 	LocationID        *uuid.UUID `json:"location_id"`
 	Name              string     `json:"name" validate:"required,min=1,max=200"`
 	Description       *string    `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string    `json:"image_url" validate:"omitempty,url"`
+	ImageURL          *string    `json:"image_url" validate:"omitempty,optional_url"`
 	ImageMediaID      *uuid.UUID `json:"image_media_id"`
 	IsCommon          bool       `json:"is_common"`
 	Level             int32      `json:"level" validate:"min=1,max=10"`
@@ -146,7 +146,7 @@ type UpdateClueRequest struct {
 	LocationID        *uuid.UUID   `json:"location_id"`
 	Name              string       `json:"name" validate:"required,min=1,max=200"`
 	Description       *string      `json:"description" validate:"omitempty,max=2000"`
-	ImageURL          *string      `json:"image_url" validate:"omitempty,url"`
+	ImageURL          *string      `json:"image_url" validate:"omitempty,optional_url"`
 	ImageMediaID      OptionalUUID `json:"image_media_id"`
 	IsCommon          bool         `json:"is_common"`
 	Level             int32        `json:"level" validate:"min=1,max=10"`

--- a/apps/web/e2e/location-hierarchy.spec.ts
+++ b/apps/web/e2e/location-hierarchy.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  BASE,
+  THEME_ID,
+  MAP_ID,
+  freshState,
+  loginAsE2EUser,
+  mockCommonApis,
+} from './helpers/editor-golden-path-fixtures';
+
+const PARENT_LOCATION_ID = 'dddddddd-0000-0000-0000-000000000101';
+const CHILD_LOCATION_ID = 'dddddddd-0000-0000-0000-000000000102';
+
+type E2ELocation = {
+  id: string;
+  theme_id: string;
+  map_id: string;
+  name: string;
+  restricted_characters: string | null;
+  image_url: string | null;
+  parent_location_id: string | null;
+  sort_order: number;
+  created_at: string;
+};
+
+function baseLocation(id: string, name: string, sortOrder: number): E2ELocation {
+  return {
+    id,
+    theme_id: THEME_ID,
+    map_id: MAP_ID,
+    name,
+    restricted_characters: null,
+    image_url: null,
+    parent_location_id: null,
+    sort_order: sortOrder,
+    created_at: '2026-05-17T00:00:00Z',
+  };
+}
+
+async function installLocationHierarchyRoutes(page: Page) {
+  const state = {
+    locations: [
+      baseLocation(PARENT_LOCATION_ID, '거실', 0),
+      baseLocation(CHILD_LOCATION_ID, '금고', 1),
+    ],
+    lastUpdateBody: null as Record<string, unknown> | null,
+  };
+
+  await page.route(`**/v1/editor/themes/${THEME_ID}/locations`, (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(state.locations),
+    });
+  });
+
+  await page.route(`**/v1/editor/locations/${CHILD_LOCATION_ID}`, async (route) => {
+    if (route.request().method() !== 'PUT') return route.continue();
+    const body = JSON.parse(route.request().postData() ?? '{}') as Record<string, unknown>;
+    state.lastUpdateBody = body;
+    state.locations = state.locations.map((location) =>
+      location.id === CHILD_LOCATION_ID
+        ? {
+            ...location,
+            parent_location_id: (body.parent_location_id as string | null) ?? null,
+            sort_order: typeof body.sort_order === 'number' ? body.sort_order : location.sort_order,
+          }
+        : location
+    );
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(state.locations.find((location) => location.id === CHILD_LOCATION_ID)),
+    });
+  });
+
+  return state;
+}
+
+test.describe('location hierarchy clue placement', () => {
+  test('장소 계층 저장 후 새로고침해도 하위장소와 단서 조사 경로가 복원된다', async ({ page }) => {
+    const commonState = freshState();
+    await mockCommonApis(page, commonState);
+    const hierarchyState = await installLocationHierarchyRoutes(page);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/locations`);
+    await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: '금고 선택' }).click();
+
+    const updateUrl = `/v1/editor/locations/${CHILD_LOCATION_ID}`;
+    const updateRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'PUT' && request.url().includes(updateUrl)
+    );
+    const updateResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' && response.url().includes(updateUrl)
+    );
+    await page.getByRole('combobox', { name: '금고 상위 장소' }).selectOption(PARENT_LOCATION_ID);
+    const request = await updateRequest;
+    await updateResponse;
+    expect(JSON.parse(request.postData() ?? '{}')).toMatchObject({
+      parent_location_id: PARENT_LOCATION_ID,
+    });
+    expect(hierarchyState.lastUpdateBody).toMatchObject({
+      parent_location_id: PARENT_LOCATION_ID,
+    });
+
+    await page.reload();
+    await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: '거실 / 금고 선택' }).click();
+    await expect(page.getByLabel('거실 / 금고 단서 조사')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/apps/web/src/features/editor/components/ClueForm.tsx
+++ b/apps/web/src/features/editor/components/ClueForm.tsx
@@ -124,8 +124,11 @@ export function ClueForm({ themeId, clue, isOpen, onClose }: ClueFormProps) {
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) return;
 
+    const imageMediaChanged = imageMediaId !== (clue?.image_media_id ?? null);
     const nextImageUrl = imageMediaId
-      ? ''
+      ? imageMediaChanged
+        ? ''
+        : (clue?.image_url ?? undefined)
       : clue?.image_url && imageUrl === ''
         ? ''
         : imageUrl || undefined;

--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -242,6 +242,42 @@ describe('ClueForm', () => {
     expect(args.body.image_url).toBe('');
   });
 
+  it('edit 모드에서 이름만 수정하면 기존 media id와 legacy URL을 보존한다', () => {
+    const onClose = vi.fn();
+    const existing = {
+      id: 'clue-with-image',
+      theme_id: 'theme-1',
+      location_id: null,
+      name: '이미지 단서',
+      description: null,
+      image_url: 'https://cdn.example/legacy-clue.webp',
+      image_media_id: 'image-1',
+      is_common: false,
+      level: 1,
+      sort_order: 0,
+      created_at: '2026-04-15T00:00:00Z',
+      is_usable: false,
+      use_effect: null,
+      use_target: null,
+      use_consumed: false,
+    };
+
+    render(
+      <ClueForm themeId="theme-1" clue={existing} isOpen onClose={onClose} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '이름만 변경' },
+    });
+    fireEvent.submit(document.getElementById('clue-form')!);
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    const [args] = updateMutate.mock.calls[0];
+    expect(args.body.name).toBe('이름만 변경');
+    expect(args.body.image_media_id).toBe('image-1');
+    expect(args.body.image_url).toBe('https://cdn.example/legacy-clue.webp');
+  });
+
   it('edit 모드에서는 useUpdateClue.mutate가 호출된다', () => {
     const onClose = vi.fn();
     const existing = {

--- a/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
@@ -13,10 +13,29 @@ import {
   writeCluePolicy,
   type EditorConfig,
 } from '@/features/editor/utils/configShape';
+import {
+  readDeckInvestigationConfig,
+  writeDeckInvestigationConfig,
+  type InvestigationTokenDraft,
+} from '@/features/editor/entities/deckInvestigation/deckInvestigationAdapter';
+import {
+  writeLocationClueInvestigationCost,
+  type InvestigationCostDraft,
+} from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
 import type {
   ProgressNodeRevealOption,
 } from '@/features/editor/entities/reveal/revealTimingOptions';
 import { SceneSelectField } from '@/features/editor/components/SceneSelectField';
+import { InvestigationCostSelector } from '@/features/editor/components/design/InvestigationCostSelector';
+
+export interface ClueInvestigationCostSettings {
+  enabled: boolean;
+  tokens: InvestigationTokenDraft[];
+  cost: InvestigationCostDraft | null;
+  locationId: string | null;
+  locationName: string | null;
+  requiredClueIds: string[];
+}
 
 interface ClueBasicInfoCardProps {
   themeId: string;
@@ -25,8 +44,10 @@ interface ClueBasicInfoCardProps {
   isSaving?: boolean;
   isConfigSaving?: boolean;
   sceneOptions?: ProgressNodeRevealOption[];
+  investigationSettings?: ClueInvestigationCostSettings;
   onDelete: (clue: ClueResponse) => void;
   onDraftStateChange?: (state: ClueBasicInfoDraftState) => void;
+  onAutoSaveFlush?: () => void;
 }
 
 interface DraftState {
@@ -39,6 +60,7 @@ interface DraftState {
   isProtected: boolean;
   revealSceneId: string | null;
   hideSceneId: string | null;
+  investigationCost: InvestigationCostDraft | null;
 }
 
 export interface ClueBasicInfoDraftState {
@@ -59,7 +81,11 @@ export interface ClueBasicInfoCardHandle {
   getSaveRequest: () => ClueBasicInfoSaveRequest;
 }
 
-function toDraft(clue: ClueResponse, configJson: EditorConfig | null | undefined): DraftState {
+function toDraft(
+  clue: ClueResponse,
+  configJson: EditorConfig | null | undefined,
+  investigationSettings?: ClueInvestigationCostSettings,
+): DraftState {
   const policy = readCluePolicy(configJson, clue.id);
   return {
     name: clue.name,
@@ -71,13 +97,15 @@ function toDraft(clue: ClueResponse, configJson: EditorConfig | null | undefined
     isProtected: policy.protected,
     revealSceneId: clue.reveal_scene_id ?? null,
     hideSceneId: clue.hide_scene_id ?? null,
+    investigationCost: investigationSettings?.cost ?? null,
   };
 }
 
 function isDirty(
   draft: DraftState,
   clue: ClueResponse,
-  configJson: EditorConfig | null | undefined
+  configJson: EditorConfig | null | undefined,
+  investigationSettings?: ClueInvestigationCostSettings,
 ): boolean {
   const policy = readCluePolicy(configJson, clue.id);
   return (
@@ -89,7 +117,8 @@ function isDirty(
     (!draft.isCommon && draft.isRevealable !== policy.revealable) ||
     draft.isProtected !== policy.protected ||
     draft.revealSceneId !== (clue.reveal_scene_id ?? null) ||
-    draft.hideSceneId !== (clue.hide_scene_id ?? null)
+    draft.hideSceneId !== (clue.hide_scene_id ?? null) ||
+    isInvestigationCostDirty(draft, investigationSettings)
   );
 }
 
@@ -155,6 +184,19 @@ function isPolicyDirty(
   );
 }
 
+function isInvestigationCostDirty(
+  draft: DraftState,
+  investigationSettings?: ClueInvestigationCostSettings,
+): boolean {
+  if (!investigationSettings?.enabled || !investigationSettings.locationId) return false;
+  return JSON.stringify(draft.investigationCost) !== JSON.stringify(investigationSettings.cost);
+}
+
+function parseInvestigationCostKey(value: string): InvestigationCostDraft | null {
+  if (value === 'null') return null;
+  return JSON.parse(value) as InvestigationCostDraft;
+}
+
 export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicInfoCardProps>(function ClueBasicInfoCard({
   themeId,
   clue,
@@ -162,20 +204,23 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
   isSaving = false,
   isConfigSaving = false,
   sceneOptions = [],
+  investigationSettings,
   onDelete,
   onDraftStateChange,
+  onAutoSaveFlush,
 }, ref) {
-  const [draft, setDraft] = useState<DraftState>(() => toDraft(clue, configJson));
+  const [draft, setDraft] = useState<DraftState>(() => toDraft(clue, configJson, investigationSettings));
   const [errors, setErrors] = useState<Record<string, string>>({});
   const view = toClueEditorViewModel(clue);
   const policy = readCluePolicy(configJson, clue.id);
   const runtimeEffect = readClueItemEffect(configJson, clue.id);
-  const dirty = isDirty(draft, clue, configJson);
+  const dirty = isDirty(draft, clue, configJson, investigationSettings);
   const saving = isSaving || isConfigSaving;
   const selectedRevealSceneLabel =
     sceneOptions.find((option) => option.value === draft.revealSceneId)?.label ?? '처음부터';
   const selectedHideSceneLabel =
     sceneOptions.find((option) => option.value === draft.hideSceneId)?.label ?? '끝까지';
+  const investigationCostKey = JSON.stringify(investigationSettings?.cost ?? null);
 
   useEffect(() => {
     setDraft({
@@ -188,6 +233,7 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
       isProtected: policy.protected,
       revealSceneId: clue.reveal_scene_id ?? null,
       hideSceneId: clue.hide_scene_id ?? null,
+      investigationCost: parseInvestigationCostKey(investigationCostKey),
     });
     setErrors({});
   }, [
@@ -201,6 +247,9 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
     clue.hide_scene_id,
     policy.revealable,
     policy.protected,
+    investigationCostKey,
+    investigationSettings?.enabled,
+    investigationSettings?.locationId,
   ]);
 
   function patch(next: Partial<DraftState>) {
@@ -215,17 +264,41 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
     const nextErrors = validate(draft);
     setErrors(nextErrors);
     const rowDirty = isRowDirty(draft, clue);
-    const configDirty = isPolicyDirty(draft, clue, configJson);
+    const policyDirty = isPolicyDirty(draft, clue, configJson);
+    const investigationCostDirty = isInvestigationCostDirty(draft, investigationSettings);
+    const configDirty = policyDirty || investigationCostDirty;
     return {
       valid: Object.keys(nextErrors).length === 0,
       dirty: rowDirty || configDirty,
       rowDirty,
       configDirty,
       body: rowDirty ? buildUpdateBody(clue, draft) : null,
-      writeConfig: (baseConfig) => writeCluePolicy(baseConfig, clue.id, {
-        revealable: draft.isCommon ? true : draft.isRevealable,
-        protected: draft.isProtected,
-      }),
+      writeConfig: (baseConfig) => {
+        let next = policyDirty
+          ? writeCluePolicy(baseConfig, clue.id, {
+              revealable: draft.isCommon ? true : draft.isRevealable,
+              protected: draft.isProtected,
+            })
+          : (baseConfig ?? {});
+        if (
+          investigationSettings?.enabled &&
+          investigationSettings.locationId &&
+          draft.investigationCost
+        ) {
+          next = writeDeckInvestigationConfig(
+            next,
+            writeLocationClueInvestigationCost(readDeckInvestigationConfig(next), {
+              locationId: investigationSettings.locationId,
+              locationName: investigationSettings.locationName ?? '배치된 장소',
+              clueId: clue.id,
+              clueName: draft.name.trim() || clue.name,
+              requiredClueIds: investigationSettings.requiredClueIds,
+              cost: draft.investigationCost,
+            }),
+          );
+        }
+        return next;
+      },
     };
   }
 
@@ -241,7 +314,10 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
   }, [dirty, draft, onDraftStateChange]);
 
   return (
-    <article className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+    <article
+      className="rounded-xl border border-slate-800 bg-slate-950/70 p-4"
+      onBlurCapture={onAutoSaveFlush}
+    >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">
@@ -367,6 +443,36 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
             <span className="mt-1 block text-xs text-red-400">{errors.description}</span>
           )}
         </label>
+
+        {investigationSettings?.enabled ? (
+          <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-semibold text-slate-200">조사권 소비</p>
+              <p className="text-xs leading-5 text-slate-500">
+                이 단서를 조사할 때 필요한 조사권 수량입니다.
+              </p>
+            </div>
+            {investigationSettings.locationId && draft.investigationCost ? (
+              <div className="mt-3">
+                <p className="text-xs text-slate-500">
+                  배치 장소: <span className="text-slate-300">{investigationSettings.locationName ?? '배치된 장소'}</span>
+                </p>
+                <InvestigationCostSelector
+                  clueName={draft.name.trim() || clue.name}
+                  cost={draft.investigationCost}
+                  tokens={investigationSettings.tokens}
+                  disabled={saving}
+                  manageHref={`/editor/${themeId}/design/modules`}
+                  onChange={(cost) => patch({ investigationCost: cost })}
+                />
+              </div>
+            ) : (
+              <p className="mt-3 rounded-lg border border-dashed border-slate-800 px-3 py-4 text-xs leading-5 text-slate-500">
+                장소에 배치된 단서만 조사권 소비량을 설정할 수 있습니다.
+              </p>
+            )}
+          </section>
+        ) : null}
 
       </div>
 

--- a/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
@@ -103,8 +103,11 @@ function validate(draft: DraftState): Record<string, string> {
 }
 
 function buildUpdateBody(clue: ClueResponse, draft: DraftState): UpdateClueRequest {
+  const imageMediaChanged = draft.imageMediaId !== (clue.image_media_id ?? null);
   const imageUrl = draft.imageMediaId
-    ? ''
+    ? imageMediaChanged
+      ? ''
+      : (clue.image_url ?? undefined)
     : clue.image_url && draft.imageUrl === ''
       ? ''
       : draft.imageUrl || undefined;

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
@@ -1,8 +1,22 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, fireEvent, within } from '@testing-library/react';
 import type { ClueResponse, EditorCharacterResponse, LocationResponse } from '@/features/editor/api';
 import { readClueItemEffect } from '@/features/editor/utils/configShape';
 import { ClueEntityWorkspace } from './ClueEntityWorkspace';
+
+const { toastLoadingMock, toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+  toastLoadingMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    loading: toastLoadingMock,
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
 
 vi.mock('@/features/editor/flowApi', () => ({
   useFlowGraph: () => ({
@@ -81,7 +95,17 @@ const characters: EditorCharacterResponse[] = [
   } as EditorCharacterResponse,
 ];
 
-afterEach(cleanup);
+beforeEach(() => {
+  vi.useRealTimers();
+  toastLoadingMock.mockReset();
+  toastSuccessMock.mockReset();
+  toastErrorMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe('ClueEntityWorkspace', () => {
   const flowNodes = [
@@ -151,7 +175,7 @@ describe('ClueEntityWorkspace', () => {
     expect(screen.queryByRole('button', { name: '설명 변경' })).toBeNull();
   });
 
-  it('단서 상세에는 통합 저장 버튼 하나만 보여준다', () => {
+  it('단서 상세 수동 저장 버튼을 제거하고 카드별 저장 버튼도 만들지 않는다', () => {
     render(
       <ClueEntityWorkspace
         themeId="theme-1"
@@ -167,12 +191,172 @@ describe('ClueEntityWorkspace', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: '단서 저장' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: '단서 저장' })).toBeNull();
     expect(screen.queryByRole('button', { name: '기본 정보 저장' })).toBeNull();
     expect(screen.queryByRole('button', { name: '사용 설정 저장' })).toBeNull();
   });
 
-  it('통합 저장 시 선택 단서 update payload와 보호 정책을 함께 보낸다', () => {
+  it('단서 목록에는 설명 대신 장소, 사용 설정, 살해 수치, 조사권 배지를 보여준다', () => {
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[
+          clue({
+            id: 'clue-1',
+            name: '301호',
+            description: null,
+            is_common: false,
+            is_usable: true,
+            use_effect: 'kill',
+            use_target: 'player',
+          }),
+        ]}
+        configJson={{
+          locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+          modules: {
+            clue_interaction: {
+              enabled: true,
+              config: {
+                itemEffects: {
+                  'clue-1': {
+                    effect: 'kill',
+                    target: 'player',
+                    consume: true,
+                    attackPower: 2,
+                    defensePower: 2,
+                  },
+                },
+              },
+            },
+            deck_investigation: {
+              enabled: true,
+              config: {
+                tokens: [{ id: 'basic-token', name: '기본 조사권', iconLabel: '권', defaultAmount: 1 }],
+                decks: [
+                  {
+                    id: 'location-clue-loc-1-clue-1',
+                    title: '서재 - 301호 조사',
+                    description: '',
+                    tokenId: 'basic-token',
+                    tokenCost: 1,
+                    drawOrder: 'sequential',
+                    emptyMessage: '더 이상 얻을 단서가 없습니다.',
+                    access: {
+                      phaseIds: [],
+                      locationIds: ['loc-1'],
+                      blockedCharacterIds: [],
+                      requiredClueIds: [],
+                    },
+                    cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+                  },
+                ],
+              },
+            },
+          },
+        }}
+        flowNodes={flowNodes}
+        locations={locations}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const item = screen.getByRole('button', { name: '301호 선택' });
+    expect(within(item).queryByText('설명 없음')).toBeNull();
+    expect(within(item).getByText('장소: 서재')).toBeDefined();
+    expect(within(item).getByText('사용 가능')).toBeDefined();
+    expect(within(item).getByText('살해 요청')).toBeDefined();
+    expect(within(item).getByText('공격력 2')).toBeDefined();
+    expect(within(item).getByText('방어력 2')).toBeDefined();
+    expect(within(item).getByText('조사권 1개')).toBeDefined();
+    expect(within(item).queryByText(/연결/)).toBeNull();
+  });
+
+  it('공개 단서 목록에는 전체 공개와 조사권 무료 배지를 보여준다', () => {
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1', name: '책장', is_common: true, is_usable: false })]}
+        configJson={{
+          locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+          modules: {
+            deck_investigation: {
+              enabled: true,
+              config: {
+                tokens: [{ id: 'basic-token', name: '기본 조사권', iconLabel: '권', defaultAmount: 1 }],
+                decks: [
+                  {
+                    id: 'location-clue-loc-1-clue-1',
+                    title: '서재 - 책장 조사',
+                    description: '',
+                    tokenId: '',
+                    tokenCost: 0,
+                    drawOrder: 'sequential',
+                    emptyMessage: '더 이상 얻을 단서가 없습니다.',
+                    access: {
+                      phaseIds: [],
+                      locationIds: ['loc-1'],
+                      blockedCharacterIds: [],
+                      requiredClueIds: [],
+                    },
+                    cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+                  },
+                ],
+              },
+            },
+          },
+        }}
+        flowNodes={flowNodes}
+        locations={locations}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const item = screen.getByRole('button', { name: '책장 선택' });
+    expect(within(item).getByText('장소: 서재')).toBeDefined();
+    expect(within(item).getByText('전체 공개')).toBeDefined();
+    expect(within(item).getByText('조사권 무료')).toBeDefined();
+    expect(within(item).queryByText(/연결/)).toBeNull();
+  });
+
+  it('단서 설명은 목록에 표시하지 않지만 검색에는 사용한다', () => {
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[
+          clue({ id: 'clue-1', name: '책장', description: '숨겨진 서류 봉투' }),
+          clue({ id: 'clue-2', name: '우산걸이', description: '젖은 우비' }),
+        ]}
+        configJson={{}}
+        flowNodes={flowNodes}
+        locations={[]}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const list = screen.getByRole('region', { name: '단서 목록' });
+    expect(within(list).queryByText('숨겨진 서류 봉투')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('단서 검색'), { target: { value: '숨겨진 서류' } });
+
+    expect(within(list).getByText('책장')).toBeDefined();
+    expect(within(list).queryByText('우산걸이')).toBeNull();
+    expect(within(list).queryByText('숨겨진 서류 봉투')).toBeNull();
+  });
+
+  it('기본 정보 변경 후 1.5초가 지나면 선택 단서 update payload와 보호 정책을 자동저장한다', async () => {
+    vi.useFakeTimers();
     const onUpdate = vi.fn();
     const onConfigChange = vi.fn();
 
@@ -201,8 +385,13 @@ describe('ClueEntityWorkspace', () => {
       target: { value: 'scene-2' },
     });
     fireEvent.click(screen.getByLabelText(/단서 보호/));
-    fireEvent.click(screen.getByRole('button', { name: '단서 저장' }));
 
+    await act(async () => {});
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(onUpdate).toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalledWith(
       'clue-1',
       expect.objectContaining({
@@ -216,6 +405,7 @@ describe('ClueEntityWorkspace', () => {
         reveal_scene_id: 'scene-1',
         hide_scene_id: 'scene-2',
       }),
+      expect.any(Object),
     );
     expect(onConfigChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -229,10 +419,13 @@ describe('ClueEntityWorkspace', () => {
           }),
         }),
       }),
+      expect.any(Object),
     );
+    expect(toastLoadingMock).toHaveBeenCalledWith('단서 자동저장 중...', expect.objectContaining({ id: 'clue-detail-autosave' }));
   });
 
-  it('기본 정보와 사용 설정 변경을 단서 저장 한 번으로 저장한다', () => {
+  it('기본 정보와 사용 설정 변경을 하나의 자동저장 주기로 저장한다', async () => {
+    vi.useFakeTimers();
     const onUpdate = vi.fn();
     const onConfigChange = vi.fn();
 
@@ -257,11 +450,17 @@ describe('ClueEntityWorkspace', () => {
     fireEvent.click(screen.getByLabelText('사용 가능한 아이템'));
     fireEvent.click(screen.getByRole('button', { name: '살해 요청' }));
     fireEvent.change(screen.getByLabelText('공격력'), { target: { value: '3' } });
-    fireEvent.click(screen.getByRole('button', { name: '단서 저장' }));
 
+    await act(async () => {});
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(onUpdate).toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalledWith(
       'clue-1',
       expect.objectContaining({ name: '피 묻은 열쇠 조각' }),
+      expect.any(Object),
     );
     expect(onConfigChange).toHaveBeenCalledTimes(1);
     const savedConfig = onConfigChange.mock.calls[0][0];
@@ -270,6 +469,241 @@ describe('ClueEntityWorkspace', () => {
       target: 'player',
       attackPower: 3,
     });
+  });
+
+  it('조사권 설정이 꺼져 있으면 단서 상세에 소비량 설정을 보여주지 않는다', () => {
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1' })]}
+        configJson={{
+          locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+          modules: {
+            deck_investigation: {
+              enabled: false,
+              config: {
+                tokens: [{ id: 'basic-token', name: '기본 조사권', iconLabel: '권', defaultAmount: 1 }],
+                decks: [],
+              },
+            },
+          },
+        }}
+        flowNodes={flowNodes}
+        locations={locations}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('조사권 소비')).toBeNull();
+  });
+
+  it('조사권 설정이 켜져 있으면 배치된 단서의 소비량을 단서 상세에서 자동저장한다', async () => {
+    vi.useFakeTimers();
+    const onConfigChange = vi.fn();
+
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1' })]}
+        configJson={{
+          locations: [{ id: 'loc-1', locationClueConfig: { clueIds: ['clue-1'] } }],
+          modules: {
+            deck_investigation: {
+              enabled: true,
+              config: {
+                tokens: [{ id: 'basic-token', name: '기본 조사권', iconLabel: '권', defaultAmount: 1 }],
+                decks: [],
+              },
+            },
+          },
+        }}
+        flowNodes={flowNodes}
+        locations={locations}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onConfigChange={onConfigChange}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('조사권 소비')).toBeDefined();
+    expect(screen.getByText(/배치 장소:/)).toBeDefined();
+    fireEvent.change(screen.getByLabelText('피 묻은 열쇠 조사권 소비량'), {
+      target: { value: '3' },
+    });
+
+    await act(async () => {});
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(onConfigChange).toHaveBeenCalledTimes(1);
+    const savedConfig = onConfigChange.mock.calls[0][0];
+    expect(savedConfig.modules.deck_investigation.config.decks).toEqual([
+      expect.objectContaining({
+        id: 'location-clue-loc-1-clue-1',
+        title: '서재 - 피 묻은 열쇠 조사',
+        tokenId: 'basic-token',
+        tokenCost: 3,
+        access: expect.objectContaining({ locationIds: ['loc-1'] }),
+        cards: [{ clueId: 'clue-1', delivery: 'private_ownership' }],
+      }),
+    ]);
+  });
+
+  it('조사권 설정이 켜져 있어도 미배치 단서는 배치 안내만 보여준다', () => {
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1' })]}
+        configJson={{
+          modules: {
+            deck_investigation: {
+              enabled: true,
+              config: {
+                tokens: [{ id: 'basic-token', name: '기본 조사권', iconLabel: '권', defaultAmount: 1 }],
+                decks: [],
+              },
+            },
+          },
+        }}
+        flowNodes={flowNodes}
+        locations={locations}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('조사권 소비')).toBeDefined();
+    expect(screen.getByText('장소에 배치된 단서만 조사권 소비량을 설정할 수 있습니다.')).toBeDefined();
+    expect(screen.queryByLabelText('피 묻은 열쇠 조사권 소비량')).toBeNull();
+  });
+
+  it('blur 시 대기 중인 자동저장을 즉시 실행한다', async () => {
+    vi.useFakeTimers();
+    const onUpdate = vi.fn();
+
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1' })]}
+        configJson={{}}
+        flowNodes={flowNodes}
+        locations={[]}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const nameInput = screen.getByLabelText('이름');
+    fireEvent.change(nameInput, {
+      target: { value: '피 묻은 열쇠 조각' },
+    });
+    fireEvent.blur(nameInput);
+
+    expect(onUpdate).toHaveBeenCalled();
+    expect(onUpdate).toHaveBeenCalledWith(
+      'clue-1',
+      expect.objectContaining({ name: '피 묻은 열쇠 조각' }),
+      expect.any(Object),
+    );
+  });
+
+  it('자동저장 실패 토스트에서 같은 변경을 재시도할 수 있다', async () => {
+    vi.useFakeTimers();
+    let shouldFail = true;
+    const onUpdate = vi.fn((_clueId, _body, options) => {
+      if (shouldFail) {
+        options?.onError?.(new Error('boom'));
+        return;
+      }
+      options?.onSuccess?.();
+    });
+
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1' })]}
+        configJson={{}}
+        flowNodes={flowNodes}
+        locations={[]}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '피 묻은 열쇠 조각' },
+    });
+    await act(async () => {});
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(toastErrorMock).toHaveBeenCalled();
+    const [, errorOptions] = toastErrorMock.mock.calls[0];
+    expect(errorOptions.action.label).toBe('재시도');
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '다른 변경' },
+    });
+    shouldFail = false;
+    errorOptions.action.onClick();
+
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onUpdate.mock.calls[1][1]).toEqual(expect.objectContaining({ name: '피 묻은 열쇠 조각' }));
+  });
+
+  it('자동저장 재시도도 실패하면 실패 토스트를 다시 보여준다', async () => {
+    vi.useFakeTimers();
+    const onUpdate = vi.fn((_clueId, _body, options) => {
+      options?.onError?.(new Error('boom'));
+    });
+
+    render(
+      <ClueEntityWorkspace
+        themeId="theme-1"
+        clues={[clue({ id: 'clue-1' })]}
+        configJson={{}}
+        flowNodes={flowNodes}
+        locations={[]}
+        characters={[]}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+        onConfigChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('이름'), {
+      target: { value: '피 묻은 열쇠 조각' },
+    });
+    await act(async () => {});
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    const [, firstErrorOptions] = toastErrorMock.mock.calls[0];
+    firstErrorOptions.action.onClick();
+
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(toastErrorMock).toHaveBeenCalledTimes(2);
+    const [, secondErrorOptions] = toastErrorMock.mock.calls[1];
+    expect(secondErrorOptions.action.label).toBe('재시도');
   });
 
   it('플레이어킬 모듈 상태에 따라 살해 요청 효과를 숨기거나 보여준다', () => {

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { Save } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
 import type {
   ClueResponse,
   EditorCharacterResponse,
@@ -9,18 +9,24 @@ import type {
 import type { FlowNodeResponse } from '@/features/editor/flowTypes';
 import {
   PLAYER_KILL_MODULE_ID,
+  readClueItemEffect,
+  readCluePlacement,
   readEnabledModuleIds,
+  readLocationDiscoveries,
   type EditorConfig,
 } from '@/features/editor/utils/configShape';
+import {
+  DECK_INVESTIGATION_MODULE_ID,
+  readDeckInvestigationConfig,
+} from '@/features/editor/entities/deckInvestigation/deckInvestigationAdapter';
+import { readLocationClueInvestigationCost } from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
+import { getLocationPathLabel } from '@/features/editor/entities/location/locationHierarchy';
 import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import {
   buildClueUsageMap,
   getClueBacklinks,
   type EntityReference,
 } from '@/features/editor/utils/entityReferences';
-import {
-  buildClueBadges,
-} from '@/features/editor/entities/clue/clueEntityAdapter';
 import { ClueRuntimeEffectCard } from './ClueRuntimeEffectCard';
 import type {
   ClueRuntimeEffectCardHandle,
@@ -34,6 +40,21 @@ import type {
 import {
   buildProgressNodeRevealOptions,
 } from '@/features/editor/entities/reveal/revealTimingOptions';
+import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
+
+const CLUE_DETAIL_AUTOSAVE_MS = 1500;
+const CLUE_AUTOSAVE_TOAST_ID = 'clue-detail-autosave';
+
+interface AutosaveMutationOptions {
+  onSuccess?: () => void;
+  onError?: (error?: unknown) => void;
+}
+
+interface ClueDetailAutosaveBody {
+  clueId: string;
+  rowBody: UpdateClueRequest | null;
+  nextConfig: EditorConfig | null;
+}
 
 interface ClueEntityWorkspaceProps {
   themeId?: string;
@@ -43,10 +64,10 @@ interface ClueEntityWorkspaceProps {
   locations: LocationResponse[];
   characters: EditorCharacterResponse[];
   onCreate: () => void;
-  onUpdate: (clueId: string, body: UpdateClueRequest) => void;
+  onUpdate: (clueId: string, body: UpdateClueRequest, options?: AutosaveMutationOptions) => void;
   onDelete: (clue: ClueResponse) => void;
   isClueSaving?: boolean;
-  onConfigChange?: (configJson: EditorConfig) => void;
+  onConfigChange?: (configJson: EditorConfig, options?: AutosaveMutationOptions) => void;
   isConfigSaving?: boolean;
 }
 
@@ -75,6 +96,7 @@ export function ClueEntityWorkspace({
     dirty: false,
     valid: true,
   });
+  const [draftRevision, setDraftRevision] = useState(0);
   const usageMap = useMemo(
     () => buildClueUsageMap({ configJson, clues, locations, characters }),
     [configJson, clues, locations, characters]
@@ -93,26 +115,125 @@ export function ClueEntityWorkspace({
     () => readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID),
     [configJson],
   );
-  const isSaving = Boolean(isClueSaving || isConfigSaving);
-  const hasDetailChanges = basicInfoState.dirty || runtimeEffectState.dirty;
-  const canSaveDetail =
-    hasDetailChanges && basicInfoState.valid && runtimeEffectState.valid && !isSaving;
-  const handleBasicInfoStateChange = useCallback((state: ClueBasicInfoDraftState) => {
-    setBasicInfoState(state);
-  }, []);
-  const handleRuntimeEffectStateChange = useCallback((state: ClueRuntimeEffectDraftState) => {
-    setRuntimeEffectState(state);
-  }, []);
-  const handleSaveDetail = useCallback(
+  const enabledModuleIds = useMemo(() => readEnabledModuleIds(configJson), [configJson]);
+  const isDeckInvestigationEnabled = enabledModuleIds.includes(DECK_INVESTIGATION_MODULE_ID);
+  const deckInvestigationDraft = useMemo(
+    () => readDeckInvestigationConfig(configJson),
+    [configJson],
+  );
+  const cluePlacement = useMemo(() => readCluePlacement(configJson), [configJson]);
+  const locationById = useMemo(
+    () => new Map(locations.map((location) => [location.id, location])),
+    [locations],
+  );
+  const getClueLocationContext = useCallback(
     (clue: ClueResponse) => {
+      const placedLocationId = cluePlacement[clue.id] ?? clue.location_id ?? null;
+      const placedLocation = placedLocationId ? locationById.get(placedLocationId) ?? null : null;
+      const locationName = placedLocation
+        ? getLocationPathLabel(placedLocation, locations)
+        : null;
+      return { placedLocationId, locationName };
+    },
+    [cluePlacement, locationById, locations],
+  );
+  const buildListBadges = useCallback(
+    (clue: ClueResponse) => {
+      const { placedLocationId, locationName } = getClueLocationContext(clue);
+      const effect = readClueItemEffect(configJson, clue.id);
+      const badges: string[] = [locationName ? `장소: ${locationName}` : '미배치'];
+      if (clue.is_common) badges.push('전체 공개');
+      if (clue.is_usable) badges.push('사용 가능');
+      if (effect?.effect === 'kill') {
+        badges.push('살해 요청');
+        if ((effect.attackPower ?? 0) > 0) badges.push(`공격력 ${effect.attackPower}`);
+        if ((effect.defensePower ?? 0) > 0) badges.push(`방어력 ${effect.defensePower}`);
+      }
+      if (isDeckInvestigationEnabled && placedLocationId) {
+        const cost = readLocationClueInvestigationCost(deckInvestigationDraft, placedLocationId, clue.id);
+        badges.push(cost.mode === 'free' ? '조사권 무료' : `조사권 ${Math.max(1, cost.tokenCost)}개`);
+      }
+      return badges;
+    },
+    [configJson, deckInvestigationDraft, getClueLocationContext, isDeckInvestigationEnabled],
+  );
+  const saveDetailBody = useCallback(
+    (body: ClueDetailAutosaveBody, opts?: { onError?: (error?: unknown) => void }) => {
+      const saveOperations =
+        (body.rowBody ? 1 : 0) + (body.nextConfig && onConfigChange ? 1 : 0);
+      if (saveOperations === 0) return;
+
+      toast.loading('단서 자동저장 중...', { id: CLUE_AUTOSAVE_TOAST_ID });
+
+      let remaining = saveOperations;
+      let failed = false;
+      const markSuccess = () => {
+        if (failed) return;
+        remaining -= 1;
+        if (remaining === 0) {
+          toast.success('단서가 자동저장되었습니다', {
+            id: CLUE_AUTOSAVE_TOAST_ID,
+            duration: 1200,
+          });
+        }
+      };
+      const markError = (error?: unknown) => {
+        if (failed) return;
+        failed = true;
+        opts?.onError?.(error);
+      };
+
+      if (body.rowBody) {
+        onUpdate(body.clueId, body.rowBody, {
+          onSuccess: markSuccess,
+          onError: markError,
+        });
+      }
+      if (body.nextConfig && onConfigChange) {
+        onConfigChange(body.nextConfig, {
+          onSuccess: markSuccess,
+          onError: markError,
+        });
+      }
+    },
+    [onConfigChange, onUpdate],
+  );
+
+  const showFailureToast = useCallback((body: ClueDetailAutosaveBody | null) => {
+    toast.error('단서 자동저장에 실패했습니다', {
+      id: CLUE_AUTOSAVE_TOAST_ID,
+      duration: 6000,
+      action: body
+        ? {
+            label: '재시도',
+            onClick: () => {
+              saveDetailBody(body, {
+                onError: () => showFailureToast(body),
+              });
+            },
+          }
+        : undefined,
+    });
+  }, [saveDetailBody]);
+
+  const { schedule, flush } = useDebouncedMutation<ClueDetailAutosaveBody>({
+    debounceMs: CLUE_DETAIL_AUTOSAVE_MS,
+    mutate: (body, opts) => {
+      saveDetailBody(body, {
+        onError: (error) => {
+          opts.onError(error);
+          showFailureToast(body);
+        },
+      });
+    },
+  });
+
+  const buildAutosaveBody = useCallback(
+    (clue: ClueResponse): ClueDetailAutosaveBody | null => {
       const basicRequest = basicInfoRef.current?.getSaveRequest();
       const runtimeRequest = runtimeEffectRef.current?.getSaveRequest();
-      if (!basicRequest?.valid || !runtimeRequest?.valid) return;
-      if (!basicRequest.dirty && !runtimeRequest.dirty) return;
-
-      if (basicRequest.rowDirty && basicRequest.body) {
-        onUpdate(clue.id, basicRequest.body);
-      }
+      if (!basicRequest?.valid || !runtimeRequest?.valid) return null;
+      if (!basicRequest.dirty && !runtimeRequest.dirty) return null;
 
       let nextConfig = configJson ?? {};
       let shouldSaveConfig = false;
@@ -124,64 +245,123 @@ export function ClueEntityWorkspace({
         nextConfig = runtimeRequest.writeConfig(nextConfig);
         shouldSaveConfig = true;
       }
-      if (shouldSaveConfig) {
-        onConfigChange?.(nextConfig);
-      }
+
+      const body = {
+        clueId: clue.id,
+        rowBody: basicRequest.rowDirty ? basicRequest.body : null,
+        nextConfig: shouldSaveConfig ? nextConfig : null,
+      };
+      return body.rowBody || body.nextConfig ? body : null;
     },
-    [configJson, onConfigChange, onUpdate],
+    [configJson],
   );
+
+  const scheduleAutosave = useCallback(
+    (clue: ClueResponse) => {
+      if (!basicInfoState.valid || !runtimeEffectState.valid) return;
+      if (!basicInfoState.dirty && !runtimeEffectState.dirty) return;
+      const body = buildAutosaveBody(clue);
+      if (!body) return;
+      schedule(body);
+    },
+    [basicInfoState, buildAutosaveBody, runtimeEffectState, schedule],
+  );
+
+  const selectedClue = clues.find((clue) => clue.id === selectedId) ?? clues[0];
+  useEffect(() => {
+    if (!selectedClue) return;
+    scheduleAutosave(selectedClue);
+  }, [draftRevision, scheduleAutosave, selectedClue]);
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      flush();
+      setSelectedId(id);
+    },
+    [flush],
+  );
+
+  const handleFlushAutosave = useCallback(() => {
+    if (
+      selectedClue &&
+      basicInfoState.valid &&
+      runtimeEffectState.valid &&
+      (basicInfoState.dirty || runtimeEffectState.dirty)
+    ) {
+      const body = buildAutosaveBody(selectedClue);
+      if (body) {
+        schedule(body);
+      }
+    }
+    flush();
+  }, [basicInfoState, buildAutosaveBody, flush, runtimeEffectState, schedule, selectedClue]);
+
+  const handleBasicInfoStateChange = useCallback((state: ClueBasicInfoDraftState) => {
+    setDraftRevision((revision) => revision + 1);
+    setBasicInfoState((current) =>
+      current.dirty === state.dirty && current.valid === state.valid ? current : state,
+    );
+  }, []);
+  const handleRuntimeEffectStateChange = useCallback((state: ClueRuntimeEffectDraftState) => {
+    setDraftRevision((revision) => revision + 1);
+    setRuntimeEffectState((current) =>
+      current.dirty === state.dirty && current.valid === state.valid ? current : state,
+    );
+  }, []);
 
   return (
     <EntityEditorShell
       title="단서"
       items={clues}
       selectedId={selectedId}
-      onSelect={setSelectedId}
+      onSelect={handleSelect}
       onCreate={onCreate}
       getItemId={(clue) => clue.id}
       getItemTitle={(clue) => clue.name}
-      getItemDescription={(clue) => clue.description || '설명 없음'}
-      getItemBadges={(clue) => buildClueBadges(clue, usageMap[clue.id]?.references.length ?? 0)}
-      renderDetail={(clue) => (
-        <div className="space-y-4">
-          <div className="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-950/70 p-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p className="text-sm font-semibold text-slate-100">단서 상세 저장</p>
-              <p className="mt-1 text-xs leading-5 text-slate-500">
-                기본 정보와 사용 설정을 한 번에 저장합니다.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => handleSaveDetail(clue)}
-              disabled={!canSaveDetail}
-              className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-100 hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:border-slate-800 disabled:bg-transparent disabled:text-slate-600"
-            >
-              <Save className="h-4 w-4" />
-              {isSaving ? '저장 중' : '단서 저장'}
-            </button>
+      getItemDescription={() => ''}
+      getItemSearchText={(clue) => clue.description ?? ''}
+      getItemBadges={buildListBadges}
+      renderDetail={(clue) => {
+        const { placedLocationId, locationName } = getClueLocationContext(clue);
+        const discovery = placedLocationId
+          ? readLocationDiscoveries(configJson, placedLocationId).find((item) => item.clueId === clue.id)
+          : undefined;
+        return (
+          <div className="space-y-4">
+            <ClueBasicInfoCard
+              ref={basicInfoRef}
+              themeId={themeId ?? ''}
+              clue={clue}
+              configJson={configJson}
+              isSaving={isClueSaving}
+              isConfigSaving={isConfigSaving}
+              sceneOptions={sceneOptions}
+              investigationSettings={{
+                enabled: isDeckInvestigationEnabled,
+                tokens: deckInvestigationDraft.tokens,
+                cost: placedLocationId
+                  ? readLocationClueInvestigationCost(deckInvestigationDraft, placedLocationId, clue.id)
+                  : null,
+                locationId: placedLocationId,
+                locationName,
+                requiredClueIds: discovery?.requiredClueIds ?? [],
+              }}
+              onDelete={onDelete}
+              onDraftStateChange={handleBasicInfoStateChange}
+              onAutoSaveFlush={handleFlushAutosave}
+            />
+            <ClueRuntimeEffectCard
+              ref={runtimeEffectRef}
+              clue={clue}
+              clues={clues}
+              configJson={configJson}
+              isPlayerKillEnabled={isPlayerKillEnabled}
+              onDraftStateChange={handleRuntimeEffectStateChange}
+              onAutoSaveFlush={handleFlushAutosave}
+            />
           </div>
-          <ClueBasicInfoCard
-            ref={basicInfoRef}
-            themeId={themeId ?? ''}
-            clue={clue}
-            configJson={configJson}
-            isSaving={isClueSaving}
-            isConfigSaving={isConfigSaving}
-            sceneOptions={sceneOptions}
-            onDelete={onDelete}
-            onDraftStateChange={handleBasicInfoStateChange}
-          />
-          <ClueRuntimeEffectCard
-            ref={runtimeEffectRef}
-            clue={clue}
-            clues={clues}
-            configJson={configJson}
-            isPlayerKillEnabled={isPlayerKillEnabled}
-            onDraftStateChange={handleRuntimeEffectStateChange}
-          />
-        </div>
-      )}
+        );
+      }}
       renderInspector={(clue) => <ClueUsageCard references={getClueBacklinks(usageMap, clue.id)} />}
     />
   );

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -21,6 +21,11 @@ import { ClueEntityWorkspace } from './ClueEntityWorkspace';
 import { useFlowGraph } from '@/features/editor/flowApi';
 import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
+interface ClueAutosaveOptions {
+  onSuccess?: () => void;
+  onError?: (error?: unknown) => void;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -53,12 +58,24 @@ export function ClueListView({ themeId }: ClueListViewProps) {
     setIsFormOpen(false);
   }
 
-  function handleUpdate(clueId: string, body: UpdateClueRequest) {
+  function handleUpdate(clueId: string, body: UpdateClueRequest, options?: ClueAutosaveOptions) {
     updateClue.mutate(
       { clueId, body },
       {
-        onSuccess: () => toast.success('단서가 수정되었습니다'),
-        onError: (err) => showUnknownErrorToast(err, '단서 수정에 실패했습니다'),
+        onSuccess: () => {
+          if (options?.onSuccess) {
+            options.onSuccess();
+            return;
+          }
+          toast.success('단서가 수정되었습니다');
+        },
+        onError: (err) => {
+          if (options?.onError) {
+            options.onError(err);
+            return;
+          }
+          showUnknownErrorToast(err, '단서 수정에 실패했습니다');
+        },
       }
     );
   }
@@ -77,10 +94,22 @@ export function ClueListView({ themeId }: ClueListViewProps) {
     });
   }
 
-  function handleConfigChange(nextConfig: EditorConfig) {
+  function handleConfigChange(nextConfig: EditorConfig, options?: ClueAutosaveOptions) {
     updateConfig.mutate(nextConfig, {
-      onSuccess: () => toast.success('단서 설정이 저장되었습니다'),
-      onError: () => toast.error('단서 설정 저장에 실패했습니다'),
+      onSuccess: () => {
+        if (options?.onSuccess) {
+          options.onSuccess();
+          return;
+        }
+        toast.success('단서 설정이 저장되었습니다');
+      },
+      onError: (err) => {
+        if (options?.onError) {
+          options.onError(err);
+          return;
+        }
+        toast.error('단서 설정 저장에 실패했습니다');
+      },
     });
   }
 

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
@@ -17,6 +17,7 @@ interface ClueRuntimeEffectCardProps {
   configJson: EditorConfig | null | undefined;
   isPlayerKillEnabled: boolean;
   onDraftStateChange?: (state: ClueRuntimeEffectDraftState) => void;
+  onAutoSaveFlush?: () => void;
 }
 
 interface DraftState {
@@ -223,6 +224,7 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
   configJson,
   isPlayerKillEnabled,
   onDraftStateChange,
+  onAutoSaveFlush,
 }, ref) {
   const savedEffect = useMemo(
     () => readClueItemEffect(configJson, clue.id),
@@ -293,10 +295,13 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
 
   useEffect(() => {
     onDraftStateChange?.({ dirty, valid });
-  }, [dirty, onDraftStateChange, valid]);
+  }, [dirty, draftEffect, onDraftStateChange, valid]);
 
   return (
-    <section className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+    <section
+      className="rounded-xl border border-slate-800 bg-slate-950/70 p-4"
+      onBlurCapture={onAutoSaveFlush}
+    >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/70">

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -22,12 +22,14 @@ import {
   writeLocationClueInvestigationCost,
   type InvestigationCostDraft,
 } from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
+import { getLocationPathLabel } from '@/features/editor/entities/location/locationHierarchy';
 import { LocationSelectedClueItem } from './LocationSelectedClueItem';
 
 interface LocationClueAssignPanelProps {
   themeId: string;
   theme: EditorThemeResponse;
   location: LocationResponse;
+  allLocations?: LocationResponse[];
   allClues?: ClueResponse[];
   onChange?: (clueIds: string[]) => void;
 }
@@ -46,6 +48,7 @@ export function LocationClueAssignPanel({
   themeId,
   theme,
   location,
+  allLocations,
   allClues,
   onChange,
 }: LocationClueAssignPanelProps) {
@@ -81,6 +84,10 @@ export function LocationClueAssignPanel({
   const clueById = useMemo(() => new Map(clues.map((clue) => [clue.id, clue])), [clues]);
   const selectedClues = clues.filter((clue) => assignedSet.has(clue.id));
   const activeClue = selectedClues.find((clue) => clue.id === activeClueId) ?? selectedClues[0] ?? null;
+  const locationPathLabel = useMemo(
+    () => getLocationPathLabel(location, allLocations ?? [location]),
+    [allLocations, location]
+  );
   const visibleClues = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return clues;
@@ -154,7 +161,7 @@ export function LocationClueAssignPanel({
     const nextDeckDraft = clue
       ? writeLocationClueInvestigationCost(currentInvestigationDraft, {
           locationId: location.id,
-          locationName: location.name,
+          locationName: locationPathLabel,
           clueId,
           clueName: clue.name,
           requiredClueIds: [],
@@ -214,7 +221,7 @@ export function LocationClueAssignPanel({
       discoveries,
       writeLocationClueInvestigationCost(investigationDraft, {
         locationId: location.id,
-        locationName: location.name,
+        locationName: locationPathLabel,
         clueId: clue.id,
         clueName: clue.name,
         requiredClueIds: discovery.requiredClueIds,
@@ -234,7 +241,7 @@ export function LocationClueAssignPanel({
   if (!allClues && isError) {
     return (
       <section
-        aria-label={`${location.name} 단서 조사`}
+        aria-label={`${locationPathLabel} 단서 조사`}
         className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-center text-xs text-red-100"
       >
         <p>단서 목록을 불러오지 못했습니다.</p>
@@ -251,12 +258,12 @@ export function LocationClueAssignPanel({
 
   return (
     <section
-      aria-label={`${location.name} 단서 조사`}
+      aria-label={`${locationPathLabel} 단서 조사`}
       className="rounded-lg border border-slate-800 bg-slate-950/70 p-3"
     >
       <header className="mb-3 flex flex-wrap items-center gap-2">
         <MapPin className="h-3.5 w-3.5 text-amber-500/70" />
-        <h4 className="text-sm font-semibold text-slate-200">{location.name} 단서 조사</h4>
+        <h4 className="text-sm font-semibold text-slate-200">{locationPathLabel} 단서 조사</h4>
         <span className="text-xs text-slate-600">
           ({assignedIds.length}/{clues.length})
         </span>

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -383,6 +383,7 @@ function SelectedLocationDetail({
         themeId={themeId}
         theme={theme}
         location={location}
+        allLocations={mapLocations}
         allClues={clues}
       />
     </div>

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -112,7 +112,7 @@ export function LocationDetailPanel({
 
   return (
     <>
-      <div className="grid h-full min-h-0 gap-4 lg:grid-cols-[minmax(16rem,0.32fr)_minmax(0,1fr)]">
+      <div className="grid min-h-0 gap-4 md:h-full md:grid-cols-[minmax(16rem,0.34fr)_minmax(0,1fr)] lg:grid-cols-[minmax(16rem,0.32fr)_minmax(0,1fr)]">
         <LocationHierarchyList
           locations={mapLocations}
           theme={theme}
@@ -125,7 +125,7 @@ export function LocationDetailPanel({
           renderAddChildInput={(parentId) => renderAddInput(parentId)}
           onMoveLocation={moveLocation}
         />
-        <div className="min-w-0">
+        <div className="min-w-0 md:min-h-0 md:overflow-y-auto">
           {selectedLocation ? (
             <SelectedLocationDetail
               themeId={themeId}

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
-import { GripVertical, MapPin, Trash2 } from 'lucide-react';
+import { GripVertical, MapPin } from 'lucide-react';
 import { toast } from 'sonner';
 import type { EditorThemeResponse, MapResponse, LocationResponse } from '@/features/editor/api';
 import { useEditorClues, useUpdateConfigJson, useUpdateLocation } from '@/features/editor/api';
@@ -15,11 +15,12 @@ import type { ProgressNodeRevealOption } from '@/features/editor/entities/reveal
 import { toLocationEditorViewModel } from '@/features/editor/entities/location/locationEntityAdapter';
 import { readLocationMeta } from '@/features/editor/utils/entityMeta';
 import { AddNameInput } from './AddNameInput';
-import { EntityEditorShell } from '@/features/editor/entities/shell/EntityEditorShell';
 import { ConfirmDialog } from '@/shared/components/ui';
 import { LocationAccessPolicyPanel } from './LocationAccessPolicyPanel';
 import { LocationClueAssignPanel } from './LocationClueAssignPanel';
+import { LocationHierarchyList } from './LocationHierarchyList';
 import { LocationImageMediaField } from './LocationImageMediaField';
+import { LocationStructurePanel } from './LocationStructurePanel';
 
 interface LocationDetailPanelProps {
   themeId: string;
@@ -28,11 +29,12 @@ interface LocationDetailPanelProps {
   selectedLocation: LocationResponse | null;
   mapLocations: LocationResponse[];
   sceneOptions?: ProgressNodeRevealOption[];
-  addingLocation: boolean;
+  addingLocationParentId: string | null | 'top';
   isCreatingLocation: boolean;
-  onStartAdd: () => void;
+  onStartAddTopLevel: () => void;
+  onStartAddChild: (parentId: string) => void;
   onCancelAdd: () => void;
-  onAddLocation: (name: string) => void;
+  onAddLocation: (name: string, parentLocationId?: string | null) => void;
   onSelectLocation: (locationId: string) => void;
   onDeleteLocation: (locationId: string) => void;
 }
@@ -50,9 +52,10 @@ export function LocationDetailPanel({
   selectedLocation,
   mapLocations,
   sceneOptions = [],
-  addingLocation,
+  addingLocationParentId,
   isCreatingLocation,
-  onStartAdd,
+  onStartAddTopLevel,
+  onStartAddChild,
   onCancelAdd,
   onAddLocation,
   onSelectLocation,
@@ -60,67 +63,84 @@ export function LocationDetailPanel({
 }: LocationDetailPanelProps) {
   const [pendingDeleteLocation, setPendingDeleteLocation] =
     useState<LocationResponse | null>(null);
+  const updateLocation = useUpdateLocation(themeId);
 
   if (!selectedMap) return <LocationEmptyState message="좌측에서 맵을 선택하세요" />;
 
+  function renderAddInput(parentId: string | null | 'top') {
+    if (addingLocationParentId !== parentId) return null;
+    const parentLocationId = parentId === 'top' ? null : parentId;
+    return (
+      <div className="mb-3 rounded-md border border-amber-500/30 bg-slate-900 p-2">
+        <AddNameInput
+          placeholder={parentLocationId ? '하위장소 이름' : '장소 이름'}
+          onAdd={(name) => onAddLocation(name, parentLocationId)}
+          onCancel={onCancelAdd}
+          isPending={isCreatingLocation}
+        />
+      </div>
+    );
+  }
+
+  function moveLocation(locationId: string, parentLocationId: string | null, sortOrder: number) {
+    const target = mapLocations.find((candidate) => candidate.id === locationId);
+    if (!target) return;
+    updateLocation.mutate(
+      {
+        locationId,
+        body: {
+          name: target.name,
+          restricted_characters: target.restricted_characters,
+          image_url: target.image_url,
+          public_description: target.public_description ?? null,
+          entry_message: target.entry_message ?? null,
+          parent_location_id: parentLocationId,
+          sort_order: sortOrder,
+          appearance_scene_id: target.appearance_scene_id ?? null,
+          hide_scene_id: target.hide_scene_id ?? null,
+          ...(target.image_media_id !== undefined
+            ? { image_media_id: target.image_media_id ?? null }
+            : {}),
+        },
+      },
+      {
+        onSuccess: () => toast.success('장소 위치가 저장되었습니다'),
+        onError: () => toast.error('장소 위치 저장에 실패했습니다'),
+      }
+    );
+  }
+
   return (
     <>
-      <EntityEditorShell
-        title="장소"
-        items={mapLocations}
-        selectedId={selectedLocation?.id}
-        onSelect={onSelectLocation}
-        onCreate={onStartAdd}
-        createLabel="장소 추가"
-        emptyMessage="장소 없음"
-        emptyDescription="이 맵에 배치할 장소를 추가하세요."
-        listAccessory={
-          addingLocation ? (
-            <div className="mb-3 rounded-md border border-amber-500/30 bg-slate-900 p-2">
-              <AddNameInput
-                placeholder="장소 이름"
-                onAdd={onAddLocation}
-                onCancel={onCancelAdd}
-                isPending={isCreatingLocation}
-              />
-            </div>
-          ) : null
-        }
-        getItemId={(location) => location.id}
-        getItemTitle={(location) => location.name}
-        getItemDescription={(location) =>
-          toLocationEditorViewModel(location, {
-            clueCount: readLocationClueIds(theme.config_json, location.id).length,
-            mapName: selectedMap.name,
-          }).roundLabel
-        }
-        getItemBadges={(location) =>
-          toLocationEditorViewModel(location, {
-            clueCount: readLocationClueIds(theme.config_json, location.id).length,
-            mapName: selectedMap.name,
-          }).badges
-        }
-        renderItemActions={(location) => (
-          <button
-            type="button"
-            onClick={() => setPendingDeleteLocation(location)}
-            aria-label={`${location.name} 삭제`}
-            className="rounded-md p-2 text-slate-700 opacity-100 transition hover:bg-red-950/40 hover:text-red-300 md:opacity-0 md:group-hover:opacity-100"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </button>
-        )}
-        renderDetail={(location) => (
-          <SelectedLocationDetail
-            themeId={themeId}
-            theme={theme}
-            map={selectedMap}
-            location={location}
-            mapLocations={mapLocations}
-            sceneOptions={sceneOptions}
-          />
-        )}
-      />
+      <div className="grid h-full min-h-0 gap-4 lg:grid-cols-[minmax(16rem,0.32fr)_minmax(0,1fr)]">
+        <LocationHierarchyList
+          locations={mapLocations}
+          theme={theme}
+          selectedId={selectedLocation?.id}
+          onSelect={onSelectLocation}
+          onDelete={setPendingDeleteLocation}
+          onStartAddTopLevel={onStartAddTopLevel}
+          onStartAddChild={onStartAddChild}
+          renderAddTopLevelInput={() => renderAddInput('top')}
+          renderAddChildInput={(parentId) => renderAddInput(parentId)}
+          onMoveLocation={moveLocation}
+        />
+        <div className="min-w-0">
+          {selectedLocation ? (
+            <SelectedLocationDetail
+              themeId={themeId}
+              theme={theme}
+              map={selectedMap}
+              location={selectedLocation}
+              mapLocations={mapLocations}
+              sceneOptions={sceneOptions}
+              onStartAddChild={onStartAddChild}
+            />
+          ) : (
+            <LocationEmptyState message="장소를 선택하세요" compact />
+          )}
+        </div>
+      </div>
       <ConfirmDialog
         isOpen={pendingDeleteLocation != null}
         title="장소를 삭제할까요?"
@@ -144,6 +164,7 @@ function SelectedLocationDetail({
   location,
   mapLocations,
   sceneOptions,
+  onStartAddChild,
 }: {
   themeId: string;
   theme: EditorThemeResponse;
@@ -151,6 +172,7 @@ function SelectedLocationDetail({
   location: LocationResponse;
   mapLocations: LocationResponse[];
   sceneOptions: ProgressNodeRevealOption[];
+  onStartAddChild: (parentId: string) => void;
 }) {
   const updateLocation = useUpdateLocation(themeId);
   const updateConfig = useUpdateConfigJson(themeId);
@@ -229,7 +251,10 @@ function SelectedLocationDetail({
       image_url: nextImageUrl,
       public_description: patch.public_description ?? location.public_description ?? null,
       entry_message: patch.entry_message ?? location.entry_message ?? null,
-      parent_location_id: null,
+      parent_location_id:
+        patch.parent_location_id !== undefined
+          ? patch.parent_location_id
+          : (location.parent_location_id ?? null),
       sort_order: patch.sort_order ?? location.sort_order,
       appearance_scene_id: nextAppearanceSceneId,
       hide_scene_id: nextHideSceneId,
@@ -321,6 +346,21 @@ function SelectedLocationDetail({
               setAppearanceSceneId={setAppearanceSceneId}
               setHideSceneId={setHideSceneId}
               onCommit={saveLocation}
+            />
+            <LocationStructurePanel
+              location={location}
+              locations={mapLocations}
+              isSaving={updateLocation.isPending}
+              onStartAddChild={onStartAddChild}
+              onChangeParent={(parentLocationId) =>
+                saveLocation(
+                  { parent_location_id: parentLocationId },
+                  {
+                    onSuccess: () => toast.success('장소 구조가 저장되었습니다'),
+                    onErrorMessage: '장소 구조 저장에 실패했습니다',
+                  }
+                )
+              }
             />
             <LocationInvestigationStructurePanel
               location={location}

--- a/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
+++ b/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
@@ -62,7 +62,7 @@ export function LocationHierarchyList({
   return (
     <section
       aria-label="장소 목록"
-      className="flex min-h-0 flex-col rounded-xl border border-slate-800 bg-slate-950/70 p-3"
+      className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-slate-800 bg-slate-950/70 p-3"
     >
       <header className="mb-3 flex items-center justify-between gap-2">
         <div>

--- a/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
+++ b/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
@@ -1,0 +1,258 @@
+import { useMemo, useState, type DragEventHandler, type ReactNode } from 'react';
+import { GripVertical, Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import type { EditorThemeResponse, LocationResponse } from '@/features/editor/api';
+import {
+  buildLocationHierarchy,
+  buildLocationMovePatch,
+  getLocationPathLabel,
+  validateLocationDrop,
+} from '@/features/editor/entities/location/locationHierarchy';
+import { readLocationClueIds } from '@/features/editor/editorTypes';
+
+interface LocationHierarchyListProps {
+  locations: LocationResponse[];
+  theme: EditorThemeResponse;
+  selectedId?: string | null;
+  onSelect: (locationId: string) => void;
+  onDelete: (location: LocationResponse) => void;
+  onStartAddTopLevel: () => void;
+  onStartAddChild: (parentId: string) => void;
+  renderAddTopLevelInput: () => ReactNode;
+  renderAddChildInput: (parentId: string) => ReactNode;
+  onMoveLocation: (locationId: string, parentLocationId: string | null, sortOrder: number) => void;
+}
+
+export function LocationHierarchyList({
+  locations,
+  theme,
+  selectedId,
+  onSelect,
+  onDelete,
+  onStartAddTopLevel,
+  onStartAddChild,
+  renderAddTopLevelInput,
+  renderAddChildInput,
+  onMoveLocation,
+}: LocationHierarchyListProps) {
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const clueCounts = useMemo(
+    () =>
+      Object.fromEntries(
+        locations.map((location) => [
+          location.id,
+          readLocationClueIds(theme.config_json, location.id).length,
+        ])
+      ),
+    [locations, theme.config_json]
+  );
+  const tree = useMemo(() => buildLocationHierarchy(locations, clueCounts), [locations, clueCounts]);
+
+  function dropLocation(draggedId: string | null, targetParentId: string | null, targetIndex: number) {
+    if (!draggedId) return;
+    const validation = validateLocationDrop({ locations, draggedId, targetParentId });
+    if (!validation.ok) {
+      toast.error(dropErrorMessage(validation.reason));
+      return;
+    }
+    const patch = buildLocationMovePatch({ locations, draggedId, targetParentId, targetIndex });
+    onMoveLocation(draggedId, patch.parent_location_id, patch.sort_order);
+  }
+
+  return (
+    <section
+      aria-label="장소 목록"
+      className="flex min-h-0 flex-col rounded-xl border border-slate-800 bg-slate-950/70 p-3"
+    >
+      <header className="mb-3 flex items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-100">장소 목록</h3>
+          <p className="text-xs text-slate-500">부모/하위 장소 모두 단서를 배치할 수 있습니다.</p>
+        </div>
+        <button
+          type="button"
+          onClick={onStartAddTopLevel}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-700 px-2.5 text-xs font-medium text-slate-300 transition hover:border-amber-500/50 hover:text-amber-100"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          장소 추가
+        </button>
+      </header>
+      <div
+        aria-label="최상위 장소 드롭 영역"
+        onDragEnter={(event) => event.preventDefault()}
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = 'move';
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          const sourceId = draggingId || event.dataTransfer.getData('text/plain');
+          dropLocation(sourceId, null, tree.length);
+          setDraggingId(null);
+        }}
+        className="mb-3 rounded-md border border-dashed border-slate-800 px-3 py-2 text-xs text-slate-500"
+      >
+        최상위로 이동
+      </div>
+      {renderAddTopLevelInput()}
+
+      {tree.length > 0 ? (
+        <div className="space-y-3">
+          {tree.map((node) => (
+            <div key={node.location.id} className="space-y-2">
+              <LocationCard
+                location={node.location}
+                label={node.location.name}
+                directClueCount={node.directClueCount}
+                childCount={node.children.length}
+                selected={selectedId === node.location.id}
+                draggable
+                onSelect={() => onSelect(node.location.id)}
+                onDelete={() => onDelete(node.location)}
+                onDragStart={(event) => {
+                  setDraggingId(node.location.id);
+                  event.dataTransfer.effectAllowed = 'move';
+                  event.dataTransfer.setData('text/plain', node.location.id);
+                }}
+                onDragEnd={() => setDraggingId(null)}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  const sourceId = draggingId || event.dataTransfer.getData('text/plain');
+                  dropLocation(sourceId, node.location.id, node.children.length);
+                  setDraggingId(null);
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => onStartAddChild(node.location.id)}
+                aria-label={`${node.location.name} 하위장소 추가`}
+                className="ml-2 inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-800 px-2.5 text-xs text-slate-400 transition hover:border-amber-500/50 hover:text-amber-100"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                하위 장소 추가
+              </button>
+              {renderAddChildInput(node.location.id)}
+              {node.children.length > 0 ? (
+                <div className="ml-5 space-y-2 border-l border-slate-800 pl-3">
+                  {node.children.map((child) => (
+                    <LocationCard
+                      key={child.location.id}
+                      location={child.location}
+                      label={getLocationPathLabel(child.location, locations)}
+                      directClueCount={child.directClueCount}
+                      childCount={0}
+                      selected={selectedId === child.location.id}
+                      draggable
+                      child
+                      onSelect={() => onSelect(child.location.id)}
+                      onDelete={() => onDelete(child.location)}
+                      onDragStart={(event) => {
+                        setDraggingId(child.location.id);
+                        event.dataTransfer.effectAllowed = 'move';
+                        event.dataTransfer.setData('text/plain', child.location.id);
+                      }}
+                      onDragEnd={() => setDraggingId(null)}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        const sourceId = draggingId || event.dataTransfer.getData('text/plain');
+                        dropLocation(sourceId, child.location.id, 0);
+                        setDraggingId(null);
+                      }}
+                    />
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="rounded-md border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-500">
+          장소 없음
+        </p>
+      )}
+    </section>
+  );
+}
+
+function LocationCard({
+  location,
+  label,
+  directClueCount,
+  childCount,
+  selected,
+  child = false,
+  draggable,
+  onSelect,
+  onDelete,
+  onDragStart,
+  onDragEnd,
+  onDrop,
+}: {
+  location: LocationResponse;
+  label: string;
+  directClueCount: number;
+  childCount: number;
+  selected: boolean;
+  child?: boolean;
+  draggable: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  onDragStart: DragEventHandler<HTMLDivElement>;
+  onDragEnd: () => void;
+  onDrop: DragEventHandler<HTMLDivElement>;
+}) {
+  return (
+    <div
+      aria-label={`${location.name} 드래그 영역`}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragEnter={(event) => event.preventDefault()}
+      onDragOver={(event) => {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+      }}
+      onDrop={onDrop}
+      className={`group rounded-lg border transition ${
+        selected
+          ? 'border-amber-400/60 bg-amber-500/10'
+          : child
+            ? 'border-slate-800 bg-slate-900/70 hover:border-slate-700'
+            : 'border-slate-700 bg-slate-900 hover:border-amber-500/40'
+      }`}
+    >
+      <div className="flex items-start gap-2 p-2.5">
+        <GripVertical className="mt-1 h-3.5 w-3.5 shrink-0 text-slate-600" aria-hidden="true" />
+        <button
+          type="button"
+          aria-label={`${label} 선택`}
+          onClick={onSelect}
+          className="min-w-0 flex-1 text-left"
+        >
+          <span className={`block truncate font-medium ${child ? 'text-sm' : 'text-base'} text-slate-100`}>
+            {location.name}
+          </span>
+          <span className="mt-1 block text-xs text-slate-500">
+            직접 배치 단서 {directClueCount}개 · 하위장소 {childCount}개
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          aria-label={`${location.name} 삭제`}
+          className="rounded-md p-2 text-slate-600 transition hover:bg-red-950/40 hover:text-red-300"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function dropErrorMessage(reason: string) {
+  if (reason === 'grandchild') return '하위장소 아래에는 장소를 넣을 수 없습니다';
+  if (reason === 'child-parent') return '하위장소가 있는 장소는 다른 장소 아래로 옮길 수 없습니다';
+  if (reason === 'self') return '자기 자신 아래로 옮길 수 없습니다';
+  return '장소 이동을 할 수 없습니다';
+}

--- a/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
+++ b/apps/web/src/features/editor/components/design/LocationImageMediaField.tsx
@@ -78,7 +78,7 @@ export function LocationImageMediaField({
           className={
             compact
               ? 'shrink-0 rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-1.5 text-xs text-slate-400 hover:border-amber-500/50 hover:text-slate-200'
-              : 'flex aspect-[16/10] w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200'
+              : 'flex aspect-[16/10] max-h-60 min-h-28 w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200'
           }
         >
           {emptyLabel}

--- a/apps/web/src/features/editor/components/design/LocationStructurePanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationStructurePanel.tsx
@@ -1,0 +1,65 @@
+import { Plus } from 'lucide-react';
+import type { LocationResponse } from '@/features/editor/api';
+import { buildLocationParentOptions } from '@/features/editor/entities/location/locationHierarchy';
+
+interface LocationStructurePanelProps {
+  location: LocationResponse;
+  locations: LocationResponse[];
+  onChangeParent: (parentLocationId: string | null) => void;
+  onStartAddChild: (parentId: string) => void;
+  isSaving: boolean;
+}
+
+export function LocationStructurePanel({
+  location,
+  locations,
+  onChangeParent,
+  onStartAddChild,
+  isSaving,
+}: LocationStructurePanelProps) {
+  const options = buildLocationParentOptions(location.id, locations);
+  const selectedParentId = location.parent_location_id ?? '';
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <p className="text-xs font-semibold text-slate-300">장소 구조</p>
+        {location.parent_location_id ? (
+          <button
+            type="button"
+            onClick={() => onChangeParent(null)}
+            disabled={isSaving}
+            className="rounded-md border border-slate-700 px-2.5 py-1.5 text-xs text-slate-300 transition hover:border-amber-500/50 hover:text-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            최상위로 이동
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onStartAddChild(location.id)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-slate-700 px-2.5 py-1.5 text-xs text-slate-300 transition hover:border-amber-500/50 hover:text-amber-100"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {location.name} 하위장소 추가
+          </button>
+        )}
+      </div>
+      <label className="text-xs text-slate-500">
+        상위 장소
+        <select
+          aria-label={`${location.name} 상위 장소`}
+          value={selectedParentId}
+          onChange={(event) => onChangeParent(event.target.value || null)}
+          disabled={isSaving}
+          className="mt-1 h-9 w-full rounded-md border border-slate-700 bg-slate-950 px-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {options.map((option) => (
+            <option key={option.id ?? 'top'} value={option.id ?? ''}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </section>
+  );
+}

--- a/apps/web/src/features/editor/components/design/LocationStructurePanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationStructurePanel.tsx
@@ -1,6 +1,10 @@
 import { Plus } from 'lucide-react';
+import { toast } from 'sonner';
 import type { LocationResponse } from '@/features/editor/api';
-import { buildLocationParentOptions } from '@/features/editor/entities/location/locationHierarchy';
+import {
+  buildLocationParentOptions,
+  validateLocationDrop,
+} from '@/features/editor/entities/location/locationHierarchy';
 
 interface LocationStructurePanelProps {
   location: LocationResponse;
@@ -20,6 +24,19 @@ export function LocationStructurePanel({
   const options = buildLocationParentOptions(location.id, locations);
   const selectedParentId = location.parent_location_id ?? '';
 
+  function handleChangeParent(parentLocationId: string | null) {
+    const validation = validateLocationDrop({
+      locations,
+      draggedId: location.id,
+      targetParentId: parentLocationId,
+    });
+    if (!validation.ok) {
+      toast.error(locationStructureErrorMessage(validation.reason));
+      return;
+    }
+    onChangeParent(parentLocationId);
+  }
+
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
       <div className="mb-3 flex items-center justify-between gap-2">
@@ -27,7 +44,7 @@ export function LocationStructurePanel({
         {location.parent_location_id ? (
           <button
             type="button"
-            onClick={() => onChangeParent(null)}
+            onClick={() => handleChangeParent(null)}
             disabled={isSaving}
             className="rounded-md border border-slate-700 px-2.5 py-1.5 text-xs text-slate-300 transition hover:border-amber-500/50 hover:text-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
           >
@@ -49,7 +66,7 @@ export function LocationStructurePanel({
         <select
           aria-label={`${location.name} 상위 장소`}
           value={selectedParentId}
-          onChange={(event) => onChangeParent(event.target.value || null)}
+          onChange={(event) => handleChangeParent(event.target.value || null)}
           disabled={isSaving}
           className="mt-1 h-9 w-full rounded-md border border-slate-700 bg-slate-950 px-2 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 disabled:cursor-not-allowed disabled:opacity-60"
         >
@@ -62,4 +79,11 @@ export function LocationStructurePanel({
       </label>
     </section>
   );
+}
+
+function locationStructureErrorMessage(reason: string) {
+  if (reason === 'grandchild') return '하위장소 아래에는 장소를 넣을 수 없습니다';
+  if (reason === 'child-parent') return '하위장소가 있는 장소는 다른 장소 아래로 옮길 수 없습니다';
+  if (reason === 'self') return '자기 자신 아래로 옮길 수 없습니다';
+  return '장소 구조를 변경할 수 없습니다';
 }

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -42,7 +42,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   const [selectedMapId, setSelectedMapId] = useState<string | null>(null);
   const [selectedLocationId, setSelectedLocationId] = useState<string | null>(null);
   const [addingMap, setAddingMap] = useState(false);
-  const [addingLocation, setAddingLocation] = useState(false);
+  const [addingLocationParentId, setAddingLocationParentId] = useState<string | null | 'top'>(null);
   const [pendingDeleteMapId, setPendingDeleteMapId] = useState<string | null>(null);
 
   const effectiveSelectedMapId = selectedMapId ?? maps?.[0]?.id ?? null;
@@ -90,14 +90,14 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
     });
   }
 
-  function handleAddLocation(name: string) {
+  function handleAddLocation(name: string, parentLocationId: string | null = null) {
     if (!effectiveSelectedMapId) return;
     createLocation.mutate(
-      { mapId: effectiveSelectedMapId, body: { name } },
+      { mapId: effectiveSelectedMapId, body: { name, parent_location_id: parentLocationId } },
       {
         onSuccess: (newLocation) => {
           toast.success('장소가 추가되었습니다');
-          setAddingLocation(false);
+          setAddingLocationParentId(null);
           setSelectedLocationId(newLocation.id);
         },
         onError: () => toast.error('장소 추가에 실패했습니다'),
@@ -155,10 +155,11 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           selectedLocation={selectedLocation}
           mapLocations={mapLocations}
           sceneOptions={sceneOptions}
-          addingLocation={addingLocation}
+          addingLocationParentId={addingLocationParentId}
           isCreatingLocation={createLocation.isPending}
-          onStartAdd={() => setAddingLocation(true)}
-          onCancelAdd={() => setAddingLocation(false)}
+          onStartAddTopLevel={() => setAddingLocationParentId('top')}
+          onStartAddChild={(parentId) => setAddingLocationParentId(parentId)}
+          onCancelAdd={() => setAddingLocationParentId(null)}
           onAddLocation={handleAddLocation}
           onSelectLocation={setSelectedLocationId}
           onDeleteLocation={handleDeleteLocation}

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -153,6 +153,33 @@ describe('LocationClueAssignPanel', () => {
     expect(screen.getByText('(1/2)')).toBeDefined();
   });
 
+  it('하위장소는 부모 경로를 포함한 단서 조사 라벨로 표시한다', () => {
+    const parentLocation: LocationResponse = {
+      ...mockLocation,
+      id: 'loc-parent',
+      name: '거실',
+      parent_location_id: null,
+    };
+    const childLocation: LocationResponse = {
+      ...mockLocation,
+      id: 'loc-child',
+      name: '금고',
+      parent_location_id: 'loc-parent',
+    };
+
+    renderQC(
+      <LocationClueAssignPanel
+        themeId="theme-1"
+        theme={baseTheme}
+        location={childLocation}
+        allLocations={[parentLocation, childLocation]}
+      />
+    );
+
+    expect(screen.getByLabelText('거실 / 금고 단서 조사')).toBeDefined();
+    expect(screen.getByText('거실 / 금고 단서 조사')).toBeDefined();
+  });
+
   it('배정된 clue는 전체 목록에서 비활성화되고 우측 목록에 표시된다', () => {
     const theme: EditorThemeResponse = {
       ...baseTheme,

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -239,6 +239,24 @@ describe('LocationsSubTab', () => {
       );
     });
 
+    it('자식이 있는 부모 장소는 구조 패널로 다른 부모 밑에 넣을 수 없다', () => {
+      useEditorLocationsMock.mockReturnValue({
+        data: [
+          { ...baseLocation('loc-parent', '거실'), parent_location_id: null },
+          { ...baseLocation('loc-child', '프런트'), parent_location_id: 'loc-parent' },
+          { ...baseLocation('loc-target', '주방'), parent_location_id: null },
+        ],
+        isLoading: false,
+      });
+      renderLocationsSubTab();
+
+      fireEvent.change(screen.getByRole('combobox', { name: '거실 상위 장소' }), {
+        target: { value: 'loc-target' },
+      });
+
+      expect(updateLocationMutateMock).not.toHaveBeenCalled();
+    });
+
     it('드래그앤드롭으로 부모 장소 아래 이동 시 parent_location_id payload를 저장한다', () => {
       renderLocationsSubTab();
       const dataTransfer = createDataTransfer();
@@ -250,6 +268,29 @@ describe('LocationsSubTab', () => {
         expect.objectContaining({
           locationId: 'loc-2',
           body: expect.objectContaining({ parent_location_id: 'loc-1' }),
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('드래그앤드롭으로 하위장소를 최상위로 이동하면 parent_location_id null을 저장한다', () => {
+      useEditorLocationsMock.mockReturnValue({
+        data: [
+          { ...baseLocation('loc-parent', '거실'), parent_location_id: null },
+          { ...baseLocation('loc-child', '프런트'), parent_location_id: 'loc-parent' },
+        ],
+        isLoading: false,
+      });
+      renderLocationsSubTab();
+      const dataTransfer = createDataTransfer();
+
+      fireEvent.dragStart(screen.getByLabelText('프런트 드래그 영역'), { dataTransfer });
+      fireEvent.drop(screen.getByLabelText('최상위 장소 드롭 영역'), { dataTransfer });
+
+      expect(updateLocationMutateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          locationId: 'loc-child',
+          body: expect.objectContaining({ parent_location_id: null }),
         }),
         expect.any(Object)
       );

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -5,12 +5,13 @@ import {
   renderLocationsSubTab,
   setupDefaultMocks,
   updateConfigMutateMock,
+  updateLocationMutateMock,
   useEditorLocationsMock,
   useEditorMapsMock,
   useMediaListMock,
 } from './locationsSubTabTestUtils';
 import { writeLocationDiscoveries } from '@/features/editor/editorTypes';
-import { mockTheme } from './locationsSubTabTestUtils';
+import { baseLocation, mockTheme } from './locationsSubTabTestUtils';
 
 describe('LocationsSubTab', () => {
   describe('로딩 상태', () => {
@@ -107,11 +108,11 @@ describe('LocationsSubTab', () => {
       expect(screen.getAllByText('거실').length).toBeGreaterThan(0);
     });
 
-    it('장소 상세에서 하위장소 설정을 표시하지 않는다', () => {
+    it('장소 상세에서 장소 구조 설정을 표시한다', () => {
       renderLocationsSubTab();
 
-      expect(screen.queryByText('장소 구조')).toBeNull();
-      expect(screen.queryByText('부모 장소')).toBeNull();
+      expect(screen.getByText('장소 구조')).toBeDefined();
+      expect(screen.getByRole('combobox', { name: '거실 상위 장소' })).toBeDefined();
       expect(screen.queryByText(/하위 조사 항목/)).toBeNull();
       expect(screen.queryByText(/2단계/)).toBeNull();
       expect(screen.getByText('소속 맵: 저택 1층')).toBeDefined();
@@ -153,6 +154,26 @@ describe('LocationsSubTab', () => {
       expect(screen.getByText('장소 없음')).toBeDefined();
     });
 
+    it('부모 장소 아래에 하위장소를 들여쓰기 카드로 표시한다', () => {
+      useEditorLocationsMock.mockReturnValue({
+        data: [
+          { ...baseLocation('loc-parent', '호텔 로비'), sort_order: 0, parent_location_id: null },
+          {
+            ...baseLocation('loc-child', '프런트 데스크'),
+            sort_order: 0,
+            parent_location_id: 'loc-parent',
+          },
+        ],
+        isLoading: false,
+      });
+
+      renderLocationsSubTab();
+
+      expect(screen.getByRole('button', { name: '호텔 로비 선택' })).toBeDefined();
+      expect(screen.getByRole('button', { name: '호텔 로비 / 프런트 데스크 선택' })).toBeDefined();
+      expect(screen.getByText('직접 배치 단서 0개 · 하위장소 1개')).toBeDefined();
+    });
+
     it('장소가 없는 맵에서도 장소 추가 입력을 표시한다', () => {
       useEditorLocationsMock.mockReturnValue({ data: [], isLoading: false });
       renderLocationsSubTab();
@@ -184,9 +205,72 @@ describe('LocationsSubTab', () => {
       fireEvent.change(input, { target: { value: '서재' } });
       fireEvent.keyDown(input, { key: 'Enter' });
       expect(mutateMock).toHaveBeenCalledWith(
-        { mapId: 'map-1', body: { name: '서재' } },
+        { mapId: 'map-1', body: { name: '서재', parent_location_id: null } },
         expect.any(Object)
       );
+    });
+
+    it('부모 카드의 하위장소 추가 버튼은 parent_location_id를 담아 createLocation을 호출한다', () => {
+      renderLocationsSubTab();
+      fireEvent.click(screen.getAllByRole('button', { name: '거실 하위장소 추가' })[0]);
+      const input = screen.getByPlaceholderText('하위장소 이름');
+      fireEvent.change(input, { target: { value: '금고 앞' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(mutateMock).toHaveBeenCalledWith(
+        { mapId: 'map-1', body: { name: '금고 앞', parent_location_id: 'loc-1' } },
+        expect.any(Object)
+      );
+    });
+
+    it('장소 구조 패널에서 상위 장소를 바꾸면 parent_location_id를 저장한다', () => {
+      renderLocationsSubTab();
+
+      fireEvent.change(screen.getByRole('combobox', { name: '거실 상위 장소' }), {
+        target: { value: 'loc-2' },
+      });
+
+      expect(updateLocationMutateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          locationId: 'loc-1',
+          body: expect.objectContaining({ parent_location_id: 'loc-2' }),
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('드래그앤드롭으로 부모 장소 아래 이동 시 parent_location_id payload를 저장한다', () => {
+      renderLocationsSubTab();
+      const dataTransfer = createDataTransfer();
+
+      fireEvent.dragStart(screen.getByLabelText('주방 드래그 영역'), { dataTransfer });
+      fireEvent.drop(screen.getByLabelText('거실 드래그 영역'), { dataTransfer });
+
+      expect(updateLocationMutateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          locationId: 'loc-2',
+          body: expect.objectContaining({ parent_location_id: 'loc-1' }),
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('드래그앤드롭으로 하위장소 아래 이동하려 하면 차단한다', () => {
+      useEditorLocationsMock.mockReturnValue({
+        data: [
+          { ...baseLocation('loc-parent', '거실'), parent_location_id: null },
+          { ...baseLocation('loc-child', '프런트'), parent_location_id: 'loc-parent' },
+          { ...baseLocation('loc-source', '주방'), parent_location_id: null },
+        ],
+        isLoading: false,
+      });
+      renderLocationsSubTab();
+      const dataTransfer = createDataTransfer();
+
+      fireEvent.dragStart(screen.getByLabelText('주방 드래그 영역'), { dataTransfer });
+      fireEvent.drop(screen.getByLabelText('프런트 드래그 영역'), { dataTransfer });
+
+      expect(updateLocationMutateMock).not.toHaveBeenCalled();
     });
   });
 
@@ -300,3 +384,13 @@ describe('LocationsSubTab', () => {
   });
 
 });
+
+function createDataTransfer(): DataTransfer {
+  const data = new Map<string, string>();
+  return {
+    effectAllowed: 'move',
+    dropEffect: 'move',
+    setData: (format: string, value: string) => data.set(format, value),
+    getData: (format: string) => data.get(format) ?? '',
+  } as DataTransfer;
+}

--- a/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestData.ts
+++ b/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestData.ts
@@ -1,3 +1,5 @@
+import type { LocationResponse } from '@/features/editor/api';
+
 export const mockTheme = {
   id: 'theme-1',
   title: '테스트 테마',
@@ -124,3 +126,20 @@ export const mockCharacters = [
     sort_order: 2,
   },
 ];
+
+export function baseLocation(id: string, name: string): LocationResponse {
+  return {
+    id,
+    theme_id: 'theme-1',
+    map_id: 'map-1',
+    name,
+    restricted_characters: null,
+    image_url: null,
+    image_media_id: null,
+    public_description: null,
+    entry_message: null,
+    parent_location_id: null,
+    sort_order: 0,
+    created_at: '2026-05-17T00:00:00Z',
+  };
+}

--- a/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestUtils.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestUtils.tsx
@@ -123,7 +123,7 @@ import {
   mockTheme as fixtureTheme,
 } from './locationsSubTabTestData';
 
-export { mockLocations, mockMaps, mockTheme } from './locationsSubTabTestData';
+export { baseLocation, mockLocations, mockMaps, mockTheme } from './locationsSubTabTestData';
 
 export {
   mutateMock,

--- a/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
@@ -80,7 +80,7 @@ describe('locationEntityAdapter', () => {
     });
   });
 
-  it('API 필드를 제작자용 공개 설명으로 변환하고 부모 정보는 에디터에서 무시한다', () => {
+  it('API 필드를 제작자용 공개 설명과 부모 정보로 변환한다', () => {
     const vm = toLocationEditorViewModel(
       location({
         public_description: '모든 플레이어에게 보이는 설명',
@@ -99,8 +99,8 @@ describe('locationEntityAdapter', () => {
 
     expect(vm.publicDescription).toBe('모든 플레이어에게 보이는 설명');
     expect(vm.entryMessage).toBe('차가운 바람이 분다.');
-    expect(vm.parentLocationId).toBeNull();
-    expect(vm.parentLabel).toBe('동등 장소');
+    expect(vm.parentLocationId).toBe('loc-parent');
+    expect(vm.parentLabel).toBe('저택 1층');
   });
 
   it('신규 API 필드가 비어 있으면 locationMeta fallback을 사용한다', () => {
@@ -116,14 +116,15 @@ describe('locationEntityAdapter', () => {
     expect(vm.publicDescription).toBe('기존 설명');
     expect(vm.entryMessage).toBe('기존 진입');
     expect(vm.parentLocationId).toBeNull();
+    expect(vm.parentLabel).toBe('최상위 장소');
   });
 
-  it('부모 장소 후보를 제공하지 않는다', () => {
+  it('현재 장소를 제외한 최상위 장소만 부모 후보로 제공한다', () => {
     const locations = [
-      location({ id: 'loc-1', name: '저택' }),
-      location({ id: 'loc-2', name: '1층' }),
-      location({ id: 'loc-3', name: '서재' }),
-      location({ id: 'loc-4', name: '정원' }),
+      location({ id: 'loc-1', name: '저택', sort_order: 1 }),
+      location({ id: 'loc-2', name: '1층', sort_order: 3 }),
+      location({ id: 'loc-3', name: '서재', parent_location_id: 'loc-2', sort_order: 2 }),
+      location({ id: 'loc-4', name: '정원', sort_order: 2 }),
     ];
 
     expect(
@@ -131,23 +132,10 @@ describe('locationEntityAdapter', () => {
         'loc-2': { parentLocationId: 'loc-1' },
         'loc-3': { parentLocationId: 'loc-2' },
       })
-    ).toEqual([]);
-  });
-
-  it('API parent_location_id가 있어도 부모 장소 후보를 제공하지 않는다', () => {
-    const locations = [
-      location({ id: 'loc-1', name: '저택' }),
-      location({ id: 'loc-2', name: '1층', parent_location_id: 'loc-1' }),
-      location({ id: 'loc-3', name: '서재', parent_location_id: 'loc-2' }),
-      location({ id: 'loc-4', name: '정원' }),
-    ];
-
-    expect(
-      buildLocationParentOptions('loc-1', locations, {
-        'loc-2': { parentLocationId: null },
-        'loc-3': { parentLocationId: null },
-      })
-    ).toEqual([]);
+    ).toEqual([
+      { id: 'loc-4', label: '정원', depth: 0 },
+      { id: 'loc-2', label: '1층', depth: 0 },
+    ]);
   });
 
   it('restricted character CSV를 trim/dedupe한다', () => {

--- a/apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts
@@ -31,6 +31,22 @@ describe('locationHierarchy', () => {
     expect(tree[0].children.map((node) => node.location.id)).toEqual(['child-1', 'child-2']);
   });
 
+  it('keeps direct clue counts separate for parents and children', () => {
+    const tree = buildLocationHierarchy(
+      [
+        location({ id: 'parent-1', name: '로비', parent_location_id: null, sort_order: 1 }),
+        location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1', sort_order: 1 }),
+      ],
+      {
+        'parent-1': 2,
+        'child-1': 3,
+      }
+    );
+
+    expect(tree[0].directClueCount).toBe(2);
+    expect(tree[0].children[0].directClueCount).toBe(3);
+  });
+
   it('formats child path labels as parent slash child', () => {
     const locations = [
       location({ id: 'parent-1', name: '로비', parent_location_id: null }),
@@ -55,5 +71,21 @@ describe('locationHierarchy', () => {
         targetParentId: 'child-1',
       })
     ).toEqual({ ok: false, reason: 'grandchild' });
+  });
+
+  it('rejects moving a parent that already owns children under another parent', () => {
+    const locations = [
+      location({ id: 'parent-1', name: '로비', parent_location_id: null }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1' }),
+      location({ id: 'parent-2', name: '객실', parent_location_id: null }),
+    ];
+
+    expect(
+      validateLocationDrop({
+        locations,
+        draggedId: 'parent-1',
+        targetParentId: 'parent-2',
+      })
+    ).toEqual({ ok: false, reason: 'child-parent' });
   });
 });

--- a/apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { LocationResponse } from '@/features/editor/api/types';
 import {
   buildLocationHierarchy,
+  buildLocationMovePatch,
   getLocationPathLabel,
   validateLocationDrop,
 } from '../locationHierarchy';
@@ -87,5 +88,37 @@ describe('locationHierarchy', () => {
         targetParentId: 'parent-2',
       })
     ).toEqual({ ok: false, reason: 'child-parent' });
+  });
+
+  it('builds a patch to move a top-level location under a parent', () => {
+    const locations = [
+      location({ id: 'parent-1', name: '로비', parent_location_id: null, sort_order: 0 }),
+      location({ id: 'source', name: '금고 앞', parent_location_id: null, sort_order: 1 }),
+    ];
+
+    expect(
+      buildLocationMovePatch({
+        locations,
+        draggedId: 'source',
+        targetParentId: 'parent-1',
+        targetIndex: 0,
+      })
+    ).toEqual({ parent_location_id: 'parent-1', sort_order: 0 });
+  });
+
+  it('builds a patch to move a child back to top level', () => {
+    const locations = [
+      location({ id: 'parent-1', name: '로비', parent_location_id: null, sort_order: 0 }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1', sort_order: 0 }),
+    ];
+
+    expect(
+      buildLocationMovePatch({
+        locations,
+        draggedId: 'child-1',
+        targetParentId: null,
+        targetIndex: 1,
+      })
+    ).toEqual({ parent_location_id: null, sort_order: 1 });
   });
 });

--- a/apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts
+++ b/apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { LocationResponse } from '@/features/editor/api/types';
+import {
+  buildLocationHierarchy,
+  getLocationPathLabel,
+  validateLocationDrop,
+} from '../locationHierarchy';
+
+function location(partial: Partial<LocationResponse> & { id: string; name: string }): LocationResponse {
+  return {
+    theme_id: 'theme-1',
+    map_id: 'map-1',
+    restricted_characters: null,
+    image_url: null,
+    sort_order: 0,
+    created_at: '2026-05-17T00:00:00Z',
+    ...partial,
+  };
+}
+
+describe('locationHierarchy', () => {
+  it('builds top-level parents with one-level children sorted by sort_order', () => {
+    const tree = buildLocationHierarchy([
+      location({ id: 'child-2', name: '금고', parent_location_id: 'parent-1', sort_order: 2 }),
+      location({ id: 'parent-1', name: '로비', parent_location_id: null, sort_order: 1 }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1', sort_order: 1 }),
+      location({ id: 'parent-2', name: '객실', parent_location_id: null, sort_order: 2 }),
+    ]);
+
+    expect(tree.map((node) => node.location.id)).toEqual(['parent-1', 'parent-2']);
+    expect(tree[0].children.map((node) => node.location.id)).toEqual(['child-1', 'child-2']);
+  });
+
+  it('formats child path labels as parent slash child', () => {
+    const locations = [
+      location({ id: 'parent-1', name: '로비', parent_location_id: null }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1' }),
+    ];
+
+    expect(getLocationPathLabel(locations[0], locations)).toBe('로비');
+    expect(getLocationPathLabel(locations[1], locations)).toBe('로비 / 프런트');
+  });
+
+  it('rejects drops that would create a grandchild', () => {
+    const locations = [
+      location({ id: 'parent-1', name: '로비', parent_location_id: null }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1' }),
+      location({ id: 'source', name: '영수증', parent_location_id: null }),
+    ];
+
+    expect(
+      validateLocationDrop({
+        locations,
+        draggedId: 'source',
+        targetParentId: 'child-1',
+      })
+    ).toEqual({ ok: false, reason: 'grandchild' });
+  });
+});

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -34,6 +34,9 @@ export function toLocationEditorViewModel(
   } = {}
 ): LocationEditorViewModel {
   const clueCount = options.clueCount ?? 0;
+  const parent = location.parent_location_id
+    ? options.allLocations?.find((candidate) => candidate.id === location.parent_location_id)
+    : null;
   return {
     id: location.id,
     name: location.name,
@@ -48,8 +51,8 @@ export function toLocationEditorViewModel(
       location.public_description ?? options.locationMeta?.publicDescription
     ),
     entryMessage: normalizeMetaText(location.entry_message ?? options.locationMeta?.entryMessage),
-    parentLocationId: null,
-    parentLabel: '동등 장소',
+    parentLocationId: location.parent_location_id ?? null,
+    parentLabel: parent ? parent.name : '최상위 장소',
     clueCountLabel: `단서 조사 ${clueCount}개`,
     clueShortLabel: `단서 ${clueCount}개`,
     badges: buildLocationBadges(location, clueCount, options.mapName),
@@ -61,10 +64,12 @@ export function buildLocationParentOptions(
   locations: LocationResponse[],
   metaByLocationId: Record<string, LocationMeta | undefined> = {}
 ): LocationParentOption[] {
-  void currentLocationId;
-  void locations;
   void metaByLocationId;
-  return [];
+  return locations
+    .filter((location) => location.id !== currentLocationId)
+    .filter((location) => !location.parent_location_id)
+    .sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name, 'ko'))
+    .map((location) => ({ id: location.id, label: location.name, depth: 0 }));
 }
 
 export function parseLocationRestrictedCharacterIds(value: string | null | undefined): string[] {

--- a/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/location/locationEntityAdapter.ts
@@ -68,7 +68,10 @@ export function buildLocationParentOptions(
   return locations
     .filter((location) => location.id !== currentLocationId)
     .filter((location) => !location.parent_location_id)
-    .sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name, 'ko'))
+    .sort(
+      (a, b) =>
+        a.sort_order - b.sort_order || a.name.localeCompare(b.name, 'ko') || a.id.localeCompare(b.id)
+    )
     .map((location) => ({ id: location.id, label: location.name, depth: 0 }));
 }
 

--- a/apps/web/src/features/editor/entities/location/locationHierarchy.ts
+++ b/apps/web/src/features/editor/entities/location/locationHierarchy.ts
@@ -9,7 +9,7 @@ export interface LocationHierarchyNode {
 
 export type LocationDropValidation =
   | { ok: true }
-  | { ok: false; reason: 'missing-location' | 'self' | 'grandchild' };
+  | { ok: false; reason: 'missing-location' | 'self' | 'grandchild' | 'child-parent' };
 
 export function buildLocationHierarchy(
   locations: LocationResponse[],
@@ -72,11 +72,14 @@ export function validateLocationDrop({
   const targetParent = locations.find((location) => location.id === targetParentId);
   if (!targetParent) return { ok: false, reason: 'missing-location' };
   if (targetParent.parent_location_id) return { ok: false, reason: 'grandchild' };
+  if (locations.some((location) => location.parent_location_id === draggedId)) {
+    return { ok: false, reason: 'child-parent' };
+  }
 
   return { ok: true };
 }
 
 function compareLocations(a: LocationResponse, b: LocationResponse): number {
   if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
-  return a.name.localeCompare(b.name, 'ko');
+  return a.name.localeCompare(b.name, 'ko') || a.id.localeCompare(b.id);
 }

--- a/apps/web/src/features/editor/entities/location/locationHierarchy.ts
+++ b/apps/web/src/features/editor/entities/location/locationHierarchy.ts
@@ -11,6 +11,16 @@ export type LocationDropValidation =
   | { ok: true }
   | { ok: false; reason: 'missing-location' | 'self' | 'grandchild' | 'child-parent' };
 
+export interface LocationParentOption {
+  id: string | null;
+  label: string;
+}
+
+export interface LocationMovePatch {
+  parent_location_id: string | null;
+  sort_order: number;
+}
+
 export function buildLocationHierarchy(
   locations: LocationResponse[],
   clueCounts: Record<string, number> = {}
@@ -55,6 +65,20 @@ export function getLocationPathLabel(
   return parent ? `${parent.name} / ${location.name}` : location.name;
 }
 
+export function buildLocationParentOptions(
+  locationId: string,
+  locations: LocationResponse[]
+): LocationParentOption[] {
+  return [
+    { id: null, label: '최상위 장소' },
+    ...locations
+      .filter((location) => location.id !== locationId && !location.parent_location_id)
+      .filter((location) => !isChildOf(location.id, locationId, locations))
+      .sort(compareLocations)
+      .map((location) => ({ id: location.id, label: location.name })),
+  ];
+}
+
 export function validateLocationDrop({
   locations,
   draggedId,
@@ -77,6 +101,34 @@ export function validateLocationDrop({
   }
 
   return { ok: true };
+}
+
+export function buildLocationMovePatch({
+  locations,
+  draggedId,
+  targetParentId,
+  targetIndex,
+}: {
+  locations: LocationResponse[];
+  draggedId: string;
+  targetParentId: string | null;
+  targetIndex: number;
+}): LocationMovePatch {
+  const validation = validateLocationDrop({ locations, draggedId, targetParentId });
+  if (!validation.ok) throw new Error(validation.reason);
+  return {
+    parent_location_id: targetParentId,
+    sort_order: Math.max(0, targetIndex),
+  };
+}
+
+function isChildOf(locationId: string, potentialParentId: string, locations: LocationResponse[]) {
+  let current = locations.find((location) => location.id === locationId);
+  while (current?.parent_location_id) {
+    if (current.parent_location_id === potentialParentId) return true;
+    current = locations.find((location) => location.id === current?.parent_location_id);
+  }
+  return false;
 }
 
 function compareLocations(a: LocationResponse, b: LocationResponse): number {

--- a/apps/web/src/features/editor/entities/location/locationHierarchy.ts
+++ b/apps/web/src/features/editor/entities/location/locationHierarchy.ts
@@ -1,0 +1,82 @@
+import type { LocationResponse } from '@/features/editor/api/types';
+
+export interface LocationHierarchyNode {
+  location: LocationResponse;
+  depth: 0 | 1;
+  children: LocationHierarchyNode[];
+  directClueCount: number;
+}
+
+export type LocationDropValidation =
+  | { ok: true }
+  | { ok: false; reason: 'missing-location' | 'self' | 'grandchild' };
+
+export function buildLocationHierarchy(
+  locations: LocationResponse[],
+  clueCounts: Record<string, number> = {}
+): LocationHierarchyNode[] {
+  const sorted = [...locations].sort(compareLocations);
+  const byId = new Map(sorted.map((location) => [location.id, location]));
+  const parentNodes = new Map<string, LocationHierarchyNode>();
+
+  for (const location of sorted) {
+    if (!location.parent_location_id || !byId.has(location.parent_location_id)) {
+      parentNodes.set(location.id, {
+        location,
+        depth: 0,
+        children: [],
+        directClueCount: clueCounts[location.id] ?? 0,
+      });
+    }
+  }
+
+  for (const location of sorted) {
+    if (!location.parent_location_id) continue;
+    const parent = parentNodes.get(location.parent_location_id);
+    if (!parent) continue;
+    parent.children.push({
+      location,
+      depth: 1,
+      children: [],
+      directClueCount: clueCounts[location.id] ?? 0,
+    });
+  }
+
+  return Array.from(parentNodes.values());
+}
+
+export function getLocationPathLabel(
+  location: LocationResponse,
+  allLocations: LocationResponse[]
+): string {
+  const parent = location.parent_location_id
+    ? allLocations.find((candidate) => candidate.id === location.parent_location_id)
+    : null;
+  return parent ? `${parent.name} / ${location.name}` : location.name;
+}
+
+export function validateLocationDrop({
+  locations,
+  draggedId,
+  targetParentId,
+}: {
+  locations: LocationResponse[];
+  draggedId: string;
+  targetParentId: string | null;
+}): LocationDropValidation {
+  const dragged = locations.find((location) => location.id === draggedId);
+  if (!dragged) return { ok: false, reason: 'missing-location' };
+  if (targetParentId === draggedId) return { ok: false, reason: 'self' };
+  if (!targetParentId) return { ok: true };
+
+  const targetParent = locations.find((location) => location.id === targetParentId);
+  if (!targetParent) return { ok: false, reason: 'missing-location' };
+  if (targetParent.parent_location_id) return { ok: false, reason: 'grandchild' };
+
+  return { ok: true };
+}
+
+function compareLocations(a: LocationResponse, b: LocationResponse): number {
+  if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
+  return a.name.localeCompare(b.name, 'ko');
+}

--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
@@ -46,23 +46,25 @@ describe('EntityEditorShell', () => {
     expect(screen.getByText('2개의 단서')).toBeDefined();
     expect(container.firstElementChild?.className).toContain('min-h-0');
     expect(container.firstElementChild?.className).toContain('overflow-y-auto');
+    expect(container.firstElementChild?.className).toContain('lg:overflow-hidden');
   });
 
-  it('데스크톱에서는 Shell 하나만 스크롤 책임을 가진다', () => {
+  it('데스크톱에서는 왼쪽 목록 본문과 오른쪽 상세가 각각 독립 스크롤 책임을 가진다', () => {
     renderShell();
 
     const list = screen.getByRole('region', { name: '단서 목록' });
     const detail = screen.getByRole('region', { name: '단서 상세 영역' });
     const listScroller = Array.from(list.querySelectorAll('div')).find((node) =>
-      node.className.includes('lg:overflow-y-auto'),
+      node.className.includes('overflow-y-auto'),
     );
 
     expect(list.className).toContain('flex');
     expect(list.className).toContain('min-h-0');
     expect(list.className).toContain('shrink-0');
     expect(detail.className).toContain('shrink-0');
-    expect(listScroller).toBeUndefined();
-    expect(detail.className).not.toContain('lg:overflow-y-auto');
+    expect(listScroller?.className).toContain('flex-1');
+    expect(listScroller?.className).toContain('min-h-0');
+    expect(detail.className).toContain('lg:overflow-y-auto');
   });
 
   it('검색어에 맞는 항목만 보여준다', () => {
@@ -72,6 +74,20 @@ describe('EntityEditorShell', () => {
 
     const list = screen.getByRole('region', { name: '단서 목록' });
     expect(within(list).getByText('비밀 편지')).toBeDefined();
+    expect(within(list).queryByText('첫 단서')).toBeNull();
+  });
+
+  it('화면에 표시하지 않는 검색 전용 텍스트로도 항목을 찾는다', () => {
+    renderShell({
+      getItemDescription: () => '',
+      getItemSearchText: (item) => item.description ?? '',
+    });
+
+    fireEvent.change(screen.getByLabelText('단서 검색'), { target: { value: '범인의 흔적' } });
+
+    const list = screen.getByRole('region', { name: '단서 목록' });
+    expect(within(list).getByText('비밀 편지')).toBeDefined();
+    expect(within(list).queryByText('범인의 흔적')).toBeNull();
     expect(within(list).queryByText('첫 단서')).toBeNull();
   });
 

--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
@@ -14,6 +14,7 @@ export interface EntityEditorShellProps<TItem> {
   getItemId: (item: TItem) => string;
   getItemTitle: (item: TItem) => string;
   getItemDescription?: (item: TItem) => string;
+  getItemSearchText?: (item: TItem) => string;
   getItemBadges?: (item: TItem) => string[];
   renderItemActions?: (item: TItem) => ReactNode;
   renderDetail: (item: TItem) => ReactNode;
@@ -33,6 +34,7 @@ export function EntityEditorShell<TItem>({
   getItemId,
   getItemTitle,
   getItemDescription,
+  getItemSearchText,
   getItemBadges,
   renderItemActions,
   renderDetail,
@@ -40,8 +42,8 @@ export function EntityEditorShell<TItem>({
 }: EntityEditorShellProps<TItem>) {
   const [query, setQuery] = useState('');
   const visibleItems = useMemo(
-    () => filterItems(items, query, getItemTitle, getItemDescription, getItemBadges),
-    [items, query, getItemTitle, getItemDescription, getItemBadges],
+    () => filterItems(items, query, getItemTitle, getItemDescription, getItemSearchText, getItemBadges),
+    [items, query, getItemTitle, getItemDescription, getItemSearchText, getItemBadges],
   );
 
   const selected = visibleItems.find((item) => getItemId(item) === selectedId) ?? visibleItems[0];
@@ -81,7 +83,7 @@ export function EntityEditorShell<TItem>({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto lg:grid lg:grid-cols-[minmax(14rem,0.72fr)_minmax(0,1.9fr)]">
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto lg:grid lg:grid-cols-[minmax(14rem,0.72fr)_minmax(0,1.9fr)] lg:overflow-hidden">
       <section
         aria-label={`${title} 목록`}
         className="flex min-h-0 shrink-0 flex-col rounded-xl border border-slate-800 bg-slate-950/70 p-3"
@@ -114,7 +116,7 @@ export function EntityEditorShell<TItem>({
             className="w-full rounded-lg border border-slate-800 bg-slate-900 py-2.5 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
           />
         </label>
-        <div className="space-y-2 pr-1">
+        <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
           {visibleItems.length === 0 ? (
             <p className="rounded-lg border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
               검색 결과가 없습니다.
@@ -140,7 +142,7 @@ export function EntityEditorShell<TItem>({
 
       {selected && (
         <section
-          className="min-h-0 shrink-0 overflow-y-visible lg:pr-2"
+          className="min-h-0 shrink-0 overflow-y-visible lg:overflow-y-auto lg:pr-2"
           aria-label={`${title} 상세 영역`}
         >
           <div className="space-y-4 pb-4">
@@ -238,12 +240,18 @@ function filterItems<TItem>(
   query: string,
   getItemTitle: (item: TItem) => string,
   getItemDescription?: (item: TItem) => string,
+  getItemSearchText?: (item: TItem) => string,
   getItemBadges?: (item: TItem) => string[],
 ) {
   const normalized = query.trim().toLowerCase();
   if (!normalized) return items;
   return items.filter((item) =>
-    [getItemTitle(item), getItemDescription?.(item), ...(getItemBadges?.(item) ?? [])]
+    [
+      getItemTitle(item),
+      getItemDescription?.(item),
+      getItemSearchText?.(item),
+      ...(getItemBadges?.(item) ?? []),
+    ]
       .filter(Boolean)
       .join(' ')
       .toLowerCase()

--- a/docs/superpowers/plans/2026-05-17-location-hierarchy-clue-placement.md
+++ b/docs/superpowers/plans/2026-05-17-location-hierarchy-clue-placement.md
@@ -1,0 +1,816 @@
+# Location Hierarchy Clue Placement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a frontend UX where creators can manage top-level locations and one-level sub-locations, then place clues directly on either level with persisted payload and reload verification.
+
+**Architecture:** Keep the existing backend contract: `theme_locations.parent_location_id` stores one-level location hierarchy and `theme_clues.location_id` stores the exact parent or child location where a clue belongs. Add frontend-only hierarchy helpers, replace the flat location list with a hierarchy list, preserve `parent_location_id` in save DTOs, and add explicit controls plus native HTML drag/drop for moving and sorting. Do not add a drag/drop dependency unless native events prove insufficient during implementation.
+
+**Tech Stack:** React 19, TypeScript, TanStack Query, Vitest + Testing Library, existing MMP editor API hooks.
+
+**Seed:** `seed_b82ec88c0653`
+
+---
+
+## File Structure
+
+- Modify `apps/web/src/features/editor/entities/location/locationEntityAdapter.ts`
+  - Own pure hierarchy helpers, parent options, path labels, and ViewModel parent fields.
+- Create `apps/web/src/features/editor/entities/location/locationHierarchy.ts`
+  - Own `buildLocationHierarchy`, drag/drop move validation, and reorder payload helpers.
+- Modify `apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts`
+  - Cover parent labels and parent options.
+- Create `apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts`
+  - Cover tree building, one-level limit, parent/child sorting, and rejected grandchild drops.
+- Modify `apps/web/src/features/editor/components/design/LocationsSubTab.tsx`
+  - Pass parent-aware creation handlers and current selected map locations into detail/list UI.
+- Modify `apps/web/src/features/editor/components/design/LocationDetailPanel.tsx`
+  - Replace the flat `EntityEditorShell` list for locations with a custom hierarchy list and add parent selector controls in the detail panel.
+- Create `apps/web/src/features/editor/components/design/LocationHierarchyList.tsx`
+  - Render parent cards, indented child cards, badges, action buttons, and drag/drop handlers.
+- Create `apps/web/src/features/editor/components/design/LocationStructurePanel.tsx`
+  - Render parent selection, "move to top level", and "add sub-location" controls.
+- Modify `apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx`
+  - Show path labels for location context and preserve exact selected location ID for clue discovery config.
+- Modify tests under `apps/web/src/features/editor/components/design/__tests__/`
+  - Update `LocationsSubTab.test.tsx`, `LocationClueAssignPanel.test.tsx`, and test utilities for parent/child locations.
+
+## Task 1: Pure Hierarchy Model
+
+**Files:**
+- Modify: `apps/web/src/features/editor/entities/location/locationEntityAdapter.ts`
+- Create: `apps/web/src/features/editor/entities/location/locationHierarchy.ts`
+- Test: `apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts`
+- Test: `apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts`
+
+- [ ] **Step 1: Write failing tests for hierarchy building**
+
+Add `apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { LocationResponse } from '@/features/editor/api';
+import {
+  buildLocationHierarchy,
+  getLocationPathLabel,
+  validateLocationDrop,
+} from '../locationHierarchy';
+
+function location(partial: Partial<LocationResponse> & { id: string; name: string }): LocationResponse {
+  return {
+    theme_id: 'theme-1',
+    map_id: 'map-1',
+    restricted_characters: null,
+    image_url: null,
+    sort_order: 0,
+    created_at: '2026-05-17T00:00:00Z',
+    ...partial,
+  };
+}
+
+describe('locationHierarchy', () => {
+  it('builds top-level parents with one-level children sorted by sort_order', () => {
+    const tree = buildLocationHierarchy([
+      location({ id: 'child-2', name: '금고', parent_location_id: 'parent-1', sort_order: 2 }),
+      location({ id: 'parent-1', name: '로비', parent_location_id: null, sort_order: 1 }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1', sort_order: 1 }),
+      location({ id: 'parent-2', name: '객실', parent_location_id: null, sort_order: 2 }),
+    ]);
+
+    expect(tree.map((node) => node.location.id)).toEqual(['parent-1', 'parent-2']);
+    expect(tree[0].children.map((node) => node.location.id)).toEqual(['child-1', 'child-2']);
+  });
+
+  it('formats child path labels as parent slash child', () => {
+    const locations = [
+      location({ id: 'parent-1', name: '로비', parent_location_id: null }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1' }),
+    ];
+
+    expect(getLocationPathLabel(locations[0], locations)).toBe('로비');
+    expect(getLocationPathLabel(locations[1], locations)).toBe('로비 / 프런트');
+  });
+
+  it('rejects drops that would create a grandchild', () => {
+    const locations = [
+      location({ id: 'parent-1', name: '로비', parent_location_id: null }),
+      location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1' }),
+      location({ id: 'source', name: '영수증', parent_location_id: null }),
+    ];
+
+    expect(validateLocationDrop({
+      locations,
+      draggedId: 'source',
+      targetParentId: 'child-1',
+    })).toEqual({ ok: false, reason: 'grandchild' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec vitest run src/features/editor/entities/location/__tests__/locationHierarchy.test.ts
+```
+
+Expected: fail because `locationHierarchy.ts` does not exist.
+
+- [ ] **Step 3: Implement hierarchy helpers**
+
+Create `apps/web/src/features/editor/entities/location/locationHierarchy.ts`:
+
+```ts
+import type { LocationResponse } from '@/features/editor/api';
+
+export interface LocationHierarchyNode {
+  location: LocationResponse;
+  depth: 0 | 1;
+  children: LocationHierarchyNode[];
+  directClueCount: number;
+}
+
+export type LocationDropValidation =
+  | { ok: true }
+  | { ok: false; reason: 'missing-location' | 'self' | 'grandchild' };
+
+export function buildLocationHierarchy(
+  locations: LocationResponse[],
+  clueCounts: Record<string, number> = {},
+): LocationHierarchyNode[] {
+  const sorted = [...locations].sort(compareLocations);
+  const byId = new Map(sorted.map((location) => [location.id, location]));
+  const parentNodes = new Map<string, LocationHierarchyNode>();
+
+  for (const location of sorted) {
+    if (!location.parent_location_id || !byId.has(location.parent_location_id)) {
+      parentNodes.set(location.id, {
+        location,
+        depth: 0,
+        children: [],
+        directClueCount: clueCounts[location.id] ?? 0,
+      });
+    }
+  }
+
+  for (const location of sorted) {
+    if (!location.parent_location_id) continue;
+    const parent = parentNodes.get(location.parent_location_id);
+    if (!parent) continue;
+    parent.children.push({
+      location,
+      depth: 1,
+      children: [],
+      directClueCount: clueCounts[location.id] ?? 0,
+    });
+  }
+
+  return Array.from(parentNodes.values());
+}
+
+export function getLocationPathLabel(location: LocationResponse, allLocations: LocationResponse[]): string {
+  const parent = location.parent_location_id
+    ? allLocations.find((candidate) => candidate.id === location.parent_location_id)
+    : null;
+  return parent ? `${parent.name} / ${location.name}` : location.name;
+}
+
+export function validateLocationDrop({
+  locations,
+  draggedId,
+  targetParentId,
+}: {
+  locations: LocationResponse[];
+  draggedId: string;
+  targetParentId: string | null;
+}): LocationDropValidation {
+  const dragged = locations.find((location) => location.id === draggedId);
+  if (!dragged) return { ok: false, reason: 'missing-location' };
+  if (targetParentId === draggedId) return { ok: false, reason: 'self' };
+  if (!targetParentId) return { ok: true };
+  const targetParent = locations.find((location) => location.id === targetParentId);
+  if (!targetParent) return { ok: false, reason: 'missing-location' };
+  if (targetParent.parent_location_id) return { ok: false, reason: 'grandchild' };
+  return { ok: true };
+}
+
+function compareLocations(a: LocationResponse, b: LocationResponse) {
+  if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
+  return a.name.localeCompare(b.name, 'ko');
+}
+```
+
+- [ ] **Step 4: Implement adapter parent labels and options**
+
+Update `toLocationEditorViewModel` in `locationEntityAdapter.ts`:
+
+```ts
+const parent = location.parent_location_id
+  ? options.allLocations?.find((candidate) => candidate.id === location.parent_location_id)
+  : null;
+
+return {
+  ...
+  parentLocationId: location.parent_location_id ?? null,
+  parentLabel: parent ? parent.name : '최상위 장소',
+  ...
+};
+```
+
+Replace `buildLocationParentOptions` with:
+
+```ts
+export function buildLocationParentOptions(
+  currentLocationId: string,
+  locations: LocationResponse[],
+  metaByLocationId: Record<string, LocationMeta | undefined> = {}
+): LocationParentOption[] {
+  void metaByLocationId;
+  return locations
+    .filter((location) => location.id !== currentLocationId)
+    .filter((location) => !location.parent_location_id)
+    .sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name, 'ko'))
+    .map((location) => ({ id: location.id, label: location.name, depth: 0 }));
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec vitest run src/features/editor/entities/location/__tests__/locationHierarchy.test.ts src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Hierarchy List UI With Explicit Controls
+
+**Files:**
+- Create: `apps/web/src/features/editor/components/design/LocationHierarchyList.tsx`
+- Create: `apps/web/src/features/editor/components/design/LocationStructurePanel.tsx`
+- Modify: `apps/web/src/features/editor/components/design/LocationDetailPanel.tsx`
+- Modify: `apps/web/src/features/editor/components/design/LocationsSubTab.tsx`
+- Test: `apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx`
+
+- [ ] **Step 1: Write failing UI tests**
+
+Add tests in `LocationsSubTab.test.tsx`:
+
+```ts
+it('부모 장소 아래에 하위장소를 들여쓰기 카드로 표시한다', () => {
+  useEditorLocationsMock.mockReturnValue({
+    data: [
+      { ...baseLocation('loc-parent', '호텔 로비'), sort_order: 0, parent_location_id: null },
+      { ...baseLocation('loc-child', '프런트 데스크'), sort_order: 0, parent_location_id: 'loc-parent' },
+    ],
+    isLoading: false,
+  });
+
+  renderLocationsSubTab();
+
+  expect(screen.getByRole('button', { name: '호텔 로비 선택' })).toBeDefined();
+  expect(screen.getByRole('button', { name: '호텔 로비 / 프런트 데스크 선택' })).toBeDefined();
+  expect(screen.getByText('직접 배치 단서 0개 · 하위장소 1개')).toBeDefined();
+});
+
+it('부모 카드의 하위장소 추가 버튼은 parent_location_id를 담아 createLocation을 호출한다', () => {
+  renderLocationsSubTab();
+  fireEvent.click(screen.getByRole('button', { name: '거실 하위장소 추가' }));
+  fireEvent.change(screen.getByPlaceholderText('하위장소 이름'), { target: { value: '금고 앞' } });
+  fireEvent.keyDown(screen.getByPlaceholderText('하위장소 이름'), { key: 'Enter' });
+
+  expect(mutateMock).toHaveBeenCalledWith(
+    { mapId: 'map-1', body: { name: '금고 앞', parent_location_id: 'loc-1' } },
+    expect.any(Object),
+  );
+});
+```
+
+If `baseLocation` is not present in the test utility, add it to `locationsSubTabTestData.ts`:
+
+```ts
+export function baseLocation(id: string, name: string): LocationResponse {
+  return {
+    id,
+    theme_id: 'theme-1',
+    map_id: 'map-1',
+    name,
+    restricted_characters: null,
+    image_url: null,
+    image_media_id: null,
+    public_description: null,
+    entry_message: null,
+    parent_location_id: null,
+    sort_order: 0,
+    created_at: '2026-05-17T00:00:00Z',
+  };
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+```
+
+Expected: fail because hierarchy UI does not exist and creates only top-level locations.
+
+- [ ] **Step 3: Create `LocationHierarchyList`**
+
+Implement a focused list component with these props:
+
+```ts
+interface LocationHierarchyListProps {
+  locations: LocationResponse[];
+  theme: EditorThemeResponse;
+  selectedId?: string | null;
+  onSelect: (locationId: string) => void;
+  onDelete: (location: LocationResponse) => void;
+  onStartAddTopLevel: () => void;
+  onStartAddChild: (parentId: string) => void;
+  renderAddChildInput: (parentId: string) => ReactNode;
+  onMoveLocation: (locationId: string, parentLocationId: string | null, sortOrder: number) => void;
+}
+```
+
+Render shape:
+
+```tsx
+<section aria-label="장소 목록" className="flex min-h-0 flex-col rounded-xl border border-slate-800 bg-slate-950/70 p-3">
+  <header>...장소 목록 + 장소 추가...</header>
+  {tree.map((node) => (
+    <div key={node.location.id} className="space-y-2">
+      <LocationCard ariaLabel={`${node.location.name} 선택`} />
+      {renderAddChildInput(node.location.id)}
+      <div className="ml-5 border-l border-slate-800 pl-3">
+        {node.children.map((child) => <LocationCard ariaLabel={`${node.location.name} / ${child.location.name} 선택`} />)}
+      </div>
+    </div>
+  ))}
+</section>
+```
+
+Use `getLocationPathLabel(child.location, locations)` for child card accessible labels.
+
+- [ ] **Step 4: Create `LocationStructurePanel`**
+
+Implement:
+
+```ts
+interface LocationStructurePanelProps {
+  location: LocationResponse;
+  locations: LocationResponse[];
+  onChangeParent: (parentLocationId: string | null) => void;
+  onStartAddChild: (parentId: string) => void;
+  isSaving: boolean;
+}
+```
+
+UI requirements:
+- Header text: `장소 구조`
+- Select label: `상위 장소`
+- First option: `최상위 장소`
+- Parent options from `buildLocationParentOptions(location.id, locations)`
+- If `location.parent_location_id` is set, show button `최상위로 이동`
+- If `location.parent_location_id` is null, show button `${location.name} 하위장소 추가`
+
+- [ ] **Step 5: Wire list and structure panel**
+
+In `LocationsSubTab.tsx`, replace the single `addingLocation` boolean with:
+
+```ts
+const [addingLocationParentId, setAddingLocationParentId] = useState<string | null | 'top'>(null);
+```
+
+Top-level add:
+
+```ts
+function handleAddLocation(name: string, parentLocationId: string | null = null) {
+  if (!effectiveSelectedMapId) return;
+  createLocation.mutate(
+    { mapId: effectiveSelectedMapId, body: { name, parent_location_id: parentLocationId } },
+    ...
+  );
+}
+```
+
+Pass `onStartAddChild={(parentId) => setAddingLocationParentId(parentId)}` and `onStartAdd={() => setAddingLocationParentId('top')}`.
+
+In `LocationDetailPanel.tsx`, replace `EntityEditorShell` usage for locations with a two-column layout using `LocationHierarchyList` and the existing `SelectedLocationDetail`.
+
+- [ ] **Step 6: Preserve parent in `saveLocation`**
+
+In `SelectedLocationDetail.saveLocation`, replace the hard-coded null:
+
+```ts
+parent_location_id: patch.parent_location_id !== undefined
+  ? patch.parent_location_id
+  : location.parent_location_id ?? null,
+```
+
+Call this from `LocationStructurePanel`:
+
+```ts
+onChangeParent={(parentLocationId) =>
+  saveLocation({ parent_location_id: parentLocationId }, {
+    onSuccess: () => toast.success('장소 구조가 저장되었습니다'),
+    onErrorMessage: '장소 구조 저장에 실패했습니다',
+  })
+}
+```
+
+- [ ] **Step 7: Run focused UI tests**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+```
+
+Expected: pass.
+
+## Task 3: Native Drag/Drop Move and Sort
+
+**Files:**
+- Modify: `apps/web/src/features/editor/entities/location/locationHierarchy.ts`
+- Modify: `apps/web/src/features/editor/components/design/LocationHierarchyList.tsx`
+- Test: `apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts`
+- Test: `apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx`
+
+- [ ] **Step 1: Add failing drag/drop helper tests**
+
+Extend `locationHierarchy.test.ts`:
+
+```ts
+import { buildLocationMovePatch } from '../locationHierarchy';
+
+it('builds a patch to move a top-level location under a parent', () => {
+  const locations = [
+    location({ id: 'parent-1', name: '로비', parent_location_id: null, sort_order: 0 }),
+    location({ id: 'source', name: '금고 앞', parent_location_id: null, sort_order: 1 }),
+  ];
+
+  expect(buildLocationMovePatch({
+    locations,
+    draggedId: 'source',
+    targetParentId: 'parent-1',
+    targetIndex: 0,
+  })).toEqual({ parent_location_id: 'parent-1', sort_order: 0 });
+});
+
+it('builds a patch to move a child back to top level', () => {
+  const locations = [
+    location({ id: 'parent-1', name: '로비', parent_location_id: null, sort_order: 0 }),
+    location({ id: 'child-1', name: '프런트', parent_location_id: 'parent-1', sort_order: 0 }),
+  ];
+
+  expect(buildLocationMovePatch({
+    locations,
+    draggedId: 'child-1',
+    targetParentId: null,
+    targetIndex: 1,
+  })).toEqual({ parent_location_id: null, sort_order: 1 });
+});
+```
+
+- [ ] **Step 2: Implement `buildLocationMovePatch`**
+
+Add:
+
+```ts
+export interface LocationMovePatch {
+  parent_location_id: string | null;
+  sort_order: number;
+}
+
+export function buildLocationMovePatch({
+  locations,
+  draggedId,
+  targetParentId,
+  targetIndex,
+}: {
+  locations: LocationResponse[];
+  draggedId: string;
+  targetParentId: string | null;
+  targetIndex: number;
+}): LocationMovePatch {
+  const validation = validateLocationDrop({ locations, draggedId, targetParentId });
+  if (!validation.ok) throw new Error(validation.reason);
+  return {
+    parent_location_id: targetParentId,
+    sort_order: Math.max(0, targetIndex),
+  };
+}
+```
+
+- [ ] **Step 3: Add native drag/drop UI**
+
+In `LocationHierarchyList.tsx`:
+- Add `draggable` to cards.
+- On `dragStart`, store dragged ID in React state.
+- Parent card drop zone:
+  - `targetParentId = parent.location.id`
+  - child index = `parent.children.length`
+- Top-level drop zone:
+  - `targetParentId = null`
+  - target index = `tree.length`
+- Child card drop zone:
+  - only allow sorting within same parent or moving to top-level drop zone.
+- If `validateLocationDrop` returns `grandchild`, show toast `하위장소 아래에는 장소를 넣을 수 없습니다`.
+
+Use accessible labels:
+
+```tsx
+<div aria-label={`${location.name} 드래그 영역`} draggable>
+```
+
+- [ ] **Step 4: Save drag/drop with existing update hook**
+
+In `LocationDetailPanel.tsx`, expose:
+
+```ts
+function moveLocation(locationId: string, parentLocationId: string | null, sortOrder: number) {
+  const target = mapLocations.find((candidate) => candidate.id === locationId);
+  if (!target) return;
+  updateLocation.mutate({
+    locationId,
+    body: {
+      name: target.name,
+      restricted_characters: target.restricted_characters,
+      image_url: target.image_url,
+      public_description: target.public_description ?? null,
+      entry_message: target.entry_message ?? null,
+      parent_location_id: parentLocationId,
+      sort_order: sortOrder,
+      appearance_scene_id: target.appearance_scene_id ?? null,
+      hide_scene_id: target.hide_scene_id ?? null,
+      ...(target.image_media_id !== undefined ? { image_media_id: target.image_media_id ?? null } : {}),
+    },
+  }, {
+    onSuccess: () => toast.success('장소 위치가 저장되었습니다'),
+    onError: () => toast.error('장소 위치 저장에 실패했습니다'),
+  });
+}
+```
+
+Pass `moveLocation` to `LocationHierarchyList`.
+
+- [ ] **Step 5: Test drag/drop payload**
+
+Add a test:
+
+```ts
+it('드래그앤드롭으로 부모 장소 아래 이동 시 parent_location_id payload를 저장한다', () => {
+  renderLocationsSubTab();
+  fireEvent.dragStart(screen.getByLabelText('주방 드래그 영역'));
+  fireEvent.drop(screen.getByLabelText('거실 하위장소 드롭 영역'));
+
+  expect(mutateMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      locationId: 'loc-2',
+      body: expect.objectContaining({ parent_location_id: 'loc-1' }),
+    }),
+    expect.any(Object),
+  );
+});
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec vitest run src/features/editor/entities/location/__tests__/locationHierarchy.test.ts src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+```
+
+Expected: pass.
+
+## Task 4: Clue Placement Path Labels and Exact Location IDs
+
+**Files:**
+- Modify: `apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx`
+- Modify: `apps/web/src/features/editor/components/design/LocationSelectedClueItem.tsx`
+- Test: `apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx`
+
+- [ ] **Step 1: Add failing clue placement tests**
+
+Add:
+
+```ts
+it('하위장소의 경로형 라벨을 헤더에 표시한다', () => {
+  const childLocation = {
+    ...mockLocation,
+    id: 'loc-child',
+    name: '프런트 데스크',
+    parent_location_id: 'loc-parent',
+  };
+
+  renderQC(
+    <LocationClueAssignPanel
+      themeId="theme-1"
+      theme={baseTheme}
+      location={childLocation}
+      allLocations={[
+        { ...mockLocation, id: 'loc-parent', name: '호텔 로비', parent_location_id: null },
+        childLocation,
+      ]}
+    />
+  );
+
+  expect(screen.getByText('호텔 로비 / 프런트 데스크 단서 조사')).toBeDefined();
+});
+
+it('하위장소에 단서 배치 시 discovery locationId가 하위장소 ID로 저장된다', () => {
+  const childLocation = { ...mockLocation, id: 'loc-child', name: '프런트 데스크', parent_location_id: 'loc-parent' };
+  renderQC(<LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={childLocation} />);
+  fireEvent.click(screen.getByLabelText('단검 추가'));
+
+  const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
+  const modules = config.modules as {
+    location: { config: { discoveries: Array<{ locationId: string; clueId: string }> } };
+  };
+  expect(modules.location.config.discoveries[0]).toMatchObject({
+    locationId: 'loc-child',
+    clueId: 'clue-1',
+  });
+});
+```
+
+- [ ] **Step 2: Add `allLocations` prop**
+
+Update `LocationClueAssignPanelProps`:
+
+```ts
+allLocations?: LocationResponse[];
+```
+
+Use:
+
+```ts
+const locationLabel = getLocationPathLabel(location, allLocations ?? [location]);
+```
+
+Replace header text `${location.name} 단서 조사` with `${locationLabel} 단서 조사`.
+
+- [ ] **Step 3: Pass all map locations**
+
+In `SelectedLocationDetail`, pass:
+
+```tsx
+<LocationClueAssignPanel
+  themeId={themeId}
+  theme={theme}
+  location={location}
+  allClues={clues}
+  allLocations={mapLocations}
+/>
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec vitest run src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+```
+
+Expected: pass.
+
+## Task 5: End-to-End Reload Restoration Coverage
+
+**Files:**
+- Modify: `apps/web/e2e/editor-golden-path.spec.ts` or create `apps/web/e2e/location-hierarchy.spec.ts`
+- Modify: `apps/web/e2e/helpers/editor-golden-path-fixtures.ts` only if login/fixture helpers already cover editor setup better there.
+
+- [ ] **Step 1: Create focused E2E test**
+
+Create `apps/web/e2e/location-hierarchy.spec.ts`:
+
+```ts
+import { expect, test } from '@playwright/test';
+import { loginAsE2EUser } from './helpers/editor-golden-path-fixtures';
+
+test('장소 하위장소와 단서 배치가 저장 후 새로고침되어 복원된다', async ({ page }) => {
+  await loginAsE2EUser(page);
+  await page.goto('/editor');
+
+  await page.getByRole('tab', { name: /설계|장소/ }).click();
+  await page.getByRole('button', { name: '장소 추가' }).click();
+  await page.getByPlaceholder('장소 이름').fill('호텔 로비');
+  await page.getByPlaceholder('장소 이름').press('Enter');
+
+  await page.getByRole('button', { name: '호텔 로비 하위장소 추가' }).click();
+  await page.getByPlaceholder('하위장소 이름').fill('프런트 데스크');
+  await page.getByPlaceholder('하위장소 이름').press('Enter');
+
+  await expect(page.getByRole('button', { name: '호텔 로비 / 프런트 데스크 선택' })).toBeVisible();
+
+  await page.getByRole('button', { name: '호텔 로비 / 프런트 데스크 선택' }).click();
+  await page.getByLabel(/단검 추가/).click();
+
+  await page.reload();
+
+  await expect(page.getByRole('button', { name: '호텔 로비 선택' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '호텔 로비 / 프런트 데스크 선택' })).toBeVisible();
+  await page.getByRole('button', { name: '호텔 로비 / 프런트 데스크 선택' }).click();
+  await expect(page.getByLabel(/단검 해제/)).toBeVisible();
+});
+```
+
+If the existing editor route requires a concrete theme URL, reuse the helper route pattern from `editor-golden-path.spec.ts` and replace `/editor` with that path.
+
+- [ ] **Step 2: Run E2E in headed or normal mode**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec playwright test e2e/location-hierarchy.spec.ts --project=chromium
+```
+
+Expected: pass. If the editor seed theme is unavailable, mark the test with the existing backend availability skip pattern used in nearby live specs instead of skipping unconditionally.
+
+## Task 6: Final Validation and Commit
+
+**Files:**
+- All modified frontend files.
+
+- [ ] **Step 1: Run focused Vitest suite**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec vitest run \
+  src/features/editor/entities/location/__tests__/locationHierarchy.test.ts \
+  src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts \
+  src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx \
+  src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web typecheck
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run E2E**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec playwright test e2e/location-hierarchy.spec.ts --project=chromium
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Browser sanity check**
+
+Start or reuse the current dev server:
+
+```bash
+pnpm --filter @mmp/web dev --host 127.0.0.1 --port 3000
+```
+
+Open `http://localhost:3000`, log in, and verify:
+- `호텔 로비` parent card is visible.
+- `프런트 데스크` child card is indented below the parent.
+- Parent card and child card both can be selected.
+- Parent and child clue assignment panels show path labels.
+- Dragging a location under a child location is rejected with an error toast.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add \
+  apps/web/src/features/editor/entities/location/locationEntityAdapter.ts \
+  apps/web/src/features/editor/entities/location/locationHierarchy.ts \
+  apps/web/src/features/editor/entities/location/__tests__/locationEntityAdapter.test.ts \
+  apps/web/src/features/editor/entities/location/__tests__/locationHierarchy.test.ts \
+  apps/web/src/features/editor/components/design/LocationsSubTab.tsx \
+  apps/web/src/features/editor/components/design/LocationDetailPanel.tsx \
+  apps/web/src/features/editor/components/design/LocationHierarchyList.tsx \
+  apps/web/src/features/editor/components/design/LocationStructurePanel.tsx \
+  apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx \
+  apps/web/src/features/editor/components/design/LocationSelectedClueItem.tsx \
+  apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx \
+  apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx \
+  apps/web/e2e/location-hierarchy.spec.ts
+git commit -m "feat: add location hierarchy clue placement UI"
+```
+
+## Self-Review
+
+- Spec coverage: all Seed acceptance criteria map to Tasks 1-5. One-level depth is covered by pure helper tests and drag/drop rejection tests. Payload persistence is covered by component tests and E2E reload.
+- Placeholder scan: no placeholder markers or unspecified test step remains.
+- Type consistency: use existing `LocationResponse.parent_location_id`, `CreateLocationRequest.parent_location_id`, and `UpdateLocationRequest.parent_location_id`; no backend contract changes required.


### PR DESCRIPTION
## 요약
- 장소 하위장소 계층 기반 단서 배치 UI와 경로 표시를 추가했습니다.
- 단서 상세 수동 저장 버튼을 제거하고 기본 정보/사용 설정/조사권 소비량을 자동저장합니다.
- 단서 목록에서 설명/연결 수 대신 장소, 공개 상태, 사용 가능, 살해 요청, 공격력/방어력, 조사권 배지를 보여줍니다.
- 자동저장 실패 재시도 payload 고정과 재시도 실패 토스트를 보강했습니다.

## Coverage Plan
- location hierarchy model and placement UI: `LocationClueAssignPanel.test.tsx`, `locationHierarchy.test.ts`, `LocationsSubTab.*.test.tsx`
- clue detail autosave and failure retry: `ClueEntityWorkspace.test.tsx`
- entity shell independent scroll and search-only text: `EntityEditorShell.test.tsx`
- full web/editor regression: `scripts/mmp-local-ci.sh quick`

## Local validation
- `scripts/mmp-local-ci.sh quick` success on `a5a5c95ed86d1d0bdb7a1e5fec8768980214af19`
- web test summary inside quick: 182 files / 1711 tests passed
- lint/typecheck/build passed inside quick

## CI policy
- No `ready-for-ci` label. CodeRabbit + local validation flow.