### PR TITLE
fix(web): 장소관리 모바일 스크롤 복구

### DIFF
--- a/apps/web/e2e/location-hierarchy.spec.ts
+++ b/apps/web/e2e/location-hierarchy.spec.ts
@@ -79,6 +79,37 @@ async function installLocationHierarchyRoutes(page: Page) {
 }
 
 test.describe('location hierarchy clue placement', () => {
+  test('모바일 장소관리 탭은 긴 상세 설정을 세로 스크롤로 접근할 수 있다', async ({ page }) => {
+    const commonState = freshState();
+    await mockCommonApis(page, commonState);
+    await installLocationHierarchyRoutes(page);
+    await loginAsE2EUser(page);
+
+    await page.setViewportSize({ width: 390, height: 640 });
+    await page.goto(`${BASE}/editor/${THEME_ID}/locations`);
+    await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
+
+    const scrollRoot = page.getByTestId('locations-sub-tab-scroll');
+    await expect(scrollRoot).toBeVisible();
+    await expect
+      .poll(() =>
+        scrollRoot.evaluate((element) => ({
+          clientHeight: element.clientHeight,
+          scrollHeight: element.scrollHeight,
+        }))
+      )
+      .toMatchObject({ clientHeight: expect.any(Number), scrollHeight: expect.any(Number) });
+    await expect
+      .poll(() => scrollRoot.evaluate((element) => element.scrollHeight > element.clientHeight))
+      .toBe(true);
+
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+    });
+    await expect.poll(() => scrollRoot.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    await expect(page.getByLabel('거실 단서 조사')).toBeVisible({ timeout: 3_000 });
+  });
+
   test('장소 계층 저장 후 새로고침해도 하위장소와 단서 조사 경로가 복원된다', async ({ page }) => {
     const commonState = freshState();
     await mockCommonApis(page, commonState);

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -113,7 +113,7 @@ export function LocationDetailPanel({
 
   return (
     <>
-      <div className="grid min-h-0 gap-4 md:h-full md:grid-cols-[minmax(16rem,0.34fr)_minmax(0,1fr)] lg:grid-cols-[minmax(16rem,0.32fr)_minmax(0,1fr)]">
+      <div className="grid min-h-0 gap-4 pb-4 md:h-full md:grid-cols-[minmax(16rem,0.34fr)_minmax(0,1fr)] md:overflow-hidden md:pb-0 lg:grid-cols-[minmax(16rem,0.32fr)_minmax(0,1fr)]">
         <LocationHierarchyList
           locations={mapLocations}
           theme={theme}

--- a/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
+++ b/apps/web/src/features/editor/components/design/LocationHierarchyList.tsx
@@ -62,7 +62,7 @@ export function LocationHierarchyList({
   return (
     <section
       aria-label="장소 목록"
-      className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-slate-800 bg-slate-950/70 p-3"
+      className="flex min-h-0 flex-col overflow-visible rounded-xl border border-slate-800 bg-slate-950/70 p-3 md:overflow-y-auto"
     >
       <header className="mb-3 flex items-center justify-between gap-2">
         <div>

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -124,7 +124,10 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-950/40">
+    <div
+      data-testid="locations-sub-tab-scroll"
+      className="flex h-full min-h-0 flex-col overflow-y-auto bg-slate-950/40 md:overflow-hidden"
+    >
       <div className="border-b border-slate-800 bg-slate-950/80 px-5 py-3">
         <LocationMapToolbar
           maps={maps ?? []}
@@ -147,7 +150,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
         />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden px-5 py-5">
+      <div className="min-h-0 flex-1 overflow-visible px-4 py-4 sm:px-5 sm:py-5 md:overflow-hidden">
         <LocationDetailPanel
           themeId={themeId}
           theme={theme}

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -32,12 +32,25 @@ describe('LocationsSubTab', () => {
 
     it('맵 이름들을 렌더링한다', () => {
       const { container } = renderLocationsSubTab();
-      expect(container.firstElementChild?.className).toContain('overflow-hidden');
+      expect(container.firstElementChild?.className).toContain('overflow-y-auto');
+      expect(container.firstElementChild?.className).toContain('md:overflow-hidden');
       expect(container.firstElementChild?.className).toContain('bg-slate-950/40');
       expect(screen.getByRole('combobox', { name: '맵 선택' })).toBeDefined();
       expect(screen.queryByText('맵은 조사 단계가 아니라 장소들을 묶는 배치 컨테이너입니다.')).toBeNull();
       expect(screen.getAllByText('저택 1층').length).toBeGreaterThan(0);
       expect(screen.getByText('저택 2층')).toBeDefined();
+    });
+
+    it('모바일에서는 장소관리 탭 전체가 세로 스크롤 책임을 가진다', () => {
+      renderLocationsSubTab();
+
+      const scrollRoot = screen.getByTestId('locations-sub-tab-scroll');
+      const locationList = screen.getByRole('region', { name: '장소 목록' });
+
+      expect(scrollRoot.className).toContain('overflow-y-auto');
+      expect(scrollRoot.className).toContain('md:overflow-hidden');
+      expect(locationList.className).toContain('overflow-visible');
+      expect(locationList.className).toContain('md:overflow-y-auto');
     });
 
     it('맵이 없을 때 빈 상태를 표시한다', () => {

--- a/docs/superpowers/plans/2026-05-18-location-mobile-scroll.md
+++ b/docs/superpowers/plans/2026-05-18-location-mobile-scroll.md
@@ -1,0 +1,21 @@
+# 장소관리 모바일 스크롤 복구 계획
+
+## 원인
+
+- 장소관리 탭 최상위와 본문 wrapper가 모바일에서도 `overflow-hidden`을 사용한다.
+- 상세 카드가 화면 높이보다 길어질 때 모바일에는 세로 스크롤 책임을 가진 컨테이너가 없어 하단 설정이 잘린다.
+- 데스크톱은 목록/상세 패널 내부 스크롤이 필요하지만, 모바일은 단일 세로 흐름이 더 자연스럽다.
+
+## 작업
+
+- [x] 모바일 기본값은 장소관리 탭 전체 스크롤로 바꾼다.
+- [x] `md` 이상에서는 기존처럼 내부 목록/상세 패널 스크롤을 유지한다.
+- [x] 컴포넌트 테스트로 스크롤 클래스 회귀를 막는다.
+- [x] Playwright 모바일 E2E로 실제 스크롤 가능 여부를 검증한다.
+
+## 검증
+
+- [x] `pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx`
+- [x] `pnpm --filter @mmp/web typecheck`
+- [x] `pnpm --filter @mmp/web exec playwright test e2e/location-hierarchy.spec.ts --project=chromium --grep "모바일"`
+- [ ] `scripts/mmp-local-ci.sh quick`


### PR DESCRIPTION
## 요약
- 모바일 장소관리 탭의 최상위 컨테이너를 세로 스크롤 가능하게 조정했습니다.
- 데스크톱에서는 기존처럼 목록/상세 내부 스크롤을 유지하도록 breakpoint를 분리했습니다.
- 모바일 E2E에서 실제 스크롤 가능 여부를 검증했습니다.

## Coverage Plan
- apps/web/src/features/editor/components/design/LocationsSubTab.tsx: 모바일 최상위 스크롤 컨테이너와 데스크톱 overflow 분기 검증
- apps/web/src/features/editor/components/design/LocationDetailPanel.tsx: 모바일 단일 세로 흐름, 데스크톱 내부 패널 스크롤 유지 검증
- apps/web/src/features/editor/components/design/LocationHierarchyList.tsx: 모바일 중첩 스크롤 제거, 데스크톱 목록 스크롤 유지 검증
- apps/web/e2e/location-hierarchy.spec.ts: 390px 모바일 viewport에서 scrollHeight/clientHeight 및 scrollTop 이동 검증

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
- pnpm --filter @mmp/web typecheck
- pnpm --filter @mmp/web exec playwright test e2e/location-hierarchy.spec.ts --project=chromium --grep "모바일"
- scripts/mmp-local-ci.sh quick: success @ 3d8666f2a9fa1cfbd0006a287f1348a837159cbd

Closes #618