### PR TITLE
조사권 시작 수량 제거 및 장면 액션 중심 수량 관리

### DIFF
--- a/apps/server/internal/module/exploration/deck_investigation/module.go
+++ b/apps/server/internal/module/exploration/deck_investigation/module.go
@@ -48,7 +48,7 @@ func (m *Module) Init(ctx context.Context, deps engine.ModuleDeps, config json.R
 
 	m.defaultTokenAmounts = make(map[string]int, len(m.config.Tokens))
 	for _, token := range m.config.Tokens {
-		m.defaultTokenAmounts[token.ID] = token.DefaultAmount
+		m.defaultTokenAmounts[token.ID] = 0
 	}
 	m.balancesByCharacter = map[string]map[string]int{}
 	m.ensureRosterLocked(ctx)
@@ -98,19 +98,14 @@ func (m *Module) ReactTo(ctx context.Context, action engine.PhaseActionPayload) 
 		if err := json.Unmarshal(action.Params, &params); err != nil {
 			return fmt.Errorf("deck_investigation: invalid RESET_INVESTIGATION_TOKEN params: %w", err)
 		}
-		resetAmount := func(_ int, defaultAmount int) int {
-			return defaultAmount
-		}
 		switch params.Mode {
-		case "", investigationTokenResetModeDefault:
-		case investigationTokenResetModeZero:
-			resetAmount = func(_ int, _ int) int {
-				return 0
-			}
+		case "", investigationTokenResetModeDefault, investigationTokenResetModeZero:
 		default:
 			return fmt.Errorf("deck_investigation: unsupported reset mode %q", params.Mode)
 		}
-		return m.applyTokenAction(ctx, params, resetAmount)
+		return m.applyTokenAction(ctx, params, func(_ int, _ int) int {
+			return 0
+		})
 	default:
 		return fmt.Errorf("deck_investigation: unsupported action %q", action.Action)
 	}

--- a/apps/server/internal/module/exploration/deck_investigation/module_test.go
+++ b/apps/server/internal/module/exploration/deck_investigation/module_test.go
@@ -37,11 +37,11 @@ func TestModule_InitAndGrantInvestigationToken(t *testing.T) {
 	}
 
 	state := decodeModuleState(t, module)
-	if got := state.Tokens.ByCharacter["char-alice"]["coin"]; got != 3 {
-		t.Fatalf("alice coin = %d, want 3", got)
+	if got := state.Tokens.ByCharacter["char-alice"]["coin"]; got != 2 {
+		t.Fatalf("alice coin = %d, want 2", got)
 	}
-	if got := state.Tokens.ByCharacter["char-bob"]["coin"]; got != 3 {
-		t.Fatalf("bob coin = %d, want 3", got)
+	if got := state.Tokens.ByCharacter["char-bob"]["coin"]; got != 2 {
+		t.Fatalf("bob coin = %d, want 2", got)
 	}
 }
 
@@ -68,8 +68,8 @@ func TestModule_ResetInvestigationTokenForCharacter(t *testing.T) {
 	}
 
 	state := decodeModuleState(t, module)
-	if got := state.Tokens.ByCharacter["char-late"]["coin"]; got != 1 {
-		t.Fatalf("char-late coin = %d, want 1", got)
+	if got := state.Tokens.ByCharacter["char-late"]["coin"]; got != 0 {
+		t.Fatalf("char-late coin = %d, want 0", got)
 	}
 }
 
@@ -124,8 +124,8 @@ func TestModule_ResetInvestigationTokenWithDefaultModeLiteral(t *testing.T) {
 	}
 
 	state := decodeModuleState(t, module)
-	if got := state.Tokens.ByCharacter["char-late"]["coin"]; got != 2 {
-		t.Fatalf("char-late coin = %d, want 2", got)
+	if got := state.Tokens.ByCharacter["char-late"]["coin"]; got != 0 {
+		t.Fatalf("char-late coin = %d, want 0", got)
 	}
 }
 

--- a/apps/web/src/features/editor/components/design/ActionListEditor.tsx
+++ b/apps/web/src/features/editor/components/design/ActionListEditor.tsx
@@ -327,7 +327,6 @@ function InvestigationTokenActionFields({
     typeof params.amount === "number" && Number.isFinite(params.amount)
       ? Math.max(1, Math.floor(params.amount))
       : 1;
-  const resetMode = params.mode === "zero" ? "zero" : "default";
 
   return (
     <div className="rounded border border-slate-800 bg-slate-950/80 p-2">
@@ -340,7 +339,6 @@ function InvestigationTokenActionFields({
               onParamsChange({
                 ...params,
                 tokenId: event.target.value,
-                ...(action.type === "RESET_INVESTIGATION_TOKEN" ? { mode: resetMode } : {}),
               })
             }
             className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200"
@@ -370,28 +368,17 @@ function InvestigationTokenActionFields({
             />
           </label>
         ) : (
-          <label className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1">
             <span className="text-[11px] text-slate-500">재설정 방식</span>
-            <select
-              value={resetMode}
-              onChange={(event) =>
-                onParamsChange({
-                  ...params,
-                  tokenId: selectedTokenId,
-                  mode: event.target.value,
-                })
-              }
-              className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200"
-            >
-              <option value="default">시작 수량으로</option>
-              <option value="zero">0으로 초기화</option>
-            </select>
-          </label>
+            <span className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200">
+              0으로 초기화
+            </span>
+          </div>
         )}
       </div>
       {action.type === "RESET_INVESTIGATION_TOKEN" ? (
         <p className="mt-2 text-[11px] leading-4 text-slate-500">
-          시작 수량은 조사권 설정에서 정한 기본 지급량입니다.
+          장면에서 지급한 조사권을 0개로 되돌립니다. 장면 초반에 필요한 지급량은 장면 시작 액션의 조사권 추가로 설정합니다.
         </p>
       ) : null}
       {tokens.length === 0 ? (

--- a/apps/web/src/features/editor/components/design/InvestigationCostSelector.tsx
+++ b/apps/web/src/features/editor/components/design/InvestigationCostSelector.tsx
@@ -94,7 +94,7 @@ export function InvestigationCostSelector({
         </div>
       ) : null}
       <div className="mt-1.5 flex flex-wrap items-center justify-between gap-2 text-[10px] text-slate-600">
-        <span>조사권 이름과 시작 수량은 모듈 탭의 조사권 설정에서 관리합니다.</span>
+        <span>조사권 이름은 모듈 탭에서, 지급 수량은 장면 설정에서 관리합니다.</span>
         <a
           href={manageHref}
           className="rounded border border-slate-800 px-2 py-1 text-slate-400 hover:border-amber-500/50 hover:text-amber-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"

--- a/apps/web/src/features/editor/components/design/InvestigationTokenSettingsPanel.tsx
+++ b/apps/web/src/features/editor/components/design/InvestigationTokenSettingsPanel.tsx
@@ -26,12 +26,6 @@ function generateTokenId(tokens: InvestigationTokenDraft[]): string {
   return candidate;
 }
 
-function normalizeAmount(value: string): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return 0;
-  return Math.max(0, Math.floor(parsed));
-}
-
 export function InvestigationTokenSettingsPanel({
   draft,
   isSaving,
@@ -89,7 +83,7 @@ export function InvestigationTokenSettingsPanel({
         <div>
           <h4 className="text-xs font-semibold text-slate-200">조사권 설정</h4>
           <p className="mt-0.5 text-[10px] text-slate-500">
-            단서 조사에 소비할 권한 이름과 시작 수량을 정합니다.
+            단서 조사에 소비할 권한 이름을 정합니다. 지급 수량은 장면 설정에서 관리합니다.
           </p>
         </div>
         <button
@@ -107,7 +101,7 @@ export function InvestigationTokenSettingsPanel({
         {tokens.map((token) => (
           <div
             key={token.id}
-            className="grid gap-2 rounded-md border border-slate-700 bg-slate-900/60 p-2 md:grid-cols-[minmax(0,1fr)_5rem_7rem_2rem]"
+            className="grid gap-2 rounded-md border border-slate-700 bg-slate-900/60 p-2 md:grid-cols-[minmax(0,1fr)_5rem_2rem]"
           >
             <label className="min-w-0">
               <span className="mb-1 block text-[10px] font-medium text-slate-500">
@@ -134,24 +128,6 @@ export function InvestigationTokenSettingsPanel({
                 disabled={isSaving}
                 aria-label={`${token.name} 표시 라벨`}
                 placeholder="권"
-              />
-            </label>
-
-            <label>
-              <span className="mb-1 block text-[10px] font-medium text-slate-500">
-                시작 수량
-              </span>
-              <input
-                className={inputCls}
-                type="number"
-                min={0}
-                step={1}
-                value={token.defaultAmount}
-                onChange={(event) =>
-                  updateToken(token.id, { defaultAmount: normalizeAmount(event.target.value) })
-                }
-                disabled={isSaving}
-                aria-label={`${token.name} 초기 배포량`}
               />
             </label>
 

--- a/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ActionListEditor.test.tsx
@@ -343,14 +343,14 @@ describe("ActionListEditor", () => {
     ]);
   });
 
-  it("조사권 재설정 액션의 0 초기화 방식을 params로 저장한다", () => {
+  it("조사권 재설정 액션은 기본 수량 옵션 없이 0 초기화 안내를 보여준다", () => {
     const onChange = vi.fn();
 
     render(
       <ActionListEditor
         label="장면 시작 액션"
         actions={[
-          { id: "token", type: "RESET_INVESTIGATION_TOKEN", params: { tokenId: "coin", mode: "default" } },
+          { id: "token", type: "RESET_INVESTIGATION_TOKEN", params: { tokenId: "coin" } },
         ]}
         investigationTokens={[
           { id: "coin", name: "동전", iconLabel: "코", defaultAmount: 2 },
@@ -361,14 +361,17 @@ describe("ActionListEditor", () => {
       />,
     );
 
-    fireEvent.change(screen.getByRole("combobox", { name: "재설정 방식" }), {
-      target: { value: "zero" },
-    });
+    expect(screen.getByText("0으로 초기화")).toBeDefined();
+    expect(screen.queryByText("시작 수량으로")).toBeNull();
+    expect(
+      screen.getByText("장면에서 지급한 조사권을 0개로 되돌립니다. 장면 초반에 필요한 지급량은 장면 시작 액션의 조사권 추가로 설정합니다."),
+    ).toBeDefined();
+
+    fireEvent.change(screen.getByDisplayValue("코 동전"), { target: { value: "badge" } });
 
     expect(onChange).toHaveBeenCalledWith([
-      { id: "token", type: "RESET_INVESTIGATION_TOKEN", params: { tokenId: "coin", mode: "zero" } },
+      { id: "token", type: "RESET_INVESTIGATION_TOKEN", params: { tokenId: "badge" } },
     ]);
-    expect(screen.getByText("시작 수량은 조사권 설정에서 정한 기본 지급량입니다.")).toBeDefined();
   });
 
   it("컬러 테마 실행 결과를 preset token으로 저장한다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.deckInvestigation.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ModulesSubTab.deckInvestigation.test.tsx
@@ -97,10 +97,11 @@ describe('ModulesSubTab deck investigation settings', () => {
 
     expect(screen.getByText('조사권 설정')).toBeDefined();
     expect(screen.getByRole('textbox', { name: '기본 조사권 조사권 이름' })).toBeDefined();
-    expect(screen.getByRole('spinbutton', { name: '기본 조사권 초기 배포량' })).toBeDefined();
+    expect(screen.queryByText('시작 수량')).toBeNull();
+    expect(screen.getByText('단서 조사에 소비할 권한 이름을 정합니다. 지급 수량은 장면 설정에서 관리합니다.')).toBeDefined();
   });
 
-  it('조사권 시작 수량 변경을 deck_investigation module config로 저장한다', () => {
+  it('조사권 이름 변경 시 시작 수량은 0으로 정규화해 저장한다', () => {
     const themeWithDeckInvestigation: EditorThemeResponse = {
       ...baseTheme,
       config_json: {
@@ -142,8 +143,8 @@ describe('ModulesSubTab deck investigation settings', () => {
 
     render(<ModulesSubTab themeId="theme-1" theme={themeWithDeckInvestigation} />);
 
-    fireEvent.change(screen.getByRole('spinbutton', { name: '기본 조사권 초기 배포량' }), {
-      target: { value: '3' },
+    fireEvent.change(screen.getByRole('textbox', { name: '기본 조사권 조사권 이름' }), {
+      target: { value: '장면 조사권' },
     });
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
@@ -155,9 +156,9 @@ describe('ModulesSubTab deck investigation settings', () => {
           tokens: [
             {
               id: 'basic-token',
-              name: '기본 조사권',
+              name: '장면 조사권',
               iconLabel: '권',
-              defaultAmount: 3,
+              defaultAmount: 0,
             },
           ],
           decks: [{ id: 'deck-1', tokenId: 'basic-token' }],

--- a/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/__tests__/deckInvestigationAdapter.test.ts
@@ -80,7 +80,7 @@ describe('deckInvestigationAdapter', () => {
       },
     });
 
-    expect(config.tokens[0]).toMatchObject({ id: 'coin', name: '동전', defaultAmount: 2 });
+    expect(config.tokens[0]).toMatchObject({ id: 'coin', name: '동전', defaultAmount: 0 });
     expect(config.decks[0]).toMatchObject({
       id: 'deck-1',
       title: '서재 조사',
@@ -147,7 +147,7 @@ describe('deckInvestigationAdapter', () => {
         enabled: true,
         config: {
           keep: true,
-          tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 3 }],
+          tokens: [{ id: 'coin', name: '동전', iconLabel: '🪙', defaultAmount: 0 }],
           decks: [expect.objectContaining({ tokenId: 'coin' })],
         },
       },
@@ -236,7 +236,7 @@ describe('deckInvestigationAdapter', () => {
     });
 
     expect(runtime).toEqual({
-      tokens: [{ id: 'coin', defaultAmount: 2 }],
+      tokens: [{ id: 'coin', defaultAmount: 0 }],
       decks: [{
         id: 'deck-1',
         tokenId: 'coin',

--- a/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
+++ b/apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts
@@ -117,14 +117,11 @@ function normalizeToken(value: unknown, index: number): InvestigationTokenDraft 
   const rawId = typeof value.id === 'string' ? value.id.trim() : '';
   const rawName = typeof value.name === 'string' ? value.name.trim() : '';
   const rawIconLabel = typeof value.iconLabel === 'string' ? value.iconLabel.trim() : '';
-  const defaultAmount = typeof value.defaultAmount === 'number' && Number.isFinite(value.defaultAmount)
-    ? Math.max(0, Math.floor(value.defaultAmount))
-    : 0;
   return {
     id: rawId || `token-${index + 1}`,
     name: rawName || '조사권',
     iconLabel: rawIconLabel || '권',
-    defaultAmount,
+    defaultAmount: 0,
   };
 }
 
@@ -218,7 +215,7 @@ export function writeDeckInvestigationConfig(
   const current = readModuleConfig(configJson, DECK_INVESTIGATION_MODULE_ID);
   return writeModuleConfig(configJson, DECK_INVESTIGATION_MODULE_ID, {
     ...current,
-    tokens: draft.tokens,
+    tokens: draft.tokens.map((token) => ({ ...token, defaultAmount: 0 })),
     decks: draft.decks,
   });
 }
@@ -227,7 +224,7 @@ export function toDeckInvestigationRuntimeDraft(
   draft: DeckInvestigationConfigDraft,
 ): DeckInvestigationRuntimeDraft {
   return {
-    tokens: draft.tokens.map((token) => ({ id: token.id, defaultAmount: token.defaultAmount })),
+    tokens: draft.tokens.map((token) => ({ id: token.id, defaultAmount: 0 })),
     decks: draft.decks.map((deck) => ({
       id: deck.id,
       tokenId: deck.tokenId,

--- a/apps/web/src/features/editor/entities/sceneAction/__tests__/sceneActionRegistry.test.ts
+++ b/apps/web/src/features/editor/entities/sceneAction/__tests__/sceneActionRegistry.test.ts
@@ -40,7 +40,6 @@ describe("sceneActionRegistry", () => {
     });
     expect(createSceneActionDefaultParams("RESET_INVESTIGATION_TOKEN")).toEqual({
       tokenId: "",
-      mode: "default",
     });
   });
 

--- a/apps/web/src/features/editor/entities/sceneAction/sceneActionRegistry.ts
+++ b/apps/web/src/features/editor/entities/sceneAction/sceneActionRegistry.ts
@@ -55,7 +55,7 @@ const SCENE_ACTION_DEFINITIONS: SceneActionDefinition[] = [
     value: SCENE_ACTION_TYPES.RESET_INVESTIGATION_TOKEN,
     label: "조사권 재설정",
     requiredModuleId: DECK_INVESTIGATION_MODULE_ID,
-    defaultParams: { tokenId: "", mode: "default" },
+    defaultParams: { tokenId: "" },
   },
 ];
 


### PR DESCRIPTION
## 요약
- 조사권 설정 패널에서 시작 수량 입력을 제거했습니다.
- 조사권 지급 수량은 장면 시작/종료 액션의 `조사권 추가`에서 관리하도록 UI 문구를 정리했습니다.
- 런타임은 기존 config에 `defaultAmount`가 남아 있어도 조사권을 0에서 시작하고, 재설정 액션도 0으로 처리합니다.

Closes #598

## Coverage Plan
- `apps/server/internal/module/exploration/deck_investigation/module.go`: 기존 `defaultAmount`가 남아 있어도 시작 잔액과 reset 결과가 0인지 Go unit test로 검증했습니다.
- `apps/web/src/features/editor/components/design/InvestigationTokenSettingsPanel.tsx`: 시작 수량 입력 제거와 안내 문구 변경을 `ModulesSubTab.deckInvestigation.test.tsx`로 검증했습니다.
- `apps/web/src/features/editor/components/design/ActionListEditor.tsx`: reset 액션의 시작 수량 옵션 제거와 0 초기화 안내를 `ActionListEditor.test.tsx`로 검증했습니다.
- `apps/web/src/features/editor/entities/deckInvestigation/deckInvestigationAdapter.ts`: 저장/runtime draft의 `defaultAmount` 0 정규화를 adapter test로 검증했습니다.

## Local validation
- `go test ./internal/module/exploration/deck_investigation`
- `pnpm --filter @mmp/web test -- ActionListEditor.test.tsx ModulesSubTab.deckInvestigation.test.tsx deckInvestigationAdapter.test.ts sceneActionRegistry.test.ts`
- `pnpm --filter @mmp/web typecheck`
- `scripts/mmp-local-ci.sh quick`

## E2E 미작성 사유
- 새 라우트나 브라우저 전용 흐름 추가가 아니라 기존 에디터 폼의 필드 제거와 backend engine 액션 계약 변경입니다. 사용자 행동은 focused Vitest와 Go unit test, 전체 quick 검증으로 대체했습니다.
