### PR TITLE
단서·장소 장면 선택지를 용도별로 정리

### DIFF
--- a/apps/web/e2e/editor-golden-path.spec.ts
+++ b/apps/web/e2e/editor-golden-path.spec.ts
@@ -146,8 +146,13 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await expect(page.getByLabel('단서 목록')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByLabel('단서 상세 영역')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('첫 단서').first()).toBeVisible();
-    await expect(page.getByText('정보 공개하기')).toBeVisible();
-    await expect(page.getByText('사용하면 내 단서함에서 사라짐')).toBeVisible();
+    await expect(page.getByText('단서 사용 설정')).toBeVisible();
+    await expect(page.getByLabel('획득 가능 종료')).toBeVisible();
+    await expect(page.getByText(/이미 플레이어가 가진 단서를/)).toBeVisible();
+    await expect(page.getByLabel('획득 가능 종료').locator('option')).toHaveText([
+      '계속 획득 가능',
+      '조사 단계 (장면)',
+    ]);
     await expect(page.getByText('이 단서가 쓰이는 곳')).toBeVisible();
   });
 
@@ -251,6 +256,10 @@ test.describe('Phase 18.4 에디터 골든패스 (mocked — UI interaction)', (
     await expect(page.getByLabel('장소 목록')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByLabel('거실 단서 조사')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText('저택 1층').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel('거실 출현 장면').locator('option')).toHaveText([
+      '처음부터 공개',
+      '조사 단계 (장면)',
+    ]);
 
     await page.goto(`${BASE}/editor/${THEME_ID}/endings`);
     await expect(page.getByRole('tab', { name: /게임 설계|게임설계/, selected: true })).toBeVisible({

--- a/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueBasicInfoCard.tsx
@@ -219,7 +219,7 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
   const selectedRevealSceneLabel =
     sceneOptions.find((option) => option.value === draft.revealSceneId)?.label ?? '처음부터';
   const selectedHideSceneLabel =
-    sceneOptions.find((option) => option.value === draft.hideSceneId)?.label ?? '끝까지';
+    sceneOptions.find((option) => option.value === draft.hideSceneId)?.label ?? '계속 획득 가능';
   const investigationCostKey = JSON.stringify(investigationSettings?.cost ?? null);
 
   useEffect(() => {
@@ -388,14 +388,18 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
             onChange={(sceneId) => patch({ revealSceneId: sceneId })}
           />
           <SceneSelectField
-            label="숨김 시점"
+            label="획득 가능 종료"
             selectedId={draft.hideSceneId}
             options={sceneOptions}
-            emptyLabel="끝까지"
+            emptyLabel="계속 획득 가능"
             disabled={saving}
             onChange={(sceneId) => patch({ hideSceneId: sceneId })}
           />
         </div>
+        <p className="-mt-2 text-xs leading-5 text-slate-500">
+          획득 가능 종료는 새로 얻을 수 있는 기간의 끝을 표시합니다. 이미 플레이어가 가진
+          단서를 단서함에서 회수하지는 않습니다.
+        </p>
 
         <div className="grid gap-3 md:grid-cols-2">
           <label className={`flex items-start gap-2 rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm ${draft.isCommon ? 'text-slate-500' : 'text-slate-300'}`}>
@@ -479,7 +483,7 @@ export const ClueBasicInfoCard = forwardRef<ClueBasicInfoCardHandle, ClueBasicIn
       <div className="mt-5 grid gap-3 md:grid-cols-4">
         <InfoBlock title="공개 범위" value={view.publicScopeLabel} />
         <InfoBlock title="공개 시점" value={selectedRevealSceneLabel} />
-        <InfoBlock title="숨김 시점" value={selectedHideSceneLabel} />
+        <InfoBlock title="획득 가능 종료" value={selectedHideSceneLabel} />
         <InfoBlock title="사용 후 처리" value={formatClueConsumeLabel(clue, runtimeEffect)} />
       </div>
     </article>

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.test.tsx
@@ -22,7 +22,8 @@ vi.mock('@/features/editor/flowApi', () => ({
   useFlowGraph: () => ({
     data: {
       nodes: [
-        { id: 'scene-1', type: 'phase', data: { label: '조사 장면' } },
+        { id: 'scene-1', type: 'phase', data: { label: '조사 장면', phase_type: 'investigation' } },
+        { id: 'scene-2', type: 'phase', data: { label: '토론 장면', phase_type: 'discussion' } },
         { id: 'ending-1', type: 'ending', data: { label: '진엔딩' } },
       ],
     },
@@ -109,9 +110,11 @@ afterEach(() => {
 
 describe('ClueEntityWorkspace', () => {
   const flowNodes = [
-    { id: 'scene-1', type: 'phase', data: { label: '조사 장면' } },
-    { id: 'scene-2', type: 'phase', data: { label: '정리 장면' } },
+    { id: 'scene-1', type: 'phase', data: { label: '조사 장면', phase_type: 'investigation' } },
+    { id: 'scene-2', type: 'phase', data: { label: '정리 장면', phase_type: 'discussion' } },
+    { id: 'scene-3', type: 'phase', data: { label: '재수사 장면', phase_type: 'investigation' } },
     { id: 'branch-1', type: 'branch', data: { label: '이전 분기' } },
+    { id: 'ending-1', type: 'ending', data: { label: '진엔딩' } },
   ] as never;
 
   it('선택한 단서의 인라인 편집 상세와 사용 공개 규칙을 제작자 언어로 보여준다', () => {
@@ -375,14 +378,21 @@ describe('ClueEntityWorkspace', () => {
       />,
     );
 
+    expect(screen.getAllByText('계속 획득 가능').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('조사 장면 (장면)').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('재수사 장면 (장면)').length).toBeGreaterThan(0);
+    expect(screen.queryByText('정리 장면 (장면)')).toBeNull();
+    expect(screen.queryByText('진엔딩 (결말)')).toBeNull();
+    expect(screen.getByText(/이미 플레이어가 가진 단서를/)).toBeDefined();
+
     fireEvent.change(screen.getByLabelText('이름'), {
       target: { value: '피 묻은 열쇠 조각' },
     });
     fireEvent.change(screen.getByLabelText('공개 시점'), {
       target: { value: 'scene-1' },
     });
-    fireEvent.change(screen.getByLabelText('숨김 시점'), {
-      target: { value: 'scene-2' },
+    fireEvent.change(screen.getByLabelText('획득 가능 종료'), {
+      target: { value: 'scene-3' },
     });
     fireEvent.click(screen.getByLabelText(/단서 보호/));
 
@@ -403,7 +413,7 @@ describe('ClueEntityWorkspace', () => {
         reveal_round: null,
         hide_round: null,
         reveal_scene_id: 'scene-1',
-        hide_scene_id: 'scene-2',
+        hide_scene_id: 'scene-3',
       }),
       expect.any(Object),
     );

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -108,6 +108,7 @@ export function ClueEntityWorkspace({
         clue.reveal_scene_id,
         clue.hide_scene_id,
       ]),
+      { scope: 'investigation_phase' },
     ),
     [flowNodes, clues],
   );

--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -99,6 +99,7 @@ export function CharacterAssignPanel({
         ...missionList.map((mission) => mission.revealNodeId),
         ...aliasRules.map((rule) => readAliasNodeValue(rule.condition)),
       ],
+      { scope: 'phase' },
     ),
     [flowGraph?.nodes, missionList, aliasRules],
   );

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -58,7 +58,8 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
         locations?.flatMap((location) => [
           location.appearance_scene_id ?? null,
           location.hide_scene_id ?? null,
-        ]) ?? []
+        ]) ?? [],
+        { scope: 'investigation_phase' },
       ),
     [flowGraph?.nodes, locations]
   );

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -63,6 +63,7 @@ vi.mock('@/features/editor/flowApi', () => ({
       nodes: [
         { id: 'scene-1', type: 'phase', data: { label: '오프닝', rounds: 2 } },
         { id: 'scene-2', type: 'phase', data: { label: '현장 조사', rounds: 3 } },
+        { id: 'ending-1', type: 'ending', data: { label: '진엔딩' } },
       ],
     },
   }),
@@ -1045,6 +1046,33 @@ describe('CharacterAssignPanel', () => {
     const [config] = mutateMock.mock.calls[0] as [Record<string, unknown>];
     const cm = config.character_missions as Record<string, unknown[]>;
     expect(cm['char-1']).toHaveLength(1);
+  });
+
+  it('미션 공개 장면 선택지에서는 결말을 제외한다', () => {
+    renderPanel({
+      ...baseTheme,
+      config_json: {
+        modules: [],
+        character_missions: {
+          'char-1': [{
+            id: 'mission-1',
+            type: 'secret',
+            description: '비밀 목표',
+            points: 0,
+            verification: 'auto',
+            visibleFrom: 'node_reached',
+            revealNodeId: 'scene-1',
+          }],
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openHiddenMissionSection();
+
+    expect(screen.getByLabelText('미션 공개 장면')).toBeDefined();
+    expect(screen.getAllByText('오프닝 (장면)').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('현장 조사 (장면)').length).toBeGreaterThan(0);
+    expect(screen.queryByText('진엔딩 (결말)')).toBeNull();
   });
 
   it('다른 캐릭터 선택 시 pending save가 flush된다', async () => {

--- a/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.rounds.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/LocationsSubTab.rounds.test.tsx
@@ -17,6 +17,9 @@ describe('LocationsSubTab 장면 공개 시점', () => {
     expect(screen.getAllByText('처음부터 끝까지').length).toBeGreaterThan(0);
     expect(screen.getByLabelText('거실 출현 장면')).toBeDefined();
     expect(screen.getByLabelText('거실 숨김 장면')).toBeDefined();
+    expect(screen.getAllByText('조사 장면 (장면)').length).toBeGreaterThan(0);
+    expect(screen.queryByText('토론 장면 (장면)')).toBeNull();
+    expect(screen.queryByText('진엔딩 (결말)')).toBeNull();
   });
 
   it('출현 장면을 선택하면 useUpdateLocation.mutate 가 호출된다', () => {

--- a/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestUtils.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/locationsSubTabTestUtils.tsx
@@ -68,7 +68,8 @@ vi.mock('@/features/editor/flowApi', () => ({
   useFlowGraph: () => ({
     data: {
       nodes: [
-        { id: 'scene-1', type: 'phase', data: { label: '조사 장면' } },
+        { id: 'scene-1', type: 'phase', data: { label: '조사 장면', phase_type: 'investigation' } },
+        { id: 'scene-2', type: 'phase', data: { label: '토론 장면', phase_type: 'discussion' } },
         { id: 'ending-1', type: 'ending', data: { label: '진엔딩' } },
       ],
     },

--- a/apps/web/src/features/editor/entities/reveal/__tests__/revealTimingOptions.test.ts
+++ b/apps/web/src/features/editor/entities/reveal/__tests__/revealTimingOptions.test.ts
@@ -10,6 +10,7 @@ function node(
   type: FlowNodeResponse["type"],
   label: string | undefined,
   rounds?: number,
+  phaseType?: string,
 ): FlowNodeResponse {
   return {
     id,
@@ -18,6 +19,7 @@ function node(
     data: {
       ...(label ? { label } : {}),
       ...(rounds ? { rounds } : {}),
+      ...(phaseType ? { phase_type: phaseType } : {}),
     },
     position_x: 0,
     position_y: 0,
@@ -55,6 +57,46 @@ describe("revealTimingOptions", () => {
     expect(options).toEqual([
       { value: "phase-1", label: "현장 조사 (장면)" },
       { value: "ending-1", label: "진엔딩 (결말)" },
+      { value: "legacy-node", label: "기존 저장값 (legacy-node)" },
+    ]);
+  });
+
+  it("phase 범위에서는 결말을 제외하고 장면만 복원한다", () => {
+    const options = buildProgressNodeRevealOptions(
+      [
+        node("phase-0", "phase", "기존 장면"),
+        node("phase-1", "phase", "현장 조사", undefined, "investigation"),
+        node("phase-2", "phase", "토론", undefined, "discussion"),
+        node("ending-1", "ending", "진엔딩"),
+      ],
+      ["legacy-node"],
+      { scope: "phase" },
+    );
+
+    expect(options).toEqual([
+      { value: "phase-0", label: "기존 장면 (장면)" },
+      { value: "phase-1", label: "현장 조사 (장면)" },
+      { value: "phase-2", label: "토론 (장면)" },
+      { value: "legacy-node", label: "기존 저장값 (legacy-node)" },
+    ]);
+  });
+
+  it("수사 phase 범위에서는 investigation 장면만 노출하고 기존 저장값은 보존한다", () => {
+    const options = buildProgressNodeRevealOptions(
+      [
+        node("phase-0", "phase", "기존 장면"),
+        node("phase-1", "phase", "현장 조사", undefined, "investigation"),
+        node("phase-2", "phase", "토론", undefined, "discussion"),
+        node("ending-1", "ending", "진엔딩"),
+      ],
+      ["phase-2", "legacy-node"],
+      { scope: "investigation_phase" },
+    );
+
+    expect(options).toEqual([
+      { value: "phase-0", label: "기존 장면 (장면)" },
+      { value: "phase-1", label: "현장 조사 (장면)" },
+      { value: "phase-2", label: "기존 저장값 (phase-2)" },
       { value: "legacy-node", label: "기존 저장값 (legacy-node)" },
     ]);
   });

--- a/apps/web/src/features/editor/entities/reveal/revealTimingOptions.ts
+++ b/apps/web/src/features/editor/entities/reveal/revealTimingOptions.ts
@@ -10,6 +10,12 @@ export interface ProgressNodeRevealOption {
   label: string;
 }
 
+export type ProgressNodeRevealScope = "progress" | "phase" | "investigation_phase";
+
+interface ProgressNodeRevealOptionsConfig {
+  scope?: ProgressNodeRevealScope;
+}
+
 const FALLBACK_ROUND_COUNT = 5;
 
 const FLOW_NODE_TYPE_LABELS: Record<FlowNodeResponse["type"], string> = {
@@ -47,9 +53,11 @@ export function buildRoundRevealOptions(
 export function buildProgressNodeRevealOptions(
   nodes: FlowNodeResponse[] | undefined,
   currentValues: Array<string | null | undefined> = [],
+  config: ProgressNodeRevealOptionsConfig = {},
 ): ProgressNodeRevealOption[] {
+  const scope = config.scope ?? "progress";
   const options = (nodes ?? [])
-    .filter((node) => node.type !== "start" && node.type !== "branch")
+    .filter((node) => isNodeInRevealScope(node, scope))
     .map((node, index) => ({
       value: node.id,
       label: formatFlowNodeLabel(node, index),
@@ -62,6 +70,13 @@ export function buildProgressNodeRevealOptions(
     .map((value) => ({ value, label: `기존 저장값 (${value})` }));
 
   return [...options, ...legacyOptions];
+}
+
+function isNodeInRevealScope(node: FlowNodeResponse, scope: ProgressNodeRevealScope): boolean {
+  if (scope === "progress") return node.type !== "start" && node.type !== "branch";
+  if (node.type !== "phase") return false;
+  if (scope === "phase") return true;
+  return !node.data.phase_type || node.data.phase_type === "investigation";
 }
 
 function formatFlowNodeLabel(node: FlowNodeResponse, index: number): string {


### PR DESCRIPTION
## 요약
- 공개/획득 종료 장면 선택 helper에 용도별 scope를 추가했습니다.
- 장소관리와 단서관리는 수사 장면만 노출하고, 캐릭터 미션 공개 장면은 결말을 제외한 장면만 노출합니다.
- 단서의 '숨김 시점' 문구를 '획득 가능 종료'로 바꾸고, 이미 가진 단서는 회수되지 않는다는 안내를 추가했습니다.

## Coverage Plan
- revealTimingOptions: 기본 진행 노드, phase-only, investigation-only scope와 기존 저장값 보존 분기를 단위 테스트로 검증했습니다.
- LocationsSubTab: 장소 출현/숨김 장면 선택지에서 수사 장면만 보이고 토론/결말은 제외되는지 검증했습니다.
- ClueEntityWorkspace/ClueBasicInfoCard: 단서 공개/획득 종료 선택지, 자동저장 payload, 안내 문구를 검증했습니다.
- CharacterAssignPanel: 미션 공개 장면 선택지에서 결말이 제외되는지 검증했습니다.
- editor golden path E2E: 단서 탭과 장소 탭의 실제 드롭다운 옵션을 검증했습니다.

## Local validation
- pnpm --filter @mmp/web test -- revealTimingOptions LocationsSubTab.rounds ClueEntityWorkspace CharacterAssignPanel
- pnpm --filter @mmp/web typecheck
- pnpm --filter @mmp/web exec playwright test e2e/editor-golden-path.spec.ts --project=chromium --grep "\[2A\]|\[8\]"
- git diff --check
- scripts/mmp-local-ci.sh quick

## 메모
- ready-for-ci 라벨은 붙이지 않았습니다.
- 기존 저장값이 새 필터 범위 밖에 있어도 기존 저장값 옵션으로 보존됩니다.
