### PR TITLE
에디터 저장 방식을 자동저장 토스트로 통일

### DIFF
--- a/apps/web/src/features/editor/components/OverviewTab.tsx
+++ b/apps/web/src/features/editor/components/OverviewTab.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
-import { toast } from 'sonner';
+import { useState, useCallback, useEffect, useMemo, useRef, type FormEvent } from 'react';
 import { Button } from '@/shared/components/ui/Button';
 import {
   useUpdateTheme,
@@ -9,7 +8,7 @@ import {
 import { SectionDivider } from './SectionDivider';
 import { ImageMediaReferenceField } from '@/features/editor/components/media/ImageMediaReferenceField';
 import { TemplateSettingsSection } from './TemplateConfigTab';
-import { showUnknownErrorToast } from '@/lib/show-error-toast';
+import { useEditorAutosaveToast } from '@/features/editor/hooks/useEditorAutosaveToast';
 
 // ---------------------------------------------------------------------------
 // SpecField — inline number input with label + unit
@@ -105,10 +104,23 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
   const [price, setPrice] = useState(theme.price);
   const [coinPrice, setCoinPrice] = useState(theme.coin_price);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const skipNextAutosaveRef = useRef(true);
 
   const updateTheme = useUpdateTheme(themeId);
+  const { schedule: scheduleOverviewSave, flush: flushOverviewSave } =
+    useEditorAutosaveToast<UpdateThemeRequest>({
+    debounceMs: 1200,
+    messages: {
+      toastId: 'theme-overview-autosave',
+      loading: '테마 기본 정보를 저장 중입니다',
+      success: '테마 기본 정보가 저장되었습니다',
+      error: '테마 기본 정보 저장에 실패했습니다',
+    },
+    mutate: (body, opts) => updateTheme.mutate(body, opts),
+  });
 
   useEffect(() => {
+    skipNextAutosaveRef.current = true;
     setTitle(theme.title);
     setDescription(theme.description ?? '');
     setCoverImage(theme.cover_image || null);
@@ -119,9 +131,59 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
     setPrice(theme.price);
     setCoinPrice(theme.coin_price);
     setErrors({});
-  }, [theme.id, theme.version]);
+  }, [
+    theme.id,
+    theme.version,
+    theme.title,
+    theme.description,
+    theme.cover_image,
+    theme.cover_image_media_id,
+    theme.min_players,
+    theme.max_players,
+    theme.duration_min,
+    theme.price,
+    theme.coin_price,
+  ]);
 
-  function validate(): Record<string, string> {
+  const autosaveBody = useMemo<UpdateThemeRequest>(
+    () => ({
+      title: title.trim(),
+      description: description || undefined,
+      cover_image: coverImage || undefined,
+      cover_image_media_id: coverImageMediaId,
+      min_players: minPlayers,
+      max_players: maxPlayers,
+      duration_min: durationMin,
+      price,
+      coin_price: coinPrice,
+    }),
+    [
+      coinPrice,
+      coverImage,
+      coverImageMediaId,
+      description,
+      durationMin,
+      maxPlayers,
+      minPlayers,
+      price,
+      title,
+    ],
+  );
+  const isOverviewDirty = useMemo(
+    () =>
+      autosaveBody.title !== theme.title ||
+      (autosaveBody.description ?? '') !== (theme.description ?? '') ||
+      (autosaveBody.cover_image ?? '') !== (theme.cover_image ?? '') ||
+      (autosaveBody.cover_image_media_id ?? null) !== (theme.cover_image_media_id ?? null) ||
+      autosaveBody.min_players !== theme.min_players ||
+      autosaveBody.max_players !== theme.max_players ||
+      autosaveBody.duration_min !== theme.duration_min ||
+      autosaveBody.price !== theme.price ||
+      autosaveBody.coin_price !== theme.coin_price,
+    [autosaveBody, theme],
+  );
+
+  const validateDraft = useCallback((): Record<string, string> => {
     const next: Record<string, string> = {};
     const trimmedTitle = title.trim();
     if (!trimmedTitle) next.title = '제목은 필수입니다';
@@ -136,31 +198,31 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
     if (coinPrice < 0 || coinPrice > 100000)
       next.coinPrice = '코인 가격은 0~100,000 사이여야 합니다';
     return next;
-  }
+  }, [coinPrice, description, durationMin, maxPlayers, minPlayers, price, title]);
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const validationErrors = validate();
+    const validationErrors = validateDraft();
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) return;
 
-    const body: UpdateThemeRequest = {
-      title: title.trim(),
-      description: description || undefined,
-      cover_image: coverImage || undefined,
-      cover_image_media_id: coverImageMediaId,
-      min_players: minPlayers,
-      max_players: maxPlayers,
-      duration_min: durationMin,
-      price,
-      coin_price: coinPrice,
-    };
-
-    updateTheme.mutate(body, {
-      onSuccess: () => toast.success('테마가 수정되었습니다'),
-      onError: (err) => showUnknownErrorToast(err, '테마 수정에 실패했습니다'),
-    });
+    scheduleOverviewSave(autosaveBody);
+    flushOverviewSave();
   }
+
+  useEffect(() => {
+    if (skipNextAutosaveRef.current) {
+      skipNextAutosaveRef.current = false;
+      return;
+    }
+    if (!isOverviewDirty) return;
+    const validationErrors = validateDraft();
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
+    scheduleOverviewSave(autosaveBody);
+  }, [autosaveBody, isOverviewDirty, scheduleOverviewSave, validateDraft]);
 
   return (
     <form onSubmit={handleSubmit} className="mx-auto max-w-2xl px-4 py-6">

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -1,8 +1,7 @@
 import { useId, useState, type ReactNode } from "react";
 import type { Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+import { useEditorAutosaveToast } from "@/features/editor/hooks/useEditorAutosaveToast";
 import { RichContentEditor } from "@/features/editor/components/content/RichContentEditor";
 import type { MediaType } from "@/features/editor/mediaApi";
 import { useUpdateFlowNode } from "../../flowApi";
@@ -33,8 +32,14 @@ export function EndingEntityDetail({
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
 
-  const debouncer = useDebouncedMutation<FlowNodeData>({
+  const debouncer = useEditorAutosaveToast<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
+    messages: {
+      toastId: `ending-detail-autosave-${node.id}`,
+      loading: "결말을 저장 중입니다",
+      success: "결말이 저장되었습니다",
+      error: "결말 저장에 실패했습니다",
+    },
     mutate: (body, opts) =>
       updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
     applyOptimistic: (body) => {
@@ -51,7 +56,6 @@ export function EndingEntityDetail({
       });
       return () => queryClient.setQueryData(cacheKey, previous);
     },
-    onError: () => toast.error("결말 저장에 실패했습니다"),
   });
 
   const handleChange = (patch: Partial<FlowNodeData>) => {

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -21,6 +21,7 @@ import { LocationClueAssignPanel } from './LocationClueAssignPanel';
 import { LocationHierarchyList } from './LocationHierarchyList';
 import { LocationImageMediaField } from './LocationImageMediaField';
 import { LocationStructurePanel } from './LocationStructurePanel';
+import { useEditorAutosaveToast } from '@/features/editor/hooks/useEditorAutosaveToast';
 
 interface LocationDetailPanelProps {
   themeId: string;
@@ -179,6 +180,7 @@ function SelectedLocationDetail({
   const { data: clues } = useEditorClues(themeId);
   const [appearanceSceneId, setAppearanceSceneId] = useState(location.appearance_scene_id ?? null);
   const [hideSceneId, setHideSceneId] = useState(location.hide_scene_id ?? null);
+  const skipNextBasicAutosaveRef = useRef(true);
   const locationMeta = useMemo(
     () => readLocationMeta(theme.config_json, location.id),
     [theme.config_json, location.id]
@@ -211,27 +213,14 @@ function SelectedLocationDetail({
     allLocations: mapLocations,
   });
 
-  useEffect(() => {
-    setAppearanceSceneId(location.appearance_scene_id ?? null);
-    setHideSceneId(location.hide_scene_id ?? null);
-    setBasicDraft({
-      name: location.name,
-      publicDescription: location.public_description ?? locationMeta.publicDescription ?? '',
-      entryMessage: location.entry_message ?? locationMeta.entryMessage ?? '',
-    });
-  }, [
-    location.id,
-    location.name,
-    location.appearance_scene_id,
-    location.hide_scene_id,
-    location.public_description,
-    location.entry_message,
-    locationMeta,
-  ]);
-
   function saveLocation(
     patch: Partial<LocationResponse>,
-    options: { onSuccess?: () => void; onErrorMessage?: string } = {}
+    options: {
+      onSuccess?: () => void;
+      onError?: (error?: unknown) => void;
+      onErrorMessage?: string;
+      suppressErrorToast?: boolean;
+    } = {}
   ) {
     const nextAppearanceSceneId =
       patch.appearance_scene_id !== undefined
@@ -267,10 +256,56 @@ function SelectedLocationDetail({
       },
       {
         onSuccess: options.onSuccess,
-        onError: () => toast.error(options.onErrorMessage ?? '장소 저장에 실패했습니다'),
+        onError: (error) => {
+          options.onError?.(error);
+          if (!options.suppressErrorToast) {
+            toast.error(options.onErrorMessage ?? '장소 저장에 실패했습니다');
+          }
+        },
       }
     );
   }
+
+  const {
+    schedule: scheduleBasicInfoSave,
+    flush: flushBasicInfoSave,
+    cancel: cancelBasicInfoSave,
+  } = useEditorAutosaveToast<Partial<LocationResponse>>({
+    debounceMs: 1000,
+    messages: {
+      toastId: `location-basic-autosave-${location.id}`,
+      loading: '장소 기본 정보를 저장 중입니다',
+      success: '장소 기본 정보가 저장되었습니다',
+      error: '장소 기본 정보 저장에 실패했습니다',
+    },
+    mutate: (body, opts) =>
+      saveLocation(body, {
+        onSuccess: opts.onSuccess,
+        onError: opts.onError,
+        suppressErrorToast: true,
+      }),
+  });
+
+  useEffect(() => {
+    cancelBasicInfoSave();
+    skipNextBasicAutosaveRef.current = true;
+    setAppearanceSceneId(location.appearance_scene_id ?? null);
+    setHideSceneId(location.hide_scene_id ?? null);
+    setBasicDraft({
+      name: location.name,
+      publicDescription: location.public_description ?? locationMeta.publicDescription ?? '',
+      entryMessage: location.entry_message ?? locationMeta.entryMessage ?? '',
+    });
+  }, [
+    location.id,
+    location.name,
+    location.appearance_scene_id,
+    location.hide_scene_id,
+    location.public_description,
+    location.entry_message,
+    locationMeta,
+    cancelBasicInfoSave,
+  ]);
 
   function saveBasicInfo() {
     const nextName = basicDraft.name.trim();
@@ -279,18 +314,54 @@ function SelectedLocationDetail({
       return;
     }
 
-    saveLocation(
-      {
-        name: nextName,
-        public_description: basicDraft.publicDescription.trim() || null,
-        entry_message: basicDraft.entryMessage.trim() || null,
-      },
-      {
-        onSuccess: () => toast.success('장소 기본 정보가 저장되었습니다'),
-        onErrorMessage: '장소 기본 정보 저장에 실패했습니다',
-      }
-    );
+    scheduleBasicInfoSave({
+      name: nextName,
+      public_description: basicDraft.publicDescription.trim() || null,
+      entry_message: basicDraft.entryMessage.trim() || null,
+    });
+    flushBasicInfoSave();
   }
+
+  const isBasicInfoDirty = useMemo(() => {
+    const currentPublicDescription =
+      location.public_description ?? locationMeta.publicDescription ?? '';
+    const currentEntryMessage = location.entry_message ?? locationMeta.entryMessage ?? '';
+    return (
+      basicDraft.name !== location.name ||
+      basicDraft.publicDescription !== currentPublicDescription ||
+      basicDraft.entryMessage !== currentEntryMessage
+    );
+  }, [
+    basicDraft.entryMessage,
+    basicDraft.name,
+    basicDraft.publicDescription,
+    location.entry_message,
+    location.name,
+    location.public_description,
+    locationMeta.entryMessage,
+    locationMeta.publicDescription,
+  ]);
+
+  useEffect(() => {
+    if (skipNextBasicAutosaveRef.current) {
+      skipNextBasicAutosaveRef.current = false;
+      return;
+    }
+    if (!isBasicInfoDirty) return;
+    const nextName = basicDraft.name.trim();
+    if (!nextName) return;
+    scheduleBasicInfoSave({
+      name: nextName,
+      public_description: basicDraft.publicDescription.trim() || null,
+      entry_message: basicDraft.entryMessage.trim() || null,
+    });
+  }, [
+    basicDraft.entryMessage,
+    basicDraft.name,
+    basicDraft.publicDescription,
+    isBasicInfoDirty,
+    scheduleBasicInfoSave,
+  ]);
 
   function saveDiscoveryOrder(nextDiscoveries: LocationDiscoveryConfig[]) {
     const nextConfig = writeLocationDiscoveries(

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -13,7 +13,7 @@ import type {
   PhaseAction,
 } from "../../flowTypes";
 import { flowKeys } from "../../flowTypes";
-import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+import { useEditorAutosaveToast } from "@/features/editor/hooks/useEditorAutosaveToast";
 import { ActionListEditor, hasIncompletePresentationCueActions } from "./ActionListEditor";
 import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
 import { normalizePhaseType } from "./phaseTypeOptions";
@@ -43,6 +43,9 @@ interface PhaseNodePanelProps {
 
 /** Debounce window for flow-node saves (W2 PR-5: 500→1500ms). */
 const SAVE_DEBOUNCE_MS = 1500;
+const toastWithLoading = toast as typeof toast & {
+  loading?: (message: string, options?: Record<string, unknown>) => void;
+};
 
 export function PhaseNodePanel({
   node,
@@ -82,8 +85,14 @@ export function PhaseNodePanel({
   const sceneKillEnabled = playerKillConfig.allowedSceneIds.includes(node.id);
   const isPhaseSceneNode = node.type === "phase";
 
-  const debouncer = useDebouncedMutation<FlowNodeData>({
+  const debouncer = useEditorAutosaveToast<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
+    messages: {
+      toastId: `phase-node-autosave-${node.id}`,
+      loading: "장면 설정을 저장 중입니다",
+      success: "장면 설정이 저장되었습니다",
+      error: "저장에 실패했습니다",
+    },
     mutate: (body, opts) =>
       updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
     applyOptimistic: (body) => {
@@ -98,7 +107,6 @@ export function PhaseNodePanel({
       });
       return () => queryClient.setQueryData(cacheKey, previous);
     },
-    onError: () => toast.error("저장에 실패했습니다"),
   });
   const flush = debouncer.flush;
 
@@ -115,7 +123,24 @@ export function PhaseNodePanel({
   const handleSceneKillToggle = (enabled: boolean) => {
     if (!theme || updateConfig.isPending || !isPhaseSceneNode) return;
     const nextConfig = writePlayerKillSceneEnabled(configJson, node.id, enabled);
-    updateConfig.mutate({ ...nextConfig, version: theme.version });
+    toastWithLoading.loading?.("장면 설정을 저장 중입니다", {
+      id: `phase-kill-autosave-${node.id}`,
+    });
+    updateConfig.mutate(
+      { ...nextConfig, version: theme.version },
+      {
+        onSuccess: () =>
+          toast.success("장면 설정이 저장되었습니다", {
+            id: `phase-kill-autosave-${node.id}`,
+            duration: 1200,
+          }),
+        onError: () =>
+          toast.error("장면 설정 저장에 실패했습니다", {
+            id: `phase-kill-autosave-${node.id}`,
+            duration: 6000,
+          }),
+      },
+    );
   };
 
   return (

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx
@@ -49,6 +49,9 @@ describe('LocationsSubTab 장소 기본 정보', () => {
     ];
     updateLocationOptions.onSuccess?.();
     expect(updateConfigMutateMock).not.toHaveBeenCalled();
-    expect(toastSuccess).toHaveBeenCalledWith('장소 기본 정보가 저장되었습니다');
+    expect(toastSuccess).toHaveBeenCalledWith(
+      '장소 기본 정보가 저장되었습니다',
+      expect.objectContaining({ id: 'location-basic-autosave-loc-1' })
+    );
   });
 });

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx
@@ -238,7 +238,10 @@ describe("PhaseNodePanel optimistic update + rollback", () => {
 
     const cached = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
     expect(cached?.nodes[0].data.label).toBe("테스트"); // rolled back
-    expect(toastError).toHaveBeenCalledWith("저장에 실패했습니다");
+    expect(toastError).toHaveBeenCalledWith(
+      "저장에 실패했습니다",
+      expect.objectContaining({ id: "phase-node-autosave-node-1" }),
+    );
   });
 
   it("unmount 시 pending 변경도 flush()와 동일한 optimistic+rollback 경로를 탄다 (M1)", () => {
@@ -268,7 +271,10 @@ describe("PhaseNodePanel optimistic update + rollback", () => {
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const cached = qc.getQueryData<FlowGraphResponse>(flowKeys.graph("t1"));
     expect(cached?.nodes[0].data.label).toBe("테스트"); // rolled back
-    expect(toastError).toHaveBeenCalledWith("저장에 실패했습니다");
+    expect(toastError).toHaveBeenCalledWith(
+      "저장에 실패했습니다",
+      expect.objectContaining({ id: "phase-node-autosave-node-1" }),
+    );
   });
 
   it("graph 캐시가 없을 때는 rollback 없이 mutate만 호출된다", () => {

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -122,6 +122,7 @@ describe("PhaseNodePanel type-specific fields", () => {
           }),
         }),
       }),
+      expect.any(Object),
     );
   });
 

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Plus, Save, Trash2, X } from 'lucide-react';
 
 import {
@@ -14,6 +14,7 @@ import { ConfirmDialog, Spinner } from '@/shared/components/ui';
 import { InfoDeliverySettingsCard } from './InfoDeliverySettingsCard';
 import { InfoBodyPreview } from './InfoBodyPreview';
 import { InfoMarkdownEditor } from './InfoMarkdownEditor';
+import { useEditorAutosaveToast } from '@/features/editor/hooks/useEditorAutosaveToast';
 
 interface InfoTabProps {
   themeId: string;
@@ -138,10 +139,57 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   const [error, setError] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(() => !hasDisplayableBody(info));
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const exitEditModeAfterSaveRef = useRef(false);
   const updateInfo = useUpdateStoryInfo(themeId);
   const deleteInfo = useDeleteStoryInfo(themeId);
+  const { schedule: scheduleInfoSave, flush: flushInfoSave, cancel: cancelInfoSave } =
+    useEditorAutosaveToast<StoryInfoResponse>({
+      debounceMs: 1000,
+      messages: {
+        toastId: `story-info-autosave-${info.id}`,
+        loading: '정보를 저장 중입니다',
+        success: '정보가 저장되었습니다',
+        error: '정보 저장에 실패했습니다',
+      },
+      mutate: (body, opts) => {
+        updateInfo
+          .mutateAsync({
+            id: info.id,
+            patch: {
+              title: body.title,
+              body: body.body,
+              imageMediaId: body.imageMediaId ?? null,
+              relatedCharacterIds: body.relatedCharacterIds,
+              relatedClueIds: body.relatedClueIds,
+              relatedLocationIds: body.relatedLocationIds,
+              sortOrder: body.sortOrder,
+              version: body.version,
+            },
+          })
+          .then((saved) => {
+            const editableSaved = toEditableInfo(saved);
+            setBaseline(editableSaved);
+            setDraft((current) =>
+              hasEditableChanges(current, body)
+                ? { ...current, version: editableSaved.version }
+                : editableSaved,
+            );
+            if (exitEditModeAfterSaveRef.current) {
+              setIsEditing(!hasDisplayableBody(editableSaved));
+              exitEditModeAfterSaveRef.current = false;
+            }
+            opts.onSuccess?.();
+          })
+          .catch((error) => {
+            exitEditModeAfterSaveRef.current = false;
+            opts.onError(error);
+          });
+      },
+      onError: (err) => setError(errorMessage(err, '저장에 실패했습니다')),
+    });
 
   useEffect(() => {
+    cancelInfoSave();
     const editableInfo = toEditableInfo(info);
     setDraft(editableInfo);
     setBaseline(editableInfo);
@@ -149,7 +197,8 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
     setError(null);
     setIsEditing(!hasDisplayableBody(info));
     setDeleteDialogOpen(false);
-  }, [info]);
+    exitEditModeAfterSaveRef.current = false;
+  }, [cancelInfoSave, info]);
 
   useEffect(() => {
     if (!error) return undefined;
@@ -159,6 +208,11 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
 
   const isDirty = hasEditableChanges(draft, baseline);
 
+  useEffect(() => {
+    if (!isDirty) return;
+    scheduleInfoSave(draft);
+  }, [draft, isDirty, scheduleInfoSave]);
+
   function updateDraft(patch: Partial<StoryInfoResponse>) {
     setError(null);
     setDraft((current) => ({ ...current, ...patch }));
@@ -166,27 +220,10 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
 
   async function handleSave() {
     setError(null);
-    try {
-      const saved = await updateInfo.mutateAsync({
-        id: info.id,
-        patch: {
-          title: draft.title,
-          body: draft.body,
-          imageMediaId: draft.imageMediaId ?? null,
-          relatedCharacterIds: draft.relatedCharacterIds,
-          relatedClueIds: draft.relatedClueIds,
-          relatedLocationIds: draft.relatedLocationIds,
-          sortOrder: draft.sortOrder,
-          version: draft.version,
-        },
-      });
-      const editableSaved = toEditableInfo(saved);
-      setDraft(editableSaved);
-      setBaseline(editableSaved);
-      setIsEditing(!hasDisplayableBody(saved));
-    } catch (err) {
-      setError(errorMessage(err, '저장에 실패했습니다'));
-    }
+    if (!isDirty) return;
+    exitEditModeAfterSaveRef.current = true;
+    scheduleInfoSave(draft);
+    flushInfoSave();
   }
 
   async function handleDelete() {

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -23,6 +23,7 @@ import { ReadingSectionBgmPanel } from './ReadingSectionBgmPanel';
 import { ReadingSectionPreviewModal } from './ReadingSectionPreviewModal';
 import { ReadingScriptImportModal } from './ReadingScriptImportModal';
 import { EditorSaveConflictBanner } from '../EditorSaveConflictBanner';
+import { useEditorAutosaveToast } from '../../hooks/useEditorAutosaveToast';
 import type { CharacterOption } from './readingBlockUiTypes';
 import {
   blockActions,
@@ -47,6 +48,33 @@ export interface ReadingSectionEditorProps {
   section: ReadingSectionResponse;
   characters: CharacterOption[];
   onDeleted?: () => void;
+}
+
+function buildReadingPatch(
+  draft: ReadingSectionDraft,
+  section: ReadingSectionResponse,
+  characters: CharacterOption[],
+  narratorCharacterId: string | null,
+): { patch: UpdateReadingSectionRequest; issues: ReadingSaveValidationIssue[] } {
+  const normalizedLines = normalizeReadingLinesForSave(
+    draft.lines,
+    characters,
+    narratorCharacterId,
+  );
+  const issues = validateReadingLinesForSave(normalizedLines);
+  return {
+    issues,
+    patch: {
+      version: section.version,
+      name: draft.name,
+      // bgmMediaId uses triple-state: null = clear, string = set, undefined = keep
+      bgmMediaId: draft.bgmMediaId,
+      bgmMode: draft.bgmMode,
+      narratorCharacterId,
+      lines: normalizedLines,
+      sortOrder: draft.sortOrder,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -79,16 +107,43 @@ export function ReadingSectionEditor({
 
   const updateMutation = useUpdateReadingSection(themeId);
   const deleteMutation = useDeleteReadingSection(themeId);
+  const {
+    schedule: scheduleReadingSave,
+    flush: flushReadingSave,
+    cancel: cancelReadingSave,
+  } = useEditorAutosaveToast<UpdateReadingSectionRequest>({
+    debounceMs: 1200,
+    messages: {
+      toastId: `reading-section-autosave-${section.id}`,
+      loading: '읽기 대사를 저장 중입니다',
+      success: '읽기 대사가 저장되었습니다',
+      error: '읽기 대사 저장에 실패했습니다',
+    },
+    mutate: (patch, opts) => {
+      updateMutation
+        .mutateAsync({ id: section.id, patch })
+        .then(() => opts.onSuccess?.())
+        .catch(opts.onError);
+    },
+    onError: (err) => {
+      if (isConflictError(err)) {
+        setConflict(true);
+        return;
+      }
+      setSaveError(getReadingSaveErrorMessage(err));
+    },
+  });
 
   // Refresh local draft whenever the underlying section changes (e.g. after
   // a successful save returns a new version, or a refetch).
   useEffect(() => {
+    cancelReadingSave();
     setDraft(toDraft(section));
     setLineKeys(section.lines.map(() => createLineKey()));
     setConflict(false);
     setSaveError(null);
     setValidationIssues([]);
-  }, [createLineKey, section]);
+  }, [cancelReadingSave, createLineKey, section]);
 
   // BGM list (BGM filter only) — used to display selected BGM name without
   // an extra fetch when picker is closed.
@@ -120,6 +175,20 @@ export function ReadingSectionEditor({
     () => new Map(validationIssues.map((issue) => [issue.lineIndex, issue.message])),
     [validationIssues]
   );
+
+  const autosavePatch = useMemo(
+    () => buildReadingPatch(draft, section, characters, effectiveNarratorCharacterId),
+    [characters, draft, effectiveNarratorCharacterId, section],
+  );
+
+  useEffect(() => {
+    if (!isDirty) return;
+    if (autosavePatch.issues.length > 0) {
+      cancelReadingSave();
+      return;
+    }
+    scheduleReadingSave(autosavePatch.patch);
+  }, [autosavePatch, cancelReadingSave, isDirty, scheduleReadingSave]);
 
   // -------------------------------------------------------------------------
   // Block operations
@@ -223,38 +292,14 @@ export function ReadingSectionEditor({
     setSaveError(null);
     setConflict(false);
     setValidationIssues([]);
-    const normalizedLines = normalizeReadingLinesForSave(
-      draft.lines,
-      characters,
-      effectiveNarratorCharacterId
-    );
-    const issues = validateReadingLinesForSave(normalizedLines);
-    if (issues.length > 0) {
-      setValidationIssues(issues);
+    if (autosavePatch.issues.length > 0) {
+      setValidationIssues(autosavePatch.issues);
       setSaveError('저장 전에 미디어가 빠진 블록을 확인해 주세요.');
       return;
     }
 
-    const patch: UpdateReadingSectionRequest = {
-      version: section.version,
-      name: draft.name,
-      // bgmMediaId uses triple-state: null = clear, string = set, undefined = keep
-      bgmMediaId: draft.bgmMediaId,
-      bgmMode: draft.bgmMode,
-      narratorCharacterId: effectiveNarratorCharacterId,
-      lines: normalizedLines,
-      sortOrder: draft.sortOrder,
-    };
-
-    try {
-      await updateMutation.mutateAsync({ id: section.id, patch });
-    } catch (err) {
-      if (isConflictError(err)) {
-        setConflict(true);
-        return;
-      }
-      setSaveError(getReadingSaveErrorMessage(err));
-    }
+    scheduleReadingSave(autosavePatch.patch);
+    flushReadingSave();
   }
 
   async function handleDelete() {

--- a/apps/web/src/features/editor/hooks/useEditorAutosaveToast.ts
+++ b/apps/web/src/features/editor/hooks/useEditorAutosaveToast.ts
@@ -1,0 +1,87 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+
+import {
+  useDebouncedMutation,
+  type UseDebouncedMutationReturn,
+} from "@/hooks/useDebouncedMutation";
+
+const toastWithLoading = toast as typeof toast & {
+  loading?: (message: string, options?: Record<string, unknown>) => void;
+};
+
+interface EditorAutosaveToastMessages {
+  toastId: string;
+  loading: string;
+  success: string;
+  error: string;
+}
+
+interface EditorAutosaveToastOptions<TBody> {
+  debounceMs?: number;
+  messages: EditorAutosaveToastMessages;
+  mutate: (
+    body: TBody,
+    opts: { onError: (error?: unknown) => void; onSuccess?: () => void },
+  ) => void;
+  applyOptimistic?: (body: TBody) => (() => void) | null;
+  onSuccess?: (body: TBody) => void;
+  onError?: (error?: unknown) => void;
+}
+
+export function useEditorAutosaveToast<TBody>({
+  debounceMs,
+  messages,
+  mutate,
+  applyOptimistic,
+  onSuccess,
+  onError,
+}: EditorAutosaveToastOptions<TBody>): UseDebouncedMutationReturn<TBody> {
+  const retryMutation = useCallback(
+    (body: TBody) => {
+      toastWithLoading.loading?.(messages.loading, { id: messages.toastId });
+      mutate(body, {
+        onSuccess: () => {
+          onSuccess?.(body);
+          toast.success(messages.success, { id: messages.toastId, duration: 1200 });
+        },
+        onError: (error) => {
+          onError?.(error);
+          toast.error(messages.error, {
+            id: messages.toastId,
+            duration: 6000,
+            action: {
+              label: "재시도",
+              onClick: () => retryMutation(body),
+            },
+          });
+        },
+      });
+    },
+    [messages, mutate, onError, onSuccess],
+  );
+
+  return useDebouncedMutation<TBody>({
+    debounceMs,
+    applyOptimistic,
+    mutate: (body, opts) => {
+      toastWithLoading.loading?.(messages.loading, { id: messages.toastId });
+      mutate(body, opts);
+    },
+    onSuccess: (body) => {
+      onSuccess?.(body);
+      toast.success(messages.success, { id: messages.toastId, duration: 1200 });
+    },
+    onFailure: (error, body) => {
+      onError?.(error);
+      toast.error(messages.error, {
+        id: messages.toastId,
+        duration: 6000,
+        action: {
+          label: "재시도",
+          onClick: () => retryMutation(body),
+        },
+      });
+    },
+  });
+}

--- a/apps/web/src/hooks/useDebouncedMutation.ts
+++ b/apps/web/src/hooks/useDebouncedMutation.ts
@@ -73,7 +73,10 @@ export interface UseDebouncedMutationOptions<TBody> {
    * **재진입 금지**: 이 콜백 안에서 `schedule`/`flush`/`cancel`을 동기 호출
    * 하지 마라. 필요하면 `queueMicrotask`로 다음 tick에 dispatch.
    */
-  mutate: (body: TBody, opts: { onError: (error?: unknown) => void }) => void;
+  mutate: (
+    body: TBody,
+    opts: { onError: (error?: unknown) => void; onSuccess?: () => void },
+  ) => void;
   /** Debounce window in milliseconds. Defaults to 1500 (Phase 18.5 W2 PR-5). */
   debounceMs?: number;
   /**
@@ -85,6 +88,10 @@ export interface UseDebouncedMutationOptions<TBody> {
   applyOptimistic?: (body: TBody) => (() => void) | null;
   /** Fired after rollback when the mutation hits onError. */
   onError?: (error?: unknown) => void;
+  /** Fired after rollback with the failed body for retry-aware wrappers. */
+  onFailure?: (error: unknown | undefined, body: TBody) => void;
+  /** Fired after the mutation succeeds. */
+  onSuccess?: (body: TBody) => void;
 }
 
 export interface UseDebouncedMutationReturn<TBody> {
@@ -108,6 +115,8 @@ interface OptsRef<TBody> {
   mutate: UseDebouncedMutationOptions<TBody>["mutate"];
   applyOptimistic: UseDebouncedMutationOptions<TBody>["applyOptimistic"];
   onError: UseDebouncedMutationOptions<TBody>["onError"];
+  onFailure: UseDebouncedMutationOptions<TBody>["onFailure"];
+  onSuccess: UseDebouncedMutationOptions<TBody>["onSuccess"];
 }
 
 type TimerRef = React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
@@ -139,6 +148,10 @@ function flushPending<TBody>(
     onError: (error) => {
       rollback?.();
       optsRef.current.onError?.(error);
+      optsRef.current.onFailure?.(error, body);
+    },
+    onSuccess: () => {
+      optsRef.current.onSuccess?.(body);
     },
   });
 }
@@ -146,7 +159,14 @@ function flushPending<TBody>(
 export function useDebouncedMutation<TBody>(
   options: UseDebouncedMutationOptions<TBody>,
 ): UseDebouncedMutationReturn<TBody> {
-  const { mutate, debounceMs = DEFAULT_DEBOUNCE_MS, applyOptimistic, onError } = options;
+  const {
+    mutate,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    applyOptimistic,
+    onError,
+    onFailure,
+    onSuccess,
+  } = options;
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingRef = useRef<TBody | null>(null);
@@ -154,10 +174,16 @@ export function useDebouncedMutation<TBody>(
   // Latest options snapshot, synced via useEffect so we only mutate the ref
   // post-commit (Round-2 N-2: render-body ref writes are unsafe under React 19
   // concurrent rendering — speculative renders can replay).
-  const optsRef = useRef<OptsRef<TBody>>({ mutate, applyOptimistic, onError });
+  const optsRef = useRef<OptsRef<TBody>>({
+    mutate,
+    applyOptimistic,
+    onError,
+    onFailure,
+    onSuccess,
+  });
   useEffect(() => {
-    optsRef.current = { mutate, applyOptimistic, onError };
-  }, [mutate, applyOptimistic, onError]);
+    optsRef.current = { mutate, applyOptimistic, onError, onFailure, onSuccess };
+  }, [mutate, applyOptimistic, onError, onFailure, onSuccess]);
 
   const flush = useCallback(
     () => flushPending(timerRef, pendingRef, optsRef),


### PR DESCRIPTION
## 요약
- 에디터 자동저장 토스트 공통 훅을 추가해 저장 중/저장됨/저장 실패 표시와 실패 재시도를 통일했습니다.
- 정보, 읽기 대사, 장소 기본 정보, 결말 상세, 게임 진행 장면 설정, 테마 개요 저장 흐름을 자동저장 + 토스트 기준으로 맞췄습니다.
- `useDebouncedMutation`에 성공/실패 본문 콜백을 추가해 기존 optimistic rollback 흐름을 유지하면서 화면별 후처리를 연결할 수 있게 했습니다.

## Coverage Plan
- `useDebouncedMutation`: 성공/실패 콜백과 flush 경로를 기존 hook 단위 테스트로 검증했습니다.
- 정보/읽기 대사/장소/장면 설정: 자동저장 호출, 실패 토스트, 수동 flush 버튼 호환성을 focused component tests로 검증했습니다.
- 전체 에디터 영향: web typecheck, web 전체 Vitest, web build를 포함하는 local quick 검증으로 회귀를 확인했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- --run src/hooks/__tests__/useDebouncedMutation.test.ts src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx` 통과: 6 files, 83 tests.
- `pnpm --filter @mmp/web typecheck` 통과.
- `MMP_LOCAL_CI_SKIP_INSTALL=1 scripts/mmp-local-ci.sh quick` 통과: backend Go tests, web lint, web Vitest 185 files/1746 tests, web build.

## 비고
- `ready-for-ci` 라벨이나 GitHub Actions 수동 실행은 사용하지 않았습니다.
- lint의 기존 warning들은 실패 조건이 아니며 이번 변경 파일의 blocker는 없습니다.