### PR TITLE
정보별 장면 시작 배포 설정 추가

### DIFF
--- a/apps/web/src/features/editor/components/info/InfoDeliverySettingsCard.tsx
+++ b/apps/web/src/features/editor/components/info/InfoDeliverySettingsCard.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useMemo, useState } from "react";
+import { Save } from "lucide-react";
+
+import { useEditorCharacters } from "@/features/editor/api";
+import { useFlowGraph, useUpdateFlowNode } from "@/features/editor/flowApi";
+import type { FlowNodeResponse } from "@/features/editor/flowTypes";
+import {
+  normalizeTarget,
+  readInfoDeliveryTarget,
+  targetsEqual,
+  writeInfoDeliveryTarget,
+  type InfoDeliveryTargetDraft,
+  type InfoDeliveryTargetMode,
+} from "@/features/editor/entities/info/infoDeliverySettingsAdapter";
+
+interface InfoDeliverySettingsCardProps {
+  themeId: string;
+  storyInfoId: string;
+}
+
+interface PhaseOption {
+  id: string;
+  label: string;
+  node: FlowNodeResponse;
+}
+
+export function InfoDeliverySettingsCard({
+  themeId,
+  storyInfoId,
+}: InfoDeliverySettingsCardProps) {
+  const { data: flowGraph, isLoading: flowLoading, isError: flowError, refetch: refetchFlow } =
+    useFlowGraph(themeId);
+  const {
+    data: characters = [],
+    isLoading: charactersLoading,
+    isError: charactersError,
+    refetch: refetchCharacters,
+  } = useEditorCharacters(themeId);
+  const updateNode = useUpdateFlowNode(themeId);
+
+  const phaseOptions = useMemo(
+    () =>
+      (flowGraph?.nodes ?? [])
+        .filter((node) => node.type === "phase")
+        .map((node, index): PhaseOption => ({
+          id: node.id,
+          label: node.data.label?.trim() || `장면 ${index + 1}`,
+          node,
+        })),
+    [flowGraph?.nodes],
+  );
+
+  const isLoading = flowLoading || charactersLoading;
+  const isError = flowError || charactersError;
+
+  return (
+    <section className="rounded border border-slate-800 bg-slate-950 p-4" aria-label="정보 배포 설정">
+      <div className="flex flex-col gap-2 border-b border-slate-800 pb-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-100">장면 시작 배포</h3>
+          <p className="mt-1 text-xs text-slate-400">
+            선택한 장면이 시작될 때 이 정보를 누구에게 보여줄지 정합니다.
+          </p>
+        </div>
+        {isError ? (
+          <button
+            type="button"
+            onClick={() => {
+              if (flowError) void refetchFlow();
+              if (charactersError) void refetchCharacters();
+            }}
+            className="self-start rounded border border-slate-700 px-3 py-1.5 text-xs text-slate-200 hover:border-slate-500"
+          >
+            다시 불러오기
+          </button>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <p className="py-4 text-xs text-slate-500">장면과 캐릭터를 불러오는 중입니다.</p>
+      ) : isError ? (
+        <p className="py-4 text-xs text-rose-300">배포 설정을 불러오지 못했습니다.</p>
+      ) : phaseOptions.length === 0 ? (
+        <p className="py-4 text-xs text-slate-500">
+          게임 진행 플로우에 장면을 먼저 추가하면 이 정보를 배포할 수 있습니다.
+        </p>
+      ) : (
+        <div className="mt-3 space-y-3">
+          {phaseOptions.map((phase) => (
+            <InfoDeliveryPhaseRow
+              key={phase.id}
+              phase={phase}
+              storyInfoId={storyInfoId}
+              characters={characters}
+              isSaving={updateNode.isPending}
+              onSave={(target) =>
+                updateNode.mutateAsync({
+                  nodeId: phase.id,
+                  body: {
+                    data: {
+                      ...phase.node.data,
+                      ...writeInfoDeliveryTarget(phase.node.data, storyInfoId, target),
+                    },
+                  },
+                })
+              }
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function InfoDeliveryPhaseRow({
+  phase,
+  storyInfoId,
+  characters,
+  isSaving,
+  onSave,
+}: {
+  phase: PhaseOption;
+  storyInfoId: string;
+  characters: Array<{ id: string; name: string }>;
+  isSaving: boolean;
+  onSave: (target: InfoDeliveryTargetDraft) => Promise<unknown>;
+}) {
+  const savedTarget = useMemo(
+    () => readInfoDeliveryTarget(phase.node.data, storyInfoId),
+    [phase.node.data, storyInfoId],
+  );
+  const [draftTarget, setDraftTarget] = useState(savedTarget);
+  const [saveState, setSaveState] = useState<"idle" | "saved" | "failed">("idle");
+
+  useEffect(() => {
+    setDraftTarget(savedTarget);
+    setSaveState("idle");
+  }, [savedTarget]);
+
+  const normalizedDraft = normalizeTarget(draftTarget);
+  const isDirty = !targetsEqual(savedTarget, draftTarget);
+  const hasCharacters = characters.length > 0;
+  const canApply = draftTarget.mode !== "characters" || draftTarget.characterIds.length > 0;
+
+  async function handleSave() {
+    setSaveState("idle");
+    try {
+      await onSave(normalizedDraft);
+      setSaveState("saved");
+    } catch {
+      setSaveState("failed");
+    }
+  }
+
+  return (
+    <article className="rounded-lg border border-slate-800 bg-slate-900/55 p-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h4 className="text-sm font-medium text-slate-100">{phase.label}</h4>
+          <p className="mt-0.5 text-xs text-slate-500">{targetSummary(savedTarget, characters)}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {saveState === "saved" ? <span className="text-xs text-emerald-300">저장됨</span> : null}
+          {saveState === "failed" ? <span className="text-xs text-rose-300">저장 실패</span> : null}
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={!isDirty || !canApply || isSaving}
+            className="inline-flex items-center gap-1 rounded bg-amber-500 px-3 py-1.5 text-xs font-medium text-slate-950 hover:bg-amber-400 disabled:bg-slate-700 disabled:text-slate-500"
+          >
+            <Save className="h-3.5 w-3.5" />
+            {isSaving ? "적용 중..." : "배포 적용"}
+          </button>
+        </div>
+      </div>
+
+      <fieldset className="mt-3 grid gap-2 text-xs text-slate-300 sm:grid-cols-3">
+        <legend className="sr-only">{phase.label} 배포 대상</legend>
+        {(["none", "all_players", "characters"] as InfoDeliveryTargetMode[]).map((mode) => (
+          <label
+            key={mode}
+            className="flex items-center gap-2 rounded border border-slate-800 bg-slate-950/70 px-3 py-2"
+          >
+            <input
+              type="radio"
+              name={`info-delivery-${phase.id}`}
+              value={mode}
+              checked={draftTarget.mode === mode}
+              disabled={mode === "characters" && !hasCharacters}
+              onChange={() => setDraftTarget(mode === "characters" ? { mode, characterIds: [] } : { mode, characterIds: [] })}
+            />
+            {modeLabel(mode)}
+          </label>
+        ))}
+      </fieldset>
+
+      {draftTarget.mode === "characters" ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          {characters.map((character) => (
+            <label
+              key={character.id}
+              className="flex items-center gap-2 rounded border border-slate-800 bg-slate-950/70 px-3 py-2 text-xs text-slate-200"
+            >
+              <input
+                type="checkbox"
+                checked={draftTarget.characterIds.includes(character.id)}
+                onChange={() =>
+                  setDraftTarget({
+                    mode: "characters",
+                    characterIds: toggleId(draftTarget.characterIds, character.id),
+                  })
+                }
+              />
+              <span className="truncate">{character.name}</span>
+            </label>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function targetSummary(target: InfoDeliveryTargetDraft, characters: Array<{ id: string; name: string }>): string {
+  const normalized = normalizeTarget(target);
+  if (normalized.mode === "all_players") return "현재 전체 캐릭터에게 공개됩니다.";
+  if (normalized.mode === "characters") {
+    const names = normalized.characterIds
+      .map((id) => characters.find((character) => character.id === id)?.name ?? "이름 없는 캐릭터")
+      .join(", ");
+    return `현재 ${names}에게 공개됩니다.`;
+  }
+  return "현재 이 장면에서는 공개되지 않습니다.";
+}
+
+function modeLabel(mode: InfoDeliveryTargetMode): string {
+  if (mode === "all_players") return "전체 캐릭터";
+  if (mode === "characters") return "캐릭터 선택";
+  return "배포 안 함";
+}
+
+function toggleId(ids: string[], id: string): string[] {
+  return ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id];
+}

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -11,6 +11,7 @@ import {
 import type { MediaType } from '@/features/editor/mediaApi';
 import { normalizeLegacyEscapedMarkdown } from '@/features/editor/components/content/legacyMarkdown';
 import { ConfirmDialog, Spinner } from '@/shared/components/ui';
+import { InfoDeliverySettingsCard } from './InfoDeliverySettingsCard';
 import { InfoBodyPreview } from './InfoBodyPreview';
 import { InfoMarkdownEditor } from './InfoMarkdownEditor';
 
@@ -214,14 +215,17 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   if (!isEditing) {
     return (
       <>
-        <InfoBodyPreview
-          themeId={themeId}
-          info={baseline}
-          error={error}
-          deletePending={deleteInfo.isPending}
-          onEdit={() => setIsEditing(true)}
-          onDelete={() => setDeleteDialogOpen(true)}
-        />
+        <div className="space-y-4">
+          <InfoBodyPreview
+            themeId={themeId}
+            info={baseline}
+            error={error}
+            deletePending={deleteInfo.isPending}
+            onEdit={() => setIsEditing(true)}
+            onDelete={() => setDeleteDialogOpen(true)}
+          />
+          <InfoDeliverySettingsCard themeId={themeId} storyInfoId={info.id} />
+        </div>
         {deleteDialog}
       </>
     );
@@ -290,6 +294,9 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
               {updateInfo.isPending ? '저장 중...' : '저장'}
             </button>
           </div>
+        </div>
+        <div className="mt-4">
+          <InfoDeliverySettingsCard themeId={themeId} storyInfoId={info.id} />
         </div>
       </section>
       {deleteDialog}

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -7,6 +7,9 @@ const {
   useCreateStoryInfoMock,
   useUpdateStoryInfoMock,
   useDeleteStoryInfoMock,
+  useFlowGraphMock,
+  useUpdateFlowNodeMock,
+  useEditorCharactersMock,
   useMediaListMock,
   useMediaDownloadUrlMock,
   mediaPickerPropsMock,
@@ -15,6 +18,9 @@ const {
   useCreateStoryInfoMock: vi.fn(),
   useUpdateStoryInfoMock: vi.fn(),
   useDeleteStoryInfoMock: vi.fn(),
+  useFlowGraphMock: vi.fn(),
+  useUpdateFlowNodeMock: vi.fn(),
+  useEditorCharactersMock: vi.fn(),
   useMediaListMock: vi.fn(),
   useMediaDownloadUrlMock: vi.fn(),
   mediaPickerPropsMock: vi.fn(),
@@ -30,6 +36,15 @@ vi.mock('@/features/editor/storyInfoApi', () => ({
 vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
   useMediaDownloadUrl: (...args: unknown[]) => useMediaDownloadUrlMock(...args),
+}));
+
+vi.mock('@/features/editor/flowApi', () => ({
+  useFlowGraph: (...args: unknown[]) => useFlowGraphMock(...args),
+  useUpdateFlowNode: (...args: unknown[]) => useUpdateFlowNodeMock(...args),
+}));
+
+vi.mock('@/features/editor/api', () => ({
+  useEditorCharacters: (...args: unknown[]) => useEditorCharactersMock(...args),
 }));
 
 vi.mock('@mdxeditor/editor', () => ({
@@ -161,11 +176,13 @@ function enterInfoEditMode() {
 let createMutate: ReturnType<typeof vi.fn>;
 let updateMutate: ReturnType<typeof vi.fn>;
 let deleteMutate: ReturnType<typeof vi.fn>;
+let updateFlowNode: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   createMutate = vi.fn().mockResolvedValue({ ...baseInfo, id: 'info-2' });
   updateMutate = vi.fn().mockResolvedValue({ ...baseInfo, title: '수정된 정보' });
   deleteMutate = vi.fn().mockResolvedValue(undefined);
+  updateFlowNode = vi.fn().mockResolvedValue({});
 
   useStoryInfosMock.mockReturnValue({
     data: [baseInfo],
@@ -184,6 +201,56 @@ beforeEach(() => {
   useDeleteStoryInfoMock.mockReturnValue({
     mutateAsync: deleteMutate,
     isPending: false,
+  });
+  useFlowGraphMock.mockReturnValue({
+    data: {
+      nodes: [
+        {
+          id: 'phase-1',
+          theme_id: 'theme-1',
+          type: 'phase',
+          data: {
+            label: '오프닝',
+            onEnter: [
+              {
+                id: 'info-action',
+                type: 'DELIVER_INFORMATION',
+                params: {
+                  deliveries: [
+                    {
+                      id: 'all',
+                      target: { type: 'all_players' },
+                      story_info_ids: ['info-1'],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          position_x: 0,
+          position_y: 0,
+          created_at: '2026-05-06T00:00:00Z',
+          updated_at: '2026-05-06T00:00:00Z',
+        },
+      ],
+      edges: [],
+    },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  useUpdateFlowNodeMock.mockReturnValue({
+    mutateAsync: updateFlowNode,
+    isPending: false,
+  });
+  useEditorCharactersMock.mockReturnValue({
+    data: [
+      { id: 'char-1', name: '고동' },
+      { id: 'char-2', name: '송 사장' },
+    ],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
   });
   useMediaListMock.mockReturnValue({
     data: [
@@ -224,6 +291,11 @@ describe('InfoTab', () => {
     expect(screen.queryByText('관련 단서')).toBeNull();
     expect(screen.queryByText('관련 장소')).toBeNull();
     expect(screen.queryByRole('region', { name: '정보 카드 프리뷰' })).toBeNull();
+    expect(screen.getByRole('region', { name: '정보 배포 설정' })).toHaveProperty(
+      'textContent',
+      expect.stringContaining('오프닝'),
+    );
+    expect(screen.getByText('현재 전체 캐릭터에게 공개됩니다.')).toBeDefined();
   });
 
   it('shows typed markdown shortcuts as formatted content in the information editor', () => {
@@ -367,6 +439,39 @@ describe('InfoTab', () => {
         relatedLocationIds: ['loc-1'],
         sortOrder: 0,
         version: 3,
+      },
+    });
+  });
+
+  it('updates scene-start delivery settings for the selected story info', async () => {
+    render(<InfoTab themeId="theme-1" />);
+
+    const deliverySettings = screen.getByRole('region', { name: '정보 배포 설정' });
+    fireEvent.click(within(deliverySettings).getByLabelText('캐릭터 선택'));
+    fireEvent.click(within(deliverySettings).getByLabelText('고동'));
+    fireEvent.click(within(deliverySettings).getByRole('button', { name: /배포 적용/ }));
+
+    await waitFor(() => expect(updateFlowNode).toHaveBeenCalledTimes(1));
+    expect(updateFlowNode).toHaveBeenCalledWith({
+      nodeId: 'phase-1',
+      body: {
+        data: {
+          label: '오프닝',
+          onEnter: [
+            {
+              id: 'info-action',
+              type: 'DELIVER_INFORMATION',
+              params: {
+                deliveries: [
+                  expect.objectContaining({
+                    target: { type: 'character', character_id: 'char-1' },
+                    story_info_ids: ['info-1'],
+                  }),
+                ],
+              },
+            },
+          ],
+        },
       },
     });
   });

--- a/apps/web/src/features/editor/entities/info/__tests__/infoDeliverySettingsAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/info/__tests__/infoDeliverySettingsAdapter.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FlowNodeData } from "../../../flowTypes";
+import {
+  readInfoDeliveryTarget,
+  targetsEqual,
+  writeInfoDeliveryTarget,
+} from "../infoDeliverySettingsAdapter";
+
+vi.stubGlobal("crypto", {
+  randomUUID: vi.fn(() => "new-effect-id"),
+});
+
+describe("infoDeliverySettingsAdapter", () => {
+  it("reads all-player and character delivery targets for one info", () => {
+    const data: FlowNodeData = {
+      onEnter: [
+        {
+          id: "info-action",
+          type: "DELIVER_INFORMATION",
+          params: {
+            deliveries: [
+              {
+                id: "all",
+                target: { type: "all_players" },
+                story_info_ids: ["info-1"],
+              },
+              {
+                id: "char",
+                target: { type: "character", character_id: "char-1" },
+                story_info_ids: ["info-2"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(readInfoDeliveryTarget(data, "info-1")).toEqual({ mode: "all_players", characterIds: [] });
+    expect(readInfoDeliveryTarget(data, "info-2")).toEqual({ mode: "characters", characterIds: ["char-1"] });
+  });
+
+  it("writes one info target without removing other info or clue grants", () => {
+    const data: FlowNodeData = {
+      onEnter: [
+        { id: "bgm", type: "SET_BGM", params: { mediaId: "m1" } },
+        {
+          id: "info-action",
+          type: "DELIVER_INFORMATION",
+          params: {
+            deliveries: [
+              {
+                id: "all",
+                target: { type: "all_players" },
+                reading_section_ids: ["read-1"],
+                story_info_ids: ["info-1", "info-2"],
+              },
+            ],
+          },
+        },
+        {
+          id: "clue-action",
+          type: "GRANT_CLUE",
+          params: {
+            deliveries: [
+              {
+                id: "clue",
+                target: { type: "all_players" },
+                clue_ids: ["clue-1"],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const patch = writeInfoDeliveryTarget(data, "info-1", {
+      mode: "characters",
+      characterIds: ["char-1", "char-1"],
+    });
+
+    expect(patch.onEnter).toEqual([
+      { id: "bgm", type: "SET_BGM", params: { mediaId: "m1" } },
+      expect.objectContaining({
+        id: "info-action",
+        type: "DELIVER_INFORMATION",
+        params: {
+          deliveries: [
+            {
+              id: "all",
+              target: { type: "all_players" },
+              reading_section_ids: ["read-1"],
+              story_info_ids: ["info-2"],
+            },
+            {
+              id: "new-effect-id",
+              target: { type: "character", character_id: "char-1" },
+              reading_section_ids: [],
+              story_info_ids: ["info-1"],
+            },
+          ],
+        },
+      }),
+      expect.objectContaining({
+        id: "clue-action",
+        type: "GRANT_CLUE",
+      }),
+    ]);
+  });
+
+  it("removes the info delivery action when the selected info is no longer delivered", () => {
+    const patch = writeInfoDeliveryTarget(
+      {
+        onEnter: [
+          {
+            id: "info-action",
+            type: "DELIVER_INFORMATION",
+            params: {
+              deliveries: [
+                {
+                  id: "all",
+                  target: { type: "all_players" },
+                  story_info_ids: ["info-1"],
+                },
+              ],
+            },
+          },
+        ],
+      },
+      "info-1",
+      { mode: "none", characterIds: [] },
+    );
+
+    expect(patch.onEnter).toEqual([]);
+  });
+
+  it("compares normalized targets", () => {
+    expect(
+      targetsEqual(
+        { mode: "characters", characterIds: ["char-1", "char-1"] },
+        { mode: "characters", characterIds: ["char-1"] },
+      ),
+    ).toBe(true);
+    expect(targetsEqual({ mode: "characters", characterIds: [] }, { mode: "none", characterIds: [] })).toBe(true);
+  });
+});

--- a/apps/web/src/features/editor/entities/info/infoDeliverySettingsAdapter.ts
+++ b/apps/web/src/features/editor/entities/info/infoDeliverySettingsAdapter.ts
@@ -1,0 +1,118 @@
+import type { FlowNodeData } from "../../flowTypes";
+import {
+  flowNodeToSceneEntryEffects,
+  isCompleteSceneEntryEffect,
+  makeEmptySceneEntryEffect,
+  sceneEntryEffectsToFlowNodePatch,
+  type SceneEntryEffectViewModel,
+} from "../shared/sceneEntryEffectAdapter";
+
+export type InfoDeliveryTargetMode = "none" | "all_players" | "characters";
+
+export interface InfoDeliveryTargetDraft {
+  mode: InfoDeliveryTargetMode;
+  characterIds: string[];
+}
+
+const EMPTY_TARGET: InfoDeliveryTargetDraft = { mode: "none", characterIds: [] };
+
+export function readInfoDeliveryTarget(
+  data: FlowNodeData,
+  storyInfoId: string,
+): InfoDeliveryTargetDraft {
+  const effects = flowNodeToSceneEntryEffects(data).filter((effect) =>
+    effect.storyInfoIds.includes(storyInfoId),
+  );
+  if (effects.some((effect) => effect.recipientType === "all_players")) {
+    return { mode: "all_players", characterIds: [] };
+  }
+
+  const characterIds = effects
+    .filter((effect) => effect.recipientType === "character" && effect.characterId)
+    .map((effect) => effect.characterId as string);
+
+  return characterIds.length > 0
+    ? { mode: "characters", characterIds: uniqueStrings(characterIds) }
+    : EMPTY_TARGET;
+}
+
+export function writeInfoDeliveryTarget(
+  data: FlowNodeData,
+  storyInfoId: string,
+  target: InfoDeliveryTargetDraft,
+): Pick<FlowNodeData, "onEnter"> {
+  const effectsWithoutInfo = flowNodeToSceneEntryEffects(data)
+    .map((effect) => ({
+      ...effect,
+      storyInfoIds: effect.storyInfoIds.filter((id) => id !== storyInfoId),
+    }))
+    .filter(isCompleteSceneEntryEffect);
+
+  const nextEffects = addInfoTargetEffects(effectsWithoutInfo, storyInfoId, normalizeTarget(target));
+  return sceneEntryEffectsToFlowNodePatch(data, nextEffects);
+}
+
+export function normalizeTarget(target: InfoDeliveryTargetDraft): InfoDeliveryTargetDraft {
+  if (target.mode === "all_players") {
+    return { mode: "all_players", characterIds: [] };
+  }
+  if (target.mode === "characters") {
+    const characterIds = uniqueStrings(target.characterIds);
+    return characterIds.length > 0 ? { mode: "characters", characterIds } : EMPTY_TARGET;
+  }
+  return EMPTY_TARGET;
+}
+
+export function targetsEqual(a: InfoDeliveryTargetDraft, b: InfoDeliveryTargetDraft): boolean {
+  const left = normalizeTarget(a);
+  const right = normalizeTarget(b);
+  return left.mode === right.mode && left.characterIds.join("\u0000") === right.characterIds.join("\u0000");
+}
+
+function addInfoTargetEffects(
+  effects: SceneEntryEffectViewModel[],
+  storyInfoId: string,
+  target: InfoDeliveryTargetDraft,
+): SceneEntryEffectViewModel[] {
+  if (target.mode === "none") return effects;
+  if (target.mode === "all_players") {
+    return upsertEffect(effects, "all_players", undefined, storyInfoId);
+  }
+  return target.characterIds.reduce(
+    (next, characterId) => upsertEffect(next, "character", characterId, storyInfoId),
+    effects,
+  );
+}
+
+function upsertEffect(
+  effects: SceneEntryEffectViewModel[],
+  recipientType: "all_players" | "character",
+  characterId: string | undefined,
+  storyInfoId: string,
+): SceneEntryEffectViewModel[] {
+  const index = effects.findIndex((effect) => {
+    if (effect.recipientType !== recipientType) return false;
+    return recipientType === "all_players" || effect.characterId === characterId;
+  });
+  if (index < 0) {
+    const next = makeEmptySceneEntryEffect(recipientType);
+    return [
+      ...effects,
+      {
+        ...next,
+        characterId,
+        storyInfoIds: [storyInfoId],
+      },
+    ];
+  }
+
+  return effects.map((effect, effectIndex) =>
+    effectIndex === index
+      ? { ...effect, storyInfoIds: uniqueStrings([...effect.storyInfoIds, storyInfoId]) }
+      : effect,
+  );
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values)).filter(Boolean);
+}

--- a/docs/superpowers/plans/2026-05-17-info-delivery-scene-settings.md
+++ b/docs/superpowers/plans/2026-05-17-info-delivery-scene-settings.md
@@ -1,0 +1,30 @@
+# 정보별 장면 시작 배포 설정
+
+## 목표
+
+- 정보관리의 각 정보에서 게임 진행 플로우의 장면을 선택해, 해당 장면 시작 시 정보를 전체 캐릭터 또는 특정 캐릭터에게 배포하도록 설정한다.
+- 저장 위치는 별도 `story_info` 필드가 아니라 런타임이 이미 읽는 `flow_nodes.data.onEnter`의 `DELIVER_INFORMATION` 액션으로 둔다.
+
+## 범위
+
+- 정보 상세 화면 아래에 `장면 시작 배포` 섹션을 추가한다.
+- 장면별 배포 대상은 `배포 안 함`, `전체 캐릭터`, `캐릭터 선택`으로 편집한다.
+- 기존 장면 시작 액션의 다른 정보 배포, 단서 지급, BGM 등은 유지한다.
+
+## Coverage Plan
+
+- `infoDeliverySettingsAdapter.test.ts`
+  - 정보별 배포 대상 읽기
+  - 특정 정보만 대상 변경
+  - 다른 정보와 단서 지급 액션 보존
+  - 배포 안 함으로 변경 시 정보 배포 제거
+- `InfoTab.test.tsx`
+  - 정보 상세에서 배포 설정 섹션 노출
+  - 장면 시작 배포 대상을 특정 캐릭터로 저장하는 사용자 흐름
+
+## 검증
+
+- `pnpm --filter @mmp/web test -- infoDeliverySettingsAdapter.test.ts InfoTab.test.tsx`
+- `pnpm --filter @mmp/web typecheck`
+- `pnpm --filter @mmp/web lint`
+- `scripts/mmp-local-ci.sh quick`


### PR DESCRIPTION
## 요약
- 정보관리의 각 정보 상세에 장면 시작 배포 설정을 추가했습니다.
- 배포 대상은 배포 안 함 / 전체 캐릭터 / 캐릭터 선택으로 설정할 수 있습니다.
- 저장은 별도 story_info 필드가 아니라 flow_nodes.data.onEnter의 DELIVER_INFORMATION 액션에 반영해 런타임 source-of-truth와 맞췄습니다.

## Coverage Plan
- infoDeliverySettingsAdapter.test.ts: 정보별 배포 대상 읽기/쓰기, 다른 정보와 단서 지급 액션 보존, 배포 제거 검증
- InfoTab.test.tsx: 정보 상세에서 배포 설정 노출, 특정 캐릭터 배포 저장 사용자 흐름 검증

## Local validation
- pnpm --filter @mmp/web test -- infoDeliverySettingsAdapter.test.ts InfoTab.test.tsx 통과
- pnpm --filter @mmp/web typecheck 통과
- pnpm --filter @mmp/web lint 통과, 기존 warning 48개 유지
- scripts/mmp-local-ci.sh quick 통과: head `3209cc8f6597c291c1444da91e7705fbf6f97e07`, finished `2026-05-17T03:56:06Z`

## E2E
- 이번 PR은 정보 상세 내부의 flow action 편집과 adapter 변환 중심이라 Vitest component/unit 및 local-ci quick으로 검증했습니다. 새 Playwright E2E는 추가하지 않았습니다.

Closes #589