### PR TITLE
게임 진행 플로우 저장 후 장면 선택 유지

### DIFF
--- a/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
@@ -124,6 +124,34 @@ describe('useFlowData', () => {
     expect(latestSavedGraph().nodes[0]).toMatchObject({ position_x: 50, position_y: 50 });
   });
 
+  it('flow graph refetch 후에도 선택한 장면 설정 패널을 유지한다', () => {
+    const { result, rerender } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.onSelectionChange({ nodes: [result.current.nodes[0]] });
+    });
+
+    expect(result.current.selectedNode?.id).toBe('n1');
+
+    const refreshedGraph = cloneServerGraph();
+    refreshedGraph.nodes[0].data = { label: '저장된 오프닝' };
+    useFlowGraphMock.mockReturnValue({
+      data: refreshedGraph,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    rerender();
+
+    expect(result.current.selectedNode).toMatchObject({
+      id: 'n1',
+      data: { label: '저장된 오프닝' },
+    });
+    expect(result.current.nodes.find((node) => node.id === 'n1')?.selected).toBe(true);
+  });
+
   it('onEdgesChange가 edge 삭제를 ref와 autosave payload에 반영한다', () => {
     const { result } = renderHook(() => useFlowData('theme-1'));
 

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -40,6 +40,7 @@ export function useFlowData(themeId: string) {
   const [nodes, setNodes] = useNodesState(initialNodes);
   const [edges, setEdges] = useEdgesState(initialEdges);
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const selectedNodeIdRef = useRef<string | null>(null);
   const nodesRef = useRef(nodes);
   nodesRef.current = nodes;
   const edgesRef = useRef(edges);
@@ -74,10 +75,20 @@ export function useFlowData(themeId: string) {
       saveFlow.mutate(toSaveRequest(tpl.nodes, tpl.edges));
       return;
     }
-    const nextNodes = nodes_.map(toReactFlowNode);
+    const selectedNodeId = selectedNodeIdRef.current;
+    const nextNodes = nodes_.map((node) => {
+      const nextNode = toReactFlowNode(node);
+      return selectedNodeId === nextNode.id ? { ...nextNode, selected: true } : nextNode;
+    });
     const nextEdges = edges_.map(toReactFlowEdge);
     setNodesAndRef(nextNodes);
     setEdgesAndRef(nextEdges);
+    setSelectedNode((prev) => {
+      if (!prev) return null;
+      const refreshed = nextNodes.find((node) => node.id === prev.id) ?? null;
+      selectedNodeIdRef.current = refreshed?.id ?? null;
+      return refreshed;
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
@@ -204,7 +215,9 @@ export function useFlowData(themeId: string) {
       setNodesAndRef(next);
       autoSave(next, edgesRef.current);
       setSelectedNode((prev) =>
-        prev && prev.id === id ? { ...prev, data: { ...prev.data, ...patch } } : prev
+        prev && prev.id === id
+          ? { ...prev, data: { ...prev.data, ...patch } }
+          : prev
       );
     },
     [setNodesAndRef, autoSave]
@@ -219,7 +232,11 @@ export function useFlowData(themeId: string) {
           setNodesAndRef(nextNodes);
           setEdgesAndRef(nextEdges);
           autoSave(nextNodes, nextEdges);
-          setSelectedNode((prev) => (prev?.id === id ? null : prev));
+          setSelectedNode((prev) => {
+            if (prev?.id !== id) return prev;
+            selectedNodeIdRef.current = null;
+            return null;
+          });
         },
       });
     },
@@ -236,7 +253,9 @@ export function useFlowData(themeId: string) {
   );
 
   const onSelectionChange = useCallback(({ nodes: selected }: { nodes: Node[] }) => {
-    setSelectedNode(selected.length === 1 ? selected[0] : null);
+    const nextSelectedNode = selected.length === 1 ? selected[0] : null;
+    selectedNodeIdRef.current = nextSelectedNode?.id ?? null;
+    setSelectedNode(nextSelectedNode);
   }, []);
 
   const getNodes = useCallback(() => nodesRef.current, []);


### PR DESCRIPTION
## 요약
- 장면 설정 저장 후 flow graph refetch가 발생해도 선택한 장면 패널이 닫히지 않도록 선택 노드 ID를 보존합니다.
- refetch된 최신 노드 데이터에 기존 선택 상태를 다시 붙이고, 오른쪽 패널의 selectedNode도 최신 데이터로 갱신합니다.
- 선택 보존 회귀 테스트를 추가했습니다.

Closes #594

## Coverage Plan
- `apps/web/src/features/editor/hooks/useFlowData.ts`: flow graph refetch 시 선택 노드 보존 분기
- `apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts`: 선택한 장면이 refetch 뒤에도 유지되는지 검증

## Local validation
- `pnpm --filter @mmp/web test -- useFlowData.test.ts FlowCanvas.test.tsx PhaseNodePanelDebounce.test.tsx`
- `pnpm --filter @mmp/web typecheck`
- `scripts/mmp-local-ci.sh quick`

## Notes
- 이 증상은 저장 API 자체 실패가 아니라 `useUpdateFlowNode` 성공 후 flow graph query invalidation/refetch가 ReactFlow 선택 상태를 잃게 만들면서 발생했습니다.
