### PR TITLE
에디터 디자인 최종 누락 재적용

### DIFF
--- a/apps/web/src/features/editor/design-system/editorNotionTheme.css
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.css
@@ -206,3 +206,130 @@
   font-weight: 600;
   line-height: 1.4;
 }
+
+/*
+ * Legacy Tailwind bridge for editor-only screens.
+ *
+ * PR A/B/C moved the main editor shell and high-traffic tabs onto explicit
+ * DESIGN.md-backed tokens. Some secondary editor modules still carry old
+ * slate/amber utility classes. Keep those modules visually inside the new
+ * editor design language without leaking the palette outside /editor.
+ */
+.mmp-editor-design-scope .bg-slate-950,
+.mmp-editor-design-scope .bg-slate-900,
+.mmp-editor-design-scope .bg-slate-800 {
+  background-color: var(--mmp-editor-color-canvas);
+}
+
+.mmp-editor-design-scope .bg-slate-900\/70,
+.mmp-editor-design-scope .bg-slate-900\/60,
+.mmp-editor-design-scope .bg-slate-900\/55,
+.mmp-editor-design-scope .bg-slate-900\/50,
+.mmp-editor-design-scope .bg-slate-800\/90,
+.mmp-editor-design-scope .bg-slate-800\/70,
+.mmp-editor-design-scope .bg-slate-800\/60,
+.mmp-editor-design-scope .bg-slate-800\/50,
+.mmp-editor-design-scope .bg-white\/5 {
+  background-color: var(--mmp-editor-color-surface-soft);
+}
+
+.mmp-editor-design-scope .bg-slate-700,
+.mmp-editor-design-scope .bg-slate-700\/50 {
+  background-color: var(--mmp-editor-color-surface);
+}
+
+.mmp-editor-design-scope .border-slate-900,
+.mmp-editor-design-scope .border-slate-800,
+.mmp-editor-design-scope .border-slate-700,
+.mmp-editor-design-scope .border-slate-600,
+.mmp-editor-design-scope .border-white\/10 {
+  border-color: var(--mmp-editor-color-hairline);
+}
+
+.mmp-editor-design-scope .border-slate-500,
+.mmp-editor-design-scope .border-slate-500\/30 {
+  border-color: var(--mmp-editor-color-hairline-strong);
+}
+
+.mmp-editor-design-scope .text-slate-50,
+.mmp-editor-design-scope .text-slate-100,
+.mmp-editor-design-scope .text-slate-200 {
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .text-slate-300,
+.mmp-editor-design-scope .text-slate-400 {
+  color: var(--mmp-editor-color-slate);
+}
+
+.mmp-editor-design-scope .text-slate-500,
+.mmp-editor-design-scope .text-slate-600,
+.mmp-editor-design-scope .text-slate-700 {
+  color: var(--mmp-editor-color-steel);
+}
+
+.mmp-editor-design-scope .placeholder-slate-500::placeholder,
+.mmp-editor-design-scope .placeholder-slate-600::placeholder,
+.mmp-editor-design-scope .placeholder\:text-slate-500::placeholder,
+.mmp-editor-design-scope .placeholder\:text-slate-600::placeholder {
+  color: var(--mmp-editor-color-muted);
+}
+
+.mmp-editor-design-scope .hover\:bg-slate-900:hover,
+.mmp-editor-design-scope .hover\:bg-slate-800:hover,
+.mmp-editor-design-scope .hover\:bg-slate-700:hover,
+.mmp-editor-design-scope .hover\:bg-white\/10:hover {
+  background-color: var(--mmp-editor-color-surface);
+}
+
+.mmp-editor-design-scope .hover\:text-slate-100:hover,
+.mmp-editor-design-scope .hover\:text-slate-200:hover,
+.mmp-editor-design-scope .hover\:text-slate-300:hover {
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .hover\:border-slate-700:hover,
+.mmp-editor-design-scope .hover\:border-slate-600:hover {
+  border-color: var(--mmp-editor-color-hairline-strong);
+}
+
+.mmp-editor-design-scope .bg-amber-500,
+.mmp-editor-design-scope .hover\:bg-amber-400:hover {
+  background-color: var(--mmp-editor-color-primary);
+  color: var(--mmp-editor-color-on-primary);
+}
+
+.mmp-editor-design-scope .text-amber-300,
+.mmp-editor-design-scope .text-amber-400,
+.mmp-editor-design-scope .text-amber-500,
+.mmp-editor-design-scope .hover\:text-amber-300:hover,
+.mmp-editor-design-scope .hover\:text-amber-400:hover {
+  color: var(--mmp-editor-color-primary);
+}
+
+.mmp-editor-design-scope .border-amber-500,
+.mmp-editor-design-scope .border-amber-500\/60,
+.mmp-editor-design-scope .hover\:border-amber-500\/60:hover,
+.mmp-editor-design-scope .focus\:border-amber-500:focus {
+  border-color: var(--mmp-editor-color-primary);
+}
+
+.mmp-editor-design-scope .bg-amber-500\/10 {
+  background-color: color-mix(in srgb, var(--mmp-editor-color-primary) 9%, var(--mmp-editor-color-canvas));
+}
+
+.mmp-editor-design-scope .focus\:ring-amber-500\/30:focus,
+.mmp-editor-design-scope .focus-visible\:ring-amber-500\/60:focus-visible {
+  --tw-ring-color: color-mix(in srgb, var(--mmp-editor-color-primary) 32%, transparent);
+}
+
+.mmp-editor-design-scope .rounded-xl,
+.mmp-editor-design-scope .rounded-2xl {
+  border-radius: var(--mmp-editor-radius-lg);
+}
+
+.mmp-editor-design-scope .shadow-lg,
+.mmp-editor-design-scope .shadow-xl,
+.mmp-editor-design-scope .shadow-2xl {
+  box-shadow: var(--mmp-editor-shadow-card);
+}

--- a/apps/web/src/features/editor/design-system/editorNotionTheme.test.ts
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'editorNotionTheme.css');
+
+describe('editorNotionTheme legacy bridge', () => {
+  it('keeps legacy utility overrides scoped to the editor boundary', () => {
+    const css = readFileSync(cssPath, 'utf8');
+
+    expect(css).toContain('.mmp-editor-design-scope .bg-slate-900');
+    expect(css).toContain('.mmp-editor-design-scope .text-slate-100');
+    expect(css).toContain('.mmp-editor-design-scope .border-slate-700');
+    expect(css).toContain('var(--mmp-editor-color-canvas)');
+    expect(css).not.toMatch(/(^|\n)\.bg-slate-900[,\s{]/);
+  });
+
+  it('maps legacy amber actions to the editor primary token', () => {
+    const css = readFileSync(cssPath, 'utf8');
+
+    expect(css).toContain('.mmp-editor-design-scope .bg-amber-500');
+    expect(css).toContain('var(--mmp-editor-color-primary)');
+    expect(css).toContain('var(--mmp-editor-color-on-primary)');
+  });
+});


### PR DESCRIPTION
## 요약
- `/editor` 디자인 scope 안에서만 동작하는 legacy Tailwind bridge를 추가해 PR A/B/C 이후 남은 slate/amber 계열 구형 유틸리티를 DESIGN.md 기반 editor token 색상으로 매핑했습니다.
- 구형 보조 탭 컴포넌트를 대량 수정하지 않고도 editor-only 디자인 경계를 유지하도록 CSS fallback을 좁게 추가했습니다.
- bridge가 `/editor` 밖으로 새지 않는지 확인하는 design-system 테스트를 추가했습니다.

Closes #627

## Coverage Plan
- `editorNotionTheme.css`: 남은 editor 내부 legacy slate/amber utility가 editor token으로 계산되는지 브라우저 smoke로 확인합니다.
- `editorNotionTheme.test.ts`: legacy bridge selector가 `.mmp-editor-design-scope` 아래에만 존재하고 primary token을 참조하는지 단위 테스트로 확인합니다.
- editor shell route: `EditorPage`/`EditorLayout` 테스트와 실제 route smoke로 scope 적용 및 overflow 회귀를 확인합니다.

## Local validation
- `pnpm --filter @mmp/web test -- --run src/features/editor/design-system/editorNotionTheme.test.ts src/features/editor/components/__tests__/EditorLayout.test.tsx src/pages/__tests__/EditorPage.test.tsx` ✅ 3 files / 44 tests
- `pnpm --filter @mmp/web typecheck` ✅
- `pnpm --filter @mmp/web build` ✅ existing Rollup circular/chunk warnings only
- Browser smoke ✅ desktop 1440x1000 + mobile 390x844 for `/editor/e2e-test-theme/{overview,info,design/flow,design/locations,design/modules,design/endings,story}`: scope true, horizontal overflow false, legacy classes resolve to editor token colors
- `scripts/mmp-local-ci.sh quick` ✅ web tests 190 files / 1781 tests, lint 49 existing warnings / 0 errors, typecheck/build pass

## Notes
- 기능 payload/API/DB 변경은 없습니다.
- GitHub Actions worker는 개발 최소 워커 정책에 따라 수동 실행하지 않았습니다.