### PR TITLE
미디어 관리 모바일 레이아웃 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ graphify-out/obsidian/
 # graphify-out and Playwright HTML reports are generated artifacts.
 graphify-out/
 apps/web/playwright-report/
+apps/web/test-results/
 
 # ─── Local Codex runtime config ───────────────────────
 .codex/config.toml

--- a/apps/web/e2e/editor-media-mobile-layout.spec.ts
+++ b/apps/web/e2e/editor-media-mobile-layout.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  BASE,
+  THEME_ID,
+  freshState,
+  loginAsE2EUser,
+  mockCommonApis,
+} from './helpers/editor-golden-path-fixtures';
+
+const MOBILE_WIDTHS = [360, 390, 430] as const;
+
+test.describe('미디어 관리 모바일 레이아웃', () => {
+  for (const width of MOBILE_WIDTHS) {
+    test(`${width}px에서 목록과 상세 하단 시트가 겹치지 않는다`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 812 });
+      await mockCommonApis(page, freshState());
+      await page.route('**/v1/editor/media/*/references', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ references: [] }),
+        }),
+      );
+      await loginAsE2EUser(page);
+
+      await page.goto(`${BASE}/editor/${THEME_ID}/media`);
+      await expect(page.getByRole('tab', { name: /미디어/, selected: true })).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page.getByRole('button', { name: '파일 업로드' })).toBeVisible();
+      await expect(page.getByLabel('미디어 검색')).toBeVisible();
+
+      await page.getByText('긴장감 배경음').click();
+
+      const sheet = page.getByRole('dialog', { name: '미디어 상세' });
+      await expect(sheet).toBeVisible();
+      await expect(page.locator('aside')).toHaveCount(0);
+
+      const metrics = await page.evaluate(() => ({
+        clientWidth: document.documentElement.clientWidth,
+        scrollWidth: document.documentElement.scrollWidth,
+        bodyOverflow: document.body.style.overflow,
+      }));
+      expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+      expect(metrics.bodyOverflow).toBe('hidden');
+
+      const sheetBox = await sheet.boundingBox();
+      expect(sheetBox?.height ?? 0).toBeLessThanOrEqual(812 * 0.82);
+
+      await page.screenshot({
+        path: `test-results/media-mobile-layout-${width}.png`,
+        fullPage: true,
+      });
+
+      await page.keyboard.press('Escape');
+      await expect(sheet).toBeHidden();
+      await expect
+        .poll(() => page.evaluate(() => document.body.style.overflow))
+        .toBe('');
+    });
+  }
+});

--- a/apps/web/src/features/editor/components/media/MediaTab.tsx
+++ b/apps/web/src/features/editor/components/media/MediaTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { AlertTriangle, CheckCircle2, ListChecks, Trash2, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { ConfirmDialog, Modal, Spinner } from "@/shared/components/ui";
@@ -58,6 +58,8 @@ export function MediaTab({ themeId }: MediaTabProps) {
   // Modal state.
   const [uploadOpen, setUploadOpen] = useState(false);
   const [youtubeOpen, setYoutubeOpen] = useState(false);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+  const isDesktopLayout = useMediaQuery("(min-width: 1024px)", true);
 
   const queryType: MediaType | undefined =
     filter === "all" ? undefined : filter;
@@ -141,6 +143,9 @@ export function MediaTab({ themeId }: MediaTabProps) {
       toggleBulkSelection(item.id);
       return;
     }
+    lastFocusedElementRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
     setSelectedId(item.id);
   };
 
@@ -177,6 +182,10 @@ export function MediaTab({ themeId }: MediaTabProps) {
 
   const handleClose = () => {
     setSelectedId(null);
+    window.requestAnimationFrame(() => {
+      lastFocusedElementRef.current?.focus();
+      lastFocusedElementRef.current = null;
+    });
   };
 
   const handleOpenBulkDelete = () => {
@@ -335,12 +344,18 @@ export function MediaTab({ themeId }: MediaTabProps) {
         </div>
 
         {/* Detail */}
-        {selected && (
+        {selected && isDesktopLayout && (
           <aside className="min-h-0 w-full shrink-0 border-t border-slate-800 pt-4 lg:w-96 lg:overflow-y-auto lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
             <MediaDetail media={selected} themeId={themeId} onClose={handleClose} />
           </aside>
         )}
       </div>
+
+      {!isDesktopLayout && (
+        <MediaMobileDetailSheet open={selected != null} onClose={handleClose}>
+          {selected && <MediaDetail media={selected} themeId={themeId} onClose={handleClose} />}
+        </MediaMobileDetailSheet>
+      )}
 
       <MediaUploadModal
         open={uploadOpen}
@@ -373,6 +388,118 @@ export function MediaTab({ themeId }: MediaTabProps) {
         onConfirm={handleConfirmDeleteCategory}
       />
     </div>
+  );
+}
+
+function MediaMobileDetailSheet({
+  open,
+  onClose,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const firstFocusable = getFocusableElements(dialogRef.current)[0];
+    firstFocusable?.focus();
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = getFocusableElements(dialogRef.current);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 lg:hidden" aria-labelledby="media-mobile-detail-title">
+      <button
+        type="button"
+        aria-label="미디어 상세 닫기"
+        className="absolute inset-0 h-full w-full cursor-default bg-slate-950/70"
+        onClick={onClose}
+      />
+      <section
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="media-mobile-detail-title"
+        className="absolute inset-x-0 bottom-0 flex max-h-[80dvh] min-h-[18rem] flex-col rounded-t-2xl border border-slate-800 bg-slate-950 p-4 shadow-2xl shadow-black/60 outline-none"
+      >
+        <h2 id="media-mobile-detail-title" className="sr-only">
+          미디어 상세
+        </h2>
+        <div className="mx-auto mb-3 h-1 w-12 rounded-full bg-slate-700" aria-hidden="true" />
+        <div className="min-h-0 flex-1 overflow-y-auto pr-1">{children}</div>
+      </section>
+    </div>
+  );
+}
+
+function useMediaQuery(query: string, defaultValue: boolean) {
+  const getMatches = () => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return defaultValue;
+    }
+    return window.matchMedia(query).matches;
+  };
+  const [matches, setMatches] = useState(getMatches);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia(query);
+    const handleChange = () => setMatches(mediaQuery.matches);
+    handleChange();
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [query]);
+
+  return matches;
+}
+
+function getFocusableElements(root: HTMLElement | null): HTMLElement[] {
+  if (!root) return [];
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      [
+        "button:not([disabled])",
+        "input:not([disabled])",
+        "select:not([disabled])",
+        "textarea:not([disabled])",
+        "a[href]",
+        "[tabindex]:not([tabindex='-1'])",
+      ].join(","),
+    ),
   );
 }
 

--- a/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaTab.test.tsx
@@ -129,6 +129,24 @@ function mutationStub() {
   };
 }
 
+const originalMatchMedia = window.matchMedia;
+
+function mockMediaQuery(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -161,6 +179,11 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: originalMatchMedia,
+  });
+  document.body.style.overflow = '';
 });
 
 // =========================================================================
@@ -360,6 +383,59 @@ describe('MediaTab', () => {
     expect(screen.queryByText('size: 1234567 B')).toBeNull();
     expect(screen.getByText('아직 연결된 제작 요소가 없습니다.')).toBeDefined();
     expect(screen.getByRole('button', { name: '교체' })).toBeDefined();
+  });
+
+  it('모바일에서는 선택 상세를 하단 시트 dialog로 열고 ESC로 닫는다', async () => {
+    mockMediaQuery(false);
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<MediaTab themeId="theme-1" />);
+
+    const card = screen.getByText('오프닝 BGM').closest("[role='button']") as HTMLElement;
+    card.focus();
+    fireEvent.click(card);
+
+    const dialog = screen.getByRole('dialog', { name: '미디어 상세' });
+    expect(dialog.className).toContain('max-h-[80dvh]');
+    expect(dialog.querySelector('.overflow-y-auto')).toBeDefined();
+    expect(screen.getByDisplayValue('오프닝 BGM')).toBeDefined();
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.querySelector('aside')).toBeNull();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: '미디어 상세' })).toBeNull();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(card);
+    });
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('모바일 하단 시트는 backdrop 클릭으로 닫힌다', async () => {
+    mockMediaQuery(false);
+    useMediaListMock.mockReturnValue({
+      data: mockMedia,
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<MediaTab themeId="theme-1" />);
+
+    fireEvent.click(screen.getByText('오프닝 BGM').closest("[role='button']")!);
+    expect(screen.getByRole('dialog', { name: '미디어 상세' })).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: '미디어 상세 닫기' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: '미디어 상세' })).toBeNull();
+    });
+    expect(document.body.style.overflow).toBe('');
   });
 
   it('오디오 미디어는 같은 오디오 묶음 안에서만 분류를 바꿔 저장한다', () => {


### PR DESCRIPTION
## 요약
- 모바일 미디어 관리에서 선택 상세를 하단 시트로 열어 목록/검색/업로드 영역과 겹치지 않게 했습니다.
- 하단 시트에 accessible dialog label, body scroll lock, ESC/backdrop close, 내부 스크롤, focus return을 추가했습니다.
- 데스크톱은 기존 2컬럼 목록/상세 aside 흐름을 유지했습니다.
- Playwright screenshot artifact가 로컬에 남아도 커밋되지 않도록 `apps/web/test-results/`를 ignore했습니다.

## Coverage Plan
- `MediaTab` component test: 모바일 matchMedia에서 하단 시트 open/close, body scroll lock, ESC/backdrop close, focus return, desktop aside 회귀.
- Playwright mobile E2E: 360/390/430px에서 미디어 탭 진입, 업로드/검색 노출, 카드 선택, 하단 시트 노출, horizontal overflow 없음, ESC close.
- Typecheck/build: web typecheck와 local quick로 전체 프론트 회귀 확인.

## Local validation
- `pnpm --filter @mmp/web test -- --run src/features/editor/components/media/__tests__/MediaTab.test.tsx` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web exec playwright test e2e/editor-media-mobile-layout.spec.ts --project=chromium` 통과
- `scripts/mmp-local-ci.sh quick` 통과

## Screenshot evidence
- E2E 실행 중 `apps/web/test-results/media-mobile-layout-360.png`, `390.png`, `430.png`를 생성해 확인했습니다. 해당 경로는 로컬 artifact로 ignore 처리했습니다.

Closes #624
