### PR TITLE
ResourcePicker 파일 이미지 프리뷰 복구

### DIFF
--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@/features/editor/mediaApi", () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
   useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
   useMediaDownloadUrl: (...args: unknown[]) => useMediaDownloadUrlMock(...args),
+  useMediaDownloadUrls: () => [],
 }));
 
 vi.mock("@mdxeditor/editor", () => ({

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx
@@ -55,6 +55,7 @@ vi.mock("../../../readingApi", () => ({
 
 vi.mock("../../../mediaApi", () => ({
   useMediaList: () => ({ data: [], isLoading: false }),
+  useMediaDownloadUrls: () => [],
   useMediaCategories: () => ({ data: [] }),
   useRequestUploadUrl: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConfirmUpload: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/apps/web/src/features/editor/components/media/MediaPicker.tsx
+++ b/apps/web/src/features/editor/components/media/MediaPicker.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/features/editor/entities/mediaResource/mediaResourceAdapter";
 import {
   useMediaCategories,
+  useMediaDownloadUrls,
   useMediaList,
   type MediaResponse,
   type MediaType,
@@ -73,17 +74,27 @@ export function MediaPicker({
     () => (useCase ? resourceViewModels.filter((resource) => resource.isSelectable) : resourceViewModels),
     [resourceViewModels, useCase],
   );
-  const filteredResources = useMemo(
-    () =>
-      filterMediaResourceViewModels(selectableResources, searchQuery).map((resource) => {
-        const source = media.find((item) => item.id === resource.id);
-        return {
-          ...resource,
-          thumbnailUrl: source ? getMediaThumbnailUrl(source) : null,
-        };
-      }),
-    [media, selectableResources, searchQuery],
+  const fileImagePreviewIds = useMemo(
+    () => media.filter(needsDownloadUrlThumbnail).map((item) => item.id),
+    [media],
   );
+  const fileImagePreviewQueries = useMediaDownloadUrls(open ? fileImagePreviewIds : []);
+  const fileImagePreviewUrlById = new Map<string, string>();
+  fileImagePreviewQueries.forEach((query, index) => {
+    const previewUrl = query.data?.url;
+    if (previewUrl) {
+      fileImagePreviewUrlById.set(fileImagePreviewIds[index], previewUrl);
+    }
+  });
+  const filteredResources = filterMediaResourceViewModels(selectableResources, searchQuery).map((resource) => {
+    const source = media.find((item) => item.id === resource.id);
+    return {
+      ...resource,
+      thumbnailUrl: source
+        ? getMediaThumbnailUrl(source) ?? fileImagePreviewUrlById.get(source.id) ?? null
+        : null,
+    };
+  });
 
   if (!open) return null;
 
@@ -135,4 +146,8 @@ export function MediaPicker({
       />
     </>
   );
+}
+
+function needsDownloadUrlThumbnail(media: MediaResponse) {
+  return media.type === "IMAGE" && media.source_type === "FILE" && !media.url;
 }

--- a/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
@@ -8,12 +8,14 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 const {
   useMediaListMock,
   useMediaCategoriesMock,
+  useMediaDownloadUrlsMock,
   useRequestUploadUrlMock,
   useConfirmUploadMock,
   uploadMediaFileMock,
 } = vi.hoisted(() => ({
   useMediaListMock: vi.fn(),
   useMediaCategoriesMock: vi.fn(),
+  useMediaDownloadUrlsMock: vi.fn(),
   useRequestUploadUrlMock: vi.fn(),
   useConfirmUploadMock: vi.fn(),
   uploadMediaFileMock: vi.fn(),
@@ -22,6 +24,7 @@ const {
 vi.mock("@/features/editor/mediaApi", () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
   useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
+  useMediaDownloadUrls: (...args: unknown[]) => useMediaDownloadUrlsMock(...args),
   useRequestUploadUrl: () => useRequestUploadUrlMock(),
   useConfirmUpload: () => useConfirmUploadMock(),
   uploadMediaFile: (...args: unknown[]) => uploadMediaFileMock(...args),
@@ -114,6 +117,7 @@ beforeEach(() => {
   });
   useRequestUploadUrlMock.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
   useConfirmUploadMock.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+  useMediaDownloadUrlsMock.mockReturnValue([]);
 });
 
 afterEach(() => {
@@ -279,6 +283,43 @@ describe("MediaPicker", () => {
 
     expect(sources).toContain("https://example.com/evidence.webp");
     expect(sources).toContain("https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg");
+  });
+
+  it("공개 URL이 없는 파일 이미지도 download URL로 picker thumbnail을 표시한다", () => {
+    useMediaListMock.mockReturnValue({
+      data: [
+        {
+          ...mockMedia[3],
+          id: "private-image-1",
+          name: "비공개 증거 사진",
+          url: undefined,
+        },
+      ],
+      isLoading: false,
+    });
+    useMediaDownloadUrlsMock.mockReturnValue([
+      {
+        data: {
+          url: "https://download.example/private-image.webp",
+          expires_at: "2026-05-18T01:00:00Z",
+        },
+      },
+    ]);
+
+    render(
+      <MediaPicker
+        open={true}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        themeId="theme-1"
+      />,
+    );
+
+    expect(useMediaDownloadUrlsMock).toHaveBeenCalledWith(["private-image-1"]);
+    const images = Array.from(document.querySelectorAll("img")) as HTMLImageElement[];
+    expect(images.map((image) => image.getAttribute("src"))).toContain(
+      "https://download.example/private-image.webp",
+    );
   });
 
   it("selectedId와 일치하는 항목을 강조한다", () => {

--- a/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
+++ b/apps/web/src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx
@@ -50,6 +50,7 @@ vi.mock('@/features/editor/readingApi', async () => {
 vi.mock('@/features/editor/mediaApi', () => ({
   useMediaList: (...args: unknown[]) => useMediaListMock(...args),
   useMediaDownloadUrl: (...args: unknown[]) => useMediaDownloadUrlMock(...args),
+  useMediaDownloadUrls: () => [],
   useMediaCategories: (...args: unknown[]) => useMediaCategoriesMock(...args),
   useRequestUploadUrl: (...args: unknown[]) => useRequestUploadUrlMock(...args),
   useConfirmUpload: (...args: unknown[]) => useConfirmUploadMock(...args),

--- a/apps/web/src/features/editor/mediaApi.test.ts
+++ b/apps/web/src/features/editor/mediaApi.test.ts
@@ -36,6 +36,7 @@ import {
   useDeleteMedia,
   useMediaCategories,
   useMediaDownloadUrl,
+  useMediaDownloadUrls,
   useMediaList,
   useMediaDeletePreview,
   useRequestReplacementUpload,
@@ -236,6 +237,49 @@ describe("useMediaDownloadUrl", () => {
 
   it("does not fetch download URL without media id", () => {
     renderHook(() => useMediaDownloadUrl(undefined), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(api.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMediaDownloadUrls", () => {
+  it("fetches editor media download URLs for every requested media id", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({
+        url: "https://download.example/evidence-1.webp",
+        expires_at: "2026-05-02T00:10:00Z",
+      })
+      .mockResolvedValueOnce({
+        url: "https://download.example/evidence-2.webp",
+        expires_at: "2026-05-02T00:10:00Z",
+      });
+
+    const { result } = renderHook(
+      () => useMediaDownloadUrls(["media-image-1", "media-image-2"]),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.every((query) => query.isSuccess)).toBe(true);
+    });
+    expect(api.get).toHaveBeenNthCalledWith(
+      1,
+      "/v1/editor/media/media-image-1/download-url",
+    );
+    expect(api.get).toHaveBeenNthCalledWith(
+      2,
+      "/v1/editor/media/media-image-2/download-url",
+    );
+    expect(result.current.map((query) => query.data?.url)).toEqual([
+      "https://download.example/evidence-1.webp",
+      "https://download.example/evidence-2.webp",
+    ]);
+  });
+
+  it("does not fetch download URLs when the requested list is empty", () => {
+    renderHook(() => useMediaDownloadUrls([]), {
       wrapper: makeWrapper(),
     });
 

--- a/apps/web/src/features/editor/mediaApi.ts
+++ b/apps/web/src/features/editor/mediaApi.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 
 import { api } from "@/services/api";
 import { queryClient } from "@/services/queryClient";
@@ -157,12 +157,25 @@ export function useMediaDeletePreview(mediaId?: string) {
 export function useMediaDownloadUrl(mediaId?: string) {
   return useQuery<MediaDownloadUrlResponse>({
     queryKey: mediaKeys.downloadUrl(mediaId ?? ""),
-    queryFn: () =>
-      api.get<MediaDownloadUrlResponse>(
-        `/v1/editor/media/${mediaId}/download-url`,
-      ),
+    queryFn: () => getMediaDownloadUrl(mediaId ?? ""),
     enabled: !!mediaId,
   });
+}
+
+export function useMediaDownloadUrls(mediaIds: string[]) {
+  return useQueries({
+    queries: mediaIds.map((mediaId) => ({
+      queryKey: mediaKeys.downloadUrl(mediaId),
+      queryFn: () => getMediaDownloadUrl(mediaId),
+      enabled: mediaId.length > 0,
+    })),
+  });
+}
+
+function getMediaDownloadUrl(mediaId: string) {
+  return api.get<MediaDownloadUrlResponse>(
+    `/v1/editor/media/${mediaId}/download-url`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-05-18-resource-picker-file-image-preview.md
+++ b/docs/superpowers/plans/2026-05-18-resource-picker-file-image-preview.md
@@ -1,0 +1,30 @@
+# ResourcePicker file image preview recovery
+
+## Goal
+
+ResourcePicker should show image thumbnails for file-backed media that do not have a public `media.url`, using the same editor download-url contract already used by MediaCard and ImageMediaReferenceField.
+
+Issue: #611
+
+## Constraints
+
+- Keep ResourcePicker presentational; storage/download logic stays in MediaPicker/mediaApi.
+- Do not change selection behavior or media filtering.
+- Query download URLs only for file image media without a direct URL.
+
+## Coverage Plan
+
+- `apps/web/src/features/editor/mediaApi.test.ts`
+  - Cover batched download-url hook calls for multiple media ids.
+- `apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx`
+  - Cover ResourcePicker thumbnails receiving download URLs for file image media without `url`.
+
+## Checklist
+
+- [x] Add reusable multi-download-url hook in `mediaApi`.
+- [x] Use it in `MediaPicker` to fill `thumbnailUrl` for private file images.
+- [x] Add focused tests for the fixed behavior.
+- [x] Run focused tests and typecheck.
+- [x] Run local quick validation.
+- [x] Create issue.
+- [ ] Create PR, clear review, merge, and return to latest `main`.


### PR DESCRIPTION
Closes #611

## 변경 내용
- `mediaApi`에 복수 media download URL 조회 훅을 추가했습니다.
- `MediaPicker`가 공개 URL이 없는 FILE IMAGE 미디어에 대해 download URL을 받아 `ResourcePicker` 썸네일로 전달하도록 수정했습니다.
- 완전 mock 기반 테스트들이 새 mediaApi export를 알도록 보정했습니다.

## Coverage Plan
- `apps/web/src/features/editor/mediaApi.test.ts`: 복수 media id download URL 조회 훅 검증
- `apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx`: 공개 URL 없는 파일 이미지가 picker thumbnail으로 표시되는 회귀 테스트
- 전체 web 테스트에서 MediaPicker를 포함해 렌더링하는 기존 mock 테스트 호환성 확인

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx src/features/editor/components/media/__tests__/MediaPicker.test.tsx src/features/editor/mediaApi.test.ts` ✅ 5 files / 112 tests
- `pnpm --filter @mmp/web exec eslint src/features/editor/components/media/MediaPicker.tsx src/features/editor/mediaApi.ts src/features/editor/components/media/__tests__/MediaPicker.test.tsx src/features/editor/mediaApi.test.ts src/features/editor/components/reading/__tests__/ReadingSectionEditor.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelExtended.test.tsx` ✅
- `MMP_LOCAL_CI_SKIP_INSTALL=1 scripts/mmp-local-ci.sh quick` ✅ final HEAD da979b8a7e1a6b2220e448380a5c19d3a6cf0a96

## Notes
- Quick lint/build 로그에는 기존 repo-wide lint warnings와 Rollup chunk warnings가 남지만 실패는 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 미디어 썸네일 표시 기능 개선 - 파일 기반 이미지도 다운로드 URL을 통해 미리보기 표시 가능

* **테스트**
  * 다중 미디어 다운로드 URL 조회 기능에 대한 테스트 추가
  * 기존 테스트 환경 호환성 강화

* **문서**
  * 리소스 선택기의 파일 이미지 미리보기 기능 관련 계획 문서 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->