### PR TITLE
장면 시작·종료 액션 설정 추가

### DIFF
--- a/apps/server/internal/engine/factory.go
+++ b/apps/server/internal/engine/factory.go
@@ -203,6 +203,8 @@ func ensureImplicitPhaseActionModules(cfg *GameConfig) error {
 		ActionStopAudio,
 		ActionSetBackground,
 		ActionSetThemeColor,
+		ActionGrantInvestigationToken,
+		ActionResetInvestigationToken,
 	}
 	for _, action := range implicitActions {
 		moduleName, ok := ActionRequiresModule[action]

--- a/apps/server/internal/engine/phase_actions.go
+++ b/apps/server/internal/engine/phase_actions.go
@@ -145,21 +145,23 @@ type configuredPhaseAction struct {
 }
 
 var legacyPhaseActionAliases = map[string]PhaseAction{
-	"deliver_information": ActionDeliverInformation,
-	"enable_voting":       ActionOpenVoting,
-	"disable_voting":      ActionCloseVoting,
-	"enable_chat":         ActionUnmuteChat,
-	"disable_chat":        ActionMuteChat,
-	"play_bgm":            ActionSetBGM,
-	"set_bgm":             ActionSetBGM,
-	"play_sound":          ActionPlaySound,
-	"play_media":          ActionPlayMedia,
-	"set_background":      ActionSetBackground,
-	"set_theme_color":     ActionSetThemeColor,
-	"stop_bgm":            ActionStopAudio,
-	"stop_audio":          ActionStopAudio,
-	"broadcast":           ActionBroadcastMessage,
-	"grant_clue":          ActionGrantClue,
+	"deliver_information":       ActionDeliverInformation,
+	"enable_voting":             ActionOpenVoting,
+	"disable_voting":            ActionCloseVoting,
+	"enable_chat":               ActionUnmuteChat,
+	"disable_chat":              ActionMuteChat,
+	"play_bgm":                  ActionSetBGM,
+	"set_bgm":                   ActionSetBGM,
+	"play_sound":                ActionPlaySound,
+	"play_media":                ActionPlayMedia,
+	"set_background":            ActionSetBackground,
+	"set_theme_color":           ActionSetThemeColor,
+	"stop_bgm":                  ActionStopAudio,
+	"stop_audio":                ActionStopAudio,
+	"broadcast":                 ActionBroadcastMessage,
+	"grant_clue":                ActionGrantClue,
+	"grant_investigation_token": ActionGrantInvestigationToken,
+	"reset_investigation_token": ActionResetInvestigationToken,
 }
 
 // NormalizePhaseActionType maps editor/legacy action names to the backend

--- a/apps/server/internal/engine/types.go
+++ b/apps/server/internal/engine/types.go
@@ -12,29 +12,31 @@ import (
 type PhaseAction string
 
 const (
-	ActionResetDrawCount      PhaseAction = "RESET_DRAW_COUNT"
-	ActionResetFloorSelection PhaseAction = "RESET_FLOOR_SELECTION"
-	ActionSetClueLevel        PhaseAction = "SET_CLUE_LEVEL"
-	ActionOpenVoting          PhaseAction = "OPEN_VOTING"
-	ActionCloseVoting         PhaseAction = "CLOSE_VOTING"
-	ActionAllowExchange       PhaseAction = "ALLOW_EXCHANGE"
-	ActionBroadcastMessage    PhaseAction = "BROADCAST_MESSAGE"
-	ActionDeliverInformation  PhaseAction = "DELIVER_INFORMATION"
-	ActionGrantClue           PhaseAction = "GRANT_CLUE"
-	ActionEvaluateEnding      PhaseAction = "EVALUATE_ENDING"
-	ActionPlaySound           PhaseAction = "PLAY_SOUND"
-	ActionPlayMedia           PhaseAction = "PLAY_MEDIA"
-	ActionSetBGM              PhaseAction = "SET_BGM"
-	ActionStopAudio           PhaseAction = "STOP_AUDIO"
-	ActionSetBackground       PhaseAction = "SET_BACKGROUND"
-	ActionSetThemeColor       PhaseAction = "SET_THEME_COLOR"
-	ActionMuteChat            PhaseAction = "MUTE_CHAT"
-	ActionUnmuteChat          PhaseAction = "UNMUTE_CHAT"
-	ActionOpenGroupChat       PhaseAction = "OPEN_GROUP_CHAT"
-	ActionCloseGroupChat      PhaseAction = "CLOSE_GROUP_CHAT"
-	ActionApplyDiscussionRoom PhaseAction = "APPLY_DISCUSSION_ROOM_POLICY"
-	ActionLockModule          PhaseAction = "LOCK_MODULE"
-	ActionUnlockModule        PhaseAction = "UNLOCK_MODULE"
+	ActionResetDrawCount          PhaseAction = "RESET_DRAW_COUNT"
+	ActionResetFloorSelection     PhaseAction = "RESET_FLOOR_SELECTION"
+	ActionSetClueLevel            PhaseAction = "SET_CLUE_LEVEL"
+	ActionOpenVoting              PhaseAction = "OPEN_VOTING"
+	ActionCloseVoting             PhaseAction = "CLOSE_VOTING"
+	ActionAllowExchange           PhaseAction = "ALLOW_EXCHANGE"
+	ActionBroadcastMessage        PhaseAction = "BROADCAST_MESSAGE"
+	ActionDeliverInformation      PhaseAction = "DELIVER_INFORMATION"
+	ActionGrantClue               PhaseAction = "GRANT_CLUE"
+	ActionEvaluateEnding          PhaseAction = "EVALUATE_ENDING"
+	ActionPlaySound               PhaseAction = "PLAY_SOUND"
+	ActionPlayMedia               PhaseAction = "PLAY_MEDIA"
+	ActionSetBGM                  PhaseAction = "SET_BGM"
+	ActionStopAudio               PhaseAction = "STOP_AUDIO"
+	ActionSetBackground           PhaseAction = "SET_BACKGROUND"
+	ActionSetThemeColor           PhaseAction = "SET_THEME_COLOR"
+	ActionMuteChat                PhaseAction = "MUTE_CHAT"
+	ActionUnmuteChat              PhaseAction = "UNMUTE_CHAT"
+	ActionOpenGroupChat           PhaseAction = "OPEN_GROUP_CHAT"
+	ActionCloseGroupChat          PhaseAction = "CLOSE_GROUP_CHAT"
+	ActionApplyDiscussionRoom     PhaseAction = "APPLY_DISCUSSION_ROOM_POLICY"
+	ActionGrantInvestigationToken PhaseAction = "GRANT_INVESTIGATION_TOKEN"
+	ActionResetInvestigationToken PhaseAction = "RESET_INVESTIGATION_TOKEN"
+	ActionLockModule              PhaseAction = "LOCK_MODULE"
+	ActionUnlockModule            PhaseAction = "UNLOCK_MODULE"
 )
 
 // PhaseActionPayload carries action-specific data.
@@ -59,26 +61,28 @@ type PhaseInfo struct {
 // ActionRequiresModule maps PhaseActions to the module that must be enabled.
 // Actions not in this map are module-independent (e.g. BROADCAST_MESSAGE).
 var ActionRequiresModule = map[PhaseAction]string{
-	ActionResetDrawCount:      "clue_interaction",
-	ActionResetFloorSelection: "floor_exploration",
-	ActionSetClueLevel:        "clue_interaction",
-	ActionOpenVoting:          "voting",
-	ActionCloseVoting:         "voting",
-	ActionAllowExchange:       "trade_clue",
-	ActionMuteChat:            "text_chat",
-	ActionUnmuteChat:          "text_chat",
-	ActionOpenGroupChat:       "group_chat",
-	ActionCloseGroupChat:      "group_chat",
-	ActionApplyDiscussionRoom: "group_chat",
-	ActionDeliverInformation:  "information_delivery",
-	ActionGrantClue:           "clue_interaction",
-	ActionEvaluateEnding:      "ending_branch",
-	ActionPlaySound:           "audio",
-	ActionPlayMedia:           "audio",
-	ActionSetBGM:              "audio",
-	ActionStopAudio:           "audio",
-	ActionSetBackground:       "presentation",
-	ActionSetThemeColor:       "presentation",
+	ActionResetDrawCount:          "clue_interaction",
+	ActionResetFloorSelection:     "floor_exploration",
+	ActionSetClueLevel:            "clue_interaction",
+	ActionOpenVoting:              "voting",
+	ActionCloseVoting:             "voting",
+	ActionAllowExchange:           "trade_clue",
+	ActionMuteChat:                "text_chat",
+	ActionUnmuteChat:              "text_chat",
+	ActionOpenGroupChat:           "group_chat",
+	ActionCloseGroupChat:          "group_chat",
+	ActionApplyDiscussionRoom:     "group_chat",
+	ActionDeliverInformation:      "information_delivery",
+	ActionGrantClue:               "clue_interaction",
+	ActionEvaluateEnding:          "ending_branch",
+	ActionPlaySound:               "audio",
+	ActionPlayMedia:               "audio",
+	ActionSetBGM:                  "audio",
+	ActionStopAudio:               "audio",
+	ActionSetBackground:           "presentation",
+	ActionSetThemeColor:           "presentation",
+	ActionGrantInvestigationToken: "deck_investigation",
+	ActionResetInvestigationToken: "deck_investigation",
 }
 
 // --- Module Interfaces ---

--- a/apps/server/internal/module/exploration/deck_investigation/module.go
+++ b/apps/server/internal/module/exploration/deck_investigation/module.go
@@ -1,0 +1,215 @@
+package deck_investigation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func init() {
+	engine.Register("deck_investigation", func() engine.Module { return NewModule() })
+}
+
+type Module struct {
+	engine.PublicStateMarker
+
+	mu                  sync.RWMutex
+	deps                engine.ModuleDeps
+	config              Config
+	defaultTokenAmounts map[string]int
+	balancesByCharacter map[string]map[string]int
+}
+
+func NewModule() *Module {
+	return &Module{}
+}
+
+func (m *Module) Name() string { return "deck_investigation" }
+
+func (m *Module) Init(ctx context.Context, deps engine.ModuleDeps, config json.RawMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deps = deps
+	m.config = Config{}
+	if len(config) > 0 {
+		if err := json.Unmarshal(config, &m.config); err != nil {
+			return fmt.Errorf("deck_investigation: invalid config: %w", err)
+		}
+	}
+	if err := ValidateConfig(m.config); err != nil {
+		return err
+	}
+
+	m.defaultTokenAmounts = make(map[string]int, len(m.config.Tokens))
+	for _, token := range m.config.Tokens {
+		m.defaultTokenAmounts[token.ID] = token.DefaultAmount
+	}
+	m.balancesByCharacter = map[string]map[string]int{}
+	m.ensureRosterLocked(ctx)
+	return nil
+}
+
+func (m *Module) BuildState() (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state := map[string]any{
+		"tokens": map[string]any{
+			"byCharacter": cloneBalances(m.balancesByCharacter),
+		},
+	}
+	return json.Marshal(state)
+}
+
+func (m *Module) HandleMessage(_ context.Context, _ uuid.UUID, _ string, _ json.RawMessage) error {
+	return fmt.Errorf("deck_investigation: no direct messages supported")
+}
+
+func (m *Module) Cleanup(_ context.Context) error { return nil }
+
+func (m *Module) SupportedActions() []engine.PhaseAction {
+	return []engine.PhaseAction{
+		engine.ActionGrantInvestigationToken,
+		engine.ActionResetInvestigationToken,
+	}
+}
+
+func (m *Module) ReactTo(ctx context.Context, action engine.PhaseActionPayload) error {
+	switch action.Action {
+	case engine.ActionGrantInvestigationToken:
+		var params investigationTokenActionParams
+		if err := json.Unmarshal(action.Params, &params); err != nil {
+			return fmt.Errorf("deck_investigation: invalid GRANT_INVESTIGATION_TOKEN params: %w", err)
+		}
+		if params.Amount <= 0 {
+			return fmt.Errorf("deck_investigation: amount must be positive, got %d", params.Amount)
+		}
+		return m.applyTokenAction(ctx, params, func(current, _ int) int {
+			return current + params.Amount
+		})
+	case engine.ActionResetInvestigationToken:
+		var params investigationTokenActionParams
+		if err := json.Unmarshal(action.Params, &params); err != nil {
+			return fmt.Errorf("deck_investigation: invalid RESET_INVESTIGATION_TOKEN params: %w", err)
+		}
+		return m.applyTokenAction(ctx, params, func(_ int, defaultAmount int) int {
+			return defaultAmount
+		})
+	default:
+		return fmt.Errorf("deck_investigation: unsupported action %q", action.Action)
+	}
+}
+
+type investigationTokenActionParams struct {
+	TokenID string                 `json:"tokenId"`
+	Amount  int                    `json:"amount,omitempty"`
+	Target  map[string]interface{} `json:"target,omitempty"`
+}
+
+func (m *Module) applyTokenAction(
+	ctx context.Context,
+	params investigationTokenActionParams,
+	nextAmount func(current int, defaultAmount int) int,
+) error {
+	if params.TokenID == "" {
+		return fmt.Errorf("deck_investigation: tokenId is required")
+	}
+	defaultAmount, ok := m.defaultTokenAmounts[params.TokenID]
+	if !ok {
+		return fmt.Errorf("deck_investigation: unknown token %q", params.TokenID)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	targets := m.resolveTargetCharacterIDsLocked(ctx, params.Target)
+	for _, characterID := range targets {
+		m.ensureCharacterLocked(characterID)
+		m.balancesByCharacter[characterID][params.TokenID] = nextAmount(
+			m.balancesByCharacter[characterID][params.TokenID],
+			defaultAmount,
+		)
+	}
+	m.publishTokenChangedLocked(params.TokenID, targets)
+	return nil
+}
+
+func (m *Module) resolveTargetCharacterIDsLocked(ctx context.Context, target map[string]interface{}) []string {
+	targetType, _ := target["type"].(string)
+	if targetType == "character" {
+		if characterID, _ := target["character_id"].(string); characterID != "" {
+			return []string{characterID}
+		}
+		if characterID, _ := target["characterId"].(string); characterID != "" {
+			return []string{characterID}
+		}
+	}
+
+	m.ensureRosterLocked(ctx)
+	targets := make([]string, 0, len(m.balancesByCharacter))
+	for characterID := range m.balancesByCharacter {
+		targets = append(targets, characterID)
+	}
+	return targets
+}
+
+func (m *Module) ensureRosterLocked(ctx context.Context) {
+	rosterProvider, ok := m.deps.PlayerInfoProvider.(engine.PlayerRuntimeRosterProvider)
+	if !ok {
+		return
+	}
+	for _, player := range rosterProvider.PlayerRuntimeRoster(ctx) {
+		characterID := player.TargetCode
+		if characterID == "" {
+			characterID = player.PlayerID.String()
+		}
+		m.ensureCharacterLocked(characterID)
+	}
+}
+
+func (m *Module) ensureCharacterLocked(characterID string) {
+	if characterID == "" {
+		return
+	}
+	if _, ok := m.balancesByCharacter[characterID]; !ok {
+		m.balancesByCharacter[characterID] = make(map[string]int, len(m.defaultTokenAmounts))
+		for tokenID, amount := range m.defaultTokenAmounts {
+			m.balancesByCharacter[characterID][tokenID] = amount
+		}
+	}
+}
+
+func (m *Module) publishTokenChangedLocked(tokenID string, characterIDs []string) {
+	if m.deps.EventBus == nil {
+		return
+	}
+	m.deps.EventBus.Publish(engine.Event{
+		Type: "deck_investigation.tokens_changed",
+		Payload: map[string]any{
+			"tokenId":      tokenID,
+			"characterIds": append([]string(nil), characterIDs...),
+		},
+	})
+}
+
+func cloneBalances(source map[string]map[string]int) map[string]map[string]int {
+	clone := make(map[string]map[string]int, len(source))
+	for characterID, balances := range source {
+		clone[characterID] = make(map[string]int, len(balances))
+		for tokenID, amount := range balances {
+			clone[characterID][tokenID] = amount
+		}
+	}
+	return clone
+}
+
+var (
+	_ engine.Module       = (*Module)(nil)
+	_ engine.PhaseReactor = (*Module)(nil)
+)

--- a/apps/server/internal/module/exploration/deck_investigation/module_test.go
+++ b/apps/server/internal/module/exploration/deck_investigation/module_test.go
@@ -1,0 +1,135 @@
+package deck_investigation
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mmp-platform/server/internal/engine"
+)
+
+func TestModule_InitAndGrantInvestigationToken(t *testing.T) {
+	alice := uuid.New()
+	bob := uuid.New()
+	module := NewModule()
+	deps := engine.ModuleDeps{
+		EventBus: engine.NewEventBus(nil),
+		PlayerInfoProvider: rosterProvider{
+			players: []engine.PlayerRuntimeInfo{
+				{PlayerID: alice, TargetCode: "char-alice"},
+				{PlayerID: bob, TargetCode: "char-bob"},
+			},
+		},
+	}
+	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":1}],"decks":[]}`)
+	if err := module.Init(context.Background(), deps, config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	params := json.RawMessage(`{"tokenId":"coin","amount":2}`)
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionGrantInvestigationToken,
+		Params: params,
+	}); err != nil {
+		t.Fatalf("ReactTo grant: %v", err)
+	}
+
+	state := decodeModuleState(t, module)
+	if got := state.Tokens.ByCharacter["char-alice"]["coin"]; got != 3 {
+		t.Fatalf("alice coin = %d, want 3", got)
+	}
+	if got := state.Tokens.ByCharacter["char-bob"]["coin"]; got != 3 {
+		t.Fatalf("bob coin = %d, want 3", got)
+	}
+}
+
+func TestModule_ResetInvestigationTokenForCharacter(t *testing.T) {
+	module := NewModule()
+	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":1}],"decks":[]}`)
+	if err := module.Init(context.Background(), engine.ModuleDeps{EventBus: engine.NewEventBus(nil)}, config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	grant := json.RawMessage(`{"tokenId":"coin","amount":4,"target":{"type":"character","character_id":"char-late"}}`)
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionGrantInvestigationToken,
+		Params: grant,
+	}); err != nil {
+		t.Fatalf("ReactTo grant: %v", err)
+	}
+	reset := json.RawMessage(`{"tokenId":"coin","target":{"type":"character","character_id":"char-late"}}`)
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionResetInvestigationToken,
+		Params: reset,
+	}); err != nil {
+		t.Fatalf("ReactTo reset: %v", err)
+	}
+
+	state := decodeModuleState(t, module)
+	if got := state.Tokens.ByCharacter["char-late"]["coin"]; got != 1 {
+		t.Fatalf("char-late coin = %d, want 1", got)
+	}
+}
+
+func TestModule_RejectsUnknownTokenAction(t *testing.T) {
+	module := NewModule()
+	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":1}],"decks":[]}`)
+	if err := module.Init(context.Background(), engine.ModuleDeps{}, config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionGrantInvestigationToken,
+		Params: json.RawMessage(`{"tokenId":"missing","amount":1}`),
+	})
+	if err == nil {
+		t.Fatal("expected unknown token error")
+	}
+}
+
+type moduleState struct {
+	Tokens struct {
+		ByCharacter map[string]map[string]int `json:"byCharacter"`
+	} `json:"tokens"`
+}
+
+func decodeModuleState(t *testing.T, module *Module) moduleState {
+	t.Helper()
+	raw, err := module.BuildState()
+	if err != nil {
+		t.Fatalf("BuildState: %v", err)
+	}
+	var state moduleState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("Unmarshal state: %v", err)
+	}
+	return state
+}
+
+type rosterProvider struct {
+	players []engine.PlayerRuntimeInfo
+}
+
+func (r rosterProvider) ResolvePlayerID(_ context.Context, targetCode string) (uuid.UUID, bool) {
+	for _, player := range r.players {
+		if player.TargetCode == targetCode || player.PlayerID.String() == targetCode {
+			return player.PlayerID, true
+		}
+	}
+	return uuid.Nil, false
+}
+
+func (r rosterProvider) PlayerRuntimeInfo(_ context.Context, playerID uuid.UUID) (engine.PlayerRuntimeInfo, bool) {
+	for _, player := range r.players {
+		if player.PlayerID == playerID {
+			return player, true
+		}
+	}
+	return engine.PlayerRuntimeInfo{}, false
+}
+
+func (r rosterProvider) PlayerRuntimeRoster(_ context.Context) []engine.PlayerRuntimeInfo {
+	return append([]engine.PlayerRuntimeInfo(nil), r.players...)
+}

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -2,6 +2,7 @@ import { Plus, Trash2 } from "lucide-react";
 import type { PhaseAction } from "../../flowTypes";
 import {
   DELIVER_INFORMATION_ACTION,
+  type CreatorActionOption,
   getCreatorActionLabel,
   getVisibleCreatorActionOptions,
   isInformationDeliveryAction,
@@ -18,6 +19,7 @@ import {
 import { InformationActionFields } from "./InformationActionFields";
 import { BroadcastActionFields } from "./BroadcastActionFields";
 import { readAllPlayerReadingSectionId } from "./actionFieldHelpers";
+import type { InvestigationTokenDraft } from "../../entities/deckInvestigation/deckInvestigationAdapter";
 
 export { PRESENTATION_CUE_ACTION_TYPES } from "./PresentationCueFields";
 
@@ -28,6 +30,10 @@ interface ActionListEditorProps {
   hiddenTypes?: string[];
   allowedTypes?: readonly string[];
   themeId?: string;
+  actionOptions?: CreatorActionOption[];
+  createDefaultParamsForType?: (type: string) => Record<string, unknown> | undefined;
+  preserveDisallowedActions?: boolean;
+  investigationTokens?: InvestigationTokenDraft[];
 }
 
 export function ActionListEditor({
@@ -37,21 +43,34 @@ export function ActionListEditor({
   hiddenTypes = [],
   allowedTypes,
   themeId,
+  actionOptions,
+  createDefaultParamsForType,
+  preserveDisallowedActions = false,
+  investigationTokens = [],
 }: ActionListEditorProps) {
   const { data: readingSections = [] } = useReadingSections(themeId ?? "");
   const readingOptions = toReadingSectionPickerOptions(readingSections);
   const isTypeVisible = (type: string) =>
-    !hiddenTypes.includes(type) && (!allowedTypes || allowedTypes.includes(type));
+    !hiddenTypes.includes(type) &&
+    (preserveDisallowedActions || !allowedTypes || allowedTypes.includes(type));
   const visibleActions = actions
     .map((action, index) => ({ action, index }))
     .filter(({ action }) => isTypeVisible(action.type));
-  const visibleActionTypes = getVisibleCreatorActionOptions(hiddenTypes).filter(
+  const visibleActionTypes = (actionOptions ?? getVisibleCreatorActionOptions(hiddenTypes)).filter(
     (actionType) => !allowedTypes || allowedTypes.includes(actionType.value),
   );
   const defaultActionType = visibleActionTypes[0]?.value;
   const handleAdd = () => {
     if (!defaultActionType) return;
-    onChange([...actions, { id: crypto.randomUUID(), type: defaultActionType }]);
+    const params = resolveDefaultParams(defaultActionType, createDefaultParamsForType);
+    onChange([
+      ...actions,
+      {
+        id: crypto.randomUUID(),
+        type: defaultActionType,
+        ...(params ? { params } : {}),
+      },
+    ]);
   };
 
   const handleRemove = (index: number) => {
@@ -60,7 +79,7 @@ export function ActionListEditor({
 
   const handleTypeChange = (index: number, type: string) => {
     const next = actions.map((action, i) =>
-      i === index ? withActionType(action, type) : action,
+      i === index ? withActionType(action, type, createDefaultParamsForType) : action,
     );
     onChange(next);
   };
@@ -101,6 +120,7 @@ export function ActionListEditor({
           onRemove={handleRemove}
           themeId={themeId}
           readingOptions={readingOptions}
+          investigationTokens={investigationTokens}
         />
       ))}
     </div>
@@ -115,6 +135,13 @@ function createDefaultParams(type: string): Record<string, unknown> | undefined 
     return { message: "" };
   }
   return getPresentationCueConfig(type) ? {} : undefined;
+}
+
+function resolveDefaultParams(
+  type: string,
+  customFactory?: (type: string) => Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return customFactory ? customFactory(type) : createDefaultParams(type);
 }
 
 export function hasIncompletePresentationCueActions(actions: PhaseAction[]): boolean {
@@ -141,8 +168,12 @@ export function isPresentationCueAction(action: PhaseAction): boolean {
   return getPresentationCueConfig(action.type) !== null;
 }
 
-function withActionType(action: PhaseAction, type: string): PhaseAction {
-  const params = createDefaultParams(type);
+function withActionType(
+  action: PhaseAction,
+  type: string,
+  customFactory?: (type: string) => Record<string, unknown> | undefined,
+): PhaseAction {
+  const params = resolveDefaultParams(type, customFactory);
   const next: PhaseAction = { ...action, type };
   if (params) {
     next.params = params;
@@ -163,6 +194,7 @@ interface ActionRowProps {
   onRemove: (index: number) => void;
   themeId?: string;
   readingOptions: ReadingSectionPickerOption[];
+  investigationTokens: InvestigationTokenDraft[];
 }
 
 function ActionRow({
@@ -176,6 +208,7 @@ function ActionRow({
   onRemove,
   themeId,
   readingOptions,
+  investigationTokens,
 }: ActionRowProps) {
   const hasCurrentOption = visibleActionTypes.some((actionType) => actionType.value === action.type);
   const fallbackLabel = getCreatorActionLabel(action.type);
@@ -227,6 +260,81 @@ function ActionRow({
         index={displayIndex}
         onParamsChange={(params) => onParamsChange(index, params)}
       />
+      <InvestigationTokenActionFields
+        action={action}
+        tokens={investigationTokens}
+        onParamsChange={(params) => onParamsChange(index, params)}
+      />
+    </div>
+  );
+}
+
+function InvestigationTokenActionFields({
+  action,
+  tokens,
+  onParamsChange,
+}: {
+  action: PhaseAction;
+  tokens: InvestigationTokenDraft[];
+  onParamsChange: (params: Record<string, unknown>) => void;
+}) {
+  if (action.type !== "GRANT_INVESTIGATION_TOKEN" && action.type !== "RESET_INVESTIGATION_TOKEN") {
+    return null;
+  }
+
+  const params = action.params ?? {};
+  const selectedTokenId =
+    typeof params.tokenId === "string" && params.tokenId
+      ? params.tokenId
+      : tokens[0]?.id ?? "";
+  const amount =
+    typeof params.amount === "number" && Number.isFinite(params.amount)
+      ? Math.max(1, Math.floor(params.amount))
+      : 1;
+
+  return (
+    <div className="rounded border border-slate-800 bg-slate-950/80 p-2">
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_96px]">
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] text-slate-500">조사권</span>
+          <select
+            value={selectedTokenId}
+            onChange={(event) => onParamsChange({ ...params, tokenId: event.target.value })}
+            className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200"
+          >
+            {tokens.map((token) => (
+              <option key={token.id} value={token.id}>
+                {token.iconLabel} {token.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        {action.type === "GRANT_INVESTIGATION_TOKEN" ? (
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-slate-500">추가 수량</span>
+            <input
+              type="number"
+              min={1}
+              value={amount}
+              onChange={(event) =>
+                onParamsChange({
+                  ...params,
+                  tokenId: selectedTokenId,
+                  amount: Math.max(1, Number.parseInt(event.target.value || "1", 10)),
+                })
+              }
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200"
+            />
+          </label>
+        ) : (
+          <p className="rounded border border-slate-800 bg-slate-900/70 px-2 py-1.5 text-[11px] leading-4 text-slate-400">
+            선택한 조사권을 시작 수량으로 되돌립니다.
+          </p>
+        )}
+      </div>
+      {tokens.length === 0 ? (
+        <p className="mt-2 text-[11px] text-amber-300">조사권 설정에서 조사권을 먼저 추가해 주세요.</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
 import type { Edge, Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -14,7 +14,7 @@ import type {
 } from "../../flowTypes";
 import { flowKeys } from "../../flowTypes";
 import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
-import { hasIncompletePresentationCueActions } from "./ActionListEditor";
+import { ActionListEditor, hasIncompletePresentationCueActions } from "./ActionListEditor";
 import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
 import { normalizePhaseType } from "./phaseTypeOptions";
 import { InvestigationPhasePanel } from "./InvestigationPhasePanel";
@@ -27,6 +27,11 @@ import {
   readPlayerKillConfig,
   writePlayerKillSceneEnabled,
 } from "../../utils/configShape";
+import {
+  createSceneActionDefaultParams,
+  getSceneActionOptions,
+} from "../../entities/sceneAction/sceneActionRegistry";
+import { readDeckInvestigationConfig } from "../../entities/deckInvestigation/deckInvestigationAdapter";
 
 interface PhaseNodePanelProps {
   node: Node;
@@ -53,7 +58,26 @@ export function PhaseNodePanel({
   const phaseType = normalizePhaseType(data.phase_type);
   const theme = queryClient.getQueryData<EditorThemeResponse>(editorKeys.theme(themeId));
   const configJson = theme?.config_json ?? {};
-  const playerKillEnabled = readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID);
+  const enabledModuleIds = readEnabledModuleIds(configJson);
+  const playerKillEnabled = enabledModuleIds.includes(PLAYER_KILL_MODULE_ID);
+  const sceneActionOptions = getSceneActionOptions({ enabledModuleIds });
+  const sceneActionTypes = sceneActionOptions.map((option) => option.value);
+  const investigationTokens = readDeckInvestigationConfig(configJson).tokens;
+  const createSceneActionParams = useCallback(
+    (type: string) => {
+      const params = createSceneActionDefaultParams(type);
+      if (
+        (type === "GRANT_INVESTIGATION_TOKEN" || type === "RESET_INVESTIGATION_TOKEN") &&
+        params &&
+        !params.tokenId &&
+        investigationTokens[0]?.id
+      ) {
+        return { ...params, tokenId: investigationTokens[0].id };
+      }
+      return params;
+    },
+    [investigationTokens],
+  );
   const playerKillConfig = readPlayerKillConfig(configJson);
   const sceneKillEnabled = playerKillConfig.allowedSceneIds.includes(node.id);
   const isPhaseSceneNode = node.type === "phase";
@@ -130,6 +154,40 @@ export function PhaseNodePanel({
             </span>
           </span>
         </label>
+      ) : null}
+      {isPhaseSceneNode ? (
+        <section className="space-y-3 rounded-lg border border-slate-800 bg-slate-950/60 p-3">
+          <div>
+            <h4 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+              장면 액션
+            </h4>
+            <p className="mt-1 text-[11px] leading-4 text-slate-500">
+              장면이 시작되거나 끝날 때 정보 공개, BGM, 알림 같은 실행 결과를 순서대로 처리합니다.
+            </p>
+          </div>
+          <ActionListEditor
+            label="장면 시작 액션"
+            actions={data.onEnter ?? []}
+            allowedTypes={sceneActionTypes}
+            actionOptions={sceneActionOptions}
+            createDefaultParamsForType={createSceneActionParams}
+            preserveDisallowedActions
+            themeId={themeId}
+            investigationTokens={investigationTokens}
+            onChange={(actions) => handleChange({ onEnter: actions })}
+          />
+          <ActionListEditor
+            label="장면 종료 액션"
+            actions={data.onExit ?? []}
+            allowedTypes={sceneActionTypes}
+            actionOptions={sceneActionOptions}
+            createDefaultParamsForType={createSceneActionParams}
+            preserveDisallowedActions
+            themeId={themeId}
+            investigationTokens={investigationTokens}
+            onChange={(actions) => handleChange({ onExit: actions })}
+          />
+        </section>
       ) : null}
       {phaseType === "investigation" ? (
         <>

--- a/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
@@ -243,6 +243,82 @@ describe("ActionListEditor", () => {
     ]);
   });
 
+  it("preserveDisallowedActions가 켜지면 새 목록에 없는 기존 액션도 보존 표시한다", () => {
+    render(
+      <ActionListEditor
+        label="장면 시작 액션"
+        actions={[
+          { id: "old-token", type: "GRANT_INVESTIGATION_TOKEN", params: { tokenId: "coin", amount: 1 } },
+          { id: "bgm", type: "SET_BGM", params: { mediaId: "media-1" } },
+        ]}
+        allowedTypes={["SET_BGM"]}
+        preserveDisallowedActions
+        onChange={vi.fn()}
+        themeId="theme-1"
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "장면 시작 액션 1 실행 결과" })).toHaveProperty(
+      "value",
+      "GRANT_INVESTIGATION_TOKEN",
+    );
+    expect(screen.getByRole("option", { name: "조사권 추가 (기존값)" })).toBeDefined();
+    expect(screen.getByRole("combobox", { name: "장면 시작 액션 2 실행 결과" })).toHaveProperty(
+      "value",
+      "SET_BGM",
+    );
+  });
+
+  it("custom actionOptions와 기본 params로 장면 액션을 추가한다", () => {
+    const onChange = vi.fn();
+
+    render(
+      <ActionListEditor
+        label="장면 종료 액션"
+        actions={[]}
+        actionOptions={[{ value: "STOP_AUDIO", label: "BGM 종료" }]}
+        allowedTypes={["STOP_AUDIO"]}
+        createDefaultParamsForType={(type) => (type === "STOP_AUDIO" ? { scope: "bgm" } : undefined)}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "추가" }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ type: "STOP_AUDIO", params: { scope: "bgm" } }),
+    ]);
+  });
+
+  it("조사권 추가 액션의 조사권 종류와 수량을 params로 저장한다", () => {
+    const onChange = vi.fn();
+
+    render(
+      <ActionListEditor
+        label="장면 시작 액션"
+        actions={[{ id: "token", type: "GRANT_INVESTIGATION_TOKEN", params: { tokenId: "coin", amount: 1 } }]}
+        investigationTokens={[
+          { id: "coin", name: "동전", iconLabel: "코", defaultAmount: 2 },
+          { id: "badge", name: "배지", iconLabel: "배", defaultAmount: 0 },
+        ]}
+        preserveDisallowedActions
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByDisplayValue("코 동전"), { target: { value: "badge" } });
+    expect(onChange).toHaveBeenCalledWith([
+      { id: "token", type: "GRANT_INVESTIGATION_TOKEN", params: { tokenId: "badge", amount: 1 } },
+    ]);
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: "추가 수량" }), {
+      target: { value: "3" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith([
+      { id: "token", type: "GRANT_INVESTIGATION_TOKEN", params: { tokenId: "coin", amount: 3 } },
+    ]);
+  });
+
   it("컬러 테마 실행 결과를 preset token으로 저장한다", () => {
     const onChange = vi.fn();
     render(

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -156,7 +156,11 @@ describe("PhaseNodePanel type-specific fields", () => {
 
   it("수사 장면은 기본 정보, 시간, 맵 선택, 자동 진행 안내를 표시한다", () => {
     renderWithQC(
-      <PhaseNodePanel node={makeNode()} themeId="t1" onUpdate={vi.fn()} />,
+      <PhaseNodePanel
+        node={makeNode({ onEnter: [{ id: "bgm", type: "SET_BGM", params: {} }] })}
+        themeId="t1"
+        onUpdate={vi.fn()}
+      />,
     );
 
     expect(screen.getByText("장면 설정")).toBeDefined();
@@ -165,12 +169,91 @@ describe("PhaseNodePanel type-specific fields", () => {
     expect(screen.getByLabelText("시간 (분)")).toBeDefined();
     expect(screen.getByLabelText("사용할 맵")).toBeDefined();
     expect(screen.getByText(/다음 연결 장면으로 자동 진행/)).toBeDefined();
+    expect(screen.getByText("장면 액션")).toBeDefined();
+    expect(screen.getByText("장면 시작 액션")).toBeDefined();
+    expect(screen.getByText("장면 종료 액션")).toBeDefined();
 
     expect(screen.queryByText("라운드 수")).toBeNull();
     expect(screen.queryByText("장면 진입 효과")).toBeNull();
     expect(screen.queryByText("토론방 설정")).toBeNull();
     expect(screen.queryByText("읽기 대사 배치")).toBeNull();
-    expect(screen.queryByText("장면 시작 트리거")).toBeNull();
+  });
+
+  it("장면 시작 액션과 종료 액션을 onEnter/onExit에 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel node={makeNode()} themeId="t1" onUpdate={onUpdate} />,
+    );
+
+    const addButtons = screen.getAllByRole("button", { name: "추가" });
+    fireEvent.click(addButtons[0]);
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      onEnter: [expect.objectContaining({ type: "SET_BGM", params: {} })],
+    });
+
+    fireEvent.click(addButtons[1]);
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      onExit: [expect.objectContaining({ type: "SET_BGM", params: {} })],
+    });
+  });
+
+  it("조사권 모듈이 켜져 있으면 장면 액션 목록에 조사권 액션을 표시한다", () => {
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({ onEnter: [{ id: "bgm", type: "SET_BGM", params: {} }] })}
+        themeId="t1"
+        onUpdate={vi.fn()}
+      />,
+      {
+        id: "t1",
+        version: 7,
+        config_json: {
+          modules: {
+            deck_investigation: { enabled: true, config: { tokens: [] } },
+          },
+        },
+      },
+    );
+
+    const startSelect = screen.getByRole("combobox", { name: "장면 시작 액션 1 실행 결과" });
+    expect(within(startSelect).getByRole("option", { name: "조사권 추가" })).toBeDefined();
+    expect(within(startSelect).getByRole("option", { name: "조사권 초기화" })).toBeDefined();
+  });
+
+  it("조사권 액션으로 바꾸면 첫 조사권을 기본 tokenId로 저장한다", () => {
+    const onUpdate = vi.fn();
+    renderWithQC(
+      <PhaseNodePanel
+        node={makeNode({ onEnter: [{ id: "bgm", type: "SET_BGM", params: {} }] })}
+        themeId="t1"
+        onUpdate={onUpdate}
+      />,
+      {
+        id: "t1",
+        version: 7,
+        config_json: {
+          modules: {
+            deck_investigation: {
+              enabled: true,
+              config: { tokens: [{ id: "coin", name: "조사권", iconLabel: "AP", defaultAmount: 1 }] },
+            },
+          },
+        },
+      },
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "장면 시작 액션 1 실행 결과" }), {
+      target: { value: "GRANT_INVESTIGATION_TOKEN" },
+    });
+
+    expect(onUpdate).toHaveBeenLastCalledWith("node-1", {
+      onEnter: [
+        expect.objectContaining({
+          type: "GRANT_INVESTIGATION_TOKEN",
+          params: { tokenId: "coin", amount: 1 },
+        }),
+      ],
+    });
   });
 
   it("수사 장면에서 사용할 맵을 선택하면 investigationMapId를 저장한다", () => {

--- a/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
+++ b/apps/web/src/features/editor/components/story-map/__tests__/SceneInspector.test.tsx
@@ -100,7 +100,7 @@ describe("SceneInspector", () => {
     expect(screen.getByText("찢어진 초대장")).toBeDefined();
     expect(screen.getByText("공개 설정 1개 · 읽기 대사 1개 · 스토리 정보 2개")).toBeDefined();
     expect(screen.getByText("단서 실행 1개")).toBeDefined();
-    expect(screen.getByText("BGM 재생")).toBeDefined();
+    expect(screen.getByText("BGM 설정")).toBeDefined();
     expect(screen.getByText("자동 진행 · 기본 이동 없음 · 조건 이동 1개")).toBeDefined();
     expect(screen.getByText("시작: 직접 설정한 실행 · 종료: 채팅 닫기")).toBeDefined();
     expect(

--- a/apps/web/src/features/editor/entities/sceneAction/__tests__/sceneActionRegistry.test.ts
+++ b/apps/web/src/features/editor/entities/sceneAction/__tests__/sceneActionRegistry.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSceneActionDefaultParams,
+  DECK_INVESTIGATION_MODULE_ID,
+  getSceneActionOptions,
+  isSceneActionComplete,
+} from "../sceneActionRegistry";
+
+describe("sceneActionRegistry", () => {
+  it("조사권 모듈이 꺼져 있으면 조사권 액션을 새 액션 목록에서 숨긴다", () => {
+    const options = getSceneActionOptions({ enabledModuleIds: [] });
+
+    expect(options.some((option) => option.value === "SET_BGM")).toBe(true);
+    expect(options.some((option) => option.value === "GRANT_INVESTIGATION_TOKEN")).toBe(false);
+    expect(options.some((option) => option.value === "RESET_INVESTIGATION_TOKEN")).toBe(false);
+  });
+
+  it("조사권 모듈이 켜져 있으면 조사권 추가와 초기화를 노출한다", () => {
+    const options = getSceneActionOptions({
+      enabledModuleIds: [DECK_INVESTIGATION_MODULE_ID],
+    });
+
+    expect(options.some((option) => option.value === "GRANT_INVESTIGATION_TOKEN")).toBe(true);
+    expect(options.some((option) => option.value === "RESET_INVESTIGATION_TOKEN")).toBe(true);
+  });
+
+  it("장면 액션별 기본 params를 만든다", () => {
+    expect(createSceneActionDefaultParams("SET_BGM")).toEqual({});
+    expect(createSceneActionDefaultParams("STOP_AUDIO")).toEqual({ scope: "bgm" });
+    expect(createSceneActionDefaultParams("BROADCAST_MESSAGE")).toEqual({ message: "" });
+    expect(createSceneActionDefaultParams("GRANT_INVESTIGATION_TOKEN")).toEqual({
+      tokenId: "",
+      amount: 1,
+    });
+  });
+
+  it("BGM 종료 액션은 별도 미디어 선택 없이 완료 상태다", () => {
+    expect(isSceneActionComplete({ type: "STOP_AUDIO", params: { scope: "bgm" } })).toBe(true);
+  });
+});

--- a/apps/web/src/features/editor/entities/sceneAction/sceneActionRegistry.ts
+++ b/apps/web/src/features/editor/entities/sceneAction/sceneActionRegistry.ts
@@ -1,0 +1,81 @@
+import type { CreatorActionOption } from "../shared/actionAdapter";
+import {
+  DELIVER_INFORMATION_ACTION,
+  GRANT_CLUE_ACTION,
+} from "../shared/actionAdapter";
+
+export const DECK_INVESTIGATION_MODULE_ID = "deck_investigation";
+
+export const SCENE_ACTION_TYPES = {
+  SET_BGM: "SET_BGM",
+  STOP_AUDIO: "STOP_AUDIO",
+  PLAY_SOUND: "PLAY_SOUND",
+  PLAY_MEDIA: "PLAY_MEDIA",
+  SET_BACKGROUND: "SET_BACKGROUND",
+  SET_THEME_COLOR: "SET_THEME_COLOR",
+  BROADCAST_MESSAGE: "BROADCAST_MESSAGE",
+  DELIVER_INFORMATION: DELIVER_INFORMATION_ACTION,
+  GRANT_CLUE: GRANT_CLUE_ACTION,
+  OPEN_VOTING: "OPEN_VOTING",
+  CLOSE_VOTING: "CLOSE_VOTING",
+  UNMUTE_CHAT: "UNMUTE_CHAT",
+  MUTE_CHAT: "MUTE_CHAT",
+  GRANT_INVESTIGATION_TOKEN: "GRANT_INVESTIGATION_TOKEN",
+  RESET_INVESTIGATION_TOKEN: "RESET_INVESTIGATION_TOKEN",
+} as const;
+
+interface SceneActionDefinition extends CreatorActionOption {
+  requiredModuleId?: string;
+  defaultParams?: Record<string, unknown>;
+}
+
+const SCENE_ACTION_DEFINITIONS: SceneActionDefinition[] = [
+  { value: SCENE_ACTION_TYPES.SET_BGM, label: "BGM 설정", defaultParams: {} },
+  { value: SCENE_ACTION_TYPES.STOP_AUDIO, label: "BGM 종료", defaultParams: { scope: "bgm" } },
+  { value: SCENE_ACTION_TYPES.PLAY_SOUND, label: "효과음 재생", defaultParams: {} },
+  { value: SCENE_ACTION_TYPES.PLAY_MEDIA, label: "영상 재생", defaultParams: {} },
+  { value: SCENE_ACTION_TYPES.SET_BACKGROUND, label: "배경 이미지 변경", defaultParams: {} },
+  { value: SCENE_ACTION_TYPES.SET_THEME_COLOR, label: "화면 색상 변경", defaultParams: {} },
+  { value: SCENE_ACTION_TYPES.BROADCAST_MESSAGE, label: "알림 보내기", defaultParams: { message: "" } },
+  { value: SCENE_ACTION_TYPES.DELIVER_INFORMATION, label: "정보 공개", defaultParams: { deliveries: [] } },
+  { value: SCENE_ACTION_TYPES.GRANT_CLUE, label: "단서 지급" },
+  { value: SCENE_ACTION_TYPES.OPEN_VOTING, label: "투표 시작", requiredModuleId: "voting" },
+  { value: SCENE_ACTION_TYPES.CLOSE_VOTING, label: "투표 종료", requiredModuleId: "voting" },
+  { value: SCENE_ACTION_TYPES.UNMUTE_CHAT, label: "채팅 열기", requiredModuleId: "text_chat" },
+  { value: SCENE_ACTION_TYPES.MUTE_CHAT, label: "채팅 닫기", requiredModuleId: "text_chat" },
+  {
+    value: SCENE_ACTION_TYPES.GRANT_INVESTIGATION_TOKEN,
+    label: "조사권 추가",
+    requiredModuleId: DECK_INVESTIGATION_MODULE_ID,
+    defaultParams: { tokenId: "", amount: 1 },
+  },
+  {
+    value: SCENE_ACTION_TYPES.RESET_INVESTIGATION_TOKEN,
+    label: "조사권 초기화",
+    requiredModuleId: DECK_INVESTIGATION_MODULE_ID,
+    defaultParams: { tokenId: "", mode: "default" },
+  },
+];
+
+export function getSceneActionOptions({
+  enabledModuleIds,
+}: {
+  enabledModuleIds: string[];
+}): CreatorActionOption[] {
+  const enabled = new Set(enabledModuleIds);
+  return SCENE_ACTION_DEFINITIONS.filter(
+    (definition) => !definition.requiredModuleId || enabled.has(definition.requiredModuleId),
+  ).map(({ value, label }) => ({ value, label }));
+}
+
+export function createSceneActionDefaultParams(type: string): Record<string, unknown> | undefined {
+  const definition = SCENE_ACTION_DEFINITIONS.find((item) => item.value === type);
+  return definition?.defaultParams ? { ...definition.defaultParams } : undefined;
+}
+
+export function isSceneActionComplete(action: { type: string; params?: Record<string, unknown> }): boolean {
+  if (action.type === SCENE_ACTION_TYPES.STOP_AUDIO) {
+    return true;
+  }
+  return true;
+}

--- a/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/shared/__tests__/actionAdapter.test.ts
@@ -59,7 +59,7 @@ describe("actionAdapter", () => {
         [{ type: "SET_BGM" }, { type: DELIVER_INFORMATION_ACTION }, { type: "MUTE_CHAT" }],
         { excludeInformationDelivery: true },
       ),
-    ).toEqual(["BGM 재생", "채팅 닫기"]);
+    ).toEqual(["BGM 설정", "채팅 닫기"]);
   });
 
   it("legacy 소문자 action도 기존 저장 데이터용 라벨을 유지한다", () => {

--- a/apps/web/src/features/editor/entities/shared/actionAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/actionAdapter.ts
@@ -18,10 +18,10 @@ export const CREATOR_ACTION_OPTIONS: CreatorActionOption[] = [
   { value: DELIVER_INFORMATION_ACTION, label: "정보 공개" },
   { value: GRANT_CLUE_ACTION, label: "단서 지급" },
   { value: "BROADCAST_MESSAGE", label: "알림 보내기" },
-  { value: "SET_BGM", label: "BGM 재생" },
+  { value: "SET_BGM", label: "BGM 설정" },
   { value: "PLAY_SOUND", label: "효과음 재생" },
   { value: "PLAY_MEDIA", label: "영상 재생" },
-  { value: "STOP_AUDIO", label: "BGM/효과음 정지" },
+  { value: "STOP_AUDIO", label: "BGM 종료" },
   { value: "SET_BACKGROUND", label: "배경 이미지 변경" },
   { value: "SET_THEME_COLOR", label: "화면 색상 테마 변경" },
 ];
@@ -46,6 +46,8 @@ const ACTION_LABELS = new Map<string, string>([
   ["set_background", "배경 이미지 변경"],
   ["set_theme_color", "화면 색상 테마 변경"],
   ["stop_bgm", "BGM 정지"],
+  ["GRANT_INVESTIGATION_TOKEN", "조사권 추가"],
+  ["RESET_INVESTIGATION_TOKEN", "조사권 초기화"],
 ]);
 
 export function getCreatorActionLabel(type: string): string {

--- a/docs/superpowers/plans/2026-05-17-scene-entry-exit-actions.md
+++ b/docs/superpowers/plans/2026-05-17-scene-entry-exit-actions.md
@@ -1,0 +1,131 @@
+# Scene Entry Exit Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 제작자가 각 장면 설정에서 장면 시작/종료 시 실행할 액션을 편집하고, BGM이 없어도 업로드 후 바로 연결할 수 있게 한다.
+
+**Architecture:** 저장 원본은 기존 `flow_nodes.data.onEnter` / `flow_nodes.data.onExit`를 유지한다. 액션 목록은 `ActionListEditor`를 재사용하되, 장면 패널용 허용 액션을 `sceneActionRegistry`에서 계산해 모듈 활성 상태에 따라 새 액션 추가 목록만 필터링한다. 기존 저장 액션은 모듈이 꺼져도 표시해 제작자가 데이터를 잃지 않게 한다.
+
+**Tech Stack:** React 19, TanStack Query, Tailwind CSS, Vitest Testing Library, existing editor flow/media APIs.
+
+---
+
+## File Structure
+
+- Modify: `apps/web/src/features/editor/components/design/PhaseNodePanel.tsx`
+  - `ActionListEditor`를 장면 시작/종료 섹션으로 연결한다.
+  - theme config 기반 허용 액션을 계산한다.
+- Modify: `apps/web/src/features/editor/components/design/ActionListEditor.tsx`
+  - 숨겨진 기존 액션을 보존 표시한다.
+  - 액션별 기본 params를 registry에서 가져오게 한다.
+- Modify: `apps/web/src/features/editor/components/design/PresentationCueFields.tsx`
+  - `STOP_AUDIO`/`stop_bgm` 같은 종료 액션은 미디어 선택 없이 완료 상태로 다룬다.
+  - BGM 선택은 기존 `MediaPicker` 업로드 흐름을 그대로 사용한다.
+- Create: `apps/web/src/features/editor/entities/sceneAction/sceneActionRegistry.ts`
+  - 장면 액션 정의, 기본 params, 모듈 필터링, 완료 검증을 담당한다.
+- Test: `apps/web/src/features/editor/entities/sceneAction/__tests__/sceneActionRegistry.test.ts`
+- Test: `apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx`
+- Test: `apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx`
+
+## Task 1: Scene Action Registry
+
+- [ ] **Step 1: Write failing registry tests**
+
+```ts
+expect(getSceneActionOptions({ enabledModuleIds: [] }).some((a) => a.value === "GRANT_INVESTIGATION_TOKEN")).toBe(false);
+expect(getSceneActionOptions({ enabledModuleIds: ["deck_investigation"] }).some((a) => a.value === "GRANT_INVESTIGATION_TOKEN")).toBe(true);
+expect(createSceneActionDefaultParams("SET_BGM")).toEqual({});
+expect(createSceneActionDefaultParams("STOP_AUDIO")).toEqual({ scope: "bgm" });
+expect(isSceneActionComplete({ type: "STOP_AUDIO", params: { scope: "bgm" } })).toBe(true);
+```
+
+- [ ] **Step 2: Implement registry**
+
+Create `sceneActionRegistry.ts` with constants for always available actions and module-gated actions. Keep internal action type strings in code only; UI labels stay creator-friendly.
+
+- [ ] **Step 3: Run registry tests**
+
+Run: `pnpm --filter @mmp/web test -- sceneActionRegistry.test.ts`
+
+## Task 2: Action Editor Integration
+
+- [ ] **Step 1: Update `ActionListEditor` tests**
+
+Add tests for:
+- `allowedTypes` controls add/select options.
+- Existing disallowed action still renders as `(기존값)`.
+- `STOP_AUDIO` is not treated as incomplete.
+
+- [ ] **Step 2: Update `ActionListEditor`**
+
+Use registry helpers for default params and incomplete validation. Keep current field components for information, broadcast, media cues.
+
+- [ ] **Step 3: Run focused tests**
+
+Run: `pnpm --filter @mmp/web test -- ActionListEditor.test.tsx`
+
+## Task 3: Phase Panel Entry/Exit Sections
+
+- [ ] **Step 1: Update `PhaseNodePanelExtended` tests**
+
+Assert that a phase node shows:
+- `장면 시작 액션`
+- `장면 종료 액션`
+- `BGM 설정`
+- `BGM 종료`
+
+Assert that changing an entry action calls:
+
+```ts
+expect(onUpdate).toHaveBeenCalledWith("node-1", {
+  onEnter: [expect.objectContaining({ type: "SET_BGM" })],
+});
+```
+
+- [ ] **Step 2: Render action sections**
+
+Add two `ActionListEditor` instances:
+- label `장면 시작 액션`, value `data.onEnter ?? []`
+- label `장면 종료 액션`, value `data.onExit ?? []`
+
+Use `handleChange({ onEnter: actions })` and `handleChange({ onExit: actions })`.
+
+- [ ] **Step 3: Run focused tests**
+
+Run: `pnpm --filter @mmp/web test -- PhaseNodePanelExtended.test.tsx`
+
+## Task 4: BGM Upload/Link Validation
+
+- [ ] **Step 1: Verify MediaPicker reuse**
+
+`PresentationCueFields` should pass `filterType="BGM"` and `useCase="phase_bgm"` for `SET_BGM`. Existing `MediaPicker` opens `MediaUploadModal`, so BGM 없는 상태에서도 업로드 버튼이 available.
+
+- [ ] **Step 2: Add test coverage**
+
+Mock empty `useMediaList` and assert `BGM 선택` button renders. For modal upload internals, rely on `MediaPicker` tests because this component only opens the picker.
+
+## Task 5: Validation and PR
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+pnpm --filter @mmp/web test -- sceneActionRegistry.test.ts ActionListEditor.test.tsx PhaseNodePanelExtended.test.tsx
+```
+
+- [ ] **Step 2: Run local quick CI**
+
+```bash
+scripts/mmp-local-ci.sh quick
+```
+
+- [ ] **Step 3: Commit and create PR**
+
+```bash
+git add apps/web/src/features/editor docs/superpowers/plans/2026-05-17-scene-entry-exit-actions.md
+git commit -m "feat(web): add scene entry and exit actions"
+scripts/pr-create-guard.sh --title "장면 시작·종료 액션 설정과 BGM 연동 추가" --body-file /tmp/scene-entry-exit-actions-pr.md
+```
+
+- [ ] **Step 4: Review and merge**
+
+Use CodeRabbit review, resolve actionable comments, verify unresolved review threads are 0, then merge.


### PR DESCRIPTION
## 요약
- 장면 설정 패널에 장면 시작/종료 액션 편집 UI를 추가했습니다.
- BGM 설정/종료, 미디어 재생, 프레젠테이션, 정보/단서, 채팅/투표, 조사권 액션을 모듈 활성 상태에 맞춰 노출합니다.
- `deck_investigation` 런타임 모듈을 등록하고 조사권 추가/초기화 PhaseAction을 서버에서 처리하도록 연결했습니다.

## Coverage Plan
- `PhaseNodePanelExtended.test.tsx`: 장면 시작/종료 액션 섹션, onEnter/onExit 저장, 조사권 모듈 옵션 노출, 조사권 액션 기본 tokenId 검증
- `ActionListEditor.test.tsx`: action option 주입, 기본 params 생성, disallowed action 보존, 조사권 token/amount 편집 검증
- `sceneActionRegistry.test.ts`: 모듈별 장면 액션 노출과 기본 params 검증
- `actionAdapter.test.ts`, `SceneInspector.test.tsx`: BGM 라벨 변경에 따른 summary 표시 검증
- `module_test.go`: 조사권 모듈 초기 수량, 전체 지급, 캐릭터 reset, unknown token 실패 경로 검증

## Local validation
- `go test ./internal/engine ./internal/module/exploration/deck_investigation` 통과
- `pnpm --filter @mmp/web test -- sceneActionRegistry.test.ts ActionListEditor.test.tsx PhaseNodePanelExtended.test.tsx` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web lint` 통과, 기존 warning 48개 유지
- `scripts/mmp-local-ci.sh quick` 통과: head `3a030aaeb7e2dea6d59811379f031b33a0b01eba`, finished `2026-05-17T03:46:19Z`

## E2E
- 이번 PR은 editor panel/action contract와 backend PhaseAction 처리 중심이라 Vitest component/unit, Go unit, local-ci quick으로 검증했습니다. 새 Playwright E2E는 추가하지 않았습니다.

Refs #589