### PR TITLE
미디어 삭제 참조 해제 흐름 수정

### DIFF
--- a/apps/server/db/queries/media.sql
+++ b/apps/server/db/queries/media.sql
@@ -228,6 +228,25 @@ WHERE c.theme_id = t.id
   AND c.theme_id = sqlc.arg('theme_id')
   AND c.alias_rules::text ~ ('"display_icon_media_id"\s*:\s*"' || sqlc.arg('media_id')::text || '"');
 
+-- name: ClearCharacterImageMediaReferencesWithOwner :execrows
+UPDATE theme_characters c
+SET image_media_id = CASE
+      WHEN c.image_media_id = sqlc.arg('media_id')::uuid THEN NULL
+      ELSE c.image_media_id
+    END,
+    endcard_image_media_id = CASE
+      WHEN c.endcard_image_media_id = sqlc.arg('media_id')::uuid THEN NULL
+      ELSE c.endcard_image_media_id
+    END
+FROM themes t
+WHERE c.theme_id = t.id
+  AND t.creator_id = sqlc.arg('creator_id')
+  AND c.theme_id = sqlc.arg('theme_id')
+  AND (
+    c.image_media_id = sqlc.arg('media_id')::uuid
+    OR c.endcard_image_media_id = sqlc.arg('media_id')::uuid
+  );
+
 -- name: ClearThemeCoverMediaReferencesWithOwner :execrows
 UPDATE themes
 SET cover_image_media_id = NULL,
@@ -244,6 +263,24 @@ WHERE m.theme_id = t.id
   AND t.creator_id = sqlc.arg('creator_id')
   AND m.theme_id = sqlc.arg('theme_id')
   AND m.image_media_id = sqlc.arg('media_id');
+
+-- name: ClearClueMediaReferencesWithOwner :execrows
+UPDATE theme_clues c
+SET image_media_id = NULL
+FROM themes t
+WHERE c.theme_id = t.id
+  AND t.creator_id = sqlc.arg('creator_id')
+  AND c.theme_id = sqlc.arg('theme_id')
+  AND c.image_media_id = sqlc.arg('media_id');
+
+-- name: ClearLocationMediaReferencesWithOwner :execrows
+UPDATE theme_locations l
+SET image_media_id = NULL
+FROM themes t
+WHERE l.theme_id = t.id
+  AND t.creator_id = sqlc.arg('creator_id')
+  AND l.theme_id = sqlc.arg('theme_id')
+  AND l.image_media_id = sqlc.arg('media_id');
 
 -- name: ClearStoryInfoMediaReferencesWithOwner :execrows
 UPDATE story_infos si
@@ -300,6 +337,20 @@ FROM theme_characters
 WHERE theme_id = sqlc.arg('theme_id')
   AND alias_rules::text ~ ('"display_icon_media_id"\s*:\s*"' || sqlc.arg('media_id')::text || '"');
 
+-- name: FindCharacterImageReferencesForMedia :many
+SELECT id, name, 'profile'::text AS usage
+FROM theme_characters c
+WHERE c.theme_id = sqlc.arg('theme_id')
+  AND c.image_media_id = sqlc.arg('media_id')::uuid
+
+UNION ALL
+
+SELECT id, name, 'endcard'::text AS usage
+FROM theme_characters c
+WHERE c.theme_id = sqlc.arg('theme_id')
+  AND c.endcard_image_media_id = sqlc.arg('media_id')::uuid
+ORDER BY name, usage;
+
 -- name: FindThemeCoverReferencesForMedia :many
 SELECT id, title
 FROM themes
@@ -309,6 +360,18 @@ WHERE id = sqlc.arg('theme_id')
 -- name: FindMapReferencesForMedia :many
 SELECT id, name
 FROM theme_maps
+WHERE theme_id = sqlc.arg('theme_id')
+  AND image_media_id = sqlc.arg('media_id');
+
+-- name: FindClueReferencesForMedia :many
+SELECT id, name
+FROM theme_clues
+WHERE theme_id = sqlc.arg('theme_id')
+  AND image_media_id = sqlc.arg('media_id');
+
+-- name: FindLocationReferencesForMedia :many
+SELECT id, name
+FROM theme_locations
 WHERE theme_id = sqlc.arg('theme_id')
   AND image_media_id = sqlc.arg('media_id');
 

--- a/apps/server/internal/db/media.sql.go
+++ b/apps/server/internal/db/media.sql.go
@@ -42,6 +42,88 @@ func (q *Queries) ClearCharacterAliasIconMediaReferencesWithOwner(ctx context.Co
 	return result.RowsAffected(), nil
 }
 
+const clearCharacterImageMediaReferencesWithOwner = `-- name: ClearCharacterImageMediaReferencesWithOwner :execrows
+UPDATE theme_characters c
+SET image_media_id = CASE
+      WHEN c.image_media_id = $1::uuid THEN NULL
+      ELSE c.image_media_id
+    END,
+    endcard_image_media_id = CASE
+      WHEN c.endcard_image_media_id = $1::uuid THEN NULL
+      ELSE c.endcard_image_media_id
+    END
+FROM themes t
+WHERE c.theme_id = t.id
+  AND t.creator_id = $2
+  AND c.theme_id = $3
+  AND (
+    c.image_media_id = $1::uuid
+    OR c.endcard_image_media_id = $1::uuid
+  )
+`
+
+type ClearCharacterImageMediaReferencesWithOwnerParams struct {
+	MediaID   uuid.UUID `json:"media_id"`
+	CreatorID uuid.UUID `json:"creator_id"`
+	ThemeID   uuid.UUID `json:"theme_id"`
+}
+
+func (q *Queries) ClearCharacterImageMediaReferencesWithOwner(ctx context.Context, arg ClearCharacterImageMediaReferencesWithOwnerParams) (int64, error) {
+	result, err := q.db.Exec(ctx, clearCharacterImageMediaReferencesWithOwner, arg.MediaID, arg.CreatorID, arg.ThemeID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const clearClueMediaReferencesWithOwner = `-- name: ClearClueMediaReferencesWithOwner :execrows
+UPDATE theme_clues c
+SET image_media_id = NULL
+FROM themes t
+WHERE c.theme_id = t.id
+  AND t.creator_id = $1
+  AND c.theme_id = $2
+  AND c.image_media_id = $3
+`
+
+type ClearClueMediaReferencesWithOwnerParams struct {
+	CreatorID uuid.UUID   `json:"creator_id"`
+	ThemeID   uuid.UUID   `json:"theme_id"`
+	MediaID   pgtype.UUID `json:"media_id"`
+}
+
+func (q *Queries) ClearClueMediaReferencesWithOwner(ctx context.Context, arg ClearClueMediaReferencesWithOwnerParams) (int64, error) {
+	result, err := q.db.Exec(ctx, clearClueMediaReferencesWithOwner, arg.CreatorID, arg.ThemeID, arg.MediaID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const clearLocationMediaReferencesWithOwner = `-- name: ClearLocationMediaReferencesWithOwner :execrows
+UPDATE theme_locations l
+SET image_media_id = NULL
+FROM themes t
+WHERE l.theme_id = t.id
+  AND t.creator_id = $1
+  AND l.theme_id = $2
+  AND l.image_media_id = $3
+`
+
+type ClearLocationMediaReferencesWithOwnerParams struct {
+	CreatorID uuid.UUID   `json:"creator_id"`
+	ThemeID   uuid.UUID   `json:"theme_id"`
+	MediaID   pgtype.UUID `json:"media_id"`
+}
+
+func (q *Queries) ClearLocationMediaReferencesWithOwner(ctx context.Context, arg ClearLocationMediaReferencesWithOwnerParams) (int64, error) {
+	result, err := q.db.Exec(ctx, clearLocationMediaReferencesWithOwner, arg.CreatorID, arg.ThemeID, arg.MediaID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const clearMapMediaReferencesWithOwner = `-- name: ClearMapMediaReferencesWithOwner :execrows
 UPDATE theme_maps m
 SET image_media_id = NULL
@@ -493,6 +575,126 @@ func (q *Queries) FindCharacterAliasIconReferencesForMedia(ctx context.Context, 
 	items := []FindCharacterAliasIconReferencesForMediaRow{}
 	for rows.Next() {
 		var i FindCharacterAliasIconReferencesForMediaRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findCharacterImageReferencesForMedia = `-- name: FindCharacterImageReferencesForMedia :many
+SELECT id, name, 'profile'::text AS usage
+FROM theme_characters c
+WHERE c.theme_id = $1
+  AND c.image_media_id = $2::uuid
+
+UNION ALL
+
+SELECT id, name, 'endcard'::text AS usage
+FROM theme_characters c
+WHERE c.theme_id = $1
+  AND c.endcard_image_media_id = $2::uuid
+ORDER BY name, usage
+`
+
+type FindCharacterImageReferencesForMediaParams struct {
+	ThemeID uuid.UUID `json:"theme_id"`
+	MediaID uuid.UUID `json:"media_id"`
+}
+
+type FindCharacterImageReferencesForMediaRow struct {
+	ID    uuid.UUID `json:"id"`
+	Name  string    `json:"name"`
+	Usage string    `json:"usage"`
+}
+
+func (q *Queries) FindCharacterImageReferencesForMedia(ctx context.Context, arg FindCharacterImageReferencesForMediaParams) ([]FindCharacterImageReferencesForMediaRow, error) {
+	rows, err := q.db.Query(ctx, findCharacterImageReferencesForMedia, arg.ThemeID, arg.MediaID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindCharacterImageReferencesForMediaRow{}
+	for rows.Next() {
+		var i FindCharacterImageReferencesForMediaRow
+		if err := rows.Scan(&i.ID, &i.Name, &i.Usage); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findClueReferencesForMedia = `-- name: FindClueReferencesForMedia :many
+SELECT id, name
+FROM theme_clues
+WHERE theme_id = $1
+  AND image_media_id = $2
+`
+
+type FindClueReferencesForMediaParams struct {
+	ThemeID uuid.UUID   `json:"theme_id"`
+	MediaID pgtype.UUID `json:"media_id"`
+}
+
+type FindClueReferencesForMediaRow struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+func (q *Queries) FindClueReferencesForMedia(ctx context.Context, arg FindClueReferencesForMediaParams) ([]FindClueReferencesForMediaRow, error) {
+	rows, err := q.db.Query(ctx, findClueReferencesForMedia, arg.ThemeID, arg.MediaID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindClueReferencesForMediaRow{}
+	for rows.Next() {
+		var i FindClueReferencesForMediaRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findLocationReferencesForMedia = `-- name: FindLocationReferencesForMedia :many
+SELECT id, name
+FROM theme_locations
+WHERE theme_id = $1
+  AND image_media_id = $2
+`
+
+type FindLocationReferencesForMediaParams struct {
+	ThemeID uuid.UUID   `json:"theme_id"`
+	MediaID pgtype.UUID `json:"media_id"`
+}
+
+type FindLocationReferencesForMediaRow struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+func (q *Queries) FindLocationReferencesForMedia(ctx context.Context, arg FindLocationReferencesForMediaParams) ([]FindLocationReferencesForMediaRow, error) {
+	rows, err := q.db.Query(ctx, findLocationReferencesForMedia, arg.ThemeID, arg.MediaID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindLocationReferencesForMediaRow{}
+	for rows.Next() {
+		var i FindLocationReferencesForMediaRow
 		if err := rows.Scan(&i.ID, &i.Name); err != nil {
 			return nil, err
 		}

--- a/apps/server/internal/domain/editor/media_handler.go
+++ b/apps/server/internal/domain/editor/media_handler.go
@@ -245,7 +245,10 @@ func (h *MediaHandler) DeleteMedia(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.svc.DeleteMedia(r.Context(), creatorID, mediaID); err != nil {
+	opts := DeleteMediaOptions{
+		DetachReferences: r.URL.Query().Get("detach_references") == "true",
+	}
+	if err := h.svc.DeleteMedia(r.Context(), creatorID, mediaID, opts); err != nil {
 		apperror.WriteError(w, r, err)
 		return
 	}

--- a/apps/server/internal/domain/editor/media_handler_test.go
+++ b/apps/server/internal/domain/editor/media_handler_test.go
@@ -157,7 +157,7 @@ func TestMediaHandler_FileAndYouTubeMutations(t *testing.T) {
 		Return(&MediaResponse{ID: mediaID, ThemeID: themeID, Name: "updated", Type: MediaTypeImage, SourceType: SourceTypeFile, Tags: []string{}, CreatedAt: time.Now()}, nil).
 		Times(1)
 	mock.EXPECT().
-		DeleteMedia(gomock.Any(), gomock.Any(), mediaID).
+		DeleteMedia(gomock.Any(), gomock.Any(), mediaID, DeleteMediaOptions{}).
 		Return(nil).
 		Times(1)
 	mock.EXPECT().
@@ -334,6 +334,25 @@ func TestMediaHandler_InvalidJSONBodies(t *testing.T) {
 	}
 }
 
+func TestMediaHandler_DeleteMedia_ParsesDetachReferences(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := NewMockMediaService(ctrl)
+	h := NewMediaHandler(mock)
+	mediaID := uuid.New()
+	mock.EXPECT().
+		DeleteMedia(gomock.Any(), gomock.Any(), mediaID, DeleteMediaOptions{DetachReferences: true}).
+		Return(nil).
+		Times(1)
+
+	req := mediaHandlerRequest(http.MethodDelete, "/editor/media/"+mediaID.String()+"?detach_references=true", nil, map[string]string{"id": mediaID.String()})
+	w := httptest.NewRecorder()
+	h.DeleteMedia(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected delete 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestMediaHandler_ServiceErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := NewMockMediaService(ctrl)
@@ -455,7 +474,7 @@ func TestMediaHandler_ServiceErrors(t *testing.T) {
 			path:    "/editor/media/" + mediaID.String(),
 			id:      mediaID,
 			expect: func() {
-				mock.EXPECT().DeleteMedia(gomock.Any(), gomock.Any(), mediaID).Return(serviceErr)
+				mock.EXPECT().DeleteMedia(gomock.Any(), gomock.Any(), mediaID, DeleteMediaOptions{}).Return(serviceErr)
 			},
 		},
 		{

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -37,7 +37,7 @@ type MediaService interface {
 	CreateYouTube(ctx context.Context, creatorID, themeID uuid.UUID, req CreateMediaYouTubeRequest) (*MediaResponse, error)
 	UpdateMedia(ctx context.Context, creatorID, mediaID uuid.UUID, req UpdateMediaRequest) (*MediaResponse, error)
 	PreviewDeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID) (*MediaDeletePreviewResponse, error)
-	DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID) error
+	DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID, opts DeleteMediaOptions) error
 	RequestReplacementUpload(ctx context.Context, creatorID, mediaID uuid.UUID, req RequestMediaReplacementUploadRequest) (*UploadURLResponse, error)
 	ConfirmReplacementUpload(ctx context.Context, creatorID, mediaID uuid.UUID, req ConfirmUploadRequest) (*MediaResponse, error)
 	GetEditorMediaDownloadURL(ctx context.Context, creatorID, mediaID uuid.UUID) (*MediaDownloadURLResponse, error)
@@ -77,8 +77,11 @@ type mediaQueries interface {
 	ClearReadingSectionMediaReferencesWithOwner(ctx context.Context, arg db.ClearReadingSectionMediaReferencesWithOwnerParams) (int64, error)
 	ClearRoleSheetMediaReferencesWithOwner(ctx context.Context, arg db.ClearRoleSheetMediaReferencesWithOwnerParams) (int64, error)
 	ClearCharacterAliasIconMediaReferencesWithOwner(ctx context.Context, arg db.ClearCharacterAliasIconMediaReferencesWithOwnerParams) (int64, error)
+	ClearCharacterImageMediaReferencesWithOwner(ctx context.Context, arg db.ClearCharacterImageMediaReferencesWithOwnerParams) (int64, error)
 	ClearThemeCoverMediaReferencesWithOwner(ctx context.Context, arg db.ClearThemeCoverMediaReferencesWithOwnerParams) (int64, error)
 	ClearMapMediaReferencesWithOwner(ctx context.Context, arg db.ClearMapMediaReferencesWithOwnerParams) (int64, error)
+	ClearClueMediaReferencesWithOwner(ctx context.Context, arg db.ClearClueMediaReferencesWithOwnerParams) (int64, error)
+	ClearLocationMediaReferencesWithOwner(ctx context.Context, arg db.ClearLocationMediaReferencesWithOwnerParams) (int64, error)
 	ClearStoryInfoMediaReferencesWithOwner(ctx context.Context, arg db.ClearStoryInfoMediaReferencesWithOwnerParams) (int64, error)
 	DeleteStoryInfoMediaRefsForMediaWithOwner(ctx context.Context, arg db.DeleteStoryInfoMediaRefsForMediaWithOwnerParams) (int64, error)
 	FindThemeCoverReferencesForMedia(ctx context.Context, arg db.FindThemeCoverReferencesForMediaParams) ([]db.FindThemeCoverReferencesForMediaRow, error)
@@ -87,6 +90,9 @@ type mediaQueries interface {
 	FindMediaReferencesInReadingSections(ctx context.Context, arg db.FindMediaReferencesInReadingSectionsParams) ([]db.FindMediaReferencesInReadingSectionsRow, error)
 	FindRoleSheetReferencesForMedia(ctx context.Context, arg db.FindRoleSheetReferencesForMediaParams) ([]db.FindRoleSheetReferencesForMediaRow, error)
 	FindCharacterAliasIconReferencesForMedia(ctx context.Context, arg db.FindCharacterAliasIconReferencesForMediaParams) ([]db.FindCharacterAliasIconReferencesForMediaRow, error)
+	FindCharacterImageReferencesForMedia(ctx context.Context, arg db.FindCharacterImageReferencesForMediaParams) ([]db.FindCharacterImageReferencesForMediaRow, error)
+	FindClueReferencesForMedia(ctx context.Context, arg db.FindClueReferencesForMediaParams) ([]db.FindClueReferencesForMediaRow, error)
+	FindLocationReferencesForMedia(ctx context.Context, arg db.FindLocationReferencesForMediaParams) ([]db.FindLocationReferencesForMediaRow, error)
 }
 
 type mediaService struct {

--- a/apps/server/internal/domain/editor/media_service_delete.go
+++ b/apps/server/internal/domain/editor/media_service_delete.go
@@ -32,34 +32,35 @@ func (s *mediaService) PreviewDeleteMedia(ctx context.Context, creatorID, mediaI
 	return &MediaDeletePreviewResponse{References: toMediaReferenceResponses(refs)}, nil
 }
 
-func (s *mediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID) error {
-	media, err := s.deleteMediaRecord(ctx, s.q, creatorID, mediaID)
+func (s *mediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID, opts DeleteMediaOptions) error {
+	media, err := s.deleteMediaRecord(ctx, s.q, creatorID, mediaID, opts)
 	if err != nil {
 		return err
 	}
 
 	if media.SourceType == SourceTypeFile && media.StorageKey.Valid && s.storage != nil {
 		if delErr := s.storage.DeleteObject(ctx, media.StorageKey.String); delErr != nil {
-			s.logger.Warn().Err(delErr).Str("storage_key", media.StorageKey.String).Msg("failed to delete storage object")
+			s.logger.Error().Err(delErr).Str("storage_key", media.StorageKey.String).Msg("failed to delete storage object")
+			return apperror.Internal("failed to delete storage object")
 		}
 	}
 	return nil
 }
 
-func (s *mediaService) deleteMediaRecord(ctx context.Context, q mediaQueries, creatorID, mediaID uuid.UUID) (db.ThemeMedium, error) {
+func (s *mediaService) deleteMediaRecord(ctx context.Context, q mediaQueries, creatorID, mediaID uuid.UUID, opts DeleteMediaOptions) (db.ThemeMedium, error) {
 	var media db.ThemeMedium
 	if s.pool != nil && s.withTx != nil {
 		err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
 			var txErr error
-			media, txErr = s.deleteMediaRecordWithQueries(ctx, s.withTx(tx), creatorID, mediaID)
+			media, txErr = s.deleteMediaRecordWithQueries(ctx, s.withTx(tx), creatorID, mediaID, opts)
 			return txErr
 		})
 		return media, err
 	}
-	return s.deleteMediaRecordWithQueries(ctx, q, creatorID, mediaID)
+	return s.deleteMediaRecordWithQueries(ctx, q, creatorID, mediaID, opts)
 }
 
-func (s *mediaService) deleteMediaRecordWithQueries(ctx context.Context, q mediaQueries, creatorID, mediaID uuid.UUID) (db.ThemeMedium, error) {
+func (s *mediaService) deleteMediaRecordWithQueries(ctx context.Context, q mediaQueries, creatorID, mediaID uuid.UUID, opts DeleteMediaOptions) (db.ThemeMedium, error) {
 	media, err := q.GetMediaWithOwner(ctx, db.GetMediaWithOwnerParams{
 		ID:        mediaID,
 		CreatorID: creatorID,
@@ -70,6 +71,15 @@ func (s *mediaService) deleteMediaRecordWithQueries(ctx context.Context, q media
 		}
 		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to get media")
 		return db.ThemeMedium{}, apperror.Internal("failed to get media")
+	}
+
+	refs, err := s.collectMediaReferencesWithQueries(ctx, q, media, mediaID)
+	if err != nil {
+		return db.ThemeMedium{}, err
+	}
+	if len(refs) > 0 && !opts.DetachReferences {
+		return db.ThemeMedium{}, apperror.New(apperror.ErrMediaReferenceInUse, 409, "media is referenced by editor content").
+			WithParams(map[string]any{"references": toMediaReferenceResponses(refs)})
 	}
 
 	if err := s.cleanupMediaReferences(ctx, q, creatorID, media, mediaID); err != nil {
@@ -131,6 +141,42 @@ func (s *mediaService) collectMediaReferencesWithQueries(ctx context.Context, q 
 	}
 	for _, r := range mapRefs {
 		refList = append(refList, mediaReferenceInfo{Type: "map", ID: r.ID.String(), Name: r.Name})
+	}
+
+	clueRefs, err := q.FindClueReferencesForMedia(ctx, db.FindClueReferencesForMediaParams{
+		ThemeID: media.ThemeID,
+		MediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to check clue media references")
+		return nil, apperror.Internal("failed to check media references")
+	}
+	for _, r := range clueRefs {
+		refList = append(refList, mediaReferenceInfo{Type: "clue_image", ID: r.ID.String(), Name: r.Name})
+	}
+
+	locationRefs, err := q.FindLocationReferencesForMedia(ctx, db.FindLocationReferencesForMediaParams{
+		ThemeID: media.ThemeID,
+		MediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to check location media references")
+		return nil, apperror.Internal("failed to check media references")
+	}
+	for _, r := range locationRefs {
+		refList = append(refList, mediaReferenceInfo{Type: "location_image", ID: r.ID.String(), Name: r.Name})
+	}
+
+	characterImageRefs, err := q.FindCharacterImageReferencesForMedia(ctx, db.FindCharacterImageReferencesForMediaParams{
+		ThemeID: media.ThemeID,
+		MediaID: mediaID,
+	})
+	if err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to check character image media references")
+		return nil, apperror.Internal("failed to check media references")
+	}
+	for _, r := range characterImageRefs {
+		refList = append(refList, mediaReferenceInfo{Type: characterImageMediaReferenceType(r.Usage), ID: r.ID.String(), Name: r.Name})
 	}
 
 	storyInfoRefs, err := q.FindStoryInfoReferencesForMedia(ctx, db.FindStoryInfoReferencesForMediaParams{
@@ -214,6 +260,15 @@ func (s *mediaService) cleanupMediaReferences(ctx context.Context, q mediaQuerie
 		return apperror.Internal("failed to clear media references")
 	}
 
+	if _, err := q.ClearCharacterImageMediaReferencesWithOwner(ctx, db.ClearCharacterImageMediaReferencesWithOwnerParams{
+		MediaID:   mediaID,
+		CreatorID: creatorID,
+		ThemeID:   media.ThemeID,
+	}); err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to clear character image media references")
+		return apperror.Internal("failed to clear media references")
+	}
+
 	if _, err := q.ClearThemeCoverMediaReferencesWithOwner(ctx, db.ClearThemeCoverMediaReferencesWithOwnerParams{
 		MediaID:   pgtype.UUID{Bytes: mediaID, Valid: true},
 		CreatorID: creatorID,
@@ -229,6 +284,24 @@ func (s *mediaService) cleanupMediaReferences(ctx context.Context, q mediaQuerie
 		ThemeID:   media.ThemeID,
 	}); err != nil {
 		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to clear map media references")
+		return apperror.Internal("failed to clear media references")
+	}
+
+	if _, err := q.ClearClueMediaReferencesWithOwner(ctx, db.ClearClueMediaReferencesWithOwnerParams{
+		MediaID:   pgtype.UUID{Bytes: mediaID, Valid: true},
+		CreatorID: creatorID,
+		ThemeID:   media.ThemeID,
+	}); err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to clear clue media references")
+		return apperror.Internal("failed to clear media references")
+	}
+
+	if _, err := q.ClearLocationMediaReferencesWithOwner(ctx, db.ClearLocationMediaReferencesWithOwnerParams{
+		MediaID:   pgtype.UUID{Bytes: mediaID, Valid: true},
+		CreatorID: creatorID,
+		ThemeID:   media.ThemeID,
+	}); err != nil {
+		s.logger.Error().Err(err).Str("media_id", mediaID.String()).Msg("failed to clear location media references")
 		return apperror.Internal("failed to clear media references")
 	}
 
@@ -301,6 +374,15 @@ func storyInfoMediaReferenceType(usage string) string {
 		return "story_info_embedded_video"
 	default:
 		return "story_info"
+	}
+}
+
+func characterImageMediaReferenceType(usage string) string {
+	switch usage {
+	case "endcard":
+		return "character_endcard_image"
+	default:
+		return "character_image"
 	}
 }
 

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -29,6 +29,9 @@ type fakeMediaQueries struct {
 	categories    map[uuid.UUID]db.ThemeMediaCategory
 	replacements  map[uuid.UUID]db.ThemeMediaReplacementUpload
 	maps          map[uuid.UUID]db.ThemeMap
+	clues         map[uuid.UUID]db.ThemeClue
+	locations     map[uuid.UUID]db.ThemeLocation
+	characters    map[uuid.UUID]db.ThemeCharacter
 	sessions      map[uuid.UUID]db.GameSession
 	sections      map[uuid.UUID]db.ReadingSection
 	roleSheetRefs map[uuid.UUID][]db.FindRoleSheetReferencesForMediaRow
@@ -43,6 +46,9 @@ func newFakeMediaQueries() *fakeMediaQueries {
 		categories:    make(map[uuid.UUID]db.ThemeMediaCategory),
 		replacements:  make(map[uuid.UUID]db.ThemeMediaReplacementUpload),
 		maps:          make(map[uuid.UUID]db.ThemeMap),
+		clues:         make(map[uuid.UUID]db.ThemeClue),
+		locations:     make(map[uuid.UUID]db.ThemeLocation),
+		characters:    make(map[uuid.UUID]db.ThemeCharacter),
 		sessions:      make(map[uuid.UUID]db.GameSession),
 		sections:      make(map[uuid.UUID]db.ReadingSection),
 		roleSheetRefs: make(map[uuid.UUID][]db.FindRoleSheetReferencesForMediaRow),
@@ -362,6 +368,33 @@ func (f *fakeMediaQueries) ClearCharacterAliasIconMediaReferencesWithOwner(_ con
 	return 1, nil
 }
 
+func (f *fakeMediaQueries) ClearCharacterImageMediaReferencesWithOwner(_ context.Context, arg db.ClearCharacterImageMediaReferencesWithOwnerParams) (int64, error) {
+	var rows int64
+	theme, ok := f.themes[arg.ThemeID]
+	if !ok || theme.CreatorID != arg.CreatorID {
+		return 0, nil
+	}
+	for id, character := range f.characters {
+		if character.ThemeID != arg.ThemeID {
+			continue
+		}
+		changed := false
+		if character.ImageMediaID.Valid && character.ImageMediaID.Bytes == arg.MediaID {
+			character.ImageMediaID = pgtype.UUID{}
+			changed = true
+		}
+		if character.EndcardImageMediaID.Valid && character.EndcardImageMediaID.Bytes == arg.MediaID {
+			character.EndcardImageMediaID = pgtype.UUID{}
+			changed = true
+		}
+		if changed {
+			f.characters[id] = character
+			rows++
+		}
+	}
+	return rows, nil
+}
+
 func (f *fakeMediaQueries) ClearThemeCoverMediaReferencesWithOwner(_ context.Context, arg db.ClearThemeCoverMediaReferencesWithOwnerParams) (int64, error) {
 	if !arg.MediaID.Valid {
 		return 0, nil
@@ -388,6 +421,44 @@ func (f *fakeMediaQueries) ClearMapMediaReferencesWithOwner(_ context.Context, a
 		if m.ThemeID == arg.ThemeID && m.ImageMediaID.Valid && m.ImageMediaID.Bytes == arg.MediaID.Bytes {
 			m.ImageMediaID = pgtype.UUID{}
 			f.maps[id] = m
+			rows++
+		}
+	}
+	return rows, nil
+}
+
+func (f *fakeMediaQueries) ClearClueMediaReferencesWithOwner(_ context.Context, arg db.ClearClueMediaReferencesWithOwnerParams) (int64, error) {
+	if !arg.MediaID.Valid {
+		return 0, nil
+	}
+	var rows int64
+	theme, ok := f.themes[arg.ThemeID]
+	if !ok || theme.CreatorID != arg.CreatorID {
+		return 0, nil
+	}
+	for id, clue := range f.clues {
+		if clue.ThemeID == arg.ThemeID && clue.ImageMediaID.Valid && clue.ImageMediaID.Bytes == arg.MediaID.Bytes {
+			clue.ImageMediaID = pgtype.UUID{}
+			f.clues[id] = clue
+			rows++
+		}
+	}
+	return rows, nil
+}
+
+func (f *fakeMediaQueries) ClearLocationMediaReferencesWithOwner(_ context.Context, arg db.ClearLocationMediaReferencesWithOwnerParams) (int64, error) {
+	if !arg.MediaID.Valid {
+		return 0, nil
+	}
+	var rows int64
+	theme, ok := f.themes[arg.ThemeID]
+	if !ok || theme.CreatorID != arg.CreatorID {
+		return 0, nil
+	}
+	for id, location := range f.locations {
+		if location.ThemeID == arg.ThemeID && location.ImageMediaID.Valid && location.ImageMediaID.Bytes == arg.MediaID.Bytes {
+			location.ImageMediaID = pgtype.UUID{}
+			f.locations[id] = location
 			rows++
 		}
 	}
@@ -441,6 +512,32 @@ func (f *fakeMediaQueries) FindMapReferencesForMedia(_ context.Context, arg db.F
 	for _, m := range f.maps {
 		if m.ThemeID == arg.ThemeID && m.ImageMediaID.Valid && m.ImageMediaID.Bytes == arg.MediaID.Bytes {
 			out = append(out, db.FindMapReferencesForMediaRow{ID: m.ID, Name: m.Name})
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeMediaQueries) FindClueReferencesForMedia(_ context.Context, arg db.FindClueReferencesForMediaParams) ([]db.FindClueReferencesForMediaRow, error) {
+	out := []db.FindClueReferencesForMediaRow{}
+	if !arg.MediaID.Valid {
+		return out, nil
+	}
+	for _, clue := range f.clues {
+		if clue.ThemeID == arg.ThemeID && clue.ImageMediaID.Valid && clue.ImageMediaID.Bytes == arg.MediaID.Bytes {
+			out = append(out, db.FindClueReferencesForMediaRow{ID: clue.ID, Name: clue.Name})
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeMediaQueries) FindLocationReferencesForMedia(_ context.Context, arg db.FindLocationReferencesForMediaParams) ([]db.FindLocationReferencesForMediaRow, error) {
+	out := []db.FindLocationReferencesForMediaRow{}
+	if !arg.MediaID.Valid {
+		return out, nil
+	}
+	for _, location := range f.locations {
+		if location.ThemeID == arg.ThemeID && location.ImageMediaID.Valid && location.ImageMediaID.Bytes == arg.MediaID.Bytes {
+			out = append(out, db.FindLocationReferencesForMediaRow{ID: location.ID, Name: location.Name})
 		}
 	}
 	return out, nil
@@ -502,6 +599,22 @@ func (f *fakeMediaQueries) FindCharacterAliasIconReferencesForMedia(_ context.Co
 		return []db.FindCharacterAliasIconReferencesForMediaRow{}, nil
 	}
 	return f.aliasIconRefs[mediaID], nil
+}
+
+func (f *fakeMediaQueries) FindCharacterImageReferencesForMedia(_ context.Context, arg db.FindCharacterImageReferencesForMediaParams) ([]db.FindCharacterImageReferencesForMediaRow, error) {
+	out := []db.FindCharacterImageReferencesForMediaRow{}
+	for _, character := range f.characters {
+		if character.ThemeID != arg.ThemeID {
+			continue
+		}
+		if character.ImageMediaID.Valid && character.ImageMediaID.Bytes == arg.MediaID {
+			out = append(out, db.FindCharacterImageReferencesForMediaRow{ID: character.ID, Name: character.Name, Usage: "profile"})
+		}
+		if character.EndcardImageMediaID.Valid && character.EndcardImageMediaID.Bytes == arg.MediaID {
+			out = append(out, db.FindCharacterImageReferencesForMediaRow{ID: character.ID, Name: character.Name, Usage: "endcard"})
+		}
+	}
+	return out, nil
 }
 
 type fakeStorageProvider struct {
@@ -627,6 +740,9 @@ func expectEmptyMediaReferenceCollectionWithConfig(q *MockmediaQueries, themeID 
 	q.EXPECT().FindMediaReferencesInReadingSections(gomock.Any(), gomock.Any()).Return(nil, nil)
 	q.EXPECT().FindThemeCoverReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 	q.EXPECT().FindMapReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+	q.EXPECT().FindClueReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+	q.EXPECT().FindLocationReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+	q.EXPECT().FindCharacterImageReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 	q.EXPECT().FindStoryInfoReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 	q.EXPECT().FindRoleSheetReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 	q.EXPECT().FindCharacterAliasIconReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -637,8 +753,11 @@ func expectSuccessfulMediaReferenceClears(q *MockmediaQueries) {
 	q.EXPECT().ClearReadingSectionMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 	q.EXPECT().ClearRoleSheetMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 	q.EXPECT().ClearCharacterAliasIconMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+	q.EXPECT().ClearCharacterImageMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 	q.EXPECT().ClearThemeCoverMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 	q.EXPECT().ClearMapMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+	q.EXPECT().ClearClueMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+	q.EXPECT().ClearLocationMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 	q.EXPECT().ClearStoryInfoMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 	q.EXPECT().DeleteStoryInfoMediaRefsForMediaWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 }
@@ -1298,11 +1417,42 @@ func TestMediaService_Delete_Success_NoReferences(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	mediaID := seedMedia(q, themeID, MediaTypeBGM)
 
-	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID); err != nil {
+	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{}); err != nil {
 		t.Fatalf("expected delete to succeed, got %v", err)
 	}
 	if _, ok := q.media[mediaID]; ok {
 		t.Fatalf("media should have been deleted")
+	}
+}
+
+func TestMediaService_Delete_BlocksReferencesUntilDetachRequested(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeImage)
+	clueID := uuid.New()
+	q.clues[clueID] = db.ThemeClue{
+		ID:           clueID,
+		ThemeID:      themeID,
+		Name:         "1층 단서",
+		ImageMediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	}
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{})
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+	if _, ok := q.media[mediaID]; !ok {
+		t.Fatalf("media should remain when references are not detached")
+	}
+	if !q.clues[clueID].ImageMediaID.Valid {
+		t.Fatalf("clue image reference should remain on blocked delete")
+	}
+
+	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{DetachReferences: true}); err != nil {
+		t.Fatalf("DeleteMedia with detach: %v", err)
+	}
+	if _, ok := q.media[mediaID]; ok {
+		t.Fatalf("media should be deleted after detach")
+	}
+	if q.clues[clueID].ImageMediaID.Valid {
+		t.Fatalf("clue image reference should be cleared")
 	}
 }
 
@@ -1342,6 +1492,51 @@ func TestMediaService_PreviewDelete_ReportsMapImageReference(t *testing.T) {
 	refs := preview.References
 	if len(refs) != 1 || refs[0].Type != "map" || refs[0].ID != mapID.String() || refs[0].Name != "1층 지도" {
 		t.Fatalf("unexpected map references: %#v", refs)
+	}
+}
+
+func TestMediaService_PreviewDelete_ReportsEntityImageReferences(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeImage)
+	clueID := uuid.New()
+	locationID := uuid.New()
+	characterID := uuid.New()
+	q.clues[clueID] = db.ThemeClue{
+		ID:           clueID,
+		ThemeID:      themeID,
+		Name:         "우비 및 우산걸이",
+		ImageMediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	}
+	q.locations[locationID] = db.ThemeLocation{
+		ID:           locationID,
+		ThemeID:      themeID,
+		Name:         "1층",
+		ImageMediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	}
+	q.characters[characterID] = db.ThemeCharacter{
+		ID:                  characterID,
+		ThemeID:             themeID,
+		Name:                "고동",
+		ImageMediaID:        pgtype.UUID{Bytes: mediaID, Valid: true},
+		EndcardImageMediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
+	}
+
+	preview, err := svc.PreviewDeleteMedia(context.Background(), creatorID, mediaID)
+	if err != nil {
+		t.Fatalf("PreviewDeleteMedia: %v", err)
+	}
+	refs := preview.References
+	if len(refs) != 4 {
+		t.Fatalf("expected four entity references, got %#v", refs)
+	}
+	gotTypes := map[string]bool{}
+	for _, ref := range refs {
+		gotTypes[ref.Type] = true
+	}
+	for _, wantType := range []string{"clue_image", "location_image", "character_image", "character_endcard_image"} {
+		if !gotTypes[wantType] {
+			t.Fatalf("missing reference type %s in %#v", wantType, refs)
+		}
 	}
 }
 
@@ -1602,7 +1797,7 @@ func TestMediaService_Delete_BlocksMalformedConfigMediaReferenceScan(t *testing.
 	theme.ConfigJson = json.RawMessage(`{"phases": "malformed", "modules": {"event_progression": {"config": "malformed"}}}`)
 	q.themes[themeID] = theme
 
-	err := svc.DeleteMedia(context.Background(), creatorID, mediaID)
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{})
 	assertMediaAppCode(t, err, apperror.ErrValidation)
 	if _, ok := q.media[mediaID]; !ok {
 		t.Fatalf("media should not have been deleted")
@@ -1641,6 +1836,9 @@ func TestMediaService_CollectMediaReferences_QueryErrorsReturnInternal(t *testin
 				q.EXPECT().FindMediaReferencesInReadingSections(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindThemeCoverReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindMapReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindClueReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindLocationReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindCharacterImageReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindStoryInfoReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindRoleSheetReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, errors.New("db down"))
 			},
@@ -1651,6 +1849,9 @@ func TestMediaService_CollectMediaReferences_QueryErrorsReturnInternal(t *testin
 				q.EXPECT().FindMediaReferencesInReadingSections(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindThemeCoverReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindMapReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindClueReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindLocationReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindCharacterImageReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindStoryInfoReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, errors.New("db down"))
 			},
 		},
@@ -1660,6 +1861,9 @@ func TestMediaService_CollectMediaReferences_QueryErrorsReturnInternal(t *testin
 				q.EXPECT().FindMediaReferencesInReadingSections(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindThemeCoverReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindMapReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindClueReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindLocationReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
+				q.EXPECT().FindCharacterImageReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindStoryInfoReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindRoleSheetReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
 				q.EXPECT().FindCharacterAliasIconReferencesForMedia(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -1712,6 +1916,7 @@ func TestMediaService_CleanupMediaReferences_QueryErrorsReturnInternal(t *testin
 				q.EXPECT().ClearReadingSectionMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearRoleSheetMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearCharacterAliasIconMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearCharacterImageMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearThemeCoverMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), errors.New("db down"))
 				_ = mediaID
 			},
@@ -1723,6 +1928,7 @@ func TestMediaService_CleanupMediaReferences_QueryErrorsReturnInternal(t *testin
 				q.EXPECT().ClearReadingSectionMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearRoleSheetMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearCharacterAliasIconMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearCharacterImageMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearThemeCoverMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearMapMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), errors.New("db down"))
 				_ = mediaID
@@ -1757,8 +1963,11 @@ func TestMediaService_CleanupMediaReferences_QueryErrorsReturnInternal(t *testin
 				q.EXPECT().ClearReadingSectionMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearRoleSheetMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearCharacterAliasIconMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearCharacterImageMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearThemeCoverMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearMapMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearClueMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearLocationMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearStoryInfoMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), errors.New("db down"))
 				_ = mediaID
 			},
@@ -1770,8 +1979,11 @@ func TestMediaService_CleanupMediaReferences_QueryErrorsReturnInternal(t *testin
 				q.EXPECT().ClearReadingSectionMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearRoleSheetMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearCharacterAliasIconMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearCharacterImageMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearThemeCoverMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearMapMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearClueMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				q.EXPECT().ClearLocationMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().ClearStoryInfoMediaReferencesWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), nil)
 				q.EXPECT().DeleteStoryInfoMediaRefsForMediaWithOwner(gomock.Any(), gomock.Any()).Return(int64(0), errors.New("db down"))
 				_ = mediaID
@@ -2331,7 +2543,7 @@ func TestMediaService_Delete_CleansReadingAndConfigReferences(t *testing.T) {
 		ImageMediaID: pgtype.UUID{Bytes: mediaID, Valid: true},
 	}
 
-	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID); err != nil {
+	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{DetachReferences: true}); err != nil {
 		t.Fatalf("DeleteMedia: %v", err)
 	}
 	if _, ok := q.media[mediaID]; ok {
@@ -2370,7 +2582,7 @@ func TestMediaService_Delete_CleansStoryInfoMediaReferences(t *testing.T) {
 		{ID: infoID, Title: "현장 사진", Usage: "embedded_image"},
 	}
 
-	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID); err != nil {
+	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{DetachReferences: true}); err != nil {
 		t.Fatalf("DeleteMedia: %v", err)
 	}
 	if _, ok := q.media[mediaID]; ok {
@@ -2431,7 +2643,7 @@ func TestMediaService_Delete_FileMediaBestEffortStorageCleanup(t *testing.T) {
 	key := q.media[mediaID].StorageKey.String
 	st.objects[key] = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
 
-	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID); err != nil {
+	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{DetachReferences: true}); err != nil {
 		t.Fatalf("DeleteMedia: %v", err)
 	}
 	if _, ok := q.media[mediaID]; ok {

--- a/apps/server/internal/domain/editor/media_types.go
+++ b/apps/server/internal/domain/editor/media_types.go
@@ -124,6 +124,10 @@ type MediaDeletePreviewResponse struct {
 	References []MediaReferenceResponse `json:"references"`
 }
 
+type DeleteMediaOptions struct {
+	DetachReferences bool
+}
+
 type RequestMediaReplacementUploadRequest struct {
 	MimeType string `json:"mime_type" validate:"required"`
 	FileSize int64  `json:"file_size" validate:"required,min=1"`

--- a/apps/server/internal/domain/editor/mock_media_service_test.go
+++ b/apps/server/internal/domain/editor/mock_media_service_test.go
@@ -118,17 +118,17 @@ func (mr *MockMediaServiceMockRecorder) DeleteCategory(ctx, creatorID, categoryI
 }
 
 // DeleteMedia mocks base method.
-func (m *MockMediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID) error {
+func (m *MockMediaService) DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID, opts DeleteMediaOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMedia", ctx, creatorID, mediaID)
+	ret := m.ctrl.Call(m, "DeleteMedia", ctx, creatorID, mediaID, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteMedia indicates an expected call of DeleteMedia.
-func (mr *MockMediaServiceMockRecorder) DeleteMedia(ctx, creatorID, mediaID any) *gomock.Call {
+func (mr *MockMediaServiceMockRecorder) DeleteMedia(ctx, creatorID, mediaID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMedia", reflect.TypeOf((*MockMediaService)(nil).DeleteMedia), ctx, creatorID, mediaID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMedia", reflect.TypeOf((*MockMediaService)(nil).DeleteMedia), ctx, creatorID, mediaID, opts)
 }
 
 // GetEditorMediaDownloadURL mocks base method.
@@ -338,6 +338,51 @@ func (m *MockmediaQueries) ClearCharacterAliasIconMediaReferencesWithOwner(ctx c
 func (mr *MockmediaQueriesMockRecorder) ClearCharacterAliasIconMediaReferencesWithOwner(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearCharacterAliasIconMediaReferencesWithOwner", reflect.TypeOf((*MockmediaQueries)(nil).ClearCharacterAliasIconMediaReferencesWithOwner), ctx, arg)
+}
+
+// ClearCharacterImageMediaReferencesWithOwner mocks base method.
+func (m *MockmediaQueries) ClearCharacterImageMediaReferencesWithOwner(ctx context.Context, arg db.ClearCharacterImageMediaReferencesWithOwnerParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearCharacterImageMediaReferencesWithOwner", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClearCharacterImageMediaReferencesWithOwner indicates an expected call of ClearCharacterImageMediaReferencesWithOwner.
+func (mr *MockmediaQueriesMockRecorder) ClearCharacterImageMediaReferencesWithOwner(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearCharacterImageMediaReferencesWithOwner", reflect.TypeOf((*MockmediaQueries)(nil).ClearCharacterImageMediaReferencesWithOwner), ctx, arg)
+}
+
+// ClearClueMediaReferencesWithOwner mocks base method.
+func (m *MockmediaQueries) ClearClueMediaReferencesWithOwner(ctx context.Context, arg db.ClearClueMediaReferencesWithOwnerParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearClueMediaReferencesWithOwner", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClearClueMediaReferencesWithOwner indicates an expected call of ClearClueMediaReferencesWithOwner.
+func (mr *MockmediaQueriesMockRecorder) ClearClueMediaReferencesWithOwner(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearClueMediaReferencesWithOwner", reflect.TypeOf((*MockmediaQueries)(nil).ClearClueMediaReferencesWithOwner), ctx, arg)
+}
+
+// ClearLocationMediaReferencesWithOwner mocks base method.
+func (m *MockmediaQueries) ClearLocationMediaReferencesWithOwner(ctx context.Context, arg db.ClearLocationMediaReferencesWithOwnerParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearLocationMediaReferencesWithOwner", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClearLocationMediaReferencesWithOwner indicates an expected call of ClearLocationMediaReferencesWithOwner.
+func (mr *MockmediaQueriesMockRecorder) ClearLocationMediaReferencesWithOwner(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearLocationMediaReferencesWithOwner", reflect.TypeOf((*MockmediaQueries)(nil).ClearLocationMediaReferencesWithOwner), ctx, arg)
 }
 
 // ClearMapMediaReferencesWithOwner mocks base method.
@@ -561,6 +606,51 @@ func (m *MockmediaQueries) FindCharacterAliasIconReferencesForMedia(ctx context.
 func (mr *MockmediaQueriesMockRecorder) FindCharacterAliasIconReferencesForMedia(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCharacterAliasIconReferencesForMedia", reflect.TypeOf((*MockmediaQueries)(nil).FindCharacterAliasIconReferencesForMedia), ctx, arg)
+}
+
+// FindCharacterImageReferencesForMedia mocks base method.
+func (m *MockmediaQueries) FindCharacterImageReferencesForMedia(ctx context.Context, arg db.FindCharacterImageReferencesForMediaParams) ([]db.FindCharacterImageReferencesForMediaRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindCharacterImageReferencesForMedia", ctx, arg)
+	ret0, _ := ret[0].([]db.FindCharacterImageReferencesForMediaRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindCharacterImageReferencesForMedia indicates an expected call of FindCharacterImageReferencesForMedia.
+func (mr *MockmediaQueriesMockRecorder) FindCharacterImageReferencesForMedia(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCharacterImageReferencesForMedia", reflect.TypeOf((*MockmediaQueries)(nil).FindCharacterImageReferencesForMedia), ctx, arg)
+}
+
+// FindClueReferencesForMedia mocks base method.
+func (m *MockmediaQueries) FindClueReferencesForMedia(ctx context.Context, arg db.FindClueReferencesForMediaParams) ([]db.FindClueReferencesForMediaRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindClueReferencesForMedia", ctx, arg)
+	ret0, _ := ret[0].([]db.FindClueReferencesForMediaRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindClueReferencesForMedia indicates an expected call of FindClueReferencesForMedia.
+func (mr *MockmediaQueriesMockRecorder) FindClueReferencesForMedia(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindClueReferencesForMedia", reflect.TypeOf((*MockmediaQueries)(nil).FindClueReferencesForMedia), ctx, arg)
+}
+
+// FindLocationReferencesForMedia mocks base method.
+func (m *MockmediaQueries) FindLocationReferencesForMedia(ctx context.Context, arg db.FindLocationReferencesForMediaParams) ([]db.FindLocationReferencesForMediaRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindLocationReferencesForMedia", ctx, arg)
+	ret0, _ := ret[0].([]db.FindLocationReferencesForMediaRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindLocationReferencesForMedia indicates an expected call of FindLocationReferencesForMedia.
+func (mr *MockmediaQueriesMockRecorder) FindLocationReferencesForMedia(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLocationReferencesForMedia", reflect.TypeOf((*MockmediaQueries)(nil).FindLocationReferencesForMedia), ctx, arg)
 }
 
 // FindMapReferencesForMedia mocks base method.

--- a/apps/web/src/features/editor/components/media/MediaDetail.tsx
+++ b/apps/web/src/features/editor/components/media/MediaDetail.tsx
@@ -59,6 +59,8 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const { data: categories = [] } = useMediaCategories(themeId);
   const { data: deletePreview, isLoading: deletePreviewLoading } = useMediaDeletePreview(media.id);
   const references = deletePreview?.references ?? [];
+  const referencesToDetach = references.length > 0 ? references : (referenceWarning ?? []);
+  const hasReferences = referencesToDetach.length > 0;
   const canReplaceFile = media.source_type === 'FILE' && media.type !== 'VIDEO';
   const typeOptions = getEditableMediaTypeOptions(media.type);
   const canChangeMediaType = typeOptions.length > 1;
@@ -94,9 +96,9 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
   const handleDelete = async () => {
     setReferenceWarning(null);
     try {
-      await deleteMutation.mutateAsync(media.id);
+      await deleteMutation.mutateAsync({ id: media.id, detachReferences: hasReferences });
       setDeleteDialogOpen(false);
-      toast.success('미디어가 삭제되었습니다');
+      toast.success(hasReferences ? '연결을 해제하고 미디어를 삭제했습니다' : '미디어가 삭제되었습니다');
       onClose();
     } catch (err) {
       setDeleteDialogOpen(false);
@@ -213,9 +215,9 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
             <div className="flex items-start gap-2">
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-none text-amber-400" />
               <div className="min-w-0 space-y-1">
-                <p className="font-medium">이 미디어는 아직 삭제할 수 없습니다.</p>
+                <p className="font-medium">이 미디어가 아직 사용 중입니다.</p>
                 <p className="text-[11px] text-amber-200/80">
-                  먼저 아래 제작 요소에서 이 미디어 연결을 해제하세요.
+                  삭제를 다시 누르면 아래 연결을 해제한 뒤 삭제할 수 있습니다.
                 </p>
                 {referenceWarning.length > 0 && (
                   <ul className="space-y-1 pt-1">
@@ -276,8 +278,12 @@ export function MediaDetail({ media, themeId, onClose }: MediaDetailProps) {
       <ConfirmDialog
         isOpen={deleteDialogOpen}
         title="미디어를 삭제할까요?"
-        description={`"${media.name}" 미디어를 삭제합니다. 사용 중이면 삭제되지 않고 위치가 표시됩니다.`}
-        confirmLabel="미디어 삭제"
+        description={
+          hasReferences
+            ? `"${media.name}" 미디어가 ${referencesToDetach.length}곳에서 사용 중입니다. 삭제하면 해당 연결을 모두 해제합니다.`
+            : `"${media.name}" 미디어를 삭제합니다.`
+        }
+        confirmLabel={hasReferences ? '연결 해제 후 삭제' : '미디어 삭제'}
         isConfirming={deleteMutation.isPending}
         tone="danger"
         onCancel={() => setDeleteDialogOpen(false)}

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -204,7 +204,7 @@ export function MediaTab({ themeId }: MediaTabProps) {
     try {
       for (const item of bulkSelectedMedia) {
         try {
-          await deleteMediaMutation.mutateAsync(item.id);
+          await deleteMediaMutation.mutateAsync({ id: item.id });
           result.deleted.push(item);
         } catch (err) {
           if (err instanceof ApiHttpError && err.apiError.code === "MEDIA_REFERENCE_IN_USE") {

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, within, waitFor } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -550,8 +550,8 @@ describe('MediaTab', () => {
     fireEvent.click(screen.getByRole('button', { name: '삭제' }));
 
     const resultDialog = await screen.findByRole('dialog', { name: '미디어 삭제 결과' });
-    expect(mutateAsync).toHaveBeenCalledWith('media-1');
-    expect(mutateAsync).toHaveBeenCalledWith('media-2');
+    expect(mutateAsync).toHaveBeenCalledWith({ id: 'media-1' });
+    expect(mutateAsync).toHaveBeenCalledWith({ id: 'media-2' });
     expect(within(resultDialog).getByText('삭제됨 2개')).toBeDefined();
     expect(within(resultDialog).getByText('오프닝 BGM')).toBeDefined();
     expect(within(resultDialog).getByText('문 닫는 소리')).toBeDefined();
@@ -566,7 +566,7 @@ describe('MediaTab', () => {
       isLoading: false,
       isError: false,
     });
-    const mutateAsync = vi.fn((id: string) => {
+    const mutateAsync = vi.fn(({ id }: { id: string }) => {
       if (id === 'media-2') {
         return Promise.reject(
           new ApiHttpError({
@@ -618,7 +618,7 @@ describe('MediaTab', () => {
       isLoading: false,
       isError: false,
     });
-    const mutateAsync = vi.fn((id: string) => {
+    const mutateAsync = vi.fn(({ id }: { id: string }) => {
       if (id === 'media-2') {
         return Promise.reject(new Error('delete failed'));
       }
@@ -693,7 +693,7 @@ describe('MediaTab', () => {
       );
 
       const warning = await screen.findByRole('alert');
-      expect(warning.textContent).toContain('이 미디어는 아직 삭제할 수 없습니다.');
+      expect(warning.textContent).toContain('이 미디어가 아직 사용 중입니다.');
       expect(screen.getByText(/단계 연출/)).toBeDefined();
       expect(screen.getByText(/오프닝 시작 트리거에서 BGM으로 사용 중/)).toBeDefined();
       expect(screen.getByText(/트리거 연출/)).toBeDefined();
@@ -707,6 +707,48 @@ describe('MediaTab', () => {
     } finally {
       alertSpy.mockRestore();
     }
+  });
+
+  it('상세 패널에서 참조 중인 미디어는 연결 해제 후 삭제로 요청한다', async () => {
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+    useMediaDeletePreviewMock.mockReturnValue({
+      data: {
+        references: [
+          {
+            type: 'clue_image',
+            id: 'clue-1',
+            name: '우비 및 우산걸이',
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    useDeleteMediaMock.mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync,
+      isPending: false,
+    });
+
+    render(<MediaTab themeId="theme-1" />);
+
+    const card = screen.getByText('오프닝 BGM').closest("[role='button']") as HTMLElement | null;
+    fireEvent.click(card!);
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }));
+    const dialog = screen.getByRole('dialog', { name: '미디어를 삭제할까요?' });
+    expect(within(dialog).getByText(/1곳에서 사용 중/)).toBeDefined();
+    fireEvent.click(within(dialog).getByRole('button', { name: '연결 해제 후 삭제' }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        id: 'media-1',
+        detachReferences: true,
+      });
+    });
   });
 
   it('업로드와 YouTube 버튼이 렌더링된다', () => {

--- a/apps/web/src/features/editor/mediaApi.test.ts
+++ b/apps/web/src/features/editor/mediaApi.test.ts
@@ -422,7 +422,7 @@ describe("useDeleteMedia", () => {
       wrapper: makeWrapper(),
     });
 
-    await result.current.mutateAsync("media-1");
+    await result.current.mutateAsync({ id: "media-1" });
 
     expect(api.deleteVoid).toHaveBeenCalledWith("/v1/editor/media/media-1");
     expect(invalidateSpy).toHaveBeenCalledWith({
@@ -441,12 +441,26 @@ describe("useDeleteMedia", () => {
       wrapper: makeWrapper(),
     });
 
-    await expect(result.current.mutateAsync("media-1")).rejects.toMatchObject({
+    await expect(result.current.mutateAsync({ id: "media-1" })).rejects.toMatchObject({
       status: 409,
       code: "MEDIA_REFERENCE_IN_USE",
     });
     // Invalidation should NOT fire on error.
     expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("can request reference detach before deleting", async () => {
+    vi.mocked(api.deleteVoid).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useDeleteMedia(THEME_ID), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({ id: "media-1", detachReferences: true });
+
+    expect(api.deleteVoid).toHaveBeenCalledWith(
+      "/v1/editor/media/media-1?detach_references=true",
+    );
   });
 });
 

--- a/apps/web/src/features/editor/mediaApi.ts
+++ b/apps/web/src/features/editor/mediaApi.ts
@@ -88,6 +88,11 @@ export interface MediaDeletePreviewResponse {
   references: MediaReferenceInfo[];
 }
 
+export interface DeleteMediaRequest {
+  id: string;
+  detachReferences?: boolean;
+}
+
 export interface RequestReplacementUploadRequest {
   mime_type: string;
   file_size: number;
@@ -293,8 +298,11 @@ export function useConfirmReplacementUpload(themeId: string, mediaId: string) {
 }
 
 export function useDeleteMedia(themeId: string) {
-  return useMutation<void, Error, string>({
-    mutationFn: (id) => api.deleteVoid(`/v1/editor/media/${id}`),
+  return useMutation<void, Error, DeleteMediaRequest>({
+    mutationFn: ({ id, detachReferences }) => {
+      const qs = detachReferences ? "?detach_references=true" : "";
+      return api.deleteVoid(`/v1/editor/media/${id}${qs}`);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: mediaKeys.byTheme(themeId) });
     },


### PR DESCRIPTION
## 요약
- 미디어 삭제 시 참조 중인 위치를 먼저 검사하고, 기본 삭제는 `MEDIA_REFERENCE_IN_USE`로 차단하도록 정리했습니다.
- 사용자가 `연결 해제 후 삭제`를 선택하면 단서/장소/맵/캐릭터/정보/역할지/읽기 대사/테마 설정 참조를 해제한 뒤 미디어를 삭제합니다.
- 프론트 미디어 상세 삭제 UX가 참조 위치 안내, 강제 해제 삭제 요청, 성공/실패 토스트를 구분하도록 수정했습니다.

## Coverage Plan
- Backend handler/service
  - `DeleteMediaOptions.DetachReferences` 전달, query param parsing, service error propagation
  - 참조 있음 기본 삭제 차단, detach 요청 시 참조 해제 후 삭제
  - 단서/장소/캐릭터 이미지 참조 preview 및 cleanup
  - 기존 맵/테마 커버/정보/역할지/읽기 대사/theme config 참조 scanner 회귀
- Frontend adapter/component
  - `useDeleteMedia`가 `detach_references=true`를 URL에 붙이는지 검증
  - 참조 중인 미디어 상세 삭제에서 `연결 해제 후 삭제` 확인과 toast/list refresh 흐름 검증

## Local validation
- `go test ./internal/domain/editor` 통과
- `pnpm --filter @mmp/web test -- --run src/features/editor/mediaApi.test.ts src/features/editor/components/media/__tests__/MediaTab.test.tsx` 통과
- `scripts/mmp-local-ci.sh quick` 통과

## 참조 인벤토리
- 구현/검증: 단서 이미지, 장소 이미지, 맵 이미지, 캐릭터 프로필/엔드카드 이미지, 정보 이미지/본문 refs, 역할지 본문/이미지 refs, 읽기 대사 미디어 refs, 테마 커버, 캐릭터 alias icon, 테마 config 장면/action params mediaId.
- 별도 제외 없음. 현재 schema/config scanner에서 존재하는 미디어 참조 경로를 삭제 preview와 cleanup에 포함했습니다.

Closes #623
