### PR TITLE
결말 상세 선택 동기화 개선

### DIFF
--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -20,12 +20,14 @@ const {
   useCreateClueMock,
   useUpdateClueMock,
   useMediaListMock,
+  useMediaDownloadUrlMock,
   toastSuccessMock,
   toastErrorMock,
 } = vi.hoisted(() => ({
   useCreateClueMock: vi.fn(),
   useUpdateClueMock: vi.fn(),
   useMediaListMock: vi.fn(),
+  useMediaDownloadUrlMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
 }));
@@ -41,6 +43,7 @@ vi.mock('@/features/editor/api', () => ({
 
 vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: () => useMediaListMock(),
+  useMediaDownloadUrl: () => useMediaDownloadUrlMock(),
 }));
 
 vi.mock('@/features/editor/components/media/MediaPicker', () => ({
@@ -161,6 +164,7 @@ describe('ClueForm', () => {
       data: [{ id: 'image-1', name: '증거 사진', type: 'IMAGE' }],
       isLoading: false,
     });
+    useMediaDownloadUrlMock.mockReturnValue({ data: null, isLoading: false, isError: false });
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
   });

--- a/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
@@ -20,6 +20,7 @@ const {
   useDeleteCharacterMock,
   useUpdateConfigJsonMock,
   useMediaListMock,
+  useMediaDownloadUrlMock,
 } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   toastSuccess: vi.fn(),
@@ -35,6 +36,7 @@ const {
   useDeleteCharacterMock: vi.fn(),
   useUpdateConfigJsonMock: vi.fn(),
   useMediaListMock: vi.fn(),
+  useMediaDownloadUrlMock: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -63,6 +65,7 @@ vi.mock('@/features/editor/components/SchemaDrivenForm', () => ({
 
 vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: () => useMediaListMock(),
+  useMediaDownloadUrl: () => useMediaDownloadUrlMock(),
 }));
 
 vi.mock('@/features/editor/components/media/MediaPicker', () => ({
@@ -392,6 +395,7 @@ describe('OverviewTab', () => {
       data: [{ id: 'image-1', name: '커버 이미지', type: 'IMAGE' }],
       isLoading: false,
     });
+    useMediaDownloadUrlMock.mockReturnValue({ data: null, isLoading: false, isError: false });
   });
 
   it('테마 데이터가 폼에 미리 채워져 렌더링된다', () => {

--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   BlockTypeSelect,
   BoldItalicUnderlineToggles,
@@ -63,6 +63,11 @@ export function RichContentEditor({
   const normalizedMarkdown = useMemo(() => normalizeLegacyEscapedMarkdown(markdown), [markdown]);
   const [replacementTarget, setReplacementTarget] = useState<MediaEmbedAttributes | null>(null);
   const { data: media = [] } = useMediaList(themeId);
+
+  useEffect(() => {
+    editorRef.current?.setMarkdown?.(normalizedMarkdown);
+  }, [normalizedMarkdown]);
+
   const plugins = useMemo(
     () => [
       headingsPlugin(),

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -12,6 +12,7 @@ import {
   buildEndingDecisionSummary,
   toEndingEditorViewModel,
 } from '../../entities/ending/endingEntityAdapter';
+import { readEndingBranchConfig } from '../../entities/ending/endingBranchAdapter';
 import { getDisplayErrorMessage } from '@/lib/display-error';
 
 interface EndingEntitySubTabProps {
@@ -48,6 +49,18 @@ function EndingEntityWorkspace({
   } = useFlowData(themeId);
 
   const endingNodes = useMemo(() => nodes.filter((node) => node.type === 'ending'), [nodes]);
+  const endingBranchConfig = useMemo(
+    () => readEndingBranchConfig(theme.config_json),
+    [theme.config_json],
+  );
+  const conditionGroupCountByEnding = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const row of endingBranchConfig.matrix) {
+      if (!row.ending) continue;
+      counts.set(row.ending, (counts.get(row.ending) ?? 0) + 1);
+    }
+    return counts;
+  }, [endingBranchConfig.matrix]);
 
   const filteredNodes = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -66,7 +79,12 @@ function EndingEntityWorkspace({
   const decisionSummary = useMemo(() => buildEndingDecisionSummary(nodes, edges), [nodes, edges]);
 
   const handleAddEnding = () => {
-    addNode('ending', { x: 360 + endingNodes.length * 40, y: 220 });
+    addNode(
+      'ending',
+      { x: 360 + endingNodes.length * 40, y: 220 },
+      undefined,
+      { onCreated: (node) => setSelectedId(node.id) },
+    );
   };
 
   if (isLoading) {
@@ -163,31 +181,38 @@ function EndingEntityWorkspace({
                 </p>
               ) : (
                 filteredNodes.map((node) => {
-                  const incomingCount = edges.filter((edge) => edge.target === node.id).length;
-                  const viewModel = toEndingEditorViewModel(node, incomingCount);
+                  const viewModel = toEndingEditorViewModel(node, {
+                    conditionGroupCount: conditionGroupCountByEnding.get(node.id) ?? 0,
+                    isDefaultEnding: endingBranchConfig.defaultEnding === node.id,
+                  });
                   const selected = selectedNode?.id === node.id;
                   return (
                     <div
+                      role="button"
+                      tabIndex={0}
                       key={node.id}
-                      className={`rounded-xl border p-3 text-left transition focus-within:ring-2 focus-within:ring-amber-400/60 ${
+                      onClick={() => setSelectedId(node.id)}
+                      onKeyDown={(event) => {
+                        if (event.key !== 'Enter' && event.key !== ' ') return;
+                        event.preventDefault();
+                        setSelectedId(node.id);
+                      }}
+                      aria-pressed={selected}
+                      aria-label={`${viewModel.name} 선택`}
+                      className={`cursor-pointer rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-400/60 ${
                         selected
                           ? 'border-amber-500/70 bg-amber-500/10'
                           : 'border-slate-800 bg-slate-950 hover:border-slate-600'
                       }`}
                     >
                       <div className="flex items-start justify-between gap-2">
-                        <button
-                          type="button"
-                          onClick={() => setSelectedId(node.id)}
-                          aria-pressed={selected}
-                          aria-label={`${viewModel.name} 선택`}
-                          className="min-w-0 flex-1 text-left focus:outline-none"
-                        >
+                        <div className="min-w-0 flex-1">
                           <p className="truncate font-medium text-slate-100">{viewModel.name}</p>
-                        </button>
+                        </div>
                         <button
                           type="button"
-                          onClick={() => {
+                          onClick={(event) => {
+                            event.stopPropagation();
                             deleteNode(node.id);
                             if (selectedId === node.id) setSelectedId(null);
                           }}
@@ -197,12 +222,7 @@ function EndingEntityWorkspace({
                           <Trash2 className="h-4 w-4" aria-hidden="true" />
                         </button>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => setSelectedId(node.id)}
-                        className="mt-2 flex flex-wrap gap-1 text-left focus:outline-none"
-                        aria-label={`${viewModel.name} 배지 영역 선택`}
-                      >
+                      <div className="mt-2 flex flex-wrap gap-1 text-left">
                         {viewModel.badges.map((badge) => (
                           <span
                             key={badge}
@@ -211,7 +231,7 @@ function EndingEntityWorkspace({
                             {badge}
                           </span>
                         ))}
-                      </button>
+                      </div>
                     </div>
                   );
                 })
@@ -221,6 +241,7 @@ function EndingEntityWorkspace({
 
           {selectedNode && (
             <EndingEntityDetail
+              key={selectedNode.id}
               node={selectedNode}
               themeId={themeId}
               onChange={updateNodeData}

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { forwardRef, useImperativeHandle, type ComponentType, type ReactNode } from "react";
+import { forwardRef, useImperativeHandle, useState, type ComponentType, type ReactNode } from "react";
 
 const { useFlowDataMock, useEditorCharactersMock, addNodeMock, deleteNodeMock, updateNodeDataMock, mutateMock, configMutateMock, useUpdateFlowNodeMock, refetchMock, toastErrorMock, toastSuccessMock, toastLoadingMock, useMediaListMock, useMediaCategoriesMock, useMediaDownloadUrlMock } = vi.hoisted(() => ({
   useFlowDataMock: vi.fn(),
@@ -49,26 +49,35 @@ vi.mock("@/features/editor/mediaApi", () => ({
 
 vi.mock("@mdxeditor/editor", () => ({
   MDXEditor: forwardRef<
-    { insertMarkdown: (snippet: string) => void },
+    { insertMarkdown: (snippet: string) => void; setMarkdown: (nextMarkdown: string) => void },
     {
       markdown: string;
       onChange: (markdown: string) => void;
       plugins?: Array<{ jsxComponentDescriptors?: Array<{ name: string; Editor: ComponentType<{ mdastNode: { attributes: Array<{ name: string; value: string }> } }> }> }>;
     }
   >(({ markdown, onChange, plugins = [] }, ref) => {
+    const [editorMarkdown, setEditorMarkdown] = useState(markdown);
     useImperativeHandle(ref, () => ({
-      insertMarkdown: (snippet: string) => onChange(`${markdown}${snippet}`),
-    }));
+      insertMarkdown: (snippet: string) => {
+        const next = `${editorMarkdown}${snippet}`;
+        setEditorMarkdown(next);
+        onChange(next);
+      },
+      setMarkdown: setEditorMarkdown,
+    }), [editorMarkdown, onChange]);
     const mediaEmbedDescriptor = plugins
       .flatMap((plugin) => plugin.jsxComponentDescriptors ?? [])
       .find((descriptor) => descriptor.name === "MediaEmbed");
-    const mediaEmbeds = Array.from(markdown.matchAll(/<MediaEmbed\s+([^>]+)\/>/g));
+    const mediaEmbeds = Array.from(editorMarkdown.matchAll(/<MediaEmbed\s+([^>]+)\/>/g));
     return (
       <div data-testid="mdx-editor-surface">
         <textarea
           aria-label="editable markdown"
-          value={markdown}
-          onChange={(event) => onChange(event.currentTarget.value)}
+          value={editorMarkdown}
+          onChange={(event) => {
+            setEditorMarkdown(event.currentTarget.value);
+            onChange(event.currentTarget.value);
+          }}
         />
         {mediaEmbedDescriptor
           ? mediaEmbeds.map((match) => {
@@ -253,9 +262,12 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getByLabelText("결말 판정 준비")).toBeDefined();
     expect(screen.getByText("본문 작성")).toBeDefined();
     expect(screen.getByRole("heading", { name: "결말 판정 설정", level: 3 })).toBeDefined();
-    expect(screen.getAllByText("기본 결말")).toHaveLength(1);
+    expect(screen.getAllByText("기본 결말").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByLabelText("기본 결말")).toBeDefined();
     expect(screen.getByText("복수 선택 반영 기준")).toBeDefined();
+    expect(screen.getAllByText("조건 그룹 1개").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("기본 결말").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("아직 연결 없음")).toBeNull();
     expect(screen.queryByText("참가자에게만 공개")).toBeNull();
     expect(screen.queryByText("캐릭터 결과 카드 1/2명 작성")).toBeNull();
     expect(screen.queryByText("1막")).toBeNull();
@@ -311,7 +323,43 @@ describe("EndingEntitySubTab", () => {
     expect(addNodeMock).toHaveBeenCalledWith("ending", expect.objectContaining({
       x: expect.any(Number),
       y: expect.any(Number),
-    }));
+    }), undefined, expect.objectContaining({ onCreated: expect.any(Function) }));
+  });
+
+  it("결말 추가 성공 후 새로 만든 결말을 선택한다", () => {
+    const { rerender } = renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    fireEvent.click(screen.getByText("결말 추가"));
+
+    const onCreated = addNodeMock.mock.calls[0][3].onCreated;
+    act(() => {
+      onCreated(makeNode("ending-3", { label: "새 결말", endingContent: "" }));
+    });
+    useFlowDataMock.mockReturnValue({
+      nodes: [
+        makeNode("ending-1", { label: "진실", endingContent: "범인은 밝혀졌다." }),
+        makeNode("phase-1", { label: "1막" }, "phase"),
+        makeNode("ending-2", { label: "오판", description: "잘못된 선택" }),
+        makeNode("ending-3", { label: "새 결말", endingContent: "" }),
+      ],
+      edges: [{ id: "edge-1", source: "phase-1", target: "ending-1" }],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: refetchMock,
+      addNode: addNodeMock,
+      deleteNode: deleteNodeMock,
+      updateNodeData: updateNodeDataMock,
+    });
+
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })}>
+        <EndingEntitySubTab themeId="theme-1" theme={theme} />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "새 결말 선택" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("heading", { name: "새 결말", level: 3 })).toBeDefined();
   });
 
   it("결말 목록 카드에서 결말을 삭제할 수 있다", () => {
@@ -344,6 +392,26 @@ describe("EndingEntitySubTab", () => {
       { nodeId: "ending-1", body: { data: expect.objectContaining({ label: "자비" }) } },
       expect.objectContaining({ onError: expect.any(Function) }),
     );
+  });
+
+  it("다른 결말을 선택하면 본문 작성기가 선택한 결말의 본문으로 바뀐다", () => {
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    expect((screen.getByLabelText("editable markdown") as HTMLTextAreaElement).value).toBe("범인은 밝혀졌다.");
+
+    fireEvent.click(screen.getByRole("button", { name: "오판 선택" }));
+
+    expect((screen.getByLabelText("editable markdown") as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("결말 카드 전체를 한 번 클릭하면 해당 결말로 전환한다", () => {
+    renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
+
+    const endingCard = screen.getByRole("button", { name: "오판 선택" });
+    fireEvent.click(endingCard);
+
+    expect(endingCard.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("heading", { name: "오판", level: 3 })).toBeDefined();
   });
 
   it("결말 상세에서 필요한 입력만 보여주고 본문을 Markdown 작성기로 저장한다", () => {

--- a/apps/web/src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts
+++ b/apps/web/src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts
@@ -19,7 +19,7 @@ describe("endingEntityAdapter", () => {
     const vm = toEndingEditorViewModel(node("end-1", {
       label: "진실",
       endingContent: "범인이 밝혀졌다.",
-    }), 2);
+    }));
 
     expect(vm).toMatchObject({
       id: "end-1",
@@ -27,8 +27,20 @@ describe("endingEntityAdapter", () => {
       contentPreview: "범인이 밝혀졌다.",
       isReady: true,
     });
-    expect(vm.badges).toContain("도달 경로 2개");
+    expect(vm.badges).toContain("조건 없음");
     expect(vm.badges).not.toContain("참가자에게만 공개");
+  });
+
+  it("결말 목록 배지는 조건 그룹과 기본 결말 상태를 표시한다", () => {
+    const vm = toEndingEditorViewModel(node("end-1", {
+      label: "진실",
+      endingContent: "범인이 밝혀졌다.",
+    }), {
+      conditionGroupCount: 2,
+      isDefaultEnding: true,
+    });
+
+    expect(vm.badges).toEqual(["이름 있음", "본문 작성됨", "기본 결말", "조건 그룹 2개"]);
   });
 
   it("결말 준비 상태와 제작자용 경고를 요약한다", () => {

--- a/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
+++ b/apps/web/src/features/editor/entities/ending/endingEntityAdapter.ts
@@ -24,7 +24,15 @@ export interface EndingDecisionSummary {
   warnings: string[];
 }
 
-export function toEndingEditorViewModel(node: Node, incomingCount = 0): EndingEditorViewModel {
+export interface EndingEditorBadgeOptions {
+  conditionGroupCount?: number;
+  isDefaultEnding?: boolean;
+}
+
+export function toEndingEditorViewModel(
+  node: Node,
+  badgeOptions: EndingEditorBadgeOptions = {},
+): EndingEditorViewModel {
   const data = node.data as FlowNodeData;
   const name = data.label?.trim() || "이름 없는 결말";
   const content = data.endingContent?.trim() ?? "";
@@ -33,7 +41,7 @@ export function toEndingEditorViewModel(node: Node, incomingCount = 0): EndingEd
     name,
     contentPreview: content || "결말 본문을 아직 작성하지 않았습니다.",
     isReady: Boolean(data.label?.trim() && content),
-    badges: buildEndingBadges(Boolean(data.label?.trim()), Boolean(content), incomingCount),
+    badges: buildEndingBadges(Boolean(data.label?.trim()), Boolean(content), badgeOptions),
   };
 }
 
@@ -47,9 +55,7 @@ export function buildEndingDecisionSummary(nodes: Node[], edges: Edge[]): Ending
     }
   }
 
-  const viewModels = endingNodes.map((node) =>
-    toEndingEditorViewModel(node, incomingByEnding.get(node.id) ?? 0),
-  );
+  const viewModels = endingNodes.map((node) => toEndingEditorViewModel(node));
   const readyCount = viewModels.filter((ending) => ending.isReady).length;
   const connectedCount = endingNodes.filter((node) => (incomingByEnding.get(node.id) ?? 0) > 0).length;
   const warnings = buildEndingWarnings(viewModels, endingNodes.length, connectedCount);
@@ -100,12 +106,14 @@ export function endingVisibilityLabel(value: EndingVisibility): string {
 function buildEndingBadges(
   hasName: boolean,
   hasContent: boolean,
-  incomingCount: number,
+  options: EndingEditorBadgeOptions,
 ): string[] {
+  const conditionGroupCount = options.conditionGroupCount ?? 0;
   return [
     hasName ? "이름 있음" : "이름 필요",
     hasContent ? "본문 작성됨" : "본문 필요",
-    incomingCount > 0 ? `도달 경로 ${incomingCount}개` : "아직 연결 없음",
+    ...(options.isDefaultEnding ? ["기본 결말"] : []),
+    conditionGroupCount > 0 ? `조건 그룹 ${conditionGroupCount}개` : "조건 없음",
   ];
 }
 

--- a/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
+++ b/apps/web/src/features/editor/hooks/__tests__/useFlowData.test.ts
@@ -67,13 +67,13 @@ describe('useFlowData', () => {
       error: null,
       refetch: vi.fn(),
     });
-    createNodeMutateMock.mockImplementation((_body, options) => {
+    createNodeMutateMock.mockImplementation((body, options) => {
       options?.onSuccess?.({
         id: 'n3',
-        type: 'phase',
-        data: { label: '새 장면' },
-        position_x: 200,
-        position_y: 0,
+        type: body.type,
+        data: body.data,
+        position_x: body.position_x,
+        position_y: body.position_y,
       });
     });
     deleteNodeMutateMock.mockImplementation((_id, options) => {
@@ -318,5 +318,21 @@ describe('useFlowData', () => {
 
     expect(createNodeMutateMock).toHaveBeenCalled();
     expect(latestSavedGraph().nodes.map((node: { id: string }) => node.id)).toContain('n3');
+  });
+
+  it('node 생성 성공 시 생성된 React Flow node를 콜백으로 전달한다', () => {
+    const onCreated = vi.fn();
+    const { result } = renderHook(() => useFlowData('theme-1'));
+
+    act(() => {
+      result.current.addNode('ending', { x: 240, y: 160 }, undefined, { onCreated });
+    });
+
+    expect(onCreated).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'n3',
+      type: 'ending',
+      position: { x: 240, y: 160 },
+      data: {},
+    }));
   });
 });

--- a/apps/web/src/features/editor/hooks/useFlowData.ts
+++ b/apps/web/src/features/editor/hooks/useFlowData.ts
@@ -23,6 +23,10 @@ function createFlowEdgeId(): string {
   return crypto.randomUUID();
 }
 
+interface AddFlowNodeOptions {
+  onCreated?: (node: Node) => void;
+}
+
 export function useFlowData(themeId: string) {
   const { data, isLoading, isError, error, refetch } = useFlowGraph(themeId);
   const saveFlow = useSaveFlow(themeId);
@@ -157,7 +161,12 @@ export function useFlowData(themeId: string) {
   }, [saveFlow, nodes, edges]);
 
   const addNode = useCallback(
-    (type: FlowNodeType, position: XYPosition, data?: Partial<FlowNodeData>) => {
+    (
+      type: FlowNodeType,
+      position: XYPosition,
+      data?: Partial<FlowNodeData>,
+      options?: AddFlowNodeOptions,
+    ) => {
       const defaultData: Partial<FlowNodeData> = type === 'phase' ? { label: '새 장면' } : {};
 
       createNode.mutate(
@@ -169,9 +178,11 @@ export function useFlowData(themeId: string) {
         },
         {
           onSuccess: (created) => {
-            const next = [...nodesRef.current, toReactFlowNode(created)];
+            const createdNode = toReactFlowNode(created);
+            const next = [...nodesRef.current, createdNode];
             setNodesAndRef(next);
             autoSave(next, edgesRef.current);
+            options?.onCreated?.(createdNode);
           },
         }
       );


### PR DESCRIPTION
## 요약
- 결말 목록 배지를 Flow 연결 수 대신 실제 결말 조건 그룹/기본 결말 상태로 표시합니다.
- 결말 카드 전체 클릭 선택, 삭제 버튼 전파 차단, 새 결말 생성 직후 새 결말 상세 선택을 보강합니다.
- 결말 본문 에디터가 선택 전환 시 최신 markdown으로 동기화되도록 보강합니다.

## Coverage Plan
- EndingEntitySubTab: 조건/기본 결말 배지, 카드 선택, 새 결말 생성 후 선택, 본문 전환 테스트
- endingEntityAdapter: 조건 그룹/기본 결말 배지 변환 테스트
- useFlowData: 생성 성공 콜백 테스트
- RichContentEditor 소비 테스트: InfoTab/CharacterAssignPanel의 MDXEditor mock 호환 확인
- ImageMediaReferenceField 소비 테스트: ClueForm/Editor의 mediaApi mock 보강

## Local validation
- `scripts/mmp-local-ci.sh quick` 통과
- `pnpm --filter @mmp/web test -- src/features/editor/hooks/__tests__/useFlowData.test.ts src/features/editor/entities/ending/__tests__/endingEntityAdapter.test.ts src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx` 통과
- `pnpm --filter @mmp/web test -- src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/__tests__/Editor.test.tsx src/features/editor/components/__tests__/ClueForm.test.tsx` 통과
- `pnpm --filter @mmp/web exec tsc --noEmit --pretty false` 통과
- `git diff --check` 통과

Refs: 사용자 요청 hotfix