### PR TITLE
조사권 재설정 액션에 0 초기화 방식 추가

### DIFF
--- a/apps/server/internal/module/exploration/deck_investigation/module.go
+++ b/apps/server/internal/module/exploration/deck_investigation/module.go
@@ -98,17 +98,33 @@ func (m *Module) ReactTo(ctx context.Context, action engine.PhaseActionPayload) 
 		if err := json.Unmarshal(action.Params, &params); err != nil {
 			return fmt.Errorf("deck_investigation: invalid RESET_INVESTIGATION_TOKEN params: %w", err)
 		}
-		return m.applyTokenAction(ctx, params, func(_ int, defaultAmount int) int {
+		resetAmount := func(_ int, defaultAmount int) int {
 			return defaultAmount
-		})
+		}
+		switch params.Mode {
+		case "", investigationTokenResetModeDefault:
+		case investigationTokenResetModeZero:
+			resetAmount = func(_ int, _ int) int {
+				return 0
+			}
+		default:
+			return fmt.Errorf("deck_investigation: unsupported reset mode %q", params.Mode)
+		}
+		return m.applyTokenAction(ctx, params, resetAmount)
 	default:
 		return fmt.Errorf("deck_investigation: unsupported action %q", action.Action)
 	}
 }
 
+const (
+	investigationTokenResetModeDefault = "default"
+	investigationTokenResetModeZero    = "zero"
+)
+
 type investigationTokenActionParams struct {
 	TokenID string                 `json:"tokenId"`
 	Amount  int                    `json:"amount,omitempty"`
+	Mode    string                 `json:"mode,omitempty"`
 	Target  map[string]interface{} `json:"target,omitempty"`
 }
 

--- a/apps/server/internal/module/exploration/deck_investigation/module_test.go
+++ b/apps/server/internal/module/exploration/deck_investigation/module_test.go
@@ -73,6 +73,50 @@ func TestModule_ResetInvestigationTokenForCharacter(t *testing.T) {
 	}
 }
 
+func TestModule_ResetInvestigationTokenToZero(t *testing.T) {
+	module := NewModule()
+	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":2}],"decks":[]}`)
+	if err := module.Init(context.Background(), engine.ModuleDeps{EventBus: engine.NewEventBus(nil)}, config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	grant := json.RawMessage(`{"tokenId":"coin","amount":4,"target":{"type":"character","character_id":"char-late"}}`)
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionGrantInvestigationToken,
+		Params: grant,
+	}); err != nil {
+		t.Fatalf("ReactTo grant: %v", err)
+	}
+	reset := json.RawMessage(`{"tokenId":"coin","mode":"zero","target":{"type":"character","character_id":"char-late"}}`)
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionResetInvestigationToken,
+		Params: reset,
+	}); err != nil {
+		t.Fatalf("ReactTo reset: %v", err)
+	}
+
+	state := decodeModuleState(t, module)
+	if got := state.Tokens.ByCharacter["char-late"]["coin"]; got != 0 {
+		t.Fatalf("char-late coin = %d, want 0", got)
+	}
+}
+
+func TestModule_RejectsUnsupportedInvestigationTokenResetMode(t *testing.T) {
+	module := NewModule()
+	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":1}],"decks":[]}`)
+	if err := module.Init(context.Background(), engine.ModuleDeps{}, config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionResetInvestigationToken,
+		Params: json.RawMessage(`{"tokenId":"coin","mode":"unsupported"}`),
+	})
+	if err == nil {
+		t.Fatal("expected unsupported reset mode error")
+	}
+}
+
 func TestModule_RejectsUnknownTokenAction(t *testing.T) {
 	module := NewModule()
 	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":1}],"decks":[]}`)

--- a/apps/server/internal/module/exploration/deck_investigation/module_test.go
+++ b/apps/server/internal/module/exploration/deck_investigation/module_test.go
@@ -101,6 +101,34 @@ func TestModule_ResetInvestigationTokenToZero(t *testing.T) {
 	}
 }
 
+func TestModule_ResetInvestigationTokenWithDefaultModeLiteral(t *testing.T) {
+	module := NewModule()
+	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":2}],"decks":[]}`)
+	if err := module.Init(context.Background(), engine.ModuleDeps{EventBus: engine.NewEventBus(nil)}, config); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	grant := json.RawMessage(`{"tokenId":"coin","amount":4,"target":{"type":"character","character_id":"char-late"}}`)
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionGrantInvestigationToken,
+		Params: grant,
+	}); err != nil {
+		t.Fatalf("ReactTo grant: %v", err)
+	}
+	reset := json.RawMessage(`{"tokenId":"coin","mode":"default","target":{"type":"character","character_id":"char-late"}}`)
+	if err := module.ReactTo(context.Background(), engine.PhaseActionPayload{
+		Action: engine.ActionResetInvestigationToken,
+		Params: reset,
+	}); err != nil {
+		t.Fatalf("ReactTo reset: %v", err)
+	}
+
+	state := decodeModuleState(t, module)
+	if got := state.Tokens.ByCharacter["char-late"]["coin"]; got != 2 {
+		t.Fatalf("char-late coin = %d, want 2", got)
+	}
+}
+
 func TestModule_RejectsUnsupportedInvestigationTokenResetMode(t *testing.T) {
 	module := NewModule()
 	config := json.RawMessage(`{"tokens":[{"id":"coin","defaultAmount":1}],"decks":[]}`)

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -327,15 +327,22 @@ function InvestigationTokenActionFields({
     typeof params.amount === "number" && Number.isFinite(params.amount)
       ? Math.max(1, Math.floor(params.amount))
       : 1;
+  const resetMode = params.mode === "zero" ? "zero" : "default";
 
   return (
     <div className="rounded border border-slate-800 bg-slate-950/80 p-2">
-      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_96px]">
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_9rem]">
         <label className="flex flex-col gap-1">
           <span className="text-[11px] text-slate-500">조사권</span>
           <select
             value={selectedTokenId}
-            onChange={(event) => onParamsChange({ ...params, tokenId: event.target.value })}
+            onChange={(event) =>
+              onParamsChange({
+                ...params,
+                tokenId: event.target.value,
+                ...(action.type === "RESET_INVESTIGATION_TOKEN" ? { mode: resetMode } : {}),
+              })
+            }
             className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200"
           >
             {tokens.map((token) => (
@@ -363,11 +370,30 @@ function InvestigationTokenActionFields({
             />
           </label>
         ) : (
-          <p className="rounded border border-slate-800 bg-slate-900/70 px-2 py-1.5 text-[11px] leading-4 text-slate-400">
-            선택한 조사권을 시작 수량으로 되돌립니다.
-          </p>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] text-slate-500">재설정 방식</span>
+            <select
+              value={resetMode}
+              onChange={(event) =>
+                onParamsChange({
+                  ...params,
+                  tokenId: selectedTokenId,
+                  mode: event.target.value,
+                })
+              }
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200"
+            >
+              <option value="default">시작 수량으로</option>
+              <option value="zero">0으로 초기화</option>
+            </select>
+          </label>
         )}
       </div>
+      {action.type === "RESET_INVESTIGATION_TOKEN" ? (
+        <p className="mt-2 text-[11px] leading-4 text-slate-500">
+          시작 수량은 조사권 설정에서 정한 기본 지급량입니다.
+        </p>
+      ) : null}
       {tokens.length === 0 ? (
         <p className="mt-2 text-[11px] text-amber-300">조사권 설정에서 조사권을 먼저 추가해 주세요.</p>
       ) : null}

--- a/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
@@ -343,6 +343,34 @@ describe("ActionListEditor", () => {
     ]);
   });
 
+  it("조사권 재설정 액션의 0 초기화 방식을 params로 저장한다", () => {
+    const onChange = vi.fn();
+
+    render(
+      <ActionListEditor
+        label="장면 시작 액션"
+        actions={[
+          { id: "token", type: "RESET_INVESTIGATION_TOKEN", params: { tokenId: "coin", mode: "default" } },
+        ]}
+        investigationTokens={[
+          { id: "coin", name: "동전", iconLabel: "코", defaultAmount: 2 },
+          { id: "badge", name: "배지", iconLabel: "배", defaultAmount: 0 },
+        ]}
+        preserveDisallowedActions
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "재설정 방식" }), {
+      target: { value: "zero" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith([
+      { id: "token", type: "RESET_INVESTIGATION_TOKEN", params: { tokenId: "coin", mode: "zero" } },
+    ]);
+    expect(screen.getByText("시작 수량은 조사권 설정에서 정한 기본 지급량입니다.")).toBeDefined();
+  });
+
   it("컬러 테마 실행 결과를 preset token으로 저장한다", () => {
     const onChange = vi.fn();
     render(

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -217,7 +217,7 @@ describe("PhaseNodePanel type-specific fields", () => {
 
     const startSelect = screen.getByRole("combobox", { name: "장면 시작 액션 1 실행 결과" });
     expect(within(startSelect).getByRole("option", { name: "조사권 추가" })).toBeDefined();
-    expect(within(startSelect).getByRole("option", { name: "조사권 초기화" })).toBeDefined();
+    expect(within(startSelect).getByRole("option", { name: "조사권 재설정" })).toBeDefined();
   });
 
   it("조사권 액션으로 바꾸면 첫 조사권을 기본 tokenId로 저장한다", () => {

--- a/apps/web/src/features/editor/entities/sceneAction/__tests__/sceneActionRegistry.test.ts
+++ b/apps/web/src/features/editor/entities/sceneAction/__tests__/sceneActionRegistry.test.ts
@@ -17,7 +17,7 @@ describe("sceneActionRegistry", () => {
     expect(options.some((option) => option.value === "RESET_INVESTIGATION_TOKEN")).toBe(false);
   });
 
-  it("조사권 모듈이 켜져 있으면 조사권 추가와 초기화를 노출한다", () => {
+  it("조사권 모듈이 켜져 있으면 조사권 추가와 재설정을 노출한다", () => {
     const options = getSceneActionOptions({
       enabledModuleIds: [DECK_INVESTIGATION_MODULE_ID],
     });
@@ -37,6 +37,10 @@ describe("sceneActionRegistry", () => {
     expect(createSceneActionDefaultParams("GRANT_INVESTIGATION_TOKEN")).toEqual({
       tokenId: "",
       amount: 1,
+    });
+    expect(createSceneActionDefaultParams("RESET_INVESTIGATION_TOKEN")).toEqual({
+      tokenId: "",
+      mode: "default",
     });
   });
 

--- a/apps/web/src/features/editor/entities/sceneAction/sceneActionRegistry.ts
+++ b/apps/web/src/features/editor/entities/sceneAction/sceneActionRegistry.ts
@@ -53,7 +53,7 @@ const SCENE_ACTION_DEFINITIONS: SceneActionDefinition[] = [
   },
   {
     value: SCENE_ACTION_TYPES.RESET_INVESTIGATION_TOKEN,
-    label: "조사권 초기화",
+    label: "조사권 재설정",
     requiredModuleId: DECK_INVESTIGATION_MODULE_ID,
     defaultParams: { tokenId: "", mode: "default" },
   },

--- a/apps/web/src/features/editor/entities/shared/actionAdapter.ts
+++ b/apps/web/src/features/editor/entities/shared/actionAdapter.ts
@@ -47,7 +47,7 @@ const ACTION_LABELS = new Map<string, string>([
   ["set_theme_color", "화면 색상 테마 변경"],
   ["stop_bgm", "BGM 정지"],
   ["GRANT_INVESTIGATION_TOKEN", "조사권 추가"],
-  ["RESET_INVESTIGATION_TOKEN", "조사권 초기화"],
+  ["RESET_INVESTIGATION_TOKEN", "조사권 재설정"],
 ]);
 
 export function getCreatorActionLabel(type: string): string {


### PR DESCRIPTION
Closes #596

## 변경 사항
- 장면 액션의 `RESET_INVESTIGATION_TOKEN`에 `mode: "zero"`를 추가해 조사권을 0으로 초기화할 수 있게 했습니다.
- 기존 `mode` 없음 또는 `mode: "default"`는 조사권 설정의 시작 수량으로 재설정하는 기존 동작을 유지합니다.
- 제작자 UI 라벨을 `조사권 재설정`으로 바꾸고, 세부 설정에서 `시작 수량으로` / `0으로 초기화`를 선택하게 했습니다.

## Coverage Plan
- `apps/server/internal/module/exploration/deck_investigation/module.go`: default/zero/invalid reset mode 분기를 `module_test.go`에서 검증
- `apps/web/src/features/editor/components/design/ActionListEditor.tsx`: reset mode 선택 시 params 저장을 `ActionListEditor.test.tsx`에서 검증
- `sceneActionRegistry`/`PhaseNodePanelExtended`: 액션 기본 params와 제작자 라벨 변경 회귀 검증

## Local validation
- `go test ./internal/module/exploration/deck_investigation`
- `pnpm --filter @mmp/web test -- ActionListEditor.test.tsx PhaseNodePanelExtended.test.tsx sceneActionRegistry.test.ts`
- `pnpm --filter @mmp/web typecheck`
- `scripts/mmp-local-ci.sh quick`

## E2E 미작성 사유
- 새 라우트나 플레이어 전체 흐름이 아니라 장면 액션의 세부 params와 백엔드 런타임 분기 변경입니다. 사용자-visible 저장 동작은 focused component/unit test와 local quick CI로 대체 검증했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 조사권 재설정 기능이 강화되었습니다. 이제 "기본 지급량으로 복원" 또는 "0으로 초기화" 중 재설정 방식을 선택할 수 있습니다.
  * 액션 편집 UI에 재설정 방식 선택 옵션이 추가되었습니다.

* **개선**
  * 조사권 관련 기능명이 "조사권 초기화"에서 "조사권 재설정"으로 명확하게 변경되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->