### PR TITLE
에디터 자동저장 공통 엔진 도입

### DIFF
--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Plus, Save, Trash2, X } from 'lucide-react';
 
 import {
@@ -14,7 +14,7 @@ import { ConfirmDialog, Spinner } from '@/shared/components/ui';
 import { InfoDeliverySettingsCard } from './InfoDeliverySettingsCard';
 import { InfoBodyPreview } from './InfoBodyPreview';
 import { InfoMarkdownEditor } from './InfoMarkdownEditor';
-import { useEditorAutosaveToast } from '@/features/editor/hooks/useEditorAutosaveToast';
+import { useAutosavedDraft } from '@/features/editor/hooks/useAutosavedDraft';
 
 interface InfoTabProps {
   themeId: string;
@@ -133,8 +133,6 @@ export function InfoTab({ themeId }: InfoTabProps) {
 }
 
 function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoResponse }) {
-  const [draft, setDraft] = useState(() => toEditableInfo(info));
-  const [baseline, setBaseline] = useState(() => toEditableInfo(info));
   const [embedPickerType, setEmbedPickerType] = useState<MediaType | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(() => !hasDisplayableBody(info));
@@ -142,76 +140,83 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   const exitEditModeAfterSaveRef = useRef(false);
   const updateInfo = useUpdateStoryInfo(themeId);
   const deleteInfo = useDeleteStoryInfo(themeId);
-  const { schedule: scheduleInfoSave, flush: flushInfoSave, cancel: cancelInfoSave } =
-    useEditorAutosaveToast<StoryInfoResponse>({
-      debounceMs: 1000,
-      messages: {
-        toastId: `story-info-autosave-${info.id}`,
-        loading: '정보를 저장 중입니다',
-        success: '정보가 저장되었습니다',
-        error: '정보 저장에 실패했습니다',
-      },
-      mutate: (body, opts) => {
-        updateInfo
-          .mutateAsync({
-            id: info.id,
-            patch: {
-              title: body.title,
-              body: body.body,
-              imageMediaId: body.imageMediaId ?? null,
-              relatedCharacterIds: body.relatedCharacterIds,
-              relatedClueIds: body.relatedClueIds,
-              relatedLocationIds: body.relatedLocationIds,
-              sortOrder: body.sortOrder,
-              version: body.version,
-            },
-          })
-          .then((saved) => {
-            const editableSaved = toEditableInfo(saved);
-            setBaseline(editableSaved);
-            setDraft((current) =>
-              hasEditableChanges(current, body)
-                ? { ...current, version: editableSaved.version }
-                : editableSaved,
-            );
-            if (exitEditModeAfterSaveRef.current) {
-              setIsEditing(!hasDisplayableBody(editableSaved));
-              exitEditModeAfterSaveRef.current = false;
-            }
-            opts.onSuccess?.();
-          })
-          .catch((error) => {
-            exitEditModeAfterSaveRef.current = false;
-            opts.onError(error);
-          });
-      },
-      onError: (err) => setError(errorMessage(err, '저장에 실패했습니다')),
-    });
-
-  useEffect(() => {
-    cancelInfoSave();
-    const editableInfo = toEditableInfo(info);
-    setDraft(editableInfo);
-    setBaseline(editableInfo);
-    setEmbedPickerType(null);
-    setError(null);
-    setIsEditing(!hasDisplayableBody(info));
-    setDeleteDialogOpen(false);
-    exitEditModeAfterSaveRef.current = false;
-  }, [cancelInfoSave, info]);
+  const toInfoDraft = useCallback((value: StoryInfoResponse) => toEditableInfo(value), []);
+  const isSameInfoDraft = useCallback(
+    (left: StoryInfoResponse, right: StoryInfoResponse) => !hasEditableChanges(left, right),
+    [],
+  );
+  const saveInfo = useCallback(
+    (body: StoryInfoResponse) =>
+      updateInfo.mutateAsync({
+        id: info.id,
+        patch: {
+          title: body.title,
+          body: body.body,
+          imageMediaId: body.imageMediaId ?? null,
+          relatedCharacterIds: body.relatedCharacterIds,
+          relatedClueIds: body.relatedClueIds,
+          relatedLocationIds: body.relatedLocationIds,
+          sortOrder: body.sortOrder,
+          version: body.version,
+        },
+      }),
+    [info.id, updateInfo],
+  );
+  const buildInfoSaveBody = useCallback((current: StoryInfoResponse) => current, []);
+  const mergeSavedInfoDraft = useCallback(
+    ({
+      currentDraft,
+      savedDraft,
+      submittedDraft,
+    }: {
+      currentDraft: StoryInfoResponse;
+      savedDraft: StoryInfoResponse;
+      submittedDraft: StoryInfoResponse;
+    }) =>
+      hasEditableChanges(currentDraft, submittedDraft)
+        ? { ...currentDraft, version: savedDraft.version }
+        : savedDraft,
+    [],
+  );
+  const {
+    draft,
+    setDraft,
+    baseline,
+    isDirty,
+    saveNow: saveInfoNow,
+  } = useAutosavedDraft<StoryInfoResponse, StoryInfoResponse, StoryInfoResponse>({
+    serverValue: info,
+    serverKey: info.id,
+    debounceMs: 1000,
+    toDraft: toInfoDraft,
+    isEqual: isSameInfoDraft,
+    buildSaveBody: buildInfoSaveBody,
+    save: saveInfo,
+    mergeSavedDraft: mergeSavedInfoDraft,
+    messages: {
+      toastId: `story-info-autosave-${info.id}`,
+      loading: '정보를 저장 중입니다',
+      success: '정보가 저장되었습니다',
+      error: '정보 저장에 실패했습니다',
+    },
+    onSaved: (saved) => {
+      const editableSaved = toEditableInfo(saved);
+      if (exitEditModeAfterSaveRef.current) {
+        setIsEditing(!hasDisplayableBody(editableSaved));
+        exitEditModeAfterSaveRef.current = false;
+      }
+    },
+    onError: (err) => {
+      exitEditModeAfterSaveRef.current = false;
+      setError(errorMessage(err, '저장에 실패했습니다'));
+    },
+  });
 
   useEffect(() => {
     if (!error) return undefined;
     const timeout = window.setTimeout(() => setError(null), INFO_EDITOR_ERROR_AUTO_DISMISS_MS);
     return () => window.clearTimeout(timeout);
   }, [error]);
-
-  const isDirty = hasEditableChanges(draft, baseline);
-
-  useEffect(() => {
-    if (!isDirty) return;
-    scheduleInfoSave(draft);
-  }, [draft, isDirty, scheduleInfoSave]);
 
   function updateDraft(patch: Partial<StoryInfoResponse>) {
     setError(null);
@@ -222,8 +227,7 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
     setError(null);
     if (!isDirty) return;
     exitEditModeAfterSaveRef.current = true;
-    scheduleInfoSave(draft);
-    flushInfoSave();
+    saveInfoNow();
   }
 
   async function handleDelete() {

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -735,4 +735,52 @@ describe('InfoTab', () => {
       )
     );
   });
+
+  it('keeps the local title draft when an earlier autosave refetch returns stale data', async () => {
+    vi.useFakeTimers();
+    let infos = [{ ...baseInfo }];
+    useStoryInfosMock.mockImplementation(() => ({
+      data: infos,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    }));
+    updateMutate.mockResolvedValueOnce({
+      ...baseInfo,
+      title: '지',
+      version: 4,
+      updatedAt: '2026-05-06T00:01:00Z',
+    });
+
+    const { rerender } = render(<InfoTab themeId="theme-1" />);
+    enterInfoEditMode();
+    fireEvent.change(screen.getByLabelText('정보 제목'), {
+      target: { value: '지' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patch: expect.objectContaining({ title: '지', version: 3 }),
+      })
+    );
+
+    fireEvent.change(screen.getByLabelText('정보 제목'), {
+      target: { value: '지도' },
+    });
+    infos = [
+      {
+        ...baseInfo,
+        title: '지',
+        version: 4,
+        updatedAt: '2026-05-06T00:01:00Z',
+      },
+    ];
+    rerender(<InfoTab themeId="theme-1" />);
+
+    expect(screen.getByLabelText('정보 제목')).toHaveProperty('value', '지도');
+  });
 });

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -23,14 +23,13 @@ import { ReadingSectionBgmPanel } from './ReadingSectionBgmPanel';
 import { ReadingSectionPreviewModal } from './ReadingSectionPreviewModal';
 import { ReadingScriptImportModal } from './ReadingScriptImportModal';
 import { EditorSaveConflictBanner } from '../EditorSaveConflictBanner';
-import { useEditorAutosaveToast } from '../../hooks/useEditorAutosaveToast';
+import { useAutosavedDraft } from '../../hooks/useAutosavedDraft';
 import type { CharacterOption } from './readingBlockUiTypes';
 import {
   blockActions,
   createBlock,
   getReadingSaveErrorMessage,
   isConflictError,
-  isReadingDraftDirty,
   normalizeReadingLinesForSave,
   toDraft,
   toParserMedia,
@@ -92,7 +91,6 @@ export function ReadingSectionEditor({
     () => `reading-line-${section.id}-${lineKeyCounter.current++}`,
     [section.id]
   );
-  const [draft, setDraft] = useState<ReadingSectionDraft>(() => toDraft(section));
   const [lineKeys, setLineKeys] = useState<string[]>(() =>
     section.lines.map(() => createLineKey())
   );
@@ -107,23 +105,49 @@ export function ReadingSectionEditor({
 
   const updateMutation = useUpdateReadingSection(themeId);
   const deleteMutation = useDeleteReadingSection(themeId);
+  const toReadingDraft = useCallback((value: ReadingSectionResponse) => toDraft(value), []);
+  const isSameReadingDraft = useCallback(
+    (left: ReadingSectionDraft, right: ReadingSectionDraft) =>
+      JSON.stringify(left) === JSON.stringify(right),
+    [],
+  );
+  const saveReadingPatch = useCallback(
+    (patch: UpdateReadingSectionRequest) =>
+      updateMutation.mutateAsync({ id: section.id, patch }),
+    [section.id, updateMutation],
+  );
+  const buildReadingSaveBody = useCallback(
+    (currentDraft: ReadingSectionDraft, latestSection: ReadingSectionResponse) => {
+      const result = buildReadingPatch(
+        currentDraft,
+        latestSection,
+        characters,
+        currentDraft.narratorCharacterId ??
+          characters.find((character) => character.isPlayable)?.id ??
+          null,
+      );
+      return result.issues.length > 0 ? null : result.patch;
+    },
+    [characters],
+  );
   const {
-    schedule: scheduleReadingSave,
-    flush: flushReadingSave,
-    cancel: cancelReadingSave,
-  } = useEditorAutosaveToast<UpdateReadingSectionRequest>({
+    draft,
+    setDraft,
+    isDirty,
+    saveNow: saveReadingNow,
+  } = useAutosavedDraft<ReadingSectionResponse, ReadingSectionDraft, UpdateReadingSectionRequest>({
+    serverValue: section,
+    serverKey: section.id,
     debounceMs: 1200,
+    toDraft: toReadingDraft,
+    isEqual: isSameReadingDraft,
+    buildSaveBody: buildReadingSaveBody,
+    save: saveReadingPatch,
     messages: {
       toastId: `reading-section-autosave-${section.id}`,
       loading: '읽기 대사를 저장 중입니다',
       success: '읽기 대사가 저장되었습니다',
       error: '읽기 대사 저장에 실패했습니다',
-    },
-    mutate: (patch, opts) => {
-      updateMutation
-        .mutateAsync({ id: section.id, patch })
-        .then(() => opts.onSuccess?.())
-        .catch(opts.onError);
     },
     onError: (err) => {
       if (isConflictError(err)) {
@@ -134,16 +158,13 @@ export function ReadingSectionEditor({
     },
   });
 
-  // Refresh local draft whenever the underlying section changes (e.g. after
-  // a successful save returns a new version, or a refetch).
   useEffect(() => {
-    cancelReadingSave();
-    setDraft(toDraft(section));
+    if (isDirty) return;
     setLineKeys(section.lines.map(() => createLineKey()));
     setConflict(false);
     setSaveError(null);
     setValidationIssues([]);
-  }, [cancelReadingSave, createLineKey, section]);
+  }, [createLineKey, isDirty, section]);
 
   // BGM list (BGM filter only) — used to display selected BGM name without
   // an extra fetch when picker is closed.
@@ -169,7 +190,6 @@ export function ReadingSectionEditor({
   );
   const mediaById = useMemo(() => new Map(allMedia.map((media) => [media.id, media])), [allMedia]);
 
-  const isDirty = useMemo(() => isReadingDraftDirty(draft, section), [draft, section]);
   const previewLines = useMemo(() => normalizeReadingBlocks(draft.lines), [draft.lines]);
   const validationIssueByLine = useMemo(
     () => new Map(validationIssues.map((issue) => [issue.lineIndex, issue.message])),
@@ -180,15 +200,6 @@ export function ReadingSectionEditor({
     () => buildReadingPatch(draft, section, characters, effectiveNarratorCharacterId),
     [characters, draft, effectiveNarratorCharacterId, section],
   );
-
-  useEffect(() => {
-    if (!isDirty) return;
-    if (autosavePatch.issues.length > 0) {
-      cancelReadingSave();
-      return;
-    }
-    scheduleReadingSave(autosavePatch.patch);
-  }, [autosavePatch, cancelReadingSave, isDirty, scheduleReadingSave]);
 
   // -------------------------------------------------------------------------
   // Block operations
@@ -298,8 +309,7 @@ export function ReadingSectionEditor({
       return;
     }
 
-    scheduleReadingSave(autosavePatch.patch);
-    flushReadingSave();
+    saveReadingNow();
   }
 
   async function handleDelete() {

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -176,6 +176,22 @@ describe('ReadingSectionEditor', () => {
     expect(input.value).toBe('오프닝');
   });
 
+  it('keeps the local draft when the same section refetches stale data', () => {
+    const { rerender } = renderEditor();
+    const input = screen.getByLabelText('섹션 이름') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '새 오프닝' } });
+    rerender(
+      <ReadingSectionEditor
+        themeId="theme-1"
+        section={{ ...sampleSection, name: '오프닝' }}
+        characters={characters}
+      />
+    );
+
+    expect(screen.getByLabelText('섹션 이름')).toHaveProperty('value', '새 오프닝');
+  });
+
   it('renders all line rows', () => {
     renderEditor();
     expect(screen.getByDisplayValue('어두운 방 안.')).toBeTruthy();

--- a/apps/web/src/features/editor/hooks/__tests__/useAutosavedDraft.test.tsx
+++ b/apps/web/src/features/editor/hooks/__tests__/useAutosavedDraft.test.tsx
@@ -1,0 +1,152 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAutosavedDraft } from "../useAutosavedDraft";
+
+interface ServerValue {
+  id: string;
+  title: string;
+  version: number;
+}
+
+interface DraftValue {
+  title: string;
+  version: number;
+}
+
+function toDraft(value: ServerValue): DraftValue {
+  return { title: value.title, version: value.version };
+}
+
+function isEqual(left: DraftValue, right: DraftValue) {
+  return left.title === right.title && left.version === right.version;
+}
+
+describe("useAutosavedDraft", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("preserves a dirty draft when the same entity refetches stale server data", () => {
+    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "지도", version: 2 });
+    const { result, rerender } = renderHook(
+      ({ serverValue }: { serverValue: ServerValue }) =>
+        useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
+          serverValue,
+          serverKey: serverValue.id,
+          debounceMs: 1000,
+          toDraft,
+          isEqual,
+          buildSaveBody: (draft) => draft,
+          save,
+        }),
+      {
+        initialProps: {
+          serverValue: { id: "info-1", title: "지", version: 1 },
+        },
+      },
+    );
+
+    act(() => {
+      result.current.setDraft({ title: "지도", version: 1 });
+    });
+    rerender({ serverValue: { id: "info-1", title: "지", version: 1 } });
+
+    expect(result.current.draft.title).toBe("지도");
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("accepts server data when there are no local changes", () => {
+    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "지도", version: 2 });
+    const { result, rerender } = renderHook(
+      ({ serverValue }: { serverValue: ServerValue }) =>
+        useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
+          serverValue,
+          serverKey: serverValue.id,
+          debounceMs: 1000,
+          toDraft,
+          isEqual,
+          buildSaveBody: (draft) => draft,
+          save,
+        }),
+      {
+        initialProps: {
+          serverValue: { id: "info-1", title: "지", version: 1 },
+        },
+      },
+    );
+
+    rerender({ serverValue: { id: "info-1", title: "지도", version: 2 } });
+
+    expect(result.current.draft).toEqual({ title: "지도", version: 2 });
+    expect(result.current.baseline).toEqual({ title: "지도", version: 2 });
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("clears dirty state only for the draft that was submitted", async () => {
+    const serverValue = { id: "info-1", title: "", version: 1 };
+    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "지", version: 2 });
+    const { result } = renderHook(() =>
+      useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
+        serverValue,
+        serverKey: "info-1",
+        debounceMs: 1000,
+        toDraft,
+        isEqual,
+        buildSaveBody: (draft) => draft,
+        save,
+      }),
+    );
+
+    act(() => {
+      result.current.setDraft({ title: "지", version: 1 });
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    act(() => {
+      result.current.setDraft({ title: "지도", version: 1 });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(result.current.draft.title).toBe("지도");
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("saveNow flushes the current draft immediately", async () => {
+    const serverValue = { id: "info-1", title: "", version: 1 };
+    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "즉시 저장", version: 2 });
+    const { result } = renderHook(() =>
+      useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
+        serverValue,
+        serverKey: "info-1",
+        debounceMs: 1000,
+        toDraft,
+        isEqual,
+        buildSaveBody: (draft) => draft,
+        save,
+      }),
+    );
+
+    act(() => {
+      result.current.setDraft({ title: "즉시 저장", version: 1 });
+    });
+    act(() => {
+      result.current.saveNow();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ title: "즉시 저장", version: 1 });
+  });
+});

--- a/apps/web/src/features/editor/hooks/useAutosavedDraft.ts
+++ b/apps/web/src/features/editor/hooks/useAutosavedDraft.ts
@@ -1,0 +1,241 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { toast } from "sonner";
+
+import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+
+const toastWithLoading = toast as typeof toast & {
+  loading?: (message: string, options?: Record<string, unknown>) => void;
+};
+
+export interface AutosavedDraftToastMessages {
+  toastId: string;
+  loading: string;
+  success: string;
+  error: string;
+}
+
+export interface UseAutosavedDraftOptions<TServer, TDraft, TSaveBody> {
+  serverValue: TServer;
+  serverKey?: string;
+  debounceMs?: number;
+  toDraft: (serverValue: TServer) => TDraft;
+  isEqual: (left: TDraft, right: TDraft) => boolean;
+  buildSaveBody: (draft: TDraft, latestServerValue: TServer) => TSaveBody | null;
+  save: (body: TSaveBody) => Promise<TServer>;
+  mergeSavedDraft?: (args: {
+    currentDraft: TDraft;
+    savedDraft: TDraft;
+    submittedDraft: TDraft;
+  }) => TDraft;
+  messages?: AutosavedDraftToastMessages;
+  enabled?: boolean;
+  onError?: (error?: unknown) => void;
+  onSaved?: (saved: TServer) => void;
+}
+
+export interface UseAutosavedDraftReturn<TDraft> {
+  draft: TDraft;
+  setDraft: Dispatch<SetStateAction<TDraft>>;
+  baseline: TDraft;
+  isDirty: boolean;
+  saveNow: () => void;
+  flush: () => void;
+  cancel: () => void;
+}
+
+function defaultMergeSavedDraft<TDraft>({
+  currentDraft,
+  savedDraft,
+  submittedDraft,
+  isEqual,
+}: {
+  currentDraft: TDraft;
+  savedDraft: TDraft;
+  submittedDraft: TDraft;
+  isEqual: (left: TDraft, right: TDraft) => boolean;
+}): TDraft {
+  return isEqual(currentDraft, submittedDraft) ? savedDraft : currentDraft;
+}
+
+export function useAutosavedDraft<TServer, TDraft, TSaveBody>({
+  serverValue,
+  serverKey,
+  debounceMs,
+  toDraft,
+  isEqual,
+  buildSaveBody,
+  save,
+  mergeSavedDraft,
+  messages,
+  enabled = true,
+  onError,
+  onSaved,
+}: UseAutosavedDraftOptions<TServer, TDraft, TSaveBody>): UseAutosavedDraftReturn<TDraft> {
+  const initialDraft = useMemo(() => toDraft(serverValue), [serverValue, toDraft]);
+  const [draft, setDraftState] = useState(initialDraft);
+  const [baseline, setBaseline] = useState(initialDraft);
+
+  const draftRef = useRef(draft);
+  const baselineRef = useRef(baseline);
+  const latestServerValueRef = useRef(serverValue);
+  const serverKeyRef = useRef(serverKey);
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  const setDraft = useCallback<Dispatch<SetStateAction<TDraft>>>((next) => {
+    setDraftState((current) => {
+      const resolved =
+        typeof next === "function"
+          ? (next as (current: TDraft) => TDraft)(current)
+          : next;
+      draftRef.current = resolved;
+      return resolved;
+    });
+  }, []);
+
+  useEffect(() => {
+    baselineRef.current = baseline;
+  }, [baseline]);
+
+  const isDirty = !isEqual(draft, baseline);
+  const isDirtyRef = useRef(isDirty);
+  useEffect(() => {
+    isDirtyRef.current = isDirty;
+  }, [isDirty]);
+
+  const acceptSavedValue = useCallback(
+    (saved: TServer, submittedDraft: TDraft) => {
+      latestServerValueRef.current = saved;
+      const savedDraft = toDraft(saved);
+      setBaseline(savedDraft);
+      setDraft((currentDraft) => {
+        const nextDraft = mergeSavedDraft
+          ? mergeSavedDraft({
+              currentDraft,
+              savedDraft,
+              submittedDraft,
+            })
+          : defaultMergeSavedDraft({
+              currentDraft,
+              savedDraft,
+              submittedDraft,
+              isEqual,
+            });
+        draftRef.current = nextDraft;
+        return nextDraft;
+      });
+      onSaved?.(saved);
+    },
+    [isEqual, mergeSavedDraft, onSaved, setDraft, toDraft],
+  );
+
+  const retrySave = useCallback(
+    (payload: { body: TSaveBody; submittedDraft: TDraft }) => {
+      if (!messages) {
+        void save(payload.body)
+          .then((saved) => acceptSavedValue(saved, payload.submittedDraft))
+          .catch((error) => onError?.(error));
+        return;
+      }
+      toastWithLoading.loading?.(messages.loading, { id: messages.toastId });
+      save(payload.body)
+        .then((saved) => {
+          acceptSavedValue(saved, payload.submittedDraft);
+          toast.success(messages.success, { id: messages.toastId, duration: 1200 });
+        })
+        .catch((error) => {
+          onError?.(error);
+          toast.error(messages.error, {
+            id: messages.toastId,
+            duration: 6000,
+            action: { label: "재시도", onClick: () => retrySave(payload) },
+          });
+        });
+    },
+    [acceptSavedValue, messages, onError, save],
+  );
+
+  const { schedule, flush, cancel } = useDebouncedMutation<{
+    body: TSaveBody;
+    submittedDraft: TDraft;
+  }>({
+    debounceMs,
+    mutate: (payload, opts) => {
+      if (messages) {
+        toastWithLoading.loading?.(messages.loading, { id: messages.toastId });
+      }
+      save(payload.body)
+        .then((saved) => {
+          acceptSavedValue(saved, payload.submittedDraft);
+          opts.onSuccess?.();
+        })
+        .catch(opts.onError);
+    },
+    onSuccess: () => {
+      if (messages) {
+        toast.success(messages.success, { id: messages.toastId, duration: 1200 });
+      }
+    },
+    onFailure: (error, payload) => {
+      onError?.(error);
+      if (!messages) return;
+      toast.error(messages.error, {
+        id: messages.toastId,
+        duration: 6000,
+        action: { label: "재시도", onClick: () => retrySave(payload) },
+      });
+    },
+  });
+
+  useEffect(() => {
+    const incomingDraft = toDraft(serverValue);
+    const keyChanged = serverKeyRef.current !== serverKey;
+    serverKeyRef.current = serverKey;
+
+    if (keyChanged) {
+      cancel();
+      latestServerValueRef.current = serverValue;
+      setDraft(incomingDraft);
+      setBaseline(incomingDraft);
+      return;
+    }
+
+    if (isDirtyRef.current) return;
+
+    latestServerValueRef.current = serverValue;
+    setDraft(incomingDraft);
+    setBaseline(incomingDraft);
+  }, [cancel, serverKey, serverValue, setDraft, toDraft]);
+
+  useEffect(() => {
+    if (!enabled || !isDirty) return;
+    const body = buildSaveBody(draft, latestServerValueRef.current);
+    if (!body) {
+      cancel();
+      return;
+    }
+    schedule({ body, submittedDraft: draft });
+  }, [buildSaveBody, cancel, draft, enabled, isDirty, schedule]);
+
+  const saveNow = useCallback(() => {
+    if (!enabled) return;
+    const currentDraft = draftRef.current;
+    if (isEqual(currentDraft, baselineRef.current)) return;
+    const body = buildSaveBody(currentDraft, latestServerValueRef.current);
+    if (!body) return;
+    schedule({ body, submittedDraft: currentDraft });
+    flush();
+  }, [buildSaveBody, enabled, flush, isEqual, schedule]);
+
+  return { draft, setDraft, baseline, isDirty, saveNow, flush, cancel };
+}

--- a/docs/superpowers/plans/2026-05-17-editor-autosave-engine.md
+++ b/docs/superpowers/plans/2026-05-17-editor-autosave-engine.md
@@ -1,0 +1,40 @@
+# Editor Autosave Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fragile per-screen autosave draft handling with a reusable editor autosave draft engine that preserves local edits during server refetches.
+
+**Architecture:** Keep `useDebouncedMutation` as the low-level delay/flush primitive. Add a higher-level `useAutosavedDraft` hook under editor hooks to own draft, baseline, dirty state, submitted snapshot checks, server refresh policy, flush-on-unmount, and toast-compatible save status. Migrate the bug-prone Info and Reading editors first; leave graph/clue specialized flows on existing primitives until they need draft ownership.
+
+**Tech Stack:** React 19 hooks, Vitest, Testing Library, existing MMP editor API hooks, existing `useDebouncedMutation`.
+
+---
+
+## Coverage Plan
+
+- `apps/web/src/features/editor/hooks/useAutosavedDraft.ts`: unit tests cover dirty draft protection, submitted snapshot success handling, server refresh while clean, server refresh while dirty, flush/cancel behavior.
+- `apps/web/src/features/editor/components/info/InfoTab.tsx`: focused component test covers typing additional characters while an earlier autosave refetch returns stale data.
+- `apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx`: focused component or hook-level coverage verifies server section refresh does not overwrite dirty draft.
+- Existing `useDebouncedMutation` tests remain unchanged and validate low-level timer behavior.
+
+## Files
+
+- Create: `apps/web/src/features/editor/hooks/useAutosavedDraft.ts`
+- Create: `apps/web/src/features/editor/hooks/__tests__/useAutosavedDraft.test.tsx`
+- Modify: `apps/web/src/features/editor/components/info/InfoTab.tsx`
+- Modify: `apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx`
+- Modify: `apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx`
+- Modify: `apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx`
+
+## Tasks
+
+- [ ] Add `useAutosavedDraft` with clear options: `serverValue`, `toDraft`, `isEqual`, `save`, `debounceMs`, `messages`, `onConflict`, `onError`.
+- [ ] Make the hook preserve local dirty draft when `serverValue` identity changes, while updating the accepted baseline/version only when safe.
+- [ ] Make save success clear dirty only when the submitted draft is still the current draft.
+- [x] Add focused tests for the new hook.
+- [x] Replace `InfoTab` local draft/baseline autosave logic with the new hook.
+- [x] Add regression test for `지도` not reverting to `지` after stale refetch.
+- [x] Replace `ReadingSectionEditor` reset-on-section-change logic with the new hook or a compatible adapter.
+- [x] Run focused tests and typecheck.
+- [x] Create PR with Coverage Plan and local validation evidence.
+- [ ] Complete PR review and merge.


### PR DESCRIPTION
Closes #607

## 요약
- 공통 `useAutosavedDraft` 훅을 추가해 draft, baseline, dirty 상태, debounce 저장, 즉시 저장, 토스트 피드백을 한 곳에서 관리합니다.
- 정보관리와 읽기대사 편집 화면을 새 자동저장 엔진으로 이관했습니다.
- 같은 엔티티에서 오래된 서버 refetch가 사용자가 입력 중인 제목/이름을 덮어쓰는 회귀를 테스트로 막았습니다.

## Coverage Plan
- `useAutosavedDraft`: dirty draft 보존, 같은 엔티티 stale refetch 무시, serverKey 전환 reset, 즉시 저장 동작을 훅 테스트로 검증했습니다.
- `InfoTab`: 제목을 `지`에서 `지도`로 입력 중일 때 이전 서버 응답이 돌아와도 draft가 `지`로 되돌아가지 않는지 검증했습니다.
- `ReadingSectionEditor`: 읽기대사 섹션 이름 변경 중 같은 섹션의 오래된 refetch가 draft를 덮지 않는지 검증했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/hooks/__tests__/useAutosavedDraft.test.tsx src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx` 통과: 3 files, 50 tests.
- `pnpm --filter @mmp/web typecheck` 통과.
- `pnpm --filter @mmp/web exec eslint src/features/editor/hooks/useAutosavedDraft.ts` 통과.
- `scripts/mmp-local-ci.sh quick` 통과: web test 186 files / 1752 tests, build 포함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 에디터의 자동저장 시스템이 개선되어 서버에서 데이터가 새로고침되는 중에도 사용자가 입력한 내용이 더 이상 덮어써지지 않습니다.

* **Tests**
  * 자동저장 및 초안 동기화 시나리오에 대한 테스트 커버리지가 추가되어 편집 안정성이 향상되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->