### PR TITLE
feat(web): 리치 콘텐츠 이미지 블록 편집 UX 개선

### DIFF
--- a/apps/web/e2e/phase24-editor-character-role.spec.ts
+++ b/apps/web/e2e/phase24-editor-character-role.spec.ts
@@ -217,6 +217,12 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
     await expect(block.getByRole("button", { name: "보통" })).toHaveText("");
     await expect(block.getByRole("button", { name: "크게" })).toHaveText("");
 
+    const a11y = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .disableRules(["color-contrast"])
+      .analyze();
+    expect(a11y.violations).toEqual([]);
+
     await block.getByRole("button", { name: "미디어 아래에 문단 추가" }).click();
 
     const roleSheetRequestPromise = page.waitForRequest(

--- a/apps/web/e2e/phase24-editor-character-role.spec.ts
+++ b/apps/web/e2e/phase24-editor-character-role.spec.ts
@@ -150,4 +150,86 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
       .analyze();
     expect(a11y.violations).toEqual([]);
   });
+
+  test("역할지 Markdown 이미지 블록은 선택, 문단 삽입, 저장이 가능하다", async ({ page }) => {
+    const mediaSnippet =
+      '<MediaEmbed mediaId="image-media-1" type="image" align="center" width="medium" />';
+    await page.route(`**/v1/editor/themes/${THEME_ID}/media**`, (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "image-media-1",
+            theme_id: THEME_ID,
+            name: "역할지 이미지",
+            type: "IMAGE",
+            source_type: "FILE",
+            url: "https://mock-storage.example/themes/media/role-image.png",
+            duration: null,
+            file_size: 12345,
+            mime_type: "image/png",
+            tags: ["역할지"],
+            sort_order: 1,
+            created_at: new Date().toISOString(),
+          },
+        ]),
+      });
+    });
+    await page.route("https://mock-storage.example/themes/media/role-image.png", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        body: Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lLduGQAAAABJRU5ErkJggg==",
+          "base64",
+        ),
+      }),
+    );
+    await page.route("**/v1/editor/characters/char-1/role-sheet", async (route) => {
+      const method = route.request().method();
+      if (method === "GET") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            character_id: "char-1",
+            theme_id: THEME_ID,
+            format: "markdown",
+            markdown: { body: mediaSnippet },
+          }),
+        });
+      }
+      return route.fallback();
+    });
+
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+    await page.getByRole("tab", { name: "등장인물 관리" }).click();
+    await expect(page.getByRole("region", { name: "캐릭터 목록" })).toBeVisible();
+    await page.getByRole("button", { name: "탐정 A 선택" }).click();
+    await page.getByRole("button", { name: /^역할지/ }).click();
+
+    const block = page.getByRole("group", { name: "역할지 이미지 미디어 블록" });
+    await expect(block).toBeVisible();
+    await block.focus();
+    await expect(block.getByRole("button", { name: "역할지 이미지 위로 이동" })).toBeVisible();
+    await expect(block.getByRole("button", { name: "보통" })).toHaveText("");
+    await expect(block.getByRole("button", { name: "크게" })).toHaveText("");
+
+    await block.getByRole("button", { name: "미디어 아래에 문단 추가" }).click();
+
+    const roleSheetRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === "PUT" &&
+        request.url().includes("/v1/editor/characters/char-1/role-sheet"),
+    );
+    await page.getByRole("button", { name: "역할지 저장" }).click();
+    const roleSheetRequest = await roleSheetRequestPromise;
+
+    const body = roleSheetRequest.postDataJSON();
+    expect(body).toMatchObject({ format: "markdown" });
+    expect(body.markdown.body).toContain(mediaSnippet);
+    expect(body.markdown.body).toContain(`${mediaSnippet}\n\n`);
+  });
 });

--- a/apps/web/src/features/editor/components/content/MediaEmbedEditor.tsx
+++ b/apps/web/src/features/editor/components/content/MediaEmbedEditor.tsx
@@ -1,11 +1,21 @@
+import type { DragEvent, KeyboardEvent } from 'react';
 import type { JsxEditorProps } from '@mdxeditor/editor';
 import { useLexicalNodeRemove, useMdastNodeUpdater } from '@mdxeditor/editor';
-import { AlignCenter, AlignLeft, AlignRight, ImageOff, Maximize2, Minimize2, RefreshCw, Trash2 } from 'lucide-react';
-
 import {
-  useMediaDownloadUrl,
-  type MediaResponse,
-} from '@/features/editor/mediaApi';
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  ArrowDown,
+  ArrowUp,
+  GripVertical,
+  ImageOff,
+  Maximize2,
+  Minimize2,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
+
+import { useMediaDownloadUrl, type MediaResponse } from '@/features/editor/mediaApi';
 import { getMediaThumbnailUrl } from '@/features/editor/components/media/mediaVisuals';
 import {
   mediaEmbedAligns,
@@ -50,13 +60,25 @@ const alignClasses: Record<MediaEmbedAlign, string> = {
   right: 'ml-auto',
 };
 
+const mediaEmbedDragType = 'application/x-mmp-media-embed';
+
 export function MediaEmbedEditor({
   mdastNode,
   media,
   onRequestReplace,
+  onInsertParagraph,
+  onMove,
+  onDropOn,
 }: JsxEditorProps & {
   media: MediaResponse[];
   onRequestReplace: (attrs: MediaEmbedAttributes) => void;
+  onInsertParagraph: (attrs: MediaEmbedAttributes, position: 'before' | 'after') => void;
+  onMove: (attrs: MediaEmbedAttributes, direction: 'up' | 'down') => void;
+  onDropOn: (
+    source: MediaEmbedAttributes,
+    target: MediaEmbedAttributes,
+    position: 'before' | 'after'
+  ) => void;
 }) {
   const node = mdastNode as MediaEmbedMdastNode;
   const attrs = readMediaEmbedAttributes(node);
@@ -66,30 +88,85 @@ export function MediaEmbedEditor({
   const isVideo = attrs.type === 'video';
   const shouldFetchDownloadUrl = Boolean(
     selectedMedia &&
-      selectedMedia.source_type === 'FILE' &&
-      !selectedMedia.url &&
-      (selectedMedia.type === 'IMAGE' || selectedMedia.type === 'VIDEO'),
+    selectedMedia.source_type === 'FILE' &&
+    !selectedMedia.url &&
+    (selectedMedia.type === 'IMAGE' || selectedMedia.type === 'VIDEO')
   );
   const { data, isLoading, isError } = useMediaDownloadUrl(
-    shouldFetchDownloadUrl ? selectedMedia?.id : undefined,
+    shouldFetchDownloadUrl ? selectedMedia?.id : undefined
   );
   const visualUrl = selectedMedia
-    ? getMediaThumbnailUrl(selectedMedia) ?? selectedMedia.url ?? data?.url ?? null
+    ? (getMediaThumbnailUrl(selectedMedia) ?? selectedMedia.url ?? data?.url ?? null)
     : null;
 
   function patchAttributes(patch: Partial<typeof attrs>) {
     updateMdastNode(updateMediaEmbedAttributes(node, patch));
   }
 
+  function handleKeyDown(event: KeyboardEvent<HTMLElement>) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      onInsertParagraph(attrs, event.shiftKey ? 'before' : 'after');
+    }
+    if (event.key === 'ArrowUp' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      onMove(attrs, 'up');
+    }
+    if (event.key === 'ArrowDown' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      onMove(attrs, 'down');
+    }
+  }
+
+  function handleDragStart(event: DragEvent<HTMLElement>) {
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData(mediaEmbedDragType, JSON.stringify(attrs));
+  }
+
+  function handleDragOver(event: DragEvent<HTMLElement>) {
+    if (event.dataTransfer.types.includes(mediaEmbedDragType)) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  function handleDrop(event: DragEvent<HTMLElement>) {
+    const raw = event.dataTransfer.getData(mediaEmbedDragType);
+    if (!raw) return;
+    event.preventDefault();
+    try {
+      const source = JSON.parse(raw) as MediaEmbedAttributes;
+      const position =
+        event.clientY <
+        event.currentTarget.getBoundingClientRect().top + event.currentTarget.clientHeight / 2
+          ? 'before'
+          : 'after';
+      onDropOn(source, attrs, position);
+    } catch {
+      // Ignore invalid drag payloads from outside this editor.
+    }
+  }
+
   return (
     <figure
-      className={`group relative my-3 rounded outline outline-1 outline-slate-700/70 focus-within:outline-amber-400 ${widthClasses[attrs.width]} ${alignClasses[attrs.align]}`}
+      className={`group relative my-4 rounded outline outline-1 outline-slate-700/70 transition focus:outline-2 focus:outline-amber-400 focus-within:outline-2 focus-within:outline-amber-400 ${widthClasses[attrs.width]} ${alignClasses[attrs.align]}`}
       data-testid="media-embed-editor"
+      role="group"
+      aria-label={`${selectedMedia?.name ?? attrs.mediaId} 미디어 블록`}
       contentEditable={false}
+      draggable
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
     >
+      <MediaInsertionRail position="before" onInsert={() => onInsertParagraph(attrs, 'before')} />
       <MediaToolbar
         attrs={attrs}
         label={selectedMedia?.name ?? attrs.mediaId}
+        onMoveUp={() => onMove(attrs, 'up')}
+        onMoveDown={() => onMove(attrs, 'down')}
         onReplace={() => onRequestReplace(attrs)}
         onRemove={removeNode}
         onPatch={patchAttributes}
@@ -98,10 +175,19 @@ export function MediaEmbedEditor({
         <img
           src={visualUrl}
           alt={selectedMedia.name}
-          className={attrs.width === 'full' ? 'block h-auto w-full object-contain' : 'block h-auto max-w-full object-contain'}
+          className={
+            attrs.width === 'full'
+              ? 'block h-auto w-full object-contain'
+              : 'block h-auto max-w-full object-contain'
+          }
         />
       ) : selectedMedia && visualUrl && isVideo && selectedMedia.source_type === 'FILE' ? (
-        <video src={visualUrl} controls className="block h-auto w-full" aria-label={`${selectedMedia.name} 영상`} />
+        <video
+          src={visualUrl}
+          controls
+          className="block h-auto w-full"
+          aria-label={`${selectedMedia.name} 영상`}
+        />
       ) : selectedMedia && visualUrl && isVideo ? (
         <img
           src={visualUrl}
@@ -120,27 +206,87 @@ export function MediaEmbedEditor({
             : '삭제되었거나 접근할 수 없는 미디어입니다'}
         </div>
       )}
+      <p className="sr-only">
+        Enter를 누르면 아래에 문단 위치를 추가하고, Shift Enter는 위에 추가합니다. Command 또는
+        Control과 위아래 화살표로 블록 순서를 바꿀 수 있습니다.
+      </p>
+      <MediaInsertionRail position="after" onInsert={() => onInsertParagraph(attrs, 'after')} />
     </figure>
+  );
+}
+
+function MediaInsertionRail({
+  position,
+  onInsert,
+}: {
+  position: 'before' | 'after';
+  onInsert: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-rich-content-control="true"
+      className={`absolute left-0 z-10 flex w-full items-center gap-2 rounded px-2 py-1 text-[11px] font-medium text-amber-100 opacity-0 transition focus:opacity-100 group-focus:opacity-100 group-hover:opacity-100 ${
+        position === 'before' ? '-top-5' : '-bottom-5'
+      }`}
+      onClick={onInsert}
+      aria-label={position === 'before' ? '미디어 위에 문단 추가' : '미디어 아래에 문단 추가'}
+      title={position === 'before' ? '위에 문단 추가' : '아래에 문단 추가'}
+    >
+      <span className="h-px flex-1 bg-amber-300/70" aria-hidden="true" />
+      <span className="rounded-full bg-slate-950/95 px-2 py-0.5 ring-1 ring-amber-300/50">
+        {position === 'before' ? '위에 문단' : '아래에 문단'}
+      </span>
+      <span className="h-px flex-1 bg-amber-300/70" aria-hidden="true" />
+    </button>
   );
 }
 
 function MediaToolbar({
   attrs,
   label,
+  onMoveUp,
+  onMoveDown,
   onReplace,
   onRemove,
   onPatch,
 }: {
   attrs: MediaEmbedAttributes;
   label: string;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
   onReplace: () => void;
   onRemove: () => void;
   onPatch: (patch: Partial<MediaEmbedAttributes>) => void;
 }) {
   return (
-    <div className="absolute right-2 top-2 z-10 flex max-w-[calc(100%-1rem)] flex-wrap items-center justify-end gap-1 rounded bg-slate-950/90 p-1 opacity-0 shadow-lg shadow-slate-950/30 ring-1 ring-slate-700/80 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+    <div className="absolute right-2 top-2 z-20 flex max-w-[calc(100%-1rem)] flex-wrap items-center justify-end gap-1 rounded bg-slate-950/90 p-1 opacity-0 shadow-lg shadow-slate-950/30 ring-1 ring-slate-700/80 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+      <span className="rounded p-1 text-slate-400" aria-hidden="true" title="드래그해서 순서 이동">
+        <GripVertical className="h-3.5 w-3.5" />
+      </span>
       <button
         type="button"
+        data-rich-content-control="true"
+        onClick={onMoveUp}
+        className="rounded p-1.5 text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+        aria-label={`${label} 위로 이동`}
+        title="위로 이동"
+      >
+        <ArrowUp className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        data-rich-content-control="true"
+        onClick={onMoveDown}
+        className="rounded p-1.5 text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+        aria-label={`${label} 아래로 이동`}
+        title="아래로 이동"
+      >
+        <ArrowDown className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        data-rich-content-control="true"
         onClick={onReplace}
         className="rounded p-1.5 text-slate-200 hover:bg-slate-800"
         aria-label={`${label} 교체`}
@@ -154,6 +300,7 @@ function MediaToolbar({
           <button
             key={align}
             type="button"
+            data-rich-content-control="true"
             onClick={() => onPatch({ align })}
             className={`rounded p-1.5 ${
               attrs.align === align
@@ -171,6 +318,7 @@ function MediaToolbar({
         <button
           key={width}
           type="button"
+          data-rich-content-control="true"
           onClick={() => onPatch({ width })}
           className={`rounded px-1.5 py-1 text-[11px] font-medium ${
             attrs.width === width
@@ -181,13 +329,14 @@ function MediaToolbar({
           title={widthLabels[width]}
         >
           {width === 'small' ? <Minimize2 className="h-3.5 w-3.5" /> : null}
-          {width === 'medium' ? 'M' : null}
-          {width === 'large' ? 'L' : null}
+          {width === 'medium' ? <WidthGlyph size="medium" /> : null}
+          {width === 'large' ? <WidthGlyph size="large" /> : null}
           {width === 'full' ? <Maximize2 className="h-3.5 w-3.5" /> : null}
         </button>
       ))}
       <button
         type="button"
+        data-rich-content-control="true"
         onClick={onRemove}
         className="rounded p-1.5 text-rose-300 hover:bg-rose-500/10"
         aria-label={`${label} 삭제`}
@@ -196,5 +345,14 @@ function MediaToolbar({
         <Trash2 className="h-3.5 w-3.5" />
       </button>
     </div>
+  );
+}
+
+function WidthGlyph({ size }: { size: 'medium' | 'large' }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`block h-3 rounded-sm border border-current ${size === 'medium' ? 'w-3.5' : 'w-5'}`}
+    />
   );
 }

--- a/apps/web/src/features/editor/components/content/MediaEmbedEditor.tsx
+++ b/apps/web/src/features/editor/components/content/MediaEmbedEditor.tsx
@@ -104,6 +104,10 @@ export function MediaEmbedEditor({
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLElement>) {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('[data-rich-content-control="true"]')) {
+      return;
+    }
     if (event.key === 'Enter') {
       event.preventDefault();
       onInsertParagraph(attrs, event.shiftKey ? 'before' : 'after');

--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -18,16 +18,15 @@ import {
   type MDXEditorMethods,
 } from '@mdxeditor/editor';
 
-import {
-  useMediaList,
-  type MediaResponse,
-  type MediaType,
-} from '@/features/editor/mediaApi';
+import { useMediaList, type MediaResponse, type MediaType } from '@/features/editor/mediaApi';
 import { MediaEmbedPicker } from './MediaEmbedPicker';
 import { MediaEmbedEditor } from './MediaEmbedEditor';
 import {
   createMediaEmbedSnippet,
+  insertMediaEmbedParagraph,
   mediaTypeToEmbedType,
+  moveMediaEmbedBlock,
+  moveMediaEmbedBlockTo,
   type MediaEmbedAttributes,
 } from './mediaEmbedMarkdown';
 import { normalizeLegacyEscapedMarkdown } from './legacyMarkdown';
@@ -65,7 +64,9 @@ export function RichContentEditor({
   const { data: media = [] } = useMediaList(themeId);
 
   useEffect(() => {
-    editorRef.current?.setMarkdown?.(normalizedMarkdown);
+    if (editorRef.current?.getMarkdown?.() !== normalizedMarkdown) {
+      editorRef.current?.setMarkdown?.(normalizedMarkdown);
+    }
   }, [normalizedMarkdown]);
 
   const plugins = useMemo(
@@ -77,10 +78,24 @@ export function RichContentEditor({
       thematicBreakPlugin(),
       jsxPlugin({
         jsxComponentDescriptors: [
-          createMediaEmbedDescriptor(media, (attrs) => {
-            setReplacementTarget(attrs);
-            onOpenPicker(attrs.type === 'video' ? 'VIDEO' : 'IMAGE');
-          }),
+          createMediaEmbedDescriptor(
+            media,
+            (attrs) => {
+              setReplacementTarget(attrs);
+              onOpenPicker(attrs.type === 'video' ? 'VIDEO' : 'IMAGE');
+            },
+            {
+              onInsertParagraph: (attrs, position) => {
+                onChange(insertMediaEmbedParagraph(normalizedMarkdown, attrs, position));
+              },
+              onMove: (attrs, direction) => {
+                onChange(moveMediaEmbedBlock(normalizedMarkdown, attrs, direction));
+              },
+              onDropOn: (source, target, position) => {
+                onChange(moveMediaEmbedBlockTo(normalizedMarkdown, source, target, position));
+              },
+            }
+          ),
         ],
       }),
       toolbarPlugin({
@@ -96,7 +111,7 @@ export function RichContentEditor({
       }),
       markdownShortcutPlugin(),
     ],
-    [media, onOpenPicker],
+    [media, onOpenPicker]
   );
 
   function handleSelectMedia(media: MediaResponse) {
@@ -106,7 +121,7 @@ export function RichContentEditor({
         media.id,
         type,
         replacementTarget.align,
-        replacementTarget.width,
+        replacementTarget.width
       ).trim();
       onChange(replaceMediaEmbed(normalizedMarkdown, replacementTarget, snippet));
       setReplacementTarget(null);
@@ -158,6 +173,15 @@ export function RichContentEditor({
 function createMediaEmbedDescriptor(
   media: MediaResponse[],
   onRequestReplace: (attrs: MediaEmbedAttributes) => void,
+  controls: {
+    onInsertParagraph: (attrs: MediaEmbedAttributes, position: 'before' | 'after') => void;
+    onMove: (attrs: MediaEmbedAttributes, direction: 'up' | 'down') => void;
+    onDropOn: (
+      source: MediaEmbedAttributes,
+      target: MediaEmbedAttributes,
+      position: 'before' | 'after'
+    ) => void;
+  }
 ): JsxComponentDescriptor {
   return {
     name: 'MediaEmbed',
@@ -170,16 +194,19 @@ function createMediaEmbedDescriptor(
     ],
     hasChildren: false,
     Editor: (props) => (
-      <MediaEmbedEditor {...props} media={media} onRequestReplace={onRequestReplace} />
+      <MediaEmbedEditor
+        {...props}
+        media={media}
+        onRequestReplace={onRequestReplace}
+        onInsertParagraph={controls.onInsertParagraph}
+        onMove={controls.onMove}
+        onDropOn={controls.onDropOn}
+      />
     ),
   };
 }
 
-function replaceMediaEmbed(
-  markdown: string,
-  target: MediaEmbedAttributes,
-  nextSnippet: string,
-) {
+function replaceMediaEmbed(markdown: string, target: MediaEmbedAttributes, nextSnippet: string) {
   const pattern = /<MediaEmbed\s+([^>]+)\/>/g;
   for (const match of markdown.matchAll(pattern)) {
     const attrs = match[1] ?? '';

--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -60,8 +60,15 @@ export function RichContentEditor({
 }) {
   const editorRef = useRef<MDXEditorMethods>(null);
   const normalizedMarkdown = useMemo(() => normalizeLegacyEscapedMarkdown(markdown), [markdown]);
+  const markdownRef = useRef(normalizedMarkdown);
+  const onChangeRef = useRef(onChange);
   const [replacementTarget, setReplacementTarget] = useState<MediaEmbedAttributes | null>(null);
   const { data: media = [] } = useMediaList(themeId);
+
+  useEffect(() => {
+    markdownRef.current = normalizedMarkdown;
+    onChangeRef.current = onChange;
+  }, [normalizedMarkdown, onChange]);
 
   useEffect(() => {
     if (editorRef.current?.getMarkdown?.() !== normalizedMarkdown) {
@@ -86,13 +93,17 @@ export function RichContentEditor({
             },
             {
               onInsertParagraph: (attrs, position) => {
-                onChange(insertMediaEmbedParagraph(normalizedMarkdown, attrs, position));
+                onChangeRef.current(
+                  insertMediaEmbedParagraph(markdownRef.current, attrs, position)
+                );
               },
               onMove: (attrs, direction) => {
-                onChange(moveMediaEmbedBlock(normalizedMarkdown, attrs, direction));
+                onChangeRef.current(moveMediaEmbedBlock(markdownRef.current, attrs, direction));
               },
               onDropOn: (source, target, position) => {
-                onChange(moveMediaEmbedBlockTo(normalizedMarkdown, source, target, position));
+                onChangeRef.current(
+                  moveMediaEmbedBlockTo(markdownRef.current, source, target, position)
+                );
               },
             }
           ),
@@ -212,7 +223,9 @@ function replaceMediaEmbed(markdown: string, target: MediaEmbedAttributes, nextS
     const attrs = match[1] ?? '';
     if (
       readAttr(attrs, 'mediaId') !== target.mediaId ||
-      (readAttr(attrs, 'type') || 'image') !== target.type
+      (readAttr(attrs, 'type') || 'image') !== target.type ||
+      (readAttr(attrs, 'align') || 'center') !== target.align ||
+      (readAttr(attrs, 'width') || 'medium') !== target.width
     ) {
       continue;
     }

--- a/apps/web/src/features/editor/components/content/__tests__/MediaEmbedEditor.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/MediaEmbedEditor.test.tsx
@@ -94,6 +94,21 @@ describe('MediaEmbedEditor', () => {
     expect(onMove).toHaveBeenNthCalledWith(2, attrs, 'down');
   });
 
+  it('does not treat nested control Enter presses as figure-level shortcuts', () => {
+    const onInsertParagraph = vi.fn();
+    const onMove = vi.fn();
+    renderEditor({ onInsertParagraph, onMove });
+
+    fireEvent.keyDown(screen.getByRole('button', { name: '보통' }), { key: 'Enter' });
+    fireEvent.keyDown(screen.getByRole('button', { name: '포스터 위로 이동' }), {
+      key: 'ArrowUp',
+      metaKey: true,
+    });
+
+    expect(onInsertParagraph).not.toHaveBeenCalled();
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
   it('accepts a dragged media block and reports the drop direction', () => {
     const onDropOn = vi.fn();
     renderEditor({ onDropOn });

--- a/apps/web/src/features/editor/components/content/__tests__/MediaEmbedEditor.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/MediaEmbedEditor.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -114,6 +114,28 @@ describe('MediaEmbedEditor', () => {
     renderEditor({ onDropOn });
 
     const block = screen.getByRole('group', { name: '포스터 미디어 블록' });
+    const originalGetBoundingClientRect = block.getBoundingClientRect;
+    const originalClientHeight = Object.getOwnPropertyDescriptor(block, 'clientHeight');
+    Object.defineProperty(block, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        x: 0,
+        y: 100,
+        top: 100,
+        left: 0,
+        right: 320,
+        bottom: 300,
+        width: 320,
+        height: 200,
+        toJSON: () => ({}),
+      }),
+    });
+    Object.defineProperty(block, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 200;
+      },
+    });
     const data = new Map<string, string>();
     const dataTransfer = {
       types: ['application/x-mmp-media-embed'],
@@ -123,10 +145,31 @@ describe('MediaEmbedEditor', () => {
       getData: (type: string) => data.get(type) ?? '',
     };
 
-    fireEvent.dragStart(block, { dataTransfer });
-    fireEvent.drop(block, { dataTransfer, clientY: -1 });
+    try {
+      const beforeDrop = createEvent.drop(block);
+      Object.defineProperty(beforeDrop, 'dataTransfer', { value: dataTransfer });
+      Object.defineProperty(beforeDrop, 'clientY', { value: 120 });
+      const afterDrop = createEvent.drop(block);
+      Object.defineProperty(afterDrop, 'dataTransfer', { value: dataTransfer });
+      Object.defineProperty(afterDrop, 'clientY', { value: 260 });
 
-    expect(onDropOn).toHaveBeenCalledWith(attrs, attrs, 'after');
+      fireEvent.dragStart(block, { dataTransfer });
+      fireEvent(block, beforeDrop);
+      fireEvent(block, afterDrop);
+
+      expect(onDropOn).toHaveBeenNthCalledWith(1, attrs, attrs, 'before');
+      expect(onDropOn).toHaveBeenNthCalledWith(2, attrs, attrs, 'after');
+    } finally {
+      Object.defineProperty(block, 'getBoundingClientRect', {
+        configurable: true,
+        value: originalGetBoundingClientRect,
+      });
+      if (originalClientHeight) {
+        Object.defineProperty(block, 'clientHeight', originalClientHeight);
+      } else {
+        delete (block as Partial<HTMLElement>).clientHeight;
+      }
+    }
   });
 
   it('uses icon-only width controls instead of visible M and L text', () => {

--- a/apps/web/src/features/editor/components/content/__tests__/MediaEmbedEditor.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/MediaEmbedEditor.test.tsx
@@ -1,0 +1,125 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { removeMock, updateMock } = vi.hoisted(() => ({
+  removeMock: vi.fn(),
+  updateMock: vi.fn(),
+}));
+
+vi.mock('@mdxeditor/editor', () => ({
+  useLexicalNodeRemove: () => removeMock,
+  useMdastNodeUpdater: () => updateMock,
+}));
+
+vi.mock('@/features/editor/mediaApi', () => ({
+  useMediaDownloadUrl: () => ({ data: null, isLoading: false, isError: false }),
+}));
+
+import { MediaEmbedEditor } from '../MediaEmbedEditor';
+import type { MediaEmbedAttributes } from '../mediaEmbedMarkdown';
+
+const attrs: MediaEmbedAttributes = {
+  mediaId: 'image-1',
+  type: 'image',
+  align: 'center',
+  width: 'medium',
+};
+
+const mdastNode = {
+  attributes: [
+    { name: 'mediaId', value: attrs.mediaId },
+    { name: 'type', value: attrs.type },
+    { name: 'align', value: attrs.align },
+    { name: 'width', value: attrs.width },
+  ],
+};
+
+const media = [
+  {
+    id: 'image-1',
+    name: '포스터',
+    type: 'IMAGE',
+    source_type: 'URL',
+    url: 'https://example.test/poster.png',
+  },
+] as const;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderEditor(overrides: Partial<Parameters<typeof MediaEmbedEditor>[0]> = {}) {
+  return render(
+    <MediaEmbedEditor
+      mdastNode={mdastNode}
+      media={[...media]}
+      onRequestReplace={vi.fn()}
+      onInsertParagraph={vi.fn()}
+      onMove={vi.fn()}
+      onDropOn={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
+describe('MediaEmbedEditor', () => {
+  it('exposes a selectable media block with paragraph insertion controls', () => {
+    const onInsertParagraph = vi.fn();
+    renderEditor({ onInsertParagraph });
+
+    fireEvent.click(screen.getByRole('button', { name: '미디어 위에 문단 추가' }));
+    fireEvent.click(screen.getByRole('button', { name: '미디어 아래에 문단 추가' }));
+
+    expect(screen.getByRole('group', { name: '포스터 미디어 블록' })).toBeInTheDocument();
+    expect(onInsertParagraph).toHaveBeenNthCalledWith(1, attrs, 'before');
+    expect(onInsertParagraph).toHaveBeenNthCalledWith(2, attrs, 'after');
+  });
+
+  it('uses Enter and modifier arrow keys for keyboard media block editing', () => {
+    const onInsertParagraph = vi.fn();
+    const onMove = vi.fn();
+    renderEditor({ onInsertParagraph, onMove });
+
+    const block = screen.getByRole('group', { name: '포스터 미디어 블록' });
+    fireEvent.keyDown(block, { key: 'Enter' });
+    fireEvent.keyDown(block, { key: 'Enter', shiftKey: true });
+    fireEvent.keyDown(block, { key: 'ArrowUp', metaKey: true });
+    fireEvent.keyDown(block, { key: 'ArrowDown', ctrlKey: true });
+
+    expect(onInsertParagraph).toHaveBeenNthCalledWith(1, attrs, 'after');
+    expect(onInsertParagraph).toHaveBeenNthCalledWith(2, attrs, 'before');
+    expect(onMove).toHaveBeenNthCalledWith(1, attrs, 'up');
+    expect(onMove).toHaveBeenNthCalledWith(2, attrs, 'down');
+  });
+
+  it('accepts a dragged media block and reports the drop direction', () => {
+    const onDropOn = vi.fn();
+    renderEditor({ onDropOn });
+
+    const block = screen.getByRole('group', { name: '포스터 미디어 블록' });
+    const data = new Map<string, string>();
+    const dataTransfer = {
+      types: ['application/x-mmp-media-embed'],
+      effectAllowed: '',
+      dropEffect: '',
+      setData: (type: string, value: string) => data.set(type, value),
+      getData: (type: string) => data.get(type) ?? '',
+    };
+
+    fireEvent.dragStart(block, { dataTransfer });
+    fireEvent.drop(block, { dataTransfer, clientY: -1 });
+
+    expect(onDropOn).toHaveBeenCalledWith(attrs, attrs, 'after');
+  });
+
+  it('uses icon-only width controls instead of visible M and L text', () => {
+    renderEditor();
+
+    expect(screen.queryByText('M')).not.toBeInTheDocument();
+    expect(screen.queryByText('L')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '보통' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '크게' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/editor/components/content/__tests__/mediaEmbedMarkdown.test.ts
+++ b/apps/web/src/features/editor/components/content/__tests__/mediaEmbedMarkdown.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  insertMediaEmbedParagraph,
+  moveMediaEmbedBlock,
+  moveMediaEmbedBlockTo,
+  type MediaEmbedAttributes,
+} from '../mediaEmbedMarkdown';
+
+const first: MediaEmbedAttributes = {
+  mediaId: 'image-1',
+  type: 'image',
+  align: 'center',
+  width: 'medium',
+};
+
+const second: MediaEmbedAttributes = {
+  mediaId: 'image-2',
+  type: 'image',
+  align: 'left',
+  width: 'large',
+};
+
+const firstSnippet = '<MediaEmbed mediaId="image-1" type="image" align="center" width="medium" />';
+const secondSnippet = '<MediaEmbed mediaId="image-2" type="image" align="left" width="large" />';
+
+describe('mediaEmbedMarkdown helpers', () => {
+  it('adds an editable spacing point before or after a media block without changing the embed', () => {
+    expect(insertMediaEmbedParagraph(`A\n\n${firstSnippet}\n\nB`, first, 'before')).toBe(
+      `A\n\n\n\n${firstSnippet}\n\nB`
+    );
+
+    expect(insertMediaEmbedParagraph(`A\n\n${firstSnippet}\n\nB`, first, 'after')).toBe(
+      `A\n\n${firstSnippet}\n\n\n\nB`
+    );
+  });
+
+  it('moves a media block up or down across neighboring media blocks', () => {
+    const markdown = [firstSnippet, '', 'caption', '', secondSnippet].join('\n');
+
+    expect(moveMediaEmbedBlock(markdown, second, 'up')).toBe(
+      [secondSnippet, '', 'caption', '', firstSnippet].join('\n')
+    );
+
+    expect(moveMediaEmbedBlock(markdown, first, 'down')).toBe(
+      [secondSnippet, '', 'caption', '', firstSnippet].join('\n')
+    );
+  });
+
+  it('drops a dragged media block before or after a target media block', () => {
+    const markdown = [firstSnippet, '', 'caption', '', secondSnippet].join('\n');
+
+    expect(moveMediaEmbedBlockTo(markdown, first, second, 'after')).toBe(
+      ['', '', 'caption', '', secondSnippet, '', firstSnippet, '', ''].join('\n')
+    );
+
+    expect(moveMediaEmbedBlockTo(markdown, second, first, 'before')).toBe(
+      ['', '', secondSnippet, '', firstSnippet, '', 'caption', '', ''].join('\n')
+    );
+  });
+
+  it('keeps markdown unchanged when the target cannot be found', () => {
+    const markdown = `A\n\n${firstSnippet}`;
+    expect(moveMediaEmbedBlock(markdown, second, 'up')).toBe(markdown);
+    expect(insertMediaEmbedParagraph(markdown, second, 'after')).toBe(markdown);
+  });
+});

--- a/apps/web/src/features/editor/components/content/mediaEmbedMarkdown.ts
+++ b/apps/web/src/features/editor/components/content/mediaEmbedMarkdown.ts
@@ -32,9 +32,73 @@ export function createMediaEmbedSnippet(
   mediaId: string,
   type: MediaEmbedType,
   align: MediaEmbedAlign = 'center',
-  width: MediaEmbedWidth = 'medium',
+  width: MediaEmbedWidth = 'medium'
 ) {
   return `\n\n<MediaEmbed mediaId="${mediaId}" type="${type}" align="${align}" width="${width}" />\n`;
+}
+
+export function insertMediaEmbedParagraph(
+  markdown: string,
+  target: MediaEmbedAttributes,
+  position: 'before' | 'after'
+) {
+  const range = findMediaEmbedRange(markdown, target);
+  if (!range) return markdown;
+  const insertion = '\n\n';
+  return position === 'before'
+    ? `${markdown.slice(0, range.start)}${insertion}${markdown.slice(range.start)}`
+    : `${markdown.slice(0, range.end)}${insertion}${markdown.slice(range.end)}`;
+}
+
+export function moveMediaEmbedBlock(
+  markdown: string,
+  target: MediaEmbedAttributes,
+  direction: 'up' | 'down'
+) {
+  const blocks = readMediaEmbedBlocks(markdown);
+  const targetIndex = blocks.findIndex((block) => mediaEmbedMatches(block.attrs, target));
+  if (targetIndex < 0) return markdown;
+
+  const neighborIndex = direction === 'up' ? targetIndex - 1 : targetIndex + 1;
+  const neighbor = blocks[neighborIndex];
+  const targetBlock = blocks[targetIndex];
+  if (!neighbor || !targetBlock) return markdown;
+
+  if (direction === 'up') {
+    return replaceRange(
+      markdown,
+      neighbor.start,
+      targetBlock.end,
+      `${targetBlock.source}${markdown.slice(neighbor.end, targetBlock.start)}${neighbor.source}`
+    );
+  }
+
+  return replaceRange(
+    markdown,
+    targetBlock.start,
+    neighbor.end,
+    `${neighbor.source}${markdown.slice(targetBlock.end, neighbor.start)}${targetBlock.source}`
+  );
+}
+
+export function moveMediaEmbedBlockTo(
+  markdown: string,
+  source: MediaEmbedAttributes,
+  target: MediaEmbedAttributes,
+  position: 'before' | 'after'
+) {
+  if (mediaEmbedMatches(source, target)) return markdown;
+
+  const sourceRange = findMediaEmbedRange(markdown, source);
+  if (!sourceRange) return markdown;
+
+  const sourceText = markdown.slice(sourceRange.start, sourceRange.end);
+  const withoutSource = replaceRange(markdown, sourceRange.start, sourceRange.end, '');
+  const targetRange = findMediaEmbedRange(withoutSource, target);
+  if (!targetRange) return markdown;
+
+  const insertAt = position === 'before' ? targetRange.start : targetRange.end;
+  return `${withoutSource.slice(0, insertAt)}\n\n${sourceText}\n\n${withoutSource.slice(insertAt)}`;
 }
 
 export function readMediaEmbedAttributes(node: MediaEmbedMdastNode): MediaEmbedAttributes {
@@ -55,9 +119,40 @@ export function readMediaEmbedAttributesFromSource(attrs: string): MediaEmbedAtt
   return readMediaEmbedAttributes(sourceNode);
 }
 
+function findMediaEmbedRange(markdown: string, target: MediaEmbedAttributes) {
+  return readMediaEmbedBlocks(markdown).find((block) => mediaEmbedMatches(block.attrs, target));
+}
+
+function readMediaEmbedBlocks(markdown: string) {
+  return Array.from(markdown.matchAll(/<MediaEmbed\s+([^>]+)\/>/g)).map((match) => {
+    const attrs = readMediaEmbedAttributesFromSource(match[1] ?? '');
+    const start = match.index ?? 0;
+    const source = match[0];
+    return {
+      attrs,
+      start,
+      end: start + source.length,
+      source,
+    };
+  });
+}
+
+function mediaEmbedMatches(current: MediaEmbedAttributes, target: MediaEmbedAttributes) {
+  return (
+    current.mediaId === target.mediaId &&
+    current.type === target.type &&
+    current.align === target.align &&
+    current.width === target.width
+  );
+}
+
+function replaceRange(markdown: string, start: number, end: number, replacement: string) {
+  return `${markdown.slice(0, start)}${replacement}${markdown.slice(end)}`;
+}
+
 export function updateMediaEmbedAttributes(
   node: MediaEmbedMdastNode,
-  patch: Partial<MediaEmbedAttributes>,
+  patch: Partial<MediaEmbedAttributes>
 ) {
   const current = readMediaEmbedAttributes(node);
   const next = { ...current, ...patch };
@@ -105,7 +200,7 @@ function withoutKnownMediaEmbedAttributes(attributes: MdxAttributeLike[]) {
       attr.name !== 'mediaId' &&
       attr.name !== 'type' &&
       attr.name !== 'align' &&
-      attr.name !== 'width',
+      attr.name !== 'width'
   );
 }
 

--- a/docs/superpowers/plans/2026-05-18-rich-media-block-ux.md
+++ b/docs/superpowers/plans/2026-05-18-rich-media-block-ux.md
@@ -28,4 +28,10 @@
 - [x] MediaEmbed block control UI 추가
 - [x] focused unit/component test 추가
 - [x] typecheck/E2E focused 검증
+- [x] CodeRabbit 1차 리뷰 반영
+  - [x] 중첩 컨트롤 Enter 키가 figure shortcut에 잡히지 않도록 차단
+  - [x] MediaEmbed 조작 콜백의 stale markdown 참조 방지
+  - [x] 동일 mediaId 재사용 시 align/width까지 매칭해 교체 대상 고정
+  - [x] drag/drop 테스트의 layout 값 명시
+  - [x] 역할지 이미지 블록 E2E 접근성 smoke 추가
 - [ ] PR 생성, CodeRabbit 확인, merge

--- a/docs/superpowers/plans/2026-05-18-rich-media-block-ux.md
+++ b/docs/superpowers/plans/2026-05-18-rich-media-block-ux.md
@@ -1,0 +1,31 @@
+# Rich Media Block UX
+
+## 고정 결정
+
+- `MediaEmbed` 저장 포맷은 `<MediaEmbed mediaId="..." type="..." align="..." width="..." />`를 유지한다.
+- 이미지/영상은 텍스트 안에 섞이는 inline 이미지가 아니라 선택 가능한 block으로 다룬다.
+- 빈 문단을 markdown에 억지로 저장하지 않는다. 제작자가 체감하는 간격 조절은 위/아래 삽입 컨트롤과 블록 이동 컨트롤로 제공한다.
+
+## Coverage Plan
+
+- `mediaEmbedMarkdown.ts`
+  - MediaEmbed snippet 생성이 블록 앞뒤 줄바꿈을 보존한다.
+  - 대상 MediaEmbed 앞/뒤에 문단 입력 지점을 추가한다.
+  - 대상 MediaEmbed를 위/아래 MediaEmbed와 순서 교체한다.
+  - 대상이 없거나 이동할 이웃 블록이 없으면 원문을 유지한다.
+- `MediaEmbedEditor.tsx`
+  - 선택 가능한 group 역할과 키보드 조작 안내가 노출된다.
+  - 위/아래 문단 추가, 위/아래 이동, 교체, 삭제 버튼이 구분된다.
+  - M/L 텍스트 버튼은 본문처럼 보이지 않게 아이콘 기반으로 정리한다.
+- `RichContentEditor.tsx`
+  - MediaEmbed 조작은 `onChange`를 통해 기존 자동저장 흐름에 연결된다.
+  - 외부 markdown 동기화는 값이 실제로 달라질 때만 `setMarkdown`을 호출한다.
+
+## 작업 체크리스트
+
+- [x] Issue #616과 workflow seed 생성
+- [x] markdown helper 추가
+- [x] MediaEmbed block control UI 추가
+- [x] focused unit/component test 추가
+- [x] typecheck/E2E focused 검증
+- [ ] PR 생성, CodeRabbit 확인, merge


### PR DESCRIPTION
## 요약
- RichContentEditor의 이미지/미디어 블록에 포커스 가능한 편집 컨트롤, 위/아래 문단 삽입, 위/아래 이동, 드래그 재배치 콜백을 추가했습니다.
- MediaEmbed markdown helper를 분리해 삽입/이동/재배치 로직을 테스트 가능하게 만들었습니다.
- 역할지 편집 E2E에서 이미지 블록 선택, 문단 삽입, 저장 요청까지 검증했습니다.

Closes #616

## Coverage Plan
- `mediaEmbedMarkdown.ts`: 미디어 블록 위/아래 문단 삽입, 위/아래 이동, 타깃 기준 재배치 helper를 Vitest로 검증했습니다.
- `MediaEmbedEditor.tsx`: 선택 상태, 키보드 Enter 삽입, 단축키 이동, 드래그 콜백, M/L 텍스트 제거를 React Testing Library로 검증했습니다.
- `RichContentEditor.tsx` + 역할지 편집 흐름: Playwright E2E로 Markdown 이미지 블록 선택, 문단 삽입, 저장 payload 유지 여부를 검증했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/content/__tests__/mediaEmbedMarkdown.test.ts src/features/editor/components/content/__tests__/MediaEmbedEditor.test.tsx` 통과: 2 files, 8 tests
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web exec playwright test e2e/phase24-editor-character-role.spec.ts --project=chromium --grep "역할지 Markdown 이미지"` 통과: 1 test
- `scripts/mmp-local-ci.sh quick` 통과: lint/typecheck/test/build 완료, web test 188 files / 1764 tests 통과

## 메모
- backend, DB, 저장 계약 변경은 없습니다.
- Vite build의 기존 RichContentEditor chunk-size warning은 이번 변경 전에도 존재하는 번들 크기 경고로, 기능 검증에는 영향이 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 미디어 블록 위/아래에 문단 삽입, 블록 상하 이동, 드래그 앤 드롭 재배치 지원
  * 키보드 단축키(Enter로 문단 삽입, Cmd/Ctrl+방향키로 이동) 추가
  * 폭 선택이 텍스트 대신 아이콘(보통/크게)으로 표시되도록 개선
  * 미디어 표시(이미지/비디오) 및 썸네일/다운로드 URL 우선순위 개선

* **테스트**
  * 미디어 블록 E2E 및 단위 테스트 추가 (편집, 이동, 드래그/드롭, 저장 흐름 포함)

* **문서**
  * Rich Media Block UX 계획 문서 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->