### PR TITLE
R2 CORS 차단 시 미디어 업로드 fallback

### DIFF
--- a/apps/server/cmd/server/routes_editor_media.go
+++ b/apps/server/cmd/server/routes_editor_media.go
@@ -11,6 +11,7 @@ func registerEditorMediaRoutes(r chi.Router, deps authedDeps) {
 	r.Get("/themes/{id}/media/categories", deps.media.ListCategories)
 	r.Post("/themes/{id}/media/categories", deps.media.CreateCategory)
 	r.Post("/themes/{id}/media/upload-url", deps.media.RequestUpload)
+	r.Put("/themes/{id}/media/uploads/{uploadID}", deps.media.UploadObject)
 	r.Post("/themes/{id}/media/confirm", deps.media.ConfirmUpload)
 	r.Post("/themes/{id}/media/youtube", deps.media.CreateYouTube)
 	r.Patch("/media/categories/{id}", deps.media.UpdateCategory)

--- a/apps/server/internal/domain/editor/image_service_test.go
+++ b/apps/server/internal/domain/editor/image_service_test.go
@@ -183,6 +183,9 @@ func (fakeImageStorage) GenerateUploadURL(context.Context, string, string, int64
 func (fakeImageStorage) GenerateDownloadURL(_ context.Context, key string, _ time.Duration) (string, error) {
 	return "https://cdn.example/" + key, nil
 }
+func (fakeImageStorage) PutObject(context.Context, string, io.Reader, string, int64) error {
+	return nil
+}
 func (fakeImageStorage) HeadObject(_ context.Context, key string) (*storage.ObjectMeta, error) {
 	return &storage.ObjectMeta{Key: key}, nil
 }

--- a/apps/server/internal/domain/editor/media_handler.go
+++ b/apps/server/internal/domain/editor/media_handler.go
@@ -145,6 +145,28 @@ func (h *MediaHandler) RequestUpload(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusCreated, resp)
 }
 
+// UploadObject handles PUT /editor/themes/{id}/media/uploads/{uploadID}.
+func (h *MediaHandler) UploadObject(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	themeID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	uploadID, err := parseUUID(r, "uploadID")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, MaxMediaFileSize+1)
+	if err := h.svc.UploadObject(r.Context(), creatorID, themeID, uploadID, r.Body); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // ConfirmUpload handles POST /editor/themes/{id}/media/confirm.
 func (h *MediaHandler) ConfirmUpload(w http.ResponseWriter, r *http.Request) {
 	creatorID := middleware.UserIDFrom(r.Context())

--- a/apps/server/internal/domain/editor/media_handler_test.go
+++ b/apps/server/internal/domain/editor/media_handler_test.go
@@ -141,6 +141,10 @@ func TestMediaHandler_FileAndYouTubeMutations(t *testing.T) {
 		Return(&UploadURLResponse{UploadID: uploadID, UploadURL: "https://upload.example/new", ExpiresAt: time.Now()}, nil).
 		Times(1)
 	mock.EXPECT().
+		UploadObject(gomock.Any(), gomock.Any(), themeID, uploadID, gomock.Any()).
+		Return(nil).
+		Times(1)
+	mock.EXPECT().
 		ConfirmUpload(gomock.Any(), gomock.Any(), themeID, ConfirmUploadRequest{UploadID: uploadID}).
 		Return(&MediaResponse{ID: mediaID, ThemeID: themeID, Name: "map", Type: MediaTypeImage, SourceType: SourceTypeFile, Tags: []string{}, CreatedAt: time.Now()}, nil).
 		Times(1)
@@ -166,6 +170,13 @@ func TestMediaHandler_FileAndYouTubeMutations(t *testing.T) {
 	h.RequestUpload(requestUploadW, requestUpload)
 	if requestUploadW.Code != http.StatusCreated {
 		t.Fatalf("expected upload request 201, got %d: %s", requestUploadW.Code, requestUploadW.Body.String())
+	}
+
+	uploadObject := mediaHandlerRequest(http.MethodPut, "/editor/themes/"+themeID.String()+"/media/uploads/"+uploadID.String(), []byte("png-body"), map[string]string{"id": themeID.String(), "uploadID": uploadID.String()})
+	uploadObjectW := httptest.NewRecorder()
+	h.UploadObject(uploadObjectW, uploadObject)
+	if uploadObjectW.Code != http.StatusNoContent {
+		t.Fatalf("expected object upload 204, got %d: %s", uploadObjectW.Code, uploadObjectW.Body.String())
 	}
 
 	confirmUpload := mediaHandlerRequest(http.MethodPost, "/editor/themes/"+themeID.String()+"/media/confirm", []byte(`{"upload_id":"`+uploadID.String()+`"}`), map[string]string{"id": themeID.String()})

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -1,6 +1,7 @@
 package editor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -31,6 +32,7 @@ type MediaService interface {
 	UpdateCategory(ctx context.Context, creatorID, categoryID uuid.UUID, req MediaCategoryRequest) (*MediaCategoryResponse, error)
 	DeleteCategory(ctx context.Context, creatorID, categoryID uuid.UUID) error
 	RequestUpload(ctx context.Context, creatorID, themeID uuid.UUID, req RequestMediaUploadRequest) (*UploadURLResponse, error)
+	UploadObject(ctx context.Context, creatorID, themeID, uploadID uuid.UUID, body io.Reader) error
 	ConfirmUpload(ctx context.Context, creatorID, themeID uuid.UUID, req ConfirmUploadRequest) (*MediaResponse, error)
 	CreateYouTube(ctx context.Context, creatorID, themeID uuid.UUID, req CreateMediaYouTubeRequest) (*MediaResponse, error)
 	UpdateMedia(ctx context.Context, creatorID, mediaID uuid.UUID, req UpdateMediaRequest) (*MediaResponse, error)
@@ -303,6 +305,59 @@ func (s *mediaService) RequestUpload(ctx context.Context, creatorID, themeID uui
 		UploadURL: uploadURL,
 		ExpiresAt: time.Now().Add(expiry),
 	}, nil
+}
+
+func (s *mediaService) UploadObject(ctx context.Context, creatorID, themeID, uploadID uuid.UUID, body io.Reader) error {
+	if err := s.requireStorage(); err != nil {
+		return err
+	}
+	if _, err := s.ownedTheme(ctx, creatorID, themeID); err != nil {
+		return err
+	}
+	media, err := s.q.GetMediaWithOwner(ctx, db.GetMediaWithOwnerParams{
+		ID:        uploadID,
+		CreatorID: creatorID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.NotFound("upload not found")
+		}
+		s.logger.Error().Err(err).Str("media_id", uploadID.String()).Msg("failed to get media")
+		return apperror.Internal("failed to get media")
+	}
+	if media.ThemeID != themeID {
+		return apperror.NotFound("upload not found")
+	}
+	if media.SourceType != SourceTypeFile || !media.StorageKey.Valid || !media.FileSize.Valid || !media.MimeType.Valid {
+		return apperror.New(apperror.ErrMediaInvalidType, 422, "media is not a pending file upload")
+	}
+	declaredSize := media.FileSize.Int64
+	if declaredSize <= 0 || declaredSize > MaxMediaFileSize {
+		return apperror.New(apperror.ErrMediaTooLarge, 422, "file exceeds maximum size")
+	}
+	payload, err := io.ReadAll(io.LimitReader(body, declaredSize+1))
+	if err != nil {
+		return apperror.Internal("failed to read upload body")
+	}
+	if int64(len(payload)) != declaredSize {
+		return apperror.New(apperror.ErrMediaTooLarge, 422, "uploaded file size mismatch")
+	}
+	if err := s.storage.PutObject(ctx, media.StorageKey.String, bytes.NewReader(payload), media.MimeType.String, declaredSize); err != nil {
+		s.logger.Error().Err(err).Str("storage_key", media.StorageKey.String).Msg("failed to upload media object through server")
+		return apperror.Internal("failed to upload media object")
+	}
+	meta, err := s.storage.HeadObject(ctx, media.StorageKey.String)
+	if err != nil {
+		s.logger.Error().Err(err).Str("storage_key", media.StorageKey.String).Msg("failed to verify server-uploaded object")
+		return apperror.Internal("failed to verify upload")
+	}
+	if meta.Size != declaredSize {
+		cleanupCtx, cancel := storageCleanupContext(ctx)
+		defer cancel()
+		_ = s.storage.DeleteObject(cleanupCtx, media.StorageKey.String)
+		return apperror.New(apperror.ErrMediaTooLarge, 422, "uploaded file size mismatch")
+	}
+	return nil
 }
 
 func mediaUploadDurationParam(mediaType string, duration *int32) (pgtype.Int4, error) {

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -531,6 +531,15 @@ func (f *fakeStorageProvider) GenerateDownloadURL(_ context.Context, key string,
 	return "https://download.example/" + key, nil
 }
 
+func (f *fakeStorageProvider) PutObject(_ context.Context, key string, body io.Reader, _ string, _ int64) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	f.objects[key] = b
+	return nil
+}
+
 func (f *fakeStorageProvider) HeadObject(_ context.Context, key string) (*storage.ObjectMeta, error) {
 	if f.headErr != nil {
 		return nil, f.headErr
@@ -1919,6 +1928,42 @@ func TestMediaService_RequestUploadURL_ImageSuccess(t *testing.T) {
 	created := q.media[resp.UploadID]
 	if created.Type != MediaTypeImage || !created.StorageKey.Valid || !strings.HasSuffix(created.StorageKey.String, ".png") {
 		t.Fatalf("unexpected image media row: %#v", created)
+	}
+}
+
+func TestMediaService_UploadObject_StoresPendingUploadBody(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	uploadID := seedFileMedia(q, themeID, MediaTypeImage)
+	media := q.media[uploadID]
+	media.FileSize = pgtype.Int8{Int64: 8, Valid: true}
+	media.MimeType = pgtype.Text{String: "image/png", Valid: true}
+	q.media[uploadID] = media
+
+	if err := svc.UploadObject(context.Background(), creatorID, themeID, uploadID, strings.NewReader("png-body")); err != nil {
+		t.Fatalf("UploadObject: %v", err)
+	}
+
+	if got := string(st.objects[media.StorageKey.String]); got != "png-body" {
+		t.Fatalf("stored body = %q", got)
+	}
+}
+
+func TestMediaService_UploadObject_SizeMismatchCleansObject(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	uploadID := seedFileMedia(q, themeID, MediaTypeImage)
+	media := q.media[uploadID]
+	media.FileSize = pgtype.Int8{Int64: 4, Valid: true}
+	media.MimeType = pgtype.Text{String: "image/png", Valid: true}
+	q.media[uploadID] = media
+
+	err := svc.UploadObject(context.Background(), creatorID, themeID, uploadID, strings.NewReader("too-large"))
+	assertMediaAppCode(t, err, apperror.ErrMediaTooLarge)
+	if _, ok := st.objects[media.StorageKey.String]; ok {
+		t.Fatalf("size mismatch should remove stored object")
 	}
 }
 

--- a/apps/server/internal/domain/editor/mock_media_service_test.go
+++ b/apps/server/internal/domain/editor/mock_media_service_test.go
@@ -11,6 +11,7 @@ package editor
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 
 	uuid "github.com/google/uuid"
@@ -284,6 +285,20 @@ func (m *MockMediaService) UpdateMedia(ctx context.Context, creatorID, mediaID u
 func (mr *MockMediaServiceMockRecorder) UpdateMedia(ctx, creatorID, mediaID, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMedia", reflect.TypeOf((*MockMediaService)(nil).UpdateMedia), ctx, creatorID, mediaID, req)
+}
+
+// UploadObject mocks base method.
+func (m *MockMediaService) UploadObject(ctx context.Context, creatorID, themeID, uploadID uuid.UUID, body io.Reader) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadObject", ctx, creatorID, themeID, uploadID, body)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadObject indicates an expected call of UploadObject.
+func (mr *MockMediaServiceMockRecorder) UploadObject(ctx, creatorID, themeID, uploadID, body any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadObject", reflect.TypeOf((*MockMediaService)(nil).UploadObject), ctx, creatorID, themeID, uploadID, body)
 }
 
 // MockmediaQueries is a mock of mediaQueries interface.

--- a/apps/server/internal/infra/storage/local.go
+++ b/apps/server/internal/infra/storage/local.go
@@ -73,6 +73,26 @@ func (l *LocalProvider) HeadObject(_ context.Context, key string) (*ObjectMeta, 
 	}, nil
 }
 
+func (l *LocalProvider) PutObject(_ context.Context, key string, body io.Reader, _ string, _ int64) error {
+	destPath, err := l.safePath(key)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("storage: local create upload directory: %w", err)
+	}
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("storage: local create upload file: %w", err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, body); err != nil {
+		return fmt.Errorf("storage: local write upload file: %w", err)
+	}
+	l.log.Debug().Str("key", key).Str("path", destPath).Msg("local object uploaded")
+	return nil
+}
+
 // GetObjectRange reads a byte range from a locally stored file.
 func (l *LocalProvider) GetObjectRange(_ context.Context, key string, offset int64, length int64) (io.ReadCloser, error) {
 	path := filepath.Join(l.baseDir, filepath.FromSlash(key))
@@ -135,32 +155,14 @@ func (l *LocalProvider) UploadHandler() http.HandlerFunc {
 			return
 		}
 
-		destPath := filepath.Join(l.baseDir, filepath.FromSlash(key))
-
-		// Guard against path traversal: ensure resolved path stays within baseDir.
-		absBase, _ := filepath.Abs(l.baseDir)
-		absDest, _ := filepath.Abs(destPath)
-		if !strings.HasPrefix(absDest, absBase+string(os.PathSeparator)) {
+		destPath, err := l.safePath(key)
+		if err != nil {
 			apperror.WriteError(w, r, apperror.BadRequest("invalid path"))
 			return
 		}
 
-		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-			l.log.Error().Err(err).Str("path", destPath).Msg("failed to create upload directory")
-			apperror.WriteError(w, r, apperror.Internal("failed to create upload directory").Wrap(err))
-			return
-		}
-
-		f, err := os.Create(destPath)
-		if err != nil {
-			l.log.Error().Err(err).Str("path", destPath).Msg("failed to create upload file")
-			apperror.WriteError(w, r, apperror.Internal("failed to create upload file").Wrap(err))
-			return
-		}
-		defer f.Close()
-
 		r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10MB hard cap
-		if _, err := io.Copy(f, r.Body); err != nil {
+		if err := l.PutObject(r.Context(), key, r.Body, r.Header.Get("Content-Type"), r.ContentLength); err != nil {
 			l.log.Error().Err(err).Str("path", destPath).Msg("failed to write upload file")
 			apperror.WriteError(w, r, apperror.Internal("failed to write upload file").Wrap(err))
 			return
@@ -198,6 +200,16 @@ func (l *LocalProvider) ServeHandler() http.HandlerFunc {
 
 		http.ServeFile(w, r, filePath)
 	}
+}
+
+func (l *LocalProvider) safePath(key string) (string, error) {
+	destPath := filepath.Join(l.baseDir, filepath.FromSlash(key))
+	absBase, _ := filepath.Abs(l.baseDir)
+	absDest, _ := filepath.Abs(destPath)
+	if absDest != absBase && !strings.HasPrefix(absDest, absBase+string(os.PathSeparator)) {
+		return "", fmt.Errorf("storage: local invalid path")
+	}
+	return destPath, nil
 }
 
 // limitedReadCloser combines an io.Reader with an io.Closer so we can close

--- a/apps/server/internal/infra/storage/provider.go
+++ b/apps/server/internal/infra/storage/provider.go
@@ -22,6 +22,7 @@ type ObjectMeta struct {
 type Provider interface {
 	GenerateUploadURL(ctx context.Context, key string, contentType string, maxSize int64, expiry time.Duration) (string, error)
 	GenerateDownloadURL(ctx context.Context, key string, expiry time.Duration) (string, error)
+	PutObject(ctx context.Context, key string, body io.Reader, contentType string, size int64) error
 	HeadObject(ctx context.Context, key string) (*ObjectMeta, error)
 	GetObjectRange(ctx context.Context, key string, offset int64, length int64) (io.ReadCloser, error)
 	DeleteObject(ctx context.Context, key string) error

--- a/apps/server/internal/infra/storage/r2.go
+++ b/apps/server/internal/infra/storage/r2.go
@@ -96,6 +96,23 @@ func (r *r2Provider) GenerateDownloadURL(ctx context.Context, key string, expiry
 	return resp.URL, nil
 }
 
+func (r *r2Provider) PutObject(ctx context.Context, key string, body io.Reader, contentType string, size int64) error {
+	input := &s3.PutObjectInput{
+		Bucket:        aws.String(r.bucket),
+		Key:           aws.String(key),
+		Body:          body,
+		ContentType:   aws.String(contentType),
+		ContentLength: aws.Int64(size),
+	}
+
+	if _, err := r.client.PutObject(ctx, input); err != nil {
+		r.log.Error().Err(err).Str("key", key).Msg("failed to put object")
+		return fmt.Errorf("storage: put object: %w", err)
+	}
+	r.log.Debug().Str("key", key).Int64("size", size).Msg("object uploaded")
+	return nil
+}
+
 func (r *r2Provider) HeadObject(ctx context.Context, key string) (*ObjectMeta, error) {
 	input := &s3.HeadObjectInput{
 		Bucket: aws.String(r.bucket),

--- a/apps/web/e2e/editor-media-upload-fallback.spec.ts
+++ b/apps/web/e2e/editor-media-upload-fallback.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  BASE,
+  THEME_ID,
+  freshState,
+  loginAsE2EUser,
+  mockCommonApis,
+} from './helpers/editor-golden-path-fixtures';
+
+test.describe('미디어 업로드 fallback', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommonApis(page, freshState());
+    await loginAsE2EUser(page);
+  });
+
+  test('R2 직접 PUT이 막히면 백엔드 업로드 API로 이어서 confirm한다', async ({ page }) => {
+    const uploadId = '11111111-1111-1111-1111-111111111111';
+    const directPutUrls: string[] = [];
+    const fallbackUploads: Array<{ url: string; method: string; bodySize: number }> = [];
+    let confirmCalls = 0;
+
+    await page.route(`**/v1/editor/themes/${THEME_ID}/media/upload-url`, (route) =>
+      route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          upload_id: uploadId,
+          upload_url: 'https://mock-r2.example/themes/e2e/upload.png',
+          expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+        }),
+      }),
+    );
+
+    await page.route('https://mock-r2.example/**', (route) => {
+      directPutUrls.push(route.request().url());
+      return route.fulfill({ status: 403, contentType: 'text/plain', body: 'CORS blocked' });
+    });
+
+    await page.route(`**/api/v1/editor/themes/${THEME_ID}/media/uploads/${uploadId}`, async (route) => {
+      const request = route.request();
+      fallbackUploads.push({
+        url: request.url(),
+        method: request.method(),
+        bodySize: (request.postDataBuffer() ?? Buffer.alloc(0)).byteLength,
+      });
+      return route.fulfill({ status: 204, body: '' });
+    });
+
+    await page.route(`**/v1/editor/themes/${THEME_ID}/media/confirm`, async (route) => {
+      confirmCalls += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'media-uploaded',
+          theme_id: THEME_ID,
+          name: 'fallback-image',
+          type: 'IMAGE',
+          source_type: 'FILE',
+          url: 'https://mock-storage.example/themes/e2e/upload.png',
+          file_size: 4,
+          mime_type: 'image/png',
+          tags: [],
+          sort_order: 0,
+          created_at: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/media`);
+    await expect(page.getByRole('tab', { name: /미디어/, selected: true })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole('button', { name: '파일 업로드' }).click();
+    await page.setInputFiles('[data-testid="media-upload-input"]', {
+      name: 'fallback-image.png',
+      mimeType: 'image/png',
+      buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    });
+    await page.getByRole('dialog', { name: '파일 업로드' }).getByRole('button', { name: '업로드' }).click();
+
+    await expect.poll(() => directPutUrls.length).toBe(3);
+    await expect.poll(() => fallbackUploads.length).toBe(1);
+    await expect.poll(() => confirmCalls).toBe(1);
+    expect(fallbackUploads[0]).toMatchObject({
+      method: 'PUT',
+      bodySize: 4,
+    });
+  });
+});

--- a/apps/web/src/features/editor/mediaApi.test.ts
+++ b/apps/web/src/features/editor/mediaApi.test.ts
@@ -658,10 +658,44 @@ describe("uploadMediaFile", () => {
     expect(result).toEqual(mockMedia);
   });
 
-  it("fails after exhausting all PUT retry attempts", async () => {
+  it("falls back to the authenticated server upload when direct PUT attempts are exhausted", async () => {
     const requestUploadUrl = vi.fn().mockResolvedValue(mockUploadUrl);
     const confirmUpload = vi.fn().mockResolvedValue(mockMedia);
     const putFile = vi.fn().mockRejectedValue(new Error("network down"));
+    const uploadFileViaServer = vi.fn().mockResolvedValue(undefined);
+
+    const result = await uploadMediaFile({
+      themeId: THEME_ID,
+      file,
+      type: "BGM",
+      name: "song",
+      requestUploadUrl,
+      confirmUpload,
+      putFile,
+      uploadFileViaServer,
+      retryBaseDelayMs: 0,
+    });
+
+    expect(putFile).toHaveBeenCalledTimes(3);
+    expect(uploadFileViaServer).toHaveBeenCalledWith({
+      themeId: THEME_ID,
+      uploadId: mockUploadUrl.upload_id,
+      file,
+      contentType: "audio/mpeg",
+      onProgress: undefined,
+      signal: undefined,
+    });
+    expect(confirmUpload).toHaveBeenCalledWith({ upload_id: "upload-1" });
+    expect(result).toEqual(mockMedia);
+  });
+
+  it("fails when both direct PUT and the authenticated fallback upload fail", async () => {
+    const requestUploadUrl = vi.fn().mockResolvedValue(mockUploadUrl);
+    const confirmUpload = vi.fn().mockResolvedValue(mockMedia);
+    const putFile = vi.fn().mockRejectedValue(new Error("network down"));
+    const uploadFileViaServer = vi
+      .fn()
+      .mockRejectedValue(new Error("fallback unavailable"));
 
     await expect(
       uploadMediaFile({
@@ -672,11 +706,13 @@ describe("uploadMediaFile", () => {
         requestUploadUrl,
         confirmUpload,
         putFile,
+        uploadFileViaServer,
         retryBaseDelayMs: 0,
       }),
-    ).rejects.toThrow("network down");
+    ).rejects.toThrow("fallback unavailable");
 
     expect(putFile).toHaveBeenCalledTimes(3);
+    expect(uploadFileViaServer).toHaveBeenCalledTimes(1);
     expect(confirmUpload).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/features/editor/mediaApi.ts
+++ b/apps/web/src/features/editor/mediaApi.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 
 import { api } from "@/services/api";
 import { queryClient } from "@/services/queryClient";
+import { useAuthStore } from "@/stores/authStore";
 
 // ---------------------------------------------------------------------------
 // Types — match backend snake_case JSON exactly
@@ -312,6 +313,15 @@ export interface PutFileParams {
   signal?: AbortSignal;
 }
 
+export interface ServerUploadFileParams {
+  themeId: string;
+  uploadId: string;
+  file: File;
+  contentType?: string;
+  onProgress?: (percent: number) => void;
+  signal?: AbortSignal;
+}
+
 /** Default putFile implementation using XHR for progress events. */
 export function defaultPutFile(params: PutFileParams): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -352,6 +362,52 @@ export function defaultPutFile(params: PutFileParams): Promise<void> {
   });
 }
 
+export function defaultUploadFileViaServer(params: ServerUploadFileParams): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open(
+      "PUT",
+      `/api/v1/editor/themes/${params.themeId}/media/uploads/${params.uploadId}`,
+      true,
+    );
+    const contentType = params.contentType ?? params.file.type;
+    if (contentType) {
+      xhr.setRequestHeader("Content-Type", contentType);
+    }
+    const accessToken = useAuthStore.getState().accessToken;
+    if (accessToken) {
+      xhr.setRequestHeader("Authorization", `Bearer ${accessToken}`);
+    }
+
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable && params.onProgress) {
+        params.onProgress(Math.round((e.loaded / e.total) * 100));
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve();
+      } else {
+        reject(new Error(`업로드 실패: HTTP ${xhr.status}`));
+      }
+    };
+    xhr.onerror = () => reject(new Error("업로드 네트워크 오류"));
+    xhr.onabort = () => reject(new Error("업로드가 취소되었습니다"));
+
+    if (params.signal) {
+      if (params.signal.aborted) {
+        xhr.abort();
+        reject(new Error("업로드가 취소되었습니다"));
+        return;
+      }
+      params.signal.addEventListener("abort", () => xhr.abort());
+    }
+
+    xhr.send(params.file);
+  });
+}
+
 export interface UploadMediaFileParams {
   themeId: string;
   file: File;
@@ -367,6 +423,8 @@ export interface UploadMediaFileParams {
   signal?: AbortSignal;
   /** Injected for testability; defaults to XHR PUT. */
   putFile?: (params: PutFileParams) => Promise<void>;
+  /** Authenticated backend fallback used when direct object-storage PUT is blocked by CORS/network policy. */
+  uploadFileViaServer?: (params: ServerUploadFileParams) => Promise<void>;
   /** Override request MIME when browsers omit File.type (common for PDFs on some platforms). */
   mimeType?: string;
   /** Number of attempts (1 = no retry). Default 3. */
@@ -403,6 +461,7 @@ export async function uploadMediaFile(
     onProgress,
     signal,
     putFile = defaultPutFile,
+    uploadFileViaServer = defaultUploadFileViaServer,
     mimeType,
     maxAttempts = 3,
     retryBaseDelayMs = 200,
@@ -446,7 +505,14 @@ export async function uploadMediaFile(
     }
   }
   if (lastError) {
-    throw lastError;
+    await uploadFileViaServer({
+      themeId: params.themeId,
+      uploadId: uploadUrl.upload_id,
+      file,
+      contentType: effectiveMimeType,
+      onProgress,
+      signal,
+    });
   }
 
   // Step 3: confirm


### PR DESCRIPTION
## 요약
- R2 presigned PUT이 CORS/네트워크 정책으로 막힐 때 백엔드 경유 업로드로 자동 fallback합니다.
- storage Provider에 `PutObject`를 추가하고 R2/local 구현체와 media upload endpoint를 연결했습니다.
- 미디어 업로드 UI E2E에서 직접 PUT 403 이후 backend PUT, confirm까지 이어지는 흐름을 검증했습니다.

Closes #614

## Coverage Plan
- `apps/server/internal/domain/editor/media_service.go`: pending upload body 저장 성공, size mismatch 실패를 service test로 검증
- `apps/server/internal/domain/editor/media_handler.go`: 신규 PUT endpoint가 service에 theme/upload/body를 전달하고 204를 반환하는 handler test로 검증
- `apps/server/internal/infra/storage/local.go`, `apps/server/internal/infra/storage/r2.go`: Provider contract 컴파일과 storage focused test로 검증
- `apps/web/src/features/editor/mediaApi.ts`: direct PUT retry exhaustion 후 authenticated fallback 호출, fallback 실패 시 confirm 미호출을 Vitest로 검증
- `apps/web/e2e/editor-media-upload-fallback.spec.ts`: MediaUploadModal에서 R2 PUT 403 후 backend PUT + confirm 흐름을 Chromium Playwright로 검증

## Local validation
- `cd apps/server && go test ./internal/domain/editor ./internal/infra/storage ./cmd/server` ✅
- `pnpm --filter @mmp/web test -- src/features/editor/mediaApi.test.ts` ✅
- `pnpm --filter @mmp/web exec playwright test apps/web/e2e/editor-media-upload-fallback.spec.ts --project=chromium` ✅
- `MMP_LOCAL_CI_SKIP_INSTALL=1 scripts/mmp-local-ci.sh quick` ✅ (`b1c3a7b6f67013ae27636f808d9bb3a4c21a63b7`)

## 참고
- 전체 Playwright 기본 실행은 로컬 Firefox 바이너리 미설치로 Firefox project만 실패했고, 동일 테스트는 Chromium project에서 통과했습니다.
- `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않았습니다.
