### PR TITLE
보조 탭 디자인 토큰 3차 적용

### DIFF
--- a/apps/web/src/features/editor/components/design/EndingDecisionSummaryPanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingDecisionSummaryPanel.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, CheckCircle2 } from "lucide-react";
 import type { EndingDecisionSummary } from "../../entities/ending/endingEntityAdapter";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 interface EndingDecisionSummaryPanelProps {
   summary: EndingDecisionSummary;
@@ -8,22 +9,22 @@ interface EndingDecisionSummaryPanelProps {
 export function EndingDecisionSummaryPanel({ summary }: EndingDecisionSummaryPanelProps) {
   return (
     <section
-      className="grid gap-3 rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300 md:grid-cols-3"
+      className={`grid gap-3 p-4 text-sm md:grid-cols-3 ${editorDesignClassNames.panel}`}
       aria-label="결말 판정 준비"
     >
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">결말 수</p>
-        <p className="mt-1 text-lg font-semibold text-slate-100">{summary.totalCount}개</p>
+        <p className="text-xs font-semibold uppercase text-[var(--mmp-editor-color-slate)]">결말 수</p>
+        <p className="mt-1 text-lg font-semibold text-[var(--mmp-editor-color-charcoal)]">{summary.totalCount}개</p>
       </div>
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">본문 작성</p>
-        <p className="mt-1 text-lg font-semibold text-slate-100">
+        <p className="text-xs font-semibold uppercase text-[var(--mmp-editor-color-slate)]">본문 작성</p>
+        <p className="mt-1 text-lg font-semibold text-[var(--mmp-editor-color-charcoal)]">
           {summary.readyCount}/{summary.totalCount}
         </p>
       </div>
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">기본 결말 후보</p>
-        <p className="mt-1 text-lg font-semibold text-slate-100">
+        <p className="text-xs font-semibold uppercase text-[var(--mmp-editor-color-slate)]">기본 결말 후보</p>
+        <p className="mt-1 text-lg font-semibold text-[var(--mmp-editor-color-charcoal)]">
           {summary.defaultEndingName ?? "아직 없음"}
         </p>
       </div>

--- a/apps/web/src/features/editor/components/design/EndingEmptyState.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEmptyState.tsx
@@ -1,9 +1,11 @@
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
+
 export function EndingEmptyState() {
   return (
-    <div className="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-700 bg-slate-900/50 p-8 text-center">
+    <div className={`flex flex-1 items-center justify-center border-dashed p-8 text-center ${editorDesignClassNames.subtlePanel}`}>
       <div className="max-w-md space-y-3">
-        <h3 className="text-lg font-semibold text-slate-100">아직 결말이 없습니다</h3>
-        <p className="text-sm leading-6 text-slate-400">
+        <h3 className="text-lg font-semibold text-[var(--mmp-editor-color-charcoal)]">아직 결말이 없습니다</h3>
+        <p className="text-sm leading-6 text-[var(--mmp-editor-color-slate)]">
           Flow에서 결말 노드를 추가하면 이곳에서 결말 내용을 작성할 수 있어요. 바로 시작하려면 위의 “결말 추가”
           버튼을 눌러도 됩니다.
         </p>

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -10,6 +10,7 @@ import {
   type FlowGraphResponse,
   type FlowNodeData,
 } from "../../flowTypes";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 interface EndingEntityDetailProps {
   node: Node;
@@ -67,22 +68,22 @@ export function EndingEntityDetail({
   };
 
   return (
-    <section className="flex min-w-0 flex-col gap-4 rounded-2xl border border-slate-800 bg-slate-950/80 p-4 lg:p-5">
+    <section className={`flex min-w-0 flex-col gap-4 p-4 lg:p-5 ${editorDesignClassNames.panel}`}>
       <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
+        <p className="text-xs font-semibold uppercase text-[var(--mmp-editor-color-primary)]">
           결말 상세
         </p>
-        <h3 className="text-lg font-semibold text-slate-100">
+        <h3 className="text-lg font-semibold text-[var(--mmp-editor-color-charcoal)]">
           {data.label || "새 결말"}
         </h3>
-        <p className="text-sm leading-6 text-slate-400">
+        <p className="text-sm leading-6 text-[var(--mmp-editor-color-slate)]">
           게임이 끝났을 때 모두에게 공개할 결말 이름과 본문을 작성합니다.
           투표·질문·조건 결과는 서버가 판정하므로, 여기에는 플레이어에게 보여줄 내용만 적으면 됩니다.
         </p>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-[96px_1fr]">
-        <label className="text-sm font-medium text-slate-300" htmlFor={`${fieldIdPrefix}-label`}>
+        <label className="text-sm font-medium text-[var(--mmp-editor-color-charcoal)]" htmlFor={`${fieldIdPrefix}-label`}>
           결말 이름
         </label>
         <input
@@ -92,12 +93,12 @@ export function EndingEntityDetail({
           onChange={(event) => handleChange({ label: event.target.value })}
           onBlur={debouncer.flush}
           placeholder="예: 진실, 자비, 오판"
-          className="min-h-11 rounded-xl border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+          className={`min-h-11 px-3 text-sm ${editorDesignClassNames.input}`}
         />
       </div>
 
       <div className="min-w-0 space-y-2">
-        <p className="text-sm font-medium text-slate-300" id={`${fieldIdPrefix}-content-label`}>
+        <p className="text-sm font-medium text-[var(--mmp-editor-color-charcoal)]" id={`${fieldIdPrefix}-content-label`}>
           결말 본문
         </p>
         <RichContentEditor
@@ -114,12 +115,12 @@ export function EndingEntityDetail({
           videoPickerTitle="결말 영상 선택"
           onBlurCapture={() => debouncer.flush()}
         />
-        <p className="text-xs leading-5 text-slate-500">
+        <p className="text-xs leading-5 text-[var(--mmp-editor-color-slate)]">
           Markdown과 미디어 블록을 사용할 수 있습니다. 플레이어에게 보일 문장만 작성하면 됩니다.
         </p>
       </div>
       {rulesSlot ? (
-        <div className="border-t border-slate-800 pt-4">
+        <div className="border-t border-[var(--mmp-editor-color-hairline)] pt-4">
           {rulesSlot}
         </div>
       ) : null}

--- a/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityHeader.tsx
@@ -1,10 +1,12 @@
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
+
 export function EndingEntityHeader() {
   return (
-    <header className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+    <header className={`p-4 ${editorDesignClassNames.panel}`}>
       <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">결말 편집</p>
-        <h2 className="text-xl font-semibold text-slate-100">결말 목록</h2>
-        <p className="max-w-3xl text-sm leading-6 text-slate-400">
+        <p className="text-xs font-semibold uppercase text-[var(--mmp-editor-color-primary)]">결말 편집</p>
+        <h2 className="text-xl font-semibold text-[var(--mmp-editor-color-charcoal)]">결말 목록</h2>
+        <p className="max-w-3xl text-sm leading-6 text-[var(--mmp-editor-color-slate)]">
           Flow의 엔딩 노드를 결말 목록으로 모아 보여줍니다. 게임 종료 시 서버가 투표·질문·조건 결과를 판정하고,
           이곳에서는 플레이어에게 공개될 결말 이름과 본문을 정리합니다.
         </p>

--- a/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntitySubTab.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../entities/ending/endingEntityAdapter';
 import { readEndingBranchConfig } from '../../entities/ending/endingBranchAdapter';
 import { getDisplayErrorMessage } from '@/lib/display-error';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 interface EndingEntitySubTabProps {
   themeId: string;
@@ -89,7 +90,7 @@ function EndingEntityWorkspace({
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center p-6 text-sm text-slate-400">
+      <div className="flex h-full items-center justify-center p-6 text-sm text-[var(--mmp-editor-color-slate)]">
         결말 목록을 불러오는 중입니다...
       </div>
     );
@@ -97,19 +98,19 @@ function EndingEntityWorkspace({
 
   if (isError) {
     return (
-      <div className="flex h-full items-center justify-center bg-slate-950 p-6 text-center">
-        <div className="max-w-md rounded-2xl border border-rose-500/30 bg-rose-950/20 p-6">
-          <h3 className="text-lg font-semibold text-rose-100">결말 목록을 불러오지 못했습니다</h3>
-          <p className="mt-2 text-sm leading-6 text-rose-200/80">
+      <div className="flex h-full items-center justify-center p-6 text-center">
+        <div className={`max-w-md p-6 ${editorDesignClassNames.errorPanel}`}>
+          <h3 className="text-lg font-semibold">결말 목록을 불러오지 못했습니다</h3>
+          <p className="mt-2 text-sm leading-6">
             네트워크나 권한 문제일 수 있습니다. 잠시 후 다시 시도해 주세요.
           </p>
-          <p className="mt-3 rounded-xl bg-slate-950/60 p-3 text-left text-xs leading-5 text-rose-100/80">
+          <p className="mt-3 rounded-md bg-[var(--mmp-editor-color-canvas)] p-3 text-left text-xs leading-5">
             {getDisplayErrorMessage(error, '결말 목록을 불러오지 못했습니다.')}
           </p>
           <button
             type="button"
             onClick={() => void refetch()}
-            className="mt-4 inline-flex min-h-11 items-center justify-center rounded-xl border border-rose-300/40 bg-rose-300/10 px-4 text-sm font-medium text-rose-100 transition hover:bg-rose-300/20 focus:outline-none focus:ring-2 focus:ring-rose-300/60"
+            className={`mt-4 inline-flex min-h-11 items-center justify-center px-4 ${editorDesignClassNames.secondaryAction}`}
           >
             다시 불러오기
           </button>
@@ -121,7 +122,7 @@ function EndingEntityWorkspace({
   return (
     <div
       data-testid="ending-entity-panel"
-      className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto bg-slate-950 p-4 lg:p-6"
+      className={`flex h-full min-h-0 flex-col gap-4 overflow-y-auto p-4 lg:p-6 ${editorDesignClassNames.surface}`}
     >
       {section === 'endings' ? <EndingEntityHeader /> : null}
 
@@ -152,31 +153,31 @@ function EndingEntityWorkspace({
         <EndingEmptyState />
       ) : (
         <div className="grid items-start gap-4 lg:grid-cols-[minmax(220px,320px)_minmax(0,1fr)]">
-          <aside className="flex min-w-0 flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
+          <aside className={`flex min-w-0 flex-col gap-3 p-3 ${editorDesignClassNames.panel}`}>
             <button
               type="button"
               onClick={handleAddEnding}
-              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-amber-500/50 bg-amber-500/10 px-3 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-400/60"
+              className={`inline-flex min-h-11 items-center justify-center gap-2 px-3 ${editorDesignClassNames.primaryAction}`}
             >
               <Plus className="h-4 w-4" aria-hidden="true" />
               결말 추가
             </button>
 
             <label className="relative block">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--mmp-editor-color-slate)]" />
               <input
                 type="search"
                 aria-label="결말 검색"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="결말 검색"
-                className="min-h-11 w-full rounded-xl border border-slate-700 bg-slate-950 pl-9 pr-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+                className={`min-h-11 w-full pl-9 pr-3 text-sm ${editorDesignClassNames.input}`}
               />
             </label>
 
             <div className="flex min-w-0 flex-col gap-2">
               {filteredNodes.length === 0 ? (
-                <p className="rounded-xl border border-slate-800 bg-slate-950 p-4 text-sm text-slate-400">
+                <p className={`p-4 text-sm ${editorDesignClassNames.subtlePanel}`}>
                   검색 결과가 없습니다.
                 </p>
               ) : (
@@ -199,15 +200,13 @@ function EndingEntityWorkspace({
                       }}
                       aria-pressed={selected}
                       aria-label={`${viewModel.name} 선택`}
-                      className={`cursor-pointer rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-400/60 ${
-                        selected
-                          ? 'border-amber-500/70 bg-amber-500/10'
-                          : 'border-slate-800 bg-slate-950 hover:border-slate-600'
+                      className={`cursor-pointer p-3 text-left transition ${
+                        selected ? editorDesignClassNames.listItemActive : editorDesignClassNames.listItem
                       }`}
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0 flex-1">
-                          <p className="truncate font-medium text-slate-100">{viewModel.name}</p>
+                          <p className="truncate font-medium text-[var(--mmp-editor-color-charcoal)]">{viewModel.name}</p>
                         </div>
                         <button
                           type="button"
@@ -216,7 +215,7 @@ function EndingEntityWorkspace({
                             deleteNode(node.id);
                             if (selectedId === node.id) setSelectedId(null);
                           }}
-                          className="rounded-lg p-2 text-slate-500 transition hover:bg-rose-500/10 hover:text-rose-200 focus:outline-none focus:ring-2 focus:ring-rose-300/60"
+                          className={`p-2 transition ${editorDesignClassNames.iconButton}`}
                           aria-label={`${viewModel.name} 삭제`}
                         >
                           <Trash2 className="h-4 w-4" aria-hidden="true" />
@@ -226,7 +225,7 @@ function EndingEntityWorkspace({
                         {viewModel.badges.map((badge) => (
                           <span
                             key={badge}
-                            className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300"
+                            className={`px-2 py-0.5 text-[11px] ${editorDesignClassNames.tag}`}
                           >
                             {badge}
                           </span>

--- a/apps/web/src/features/editor/components/design/FlowToolbar.tsx
+++ b/apps/web/src/features/editor/components/design/FlowToolbar.tsx
@@ -3,6 +3,7 @@ import { Plus, Save, ChevronDown, LayoutTemplate, Play } from "lucide-react";
 import { ConfirmDialog } from "@/shared/components/ui";
 import { FLOW_PRESETS, createPresetFlow } from "../../hooks/flowPresets";
 import type { Node, Edge } from "@xyflow/react";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,11 +55,11 @@ export function FlowToolbar({
   }, []);
 
   return (
-    <div className="flex shrink-0 items-center gap-2 border-b border-slate-800 bg-slate-900 px-4 py-2">
+    <div className={`flex shrink-0 items-center gap-2 px-4 py-2 ${editorDesignClassNames.topBar}`}>
       <button
         type="button"
         onClick={onAddScene}
-        className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs text-slate-300 transition-colors hover:border-amber-500 hover:text-amber-400"
+        className={`flex items-center gap-1.5 px-3 py-1.5 text-xs ${editorDesignClassNames.secondaryAction}`}
       >
         <Plus className="h-3.5 w-3.5" />
         장면 추가
@@ -70,7 +71,7 @@ export function FlowToolbar({
           <button
             type="button"
             onClick={() => setPresetOpen((v) => !v)}
-            className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs text-slate-300 transition-colors hover:border-amber-500 hover:text-amber-400"
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs ${editorDesignClassNames.secondaryAction}`}
           >
             <LayoutTemplate className="h-3.5 w-3.5" />
             프리셋
@@ -78,7 +79,7 @@ export function FlowToolbar({
           </button>
 
           {presetOpen && (
-            <div className="absolute left-0 top-full z-50 mt-1 w-52 rounded border border-slate-700 bg-slate-800 py-1 shadow-lg">
+            <div className={`absolute left-0 top-full z-50 mt-1 w-52 py-1 ${editorDesignClassNames.panel}`}>
               {FLOW_PRESETS.map((preset) => (
                 <button
                   key={preset.id}
@@ -91,12 +92,12 @@ export function FlowToolbar({
                     }
                     applyPresetFromTemplate(preset);
                   }}
-                  className="flex w-full flex-col px-3 py-2 text-left transition-colors hover:bg-slate-700"
+                  className="flex w-full flex-col px-3 py-2 text-left transition-colors hover:bg-[var(--mmp-editor-color-surface)]"
                 >
-                  <span className="text-xs font-medium text-slate-200">
+                  <span className="text-xs font-medium text-[var(--mmp-editor-color-charcoal)]">
                     {preset.label}
                   </span>
-                  <span className="text-[10px] text-slate-500">
+                  <span className="text-[10px] text-[var(--mmp-editor-color-slate)]">
                     {preset.description}
                   </span>
                 </button>
@@ -111,10 +112,10 @@ export function FlowToolbar({
         <button
           type="button"
           onClick={onToggleOrderReview}
-          className={`flex items-center gap-1.5 rounded border px-3 py-1.5 text-xs transition-colors ${
+          className={`flex items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
             isOrderReviewing
-              ? "border-amber-600 bg-amber-950/30 text-amber-400"
-              : "border-slate-700 bg-slate-800 text-slate-300 hover:border-amber-500 hover:text-amber-400"
+              ? editorDesignClassNames.listItemActive
+              : editorDesignClassNames.secondaryAction
           }`}
         >
           <Play className="h-3.5 w-3.5" />
@@ -129,7 +130,7 @@ export function FlowToolbar({
         type="button"
         onClick={onSave}
         disabled={isSaving}
-        className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs text-slate-300 transition-colors hover:border-amber-500 hover:text-amber-400 disabled:cursor-not-allowed disabled:opacity-50"
+        className={`flex items-center gap-1.5 px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-50 ${editorDesignClassNames.secondaryAction}`}
       >
         <Save className="h-3.5 w-3.5" />
         {isSaving ? "저장 중..." : "저장"}

--- a/apps/web/src/features/editor/components/design/InformationDeliveryOptionList.tsx
+++ b/apps/web/src/features/editor/components/design/InformationDeliveryOptionList.tsx
@@ -1,4 +1,5 @@
 import { Search, UserRound } from "lucide-react";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 export interface OptionItem {
   id: string;
@@ -16,16 +17,16 @@ interface SearchFieldProps {
 
 export function SearchField({ label, value, placeholder, onChange }: SearchFieldProps) {
   return (
-    <label className="flex flex-col gap-1 text-[11px] text-slate-400">
+    <label className="flex flex-col gap-1 text-[11px] text-[var(--mmp-editor-color-slate)]">
       {label}
-      <span className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-2 py-1.5 focus-within:border-amber-500 focus-within:ring-2 focus-within:ring-amber-500/40">
-        <Search className="h-3.5 w-3.5 text-slate-400" />
+      <span className={`flex items-center gap-2 px-2 py-1.5 ${editorDesignClassNames.input}`}>
+        <Search className="h-3.5 w-3.5 text-[var(--mmp-editor-color-slate)]" />
         <input
           type="search"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="min-w-0 flex-1 bg-transparent text-xs text-slate-200 placeholder-slate-600 focus:outline-none"
+          className="min-w-0 flex-1 bg-transparent text-xs text-[var(--mmp-editor-color-ink)] placeholder:text-[var(--mmp-editor-color-muted)] focus:outline-none"
         />
       </span>
     </label>
@@ -56,11 +57,11 @@ export function OptionList<T extends OptionItem>({
   const selectedItems = (allItems ?? items).filter((item) => selectedIds.includes(item.id));
 
   return (
-    <div className="rounded border border-slate-800 bg-slate-950/70 p-2">
+    <div className={`p-2 ${editorDesignClassNames.subtlePanel}`}>
       <div className="mb-2 flex items-center justify-between gap-2">
-        <span className="text-[11px] font-medium text-slate-400">{title}</span>
+        <span className="text-[11px] font-medium text-[var(--mmp-editor-color-slate)]">{title}</span>
         {selectedItems.length > 0 && (
-          <span className="text-[10px] text-amber-300">{selectedItems.length}개 선택</span>
+          <span className="text-[10px] text-[var(--mmp-editor-color-primary)]">{selectedItems.length}개 선택</span>
         )}
       </div>
       {selectedItems.length > 0 && (
@@ -68,7 +69,7 @@ export function OptionList<T extends OptionItem>({
           {selectedItems.map((item) => (
             <span
               key={item.id}
-              className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-[10px] text-amber-100"
+              className={`inline-flex items-center gap-1 px-2 py-1 text-[10px] ${editorDesignClassNames.tag}`}
             >
               {single ? <UserRound className="h-3 w-3" /> : null}
               {item.name}
@@ -77,7 +78,7 @@ export function OptionList<T extends OptionItem>({
         </div>
       )}
       {items.length === 0 ? (
-        <p className="px-2 py-3 text-center text-xs text-slate-400">{emptyText}</p>
+        <p className="px-2 py-3 text-center text-xs text-[var(--mmp-editor-color-slate)]">{emptyText}</p>
       ) : (
         <div className="grid max-h-44 gap-1 overflow-y-auto pr-1">
           {items.map((item) => {
@@ -89,21 +90,21 @@ export function OptionList<T extends OptionItem>({
                 type="button"
                 onClick={() => onToggle(item.id)}
                 aria-pressed={selected}
-                className={`flex min-h-10 items-center justify-between gap-2 rounded px-2 py-2 text-left text-xs transition-colors ${
+                className={`flex min-h-10 items-center justify-between gap-2 px-2 py-2 text-left text-xs transition-colors ${
                   selected
-                    ? "bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40"
-                    : "bg-slate-900 text-slate-300 hover:bg-slate-800"
+                    ? editorDesignClassNames.listItemActive
+                    : editorDesignClassNames.listItem
                 }`}
               >
                 <span className="min-w-0 flex-1">
                   <span className="block truncate">{item.name}</span>
                   {item.summary && (
-                    <span className="mt-0.5 block truncate text-[10px] text-slate-400">
+                    <span className="mt-0.5 block truncate text-[10px] text-[var(--mmp-editor-color-slate)]">
                       {item.summary}
                     </span>
                   )}
                 </span>
-                {meta && <span className="shrink-0 text-[10px] text-slate-400">{meta}</span>}
+                {meta && <span className="shrink-0 text-[10px] text-[var(--mmp-editor-color-slate)]">{meta}</span>}
               </button>
             );
           })}

--- a/apps/web/src/features/editor/components/design/PhaseNode.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNode.tsx
@@ -2,6 +2,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { Layers } from "lucide-react";
 import type { FlowNodeData } from "../../flowTypes";
 import { getPhaseTypeLabel } from "../../entities/phase/phaseEntityAdapter";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 
 // ---------------------------------------------------------------------------
 // PhaseNode — Phase 커스텀 노드 (입력/출력 핸들, 선택 하이라이트)
@@ -15,21 +16,21 @@ export function PhaseNode({
 
   return (
     <div
-      className={`min-w-[140px] rounded-lg border bg-slate-800 p-3 shadow-md ${
+      className={`min-w-[140px] p-3 shadow-md ${
         selected
-          ? "border-amber-500 ring-1 ring-amber-500/30"
-          : "border-slate-700"
+          ? editorDesignClassNames.listItemActive
+          : editorDesignClassNames.listItem
       }`}
     >
       <Handle
         type="target"
         position={Position.Top}
-        className="!h-4 !w-4 !border-2 !border-slate-900 !bg-slate-400"
+        className="!h-4 !w-4 !border-2 !border-[var(--mmp-editor-color-canvas)] !bg-[var(--mmp-editor-color-slate)]"
       />
 
       <div className="flex items-center gap-2">
-        <Layers className="h-4 w-4 shrink-0 text-amber-400" />
-        <span className="text-xs font-medium text-slate-200">
+        <Layers className="h-4 w-4 shrink-0 text-[var(--mmp-editor-color-primary)]" />
+        <span className="text-xs font-medium text-[var(--mmp-editor-color-charcoal)]">
           {data.label ?? "새 장면"}
         </span>
       </div>
@@ -37,10 +38,10 @@ export function PhaseNode({
       {(phaseLabel ?? data.duration != null) && (
         <div className="mt-1 flex items-center gap-2">
           {phaseLabel && (
-            <span className="text-[10px] text-slate-500">{phaseLabel}</span>
+            <span className="text-[10px] text-[var(--mmp-editor-color-slate)]">{phaseLabel}</span>
           )}
           {data.duration != null && (
-            <span className="text-[10px] text-slate-500">
+            <span className="text-[10px] text-[var(--mmp-editor-color-slate)]">
               {data.duration}분
             </span>
           )}
@@ -50,7 +51,7 @@ export function PhaseNode({
       <Handle
         type="source"
         position={Position.Bottom}
-        className="!h-4 !w-4 !border-2 !border-slate-900 !bg-slate-400"
+        className="!h-4 !w-4 !border-2 !border-[var(--mmp-editor-color-canvas)] !bg-[var(--mmp-editor-color-slate)]"
       />
     </div>
   );

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -257,6 +257,7 @@ describe("EndingEntitySubTab", () => {
   it("Flow의 ending 노드만 결말 목록에 표시한다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
+    expect(screen.getByTestId("ending-entity-panel").className).toContain("mmp-editor-surface");
     expect(screen.getByText("결말 목록")).toBeDefined();
     expect(screen.getAllByText("진실").length).toBeGreaterThan(0);
     expect(screen.getAllByText("오판").length).toBeGreaterThan(0);
@@ -268,6 +269,7 @@ describe("EndingEntitySubTab", () => {
     expect(screen.getByText("복수 선택 반영 기준")).toBeDefined();
     expect(screen.getAllByText("조건 그룹 1개").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("기본 결말").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByLabelText("결말 판정 준비").className).toContain("mmp-editor-panel");
     expect(screen.queryByText("아직 연결 없음")).toBeNull();
     expect(screen.queryByText("참가자에게만 공개")).toBeNull();
     expect(screen.queryByText("캐릭터 결과 카드 1/2명 작성")).toBeNull();

--- a/apps/web/src/features/editor/components/design/__tests__/PhaseNode.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/PhaseNode.test.tsx
@@ -75,18 +75,17 @@ describe("PhaseNode", () => {
     expect(screen.getByText("15분")).toBeDefined();
   });
 
-  it("selected=true 일 때 amber 테두리 클래스를 포함한다", () => {
+  it("selected=true 일 때 editor active list item 클래스를 포함한다", () => {
     const { container } = render(<PhaseNode {...makeProps({}, true)} />);
     const wrapper = container.firstChild as HTMLElement;
-    expect(wrapper.className).toContain("border-amber-500");
-    expect(wrapper.className).toContain("ring-1");
+    expect(wrapper.className).toContain("mmp-editor-list-item-active");
   });
 
-  it("selected=false 일 때 기본 테두리 클래스를 사용한다", () => {
+  it("selected=false 일 때 editor list item 클래스를 사용한다", () => {
     const { container } = render(<PhaseNode {...makeProps({}, false)} />);
     const wrapper = container.firstChild as HTMLElement;
-    expect(wrapper.className).toContain("border-slate-700");
-    expect(wrapper.className).not.toContain("border-amber-500");
+    expect(wrapper.className).toContain("mmp-editor-list-item");
+    expect(wrapper.className).not.toContain("mmp-editor-list-item-active");
   });
 
   it("입력/출력 핸들을 모두 렌더링한다", () => {

--- a/apps/web/src/features/editor/components/info/InfoBodyPreview.tsx
+++ b/apps/web/src/features/editor/components/info/InfoBodyPreview.tsx
@@ -2,6 +2,7 @@ import { Edit3, Trash2 } from 'lucide-react';
 
 import type { StoryInfoResponse } from '@/features/editor/storyInfoApi';
 import { RichContentViewer } from '@/features/editor/components/content/RichContentViewer';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 export function InfoBodyPreview({
   themeId,
@@ -20,22 +21,22 @@ export function InfoBodyPreview({
 }) {
   return (
     <section className="min-h-full">
-      <div className="space-y-4 rounded border border-slate-800 bg-slate-950 p-4">
+      <div className={`space-y-4 p-4 ${editorDesignClassNames.panel}`}>
         {error && (
-          <div className="rounded border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+          <div className={`px-3 py-2 text-xs ${editorDesignClassNames.errorPanel}`}>
             {error}
           </div>
         )}
 
-        <div className="flex flex-col gap-3 border-b border-slate-800 pb-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-3 border-b border-[var(--mmp-editor-color-hairline)] pb-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
-            <p className="text-xs text-slate-500">정보</p>
-            <h3 className="mt-1 break-words text-lg font-semibold text-slate-100">{info.title}</h3>
+            <p className="text-xs text-[var(--mmp-editor-color-slate)]">정보</p>
+            <h3 className="mt-1 break-words text-lg font-semibold text-[var(--mmp-editor-color-charcoal)]">{info.title}</h3>
           </div>
           <button
             type="button"
             onClick={onEdit}
-            className="inline-flex items-center justify-center gap-1.5 rounded border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-amber-400 hover:text-amber-200"
+            className={`inline-flex items-center justify-center gap-1.5 px-3 py-2 ${editorDesignClassNames.secondaryAction}`}
           >
             <Edit3 className="h-4 w-4" />
             정보 수정
@@ -46,12 +47,12 @@ export function InfoBodyPreview({
           <RichContentViewer themeId={themeId} markdown={info.body} />
         </div>
 
-        <div className="flex items-center justify-between border-t border-slate-800 pt-3">
+        <div className="flex items-center justify-between border-t border-[var(--mmp-editor-color-hairline)] pt-3">
           <button
             type="button"
             onClick={onDelete}
             disabled={deletePending}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-rose-400 hover:bg-rose-500/10"
+            className={`flex items-center gap-1 px-2 py-1 text-xs ${editorDesignClassNames.dangerAction}`}
           >
             <Trash2 className="h-3 w-3" />
             정보 삭제

--- a/apps/web/src/features/editor/components/info/InfoDeliverySettingsCard.tsx
+++ b/apps/web/src/features/editor/components/info/InfoDeliverySettingsCard.tsx
@@ -7,6 +7,7 @@ import { SceneSelectField } from "@/features/editor/components/SceneSelectField"
 import { OptionList, type OptionItem } from "@/features/editor/components/design/InformationDeliveryOptionList";
 import { useFlowGraph, useUpdateFlowNode } from "@/features/editor/flowApi";
 import type { FlowNodeResponse } from "@/features/editor/flowTypes";
+import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
 import {
   normalizeTarget,
   readInfoDeliveryTarget,
@@ -202,11 +203,11 @@ export function InfoDeliverySettingsCard({
   );
 
   return (
-    <section className="rounded border border-slate-800 bg-slate-950 p-4" aria-label="정보 배포 설정">
-      <div className="flex flex-col gap-2 border-b border-slate-800 pb-3 sm:flex-row sm:items-start sm:justify-between">
+    <section className={`p-4 ${editorDesignClassNames.panel}`} aria-label="정보 배포 설정">
+      <div className="flex flex-col gap-2 border-b border-[var(--mmp-editor-color-hairline)] pb-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h3 className="text-sm font-semibold text-slate-100">장면 시작 배포</h3>
-          <p className="mt-1 text-xs text-slate-400">
+          <h3 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">장면 시작 배포</h3>
+          <p className="mt-1 text-xs text-[var(--mmp-editor-color-slate)]">
             선택한 장면이 시작될 때 이 정보를 누구에게 보여줄지 정합니다.
           </p>
         </div>
@@ -217,7 +218,7 @@ export function InfoDeliverySettingsCard({
               if (flowError) void refetchFlow();
               if (charactersError) void refetchCharacters();
             }}
-            className="self-start rounded border border-slate-700 px-3 py-1.5 text-xs text-slate-200 hover:border-slate-500"
+            className={`self-start px-3 py-1.5 text-xs ${editorDesignClassNames.secondaryAction}`}
           >
             다시 불러오기
           </button>
@@ -225,11 +226,11 @@ export function InfoDeliverySettingsCard({
       </div>
 
       {isLoading ? (
-        <p className="py-4 text-xs text-slate-500">장면과 캐릭터를 불러오는 중입니다.</p>
+        <p className="py-4 text-xs text-[var(--mmp-editor-color-slate)]">장면과 캐릭터를 불러오는 중입니다.</p>
       ) : isError ? (
         <p className="py-4 text-xs text-rose-300">배포 설정을 불러오지 못했습니다.</p>
       ) : phaseOptions.length === 0 ? (
-        <p className="py-4 text-xs text-slate-500">
+        <p className="py-4 text-xs text-[var(--mmp-editor-color-slate)]">
           게임 진행 플로우에 장면을 먼저 추가하면 이 정보를 배포할 수 있습니다.
         </p>
       ) : (
@@ -244,17 +245,17 @@ export function InfoDeliverySettingsCard({
             disabled={updateNode.isPending}
           />
 
-          <div className="rounded-lg border border-slate-800 bg-slate-900/55 p-3">
+          <div className={`p-3 ${editorDesignClassNames.subtlePanel}`}>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
               <div>
-                <h4 className="text-sm font-medium text-slate-100">
+                <h4 className="text-sm font-medium text-[var(--mmp-editor-color-charcoal)]">
                   {selectedPhase?.label ?? "장면 선택"}
                 </h4>
-                <p className="mt-0.5 text-xs text-slate-500">
+                <p className="mt-0.5 text-xs text-[var(--mmp-editor-color-slate)]">
                   {targetSummary(normalizedDraft, characters)}
                 </p>
               </div>
-              <span className="inline-flex items-center gap-1 self-start rounded-full border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] text-slate-400">
+              <span className={`inline-flex items-center gap-1 self-start px-2 py-1 text-[11px] ${editorDesignClassNames.tag}`}>
                 <CheckCircle2 className="h-3.5 w-3.5" />
                 변경하면 자동저장
               </span>
@@ -265,13 +266,13 @@ export function InfoDeliverySettingsCard({
                 type="button"
                 onClick={() => updateDraftTarget({ mode: "none", characterIds: [] })}
                 aria-pressed={normalizedDraft.mode === "none"}
-                className={`flex min-h-10 items-center gap-2 rounded border px-3 py-2 text-left text-xs transition-colors ${
+                className={`flex min-h-10 items-center gap-2 px-3 py-2 text-left text-xs transition-colors ${
                   normalizedDraft.mode === "none"
-                    ? "border-slate-600 bg-slate-800 text-slate-100"
-                    : "border-slate-800 bg-slate-950/70 text-slate-300 hover:bg-slate-900"
+                    ? editorDesignClassNames.listItemActive
+                    : editorDesignClassNames.listItem
                 }`}
               >
-                <Users className="h-4 w-4 text-slate-400" />
+                <Users className="h-4 w-4 text-[var(--mmp-editor-color-slate)]" />
                 배포하지 않음
               </button>
               <OptionList

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -15,6 +15,7 @@ import { InfoDeliverySettingsCard } from './InfoDeliverySettingsCard';
 import { InfoBodyPreview } from './InfoBodyPreview';
 import { InfoMarkdownEditor } from './InfoMarkdownEditor';
 import { useAutosavedDraft } from '@/features/editor/hooks/useAutosavedDraft';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 interface InfoTabProps {
   themeId: string;
@@ -62,7 +63,7 @@ export function InfoTab({ themeId }: InfoTabProps) {
         <button
           type="button"
           onClick={() => void refetch()}
-          className="rounded border border-rose-500/40 px-3 py-2 text-sm text-rose-200"
+          className={`px-3 py-2 text-sm ${editorDesignClassNames.errorPanel}`}
         >
           정보 목록 다시 불러오기
         </button>
@@ -72,10 +73,10 @@ export function InfoTab({ themeId }: InfoTabProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
+      <div className={`flex items-center justify-between px-4 py-3 ${editorDesignClassNames.topBar}`}>
         <div>
-          <h2 className="text-sm font-semibold text-slate-100">정보 관리</h2>
-          <p className="mt-1 text-xs text-slate-400">
+          <h2 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">정보 관리</h2>
+          <p className="mt-1 text-xs text-[var(--mmp-editor-color-slate)]">
             장면에서 공개할 정보를 대사와 분리해 카드로 관리합니다.
           </p>
           {createError && (
@@ -88,7 +89,7 @@ export function InfoTab({ themeId }: InfoTabProps) {
           type="button"
           onClick={() => void handleCreate()}
           disabled={createInfo.isPending}
-          className="flex items-center gap-2 rounded bg-amber-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-amber-400 disabled:bg-slate-700 disabled:text-slate-500"
+          className={`flex items-center gap-2 px-3 py-2 disabled:cursor-not-allowed disabled:opacity-60 ${editorDesignClassNames.primaryAction}`}
         >
           <Plus className="h-4 w-4" />
           정보 추가
@@ -98,7 +99,7 @@ export function InfoTab({ themeId }: InfoTabProps) {
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 lg:flex-row lg:overflow-hidden">
         <aside className="w-full shrink-0 space-y-2 lg:w-80 lg:overflow-y-auto">
           {sortedInfos.length === 0 ? (
-            <p className="rounded border border-dashed border-slate-700 p-4 text-center text-xs text-slate-500">
+            <p className="rounded-md border border-dashed border-[var(--mmp-editor-color-hairline)] p-4 text-center text-xs text-[var(--mmp-editor-color-slate)]">
               공개 정보가 없습니다
             </p>
           ) : (
@@ -108,9 +109,13 @@ export function InfoTab({ themeId }: InfoTabProps) {
                 type="button"
                 onClick={() => setSelectedId(info.id)}
                 aria-pressed={selected?.id === info.id}
-                className="w-full rounded border border-slate-800 bg-slate-900 p-3 text-left transition hover:border-slate-600 aria-pressed:border-amber-400"
+                className={`w-full p-3 text-left transition ${
+                  selected?.id === info.id
+                    ? editorDesignClassNames.listItemActive
+                    : editorDesignClassNames.listItem
+                }`}
               >
-                <span className="block truncate text-sm font-medium text-slate-100">
+                <span className="block truncate text-sm font-medium text-[var(--mmp-editor-color-charcoal)]">
                   {info.title}
                 </span>
               </button>
@@ -122,7 +127,7 @@ export function InfoTab({ themeId }: InfoTabProps) {
           {selected ? (
             <InfoEditor key={selected.id} themeId={themeId} info={selected} />
           ) : (
-            <div className="flex h-full items-center justify-center text-sm text-slate-500">
+            <div className="flex h-full items-center justify-center text-sm text-[var(--mmp-editor-color-slate)]">
               정보를 추가하면 여기에 편집 화면이 표시됩니다.
             </div>
           )}
@@ -257,10 +262,10 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   return (
     <>
       <section className="min-h-full">
-        <div className="space-y-4 rounded border border-slate-800 bg-slate-950 p-4">
+        <div className={`space-y-4 p-4 ${editorDesignClassNames.panel}`}>
           {error && (
             <div
-              className="flex items-start justify-between gap-3 rounded border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200"
+              className={`flex items-start justify-between gap-3 px-3 py-2 text-xs ${editorDesignClassNames.errorPanel}`}
               role="alert"
             >
               <span>{error}</span>
@@ -268,25 +273,25 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
                 type="button"
                 aria-label="오류 메시지 닫기"
                 onClick={() => setError(null)}
-                className="shrink-0 rounded p-0.5 text-rose-200 hover:bg-rose-500/20"
+                className={`shrink-0 p-0.5 ${editorDesignClassNames.iconButton}`}
               >
                 <X className="h-3.5 w-3.5" />
               </button>
             </div>
           )}
 
-          <label className="block text-xs text-slate-400">
+          <label className="block text-xs text-[var(--mmp-editor-color-slate)]">
             제목
             <input
               aria-label="정보 제목"
               value={draft.title}
               onChange={(event) => updateDraft({ title: event.target.value })}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+              className={`mt-1 w-full px-3 py-2 text-sm ${editorDesignClassNames.input}`}
             />
           </label>
 
           <div className="space-y-1">
-            <span className="block text-xs text-slate-400">본문</span>
+            <span className="block text-xs text-[var(--mmp-editor-color-slate)]">본문</span>
             <InfoMarkdownEditor
               themeId={themeId}
               markdown={draft.body}
@@ -297,12 +302,12 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
             />
           </div>
 
-          <div className="flex items-center justify-start border-t border-slate-800 pt-3">
+          <div className="flex items-center justify-start border-t border-[var(--mmp-editor-color-hairline)] pt-3">
             <button
               type="button"
               onClick={() => setDeleteDialogOpen(true)}
               disabled={deleteInfo.isPending}
-              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-rose-400 hover:bg-rose-500/10"
+              className={`flex items-center gap-1 px-2 py-1 text-xs ${editorDesignClassNames.dangerAction}`}
             >
               <Trash2 className="h-3 w-3" />
               정보 삭제

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -311,6 +311,7 @@ describe('InfoTab', () => {
     expect(screen.getByText('정보 관리')).toBeDefined();
     expect(screen.getAllByText('피해자의 비밀').length).toBeGreaterThanOrEqual(1);
     const selectedInfoButton = screen.getByRole('button', { name: /피해자의 비밀/ });
+    expect(selectedInfoButton.className).toContain('mmp-editor-list-item-active');
     expect(selectedInfoButton.textContent?.replace(/\s+/g, ' ').trim()).toBe('피해자의 비밀');
     expect(screen.getByRole('heading', { name: '피해자의 비밀' })).toBeDefined();
     expect(screen.getByRole('region', { name: '정보 본문 보기' })).toHaveProperty(
@@ -329,6 +330,9 @@ describe('InfoTab', () => {
     expect(screen.getByRole('region', { name: '정보 배포 설정' })).toHaveProperty(
       'textContent',
       expect.stringContaining('오프닝'),
+    );
+    expect(screen.getByRole('region', { name: '정보 배포 설정' }).className).toContain(
+      'mmp-editor-panel',
     );
     expect(screen.getByText('현재 전체 캐릭터에게 공개됩니다.')).toBeDefined();
   });


### PR DESCRIPTION
Refs #627

## 요약
- 정보 관리 화면의 목록, 상세/미리보기, 장면 시작 배포 설정에 editor-only 디자인 토큰을 적용했습니다.
- 결말/질문 관리의 목록, 상세, 요약, 빈 상태, 에러 상태를 공통 panel/list/input/tag 토큰으로 정리했습니다.
- 스토리 진행 플로우 toolbar와 phase node의 버튼/노드 상태도 같은 토큰 경계 안으로 맞췄습니다.
- API, 저장 payload, route 동작은 변경하지 않았습니다.

## Coverage Plan
- 정보 관리: `InfoTab.test.tsx`에서 정보 목록 active state와 배포 설정 panel token 적용을 확인합니다.
- 결말 관리: `EndingEntitySubTab.test.tsx`에서 route surface와 결말 판정 준비 panel token 적용 및 기존 결말 규칙 동작을 확인합니다.
- 스토리 진행: `PhaseNode.test.tsx`에서 selected/default phase node가 editor list item token을 사용하는지 확인합니다.
- 전체 회귀: `scripts/mmp-local-ci.sh quick`으로 backend/frontend lint/type/test/build 흐름을 확인합니다.

## Local validation
- `pnpm --filter @mmp/web test -- --run src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/components/design/__tests__/PhaseNode.test.tsx` 통과: 3 files, 46 tests.
- `pnpm --filter @mmp/web typecheck` 통과.
- `pnpm --filter @mmp/web build` 통과. 기존 Rollup circular/chunk warning만 확인했습니다.
- Browser smoke 통과: desktop/mobile `/editor/e2e-test-theme/info`, `/editor/e2e-test-theme/endings`, `/editor/e2e-test-theme/design/flow`에서 editor scope 적용과 `overflowX=false` 확인.
- Screenshot evidence: `/tmp/issue-627-pr-c-info-desktop.png`, `/tmp/issue-627-pr-c-endings-desktop.png`, `/tmp/issue-627-pr-c-flow-desktop.png`, `/tmp/issue-627-pr-c-info-mobile.png`, `/tmp/issue-627-pr-c-endings-mobile.png`, `/tmp/issue-627-pr-c-flow-mobile.png`.
- 최종 HEAD 기준 `scripts/mmp-local-ci.sh quick` 통과: web tests 189 files / 1779 tests.

## CI scope
- 개발 최소 워커 정책에 따라 `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

- 에디터 전체의 UI 스타일이 일관된 디자인 시스템으로 업데이트되었습니다.
- 패널, 버튼, 입력 필드, 리스트 아이템 등의 컬러와 타이포그래피가 개선되어 더욱 통일된 사용자 경험을 제공합니다.
- 엔딩 편집, 정보 관리, 플로우 설정 등 주요 기능 영역의 시각적 표현이 최적화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->