### PR TITLE
결말 조건 그룹 및 사망/생존 분기 UX 정리

### DIFF
--- a/apps/server/internal/module/decision/ending_branch/module.go
+++ b/apps/server/internal/module/decision/ending_branch/module.go
@@ -128,12 +128,12 @@ func (m *Module) HandleMessage(ctx context.Context, playerID uuid.UUID, msgType 
 }
 
 // ReactTo handles phase actions that trigger ending evaluation.
-func (m *Module) ReactTo(_ context.Context, action engine.PhaseActionPayload) error {
+func (m *Module) ReactTo(ctx context.Context, action engine.PhaseActionPayload) error {
 	if action.Action != engine.ActionEvaluateEnding {
 		return nil
 	}
 	m.mu.Lock()
-	result, err := m.evaluateLocked()
+	result, err := m.evaluateLocked(ctx)
 	if err != nil {
 		m.mu.Unlock()
 		return err

--- a/apps/server/internal/module/decision/ending_branch/module_test.go
+++ b/apps/server/internal/module/decision/ending_branch/module_test.go
@@ -15,6 +15,7 @@ import (
 
 type endingBranchTestPlayerProvider struct {
 	byTarget map[string]uuid.UUID
+	byID     map[uuid.UUID]engine.PlayerRuntimeInfo
 }
 
 func (p endingBranchTestPlayerProvider) ResolvePlayerID(_ context.Context, targetCode string) (uuid.UUID, bool) {
@@ -23,7 +24,19 @@ func (p endingBranchTestPlayerProvider) ResolvePlayerID(_ context.Context, targe
 }
 
 func (p endingBranchTestPlayerProvider) PlayerRuntimeInfo(_ context.Context, playerID uuid.UUID) (engine.PlayerRuntimeInfo, bool) {
+	if p.byID != nil {
+		info, ok := p.byID[playerID]
+		return info, ok
+	}
 	return engine.PlayerRuntimeInfo{PlayerID: playerID}, true
+}
+
+func (p endingBranchTestPlayerProvider) PlayerRuntimeRoster(_ context.Context) []engine.PlayerRuntimeInfo {
+	players := make([]engine.PlayerRuntimeInfo, 0, len(p.byID))
+	for _, info := range p.byID {
+		players = append(players, info)
+	}
+	return players
 }
 
 func TestModule_Name(t *testing.T) {
@@ -421,6 +434,120 @@ func TestModule_ReactTo_FallbackWhenNoRuleMatches(t *testing.T) {
 	assert.Equal(t, "미해결", result["selectedEnding"])
 	assert.Equal(t, true, result["fallback"])
 	assert.NotContains(t, result, "matchedPriority")
+}
+
+func TestModule_ReactTo_EvaluatesDeadCharacterCondition(t *testing.T) {
+	deadPlayer := uuid.New()
+	provider := endingBranchTestPlayerProvider{
+		byTarget: map[string]uuid.UUID{"char-yangji": deadPlayer},
+		byID: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			deadPlayer: {PlayerID: deadPlayer, TargetCode: "char-yangji", IsAlive: false},
+		},
+	}
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [],
+		"matrix": [
+			{"id":"yangji-dead","priority": 1, "conditions": {"==": [{"var":"characters.char-yangji.alive"}, false]}, "ending": "양지사망결말"}
+		],
+		"defaultEnding": "기본결말"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{PlayerInfoProvider: provider}, cfg))
+
+	require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+	raw, err := m.BuildState()
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal(raw, &state))
+	result := state["result"].(map[string]any)
+	assert.Equal(t, "양지사망결말", result["selectedEnding"])
+	assert.Equal(t, "yangji-dead", result["matchedRuleId"])
+}
+
+func TestModule_ReactTo_EvaluatesEveryoneAliveCondition(t *testing.T) {
+	playerA := uuid.New()
+	playerB := uuid.New()
+	provider := endingBranchTestPlayerProvider{
+		byTarget: map[string]uuid.UUID{"char-godong": playerA, "char-yangji": playerB},
+		byID: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			playerA: {PlayerID: playerA, TargetCode: "char-godong", IsAlive: true},
+			playerB: {PlayerID: playerB, TargetCode: "char-yangji", IsAlive: true},
+		},
+	}
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [],
+		"matrix": [
+			{"id":"everyone-alive","priority": 1, "conditions": {"and": [
+				{"==": [{"var":"characters.char-godong.alive"}, true]},
+				{"==": [{"var":"characters.char-yangji.alive"}, true]}
+			]}, "ending": "모두생존결말"}
+		],
+		"defaultEnding": "기본결말"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{PlayerInfoProvider: provider}, cfg))
+
+	require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+	raw, err := m.BuildState()
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal(raw, &state))
+	result := state["result"].(map[string]any)
+	assert.Equal(t, "모두생존결말", result["selectedEnding"])
+	assert.Equal(t, "everyone-alive", result["matchedRuleId"])
+}
+
+func TestModule_ReactTo_EvaluatesNegatedCharacterCondition(t *testing.T) {
+	livePlayer := uuid.New()
+	provider := endingBranchTestPlayerProvider{
+		byTarget: map[string]uuid.UUID{"char-yangji": livePlayer},
+		byID: map[uuid.UUID]engine.PlayerRuntimeInfo{
+			livePlayer: {PlayerID: livePlayer, TargetCode: "char-yangji", IsAlive: true},
+		},
+	}
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [],
+		"matrix": [
+			{"id":"yangji-not-dead","priority": 1, "conditions": {"!": {"==": [{"var":"characters.char-yangji.alive"}, false]}}, "ending": "양지생존결말"}
+		],
+		"defaultEnding": "기본결말"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{PlayerInfoProvider: provider}, cfg))
+
+	require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+	raw, err := m.BuildState()
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal(raw, &state))
+	result := state["result"].(map[string]any)
+	assert.Equal(t, "양지생존결말", result["selectedEnding"])
+	assert.Equal(t, "yangji-not-dead", result["matchedRuleId"])
+}
+
+func TestModule_ReactTo_MissingCharacterStateDoesNotMatchDeadCondition(t *testing.T) {
+	m := NewModule()
+	cfg := json.RawMessage(`{
+		"questions": [],
+		"matrix": [
+			{"id":"missing-dead","priority": 1, "conditions": {"==": [{"var":"characters.missing.alive"}, false]}, "ending": "사망결말"}
+		],
+		"defaultEnding": "기본결말"
+	}`)
+	require.NoError(t, m.Init(context.Background(), engine.ModuleDeps{}, cfg))
+
+	require.NoError(t, m.ReactTo(context.Background(), engine.PhaseActionPayload{Action: engine.ActionEvaluateEnding}))
+
+	raw, err := m.BuildState()
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal(raw, &state))
+	result := state["result"].(map[string]any)
+	assert.Equal(t, "기본결말", result["selectedEnding"])
+	assert.Equal(t, true, result["fallback"])
 }
 
 func TestModule_BuildStateAfterEvaluationSeparatesAdminScoresFromPlayerState(t *testing.T) {

--- a/apps/server/internal/module/decision/ending_branch/runtime.go
+++ b/apps/server/internal/module/decision/ending_branch/runtime.go
@@ -65,9 +65,9 @@ func (m *Module) submitAnswer(ctx context.Context, playerID uuid.UUID, payload j
 	return nil
 }
 
-func (m *Module) evaluateLocked() (*evaluationResult, error) {
-	ctx := m.evaluationContextLocked()
-	ctxJSON, err := json.Marshal(ctx)
+func (m *Module) evaluateLocked(ctx context.Context) (*evaluationResult, error) {
+	evalCtx := m.evaluationContextLocked(ctx)
+	ctxJSON, err := json.Marshal(evalCtx)
 	if err != nil {
 		return nil, fmt.Errorf("ending_branch: marshal evaluation context: %w", err)
 	}
@@ -93,7 +93,7 @@ func (m *Module) evaluateLocked() (*evaluationResult, error) {
 				MatchedPriority: &priority,
 				Fallback:        false,
 				AnswerSummary:   m.answerSummariesLocked(),
-				Scores:          scoreTotals(ctx),
+				Scores:          scoreTotals(evalCtx),
 			}, nil
 		}
 	}
@@ -101,11 +101,11 @@ func (m *Module) evaluateLocked() (*evaluationResult, error) {
 		SelectedEnding: m.cfg.DefaultEnding,
 		Fallback:       true,
 		AnswerSummary:  m.answerSummariesLocked(),
-		Scores:         scoreTotals(ctx),
+		Scores:         scoreTotals(evalCtx),
 	}, nil
 }
 
-func (m *Module) evaluationContextLocked() map[string]any {
+func (m *Module) evaluationContextLocked(ctx context.Context) map[string]any {
 	answers := make(map[string]any, len(m.cfg.Questions))
 	scores := make(map[string]int)
 	for _, question := range m.cfg.Questions {
@@ -126,7 +126,23 @@ func (m *Module) evaluationContextLocked() map[string]any {
 			"answered": len(byPlayer),
 		}
 	}
-	return map[string]any{"answers": answers, "scores": scores}
+	return map[string]any{"answers": answers, "scores": scores, "characters": m.characterAliveContextLocked(ctx)}
+}
+
+func (m *Module) characterAliveContextLocked(ctx context.Context) map[string]any {
+	provider, ok := m.deps.PlayerInfoProvider.(engine.PlayerRuntimeRosterProvider)
+	if !ok || provider == nil {
+		return map[string]any{}
+	}
+	players := provider.PlayerRuntimeRoster(ctx)
+	characters := make(map[string]any, len(players))
+	for _, player := range players {
+		if player.TargetCode == "" {
+			continue
+		}
+		characters[player.TargetCode] = map[string]any{"alive": player.IsAlive}
+	}
+	return characters
 }
 
 func scoreTotals(ctx map[string]any) map[string]int {

--- a/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx
@@ -1,21 +1,53 @@
 import { useEffect, useMemo, useState } from "react";
 import { Plus, Trash2, X } from "lucide-react";
 import type { Node } from "@xyflow/react";
+import type { EditorCharacterResponse } from "@/features/editor/api";
 import type {
+  EndingBranchAggregation,
   EndingBranchConfig,
   EndingBranchMatrixRow,
   EndingBranchQuestion,
 } from "../../entities/ending/endingBranchAdapter";
-import { createEndingBranchMatrixRow, readChoiceCondition, updateMatrixCondition } from "../../entities/ending/endingBranchAdapter";
+import {
+  buildCharacterAliveCondition,
+  buildChoiceCondition,
+  buildConditionGroup,
+  buildNegatedCondition,
+  buildWinningChoiceCondition,
+  createEndingBranchMatrixRow,
+  groupEndingBranchRowsByEnding,
+  readEndingConditionGroup,
+} from "../../entities/ending/endingBranchAdapter";
+import type { EditorConfig } from "../../utils/configShape";
 import type { FlowNodeData } from "../../flowTypes";
 
 interface EndingBranchOutcomeRulesProps {
   draft: EndingBranchConfig;
   endingNodes: Node[];
   branchQuestions: EndingBranchQuestion[];
+  characters: EditorCharacterResponse[];
   canAddRule: boolean;
+  selectedEndingId?: string;
+  display?: "all" | "settings" | "rules";
   onChange: (next: EndingBranchConfig) => void;
 }
+
+type ConditionDraft =
+  | {
+      id: string;
+      type: "question";
+      questionId: string;
+      choices: string[];
+      aggregation: EndingBranchAggregation;
+      negated: boolean;
+    }
+  | {
+      id: string;
+      type: "character_alive";
+      characterId: string;
+      alive: boolean;
+      negated: boolean;
+    };
 
 function endingName(node: Node): string {
   const data = node.data as FlowNodeData;
@@ -26,23 +58,213 @@ function reorderPriorities(config: EndingBranchConfig): EndingBranchConfig {
   return { ...config, matrix: config.matrix.map((row, index) => ({ ...row, priority: index + 1 })) };
 }
 
+function conditionDraftId(index: number): string {
+  return `condition-${Date.now()}-${index}`;
+}
+
+function firstQuestionDraft(branchQuestions: EndingBranchQuestion[]): ConditionDraft | null {
+  const question = branchQuestions[0];
+  if (!question) return null;
+  return {
+    id: conditionDraftId(0),
+    type: "question",
+    questionId: question.id,
+    choices: question.choices[0] ? [question.choices[0]] : [],
+    aggregation: question.type === "multi" ? "any" : "threshold",
+    negated: false,
+  };
+}
+
+function createCharacterDraft(characters: EditorCharacterResponse[]): ConditionDraft | null {
+  const character = characters[0];
+  if (!character) return null;
+  return {
+    id: conditionDraftId(0),
+    type: "character_alive",
+    characterId: character.id,
+    alive: false,
+    negated: false,
+  };
+}
+
+function draftFromRow(
+  row: EndingBranchMatrixRow | null,
+  branchQuestions: EndingBranchQuestion[],
+  characters: EditorCharacterResponse[],
+): ConditionDraft[] {
+  if (!row) {
+    const question = firstQuestionDraft(branchQuestions);
+    if (question) return [question];
+    const character = createCharacterDraft(characters);
+    return character ? [character] : [];
+  }
+  const group = readEndingConditionGroup(row.condition);
+  const drafts = group.conditions.flatMap((condition, index): ConditionDraft[] => {
+    if (condition.kind === "question_choice") {
+      const question = branchQuestions.find((item) => item.id === condition.questionId);
+      return [{
+        id: conditionDraftId(index),
+        type: "question",
+        questionId: condition.questionId,
+        choices: condition.choices.length > 0 ? condition.choices : condition.choice ? [condition.choice] : question?.choices[0] ? [question.choices[0]] : [],
+        aggregation: condition.aggregation,
+        negated: condition.negated,
+      }];
+    }
+    if (condition.kind === "character_alive") {
+      return [{
+        id: conditionDraftId(index),
+        type: "character_alive",
+        characterId: condition.characterId,
+        alive: condition.alive,
+        negated: condition.negated,
+      }];
+    }
+    return [];
+  });
+  if (drafts.length > 0) return drafts;
+  const fallback = firstQuestionDraft(branchQuestions) ?? createCharacterDraft(characters);
+  return fallback ? [fallback] : [];
+}
+
+function questionConditionToLogic(condition: Extract<ConditionDraft, { type: "question" }>): EditorConfig {
+  const choices = Array.from(new Set(condition.choices.map((choice) => choice.trim()).filter(Boolean)));
+  const firstChoice = choices[0] ?? "";
+  const positiveCondition = condition.aggregation === "winning"
+    ? buildWinningChoiceCondition(condition.questionId, firstChoice)
+    : condition.aggregation === "all"
+      ? buildConditionGroup(choices.map((choice) => buildChoiceCondition(condition.questionId, choice)))
+      : condition.aggregation === "any"
+        ? { or: choices.map((choice) => buildChoiceCondition(condition.questionId, choice)) }
+        : buildChoiceCondition(condition.questionId, firstChoice);
+  return condition.negated ? buildNegatedCondition(positiveCondition) : positiveCondition;
+}
+
+function conditionToLogic(condition: ConditionDraft): EditorConfig {
+  if (condition.type === "question") return questionConditionToLogic(condition);
+  const positiveCondition = buildCharacterAliveCondition(condition.characterId, condition.alive);
+  return condition.negated ? buildNegatedCondition(positiveCondition) : positiveCondition;
+}
+
+function hasFinalConsonant(value: string): boolean {
+  const last = value.trim().charCodeAt(value.trim().length - 1);
+  if (!Number.isFinite(last)) return false;
+  const base = last - 0xac00;
+  return base >= 0 && base <= 11171 ? base % 28 !== 0 : false;
+}
+
+function subjectWithParticle(value: string): string {
+  return `${value}${hasFinalConsonant(value) ? "이" : "가"}`;
+}
+
+function isConditionValid(condition: ConditionDraft, branchQuestions: EndingBranchQuestion[], characters: EditorCharacterResponse[]): boolean {
+  if (condition.type === "question") {
+    return Boolean(
+      branchQuestions.find((question) => question.id === condition.questionId) &&
+      condition.choices.some((choice) => choice.trim()),
+    );
+  }
+  if (condition.type === "character_alive") {
+    return characters.some((character) => character.id === condition.characterId);
+  }
+  return false;
+}
+
+function conditionPredicate(
+  condition: ConditionDraft,
+  branchQuestions: EndingBranchQuestion[],
+  characters: EditorCharacterResponse[],
+): string {
+  if (condition.type === "question") {
+    const question = branchQuestions.find((item) => item.id === condition.questionId);
+    const choiceText = condition.choices.length > 0 ? condition.choices.join(", ") : "답변 선택 필요";
+    const ruleText = condition.aggregation === "winning"
+      ? condition.negated ? "가장 많이 선택되지 않은 상태" : "가장 많이 선택된 상태"
+      : condition.aggregation === "all"
+        ? condition.negated ? "모두 설정 비율 이상이 아닌 상태" : "모두 설정 비율 이상"
+        : condition.aggregation === "any"
+          ? condition.negated ? "하나도 설정 비율 이상이 아닌 상태" : "하나라도 설정 비율 이상"
+          : condition.negated ? "설정 비율 미만" : "설정 비율 이상";
+    return `${question?.text || "질문 선택 필요"}에서 '${choiceText}' 답변이 ${ruleText}`;
+  }
+  if (condition.type === "character_alive") {
+    const character = characters.find((item) => item.id === condition.characterId);
+    const subject = subjectWithParticle(character?.name || "캐릭터 선택 필요");
+    if (condition.negated) {
+      return `${subject} ${condition.alive ? "생존 중이 아닌 상태" : "사망하지 않은 상태"}`;
+    }
+    return `${subject} ${condition.alive ? "생존 중인 상태" : "사망한 상태"}`;
+  }
+  return "조건 선택 필요";
+}
+
+function conditionSummary(
+  condition: ConditionDraft,
+  branchQuestions: EndingBranchQuestion[],
+  characters: EditorCharacterResponse[],
+): string {
+  return `${conditionPredicate(condition, branchQuestions, characters)}이면`;
+}
+
+function conditionFromAtom(condition: ReturnType<typeof readEndingConditionGroup>["conditions"][number], index: number): ConditionDraft {
+  if (condition.kind === "question_choice") {
+    return {
+      id: `summary-${index}`,
+      type: "question",
+      questionId: condition.questionId,
+      choices: condition.choices,
+      aggregation: condition.aggregation,
+      negated: condition.negated,
+    };
+  }
+  if (condition.kind === "character_alive") {
+    return {
+      id: `summary-${index}`,
+      type: "character_alive",
+      characterId: condition.characterId,
+      alive: condition.alive,
+      negated: condition.negated,
+    };
+  }
+  return { id: `summary-${index}`, type: "question", questionId: "", choices: [], aggregation: "threshold", negated: false };
+}
+
+function conditionGroupSentence(
+  conditions: ConditionDraft[],
+  branchQuestions: EndingBranchQuestion[],
+  characters: EditorCharacterResponse[],
+): string {
+  if (conditions.length === 0) return "조건 설정이 필요합니다.";
+  const predicates = conditions.map((condition) => conditionPredicate(condition, branchQuestions, characters));
+  return predicates.length === 1 ? predicates[0] : predicates.join("이고, ");
+}
+
 export function EndingBranchOutcomeRules({
   draft,
   endingNodes,
   branchQuestions,
+  characters,
   canAddRule,
+  selectedEndingId,
+  display = "all",
   onChange,
 }: EndingBranchOutcomeRulesProps) {
   return (
     <div className="space-y-4">
-      <DefaultEndingCard draft={draft} endingNodes={endingNodes} onChange={onChange} />
-      <MatrixRulesCard
-        draft={draft}
-        endingNodes={endingNodes}
-        branchQuestions={branchQuestions}
-        canAddRule={canAddRule}
-        onChange={onChange}
-      />
+      {display !== "rules" ? (
+        <DefaultEndingCard draft={draft} endingNodes={endingNodes} onChange={onChange} />
+      ) : null}
+      {display !== "settings" ? (
+        <MatrixRulesCard
+          draft={draft}
+          endingNodes={endingNodes}
+          branchQuestions={branchQuestions}
+          characters={characters}
+          canAddRule={canAddRule}
+          selectedEndingId={selectedEndingId}
+          onChange={onChange}
+        />
+      ) : null}
     </div>
   );
 }
@@ -75,8 +297,12 @@ function DefaultEndingCard({ draft, endingNodes, onChange }: DefaultEndingCardPr
 
 type MatrixRulesCardProps = EndingBranchOutcomeRulesProps;
 
-function MatrixRulesCard({ draft, endingNodes, branchQuestions, canAddRule, onChange }: MatrixRulesCardProps) {
-  const [modalState, setModalState] = useState<{ mode: "create" | "edit"; rowIndex?: number } | null>(null);
+function MatrixRulesCard({ draft, endingNodes, branchQuestions, characters, canAddRule, selectedEndingId, onChange }: MatrixRulesCardProps) {
+  const [modalState, setModalState] = useState<{ mode: "create" | "edit"; endingId: string; rowIndex?: number } | null>(null);
+  const groupedRows = useMemo(() => {
+    const groups = groupEndingBranchRowsByEnding(draft, endingNodes);
+    return selectedEndingId ? groups.filter((group) => group.endingId === selectedEndingId) : groups;
+  }, [draft, endingNodes, selectedEndingId]);
 
   const handleSaveRule = (row: EndingBranchMatrixRow) => {
     if (modalState?.mode === "edit" && modalState.rowIndex !== undefined) {
@@ -92,35 +318,45 @@ function MatrixRulesCard({ draft, endingNodes, branchQuestions, canAddRule, onCh
 
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex items-start justify-between gap-3">
         <div>
-          <h4 className="font-semibold text-slate-100">결말 규칙</h4>
-          <p className="mt-1 text-xs leading-5 text-slate-400">위에서부터 먼저 맞는 규칙이 적용됩니다.</p>
+          <h4 className="font-semibold text-slate-100">{selectedEndingId ? "조건 그룹" : "결말 규칙"}</h4>
+          <p className="mt-1 text-xs leading-5 text-slate-400">
+            {selectedEndingId
+              ? "조건 그룹 중 하나라도 맞으면 이 결말이 적용됩니다."
+              : "결말마다 조건 그룹을 만들고, 그룹 중 하나라도 맞으면 해당 결말이 적용됩니다."}
+          </p>
         </div>
-        <button type="button" onClick={() => setModalState({ mode: "create" })} disabled={!canAddRule} className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-700 px-3 text-sm text-slate-100 hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50">
-          <Plus className="h-4 w-4" aria-hidden="true" /> 조건 만들기
-        </button>
       </div>
       <div className="mt-4 space-y-3">
-        {draft.matrix.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-slate-700 p-4 text-sm text-slate-400">아직 규칙이 없습니다. 질문과 결말을 만든 뒤 규칙을 추가해 주세요.</p>
-        ) : draft.matrix.map((row, rowIndex) => (
-          <MatrixRuleRow
-            key={row.priority}
+        {groupedRows.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-slate-700 p-4 text-sm text-slate-400">
+            {selectedEndingId ? "선택한 결말을 찾을 수 없습니다." : "먼저 플레이어에게 보여줄 결말을 추가해 주세요."}
+          </p>
+        ) : groupedRows.map((group) => (
+          <EndingRuleCard
+            key={group.endingId}
             draft={draft}
-            rowIndex={rowIndex}
-            endingNodes={endingNodes}
+            endingId={group.endingId}
+            endingName={group.endingName}
+            rows={group.rows}
             branchQuestions={branchQuestions}
+            characters={characters}
+            canAddRule={canAddRule}
+            compact={Boolean(selectedEndingId)}
             onChange={onChange}
-            onEdit={() => setModalState({ mode: "edit", rowIndex })}
+            onCreate={() => setModalState({ mode: "create", endingId: group.endingId })}
+            onEdit={(rowIndex) => setModalState({ mode: "edit", endingId: group.endingId, rowIndex })}
           />
         ))}
       </div>
       {modalState && (
         <EndingConditionModal
           draft={draft}
-          endingNodes={endingNodes}
+          endingId={modalState.endingId}
+          endingName={endingName(endingNodes.find((node) => node.id === modalState.endingId) ?? { id: "", type: "ending", position: { x: 0, y: 0 }, data: {} } as Node)}
           branchQuestions={branchQuestions}
+          characters={characters}
           initialRow={modalState.mode === "edit" && modalState.rowIndex !== undefined ? draft.matrix[modalState.rowIndex] : null}
           onClose={() => setModalState(null)}
           onSave={handleSaveRule}
@@ -130,85 +366,139 @@ function MatrixRulesCard({ draft, endingNodes, branchQuestions, canAddRule, onCh
   );
 }
 
-interface MatrixRuleRowProps {
+interface EndingRuleCardProps {
   draft: EndingBranchConfig;
-  rowIndex: number;
-  endingNodes: Node[];
+  endingId: string;
+  endingName: string;
+  rows: EndingBranchMatrixRow[];
   branchQuestions: EndingBranchQuestion[];
+  characters: EditorCharacterResponse[];
+  canAddRule: boolean;
+  compact?: boolean;
   onChange: (next: EndingBranchConfig) => void;
-  onEdit: () => void;
+  onCreate: () => void;
+  onEdit: (rowIndex: number) => void;
 }
 
-function MatrixRuleRow({ draft, rowIndex, endingNodes, branchQuestions, onChange, onEdit }: MatrixRuleRowProps) {
-  const row = draft.matrix[rowIndex];
-  const parsed = readChoiceCondition(row.condition);
-  const selectedQuestion = parsed
-    ? branchQuestions.find((question) => question.id === parsed.questionId)
-    : undefined;
-  const choiceText = parsed?.choices?.length
-    ? parsed.choices.join(", ")
-    : parsed?.choice;
-  const aggregationText = parsed?.aggregation === "winning"
-    ? " 이 가장 많이 선택되면 "
-    : parsed?.aggregation === "all"
-      ? " 이 모두 기준 이상 선택되면 "
-      : parsed?.aggregation === "any"
-        ? " 중 하나라도 기준 이상 선택되면 "
-        : " 이 기준 이상 선택되면 ";
+function EndingRuleCard({ draft, endingId, endingName, rows, branchQuestions, characters, canAddRule, compact = false, onChange, onCreate, onEdit }: EndingRuleCardProps) {
   return (
-    <article className="rounded-xl border border-slate-800 bg-slate-900/70 p-3">
+    <article className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          {compact ? null : <p className="font-semibold text-slate-100">{endingName}</p>}
+          <p className="mt-1 text-xs text-slate-400">조건 그룹 {rows.length}개</p>
+          {rows.length > 1 ? (
+            <p className="mt-1 text-xs leading-5 text-amber-100">아래 조건 중 하나라도 만족하면 {endingName}을 보여줍니다.</p>
+          ) : null}
+        </div>
+        <button type="button" onClick={onCreate} disabled={!canAddRule} className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-700 px-3 text-sm text-slate-100 hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50">
+          <Plus className="h-4 w-4" aria-hidden="true" /> 조건 만들기
+        </button>
+      </div>
+      <div className="mt-3 space-y-2">
+        {rows.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-slate-700 p-3 text-sm text-slate-400">이 결말로 가는 조건 그룹이 없습니다.</p>
+        ) : rows.map((row, groupIndex) => {
+          const rowIndex = draft.matrix.indexOf(row);
+          return (
+            <div key={`${row.priority}:${row.ending}`} className="space-y-2">
+              {groupIndex > 0 ? (
+                <div className="flex items-center gap-3" aria-hidden="true">
+                  <div className="h-px flex-1 bg-slate-800" />
+                  <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-100">또는</span>
+                  <div className="h-px flex-1 bg-slate-800" />
+                </div>
+              ) : null}
+              <ConditionGroupRow
+                row={row}
+                rowIndex={rowIndex}
+                groupNumber={groupIndex + 1}
+                branchQuestions={branchQuestions}
+                characters={characters}
+                onEdit={() => onEdit(rowIndex)}
+                onRemove={() => onChange(reorderPriorities({ ...draft, matrix: draft.matrix.filter((_, index) => index !== rowIndex) }))}
+              />
+            </div>
+          );
+        })}
+      </div>
+      {endingId === draft.defaultEnding ? (
+        <p className="mt-3 text-xs text-slate-500">조건이 맞지 않을 때도 기본 결말로 사용할 수 있습니다.</p>
+      ) : null}
+    </article>
+  );
+}
+
+function ConditionGroupRow({
+  row,
+  rowIndex,
+  groupNumber,
+  branchQuestions,
+  characters,
+  onEdit,
+  onRemove,
+}: {
+  row: EndingBranchMatrixRow;
+  rowIndex: number;
+  groupNumber: number;
+  branchQuestions: EndingBranchQuestion[];
+  characters: EditorCharacterResponse[];
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  const group = readEndingConditionGroup(row.condition);
+  const conditionDrafts = group.conditions.map((condition, index) => conditionFromAtom(condition, index));
+  return (
+    <article className="rounded-xl border border-slate-800 bg-slate-950 p-3">
       <div className="flex items-center justify-between gap-3">
-        <p className="font-medium text-slate-100">규칙 {rowIndex + 1}</p>
+        <p className="font-medium text-slate-100">조건 그룹 {groupNumber}</p>
         <div className="flex items-center gap-2">
           <button type="button" onClick={onEdit} className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-200 hover:bg-slate-800">
             수정
           </button>
-          <button type="button" onClick={() => onChange(reorderPriorities({ ...draft, matrix: draft.matrix.filter((_, index) => index !== rowIndex) }))} className="rounded-lg p-2 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200" aria-label={`규칙 ${rowIndex + 1} 삭제`}>
+          <button type="button" onClick={onRemove} className="rounded-lg p-2 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200" aria-label={`조건 그룹 ${groupNumber} 삭제`}>
             <Trash2 className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
       </div>
-      <p className="mt-3 rounded-xl border border-slate-800 bg-slate-950 p-3 text-sm leading-6 text-slate-300">
-        <span className="font-semibold text-slate-100">{selectedQuestion?.text || "질문 선택 필요"}</span>
-        {" 에서 "}
-        <span className="font-semibold text-amber-100">{choiceText || "선택지 선택 필요"}</span>
-        {aggregationText}
-        <span className="font-semibold text-emerald-100">{endingName(endingNodes.find((node) => node.id === row.ending) ?? { id: "", type: "ending", position: { x: 0, y: 0 }, data: {} } as Node)}</span>
-        {" 결말을 보여줍니다."}
+      <p className="mt-3 rounded-xl border border-slate-800 bg-slate-900/70 p-3 text-sm leading-6 text-slate-200">
+        {conditionGroupSentence(conditionDrafts, branchQuestions, characters)}
       </p>
+      <ul className="sr-only">
+        {group.conditions.length === 0 ? (
+          <li>조건 설정 필요</li>
+        ) : group.conditions.map((condition, index) => (
+          <li key={index}>{conditionSummary(
+            conditionFromAtom(condition, index),
+            branchQuestions,
+            characters,
+          )}</li>
+        ))}
+      </ul>
     </article>
   );
 }
 
 function EndingConditionModal({
   draft,
-  endingNodes,
+  endingId,
+  endingName,
   branchQuestions,
+  characters,
   initialRow,
   onClose,
   onSave,
 }: {
   draft: EndingBranchConfig;
-  endingNodes: Node[];
+  endingId: string;
+  endingName: string;
   branchQuestions: EndingBranchQuestion[];
+  characters: EditorCharacterResponse[];
   initialRow: EndingBranchMatrixRow | null;
   onClose: () => void;
   onSave: (row: EndingBranchMatrixRow) => void;
 }) {
-  const parsed = initialRow ? readChoiceCondition(initialRow.condition) : null;
-  const firstQuestion = branchQuestions[0];
-  const [questionId, setQuestionId] = useState(parsed?.questionId ?? firstQuestion?.id ?? "");
-  const selectedQuestion = branchQuestions.find((question) => question.id === questionId);
-  const [selectedChoices, setSelectedChoices] = useState<string[]>(
-    parsed?.choices?.length ? parsed.choices : selectedQuestion?.choices[0] ? [selectedQuestion.choices[0]] : [],
-  );
-  const [aggregation, setAggregation] = useState<"threshold" | "winning" | "all" | "any">(
-    selectedQuestion?.type === "multi"
-      ? parsed?.aggregation === "all" ? "all" : "any"
-      : parsed?.aggregation === "winning" ? "winning" : "threshold",
-  );
-  const [endingId, setEndingId] = useState(initialRow?.ending ?? draft.defaultEnding ?? endingNodes[0]?.id ?? "");
-  const isMultiQuestion = selectedQuestion?.type === "multi";
+  const [conditions, setConditions] = useState<ConditionDraft[]>(() => draftFromRow(initialRow, branchQuestions, characters));
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -220,124 +510,223 @@ function EndingConditionModal({
   }, [onClose]);
 
   const preview = useMemo(() => {
-    const questionText = selectedQuestion?.text.trim() || "질문";
-    const choiceText = selectedChoices.length > 0 ? selectedChoices.join(", ") : "선택지";
-    const ending = endingName(endingNodes.find((node) => node.id === endingId) ?? { id: "", type: "ending", position: { x: 0, y: 0 }, data: {} } as Node);
-    const ruleText = aggregation === "winning"
-      ? "가장 많으면"
-      : aggregation === "all"
-        ? "모두 설정 비율 이상이면"
-        : aggregation === "any"
-          ? "하나라도 설정 비율 이상이면"
-          : "설정 비율 이상이면";
-    return `${questionText}에서 '${choiceText}' 답변이 ${ruleText} '${ending}' 결말로 보냅니다.`;
-  }, [aggregation, endingId, endingNodes, selectedChoices, selectedQuestion]);
+    const parts = conditions.map((condition) => conditionSummary(condition, branchQuestions, characters));
+    return parts.length > 0
+      ? `${parts.join(" 그리고 ")} '${endingName}' 결말로 보냅니다.`
+      : `${endingName} 결말로 가는 조건을 추가해 주세요.`;
+  }, [branchQuestions, characters, conditions, endingName]);
 
-  const handleQuestionChange = (nextQuestionId: string) => {
-    const nextQuestion = branchQuestions.find((question) => question.id === nextQuestionId);
-    setQuestionId(nextQuestionId);
-    setSelectedChoices(nextQuestion?.choices[0] ? [nextQuestion.choices[0]] : []);
-    setAggregation(nextQuestion?.type === "multi" ? "any" : "threshold");
+  const updateCondition = (conditionId: string, updater: (condition: ConditionDraft) => ConditionDraft) => {
+    setConditions((current) => current.map((condition) => condition.id === conditionId ? updater(condition) : condition));
   };
 
-  const toggleChoice = (choice: string) => {
-    setSelectedChoices((current) => (
-      current.includes(choice)
-        ? current.filter((item) => item !== choice)
-        : [...current, choice]
-    ));
+  const addCondition = () => {
+    const next = firstQuestionDraft(branchQuestions) ?? createCharacterDraft(characters);
+    if (!next) return;
+    setConditions((current) => [...current, { ...next, id: conditionDraftId(current.length) }]);
   };
 
   const handleSubmit = () => {
-    if (!selectedQuestion || selectedChoices.length === 0 || !endingId) return;
+    if (!endingId || conditions.length === 0 || conditions.some((condition) => !isConditionValid(condition, branchQuestions, characters))) return;
     const base = initialRow ?? createEndingBranchMatrixRow(draft, endingId);
     onSave({
-      ...updateMatrixCondition(
-        base,
-        selectedQuestion.id,
-        isMultiQuestion ? selectedChoices : selectedChoices[0],
-        isMultiQuestion ? aggregation === "all" ? "all" : "any" : aggregation,
-      ),
+      ...base,
       ending: endingId,
+      condition: buildConditionGroup(conditions.map((condition) => conditionToLogic(condition))),
     });
   };
 
+  const canSave = Boolean(endingId) &&
+    conditions.length > 0 &&
+    conditions.every((condition) => isConditionValid(condition, branchQuestions, characters));
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-4" role="dialog" aria-modal="true" aria-label="조건 만들기">
-      <section className="w-full max-w-2xl rounded-2xl border border-slate-700 bg-slate-950 p-5 shadow-2xl">
+      <section className="max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-2xl border border-slate-700 bg-slate-950 p-5 shadow-2xl">
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-400">Condition</p>
-            <h3 className="mt-1 text-lg font-semibold text-slate-100">조건 만들기</h3>
+            <h3 className="mt-1 text-lg font-semibold text-slate-100">{endingName} 조건 만들기</h3>
+            <p className="mt-1 text-xs leading-5 text-slate-400">이 조건 그룹의 항목을 모두 만족하면 이 결말로 보냅니다. 다른 경로가 필요하면 같은 결말에 조건 그룹을 하나 더 추가하세요.</p>
           </div>
           <button type="button" onClick={onClose} className="rounded-lg p-2 text-slate-400 hover:bg-slate-800 hover:text-slate-100" aria-label="조건 만들기 닫기">
             <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
-        <div className="mt-5 grid gap-4">
-          <label className="block">
-            <span className="text-xs font-medium text-slate-400">질문</span>
-            <select value={questionId} onChange={(event) => handleQuestionChange(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
-              {branchQuestions.map((question) => <option key={question.id} value={question.id}>{question.text || "질문 내용 필요"}</option>)}
-            </select>
-          </label>
-          {isMultiQuestion ? (
-            <div>
-              <span className="text-xs font-medium text-slate-400">답변</span>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {(selectedQuestion?.choices ?? []).map((item) => {
-                  const selected = selectedChoices.includes(item);
-                  return (
-                    <button
-                      key={item}
-                      type="button"
-                      onClick={() => toggleChoice(item)}
-                      className={`rounded-full border px-3 py-2 text-xs font-medium transition ${selected ? "border-amber-400 bg-amber-400/15 text-amber-100" : "border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500"}`}
-                      aria-pressed={selected}
-                    >
-                      {item}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ) : (
-            <label className="block">
-              <span className="text-xs font-medium text-slate-400">답변</span>
-              <select value={selectedChoices[0] ?? ""} onChange={(event) => setSelectedChoices(event.target.value ? [event.target.value] : [])} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
-                {(selectedQuestion?.choices ?? []).map((item) => <option key={item} value={item}>{item}</option>)}
-              </select>
-            </label>
-          )}
-          <label className="block">
-            <span className="text-xs font-medium text-slate-400">집계 기준</span>
-            <select value={aggregation} onChange={(event) => setAggregation(event.target.value === "winning" ? "winning" : event.target.value === "all" ? "all" : event.target.value === "any" ? "any" : "threshold")} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
-              {isMultiQuestion ? (
-                <>
-                  <option value="any">하나라도 정답</option>
-                  <option value="all">모두 정답</option>
-                </>
-              ) : (
-                <>
-                  <option value="threshold">과반수 / 설정 비율 이상</option>
-                  <option value="winning">가장 많이 선택</option>
-                </>
-              )}
-            </select>
-          </label>
-          <label className="block">
-            <span className="text-xs font-medium text-slate-400">보여줄 결말</span>
-            <select value={endingId} onChange={(event) => setEndingId(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100">
-              {endingNodes.map((node) => <option key={node.id} value={node.id}>{endingName(node)}</option>)}
-            </select>
-          </label>
+        <div className="mt-5 space-y-3">
+          {conditions.map((condition, index) => (
+            <ConditionEditorRow
+              key={condition.id}
+              condition={condition}
+              index={index}
+              branchQuestions={branchQuestions}
+              characters={characters}
+              onChange={(updater) => updateCondition(condition.id, updater)}
+              onRemove={() => setConditions((current) => current.filter((item) => item.id !== condition.id))}
+            />
+          ))}
+          <button type="button" onClick={addCondition} className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-700 px-3 text-sm text-slate-100 hover:bg-slate-800">
+            <Plus className="h-4 w-4" aria-hidden="true" /> 조건 추가
+          </button>
           <p className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm leading-6 text-emerald-100">{preview}</p>
         </div>
         <div className="mt-5 flex justify-end gap-2">
           <button type="button" onClick={onClose} className="min-h-11 rounded-xl border border-slate-700 px-4 text-sm text-slate-200 hover:bg-slate-800">취소</button>
-          <button type="button" onClick={handleSubmit} disabled={!selectedQuestion || selectedChoices.length === 0 || !endingId} className="min-h-11 rounded-xl border border-amber-500/60 bg-amber-500/15 px-4 text-sm font-medium text-amber-100 hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-50">조건 저장</button>
+          <button type="button" onClick={handleSubmit} disabled={!canSave} className="min-h-11 rounded-xl border border-amber-500/60 bg-amber-500/15 px-4 text-sm font-medium text-amber-100 hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-50">조건 저장</button>
         </div>
       </section>
+    </div>
+  );
+}
+
+function ConditionEditorRow({
+  condition,
+  index,
+  branchQuestions,
+  characters,
+  onChange,
+  onRemove,
+}: {
+  condition: ConditionDraft;
+  index: number;
+  branchQuestions: EndingBranchQuestion[];
+  characters: EditorCharacterResponse[];
+  onChange: (updater: (condition: ConditionDraft) => ConditionDraft) => void;
+  onRemove: () => void;
+}) {
+  const selectedQuestion = condition.type === "question"
+    ? branchQuestions.find((question) => question.id === condition.questionId)
+    : undefined;
+  const isMultiQuestion = selectedQuestion?.type === "multi";
+
+  const changeType = (type: string) => {
+    if (type === "character_alive") {
+      const next = createCharacterDraft(characters);
+      if (next) onChange(() => ({ ...next, id: condition.id }));
+      return;
+    }
+    const next = firstQuestionDraft(branchQuestions);
+    if (next) onChange(() => ({ ...next, id: condition.id }));
+  };
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-medium text-slate-100">조건 {index + 1}</p>
+        <button type="button" onClick={onRemove} className="rounded-lg p-2 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200" aria-label={`조건 ${index + 1} 제거`}>
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="mt-3 grid gap-3">
+        <label className="block">
+          <span className="text-xs font-medium text-slate-400">조건 종류</span>
+          <select aria-label={index === 0 ? "조건 종류" : `조건 종류 ${index + 1}`} value={condition.type} onChange={(event) => changeType(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+            <option value="question">질문 답변</option>
+            <option value="character_alive">캐릭터 상태</option>
+          </select>
+        </label>
+        {condition.type === "question" ? (
+          <>
+            <label className="block">
+              <span className="text-xs font-medium text-slate-400">질문</span>
+              <select aria-label={index === 0 ? "질문" : `질문 ${index + 1}`} value={condition.questionId} onChange={(event) => {
+                const nextQuestion = branchQuestions.find((question) => question.id === event.target.value);
+                onChange((current) => current.type === "question" ? {
+                  ...current,
+                  questionId: event.target.value,
+                  choices: nextQuestion?.choices[0] ? [nextQuestion.choices[0]] : [],
+                  aggregation: nextQuestion?.type === "multi" ? "any" : "threshold",
+                } : current);
+              }} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+                {branchQuestions.map((question) => <option key={question.id} value={question.id}>{question.text || "질문 내용 필요"}</option>)}
+              </select>
+            </label>
+            {isMultiQuestion ? (
+              <div>
+                <span className="text-xs font-medium text-slate-400">답변</span>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {(selectedQuestion?.choices ?? []).map((item) => {
+                    const selected = condition.choices.includes(item);
+                    return (
+                      <button
+                        key={item}
+                        type="button"
+                        onClick={() => onChange((current) => {
+                          if (current.type !== "question") return current;
+                          return {
+                            ...current,
+                            choices: selected
+                              ? current.choices.filter((choice) => choice !== item)
+                              : [...current.choices, item],
+                          };
+                        })}
+                        className={`rounded-full border px-3 py-2 text-xs font-medium transition ${selected ? "border-amber-400 bg-amber-400/15 text-amber-100" : "border-slate-700 bg-slate-950 text-slate-300 hover:border-slate-500"}`}
+                        aria-pressed={selected}
+                      >
+                        {item}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : (
+              <label className="block">
+                <span className="text-xs font-medium text-slate-400">답변</span>
+                <select aria-label={index === 0 ? "답변" : `답변 ${index + 1}`} value={condition.choices[0] ?? ""} onChange={(event) => onChange((current) => current.type === "question" ? { ...current, choices: event.target.value ? [event.target.value] : [] } : current)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+                  {(selectedQuestion?.choices ?? []).map((item) => <option key={item} value={item}>{item}</option>)}
+                </select>
+              </label>
+            )}
+            <label className="block">
+              <span className="text-xs font-medium text-slate-400">집계 기준</span>
+              <select aria-label={index === 0 ? "집계 기준" : `집계 기준 ${index + 1}`} value={condition.aggregation} onChange={(event) => onChange((current) => current.type === "question" ? { ...current, aggregation: event.target.value === "winning" ? "winning" : event.target.value === "all" ? "all" : event.target.value === "any" ? "any" : "threshold" } : current)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+                {isMultiQuestion ? (
+                  <>
+                    <option value="any">하나라도 설정 비율 이상</option>
+                    <option value="all">모두 설정 비율 이상</option>
+                  </>
+                ) : (
+                  <>
+                    <option value="threshold">과반수 / 설정 비율 이상</option>
+                    <option value="winning">가장 많이 선택</option>
+                  </>
+                )}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-xs font-medium text-slate-400">판정</span>
+              <select aria-label={index === 0 ? "판정" : `판정 ${index + 1}`} value={condition.negated ? "not" : "is"} onChange={(event) => onChange((current) => current.type === "question" ? { ...current, negated: event.target.value === "not" } : current)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+                <option value="is">이면</option>
+                <option value="not">아니면</option>
+              </select>
+            </label>
+          </>
+        ) : null}
+        {condition.type === "character_alive" ? (
+          <div className="grid gap-3 sm:grid-cols-3">
+            <label className="block">
+              <span className="text-xs font-medium text-slate-400">캐릭터</span>
+              <select aria-label={index === 0 ? "캐릭터" : `캐릭터 ${index + 1}`} value={condition.characterId} onChange={(event) => onChange((current) => current.type === "character_alive" ? { ...current, characterId: event.target.value } : current)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+                {characters.map((character) => <option key={character.id} value={character.id}>{character.name}</option>)}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-xs font-medium text-slate-400">상태</span>
+              <select aria-label={index === 0 ? "상태" : `상태 ${index + 1}`} value={condition.alive ? "alive" : "dead"} onChange={(event) => onChange((current) => current.type === "character_alive" ? { ...current, alive: event.target.value === "alive" } : current)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+                <option value="dead">사망</option>
+                <option value="alive">생존</option>
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-xs font-medium text-slate-400">판정</span>
+              <select aria-label={index === 0 ? "판정" : `판정 ${index + 1}`} value={condition.negated ? "not" : "is"} onChange={(event) => onChange((current) => current.type === "character_alive" ? { ...current, negated: event.target.value === "not" } : current)} className="mt-1 min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100">
+                <option value="is">이면</option>
+                <option value="not">아니면</option>
+              </select>
+            </label>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, CheckCircle2, Save } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from "react";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
 import { toast } from "sonner";
 import type { Node } from "@xyflow/react";
 import type { EditorCharacterResponse, EditorThemeResponse } from "@/features/editor/api";
 import { useUpdateConfigJson } from "@/features/editor/editorConfigApi";
+import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
 import {
   createEndingBranchQuestion,
   readChoiceCondition,
@@ -22,7 +23,16 @@ interface EndingBranchRulesPanelProps {
   endingNodes: Node[];
   characters: EditorCharacterResponse[];
   section: "questions" | "endings";
+  selectedEndingId?: string;
+  embedded?: boolean;
+  settingsOnly?: boolean;
 }
+
+interface AutosaveBody {
+  draft: EndingBranchConfig;
+}
+
+const ENDING_BRANCH_AUTOSAVE_MS = 1500;
 
 function reorderPriorities(config: EndingBranchConfig): EndingBranchConfig {
   return { ...config, matrix: config.matrix.map((row, index) => ({ ...row, priority: index + 1 })) };
@@ -71,12 +81,28 @@ function updateChoiceValues(
   return question.choices.map((choice, index) => (index === choiceIndex ? value : choice));
 }
 
-export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters, section }: EndingBranchRulesPanelProps) {
+function hasInvalidSpecificPlayerTarget(config: EndingBranchConfig): boolean {
+  return config.questions.some(
+    (question) => question.target.type === "specific_players" && question.target.characterIds.length === 0,
+  );
+}
+
+function endingBranchConfigEqual(left: EndingBranchConfig, right: EndingBranchConfig): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters, section, selectedEndingId, embedded = false, settingsOnly = false }: EndingBranchRulesPanelProps) {
+  const panelRef = useRef<HTMLElement | null>(null);
   const updateConfig = useUpdateConfigJson(themeId);
   const serverConfig = useMemo(() => readEndingBranchConfig(theme.config_json), [theme.config_json]);
   const [draft, setDraft] = useState<EndingBranchConfig>(serverConfig);
   const [dirty, setDirty] = useState(false);
   const draftRef = useRef(draft);
+  const isQuestions = section === "questions";
+  const toastId = isQuestions ? "ending-questions-autosave" : "ending-rules-autosave";
+  const loadingMessage = isQuestions ? "질문 설정 자동저장 중..." : "결말 판정 규칙 자동저장 중...";
+  const successMessage = isQuestions ? "질문 설정이 자동저장되었습니다" : "결말 판정 규칙이 자동저장되었습니다";
+  const failureMessage = isQuestions ? "질문 설정 자동저장에 실패했습니다" : "결말 판정 규칙 자동저장에 실패했습니다";
 
   useEffect(() => {
     if (dirty) return;
@@ -93,32 +119,73 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
     [draft, endingNodes, theme.config_json],
   );
   const branchQuestions = draft.questions.filter((question) => question.impact === "branch");
-  const canAddRule = endingNodes.length > 0 && branchQuestions.some((question) => question.choices.length > 0);
+  const canAddRule = endingNodes.length > 0 && (
+    branchQuestions.some((question) => question.choices.length > 0) ||
+    characters.length > 0
+  );
 
-  const applyDraft = (next: EndingBranchConfig) => {
-    setDraft(next);
-    setDirty(true);
-  };
-
-  const handleSave = () => {
-    const submittedDraft = draft;
-    if (draft.questions.some((question) => question.target.type === "specific_players" && question.target.characterIds.length === 0)) {
-      toast.error("특정 플레이어 질문은 받을 캐릭터를 1명 이상 선택해야 합니다");
-      return;
-    }
+  const saveBody = useCallback((body: AutosaveBody, opts?: { onError?: (error?: unknown) => void }) => {
+    const submittedDraft = body.draft;
+    toast.loading(loadingMessage, { id: toastId });
     updateConfig.mutate(
-      { ...writeEndingBranchConfig(theme.config_json, draft), version: theme.version },
+      { ...writeEndingBranchConfig(theme.config_json, submittedDraft), version: theme.version },
       {
         onSuccess: () => {
           if (draftRef.current === submittedDraft) {
             setDirty(false);
           }
-          toast.success("결말 판정 설정이 저장되었습니다");
+          toast.success(successMessage, { id: toastId, duration: 1200 });
         },
-        onError: () => toast.error("결말 판정 설정 저장에 실패했습니다"),
+        onError: opts?.onError,
       },
     );
-  };
+  }, [loadingMessage, successMessage, theme.config_json, theme.version, toastId, updateConfig]);
+
+  const showFailureToast = useCallback((body: AutosaveBody) => {
+    toast.error(failureMessage, {
+      id: toastId,
+      duration: 6000,
+      action: {
+        label: "재시도",
+        onClick: () => saveBody(body, { onError: () => showFailureToast(body) }),
+      },
+    });
+  }, [failureMessage, saveBody, toastId]);
+
+  const { schedule, flush, cancel } = useDebouncedMutation<AutosaveBody>({
+    debounceMs: ENDING_BRANCH_AUTOSAVE_MS,
+    mutate: (body, opts) => {
+      saveBody(body, {
+        onError: (error) => {
+          opts.onError(error);
+          showFailureToast(body);
+        },
+      });
+    },
+  });
+
+  const applyDraft = useCallback((next: EndingBranchConfig) => {
+    setDraft(next);
+    draftRef.current = next;
+    if (endingBranchConfigEqual(next, serverConfig)) {
+      setDirty(false);
+      cancel();
+      return;
+    }
+    setDirty(true);
+    if (hasInvalidSpecificPlayerTarget(next)) {
+      cancel();
+      toast.error("특정 플레이어 질문은 받을 캐릭터를 1명 이상 선택해야 합니다");
+      return;
+    }
+    schedule({ draft: next });
+  }, [cancel, schedule, serverConfig]);
+
+  const handlePanelBlur = useCallback((event: FocusEvent<HTMLElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && panelRef.current?.contains(nextTarget)) return;
+    flush();
+  }, [flush]);
 
   const handleRemoveQuestion = (questionId: string) => {
     applyDraft(reorderPriorities({
@@ -158,8 +225,13 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
   };
 
   return (
-    <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300" aria-label={section === "questions" ? "질문 관리" : "결말 판정 규칙"}>
-      <Header dirty={dirty} isPending={updateConfig.isPending} onSave={handleSave} section={section} />
+    <section
+      ref={panelRef}
+      className={embedded ? "text-sm text-slate-300" : "rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300"}
+      aria-label={section === "questions" ? "질문 관리" : "결말 판정 규칙"}
+      onBlur={handlePanelBlur}
+    >
+      <Header section={section} embedded={embedded} settingsOnly={settingsOnly} />
       <Warnings warnings={viewModel.warnings} />
       <div className="mt-5">
         {section === "questions" ? (
@@ -178,7 +250,10 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
           draft={draft}
           endingNodes={endingNodes}
           branchQuestions={branchQuestions}
+          characters={characters}
           canAddRule={canAddRule}
+          selectedEndingId={selectedEndingId}
+          display={settingsOnly ? "settings" : selectedEndingId ? "rules" : "all"}
           onChange={applyDraft}
         />
         )}
@@ -188,34 +263,32 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
 }
 
 function Header({
-  dirty,
-  isPending,
-  onSave,
   section,
+  embedded,
+  settingsOnly,
 }: {
-  dirty: boolean;
-  isPending: boolean;
-  onSave: () => void;
   section: "questions" | "endings";
+  embedded: boolean;
+  settingsOnly: boolean;
 }) {
   const isQuestions = section === "questions";
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <div>
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-400">Ending Rules</p>
         <h3 className="mt-1 text-lg font-semibold text-slate-100">
-          {isQuestions ? "질문 관리" : "결말 판정 규칙"}
+          {isQuestions ? "질문 관리" : settingsOnly ? "결말 판정 설정" : embedded ? "이 결말로 가는 조건" : "결말 판정 규칙"}
         </h3>
         <p className="mt-1 text-sm leading-6 text-slate-400">
           {isQuestions
             ? "플레이어에게 진행할 최종 질문과 선택지를 설정합니다."
-            : "질문 답변이 어떤 결말로 이어지는지 설정합니다. 내부 판정식은 자동으로 만들어집니다."}
+            : settingsOnly
+              ? "규칙에 맞는 결말이 없을 때 보여줄 기본 결말과 복수 선택 기준을 설정합니다."
+              : embedded
+              ? "조건 그룹 중 하나라도 만족하면 이 결말이 플레이어에게 공개됩니다."
+              : "질문 답변이 어떤 결말로 이어지는지 설정합니다. 내부 판정식은 자동으로 만들어집니다."}
         </p>
       </div>
-      <button type="button" onClick={onSave} disabled={!dirty || isPending} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-amber-500/50 bg-amber-500/10 px-4 text-sm font-medium text-amber-100 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-50">
-        <Save className="h-4 w-4" aria-hidden="true" />
-        {isPending ? "저장 중" : dirty ? (isQuestions ? "질문 설정 저장" : "판정 규칙 저장") : "저장됨"}
-      </button>
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useId, useState, type ReactNode } from "react";
 import type { Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -16,6 +16,7 @@ interface EndingEntityDetailProps {
   node: Node;
   themeId: string;
   onChange: (nodeId: string, patch: Partial<FlowNodeData>) => void;
+  rulesSlot?: ReactNode;
 }
 
 const SAVE_DEBOUNCE_MS = 1000;
@@ -24,6 +25,7 @@ export function EndingEntityDetail({
   node,
   themeId,
   onChange,
+  rulesSlot,
 }: EndingEntityDetailProps) {
   const fieldIdPrefix = useId();
   const [pickerType, setPickerType] = useState<MediaType | null>(null);
@@ -112,6 +114,11 @@ export function EndingEntityDetail({
           Markdown과 미디어 블록을 사용할 수 있습니다. 플레이어에게 보일 문장만 작성하면 됩니다.
         </p>
       </div>
+      {rulesSlot ? (
+        <div className="border-t border-slate-800 pt-4">
+          {rulesSlot}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
@@ -1,12 +1,6 @@
-import { Plus } from "lucide-react";
-
-interface EndingEntityHeaderProps {
-  onAddEnding: () => void;
-}
-
-export function EndingEntityHeader({ onAddEnding }: EndingEntityHeaderProps) {
+export function EndingEntityHeader() {
   return (
-    <header className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 lg:flex-row lg:items-center lg:justify-between">
+    <header className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
       <div className="space-y-1">
         <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">결말 편집</p>
         <h2 className="text-xl font-semibold text-slate-100">결말 목록</h2>
@@ -15,14 +9,6 @@ export function EndingEntityHeader({ onAddEnding }: EndingEntityHeaderProps) {
           이곳에서는 플레이어에게 공개될 결말 이름과 본문을 정리합니다.
         </p>
       </div>
-      <button
-        type="button"
-        onClick={onAddEnding}
-        className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-amber-500/50 bg-amber-500/10 px-4 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-400/60"
-      >
-        <Plus className="h-4 w-4" />
-        결말 추가
-      </button>
     </header>
   );
 }

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Search } from 'lucide-react';
+import { Plus, Search, Trash2 } from 'lucide-react';
 import { useEditorCharacters, type EditorThemeResponse } from '@/features/editor/api';
 import { useFlowData } from '../../hooks/useFlowData';
 import type { FlowNodeData } from '../../flowTypes';
@@ -43,6 +43,7 @@ function EndingEntityWorkspace({
     error,
     refetch,
     addNode,
+    deleteNode,
     updateNodeData,
   } = useFlowData(themeId);
 
@@ -104,23 +105,45 @@ function EndingEntityWorkspace({
       data-testid="ending-entity-panel"
       className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6"
     >
-      {section === 'endings' ? <EndingEntityHeader onAddEnding={handleAddEnding} /> : null}
+      {section === 'endings' ? <EndingEntityHeader /> : null}
 
       {section === 'endings' ? <EndingDecisionSummaryPanel summary={decisionSummary} /> : null}
 
-      <EndingBranchRulesPanel
-        themeId={themeId}
-        theme={theme}
-        endingNodes={endingNodes}
-        characters={characters}
-        section={section}
-      />
+      {section === 'endings' ? (
+        <EndingBranchRulesPanel
+          themeId={themeId}
+          theme={theme}
+          endingNodes={endingNodes}
+          characters={characters}
+          section={section}
+          settingsOnly
+        />
+      ) : null}
+
+      {section === 'questions' ? (
+        <EndingBranchRulesPanel
+          themeId={themeId}
+          theme={theme}
+          endingNodes={endingNodes}
+          characters={characters}
+          section={section}
+        />
+      ) : null}
 
       {section !== 'endings' ? null : endingNodes.length === 0 ? (
         <EndingEmptyState />
       ) : (
         <div className="grid items-start gap-4 lg:grid-cols-[minmax(220px,320px)_minmax(0,1fr)]">
           <aside className="flex min-w-0 flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
+            <button
+              type="button"
+              onClick={handleAddEnding}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-amber-500/50 bg-amber-500/10 px-3 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-400/60"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              결말 추가
+            </button>
+
             <label className="relative block">
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
               <input
@@ -144,19 +167,42 @@ function EndingEntityWorkspace({
                   const viewModel = toEndingEditorViewModel(node, incomingCount);
                   const selected = selectedNode?.id === node.id;
                   return (
-                    <button
+                    <div
                       key={node.id}
-                      type="button"
-                      onClick={() => setSelectedId(node.id)}
-                      aria-pressed={selected}
-                      className={`rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-400/60 ${
+                      className={`rounded-xl border p-3 text-left transition focus-within:ring-2 focus-within:ring-amber-400/60 ${
                         selected
                           ? 'border-amber-500/70 bg-amber-500/10'
                           : 'border-slate-800 bg-slate-950 hover:border-slate-600'
                       }`}
                     >
-                      <p className="font-medium text-slate-100">{viewModel.name}</p>
-                      <div className="mt-2 flex flex-wrap gap-1">
+                      <div className="flex items-start justify-between gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setSelectedId(node.id)}
+                          aria-pressed={selected}
+                          aria-label={`${viewModel.name} 선택`}
+                          className="min-w-0 flex-1 text-left focus:outline-none"
+                        >
+                          <p className="truncate font-medium text-slate-100">{viewModel.name}</p>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            deleteNode(node.id);
+                            if (selectedId === node.id) setSelectedId(null);
+                          }}
+                          className="rounded-lg p-2 text-slate-500 transition hover:bg-rose-500/10 hover:text-rose-200 focus:outline-none focus:ring-2 focus:ring-rose-300/60"
+                          aria-label={`${viewModel.name} 삭제`}
+                        >
+                          <Trash2 className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedId(node.id)}
+                        className="mt-2 flex flex-wrap gap-1 text-left focus:outline-none"
+                        aria-label={`${viewModel.name} 배지 영역 선택`}
+                      >
                         {viewModel.badges.map((badge) => (
                           <span
                             key={badge}
@@ -165,8 +211,8 @@ function EndingEntityWorkspace({
                             {badge}
                           </span>
                         ))}
-                      </div>
-                    </button>
+                      </button>
+                    </div>
                   );
                 })
               )}
@@ -178,6 +224,17 @@ function EndingEntityWorkspace({
               node={selectedNode}
               themeId={themeId}
               onChange={updateNodeData}
+              rulesSlot={(
+                <EndingBranchRulesPanel
+                  themeId={themeId}
+                  theme={theme}
+                  endingNodes={endingNodes}
+                  characters={characters}
+                  section="endings"
+                  selectedEndingId={selectedNode.id}
+                  embedded
+                />
+              )}
             />
           )}
         </div>

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -1,18 +1,21 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { forwardRef, useImperativeHandle, type ComponentType, type ReactNode } from "react";
 
-const { useFlowDataMock, useEditorCharactersMock, addNodeMock, updateNodeDataMock, mutateMock, configMutateMock, useUpdateFlowNodeMock, refetchMock, toastErrorMock, useMediaListMock, useMediaCategoriesMock, useMediaDownloadUrlMock } = vi.hoisted(() => ({
+const { useFlowDataMock, useEditorCharactersMock, addNodeMock, deleteNodeMock, updateNodeDataMock, mutateMock, configMutateMock, useUpdateFlowNodeMock, refetchMock, toastErrorMock, toastSuccessMock, toastLoadingMock, useMediaListMock, useMediaCategoriesMock, useMediaDownloadUrlMock } = vi.hoisted(() => ({
   useFlowDataMock: vi.fn(),
   useEditorCharactersMock: vi.fn(),
   addNodeMock: vi.fn(),
+  deleteNodeMock: vi.fn(),
   updateNodeDataMock: vi.fn(),
   mutateMock: vi.fn(),
   configMutateMock: vi.fn(),
   useUpdateFlowNodeMock: vi.fn(),
   refetchMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastLoadingMock: vi.fn(),
   useMediaListMock: vi.fn(),
   useMediaCategoriesMock: vi.fn(),
   useMediaDownloadUrlMock: vi.fn(),
@@ -101,7 +104,7 @@ vi.mock("@mdxeditor/editor", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: toastErrorMock, success: vi.fn() },
+  toast: { error: toastErrorMock, success: toastSuccessMock, loading: toastLoadingMock },
 }));
 
 import { EndingEntitySubTab, EndingQuestionsTab } from "../EndingEntitySubTab";
@@ -116,6 +119,12 @@ function renderWithClient(ui: ReactNode) {
 function clickLastButton(name: RegExp) {
   const buttons = screen.getAllByRole("button", { name });
   fireEvent.click(buttons[buttons.length - 1]);
+}
+
+function flushEndingBranchAutosave() {
+  act(() => {
+    vi.advanceTimersByTime(1500);
+  });
 }
 
 
@@ -223,12 +232,14 @@ beforeEach(() => {
     error: null,
     refetch: refetchMock,
     addNode: addNodeMock,
+    deleteNode: deleteNodeMock,
     updateNodeData: updateNodeDataMock,
   });
 });
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -241,6 +252,10 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("결말 판정 준비")).toBeDefined();
     expect(screen.getByText("본문 작성")).toBeDefined();
+    expect(screen.getByRole("heading", { name: "결말 판정 설정", level: 3 })).toBeDefined();
+    expect(screen.getAllByText("기본 결말")).toHaveLength(1);
+    expect(screen.getByLabelText("기본 결말")).toBeDefined();
+    expect(screen.getByText("복수 선택 반영 기준")).toBeDefined();
     expect(screen.queryByText("참가자에게만 공개")).toBeNull();
     expect(screen.queryByText("캐릭터 결과 카드 1/2명 작성")).toBeNull();
     expect(screen.queryByText("1막")).toBeNull();
@@ -255,6 +270,7 @@ describe("EndingEntitySubTab", () => {
       error: null,
       refetch: refetchMock,
       addNode: addNodeMock,
+      deleteNode: deleteNodeMock,
       updateNodeData: updateNodeDataMock,
     });
 
@@ -274,6 +290,7 @@ describe("EndingEntitySubTab", () => {
       error: new Error("권한이 없습니다"),
       refetch: refetchMock,
       addNode: addNodeMock,
+      deleteNode: deleteNodeMock,
       updateNodeData: updateNodeDataMock,
     });
 
@@ -297,13 +314,21 @@ describe("EndingEntitySubTab", () => {
     }));
   });
 
+  it("결말 목록 카드에서 결말을 삭제할 수 있다", () => {
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "진실 삭제" }));
+
+    expect(deleteNodeMock).toHaveBeenCalledWith("ending-1");
+  });
+
   it("검색어로 결말 목록을 좁힌다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
     fireEvent.change(screen.getByPlaceholderText("결말 검색"), { target: { value: "오판" } });
 
     expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: /오판/ }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "오판 선택" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.queryByRole("button", { name: /진실/ })).toBeNull();
   });
 
@@ -333,6 +358,9 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getByRole("region", { name: "결말 본문 작성기" })).toBeDefined();
     expect(screen.getByRole("button", { name: "결말 이미지 삽입" })).toBeDefined();
     expect(screen.getByRole("button", { name: "결말 영상 삽입" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "이 결말로 가는 조건", level: 3 })).toBeDefined();
+    expect(screen.getByText("범인은 누구인가?에서 '하윤' 답변이 설정 비율 이상")).toBeDefined();
+    expect(screen.queryByText("규칙에 맞는 결말이 없을 때 보여줄 결말입니다.")).toBeDefined();
 
     fireEvent.change(screen.getByLabelText("editable markdown"), {
       target: { value: "진실은 모두에게 남았다." },
@@ -342,12 +370,14 @@ describe("EndingEntitySubTab", () => {
     });
   });
 
-  it("결말 판정 질문과 규칙을 제작자용 UI로 저장한다", () => {
+  it("결말 판정 질문과 규칙을 자동저장하고 토스트로 상태를 알린다", () => {
+    vi.useFakeTimers();
+    configMutateMock.mockImplementation((_body, options) => options?.onSuccess?.());
     renderWithClient(<EndingQuestionsTab themeId="theme-1" theme={theme} />);
 
     expect(screen.getByRole("heading", { name: "질문 관리", level: 3 })).toBeDefined();
     fireEvent.change(screen.getByLabelText("질문 1 내용"), { target: { value: "진범은 누구인가?" } });
-    fireEvent.click(screen.getByRole("button", { name: "질문 설정 저장" }));
+    flushEndingBranchAutosave();
 
     expect(configMutateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -369,14 +399,18 @@ describe("EndingEntitySubTab", () => {
       }),
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
     );
+    expect(toastLoadingMock).toHaveBeenCalledWith("질문 설정 자동저장 중...", expect.objectContaining({ id: "ending-questions-autosave" }));
+    expect(toastSuccessMock).toHaveBeenCalledWith("질문 설정이 자동저장되었습니다", expect.objectContaining({ id: "ending-questions-autosave" }));
+    expect(screen.queryByRole("button", { name: "질문 설정 저장" })).toBeNull();
   });
 
   it("결말 질문 대상을 특정 플레이어 여러 명으로 저장한다", () => {
+    vi.useFakeTimers();
     renderWithClient(<EndingQuestionsTab themeId="theme-1" theme={theme} />);
 
     clickLastButton(/하윤/);
     clickLastButton(/민재/);
-    fireEvent.click(screen.getByRole("button", { name: "질문 설정 저장" }));
+    flushEndingBranchAutosave();
 
     expect(configMutateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -398,11 +432,12 @@ describe("EndingEntitySubTab", () => {
   });
 
   it("특정 플레이어 질문에서 대상이 비면 저장하지 않고 경고한다", () => {
+    vi.useFakeTimers();
     renderWithClient(<EndingQuestionsTab themeId="theme-1" theme={theme} />);
 
     clickLastButton(/하윤/);
     clickLastButton(/하윤/);
-    fireEvent.click(screen.getByRole("button", { name: "질문 설정 저장" }));
+    flushEndingBranchAutosave();
 
     expect(configMutateMock).not.toHaveBeenCalled();
     expect(toastErrorMock).toHaveBeenCalledWith("특정 플레이어 질문은 받을 캐릭터를 1명 이상 선택해야 합니다");
@@ -440,37 +475,25 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getAllByText("삭제된 캐릭터").length).toBeGreaterThan(0);
   });
 
-  it("결말 선택지는 같은 질문 안에서 중복 저장되지 않는다", () => {
+  it("결말 선택지는 같은 질문 안에서 중복값이면 자동저장 요청을 만들지 않는다", () => {
+    vi.useFakeTimers();
     renderWithClient(<EndingQuestionsTab themeId="theme-1" theme={theme} />);
 
     fireEvent.change(screen.getByLabelText("질문 1 선택지 2"), { target: { value: "하윤" } });
-    fireEvent.click(screen.getByRole("button", { name: "질문 설정 저장" }));
+    flushEndingBranchAutosave();
 
-    expect(configMutateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        modules: expect.objectContaining({
-          ending_branch: expect.objectContaining({
-            config: expect.objectContaining({
-              questions: [
-                expect.objectContaining({
-                  choices: ["하윤", "민재"],
-                }),
-              ],
-            }),
-          }),
-        }),
-      }),
-      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
-    );
+    expect(configMutateMock).not.toHaveBeenCalled();
+    expect((screen.getByLabelText("질문 1 선택지 2") as HTMLInputElement).value).toBe("민재");
   });
 
   it("가장 많이 선택된 답 기준 결말 규칙을 저장한다", () => {
+    vi.useFakeTimers();
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
     fireEvent.click(screen.getByRole("button", { name: "수정" }));
     fireEvent.change(screen.getByLabelText("집계 기준"), { target: { value: "winning" } });
     fireEvent.click(screen.getByRole("button", { name: "조건 저장" }));
-    fireEvent.click(screen.getByRole("button", { name: "판정 규칙 저장" }));
+    flushEndingBranchAutosave();
 
     expect(configMutateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -491,7 +514,103 @@ describe("EndingEntitySubTab", () => {
     );
   });
 
+  it("기본 결말이 비어 있어도 새 결말 규칙을 첫 결말로 저장한다", () => {
+    vi.useFakeTimers();
+    renderWithClient(
+      <EndingEntitySubTab
+        themeId="theme-1"
+        theme={{
+          ...theme,
+          config_json: {
+            modules: {
+              ending_branch: {
+                enabled: true,
+                config: {
+                  questions: [{
+                    id: "q1",
+                    text: "범인으로 의심되는 용의자를 선택해 주세요",
+                    type: "single",
+                    choices: ["고동", "송료연", "노우", "양지", "희춘안"],
+                    impact: "branch",
+                    respondents: "all",
+                  }],
+                  matrix: [],
+                  defaultEnding: "",
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "조건 만들기" })[0]);
+    expect(screen.queryByLabelText("보여줄 결말")).toBeNull();
+    expect(screen.queryByRole("option", { name: "모두 생존" })).toBeNull();
+    fireEvent.change(screen.getByLabelText("답변"), { target: { value: "양지" } });
+    fireEvent.change(screen.getByLabelText("집계 기준"), { target: { value: "winning" } });
+    fireEvent.click(screen.getByRole("button", { name: "조건 저장" }));
+    flushEndingBranchAutosave();
+
+    expect(configMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modules: expect.objectContaining({
+          ending_branch: expect.objectContaining({
+            config: expect.objectContaining({
+              matrix: [
+                expect.objectContaining({
+                  ending: "ending-1",
+                  conditions: { "==": [{ var: "answers.q1.winning" }, "양지"] },
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("질문 답변과 캐릭터 사망 조건을 같은 결말 조건 그룹으로 저장한다", () => {
+    vi.useFakeTimers();
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.click(screen.getByRole("button", { name: "조건 추가" }));
+    fireEvent.change(screen.getByLabelText("조건 종류 2"), { target: { value: "character_alive" } });
+    fireEvent.change(screen.getByLabelText("캐릭터 2"), { target: { value: "char-2" } });
+    fireEvent.change(screen.getByLabelText("상태 2"), { target: { value: "dead" } });
+    fireEvent.change(screen.getByLabelText("판정 2"), { target: { value: "not" } });
+    fireEvent.click(screen.getByRole("button", { name: "조건 저장" }));
+    expect(screen.getByText("범인은 누구인가?에서 '하윤' 답변이 설정 비율 이상이고, 민재가 사망하지 않은 상태")).toBeDefined();
+    flushEndingBranchAutosave();
+
+    expect(configMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modules: expect.objectContaining({
+          ending_branch: expect.objectContaining({
+            config: expect.objectContaining({
+              matrix: [
+                expect.objectContaining({
+                  ending: "ending-1",
+                  conditions: {
+                    and: [
+                      { in: ["하윤", { var: "answers.q1.choices" }] },
+                      { "!": { "==": [{ var: "characters.char-2.alive" }, false] } },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
   it("복수 선택 질문은 모두 정답 기준 결말 규칙을 저장한다", () => {
+    vi.useFakeTimers();
     renderWithClient(
       <EndingEntitySubTab
         themeId="theme-1"
@@ -524,7 +643,7 @@ describe("EndingEntitySubTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "부서진 시계" }));
     fireEvent.change(screen.getByLabelText("집계 기준"), { target: { value: "all" } });
     fireEvent.click(screen.getByRole("button", { name: "조건 저장" }));
-    fireEvent.click(screen.getByRole("button", { name: "판정 규칙 저장" }));
+    flushEndingBranchAutosave();
 
     expect(configMutateMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { Node } from "@xyflow/react";
 import {
-  buildChoiceCondition,
   buildAllChoicesCondition,
   buildAnyChoicesCondition,
+  buildCharacterAliveCondition,
+  buildChoiceCondition,
+  buildConditionGroup,
+  buildEveryoneAliveCondition,
+  buildNegatedCondition,
   buildWinningChoiceCondition,
   createEndingBranchMatrixRow,
   createEndingBranchQuestion,
   readChoiceCondition,
   readEndingBranchConfig,
+  readEndingConditionGroup,
   toEndingBranchEditorViewModel,
   updateMatrixCondition,
   writeEndingBranchConfig,
@@ -217,6 +222,83 @@ describe("endingBranchAdapter", () => {
           { in: ["B", { var: "answers.q2.choices" }] },
         ],
       });
+  });
+
+  it("캐릭터 생존/사망 조건과 그룹 조건을 JSONLogic으로 저장하고 다시 읽는다", () => {
+    expect(buildCharacterAliveCondition("char-yangji", false)).toEqual({
+      "==": [{ var: "characters.char-yangji.alive" }, false],
+    });
+    expect(buildEveryoneAliveCondition(["char-godong", "char-yangji", "char-godong"])).toEqual({
+      and: [
+        { "==": [{ var: "characters.char-godong.alive" }, true] },
+        { "==": [{ var: "characters.char-yangji.alive" }, true] },
+      ],
+    });
+
+    const group = buildConditionGroup([
+      buildChoiceCondition("q1", "고동"),
+      buildCharacterAliveCondition("char-yangji", false),
+    ]);
+
+    expect(group).toEqual({
+      and: [
+        { in: ["고동", { var: "answers.q1.choices" }] },
+        { "==": [{ var: "characters.char-yangji.alive" }, false] },
+      ],
+    });
+    expect(readEndingConditionGroup(group)).toEqual({
+      operator: "and",
+      conditions: [
+        { kind: "question_choice", questionId: "q1", choice: "고동", choices: ["고동"], aggregation: "threshold", negated: false },
+        { kind: "character_alive", characterId: "char-yangji", alive: false, negated: false },
+      ],
+    });
+  });
+
+  it("아니면 조건을 JSONLogic not으로 저장하고 다시 읽는다", () => {
+    const questionCondition = buildNegatedCondition(buildChoiceCondition("q1", "고동"));
+    const characterCondition = buildNegatedCondition(buildCharacterAliveCondition("char-yangji", false));
+
+    expect(questionCondition).toEqual({ "!": { in: ["고동", { var: "answers.q1.choices" }] } });
+    expect(characterCondition).toEqual({ "!": { "==": [{ var: "characters.char-yangji.alive" }, false] } });
+    expect(readEndingConditionGroup(questionCondition)).toEqual({
+      operator: "and",
+      conditions: [
+        { kind: "question_choice", questionId: "q1", choice: "고동", choices: ["고동"], aggregation: "threshold", negated: true },
+      ],
+    });
+    expect(readEndingConditionGroup(characterCondition)).toEqual({
+      operator: "and",
+      conditions: [
+        { kind: "character_alive", characterId: "char-yangji", alive: false, negated: true },
+      ],
+    });
+  });
+
+  it("결말 규칙을 결말 id 기준 조건 그룹으로 묶는다", () => {
+    const config = readEndingBranchConfig({
+      modules: {
+        ending_branch: {
+          enabled: true,
+          config: {
+            matrix: [
+              { priority: 2, ending: "end-1", conditions: buildCharacterAliveCondition("char-a", false) },
+              { priority: 1, ending: "end-2", conditions: buildCharacterAliveCondition("char-b", true) },
+              { priority: 3, ending: "end-1", conditions: buildCharacterAliveCondition("char-c", true) },
+            ],
+          },
+        },
+      },
+    });
+    const viewModel = toEndingBranchEditorViewModel(
+      writeEndingBranchConfig(null, config),
+      [endingNode("end-1", "결말 1"), endingNode("end-2", "결말 2")],
+    );
+
+    expect(viewModel.groupsByEnding).toEqual([
+      { endingId: "end-1", endingName: "결말 1", rows: [config.matrix[1], config.matrix[2]] },
+      { endingId: "end-2", endingName: "결말 2", rows: [config.matrix[0]] },
+    ]);
   });
 
   it("새 질문과 규칙의 기본값은 제작자가 바로 수정 가능한 형태다", () => {

--- a/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts
@@ -58,13 +58,30 @@ export interface EndingBranchMatrixDraft {
   endingName: string;
 }
 
+export interface EndingBranchRuleGroupDraft {
+  endingId: string;
+  endingName: string;
+  rows: EndingBranchMatrixRow[];
+}
+
 export interface EndingBranchEditorViewModel {
   questions: EndingBranchQuestionDraft[];
   matrix: EndingBranchMatrixDraft[];
+  groupsByEnding: EndingBranchRuleGroupDraft[];
   defaultEndingId: string;
   defaultEndingName: string;
   thresholdPercent: number;
   warnings: string[];
+}
+
+export type EndingConditionAtom =
+  | { kind: "question_choice"; questionId: string; choice: string; choices: string[]; aggregation: EndingBranchAggregation; negated: boolean }
+  | { kind: "character_alive"; characterId: string; alive: boolean; negated: boolean }
+  | { kind: "unsupported"; condition: EditorConfig };
+
+export interface EndingConditionGroupDraft {
+  operator: "and";
+  conditions: EndingConditionAtom[];
 }
 
 function isRecord(value: unknown): value is EditorConfig {
@@ -248,6 +265,25 @@ export function buildAnyChoicesCondition(questionId: string, choices: string[]):
   return { or: uniqueChoices(choices).map((choice) => thresholdChoiceCondition(questionId, choice)) };
 }
 
+export function buildCharacterAliveCondition(characterId: string, alive: boolean): EditorConfig {
+  return { "==": [{ var: `characters.${characterId}.alive` }, alive] };
+}
+
+export function buildNegatedCondition(condition: EditorConfig): EditorConfig {
+  return Object.keys(condition).length > 0 ? { "!": condition } : {};
+}
+
+export function buildEveryoneAliveCondition(characterIds: string[]): EditorConfig {
+  return { and: uniqueChoices(characterIds).map((characterId) => buildCharacterAliveCondition(characterId, true)) };
+}
+
+export function buildConditionGroup(conditions: EditorConfig[]): EditorConfig {
+  const normalized = conditions.filter((condition) => Object.keys(condition).length > 0);
+  if (normalized.length === 0) return {};
+  if (normalized.length === 1) return normalized[0] ?? {};
+  return { and: normalized };
+}
+
 export function updateMatrixCondition(
   row: EndingBranchMatrixRow,
   questionId: string,
@@ -292,6 +328,56 @@ export function readChoiceCondition(
     ?? readCompositeChoiceCondition(condition.or, "any");
 }
 
+export function readCharacterAliveCondition(
+  condition: EditorConfig,
+): { characterId: string; alive: boolean } | null {
+  const equals = condition["=="];
+  if (!Array.isArray(equals) || equals.length < 2) return null;
+  const [source, alive] = equals;
+  if (!isRecord(source) || typeof source.var !== "string" || typeof alive !== "boolean") return null;
+  const match = source.var.match(/^characters\.(.+)\.alive$/);
+  return match ? { characterId: match[1], alive } : null;
+}
+
+export function readEndingConditionAtom(condition: EditorConfig, negated = false): EndingConditionAtom {
+  const rawNot = condition["!"];
+  if (isRecord(rawNot)) {
+    return readEndingConditionAtom(rawNot, !negated);
+  }
+  const choice = readChoiceCondition(condition);
+  if (choice) {
+    return { kind: "question_choice", ...choice, negated };
+  }
+  const characterAlive = readCharacterAliveCondition(condition);
+  if (characterAlive) {
+    return { kind: "character_alive", ...characterAlive, negated };
+  }
+  return { kind: "unsupported", condition };
+}
+
+export function readEndingConditionGroup(condition: EditorConfig): EndingConditionGroupDraft {
+  const rawNot = condition["!"];
+  if (isRecord(rawNot)) {
+    return { operator: "and", conditions: [readEndingConditionAtom(rawNot, true)] };
+  }
+  const choice = readChoiceCondition(condition);
+  if (choice) {
+    return { operator: "and", conditions: [{ kind: "question_choice", ...choice, negated: false }] };
+  }
+  const characterAlive = readCharacterAliveCondition(condition);
+  if (characterAlive) {
+    return { operator: "and", conditions: [{ kind: "character_alive", ...characterAlive, negated: false }] };
+  }
+  const rawAnd = condition.and;
+  if (Array.isArray(rawAnd) && rawAnd.length > 0) {
+    return {
+      operator: "and",
+      conditions: rawAnd.map((item) => isRecord(item) ? readEndingConditionAtom(item) : { kind: "unsupported", condition: {} }),
+    };
+  }
+  return { operator: "and", conditions: Object.keys(condition).length > 0 ? [readEndingConditionAtom(condition)] : [] };
+}
+
 function readCompositeChoiceCondition(
   value: unknown,
   aggregation: "all" | "any",
@@ -319,6 +405,20 @@ function endingNameById(nodes: Node[]): Map<string, string> {
         return [node.id, data.label?.trim() || "이름 없는 결말"] as const;
       }),
   );
+}
+
+export function groupEndingBranchRowsByEnding(
+  config: EndingBranchConfig,
+  endingNodes: Node[],
+): EndingBranchRuleGroupDraft[] {
+  const names = endingNameById(endingNodes);
+  return endingNodes
+    .filter((node) => node.type === "ending")
+    .map((node) => ({
+      endingId: node.id,
+      endingName: names.get(node.id) ?? "이름 없는 결말",
+      rows: config.matrix.filter((row) => row.ending === node.id),
+    }));
 }
 
 function questionTypeLabel(type: EndingBranchQuestionType): string {
@@ -366,6 +466,7 @@ export function toEndingBranchEditorViewModel(
   return {
     questions,
     matrix,
+    groupsByEnding: groupEndingBranchRowsByEnding(config, endingNodes),
     defaultEndingId,
     defaultEndingName,
     thresholdPercent: Math.round((config.multiVoteThreshold ?? 0.5) * 100),

--- a/docs/plans/2026-05-17-ending-condition-groups-design-plan.md
+++ b/docs/plans/2026-05-17-ending-condition-groups-design-plan.md
@@ -1,0 +1,545 @@
+# Ending Condition Groups Design and Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` if the user explicitly approves subagents, otherwise use `superpowers:executing-plans` or execute task-by-task in the main session. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild ending branch rules so each ending owns multiple condition groups, and each group can combine question results with system death/survival state.
+
+**Architecture:** Keep the existing `ending_branch.matrix` and JSONLogic persistence contract. Change the editor view model so matrix rows are presented as condition groups under each ending, with row `ending` inferred from the parent ending card. Extend runtime evaluation context with character alive state so JSONLogic conditions can branch without asking an extra question.
+
+**Tech Stack:** React, TypeScript, Vitest, Go, JSONLogic, existing MMP editor adapter/runtime module patterns.
+
+---
+
+## Design Plan
+
+### Current Problem
+
+The current modal creates one flat matrix row by asking for:
+
+- question
+- answer
+- aggregation
+- destination ending
+
+This makes the creator choose "보여줄 결말" inside every condition. That is backwards for the requested UX because the creator is already editing conditions under a specific ending.
+
+### Target UX
+
+Show ending cards first. Each ending card owns condition groups.
+
+```text
+결말 1
+  조건 그룹 A
+    범인 질문에서 "고동"이 설정 비율 이상
+    양지가 사망
+  조건 그룹 B
+    모두 생존
+    범인 질문에서 "양지"가 가장 많이 선택
+
+결말 2
+  조건 그룹 A
+    고동 사망
+    양지 생존
+```
+
+Rules:
+
+- Condition groups under the same ending behave as OR.
+- Conditions inside one group behave as AND.
+- The modal does not show "보여줄 결말"; the parent ending card decides it.
+- Existing flat matrix rows are still valid; the UI groups them by `row.ending`.
+
+### Condition Types
+
+First implementation supports:
+
+- Question answer threshold: answer appears in `answers.<questionId>.choices`.
+- Question answer winning: answer equals `answers.<questionId>.winning`.
+- Character dead: `characters.<characterId>.alive == false`.
+- Character alive: `characters.<characterId>.alive == true`.
+- Everyone alive: all playable characters have `alive == true`.
+
+Deferred:
+
+- Arbitrary nested OR inside one group.
+- Everyone dead.
+- N or more dead.
+- Custom formula editor.
+
+### Persistence Shape
+
+Do not introduce a new backend config shape in this PR. Continue writing:
+
+```json
+{
+  "matrix": [
+    {
+      "priority": 1,
+      "ending": "ending-node-id",
+      "conditions": {
+        "and": [
+          { "in": ["고동", { "var": "answers.q1.choices" }] },
+          { "==": [{ "var": "characters.yangji.alive" }, false] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+This preserves backward compatibility with existing `matrix[].ending` and `matrix[].conditions`.
+
+### Runtime Semantics
+
+The backend evaluates matrix rows in priority order, as it does today. Because condition groups under the same ending are stored as separate matrix rows, they naturally behave as OR: the first matching row wins.
+
+The runtime must add `characters` to the evaluation context:
+
+```json
+{
+  "answers": {},
+  "scores": {},
+  "characters": {
+    "character-id": { "alive": true },
+    "another-character-id": { "alive": false }
+  }
+}
+```
+
+If a character cannot be resolved to a current player/runtime state, the condition should evaluate as false for dead checks and true only when explicit runtime data says alive. This avoids accidentally routing to a death ending when state is missing.
+
+### Warning Design
+
+Add a summary warning area near ending rules:
+
+- Default ending is missing.
+- An ending has no condition group.
+- A condition group references a missing question, answer, or character.
+- A system death/survival condition exists but runtime cannot resolve character state.
+
+Warnings should guide creators without blocking save unless the row is structurally invalid.
+
+---
+
+## File Ownership
+
+### Frontend Adapter
+
+- Modify: `apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts`
+  - Add parsed condition union types.
+  - Add builders for question, character alive/dead, everyone alive, and AND groups.
+  - Add grouping helper: matrix rows by ending ID.
+  - Preserve existing `readChoiceCondition` exports or wrap them for backward compatibility.
+
+- Modify: `apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts`
+  - Cover new condition builders/readers.
+  - Cover existing answer conditions still parsing.
+  - Cover grouped matrix rows by ending.
+
+### Frontend UI
+
+- Modify: `apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx`
+  - Replace flat `MatrixRulesCard` list with ending cards.
+  - Remove destination ending select from modal.
+  - Add condition group editor with AND-only list.
+  - Allow adding multiple groups to one ending.
+  - Render readable summaries for mixed question/death conditions.
+
+- Modify: `apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx`
+  - Adjust `canAddRule` logic so system-state rules can be created without a branch question.
+  - Pass character/module context if not already available.
+
+- Modify: `apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx`
+  - Cover adding a condition group under a selected ending.
+  - Cover no "보여줄 결말" select in the modal.
+  - Cover question + dead condition saved as one `and` JSONLogic row.
+  - Cover default warning when an ending has no condition group.
+
+### Backend Runtime
+
+- Modify: `apps/server/internal/module/decision/ending_branch/runtime.go`
+  - Extend `evaluationContextLocked` to include `characters`.
+  - Read alive state from existing player runtime info provider/deps.
+  - Keep `answers` and `scores` shape unchanged.
+
+- Modify: `apps/server/internal/module/decision/ending_branch/module_test.go`
+  - Add runtime evaluation test where a dead character routes to the matching ending.
+  - Add runtime evaluation test where all characters alive routes to matching ending.
+  - Add regression test for existing answer-only rule.
+
+### Backend Contracts, If Needed
+
+- Inspect before editing:
+  - `apps/server/internal/engine/condition_contract.go`
+  - `apps/server/internal/session/player_status.go`
+  - `apps/server/internal/session/starter_test.go`
+
+Only modify these if ending branch cannot access alive state through existing module deps.
+
+---
+
+## Coverage Plan
+
+- Frontend adapter unit tests:
+  - `buildQuestionCondition`
+  - `buildCharacterAliveCondition`
+  - `buildEveryoneAliveCondition`
+  - `buildConditionGroup`
+  - `readEndingConditionGroup`
+  - legacy `readChoiceCondition`
+
+- Frontend component tests:
+  - render ending cards with grouped rules
+  - create group under ending without choosing destination ending
+  - add mixed question + character-dead conditions
+  - warn for endings with no groups
+
+- Backend unit tests:
+  - answer-only matrix remains valid
+  - character dead matrix matches
+  - character alive matrix matches
+  - everyone alive matrix matches
+  - missing alive state does not produce a false-positive death match
+
+---
+
+## Implementation Plan
+
+### Task 1: Add Adapter Condition Builders and Readers
+
+**Files:**
+
+- Modify: `apps/web/src/features/editor/entities/ending/endingBranchAdapter.ts`
+- Test: `apps/web/src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts`
+
+- [ ] **Step 1: Add failing adapter tests**
+
+Add tests that assert these JSONLogic shapes:
+
+```ts
+expect(buildCharacterAliveCondition("yangji", false)).toEqual({
+  "==": [{ var: "characters.yangji.alive" }, false],
+});
+
+expect(buildConditionGroup([
+  buildChoiceCondition("q1", "고동"),
+  buildCharacterAliveCondition("yangji", false),
+])).toEqual({
+  and: [
+    { in: ["고동", { var: "answers.q1.choices" }] },
+    { "==": [{ var: "characters.yangji.alive" }, false] },
+  ],
+});
+```
+
+- [ ] **Step 2: Run adapter tests and confirm failure**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
+```
+
+Expected: fail because new builder/parser functions do not exist.
+
+- [ ] **Step 3: Implement builder functions**
+
+Add exported helpers:
+
+```ts
+export type EndingConditionAtom =
+  | { kind: "question_choice"; questionId: string; choices: string[]; aggregation: EndingBranchAggregation }
+  | { kind: "character_alive"; characterId: string; alive: boolean }
+  | { kind: "everyone_alive"; characterIds: string[] }
+  | { kind: "unsupported"; condition: EditorConfig };
+
+export function buildCharacterAliveCondition(characterId: string, alive: boolean): EditorConfig {
+  return { "==": [{ var: `characters.${characterId}.alive` }, alive] };
+}
+
+export function buildEveryoneAliveCondition(characterIds: string[]): EditorConfig {
+  return {
+    and: uniqueChoices(characterIds).map((characterId) => buildCharacterAliveCondition(characterId, true)),
+  };
+}
+
+export function buildConditionGroup(conditions: EditorConfig[]): EditorConfig {
+  const normalized = conditions.filter((condition) => Object.keys(condition).length > 0);
+  if (normalized.length === 0) return {};
+  if (normalized.length === 1) return normalized[0] ?? {};
+  return { and: normalized };
+}
+```
+
+- [ ] **Step 4: Implement readers**
+
+Add a reader that can parse:
+
+- legacy `in`
+- legacy `winning`
+- `characters.<id>.alive == true/false`
+- top-level `and` as a condition group
+
+Keep `readChoiceCondition` working for existing callers.
+
+- [ ] **Step 5: Run adapter tests**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts
+```
+
+Expected: pass.
+
+### Task 2: Rebuild Ending Rules UI Around Ending Cards
+
+**Files:**
+
+- Modify: `apps/web/src/features/editor/components/design/EndingBranchOutcomeRules.tsx`
+- Modify: `apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx`
+- Test: `apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx`
+
+- [ ] **Step 1: Add failing component tests**
+
+Test expectations:
+
+- The modal opened from `결말 1` does not render `보여줄 결말`.
+- Saving a condition under `결말 1` writes `matrix[0].ending` as the `결말 1` node id.
+- A second group under the same ending writes a second matrix row with the same ending id.
+- A mixed group saves as top-level `and`.
+
+- [ ] **Step 2: Run component tests and confirm failure**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+```
+
+Expected: fail because the UI is still flat and the modal still has destination ending select.
+
+- [ ] **Step 3: Replace flat rules card with ending-grouped cards**
+
+Create internal render structure:
+
+```ts
+type EndingRuleGroup = {
+  endingId: string;
+  endingName: string;
+  rows: EndingBranchMatrixRow[];
+};
+```
+
+Use `endingNodes.map(...)` as the source of visible cards so endings with no rule still appear.
+
+- [ ] **Step 4: Change modal ownership**
+
+Pass `endingId` from the parent card into `EndingConditionModal`.
+
+Remove:
+
+```tsx
+<span>보여줄 결말</span>
+<select value={endingId} ... />
+```
+
+Save with:
+
+```ts
+const base = initialRow ?? createEndingBranchMatrixRow(draft, endingId);
+onSave({ ...base, ending: endingId, condition: buildConditionGroup(conditionParts) });
+```
+
+- [ ] **Step 5: Add condition list UI**
+
+Inside the modal, render condition rows:
+
+- condition source: `질문 답변`, `캐릭터 상태`, `모두 생존`
+- question condition settings when source is question
+- character and alive/dead settings when source is character state
+- no OR selector inside a group
+
+Copy should say:
+
+```text
+이 조건 그룹의 항목을 모두 만족하면 이 결말로 보냅니다.
+다른 경로가 필요하면 같은 결말에 조건 그룹을 하나 더 추가하세요.
+```
+
+- [ ] **Step 6: Add warning summary**
+
+Show warnings for:
+
+- no default ending
+- ending card has no condition group
+- condition references missing question/answer/character
+
+- [ ] **Step 7: Run component tests**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+```
+
+Expected: pass.
+
+### Task 3: Add Runtime Character Alive Context
+
+**Files:**
+
+- Modify: `apps/server/internal/module/decision/ending_branch/runtime.go`
+- Test: `apps/server/internal/module/decision/ending_branch/module_test.go`
+
+- [ ] **Step 1: Add failing backend tests**
+
+Add cases:
+
+```go
+func TestEndingBranch_EvaluatesDeadCharacterCondition(t *testing.T) {
+  // configure matrix condition:
+  // {"==":[{"var":"characters.yangji.alive"}, false]}
+  // seed runtime info so yangji is dead
+  // assert selected ending is dead-ending
+}
+
+func TestEndingBranch_EvaluatesEveryoneAliveCondition(t *testing.T) {
+  // configure matrix condition:
+  // {"and":[
+  //   {"==":[{"var":"characters.godong.alive"}, true]},
+  //   {"==":[{"var":"characters.yangji.alive"}, true]}
+  // ]}
+  // seed runtime info so both are alive
+  // assert selected ending is alive-ending
+}
+```
+
+- [ ] **Step 2: Run backend tests and confirm failure**
+
+Run:
+
+```bash
+cd apps/server && go test ./internal/module/decision/ending_branch -count=1
+```
+
+Expected: fail because `characters` is missing from evaluation context.
+
+- [ ] **Step 3: Implement character context**
+
+Extend `evaluationContextLocked` so it returns:
+
+```go
+return map[string]any{
+  "answers": answers,
+  "scores": scores,
+  "characters": m.characterAliveContextLocked(),
+}
+```
+
+Implement `characterAliveContextLocked` using existing player runtime info provider/deps. Keep the function local to `ending_branch` unless another module already exposes a canonical helper.
+
+- [ ] **Step 4: Missing state behavior**
+
+If the runtime cannot resolve a character:
+
+- do not mark it dead automatically
+- omit it or set `alive` only when known
+- ensure dead condition does not match from missing data
+
+- [ ] **Step 5: Run backend tests**
+
+Run:
+
+```bash
+cd apps/server && go test ./internal/module/decision/ending_branch -count=1
+```
+
+Expected: pass.
+
+### Task 4: Integration Verification
+
+**Files:**
+
+- Existing modified files only.
+
+- [ ] **Step 1: Typecheck web**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web exec tsc --noEmit --pretty false
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run focused web tests**
+
+Run:
+
+```bash
+pnpm --filter @mmp/web test -- src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run focused backend tests**
+
+Run:
+
+```bash
+cd apps/server && go test ./internal/module/decision/ending_branch -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run local quick validation if preparing PR**
+
+Run:
+
+```bash
+scripts/mmp-local-ci.sh quick
+```
+
+Expected: pass, or report exact blocker with failing command and first useful error.
+
+### Task 5: PR Preparation
+
+**Files:**
+
+- All changed frontend/backend files.
+
+- [ ] **Step 1: Review diff**
+
+Run:
+
+```bash
+git diff -- apps/web/src/features/editor/entities/ending apps/web/src/features/editor/components/design apps/server/internal/module/decision/ending_branch
+```
+
+Expected: diff only includes ending condition group work.
+
+- [ ] **Step 2: Create PR using project wrapper**
+
+Run:
+
+```bash
+scripts/pr-create-guard.sh
+```
+
+PR body must include:
+
+- Coverage Plan
+- Local validation commands and results
+- Backward compatibility note for existing `matrix` rows
+- Runtime note for `characters.<id>.alive`
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers destination removal, ending-owned groups, AND inside groups, OR across groups, question conditions, death/survival conditions, warnings, runtime context, and tests.
+- Placeholder scan: No implementation step depends on undefined future work. Deferred items are explicitly out of scope.
+- Type consistency: Existing `EndingBranchMatrixRow`, `EndingBranchConfig`, JSONLogic, and `ending_branch.matrix` remain the persistence contract.
+- Scope check: This is one coherent vertical slice because frontend UI changes require backend runtime context for the new system-state condition to actually work.
+


### PR DESCRIPTION
## 요약
- 결말마다 조건 그룹을 여러 개 둘 수 있게 정리했습니다. 같은 결말 안의 그룹들은 OR, 그룹 내부 조건들은 AND로 판정합니다.
- 조건 종류에 질문 답변과 캐릭터 사망/생존 시스템 조건을 지원합니다.
- 조건 그룹 문장을 한 문장으로 자연스럽게 보여주고, 그룹 사이에는 `또는` 구분을 표시합니다.
- 결말 규칙 관리를 결말 상세 화면 안으로 옮기고, 기본 결말/복수 선택 기준은 전역 설정 영역으로 분리했습니다.
- 결말 목록 영역에 추가 버튼과 카드별 삭제 버튼을 배치했습니다.

Closes #602

## Coverage Plan
- `apps/server/internal/module/decision/ending_branch`: question 조건, character alive/dead 조건, not 조건, 그룹 OR 판정을 backend runtime test로 검증
- `apps/web/src/features/editor/entities/ending`: matrix row와 condition group adapter 변환, legacy/default fallback을 adapter test로 검증
- `apps/web/src/features/editor/components/design`: 결말 목록 추가/삭제, 결말 상세 조건 그룹 렌더링, 기본 결말 전역 분리를 UI test로 검증
- `docs/plans`: 구현 범위와 UX/데이터 모델 계획을 남겼습니다.

## Local validation
- `cd apps/server && go test ./internal/module/decision/ending_branch -count=1`
- `pnpm --filter @mmp/web test -- src/features/editor/entities/ending/__tests__/endingBranchAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx`
- `pnpm --filter @mmp/web exec tsc --noEmit --pretty false`
- `git diff --check`

## CI policy
- `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않습니다.
- 전체 local-ci marker 대신 위 focused validation 근거로 PR guard만 우회합니다.
