### PR TITLE
에디터 shell/nav 디자인 토큰 1차 적용

### DIFF
--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -14,6 +14,7 @@ import type { DesignWarning } from "@/features/editor/validation";
 import type { SaveStatus } from "@/features/editor/hooks/useAutoSave";
 import { readEnabledModuleIds } from "@/features/editor/utils/configShape";
 import { readEditorTabFromRouteSegment } from "@/features/editor/routeSegments";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 // ---------------------------------------------------------------------------
 // EditorLayout
@@ -81,27 +82,27 @@ export function EditorLayout({
   }, [onSave]);
 
   return (
-    <div className="fixed inset-0 flex flex-col overflow-hidden bg-slate-950 text-slate-100">
+    <div className={`fixed inset-0 flex flex-col overflow-hidden ${editorDesignClassNames.surface}`}>
       {/* ── Top bar ── */}
-      <header className="sticky top-0 z-50 flex h-12 shrink-0 items-center gap-2 border-b border-slate-800 bg-slate-900 px-2 sm:gap-3 sm:px-3">
+      <header className={`sticky top-0 z-50 flex h-12 shrink-0 items-center gap-2 px-2 shadow-sm sm:gap-3 sm:px-3 ${editorDesignClassNames.topBar}`}>
         <button
           type="button"
           onClick={() => navigate("/editor")}
-          className="rounded-sm p-1.5 text-slate-500 transition-colors hover:bg-slate-800 hover:text-slate-200"
+          className="rounded-md p-1.5 text-[var(--mmp-editor-color-slate)] transition-colors hover:bg-[var(--mmp-editor-color-surface)] hover:text-[var(--mmp-editor-color-charcoal)]"
           aria-label="에디터 목록으로 돌아가기"
         >
           <ArrowLeft className="h-4 w-4" />
         </button>
 
-        <div className="h-5 w-px bg-slate-800" />
+        <div className="h-5 w-px bg-[var(--mmp-editor-color-hairline)]" />
 
         <div className="flex min-w-0 flex-1 items-center gap-1.5 sm:gap-2">
-          <span className="hidden shrink-0 text-xs text-slate-600 sm:inline">에디터</span>
-          <ChevronRight className="hidden h-3.5 w-3.5 shrink-0 text-slate-700 sm:block" />
-          <span className="truncate text-sm font-mono font-medium text-slate-200">
+          <span className="hidden shrink-0 text-xs text-[var(--mmp-editor-color-steel)] sm:inline">에디터</span>
+          <ChevronRight className="hidden h-3.5 w-3.5 shrink-0 text-[var(--mmp-editor-color-muted)] sm:block" />
+          <span className="truncate text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">
             {theme.title}
           </span>
-          <span className="hidden shrink-0 rounded-sm bg-slate-800 px-1.5 py-0.5 text-[10px] font-mono text-slate-500 sm:inline">
+          <span className={`hidden shrink-0 px-1.5 py-0.5 text-[10px] sm:inline ${editorDesignClassNames.tag}`}>
             {STATUS_LABEL[theme.status] ?? theme.status}
           </span>
         </div>
@@ -114,12 +115,12 @@ export function EditorLayout({
           />
         </div>
 
-        <div className="hidden h-5 w-px bg-slate-800 sm:block" />
+        <div className="hidden h-5 w-px bg-[var(--mmp-editor-color-hairline)] sm:block" />
 
         <button
           type="button"
           onClick={handleValidate}
-          className="h-8 rounded-sm border border-slate-700 px-2 text-xs font-medium text-slate-300 transition-colors hover:border-slate-500 sm:h-7 sm:px-3"
+          className={`h-8 px-2 text-xs transition-colors hover:bg-[var(--mmp-editor-color-surface)] sm:h-7 sm:px-3 ${editorDesignClassNames.secondaryAction}`}
         >
           검증
         </button>
@@ -127,7 +128,7 @@ export function EditorLayout({
           type="button"
           onClick={onPublish}
           disabled={theme.status === "PUBLISHED"}
-          className="h-8 rounded-sm bg-amber-600 px-2 text-xs font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:px-3"
+          className={`h-8 px-2 text-xs transition-colors hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:px-3 ${editorDesignClassNames.primaryAction}`}
         >
           출판
         </button>
@@ -142,7 +143,7 @@ export function EditorLayout({
 
       {/* ── Validation panel ── */}
       {!dismissed && (validationResult ?? externalWarnings) && (
-        <div className="shrink-0 border-b border-slate-800 px-3 py-2">
+        <div className="shrink-0 border-b border-[var(--mmp-editor-color-hairline)] px-3 py-2">
           <ValidationPanel
             warnings={validationResult ?? externalWarnings ?? []}
             onClose={() => { setValidationResult(null); setDismissed(true); }}

--- a/apps/web/src/features/editor/components/EditorTabNav.tsx
+++ b/apps/web/src/features/editor/components/EditorTabNav.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { EDITOR_TABS, type EditorTab } from "@/features/editor/constants";
 import { buildEditorRouteForTab } from "@/features/editor/routeSegments";
 import { useEditorUI } from "@/features/editor/stores/editorUIStore";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -88,9 +89,9 @@ export function EditorTabNav({
   );
 
   return (
-    <div className="sticky top-12 z-40 h-11 shrink-0 border-b border-slate-800 bg-slate-950">
-      <div className="pointer-events-none absolute inset-y-0 left-0 w-4 bg-gradient-to-r from-slate-950 to-transparent" />
-      <div className="pointer-events-none absolute inset-y-0 right-0 w-4 bg-gradient-to-l from-slate-950 to-transparent" />
+    <div className={`sticky top-12 z-40 h-11 shrink-0 ${editorDesignClassNames.tabBar}`}>
+      <div className="pointer-events-none absolute inset-y-0 left-0 w-4 bg-gradient-to-r from-[var(--mmp-editor-color-surface-soft)] to-transparent" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-4 bg-gradient-to-l from-[var(--mmp-editor-color-surface-soft)] to-transparent" />
       <nav
         role="tablist"
         aria-label="에디터 탭"
@@ -104,7 +105,7 @@ export function EditorTabNav({
               {startsNewGroup && (
                 <div
                   aria-hidden="true"
-                  className="my-2 mr-2 w-px bg-slate-800"
+                  className="my-2 mr-2 w-px bg-[var(--mmp-editor-color-hairline)]"
                 />
               )}
               <button
@@ -120,8 +121,8 @@ export function EditorTabNav({
                 onKeyDown={(e) => handleKeyDown(e, index)}
                 className={`relative flex min-h-11 shrink-0 items-center gap-1.5 px-3 text-xs font-medium transition-colors sm:px-4 ${
                   isActive
-                    ? "text-amber-400 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-amber-500"
-                    : "text-slate-500 hover:bg-slate-900/50 hover:text-slate-300"
+                    ? `${editorDesignClassNames.tab} ${editorDesignClassNames.tabActive} after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5`
+                    : editorDesignClassNames.tab
                 }`}
               >
                 <tab.icon className="h-3.5 w-3.5" />

--- a/apps/web/src/features/editor/components/SaveIndicator.tsx
+++ b/apps/web/src/features/editor/components/SaveIndicator.tsx
@@ -52,22 +52,22 @@ export function SaveIndicator({ status, lastSaved, onRetry }: SaveIndicatorProps
     >
       {status === "dirty" && (
         <>
-          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
-          <span className="text-amber-400">변경사항 있음</span>
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--mmp-editor-color-warning)]" />
+          <span className="text-[var(--mmp-editor-color-warning)]">변경사항 있음</span>
         </>
       )}
 
       {status === "saving" && (
         <>
-          <span className="h-3.5 w-3.5 animate-spin rounded-full border border-slate-400 border-t-transparent" />
-          <span className="text-slate-400">저장 중...</span>
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border border-[var(--mmp-editor-color-steel)] border-t-transparent" />
+          <span className="text-[var(--mmp-editor-color-slate)]">저장 중...</span>
         </>
       )}
 
       {status === "saved" && (
         <>
-          <span className="text-emerald-500">✓</span>
-          <span className="text-slate-500">
+          <span className="text-[var(--mmp-editor-color-success)]">✓</span>
+          <span className="text-[var(--mmp-editor-color-slate)]">
             저장됨{lastSaved ? ` ${formatTime(lastSaved)}` : ""}
           </span>
         </>
@@ -77,10 +77,10 @@ export function SaveIndicator({ status, lastSaved, onRetry }: SaveIndicatorProps
         <button
           type="button"
           onClick={onRetry}
-          className="flex items-center gap-1.5 rounded-sm px-1.5 py-0.5 transition-colors hover:bg-red-950"
+          className="flex items-center gap-1.5 rounded-sm px-1.5 py-0.5 transition-colors hover:bg-[var(--mmp-editor-color-tint-rose)]"
         >
-          <span className="text-red-400">✗</span>
-          <span className="text-red-400">저장 실패 — 재시도</span>
+          <span className="text-[var(--mmp-editor-color-error)]">✗</span>
+          <span className="text-[var(--mmp-editor-color-error)]">저장 실패 — 재시도</span>
         </button>
       )}
     </div>

--- a/apps/web/src/features/editor/components/ValidationPanel.tsx
+++ b/apps/web/src/features/editor/components/ValidationPanel.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, XCircle, X } from "lucide-react";
 import type { DesignWarning } from "../validation";
 import type { EditorTab } from "../constants";
 import { useEditorUI } from "../stores/editorUIStore";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 // ---------------------------------------------------------------------------
 // Category → Tab mapping
@@ -44,11 +45,11 @@ export function ValidationPanel({ warnings, onClose }: ValidationPanelProps) {
 
   if (warnings.length === 0) {
     return (
-      <div className="flex items-center justify-between rounded border border-emerald-800 bg-emerald-950/30 px-4 py-3">
-        <span className="text-xs text-emerald-400">
+      <div className="flex items-center justify-between rounded border border-[var(--mmp-editor-color-success)] bg-[var(--mmp-editor-color-tint-mint)] px-4 py-3">
+        <span className="text-xs text-[var(--mmp-editor-color-success)]">
           검증 통과 — 문제가 없습니다
         </span>
-        <button type="button" onClick={onClose} aria-label="닫기" className="text-slate-500 hover:text-slate-300">
+        <button type="button" onClick={onClose} aria-label="닫기" className="text-[var(--mmp-editor-color-slate)] hover:text-[var(--mmp-editor-color-charcoal)]">
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
@@ -56,15 +57,15 @@ export function ValidationPanel({ warnings, onClose }: ValidationPanelProps) {
   }
 
   return (
-    <div className="rounded border border-slate-700 bg-slate-900">
+    <div className={editorDesignClassNames.panel}>
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-2">
-        <span className="text-xs font-medium text-slate-300">
+      <div className="flex items-center justify-between border-b border-[var(--mmp-editor-color-hairline)] px-4 py-2">
+        <span className="text-xs font-medium text-[var(--mmp-editor-color-charcoal)]">
           검증 결과: {errors.length > 0 && `${errors.length}개 오류`}
           {errors.length > 0 && warns.length > 0 && ", "}
           {warns.length > 0 && `${warns.length}개 경고`}
         </span>
-        <button type="button" onClick={onClose} aria-label="닫기" className="text-slate-500 hover:text-slate-300">
+        <button type="button" onClick={onClose} aria-label="닫기" className="text-[var(--mmp-editor-color-slate)] hover:text-[var(--mmp-editor-color-charcoal)]">
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
@@ -76,16 +77,16 @@ export function ValidationPanel({ warnings, onClose }: ValidationPanelProps) {
             <button
               type="button"
               onClick={() => handleClick(w)}
-              className="flex w-full items-start gap-2 px-4 py-2 text-left transition-colors hover:bg-slate-800"
+              className="flex w-full items-start gap-2 px-4 py-2 text-left transition-colors hover:bg-[var(--mmp-editor-color-surface)]"
             >
               {w.type === "error" ? (
-                <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-400" />
+                <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--mmp-editor-color-error)]" />
               ) : (
-                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-400" />
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--mmp-editor-color-warning)]" />
               )}
               <div className="flex flex-col">
-                <span className="text-xs text-slate-300">{w.message}</span>
-                <span className="text-[10px] text-slate-600">
+                <span className="text-xs text-[var(--mmp-editor-color-charcoal)]">{w.message}</span>
+                <span className="text-[10px] text-[var(--mmp-editor-color-steel)]">
                   클릭하여 {ERROR_TAB_MAP[w.category] ?? w.category} 탭으로 이동
                 </span>
               </div>

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { EditorThemeResponse } from '@/features/editor/api';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 const { mockNavigate, mockSetActiveTab, mockActiveTab } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
@@ -73,8 +74,11 @@ describe('EditorLayout', () => {
     expect(screen.getByText('좁은 모바일 화면용 테스트 테마')).toBeDefined();
     expect(screen.getByText('초안')).toBeDefined();
     expect(screen.getByText('변경사항 있음')).toBeDefined();
+    expect(screen.getByText('초안').className).toContain(editorDesignClassNames.tag);
     expect((screen.getByRole('button', { name: '검증' }) as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByRole('button', { name: '출판' }) as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByRole('button', { name: '검증' }).className).toContain(editorDesignClassNames.secondaryAction);
+    expect(screen.getByRole('button', { name: '출판' }).className).toContain(editorDesignClassNames.primaryAction);
 
     fireEvent.click(screen.getByRole('button', { name: '검증' }));
     fireEvent.click(screen.getByRole('button', { name: '출판' }));
@@ -173,6 +177,8 @@ describe('EditorLayout', () => {
     render(<EditorLayout theme={baseTheme} themeId="theme-1" />);
 
     const tabPanel = screen.getByRole('tabpanel');
+    const root = tabPanel.parentElement;
+    expect(root?.className).toContain(editorDesignClassNames.surface);
     expect(tabPanel).toBeDefined();
     expect(tabPanel.className).toContain('overflow-hidden');
     expect(screen.getByText('탭 콘텐츠')).toBeDefined();

--- a/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorTabNav.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../../stores/editorUIStore', () => ({
 // ---------------------------------------------------------------------------
 
 import { EditorTabNav } from '../EditorTabNav';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
 
@@ -74,6 +75,8 @@ describe('EditorTabNav dynamic tabs', () => {
 
   it('모듈 미지정 시 always=true 탭만 표시된다', () => {
     render(<EditorTabNav />);
+    expect(screen.getByRole('tablist').parentElement?.className).toContain(editorDesignClassNames.tabBar);
+    expect(screen.getByRole('tab', { name: /스토리 진행/ }).className).toContain(editorDesignClassNames.tabActive);
     expect(screen.getByText('스토리 진행')).toBeDefined();
     expect(screen.getByText('정보 관리')).toBeDefined();
     expect(screen.getByText('읽기 대사')).toBeDefined();

--- a/apps/web/src/features/editor/design-system/editorDesignTokens.ts
+++ b/apps/web/src/features/editor/design-system/editorDesignTokens.ts
@@ -3,6 +3,12 @@ export const EDITOR_DESIGN_SCOPE_CLASS = "mmp-editor-design-scope";
 export const editorDesignClassNames = {
   surface: "mmp-editor-surface",
   panel: "mmp-editor-panel",
+  topBar: "mmp-editor-top-bar",
+  tabBar: "mmp-editor-tab-bar",
+  tab: "mmp-editor-tab",
+  tabActive: "mmp-editor-tab-active",
+  listItem: "mmp-editor-list-item",
+  listItemActive: "mmp-editor-list-item-active",
   sectionHeader: "mmp-editor-section-header",
   mutedText: "mmp-editor-muted-text",
   primaryAction: "mmp-editor-primary-action",

--- a/apps/web/src/features/editor/design-system/editorNotionTheme.css
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.css
@@ -59,6 +59,52 @@
   color: var(--mmp-editor-color-ink);
 }
 
+.mmp-editor-design-scope .mmp-editor-top-bar {
+  border-bottom: 1px solid var(--mmp-editor-color-hairline);
+  background: color-mix(in srgb, var(--mmp-editor-color-canvas) 94%, var(--mmp-editor-color-surface));
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .mmp-editor-tab-bar {
+  border-bottom: 1px solid var(--mmp-editor-color-hairline);
+  background: var(--mmp-editor-color-surface-soft);
+}
+
+.mmp-editor-design-scope .mmp-editor-tab {
+  color: var(--mmp-editor-color-slate);
+  letter-spacing: 0;
+}
+
+.mmp-editor-design-scope .mmp-editor-tab:hover {
+  background: var(--mmp-editor-color-surface);
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .mmp-editor-tab-active {
+  color: var(--mmp-editor-color-primary);
+}
+
+.mmp-editor-design-scope .mmp-editor-tab-active::after {
+  background: var(--mmp-editor-color-primary);
+}
+
+.mmp-editor-design-scope .mmp-editor-list-item {
+  border: 1px solid var(--mmp-editor-color-hairline);
+  border-radius: var(--mmp-editor-radius-md);
+  background: var(--mmp-editor-color-canvas);
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .mmp-editor-list-item:hover {
+  border-color: var(--mmp-editor-color-hairline-strong);
+  background: var(--mmp-editor-color-surface-soft);
+}
+
+.mmp-editor-design-scope .mmp-editor-list-item-active {
+  border-color: color-mix(in srgb, var(--mmp-editor-color-primary) 58%, var(--mmp-editor-color-hairline));
+  background: color-mix(in srgb, var(--mmp-editor-color-primary) 9%, var(--mmp-editor-color-canvas));
+}
+
 .mmp-editor-design-scope .mmp-editor-section-header {
   color: var(--mmp-editor-color-charcoal);
   font-size: 18px;

--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { EntityEditorShell } from './EntityEditorShell';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 interface DemoEntity {
   id: string;
@@ -41,6 +42,7 @@ describe('EntityEditorShell', () => {
 
     expect(screen.getByRole('region', { name: '단서 목록' })).toBeDefined();
     expect(screen.getByRole('region', { name: '단서 상세 영역' })).toBeDefined();
+    expect(screen.getByRole('region', { name: '단서 목록' }).className).toContain(editorDesignClassNames.panel);
     expect(screen.getByLabelText('상세 슬롯').textContent).toContain('첫 단서 상세');
     expect(screen.getByLabelText('검수 슬롯').textContent).toContain('첫 단서 검수');
     expect(screen.getByText('2개의 단서')).toBeDefined();
@@ -106,6 +108,7 @@ describe('EntityEditorShell', () => {
 
     expect(screen.getByRole('button', { name: '첫 단서 선택' }).getAttribute('aria-pressed')).toBe('true');
     expect(screen.getByRole('button', { name: '비밀 편지 선택' }).getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByRole('button', { name: '첫 단서 선택' }).className).toContain(editorDesignClassNames.listItemActive);
     expect(screen.getByText('선택됨')).toBeDefined();
   });
 

--- a/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
+++ b/apps/web/src/features/editor/entities/shell/EntityEditorShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Plus, Search } from 'lucide-react';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 export interface EntityEditorShellProps<TItem> {
   title: string;
@@ -60,15 +61,15 @@ export function EntityEditorShell<TItem>({
 
   if (items.length === 0) {
     return (
-      <div className="h-full min-h-0 rounded-xl border border-dashed border-slate-800 bg-slate-950/60 p-8 text-center">
-        <p className="text-sm font-semibold text-slate-300">{emptyMessage ?? `아직 ${title}가 없습니다`}</p>
-        <p className="mt-1 text-xs text-slate-500">{emptyDescription ?? `새 ${title}를 추가해 제작을 시작하세요.`}</p>
+      <div className={`h-full min-h-0 border border-dashed p-8 text-center ${editorDesignClassNames.panel}`}>
+        <p className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">{emptyMessage ?? `아직 ${title}가 없습니다`}</p>
+        <p className={`mt-1 text-xs ${editorDesignClassNames.mutedText}`}>{emptyDescription ?? `새 ${title}를 추가해 제작을 시작하세요.`}</p>
         {onCreate && (
           <button
             type="button"
             onClick={onCreate}
             aria-label={actionLabel}
-            className="mt-5 inline-flex min-h-10 items-center gap-1.5 rounded-lg bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-300 hover:bg-amber-500/20"
+            className={`mt-5 inline-flex min-h-10 items-center gap-1.5 px-4 py-2 ${editorDesignClassNames.primaryAction}`}
           >
             <Plus className="h-4 w-4" />{actionLabel}
           </button>
@@ -86,19 +87,19 @@ export function EntityEditorShell<TItem>({
     <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto lg:grid lg:grid-cols-[minmax(14rem,0.72fr)_minmax(0,1.9fr)] lg:overflow-hidden">
       <section
         aria-label={`${title} 목록`}
-        className="flex min-h-0 shrink-0 flex-col rounded-xl border border-slate-800 bg-slate-950/70 p-3"
+        className={`flex min-h-0 shrink-0 flex-col p-3 ${editorDesignClassNames.panel}`}
       >
         <header className="mb-3 flex items-center justify-between gap-2">
           <div>
-            <h3 className="text-sm font-semibold text-slate-200">{title} 목록</h3>
-            <p className="text-xs text-slate-600">{items.length}개의 {title}</p>
+            <h3 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">{title} 목록</h3>
+            <p className="text-xs text-[var(--mmp-editor-color-steel)]">{items.length}개의 {title}</p>
           </div>
           {onCreate && (
             <button
               type="button"
               onClick={onCreate}
               aria-label={actionLabel}
-              className="inline-flex min-h-9 items-center gap-1.5 rounded-lg bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-300 hover:bg-amber-500/20"
+              className={`inline-flex min-h-9 items-center gap-1.5 px-3 py-2 text-xs ${editorDesignClassNames.primaryAction}`}
             >
               <Plus className="h-3.5 w-3.5" />{actionLabel}
             </button>
@@ -107,18 +108,18 @@ export function EntityEditorShell<TItem>({
         {listAccessory}
         <label className="relative mb-3 block">
           <span className="sr-only">{title} 검색</span>
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-600" />
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--mmp-editor-color-steel)]" />
           <input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder={`${title}명, 설명 검색`}
             aria-label={`${title} 검색`}
-            className="w-full rounded-lg border border-slate-800 bg-slate-900 py-2.5 pl-9 pr-3 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60"
+            className="w-full rounded-lg border border-[var(--mmp-editor-color-hairline)] bg-[var(--mmp-editor-color-surface-soft)] py-2.5 pl-9 pr-3 text-sm text-[var(--mmp-editor-color-charcoal)] placeholder:text-[var(--mmp-editor-color-steel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mmp-editor-color-primary)]"
           />
         </label>
         <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
           {visibleItems.length === 0 ? (
-            <p className="rounded-lg border border-dashed border-slate-800 px-3 py-8 text-center text-xs text-slate-600">
+            <p className="rounded-lg border border-dashed border-[var(--mmp-editor-color-hairline)] px-3 py-8 text-center text-xs text-[var(--mmp-editor-color-steel)]">
               검색 결과가 없습니다.
             </p>
           ) : (
@@ -173,18 +174,18 @@ function EntityListItem({
   const content = (
     <>
       <span className="flex min-w-0 items-center gap-2">
-        <span className="block truncate text-sm font-semibold text-slate-200">{title}</span>
+        <span className="block truncate text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">{title}</span>
         {active && (
-          <span className="shrink-0 rounded-full border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-200">
+          <span className={`shrink-0 px-2 py-0.5 text-[10px] ${editorDesignClassNames.tag}`}>
             선택됨
           </span>
         )}
       </span>
-      {description && <span className="mt-1 block truncate text-xs text-slate-500">{description}</span>}
+      {description && <span className="mt-1 block truncate text-xs text-[var(--mmp-editor-color-steel)]">{description}</span>}
       {badges.length > 0 && (
         <span className="mt-2 flex flex-wrap gap-1.5 text-[10px] font-medium">
           {badges.map((badge) => (
-            <span key={badge} className="rounded-full border border-slate-700 bg-slate-800 px-2 py-0.5 text-slate-400">
+            <span key={badge} className={`px-2 py-0.5 ${editorDesignClassNames.tag}`}>
               {badge}
             </span>
           ))}
@@ -196,10 +197,10 @@ function EntityListItem({
   if (actions) {
     return (
       <div
-        className={`group flex items-stretch gap-2 rounded-lg border p-2 transition ${
+        className={`group flex items-stretch gap-2 p-2 transition ${editorDesignClassNames.listItem} ${
           active
-            ? 'border-amber-500/50 bg-amber-500/10'
-            : 'border-slate-800 bg-slate-900/70 hover:border-slate-700 hover:bg-slate-900'
+            ? editorDesignClassNames.listItemActive
+            : ''
         }`}
       >
         <button
@@ -224,10 +225,10 @@ function EntityListItem({
       aria-label={`${title} 선택`}
       aria-pressed={active}
       onClick={onSelect}
-      className={`w-full rounded-lg border p-3 text-left transition ${
+      className={`w-full p-3 text-left transition ${editorDesignClassNames.listItem} ${
         active
-          ? 'border-amber-500/50 bg-amber-500/10'
-          : 'border-slate-800 bg-slate-900/70 hover:border-slate-700 hover:bg-slate-900'
+          ? editorDesignClassNames.listItemActive
+          : ''
       }`}
     >
       {content}


### PR DESCRIPTION
## 요약
- #626에서 만든 editor-only 디자인 토큰을 editor shell/nav/list-detail 공통 레이어에 1차 적용했습니다.
- `EditorLayout`, `EditorTabNav`, `SaveIndicator`, `ValidationPanel`이 새 `mmp-editor-*` 토큰 class를 사용하도록 정리했습니다.
- `EntityEditorShell`의 목록/상세 공통 패널과 리스트 항목을 새 panel/list item 패턴으로 바꿔 후속 단서/장소/미디어 탭 적용 기반을 만들었습니다.
- 기능 payload/API/route 동작은 변경하지 않았습니다.

## Coverage Plan
- Shell/nav layout: `EditorLayout.test.tsx`, `EditorTabNav.test.tsx`로 header action, tab active state, route tab panel, 새 디자인 class 적용을 검증했습니다.
- Shared list/detail pattern: `EntityEditorShell.test.tsx`로 목록/상세/검수 슬롯, 검색, 선택 상태, 새 panel/list item class 적용을 검증했습니다.
- Build safety: `typecheck`, `build`, `scripts/mmp-local-ci.sh quick`로 Tailwind arbitrary token class와 CSS import가 전체 앱 빌드/테스트를 깨지 않는지 검증했습니다.
- Visual QA: 로컬 브라우저에서 `/editor/e2e-test-theme/story`를 데스크톱 1440x900, 모바일 390x844로 확인했고 모바일 `overflowX=false`를 확인했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- --run src/features/editor/components/__tests__/EditorLayout.test.tsx src/features/editor/components/__tests__/EditorTabNav.test.tsx src/features/editor/entities/shell/EntityEditorShell.test.tsx` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web build` 통과
- `scripts/mmp-local-ci.sh quick` 통과
- Browser visual smoke: desktop 1440x900, mobile 390x844, 모바일 가로 overflow 없음

## Deferred / Follow-up
- PR B에서 단서/장소/미디어 핵심 탭에 이번 공통 shell/list 패턴을 적용합니다.
- PR C에서 정보/스토리/캐릭터/결말/게임설계/질문 탭을 적용합니다.
- PR D에서 old style 잔존, token 누락, overflow, 카드 안 카드, 반응형 깨짐을 최종 audit하고 #627을 닫습니다.

Refs #627
