### PR TITLE
feat(web): 단서 선택 검색 UI 공용화

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -156,31 +156,33 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
 
     await page.goto(`${BASE}/editor/${THEME_ID}/clues`);
     await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('게임 중 사용 효과')).toBeVisible();
+    await expect(page.getByText('단서 사용 설정')).toBeVisible();
     await expect(page.getByText('itemEffects')).toHaveCount(0);
     await expect(page.getByText('grant_clue')).toHaveCount(0);
 
+    await page.getByLabel('사용 가능한 아이템').check();
     await page.getByRole('button', { name: '새 단서 지급' }).click();
     await page.getByLabel('지급할 단서 검색').fill('금고');
-    await page.getByRole('button', { name: '금고 비밀번호', exact: true }).click();
+    await page.getByRole('button', { name: '금고 비밀번호 지급 목록에 추가' }).click();
     await page.getByLabel(/사용하면 내 단서함에서 사라짐/).check();
-    await page.getByRole('button', { name: '효과 저장' }).click();
 
-    await expect.poll(() => state.configPutCalls).toBeGreaterThanOrEqual(1);
-    const modules = state.configJson.modules as Record<
-      string,
-      { config?: Record<string, unknown> }
-    >;
-    const clueInteraction = modules.clue_interaction?.config as
-      | { itemEffects?: Record<string, Record<string, unknown>> }
-      | undefined;
-
-    expect(clueInteraction?.itemEffects?.[CLUE_ID]).toMatchObject({
-      effect: 'grant_clue',
-      target: 'self',
-      consume: true,
-      grantClueIds: [REWARD_CLUE_ID],
-    });
+    await expect
+      .poll(() => {
+        const modules = state.configJson.modules as Record<
+          string,
+          { config?: Record<string, unknown> }
+        >;
+        const clueInteraction = modules.clue_interaction?.config as
+          | { itemEffects?: Record<string, Record<string, unknown>> }
+          | undefined;
+        return clueInteraction?.itemEffects?.[CLUE_ID];
+      })
+      .toMatchObject({
+        effect: 'grant_clue',
+        target: 'self',
+        consume: true,
+        grantClueIds: [REWARD_CLUE_ID],
+      });
     expect(JSON.stringify(state.lastConfigRequestBody)).not.toContain('module_configs');
   });
 
@@ -656,19 +658,14 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
 
     await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('거실').first()).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByText('R2~4').first()).toBeVisible({ timeout: 3_000 });
     await expect(page.getByLabel('거실 단서 조사')).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByText(/접근 제한/).first()).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText('배치된 단서').first()).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText('금고 비밀번호')).toHaveCount(0);
 
-    // UI: 단서 chip/체크박스가 있으면 토글 + 즉시 반영
-    const chip = page.getByRole('checkbox').first();
-    if (await chip.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      const wasChecked = await chip.isChecked().catch(() => false);
-      await chip.click().catch(() => {});
-      await expect(chip)
-        .toBeChecked({ checked: !wasChecked, timeout: 2_000 })
-        .catch(() => {});
-    }
+    await page.getByLabel('배치할 단서 검색').fill('금고');
+    await expect(page.getByRole('button', { name: '금고 비밀번호 추가' })).toBeVisible({
+      timeout: 3_000,
+    });
   });
 
   test('[9] 템플릿 탭 GET /api/v1/templates (network-only)', async ({ page }) => {

--- a/apps/web/e2e/location-hierarchy.spec.ts
+++ b/apps/web/e2e/location-hierarchy.spec.ts
@@ -79,6 +79,22 @@ async function installLocationHierarchyRoutes(page: Page) {
 }
 
 test.describe('location hierarchy clue placement', () => {
+  test('장소 단서 배치는 선택 항목을 먼저 보이고 검색 후 후보를 보여준다', async ({ page }) => {
+    const commonState = freshState();
+    await mockCommonApis(page, commonState);
+    await installLocationHierarchyRoutes(page);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/locations`);
+    await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('거실 단서 조사')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('배치된 단서').first()).toBeVisible();
+    await expect(page.getByText('금고 비밀번호')).toHaveCount(0);
+
+    await page.getByLabel('배치할 단서 검색').fill('금고');
+    await expect(page.getByRole('button', { name: '금고 비밀번호 추가' })).toBeVisible();
+  });
+
   test('모바일 장소관리 탭은 긴 상세 설정을 세로 스크롤로 접근할 수 있다', async ({ page }) => {
     const commonState = freshState();
     await mockCommonApis(page, commonState);

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.test.tsx
@@ -107,11 +107,12 @@ describe('ClueRuntimeEffectCard', () => {
     fireEvent.change(screen.getByLabelText('지급할 단서 검색'), {
       target: { value: '금고' },
     });
-    fireEvent.click(screen.getByRole('button', { name: '금고 비밀번호' }));
+    fireEvent.click(screen.getByRole('button', { name: '금고 비밀번호 지급 목록에 추가' }));
     fireEvent.click(screen.getByLabelText('암호 사용'));
     fireEvent.change(screen.getByLabelText('사용 암호'), { target: { value: 'gold' } });
 
-    expect(screen.getByText('선택된 지급 단서')).toBeDefined();
+    expect(screen.getByText('지급할 단서')).toBeDefined();
+    expect(screen.getByRole('button', { name: '금고 비밀번호 지급 목록에서 제거' })).toBeDefined();
 
     const saved = ref.current?.getSaveRequest().writeConfig({}) as EditorConfig;
     expect(readClueItemEffect(saved, 'clue-1')).toMatchObject({

--- a/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueRuntimeEffectCard.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Eye, FileText, Gift, Search, Shuffle, TriangleAlert, X } from 'lucide-react';
+import { Eye, FileText, Gift, Search, Shuffle, TriangleAlert } from 'lucide-react';
 import type { ClueResponse } from '@/features/editor/api';
 import {
   readClueItemEffect,
@@ -8,6 +8,7 @@ import {
   type ClueItemEffectConfig,
   type EditorConfig,
 } from '@/features/editor/utils/configShape';
+import { ClueSearchMultiSelect, type ClueSearchSelectItem } from '@/features/editor/components/design/ClueSearchMultiSelect';
 
 type EffectMode = 'description' | 'reveal' | 'grant' | 'peek' | 'steal' | 'kill';
 
@@ -231,24 +232,22 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
     [configJson, clue.id],
   );
   const [draft, setDraft] = useState<DraftState>(() => draftFromConfig(savedEffect));
-  const [query, setQuery] = useState('');
 
   useEffect(() => {
     setDraft(draftFromConfig(savedEffect));
-    setQuery('');
   }, [savedEffect]);
 
-  const candidates = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return clues
-      .filter((item) => item.id !== clue.id)
-      .filter((item) => (q ? item.name.toLowerCase().includes(q) : true))
-      .slice(0, 8);
-  }, [clue.id, clues, query]);
-
-  const selectedClues = useMemo(
-    () => clues.filter((item) => draft.grantClueIds.includes(item.id)),
-    [clues, draft.grantClueIds],
+  const grantClueItems = useMemo(
+    () =>
+      clues
+        .filter((item) => item.id !== clue.id)
+        .map((item): ClueSearchSelectItem => ({
+          id: item.id,
+          name: item.name,
+          meta: item.is_common ? '공용 단서' : item.location_id ? '장소 단서' : '미배치',
+          badge: typeof item.reveal_round === 'number' ? `R${item.reveal_round}` : 'CL',
+        })),
+    [clue.id, clues],
   );
 
   const draftEffect = useMemo(() => toEffectConfig(draft), [draft]);
@@ -410,11 +409,8 @@ export const ClueRuntimeEffectCard = forwardRef<ClueRuntimeEffectCardHandle, Clu
 
           {draft.mode === 'grant' && (
             <GrantCluePicker
-              candidates={candidates}
-              selectedClues={selectedClues}
-              query={query}
+              items={grantClueItems}
               selectedIds={draft.grantClueIds}
-              onQueryChange={setQuery}
               onToggle={toggleGrantClue}
             />
           )}
@@ -531,86 +527,30 @@ function PowerField({
 }
 
 function GrantCluePicker({
-  candidates,
-  selectedClues,
-  query,
+  items,
   selectedIds,
-  onQueryChange,
   onToggle,
 }: {
-  candidates: ClueResponse[];
-  selectedClues: ClueResponse[];
-  query: string;
+  items: ClueSearchSelectItem[];
   selectedIds: string[];
-  onQueryChange: (value: string) => void;
   onToggle: (clueId: string) => void;
 }) {
   return (
-    <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(220px,0.8fr)]">
-      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
-        <label htmlFor="clue-grant-search" className="text-sm font-semibold text-slate-200">
-          지급할 단서 검색
-        </label>
-        <div className="mt-2 flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2">
-          <Search className="h-4 w-4 text-slate-500" />
-          <input
-            id="clue-grant-search"
-            value={query}
-            onChange={(e) => onQueryChange(e.target.value)}
-            placeholder="단서 이름으로 검색"
-            className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-600 focus:outline-none"
-          />
-        </div>
-        <div className="mt-3 space-y-2">
-          {candidates.map((candidate) => {
-            const selected = selectedIds.includes(candidate.id);
-            return (
-              <button
-                key={candidate.id}
-                type="button"
-                onClick={() => onToggle(candidate.id)}
-                aria-pressed={selected}
-                className={`w-full rounded-lg border px-3 py-2 text-left text-sm ${
-                  selected
-                    ? 'border-amber-500/60 bg-amber-500/10 text-amber-100'
-                    : 'border-slate-800 bg-slate-950/70 text-slate-300 hover:border-slate-700'
-                }`}
-              >
-                {candidate.name}
-              </button>
-            );
-          })}
-          {candidates.length === 0 && (
-            <p className="rounded-lg border border-dashed border-slate-800 px-3 py-6 text-center text-xs text-slate-500">
-              검색 결과가 없습니다.
-            </p>
-          )}
-        </div>
-      </div>
-      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
-        <p className="text-sm font-semibold text-slate-200">선택된 지급 단서</p>
-        {selectedClues.length === 0 ? (
-          <p className="mt-3 rounded-lg border border-dashed border-slate-800 px-3 py-6 text-center text-xs text-slate-500">
-            아직 지급할 단서를 고르지 않았습니다.
-          </p>
-        ) : (
-          <ul className="mt-3 space-y-2">
-            {selectedClues.map((selected) => (
-              <li key={selected.id} className="flex items-center justify-between gap-2 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm text-slate-200">
-                <span>{selected.name}</span>
-                <button
-                  type="button"
-                  onClick={() => onToggle(selected.id)}
-                  aria-label={`${selected.name} 지급 목록에서 제거`}
-                  className="rounded-md p-1 text-slate-500 hover:bg-slate-800 hover:text-slate-200"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+    <div className="mt-4">
+      <ClueSearchMultiSelect
+        title="지급할 단서"
+        items={items}
+        selectedIds={selectedIds}
+        searchLabel="지급할 단서 검색"
+        searchPlaceholder="단서 이름으로 검색"
+        emptySelectedText="아직 지급할 단서를 고르지 않았습니다."
+        idleSearchText="전체 단서를 펼치지 않고 검색 결과만 보여줍니다. 단서명을 입력하세요."
+        resultLimit={8}
+        getAddAriaLabel={(item) => `${item.name} 지급 목록에 추가`}
+        getRemoveAriaLabel={(item) => `${item.name} 지급 목록에서 제거`}
+        onAdd={onToggle}
+        onRemove={onToggle}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/design/ClueSearchMultiSelect.tsx
+++ b/apps/web/src/features/editor/components/design/ClueSearchMultiSelect.tsx
@@ -1,0 +1,254 @@
+import { Check, Plus, Search, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+export interface ClueSearchSelectItem {
+  id: string;
+  name: string;
+  meta?: string;
+  badge?: string;
+}
+
+interface ClueSearchMultiSelectProps<T extends ClueSearchSelectItem> {
+  title: string;
+  items: T[];
+  selectedIds: string[];
+  disabled?: boolean;
+  activeId?: string | null;
+  searchLabel: string;
+  searchPlaceholder: string;
+  emptySelectedText: string;
+  idleSearchText: string;
+  emptySearchText?: string;
+  resultLimit?: number;
+  getDisabledReason?: (item: T) => string | null | undefined;
+  getAddAriaLabel?: (item: T) => string;
+  getRemoveAriaLabel?: (item: T) => string;
+  getSelectedAriaLabel?: (item: T) => string;
+  onAdd: (id: string) => void;
+  onRemove: (id: string) => void;
+  onSelectSelected?: (id: string) => void;
+}
+
+function normalize(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export function ClueSearchMultiSelect<T extends ClueSearchSelectItem>({
+  title,
+  items,
+  selectedIds,
+  disabled = false,
+  activeId,
+  searchLabel,
+  searchPlaceholder,
+  emptySelectedText,
+  idleSearchText,
+  emptySearchText = '검색 결과가 없습니다.',
+  resultLimit = 20,
+  getDisabledReason,
+  getAddAriaLabel,
+  getRemoveAriaLabel,
+  getSelectedAriaLabel,
+  onAdd,
+  onRemove,
+  onSelectSelected,
+}: ClueSearchMultiSelectProps<T>) {
+  const [query, setQuery] = useState('');
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const selectedItems = useMemo(
+    () => items.filter((item) => selectedSet.has(item.id)),
+    [items, selectedSet],
+  );
+  const normalizedQuery = normalize(query);
+  const searchResults = useMemo(() => {
+    if (!normalizedQuery) return [];
+    return items
+      .filter((item) =>
+        [item.name, item.meta, item.badge]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+          .includes(normalizedQuery),
+      )
+      .slice(0, resultLimit);
+  }, [items, normalizedQuery, resultLimit]);
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">{title}</p>
+        <span className="text-[10px] text-slate-600">
+          {selectedItems.length}/{items.length}개 선택
+        </span>
+      </div>
+
+      {selectedItems.length === 0 ? (
+        <p className="mb-3 rounded-md border border-dashed border-slate-800 px-3 py-5 text-center text-xs text-slate-600">
+          {emptySelectedText}
+        </p>
+      ) : (
+        <div className="mb-3 grid gap-1.5">
+          {selectedItems.map((item) => (
+            <SelectedClueRow
+              key={item.id}
+              item={item}
+              active={activeId === item.id}
+              disabled={disabled}
+              removeLabel={getRemoveAriaLabel?.(item) ?? `${item.name} 제거`}
+              selectLabel={getSelectedAriaLabel?.(item) ?? `${item.name} 선택`}
+              onRemove={onRemove}
+              onSelect={onSelectSelected}
+            />
+          ))}
+        </div>
+      )}
+
+      <label className="relative block">
+        <span className="sr-only">{searchLabel}</span>
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-600" />
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={searchPlaceholder}
+          aria-label={searchLabel}
+          className="w-full rounded-lg border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+        />
+      </label>
+
+      <div className="mt-3">
+        {!normalizedQuery ? (
+          <p className="rounded-md border border-dashed border-slate-800 px-3 py-5 text-center text-xs text-slate-600">
+            {idleSearchText}
+          </p>
+        ) : searchResults.length === 0 ? (
+          <p className="rounded-md border border-dashed border-slate-800 px-3 py-5 text-center text-xs text-slate-600">
+            {emptySearchText}
+          </p>
+        ) : (
+          <div className="space-y-1 pr-1 lg:max-h-72 lg:overflow-y-auto">
+            {searchResults.map((item) => {
+              const selected = selectedSet.has(item.id);
+              const disabledReason = getDisabledReason?.(item);
+              const itemDisabled = disabled || Boolean(disabledReason);
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  disabled={itemDisabled && !selected}
+                  aria-pressed={selected}
+                  aria-label={
+                    selected
+                      ? (getSelectedAriaLabel?.(item) ?? `${item.name} 선택`)
+                      : (getAddAriaLabel?.(item) ?? `${item.name} 추가`)
+                  }
+                  onClick={() => {
+                    if (selected) onSelectSelected?.(item.id);
+                    else onAdd(item.id);
+                  }}
+                  className={`group flex w-full items-center gap-3 rounded-md border px-2 py-2 text-left transition hover:border-amber-500/30 hover:bg-slate-800/80 disabled:cursor-default disabled:border-slate-800 disabled:bg-slate-950/40 ${
+                    selected
+                      ? 'border-amber-500/20 bg-amber-950/10'
+                      : 'border-transparent'
+                  }`}
+                >
+                  <ClueBadge item={item} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium text-slate-200">
+                      {item.name}
+                    </span>
+                    {item.meta && (
+                      <span className="mt-0.5 block truncate text-xs text-slate-500">
+                        {item.meta}
+                      </span>
+                    )}
+                  </span>
+                  <span className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-slate-700 px-2 text-[10px] font-semibold text-slate-500 transition group-hover:border-amber-500 group-hover:text-amber-300">
+                    {selected ? (
+                      <>
+                        <Check className="mr-1 h-3.5 w-3.5" />
+                        선택됨
+                      </>
+                    ) : disabledReason ? (
+                      disabledReason
+                    ) : (
+                      <Plus className="h-3.5 w-3.5" />
+                    )}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SelectedClueRow<T extends ClueSearchSelectItem>({
+  item,
+  active,
+  disabled,
+  removeLabel,
+  selectLabel,
+  onRemove,
+  onSelect,
+}: {
+  item: T;
+  active: boolean;
+  disabled: boolean;
+  removeLabel: string;
+  selectLabel: string;
+  onRemove: (id: string) => void;
+  onSelect?: (id: string) => void;
+}) {
+  const content = (
+    <>
+      <ClueBadge item={item} />
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block truncate text-xs font-medium text-slate-200">{item.name}</span>
+        {item.meta && (
+          <span className="block truncate text-[10px] text-slate-600">{item.meta}</span>
+        )}
+      </span>
+    </>
+  );
+
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-lg border px-2.5 py-1.5 ${
+        active ? 'border-amber-400/50 bg-amber-500/10' : 'border-amber-500/20 bg-slate-950/80'
+      }`}
+    >
+      {onSelect ? (
+        <button
+          type="button"
+          onClick={() => onSelect(item.id)}
+          aria-label={selectLabel}
+          className="flex min-w-0 flex-1 items-center gap-2"
+        >
+          {content}
+        </button>
+      ) : (
+        <span className="flex min-w-0 flex-1 items-center gap-2">{content}</span>
+      )}
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onRemove(item.id)}
+        aria-label={removeLabel}
+        className="rounded-full p-1 text-slate-600 hover:bg-red-950/40 hover:text-red-300 disabled:opacity-50"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+function ClueBadge<T extends ClueSearchSelectItem>({ item }: { item: T }) {
+  return (
+    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-800 text-[10px] font-semibold text-amber-400">
+      {item.badge ?? 'CL'}
+    </span>
+  );
+}

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { Check, MapPin, Package, Plus, Search, X } from 'lucide-react';
+import { MapPin, Package } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import type { EditorThemeResponse, LocationResponse, ClueResponse } from '@/features/editor/api';
@@ -23,6 +23,7 @@ import {
   type InvestigationCostDraft,
 } from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
 import { getLocationPathLabel } from '@/features/editor/entities/location/locationHierarchy';
+import { ClueSearchMultiSelect, type ClueSearchSelectItem } from './ClueSearchMultiSelect';
 import { LocationSelectedClueItem } from './LocationSelectedClueItem';
 
 interface LocationClueAssignPanelProps {
@@ -44,6 +45,15 @@ function roundLabel(clue: ClueResponse) {
   return typeof clue.reveal_round === 'number' ? `R${clue.reveal_round}` : 'CL';
 }
 
+function toClueSearchItem(clue: ClueResponse): ClueSearchSelectItem {
+  return {
+    id: clue.id,
+    name: clue.name,
+    meta: clueMeta(clue),
+    badge: roundLabel(clue),
+  };
+}
+
 export function LocationClueAssignPanel({
   themeId,
   theme,
@@ -56,7 +66,6 @@ export function LocationClueAssignPanel({
   const clues = useMemo(() => allClues ?? fetchedClues ?? [], [allClues, fetchedClues]);
   const updateConfig = useUpdateConfigJson(themeId);
   const queryClient = useQueryClient();
-  const [query, setQuery] = useState('');
   const [activeClueId, setActiveClueId] = useState<string | null>(null);
 
   const discoveries = useMemo(
@@ -84,21 +93,11 @@ export function LocationClueAssignPanel({
   const clueById = useMemo(() => new Map(clues.map((clue) => [clue.id, clue])), [clues]);
   const selectedClues = clues.filter((clue) => assignedSet.has(clue.id));
   const activeClue = selectedClues.find((clue) => clue.id === activeClueId) ?? selectedClues[0] ?? null;
+  const clueSearchItems = useMemo(() => clues.map(toClueSearchItem), [clues]);
   const locationPathLabel = useMemo(
     () => getLocationPathLabel(location, allLocations ?? [location]),
     [allLocations, location]
   );
-  const visibleClues = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return clues;
-    return clues.filter((clue) =>
-      [clue.name, clue.description, clueMeta(clue), clue.reveal_round?.toString()]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase()
-        .includes(q)
-    );
-  }, [clues, query]);
 
   function readLatestConfigJson() {
     return queryClient.getQueryData<EditorThemeResponse>(editorKeys.theme(themeId))?.config_json
@@ -275,47 +274,24 @@ export function LocationClueAssignPanel({
         <EmptyClues />
       ) : (
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(13rem,0.65fr)]">
-          <section className="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
-            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
-                전체 단서 목록
-              </p>
-              <span className="text-[10px] text-slate-600">
-                {visibleClues.length}/{clues.length}개 표시
-              </span>
-            </div>
-            <label className="relative mb-3 block">
-              <span className="sr-only">단서 검색</span>
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-600" />
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="단서명, 설명, 라운드 검색"
-                aria-label="단서 검색"
-                className="w-full rounded-lg border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-              />
-            </label>
-            <div className="space-y-1 pr-1 lg:max-h-80 lg:overflow-y-auto">
-              {visibleClues.length === 0 ? (
-                <p className="rounded-md border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
-                  검색 결과가 없습니다.
-                </p>
-              ) : (
-                visibleClues.map((clue) => (
-                  <ClueOption
-                    key={clue.id}
-                    clue={clue}
-                    selected={assignedSet.has(clue.id)}
-                    active={activeClue?.id === clue.id}
-                    unavailable={globallyAssignedClueIds.has(clue.id)}
-                    disabled={updateConfig.isPending}
-                    onSelect={addClue}
-                    onRemove={removeClue}
-                  />
-                ))
-              )}
-            </div>
-          </section>
+          <ClueSearchMultiSelect
+            title="배치된 단서"
+            items={clueSearchItems}
+            selectedIds={assignedIds}
+            activeId={activeClue?.id}
+            disabled={updateConfig.isPending}
+            searchLabel="배치할 단서 검색"
+            searchPlaceholder="단서명, 상태, 라운드 검색"
+            emptySelectedText="아직 배정된 단서가 없습니다. 단서명으로 검색해 이 장소에서 발견할 단서를 추가하세요."
+            idleSearchText="전체 단서를 펼치지 않고 검색 결과만 보여줍니다. 단서명을 입력해 추가하세요."
+            getDisabledReason={(item) => (globallyAssignedClueIds.has(item.id) ? '배치됨' : null)}
+            getAddAriaLabel={(item) => `${item.name} 추가`}
+            getSelectedAriaLabel={(item) => `${item.name} 설정 열기`}
+            getRemoveAriaLabel={(item) => `${item.name} 해제`}
+            onAdd={addClue}
+            onRemove={removeClue}
+            onSelectSelected={setActiveClueId}
+          />
           <section className="rounded-lg border border-amber-500/20 bg-amber-950/10 p-2.5">
             <div className="mb-2 flex items-center justify-between gap-2">
               <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
@@ -353,76 +329,6 @@ export function LocationClueAssignPanel({
         </div>
       )}
     </section>
-  );
-}
-
-function ClueOption({
-  clue,
-  selected,
-  active,
-  unavailable,
-  disabled,
-  onSelect,
-  onRemove,
-}: {
-  clue: ClueResponse;
-  selected: boolean;
-  active: boolean;
-  unavailable: boolean;
-  disabled: boolean;
-  onSelect: (id: string) => void;
-  onRemove: (id: string) => void;
-}) {
-  return (
-    <div
-      className={`group flex w-full items-center gap-3 rounded-md border px-2 py-2 text-left transition hover:border-amber-500/30 hover:bg-slate-800/80 disabled:cursor-default disabled:border-slate-800 disabled:bg-slate-950/40 ${
-        active
-          ? 'border-amber-400/50 bg-amber-500/10'
-          : selected
-            ? 'border-amber-500/20 bg-amber-950/10'
-            : 'border-transparent'
-      }`}
-    >
-      <button
-        type="button"
-        onClick={() => onSelect(clue.id)}
-        disabled={disabled || unavailable}
-        aria-label={selected ? `${clue.name} 설정 열기` : `${clue.name} 추가`}
-        className="flex min-w-0 flex-1 items-center gap-3 text-left disabled:cursor-default"
-      >
-        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-800 text-[10px] font-semibold text-amber-400">
-          {roundLabel(clue)}
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-sm font-medium text-slate-200">{clue.name}</span>
-          <span className="mt-0.5 block truncate text-xs text-slate-500">{clueMeta(clue)}</span>
-        </span>
-        <span className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-slate-700 px-2 text-[10px] font-semibold text-slate-500 group-hover:border-amber-500 group-hover:text-amber-300">
-          {selected ? (
-            <>
-              <Check className="mr-1 h-3.5 w-3.5" />
-              선택됨
-            </>
-          ) : unavailable ? (
-            '배치됨'
-          ) : (
-            <Plus className="h-3.5 w-3.5" />
-          )}
-        </span>
-      </button>
-      {selected ? (
-        <button
-          type="button"
-          disabled={disabled}
-          aria-label={`${clue.name} 해제`}
-          onClick={() => onRemove(clue.id)}
-          className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-red-500/20 px-2 text-[10px] font-semibold text-red-300 transition hover:border-red-400/50 hover:bg-red-500/10 disabled:opacity-50"
-        >
-          <X className="mr-1 h-3 w-3" />
-          해제
-        </button>
-      ) : null}
-    </div>
   );
 }
 

--- a/apps/web/src/features/editor/components/design/LocationSelectedClueItem.tsx
+++ b/apps/web/src/features/editor/components/design/LocationSelectedClueItem.tsx
@@ -5,6 +5,7 @@ import type {
   InvestigationCostDraft,
   InvestigationTokenDraft,
 } from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
+import { ClueSearchMultiSelect, type ClueSearchSelectItem } from './ClueSearchMultiSelect';
 import { InvestigationCostSelector } from './InvestigationCostSelector';
 
 interface LocationSelectedClueItemProps {
@@ -31,6 +32,15 @@ function roundLabel(clue: ClueResponse) {
   return typeof clue.reveal_round === 'number' ? `R${clue.reveal_round}` : 'CL';
 }
 
+function toClueSearchItem(clue: ClueResponse): ClueSearchSelectItem {
+  return {
+    id: clue.id,
+    name: clue.name,
+    meta: clueMeta(clue),
+    badge: roundLabel(clue),
+  };
+}
+
 export function LocationSelectedClueItem({
   clue,
   discovery,
@@ -45,7 +55,7 @@ export function LocationSelectedClueItem({
   onCostChange,
 }: LocationSelectedClueItemProps) {
   const requiredIds = discovery?.requiredClueIds ?? [];
-  const requiredSet = new Set(requiredIds);
+  const availableItems = availableClues.map(toClueSearchItem);
   const selectedRequiredNames = requiredIds
     .map((id) => clueById.get(id)?.name)
     .filter(Boolean)
@@ -75,34 +85,23 @@ export function LocationSelectedClueItem({
         </button>
       </div>
       <div className="mt-2 rounded-md border border-slate-800 bg-slate-950/80 p-2">
-        <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-          필요 단서
-        </p>
         {availableClues.length === 0 ? (
           <p className="text-[10px] text-slate-600">조건으로 사용할 다른 단서가 없습니다.</p>
         ) : (
-          <div className="flex flex-wrap gap-1.5">
-            {availableClues.map((candidate) => {
-              const selected = requiredSet.has(candidate.id);
-              return (
-                <button
-                  key={candidate.id}
-                  type="button"
-                  disabled={disabled}
-                  onClick={() => onToggleRequired(clue.id, candidate.id)}
-                  aria-pressed={selected}
-                  aria-label={`${clue.name} 발견 조건 ${candidate.name} ${selected ? '해제' : '필요'}`}
-                  className={`rounded-full border px-2 py-1 text-[10px] transition disabled:opacity-50 ${
-                    selected
-                      ? 'border-amber-400/50 bg-amber-500/10 text-amber-200'
-                      : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-300'
-                  }`}
-                >
-                  {candidate.name}
-                </button>
-              );
-            })}
-          </div>
+          <ClueSearchMultiSelect
+            title="필요 단서"
+            items={availableItems}
+            selectedIds={requiredIds}
+            disabled={disabled}
+            searchLabel={`${clue.name} 필요 단서 검색`}
+            searchPlaceholder="먼저 보유해야 할 단서 검색"
+            emptySelectedText="조건 없음"
+            idleSearchText="필요 단서를 검색해 추가하세요."
+            getAddAriaLabel={(item) => `${clue.name} 발견 조건 ${item.name} 필요`}
+            getRemoveAriaLabel={(item) => `${clue.name} 발견 조건 ${item.name} 해제`}
+            onAdd={(requiredClueId) => onToggleRequired(clue.id, requiredClueId)}
+            onRemove={(requiredClueId) => onToggleRequired(clue.id, requiredClueId)}
+          />
         )}
         <p className="mt-1.5 text-[10px] text-slate-600">
           {selectedRequiredNames ? `${selectedRequiredNames} 보유 시 발견` : '조건 없음'}

--- a/apps/web/src/features/editor/components/design/StartingClueAssigner.tsx
+++ b/apps/web/src/features/editor/components/design/StartingClueAssigner.tsx
@@ -1,5 +1,5 @@
-import { Plus, Search, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { ClueSearchMultiSelect, type ClueSearchSelectItem } from './ClueSearchMultiSelect';
 
 interface ClueItem {
   id: string;
@@ -25,6 +25,15 @@ function getRoundLabel(clue: ClueItem) {
   return typeof clue.round === 'number' ? `R${clue.round}` : 'CL';
 }
 
+function toClueSearchItem(clue: ClueItem): ClueSearchSelectItem {
+  return {
+    id: clue.id,
+    name: clue.name,
+    meta: getClueMeta(clue),
+    badge: getRoundLabel(clue),
+  };
+}
+
 export function StartingClueAssigner({
   characterName,
   clues,
@@ -32,131 +41,25 @@ export function StartingClueAssigner({
   onClueToggle,
   selectedTitle,
 }: StartingClueAssignerProps) {
-  const [query, setQuery] = useState('');
-  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
-  const normalizedQuery = query.trim().toLowerCase();
-  const selectedClues = clues.filter((clue) => selectedSet.has(clue.id));
-  const visibleClues = clues.filter((clue) => {
-    if (!normalizedQuery) return true;
-    const haystack = [clue.name, clue.location, clue.tag, clue.round?.toString()]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase();
-    return haystack.includes(normalizedQuery);
-  });
+  const items = useMemo(() => clues.map(toClueSearchItem), [clues]);
 
   if (clues.length === 0) {
     return <p className="text-xs text-slate-600">단서가 없습니다</p>;
   }
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[minmax(0,1.6fr)_minmax(13rem,0.55fr)]">
-      <section className="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
-            전체 단서 목록
-          </p>
-          <span className="text-[10px] text-slate-600">
-            {visibleClues.length}/{clues.length}개 표시
-          </span>
-        </div>
-
-        <label className="relative mb-3 block">
-          <span className="sr-only">단서 검색</span>
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-600" />
-          <input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="단서명, 장소, 태그 검색"
-            aria-label="단서 검색"
-            className="w-full rounded-lg border border-slate-700 bg-slate-900 py-2 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
-          />
-        </label>
-
-        <div className="max-h-80 space-y-1 overflow-auto pr-1">
-          {visibleClues.length === 0 ? (
-            <p className="rounded-md border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
-              검색 결과가 없습니다.
-            </p>
-          ) : (
-            visibleClues.map((clue) => {
-              const isSelected = selectedSet.has(clue.id);
-              const meta = getClueMeta(clue);
-              return (
-                <button
-                  key={clue.id}
-                  type="button"
-                  onClick={() => onClueToggle(clue.id, true)}
-                  disabled={isSelected}
-                  className="group flex w-full items-center gap-3 rounded-md border border-transparent px-2 py-2 text-left transition hover:border-amber-500/30 hover:bg-slate-800/80 disabled:cursor-default disabled:border-amber-500/10 disabled:bg-amber-950/10"
-                >
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-800 text-[10px] font-semibold text-amber-400">
-                    {getRoundLabel(clue)}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm font-medium text-slate-200">
-                      {clue.name}
-                    </span>
-                    {meta && (
-                      <span className="mt-0.5 block truncate text-xs text-slate-500">{meta}</span>
-                    )}
-                  </span>
-                  <span className="inline-flex h-7 shrink-0 items-center justify-center rounded-full border border-slate-700 px-2 text-[10px] font-semibold text-slate-500 transition group-hover:border-amber-500 group-hover:text-amber-300 group-disabled:border-amber-500/20 group-disabled:text-amber-300/70">
-                    {isSelected ? '추가됨' : <Plus className="h-3.5 w-3.5" />}
-                  </span>
-                </button>
-              );
-            })
-          )}
-        </div>
-      </section>
-
-      <section className="rounded-lg border border-amber-500/20 bg-amber-950/10 p-2.5">
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">
-            {selectedTitle ?? `${characterName}의 시작 단서`}
-          </p>
-          <span className="text-[10px] text-slate-600">클릭 추가</span>
-        </div>
-
-        {selectedClues.length === 0 ? (
-          <p className="rounded-md border border-dashed border-slate-800 px-2.5 py-5 text-center text-xs text-slate-600">
-            아직 배정된 단서가 없습니다. 좌측 목록에서 단서를 클릭하세요.
-          </p>
-        ) : (
-          <div className="space-y-2">
-            {selectedClues.map((clue) => {
-              const meta = getClueMeta(clue);
-              return (
-                <div
-                  key={clue.id}
-                  className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-slate-950/80 px-2.5 py-1.5"
-                >
-                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-amber-500/10 text-[9px] font-semibold text-amber-300">
-                    {getRoundLabel(clue)}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-xs font-medium text-slate-200">
-                      {clue.name}
-                    </span>
-                    {meta && (
-                      <span className="block truncate text-[10px] text-slate-600">{meta}</span>
-                    )}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => onClueToggle(clue.id, false)}
-                    aria-label={`${clue.name} 제거`}
-                    className="rounded-full p-1 text-slate-600 hover:bg-red-950/40 hover:text-red-300"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </section>
-    </div>
+    <ClueSearchMultiSelect
+      title={selectedTitle ?? `${characterName}의 시작 단서`}
+      items={items}
+      selectedIds={selectedIds}
+      searchLabel="시작 단서 검색"
+      searchPlaceholder="단서명, 장소, 태그 검색"
+      emptySelectedText="아직 배정된 단서가 없습니다. 단서명으로 검색해 시작 단서를 추가하세요."
+      idleSearchText="전체 단서를 펼치지 않고 검색 결과만 보여줍니다. 단서명이나 장소를 입력하세요."
+      getAddAriaLabel={(item) => `${item.name} 시작 단서 추가`}
+      getRemoveAriaLabel={(item) => `${item.name} 제거`}
+      onAdd={(id) => onClueToggle(id, true)}
+      onRemove={(id) => onClueToggle(id, false)}
+    />
   );
 }

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -326,7 +326,10 @@ function openHiddenMissionSection() {
 
 function clickFirstClue() {
   openStartingClueSection();
-  fireEvent.click(screen.getByRole('button', { name: /피 묻은 칼/ }));
+  fireEvent.change(screen.getByRole('searchbox', { name: '시작 단서 검색' }), {
+    target: { value: '피 묻은' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: '피 묻은 칼 시작 단서 추가' }));
 }
 
 // ---------------------------------------------------------------------------
@@ -657,10 +660,12 @@ describe('CharacterAssignPanel', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openStartingClueSection();
-    expect(screen.getByText('전체 단서 목록')).toBeDefined();
     expect(screen.getByText('홍길동의 시작 단서')).toBeDefined();
+    expect(screen.getByText('아직 배정된 단서가 없습니다. 단서명으로 검색해 시작 단서를 추가하세요.')).toBeDefined();
+    fireEvent.change(screen.getByRole('searchbox', { name: '시작 단서 검색' }), {
+      target: { value: '서재' },
+    });
     expect(screen.getByText('피 묻은 칼')).toBeDefined();
-    expect(screen.getByText('비밀 편지')).toBeDefined();
   });
 
 
@@ -933,19 +938,19 @@ describe('CharacterAssignPanel', () => {
     );
   });
 
-  it('좌측 단서 목록을 장소/태그로 검색할 수 있다', () => {
+  it('단서 후보를 장소/태그로 검색할 수 있다', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openStartingClueSection();
 
-    fireEvent.change(screen.getByPlaceholderText('단서명, 장소, 태그 검색'), {
+    fireEvent.change(screen.getByRole('searchbox', { name: '시작 단서 검색' }), {
       target: { value: '부엌' },
     });
 
     expect(screen.queryByText('피 묻은 칼')).toBeNull();
     expect(screen.getByText('비밀 편지')).toBeDefined();
 
-    fireEvent.change(screen.getByPlaceholderText('단서명, 장소, 태그 검색'), {
+    fireEvent.change(screen.getByRole('searchbox', { name: '시작 단서 검색' }), {
       target: { value: '문서' },
     });
 

--- a/apps/web/src/features/editor/components/design/__tests__/ClueSearchMultiSelect.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/ClueSearchMultiSelect.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClueSearchMultiSelect, type ClueSearchSelectItem } from '../ClueSearchMultiSelect';
+
+const items: ClueSearchSelectItem[] = [
+  { id: 'clue-1', name: '우산걸이', meta: '장소 단서 · 공용', badge: 'CL' },
+  { id: 'clue-2', name: '책장', meta: '장소 단서', badge: 'R1' },
+  { id: 'clue-3', name: '프런트 데스크', meta: '미배치', badge: 'CL' },
+];
+
+function renderPicker(overrides: Partial<React.ComponentProps<typeof ClueSearchMultiSelect<ClueSearchSelectItem>>> = {}) {
+  const onAdd = vi.fn();
+  const onRemove = vi.fn();
+  const onSelectSelected = vi.fn();
+  render(
+    <ClueSearchMultiSelect
+      title="배치된 단서"
+      items={items}
+      selectedIds={[]}
+      searchLabel="단서 검색"
+      searchPlaceholder="단서명 검색"
+      emptySelectedText="선택된 단서가 없습니다."
+      idleSearchText="검색어를 입력하세요."
+      onAdd={onAdd}
+      onRemove={onRemove}
+      onSelectSelected={onSelectSelected}
+      {...overrides}
+    />,
+  );
+  return { onAdd, onRemove, onSelectSelected };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ClueSearchMultiSelect', () => {
+  it('검색어가 없으면 후보 전체를 펼치지 않는다', () => {
+    renderPicker();
+
+    expect(screen.getByText('선택된 단서가 없습니다.')).toBeDefined();
+    expect(screen.getByText('검색어를 입력하세요.')).toBeDefined();
+    expect(screen.queryByText('우산걸이')).toBeNull();
+    expect(screen.queryByText('책장')).toBeNull();
+  });
+
+  it('검색 결과에서 항목을 추가한다', () => {
+    const { onAdd } = renderPicker();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: '단서 검색' }), {
+      target: { value: '책장' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '책장 추가' }));
+
+    expect(onAdd).toHaveBeenCalledWith('clue-2');
+  });
+
+  it('선택된 항목은 검색 없이 먼저 보이고 제거할 수 있다', () => {
+    const { onRemove, onSelectSelected } = renderPicker({
+      selectedIds: ['clue-1'],
+      getRemoveAriaLabel: (item) => `${item.name} 해제`,
+      getSelectedAriaLabel: (item) => `${item.name} 설정 열기`,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '우산걸이 설정 열기' }));
+    fireEvent.click(screen.getByRole('button', { name: '우산걸이 해제' }));
+
+    expect(onSelectSelected).toHaveBeenCalledWith('clue-1');
+    expect(onRemove).toHaveBeenCalledWith('clue-1');
+  });
+
+  it('비활성 후보는 추가하지 못하게 막는다', () => {
+    renderPicker({
+      getDisabledReason: (item) => (item.id === 'clue-3' ? '배치됨' : null),
+    });
+
+    fireEvent.change(screen.getByRole('searchbox', { name: '단서 검색' }), {
+      target: { value: '프런트' },
+    });
+
+    expect((screen.getByRole('button', { name: '프런트 데스크 추가' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('배치됨')).toBeDefined();
+  });
+});

--- a/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx
@@ -131,15 +131,24 @@ function renderQC(ui: ReactElement): { qc: QueryClient } {
   return { qc };
 }
 
+function searchAssignableClue(value = '단검') {
+  fireEvent.change(screen.getByRole('searchbox', { name: '배치할 단서 검색' }), {
+    target: { value },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe('LocationClueAssignPanel', () => {
-  it('모든 clue가 chip으로 렌더링된다', () => {
+  it('검색 전에는 전체 후보를 펼치지 않고 검색 후 후보를 표시한다', () => {
     renderQC(
       <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
+    expect(screen.getByText('배치된 단서')).toBeDefined();
+    expect(screen.queryByText('단검')).toBeNull();
+    searchAssignableClue('미배치');
     expect(screen.getByText('단검')).toBeDefined();
     expect(screen.getByText('편지')).toBeDefined();
   });
@@ -187,6 +196,7 @@ describe('LocationClueAssignPanel', () => {
     };
   renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
     expect(screen.getByLabelText('단검 설정 열기')).toBeDefined();
+    searchAssignableClue('편지');
     expect((screen.getByLabelText('편지 추가') as HTMLButtonElement).disabled).toBe(false);
     expect(screen.getByLabelText('단검 해제')).toBeDefined();
   });
@@ -195,6 +205,7 @@ describe('LocationClueAssignPanel', () => {
     renderQC(
       <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
+    searchAssignableClue();
     fireEvent.click(screen.getByLabelText('단검 추가'));
     expect(mutateMock).toHaveBeenCalledOnce();
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
@@ -279,6 +290,9 @@ describe('LocationClueAssignPanel', () => {
     renderQC(<LocationClueAssignPanel themeId="theme-1" theme={theme} location={mockLocation} />);
 
     expect(screen.getByText('1회 발견')).toBeDefined();
+    fireEvent.change(screen.getByRole('searchbox', { name: '단검 필요 단서 검색' }), {
+      target: { value: '편지' },
+    });
     fireEvent.click(screen.getByLabelText('단검 발견 조건 편지 필요'));
 
     expect(mutateMock).toHaveBeenCalledOnce();
@@ -480,6 +494,7 @@ describe('LocationClueAssignPanel', () => {
         onChange={onChange}
       />
     );
+    searchAssignableClue();
     fireEvent.click(screen.getByLabelText('단검 추가'));
     expect(onChange).toHaveBeenCalledWith(['clue-1']);
   });
@@ -502,6 +517,7 @@ describe('LocationClueAssignPanel', () => {
         allClues={mockClues}
       />
     );
+    searchAssignableClue();
     expect(screen.getByText('단검')).toBeDefined();
   });
 
@@ -510,6 +526,7 @@ describe('LocationClueAssignPanel', () => {
     renderQC(
       <LocationClueAssignPanel themeId="theme-1" theme={baseTheme} location={mockLocation} />
     );
+    searchAssignableClue();
     const chip = screen.getByLabelText('단검 추가') as HTMLButtonElement;
     expect(chip.disabled).toBe(true);
   });
@@ -528,6 +545,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     );
     qc.setQueryData(cacheKey, baseTheme);
 
+    searchAssignableClue();
     fireEvent.click(screen.getByLabelText('단검 추가'));
 
     const cached = qc.getQueryData<EditorThemeResponse>(cacheKey);
@@ -551,6 +569,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     );
     qc.setQueryData(cacheKey, baseTheme);
 
+    searchAssignableClue();
     fireEvent.click(screen.getByLabelText('단검 추가'));
 
     const cached = qc.getQueryData<EditorThemeResponse>(cacheKey);
@@ -585,6 +604,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     qc.setQueryData(cacheKey, baseTheme);
 
     // 1st toggle: clue-1 추가 → 캐시 optimistic = {locations:[{loc-1,[clue-1]}]}
+    searchAssignableClue('미배치');
     fireEvent.click(screen.getByLabelText('단검 추가'));
 
     // 2nd toggle: 같은 컴포넌트의 `theme` prop 은 불변이므로 여전히 baseTheme 기준이지만,
@@ -611,6 +631,7 @@ describe('LocationClueAssignPanel optimistic update + rollback', () => {
     );
     // no setQueryData
 
+    searchAssignableClue();
     fireEvent.click(screen.getByLabelText('단검 추가'));
 
     expect(mutateMock).toHaveBeenCalledOnce();

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.test.tsx
@@ -334,18 +334,24 @@ describe('LocationsSubTab', () => {
 
     it('맵 선택 시 장소 선택 picker 가 표시된다', () => {
       renderLocationsSubTab();
-      expect(screen.getByText('전체 단서 목록')).toBeDefined();
+      expect(screen.getByText('배치된 단서')).toBeDefined();
     });
 
     it('location picker 를 통해 선택한 location 에 대해 LocationClueAssignPanel 이 렌더된다', () => {
       renderLocationsSubTab();
       fireEvent.click(screen.getByRole('button', { name: '주방 선택' }));
       expect(screen.getByLabelText('주방 단서 조사')).toBeDefined();
+      fireEvent.change(screen.getByRole('searchbox', { name: '배치할 단서 검색' }), {
+        target: { value: '단검' },
+      });
       expect(screen.getByLabelText('단검 추가')).toBeDefined();
     });
 
     it('chip 토글 시 useUpdateConfigJson.mutate 가 호출된다', () => {
       renderLocationsSubTab();
+      fireEvent.change(screen.getByRole('searchbox', { name: '배치할 단서 검색' }), {
+        target: { value: '단검' },
+      });
       fireEvent.click(screen.getByLabelText('단검 추가'));
       expect(updateConfigMutateMock).toHaveBeenCalledOnce();
       const [config] = updateConfigMutateMock.mock.calls[0] as [Record<string, unknown>];
@@ -434,7 +440,7 @@ describe('LocationsSubTab', () => {
     it('맵이 없으면 단서 배정 picker 가 표시되지 않는다', () => {
       useEditorMapsMock.mockReturnValue({ data: [], isLoading: false });
       renderLocationsSubTab();
-      expect(screen.queryByText('전체 단서 목록')).toBeNull();
+      expect(screen.queryByText('배치된 단서')).toBeNull();
     });
   });
 

--- a/apps/web/src/features/editor/components/design/__tests__/StartingClueAssigner.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/StartingClueAssigner.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { StartingClueAssigner } from '../StartingClueAssigner';
 
 const clues = [
@@ -38,9 +38,11 @@ describe('StartingClueAssigner', () => {
     expect(screen.getByText('단서가 없습니다')).toBeDefined();
   });
 
-  it('단서명, 장소, 태그, 라운드로 좌측 목록을 검색한다', () => {
+  it('단서명, 장소, 태그, 라운드로 후보 목록을 검색한다', () => {
     renderAssigner();
-    const search = screen.getByRole('textbox', { name: '단서 검색' });
+    const search = screen.getByRole('searchbox', { name: '시작 단서 검색' });
+
+    expect(screen.queryByText('피 묻은 칼')).toBeNull();
 
     fireEvent.change(search, { target: { value: '부엌' } });
     expect(screen.queryByText('피 묻은 칼')).toBeNull();
@@ -58,24 +60,21 @@ describe('StartingClueAssigner', () => {
     expect(screen.getByText('검색 결과가 없습니다.')).toBeDefined();
   });
 
-  it('좌측 단서를 클릭하면 추가 이벤트를 보낸다', () => {
+  it('검색한 단서를 클릭하면 추가 이벤트를 보낸다', () => {
     const { onClueToggle } = renderAssigner();
 
-    fireEvent.click(screen.getByRole('button', { name: /비밀 편지/ }));
+    fireEvent.change(screen.getByRole('searchbox', { name: '시작 단서 검색' }), {
+      target: { value: '비밀' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '비밀 편지 시작 단서 추가' }));
 
     expect(onClueToggle).toHaveBeenCalledWith('clue-2', true);
   });
 
-  it('이미 선택된 단서는 좌측에서 비활성화되고 우측에서 제거할 수 있다', () => {
+  it('이미 선택된 단서는 검색 없이 먼저 보이고 제거할 수 있다', () => {
     const { onClueToggle } = renderAssigner(['clue-1']);
-    const listSection = screen.getByText('전체 단서 목록').closest('section');
-    const assignedSection = screen.getAllByText('홍길동의 시작 단서')[0].closest('section');
-    expect(listSection).not.toBeNull();
-    expect(assignedSection).not.toBeNull();
-
-    expect(within(listSection as HTMLElement).getByRole('button', { name: /피 묻은 칼/ }).disabled).toBe(true);
-    expect(screen.getByText('추가됨')).toBeDefined();
-    expect(within(assignedSection as HTMLElement).getByText('서재 · 물증')).toBeDefined();
+    expect(screen.getByText('피 묻은 칼')).toBeDefined();
+    expect(screen.getByText('서재 · 물증')).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: '피 묻은 칼 제거' }));
 
@@ -85,6 +84,6 @@ describe('StartingClueAssigner', () => {
   it('배정된 단서가 없으면 우측 빈 상태를 표시한다', () => {
     renderAssigner();
 
-    expect(screen.getByText('아직 배정된 단서가 없습니다. 좌측 목록에서 단서를 클릭하세요.')).toBeDefined();
+    expect(screen.getByText('아직 배정된 단서가 없습니다. 단서명으로 검색해 시작 단서를 추가하세요.')).toBeDefined();
   });
 });


### PR DESCRIPTION
## 요약
- 단서 선택 UI를 `ClueSearchMultiSelect` 공용 컴포넌트로 추출했습니다.
- 장소 배치 단서, 필요 단서, 캐릭터 시작 단서, 단서 지급 설정을 모두 “선택된 항목 우선 + 검색해서 추가” 패턴으로 통일했습니다.
- 전체 후보를 기본 노출하지 않도록 바꿔 긴 단서 목록이 화면을 밀어내는 문제를 줄였습니다.

Closes #620

## Coverage Plan
- `ClueSearchMultiSelect`: 선택 항목 우선 표시, 빈 검색어에서 후보 숨김, 검색 후 추가/제거 동작을 컴포넌트 테스트로 검증합니다.
- 장소관리 단서 배치/필요 단서: 기존 location hierarchy 테스트와 E2E로 선택 패턴 회귀를 검증합니다.
- 캐릭터 시작 단서/단서 지급 설정: 기존 컴포넌트 테스트를 새 검색 기반 UI에 맞춰 갱신해 회귀를 검증합니다.

## Local validation
- `pnpm --filter @mmp/web test -- ClueSearchMultiSelect LocationClueAssignPanel StartingClueAssigner CharacterAssignPanel LocationsSubTab ClueRuntimeEffectCard` 통과: 9 files, 115 tests
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web exec playwright test e2e/location-hierarchy.spec.ts e2e/editor-golden-path.spec.ts --project=chromium --grep "장소 단서 배치는|모바일 장소관리|\[2C\]|\[8\]"` 통과: 4 tests
- `scripts/mmp-local-ci.sh quick` 통과: web lint/typecheck/test/build 포함

## 비고
- `InformationDeliveryOptionList`는 정보/장면/결말 액션에서 함께 쓰는 범용 컴포넌트라 이번 단서 선택 범위에서는 변경하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 단서 검색 및 다중 선택 UI 추가

* **개선 사항**
  * 단서 배치, 시작 단서 지정, 런타임 효과 설정 등 여러 화면에서 일관된 검색 기반 단서 선택 인터페이스로 개선
  * 단서 검색 입력을 통한 필터링 및 선택 흐름 최적화

* **테스트**
  * 새로운 검색 UI의 동작을 검증하는 테스트 추가
  * 단서 배치 및 설정 관련 E2E 테스트 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->