### PR TITLE
자동저장 화면의 수동 저장 버튼 제거

### DIFF
--- a/apps/web/src/features/editor/components/OverviewTab.tsx
+++ b/apps/web/src/features/editor/components/OverviewTab.tsx
@@ -1,5 +1,4 @@
-import { useState, useCallback, useEffect, useMemo, useRef, type FormEvent } from 'react';
-import { Button } from '@/shared/components/ui/Button';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   useUpdateTheme,
   type EditorThemeResponse,
@@ -107,7 +106,7 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
   const skipNextAutosaveRef = useRef(true);
 
   const updateTheme = useUpdateTheme(themeId);
-  const { schedule: scheduleOverviewSave, flush: flushOverviewSave } =
+  const { schedule: scheduleOverviewSave } =
     useEditorAutosaveToast<UpdateThemeRequest>({
     debounceMs: 1200,
     messages: {
@@ -200,16 +199,6 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
     return next;
   }, [coinPrice, description, durationMin, maxPlayers, minPlayers, price, title]);
 
-  function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    const validationErrors = validateDraft();
-    setErrors(validationErrors);
-    if (Object.keys(validationErrors).length > 0) return;
-
-    scheduleOverviewSave(autosaveBody);
-    flushOverviewSave();
-  }
-
   useEffect(() => {
     if (skipNextAutosaveRef.current) {
       skipNextAutosaveRef.current = false;
@@ -225,7 +214,7 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
   }, [autosaveBody, isOverviewDirty, scheduleOverviewSave, validateDraft]);
 
   return (
-    <form onSubmit={handleSubmit} className="mx-auto max-w-2xl px-4 py-6">
+    <div className="mx-auto max-w-2xl px-4 py-6">
       {/* ── 기본 정보 ── */}
       <SectionDivider label="기본 정보" />
 
@@ -346,12 +335,6 @@ export function OverviewTab({ themeId, theme }: OverviewTabProps) {
       <SectionDivider label="게임 유형" />
       <TemplateSettingsSection />
 
-      {/* Save */}
-      <div className="mt-8 flex justify-end">
-        <Button type="submit" isLoading={updateTheme.isPending}>
-          저장
-        </Button>
-      </div>
-    </form>
+    </div>
   );
 }

--- a/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/Editor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks (available inside vi.mock factories)
@@ -249,6 +249,13 @@ function defaultMutationReturn() {
   return { mutate: mutateMock, isPending: false };
 }
 
+async function flushOverviewAutosave() {
+  await act(async () => {
+    vi.advanceTimersByTime(1200);
+    await Promise.resolve();
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -256,6 +263,7 @@ function defaultMutationReturn() {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.useRealTimers();
 });
 
 // =========================================================================
@@ -411,33 +419,32 @@ describe('OverviewTab', () => {
     expect(screen.getByText('게임 유형과 초기 프리셋')).toBeDefined();
   });
 
-  it('빈 제목으로 제출 시 에러를 표시한다', () => {
+  it('빈 제목으로 자동저장 시 에러를 표시한다', async () => {
+    vi.useFakeTimers();
     render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
 
     // 제목을 공백만으로 설정 (trim 후 빈 문자열)
     const titleInput = screen.getByDisplayValue('테스트 테마');
     fireEvent.change(titleInput, { target: { value: '   ' } });
 
-    // 폼 제출 (저장 버튼 클릭)
-    const submitButton = screen.getByText('저장');
-    fireEvent.click(submitButton);
+    await flushOverviewAutosave();
 
     // 에러 메시지 표시
     expect(screen.getByText('제목은 필수입니다')).toBeDefined();
     // mutate가 호출되지 않아야 한다
     expect(mutateMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /^저장$/ })).toBeNull();
   });
 
-  it('유효한 제출 시 mutate를 올바른 body로 호출한다', () => {
+  it('유효한 변경 시 자동저장으로 mutate를 올바른 body로 호출한다', async () => {
+    vi.useFakeTimers();
     render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
 
     // 제목 변경
     const titleInput = screen.getByDisplayValue('테스트 테마');
     fireEvent.change(titleInput, { target: { value: '수정된 제목' } });
 
-    // 폼 제출
-    const submitButton = screen.getByText('저장');
-    fireEvent.click(submitButton);
+    await flushOverviewAutosave();
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const [body] = mutateMock.mock.calls[0];
@@ -447,13 +454,14 @@ describe('OverviewTab', () => {
     expect(body).toHaveProperty('duration_min', 90);
   });
 
-  it('미디어 관리 IMAGE를 커버 이미지 참조로 저장한다', () => {
+  it('미디어 관리 IMAGE를 커버 이미지 참조로 자동저장한다', async () => {
+    vi.useFakeTimers();
     render(<OverviewTab themeId="theme-1" theme={mockTheme} />);
 
     fireEvent.click(screen.getByText('미디어에서 커버 선택'));
     expect(screen.getByText('filter:IMAGE')).toBeDefined();
     fireEvent.click(screen.getByText('커버 이미지 선택'));
-    fireEvent.click(screen.getByText('저장'));
+    await flushOverviewAutosave();
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const [body] = mutateMock.mock.calls[0];

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -268,7 +268,6 @@ function SelectedLocationDetail({
 
   const {
     schedule: scheduleBasicInfoSave,
-    flush: flushBasicInfoSave,
     cancel: cancelBasicInfoSave,
   } = useEditorAutosaveToast<Partial<LocationResponse>>({
     debounceMs: 1000,
@@ -306,21 +305,6 @@ function SelectedLocationDetail({
     locationMeta,
     cancelBasicInfoSave,
   ]);
-
-  function saveBasicInfo() {
-    const nextName = basicDraft.name.trim();
-    if (!nextName) {
-      toast.error('장소 이름을 입력해 주세요');
-      return;
-    }
-
-    scheduleBasicInfoSave({
-      name: nextName,
-      public_description: basicDraft.publicDescription.trim() || null,
-      entry_message: basicDraft.entryMessage.trim() || null,
-    });
-    flushBasicInfoSave();
-  }
 
   const isBasicInfoDirty = useMemo(() => {
     const currentPublicDescription =
@@ -406,8 +390,6 @@ function SelectedLocationDetail({
               locationName={location.name}
               draft={basicDraft}
               onDraftChange={setBasicDraft}
-              onSave={saveBasicInfo}
-              isSaving={updateLocation.isPending}
             />
             <SceneVisibilityFields
               location={location}
@@ -465,27 +447,15 @@ function LocationBasicInfoFields({
   locationName,
   draft,
   onDraftChange,
-  onSave,
-  isSaving,
 }: {
   locationName: string;
   draft: LocationBasicDraft;
   onDraftChange: Dispatch<SetStateAction<LocationBasicDraft>>;
-  onSave: () => void;
-  isSaving: boolean;
 }) {
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
       <div className="flex items-center justify-between gap-2">
         <p className="text-xs font-semibold text-slate-300">기본 정보</p>
-        <button
-          type="button"
-          onClick={onSave}
-          disabled={isSaving}
-          className="rounded-md border border-amber-500/40 px-3 py-1.5 text-xs font-medium text-amber-100 transition hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          저장
-        </button>
       </div>
       <div className="mt-3 grid gap-3">
         <label className="text-xs text-slate-500">

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { screen, fireEvent, act } from '@testing-library/react';
 import {
   mockLocations,
   renderLocationsSubTab,
@@ -12,8 +12,19 @@ import {
 
 describe('LocationsSubTab 장소 기본 정보', () => {
   beforeEach(setupDefaultMocks);
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
-  it('공개 설명과 진입 메시지를 Location API payload로 저장한다', () => {
+  async function flushLocationAutosave() {
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+  }
+
+  it('공개 설명과 진입 메시지를 Location API payload로 자동저장한다', async () => {
+    vi.useFakeTimers();
     useEditorLocationsMock.mockReturnValue({
       data: [{ ...mockLocations[0], name: '거실' }, ...mockLocations.slice(1)],
       isLoading: false,
@@ -30,7 +41,8 @@ describe('LocationsSubTab 장소 기본 정보', () => {
     fireEvent.change(screen.getByLabelText('거실 진입 메시지'), {
       target: { value: '낡은 시계 소리가 들린다.' },
     });
-    fireEvent.click(screen.getByText('저장'));
+    expect(screen.queryByRole('button', { name: /^저장$/ })).toBeNull();
+    await flushLocationAutosave();
 
     expect(updateLocationMutateMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Plus, Save, Trash2, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Plus, Trash2, X } from 'lucide-react';
 
 import {
   useCreateStoryInfo,
@@ -137,7 +137,6 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   const [error, setError] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(() => !hasDisplayableBody(info));
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const exitEditModeAfterSaveRef = useRef(false);
   const updateInfo = useUpdateStoryInfo(themeId);
   const deleteInfo = useDeleteStoryInfo(themeId);
   const toInfoDraft = useCallback((value: StoryInfoResponse) => toEditableInfo(value), []);
@@ -182,8 +181,6 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
     draft,
     setDraft,
     baseline,
-    isDirty,
-    saveNow: saveInfoNow,
   } = useAutosavedDraft<StoryInfoResponse, StoryInfoResponse, StoryInfoResponse>({
     serverValue: info,
     serverKey: info.id,
@@ -199,15 +196,7 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
       success: '정보가 저장되었습니다',
       error: '정보 저장에 실패했습니다',
     },
-    onSaved: (saved) => {
-      const editableSaved = toEditableInfo(saved);
-      if (exitEditModeAfterSaveRef.current) {
-        setIsEditing(!hasDisplayableBody(editableSaved));
-        exitEditModeAfterSaveRef.current = false;
-      }
-    },
     onError: (err) => {
-      exitEditModeAfterSaveRef.current = false;
       setError(errorMessage(err, '저장에 실패했습니다'));
     },
   });
@@ -221,13 +210,6 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   function updateDraft(patch: Partial<StoryInfoResponse>) {
     setError(null);
     setDraft((current) => ({ ...current, ...patch }));
-  }
-
-  async function handleSave() {
-    setError(null);
-    if (!isDirty) return;
-    exitEditModeAfterSaveRef.current = true;
-    saveInfoNow();
   }
 
   async function handleDelete() {
@@ -315,7 +297,7 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
             />
           </div>
 
-          <div className="flex items-center justify-between border-t border-slate-800 pt-3">
+          <div className="flex items-center justify-start border-t border-slate-800 pt-3">
             <button
               type="button"
               onClick={() => setDeleteDialogOpen(true)}
@@ -324,15 +306,6 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
             >
               <Trash2 className="h-3 w-3" />
               정보 삭제
-            </button>
-            <button
-              type="button"
-              onClick={() => void handleSave()}
-              disabled={!isDirty || updateInfo.isPending}
-              className="flex items-center gap-1 rounded bg-amber-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-amber-400 disabled:bg-slate-700 disabled:text-slate-500"
-            >
-              <Save className="h-4 w-4" />
-              {updateInfo.isPending ? '저장 중...' : '저장'}
             </button>
           </div>
         </div>

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -187,6 +187,14 @@ function enterInfoEditMode() {
   fireEvent.click(screen.getByRole('button', { name: /정보 수정/ }));
 }
 
+async function flushInfoAutosave() {
+  await act(async () => {
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 let createMutate: ReturnType<typeof vi.fn>;
 let updateMutate: ReturnType<typeof vi.fn>;
 let deleteMutate: ReturnType<typeof vi.fn>;
@@ -446,15 +454,17 @@ describe('InfoTab', () => {
   });
 
   it('saves title/body without exposing image or reference fields', async () => {
+    vi.useFakeTimers();
     render(<InfoTab themeId="theme-1" />);
 
     enterInfoEditMode();
     fireEvent.change(screen.getByLabelText('정보 제목'), {
       target: { value: '수정된 정보' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    expect(screen.queryByRole('button', { name: /^저장$/ })).toBeNull();
+    await flushInfoAutosave();
 
-    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate).toHaveBeenCalledTimes(1);
     expect(updateMutate).toHaveBeenCalledWith({
       id: 'info-1',
       patch: {
@@ -560,7 +570,7 @@ describe('InfoTab', () => {
     fireEvent.change(screen.getByLabelText('정보 제목'), {
       target: { value: '저장 실패 확인' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushInfoAutosave();
 
     await act(async () => {
       await Promise.resolve();
@@ -582,7 +592,10 @@ describe('InfoTab', () => {
     expect(screen.queryByRole('alert')).toBeNull();
 
     updateMutate.mockRejectedValueOnce(new Error('failed to update story info'));
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    fireEvent.change(screen.getByLabelText('정보 제목'), {
+      target: { value: '저장 실패 재확인' },
+    });
+    await flushInfoAutosave();
     await act(async () => {
       await Promise.resolve();
     });
@@ -593,6 +606,7 @@ describe('InfoTab', () => {
   });
 
   it('clears a save error when the creator edits the story info again', async () => {
+    vi.useFakeTimers();
     updateMutate.mockRejectedValueOnce(new Error('failed to update story info'));
     render(<InfoTab themeId="theme-1" />);
 
@@ -600,9 +614,9 @@ describe('InfoTab', () => {
     fireEvent.change(screen.getByLabelText('정보 제목'), {
       target: { value: '저장 실패 확인' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushInfoAutosave();
 
-    expect(await screen.findByRole('alert')).toBeDefined();
+    expect(screen.getByRole('alert')).toBeDefined();
 
     fireEvent.change(screen.getByLabelText('정보 제목'), {
       target: { value: '다시 수정' },
@@ -612,6 +626,7 @@ describe('InfoTab', () => {
   });
 
   it('inserts media embeds into the MDX body and renders referenced media inside the editor', async () => {
+    vi.useFakeTimers();
     render(<InfoTab themeId="theme-1" />);
 
     enterInfoEditMode();
@@ -639,8 +654,8 @@ describe('InfoTab', () => {
     expect(within(editorSurface).getByLabelText('CCTV 후속 영상')).toBeDefined();
     expect(within(editorSurface).getByRole('button', { name: 'CCTV 후속 교체' })).toBeDefined();
 
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
-    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    await flushInfoAutosave();
+    expect(updateMutate).toHaveBeenCalledTimes(1);
     expect(updateMutate).toHaveBeenCalledWith({
       id: 'info-1',
       patch: expect.objectContaining({
@@ -681,17 +696,18 @@ describe('InfoTab', () => {
     );
   });
 
-  it('does not mark legacy image or reference metadata as editable changes', async () => {
+  it('does not expose a manual save button for legacy image or reference metadata', async () => {
     render(<InfoTab themeId="theme-1" />);
 
     enterInfoEditMode();
-    expect(screen.getByRole('button', { name: /저장/ })).toHaveProperty('disabled', true);
+    expect(screen.queryByRole('button', { name: /^저장$/ })).toBeNull();
     expect(mediaPickerPropsMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ filterType: 'IMAGE', selectedId: 'image-1' })
     );
   });
 
   it('uses the saved version for a second save without stale dirty metadata', async () => {
+    vi.useFakeTimers();
     updateMutate
       .mockResolvedValueOnce({
         ...baseInfo,
@@ -711,28 +727,22 @@ describe('InfoTab', () => {
     fireEvent.change(screen.getByLabelText('정보 제목'), {
       target: { value: '1차 수정' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
-    await waitFor(() =>
-      expect(updateMutate).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          patch: expect.objectContaining({ title: '1차 수정', version: 3 }),
-        })
-      )
+    await flushInfoAutosave();
+    expect(updateMutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        patch: expect.objectContaining({ title: '1차 수정', version: 3 }),
+      })
     );
 
-    await waitFor(() => expect(screen.getByRole('heading', { name: '1차 수정' })).toBeDefined());
-    enterInfoEditMode();
     fireEvent.change(screen.getByLabelText('정보 제목'), {
       target: { value: '2차 수정' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushInfoAutosave();
 
-    await waitFor(() =>
-      expect(updateMutate).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          patch: expect.objectContaining({ title: '2차 수정', version: 4 }),
-        })
-      )
+    expect(updateMutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        patch: expect.objectContaining({ title: '2차 수정', version: 4 }),
+      })
     );
   });
 

--- a/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
+++ b/apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FileInput, Play, Save, Trash2 } from 'lucide-react';
+import { FileInput, Play, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { queryClient } from '@/services/queryClient';
@@ -126,7 +126,14 @@ export function ReadingSectionEditor({
           characters.find((character) => character.isPlayable)?.id ??
           null,
       );
-      return result.issues.length > 0 ? null : result.patch;
+      if (result.issues.length > 0) {
+        setValidationIssues(result.issues);
+        setSaveError('저장 전에 미디어가 빠진 블록을 확인해 주세요.');
+        return null;
+      }
+      setValidationIssues([]);
+      setSaveError(null);
+      return result.patch;
     },
     [characters],
   );
@@ -134,7 +141,6 @@ export function ReadingSectionEditor({
     draft,
     setDraft,
     isDirty,
-    saveNow: saveReadingNow,
   } = useAutosavedDraft<ReadingSectionResponse, ReadingSectionDraft, UpdateReadingSectionRequest>({
     serverValue: section,
     serverKey: section.id,
@@ -194,11 +200,6 @@ export function ReadingSectionEditor({
   const validationIssueByLine = useMemo(
     () => new Map(validationIssues.map((issue) => [issue.lineIndex, issue.message])),
     [validationIssues]
-  );
-
-  const autosavePatch = useMemo(
-    () => buildReadingPatch(draft, section, characters, effectiveNarratorCharacterId),
-    [characters, draft, effectiveNarratorCharacterId, section],
   );
 
   // -------------------------------------------------------------------------
@@ -293,23 +294,6 @@ export function ReadingSectionEditor({
   function clearSaveFeedback() {
     setSaveError(null);
     setValidationIssues([]);
-  }
-
-  // -------------------------------------------------------------------------
-  // Save / Delete
-  // -------------------------------------------------------------------------
-
-  async function handleSave() {
-    setSaveError(null);
-    setConflict(false);
-    setValidationIssues([]);
-    if (autosavePatch.issues.length > 0) {
-      setValidationIssues(autosavePatch.issues);
-      setSaveError('저장 전에 미디어가 빠진 블록을 확인해 주세요.');
-      return;
-    }
-
-    saveReadingNow();
   }
 
   async function handleDelete() {
@@ -473,7 +457,7 @@ export function ReadingSectionEditor({
       </div>
 
       {/* Action bar */}
-      <div className="flex items-center justify-between border-t border-slate-700 pt-3">
+      <div className="flex items-center justify-start border-t border-slate-700 pt-3">
         <button
           type="button"
           onClick={() => setConfirmDelete((v) => !v)}
@@ -481,16 +465,6 @@ export function ReadingSectionEditor({
         >
           <Trash2 className="h-3 w-3" />
           섹션 삭제
-        </button>
-
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || updateMutation.isPending}
-          className="flex items-center gap-1 rounded bg-amber-500 px-3 py-1 text-xs font-medium text-slate-900 hover:bg-amber-400 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-500"
-        >
-          <Save className="h-3 w-3" />
-          {updateMutation.isPending ? '저장 중...' : '저장'}
         </button>
       </div>
 

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -120,6 +120,14 @@ const characters = [
 let mutateAsyncUpdate: ReturnType<typeof vi.fn>;
 let mutateAsyncDelete: ReturnType<typeof vi.fn>;
 
+async function flushReadingAutosave() {
+  await act(async () => {
+    vi.advanceTimersByTime(1200);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn();
   Object.assign(navigator, {
@@ -216,6 +224,7 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('saves section background music playback mode', async () => {
+    vi.useFakeTimers();
     useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
       if (type === 'BGM') {
         return {
@@ -241,9 +250,9 @@ describe('ReadingSectionEditor', () => {
     fireEvent.click(screen.getByRole('button', { name: '배경음악 선택' }));
     fireEvent.click(screen.getByText('오프닝 배경음악').closest('button') as HTMLElement);
     fireEvent.click(screen.getByRole('button', { name: '1회' }));
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.bgmMediaId).toBe('bgm-1');
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.bgmMode).toBe('once');
   });
@@ -278,14 +287,15 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('save calls useUpdateReadingSection with version + patch', async () => {
+    vi.useFakeTimers();
     renderEditor();
     const input = screen.getByLabelText('섹션 이름') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '재명명' } });
 
-    const saveBtn = screen.getByRole('button', { name: /저장/ });
-    fireEvent.click(saveBtn);
+    expect(screen.queryByRole('button', { name: /^저장$/ })).toBeNull();
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     const callArg = mutateAsyncUpdate.mock.calls[0][0];
     expect(callArg.id).toBe('sec-1');
     expect(callArg.patch.version).toBe(3);
@@ -294,6 +304,7 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('blocks save with a clear message when an image block has no selected image', async () => {
+    vi.useFakeTimers();
     renderEditor({
       section: {
         ...sampleSection,
@@ -310,7 +321,7 @@ describe('ReadingSectionEditor', () => {
       },
     });
     fireEvent.change(screen.getByLabelText('섹션 이름'), { target: { value: '이미지 확인' } });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
     expect(mutateAsyncUpdate).not.toHaveBeenCalled();
     expect(screen.getByText('저장 전에 미디어가 빠진 블록을 확인해 주세요.')).toBeTruthy();
@@ -318,6 +329,7 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('serializes cleared dialogue image references', async () => {
+    vi.useFakeTimers();
     useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
       if (type === 'IMAGE') {
         return {
@@ -349,13 +361,14 @@ describe('ReadingSectionEditor', () => {
 
     expect(screen.queryByText('현장 사진')).toBeNull();
     fireEvent.change(screen.getByLabelText('섹션 이름'), { target: { value: '이미지 정리' } });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines[0].ImageMediaID).toBe('');
   });
 
   it('imports pasted script into ordered reading blocks', async () => {
+    vi.useFakeTimers();
     useMediaListMock.mockImplementation((_themeId: string, type?: string) => {
       if (type === 'IMAGE') {
         return {
@@ -408,9 +421,9 @@ describe('ReadingSectionEditor', () => {
     });
     fireEvent.click(screen.getByLabelText('현재 블록을 대본 입력 결과로 교체합니다.'));
     fireEvent.click(screen.getByRole('button', { name: '블록으로 적용' }));
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines).toMatchObject([
       { Index: 0, Type: 'dialogue', Speaker: '나레이션' },
       { Index: 1, Type: 'image', MediaID: 'image-1' },
@@ -435,6 +448,7 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('does not save voice auto advance for blocks without voice media', async () => {
+    vi.useFakeTimers();
     renderEditor({
       section: {
         ...sampleSection,
@@ -457,9 +471,9 @@ describe('ReadingSectionEditor', () => {
       },
     });
     fireEvent.change(screen.getByLabelText('섹션 이름'), { target: { value: '정규화' } });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines).toMatchObject([
       { Index: 0, Type: 'image', AdvanceBy: 'gm' },
       { Index: 1, Type: 'dialogue', AdvanceBy: 'role:c1' },
@@ -467,6 +481,7 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('does not save role advance when no matching character exists', async () => {
+    vi.useFakeTimers();
     renderEditor({
       characters: [],
       section: {
@@ -483,14 +498,15 @@ describe('ReadingSectionEditor', () => {
       },
     });
     fireEvent.change(screen.getByLabelText('섹션 이름'), { target: { value: '역할 없음' } });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines[0].AdvanceBy).toBe('gm');
     expect(screen.queryByLabelText('진행 방식')).toBeNull();
   });
 
   it('saves narration and NPC dialogue with the selected narrator role', async () => {
+    vi.useFakeTimers();
     renderEditor({
       section: {
         ...sampleSection,
@@ -502,9 +518,9 @@ describe('ReadingSectionEditor', () => {
       },
     });
     fireEvent.change(screen.getByLabelText('나레이션 진행'), { target: { value: 'c2' } });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.narratorCharacterId).toBe('c2');
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines).toMatchObject([
       { AdvanceBy: 'role:c2' },
@@ -514,11 +530,12 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('moves blocks and keeps saved indices sequential', async () => {
+    vi.useFakeTimers();
     renderEditor();
     fireEvent.click(screen.getAllByLabelText('블록 아래로 이동')[0]);
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() => expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncUpdate).toHaveBeenCalledTimes(1);
     expect(mutateAsyncUpdate.mock.calls[0][0].patch.lines).toMatchObject([
       { Index: 0, Text: '누구냐?' },
       { Index: 1, Text: '어두운 방 안.' },
@@ -721,10 +738,9 @@ describe('ReadingSectionEditor', () => {
     expect(within(dialog).getByText('조명을 낮춘다.')).toBeTruthy();
   });
 
-  it('save button is disabled when not dirty', () => {
+  it('does not render a manual save button when autosave is active', () => {
     renderEditor();
-    const saveBtn = screen.getByRole('button', { name: /저장/ }) as HTMLButtonElement;
-    expect(saveBtn.disabled).toBe(true);
+    expect(screen.queryByRole('button', { name: /^저장$/ })).toBeNull();
   });
 
   it('delete section calls useDeleteReadingSection after confirm', async () => {
@@ -738,15 +754,14 @@ describe('ReadingSectionEditor', () => {
   });
 
   it('409 conflict error shows reload, preserve, and cancel recovery actions', async () => {
+    vi.useFakeTimers();
     mutateAsyncUpdate.mockRejectedValueOnce(new Error('HTTP 409 Conflict'));
     renderEditor();
     const input = screen.getByLabelText('섹션 이름') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'x' } });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() =>
-      expect(screen.getByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeTruthy()
-    );
+    expect(screen.getByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeTruthy();
     expect(screen.getByText(/다른 탭이나 사용자가 더 최신 내용을 저장했습니다/)).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: '내 변경 복사' }));
@@ -764,38 +779,40 @@ describe('ReadingSectionEditor', () => {
         2
       )
     );
-    await waitFor(() =>
-      expect(toast.success).toHaveBeenCalledWith('내 변경 내용을 클립보드에 복사했습니다')
-    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(toast.success).toHaveBeenCalledWith('내 변경 내용을 클립보드에 복사했습니다');
 
     fireEvent.click(screen.getByRole('button', { name: '최신 상태 다시 불러오기' }));
     expect(invalidateQueriesMock).toHaveBeenCalled();
     expect(screen.queryByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeNull();
 
     mutateAsyncUpdate.mockRejectedValueOnce(new Error('HTTP 409 Conflict'));
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
-    await waitFor(() =>
-      expect(screen.getByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeTruthy()
-    );
+    fireEvent.change(input, { target: { value: 'y' } });
+    await flushReadingAutosave();
+    expect(screen.getByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: '취소' }));
     expect(screen.queryByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeNull();
   });
 
   it('copy draft reports clipboard failure', async () => {
+    vi.useFakeTimers();
     writeTextMock.mockRejectedValueOnce(new Error('denied'));
     mutateAsyncUpdate.mockRejectedValueOnce(new Error('HTTP 409 Conflict'));
 
     renderEditor();
     const input = screen.getByLabelText('섹션 이름') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'x' } });
-    fireEvent.click(screen.getByRole('button', { name: /저장/ }));
+    await flushReadingAutosave();
 
-    await waitFor(() =>
-      expect(screen.getByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeTruthy()
-    );
+    expect(screen.getByRole('alert', { name: '읽기 대사 저장 충돌' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: '내 변경 복사' }));
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('클립보드에 복사할 수 없습니다'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(toast.error).toHaveBeenCalledWith('클립보드에 복사할 수 없습니다');
     expect(toast.success).not.toHaveBeenCalledWith('내 변경 내용을 클립보드에 복사했습니다');
   });
 });

--- a/docs/superpowers/plans/2026-05-17-remove-autosave-save-buttons.md
+++ b/docs/superpowers/plans/2026-05-17-remove-autosave-save-buttons.md
@@ -1,0 +1,35 @@
+# Remove Autosave Save Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 자동저장이 적용된 에디터 화면에서 혼동되는 일반 저장 버튼을 제거한다.
+
+**Architecture:** 저장 동작은 기존 자동저장 훅과 토스트를 유지하고, UI에서 수동 저장 버튼만 제거한다. 명시적 확정이 필요한 모달/트리거/역할지 저장 버튼은 자동저장 흐름이 아니므로 유지한다.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, MMP editor autosave hooks.
+
+---
+
+## Files
+
+- Modify: `apps/web/src/features/editor/components/info/InfoTab.tsx`
+- Modify: `apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx`
+- Modify: `apps/web/src/features/editor/components/reading/ReadingSectionEditor.tsx`
+- Modify: `apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx`
+- Modify: `apps/web/src/features/editor/components/OverviewTab.tsx`
+- Modify: `apps/web/src/features/editor/components/__tests__/Editor.test.tsx`
+- Modify: `apps/web/src/features/editor/components/design/LocationDetailPanel.tsx`
+- Modify: `apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx`
+
+## Tasks
+
+- [x] Remove the `InfoTab` edit-mode save button and unused manual save branch.
+- [x] Update `InfoTab` tests so save behavior is asserted through autosave instead of button clicks.
+- [x] Remove the `ReadingSectionEditor` save button and keep validation feedback tied to autosave errors.
+- [x] Update reading section tests so automatic save and validation behavior remain covered.
+- [x] Remove `OverviewTab` submit save button and prevent form submit from being the primary save path.
+- [x] Update overview/theme tests for autosave-only behavior.
+- [x] Remove `LocationDetailPanel` basic info save button while keeping delete and other explicit actions.
+- [x] Update location basic info tests for autosave-only behavior.
+- [x] Run focused frontend tests, typecheck, and local quick validation.
+- [ ] Create PR with Coverage Plan, handle CodeRabbit, and merge.


### PR DESCRIPTION
Closes #609

## 요약
- 자동저장이 적용된 정보/읽기 대사/테마 기본정보/장소 기본정보 화면의 일반 저장 버튼을 제거했습니다.
- 읽기 대사의 미디어 누락 검증은 자동저장 시점에도 같은 안내가 나오도록 유지했습니다.
- 관련 테스트를 버튼 클릭 기준에서 자동저장 타이머 기준으로 갱신했습니다.

## Coverage Plan
- InfoTab: 정보 제목/본문 자동저장, 오류 표시, 미디어 임베드 저장, saved version 갱신 경로를 테스트로 확인했습니다.
- ReadingSectionEditor: 섹션 기본정보, BGM, 블록 정규화, 검증 실패, 충돌 복구를 자동저장 기준으로 확인했습니다.
- OverviewTab: 테마 기본정보 유효성 검사와 커버 미디어 자동저장을 확인했습니다.
- LocationDetailPanel: 장소 기본정보 자동저장 payload와 토스트 성공 경로를 확인했습니다.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/components/__tests__/Editor.test.tsx src/features/editor/components/design/__tests__/LocationsSubTab.basicInfo.test.tsx
- pnpm --filter @mmp/web typecheck
- pnpm --filter @mmp/web exec eslint src/features/editor/components/info/InfoTab.tsx src/features/editor/components/reading/ReadingSectionEditor.tsx src/features/editor/components/OverviewTab.tsx src/features/editor/components/design/LocationDetailPanel.tsx
- scripts/mmp-local-ci.sh quick

## 비고
- local-ci quick의 전체 lint/build 단계는 기존 warning만 출력하고 성공했습니다.