### PR TITLE
장소 하위장소 카드 요약 문구 정리

### DIFF
--- a/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
+++ b/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
@@ -234,7 +234,9 @@ function LocationCard({
             {location.name}
           </span>
           <span className="mt-1 block text-xs text-slate-500">
-            직접 배치 단서 {directClueCount}개 · 하위장소 {childCount}개
+            {child
+              ? `직접 배치 단서 ${directClueCount}개`
+              : `직접 배치 단서 ${directClueCount}개 · 하위장소 ${childCount}개`}
           </span>
         </button>
         <button

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -172,6 +172,7 @@ describe('LocationsSubTab', () => {
       expect(screen.getByRole('button', { name: '호텔 로비 선택' })).toBeDefined();
       expect(screen.getByRole('button', { name: '호텔 로비 / 프런트 데스크 선택' })).toBeDefined();
       expect(screen.getByText('직접 배치 단서 0개 · 하위장소 1개')).toBeDefined();
+      expect(screen.queryByText('직접 배치 단서 0개 · 하위장소 0개')).toBeNull();
     });
 
     it('장소가 없는 맵에서도 장소 추가 입력을 표시한다', () => {


### PR DESCRIPTION
## 요약
- 하위장소 카드에서는 `하위장소 0개` 문구를 숨기고 직접 배치 단서 수만 표시합니다.
- 부모 장소 카드는 기존처럼 직접 배치 단서 수와 하위장소 수를 함께 표시합니다.
- 하위장소에 `하위장소 0개` 문구가 다시 나오지 않도록 회귀 테스트를 추가했습니다.

## Coverage Plan
- LocationHierarchyList: `child` 카드일 때 보조 문구 분기 렌더링
- LocationsSubTab: 부모 장소 요약 유지 및 하위장소의 `하위장소 0개` 미표시 검증

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx` 통과
- `pnpm --filter @mmp/web exec tsc --noEmit --pretty false` 통과
- `scripts/mmp-local-ci.sh quick` 통과
- `git diff --check` 통과

Refs: 사용자 요청 hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 위치 카드의 안내 문구 표시 로직을 개선하여, 하위 장소가 없을 때 불필요한 정보 표시 제외

* **테스트**
  * 위치 카드 렌더링 검증 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->