### PR TITLE
미디어 삭제 별칭 아이콘 정리 오류 수정

### DIFF
--- a/apps/server/db/queries/media.sql
+++ b/apps/server/db/queries/media.sql
@@ -220,8 +220,7 @@ SET alias_rules = regexp_replace(
       '"display_icon_media_id"\s*:\s*"' || sqlc.arg('media_id')::text || '"',
       '"display_icon_media_id":null',
       'g'
-    )::jsonb,
-    updated_at = NOW()
+    )::jsonb
 FROM themes t
 WHERE c.theme_id = t.id
   AND t.creator_id = sqlc.arg('creator_id')

--- a/apps/server/internal/db/media.sql.go
+++ b/apps/server/internal/db/media.sql.go
@@ -19,8 +19,7 @@ SET alias_rules = regexp_replace(
       '"display_icon_media_id"\s*:\s*"' || $1::text || '"',
       '"display_icon_media_id":null',
       'g'
-    )::jsonb,
-    updated_at = NOW()
+    )::jsonb
 FROM themes t
 WHERE c.theme_id = t.id
   AND t.creator_id = $2

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -1701,6 +1701,34 @@ func TestMediaService_PreviewDelete_ReportsCharacterAliasIconReference(t *testin
 	}
 }
 
+func TestMediaService_Delete_DetachesCharacterAliasIconReference(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	mediaID := seedMedia(q, themeID, MediaTypeImage)
+	charID := uuid.New()
+	q.aliasIconRefs[mediaID] = []db.FindCharacterAliasIconReferencesForMediaRow{
+		{ID: charID, Name: "밤의 목격자"},
+	}
+
+	err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{})
+	assertMediaAppCode(t, err, apperror.ErrMediaReferenceInUse)
+	if _, ok := q.media[mediaID]; !ok {
+		t.Fatalf("media should remain when alias icon references are not detached")
+	}
+	if refs := q.aliasIconRefs[mediaID]; len(refs) != 1 {
+		t.Fatalf("alias icon reference should remain on blocked delete, got %#v", refs)
+	}
+
+	if err := svc.DeleteMedia(context.Background(), creatorID, mediaID, DeleteMediaOptions{DetachReferences: true}); err != nil {
+		t.Fatalf("DeleteMedia with alias icon detach: %v", err)
+	}
+	if _, ok := q.media[mediaID]; ok {
+		t.Fatalf("media should be deleted after alias icon detach")
+	}
+	if refs := q.aliasIconRefs[mediaID]; len(refs) != 0 {
+		t.Fatalf("alias icon references should be cleared, got %#v", refs)
+	}
+}
+
 func TestMediaService_PreviewDelete_ReportsPhaseOnEnterMediaReference(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	mediaID := seedMedia(q, themeID, MediaTypeBGM)


### PR DESCRIPTION
## 요약
- 미디어 삭제 전 참조 정리 중 `theme_characters.updated_at`을 갱신하던 잘못된 SQL을 제거했습니다.
- 캐릭터 별칭 아이콘이 참조한 미디어도 `detach_references=true` 삭제에서 정상 해제되도록 회귀 테스트를 추가했습니다.

## 연결 이슈
Refs #623

## Coverage Plan
- `apps/server/db/queries/media.sql`: 존재하지 않는 컬럼을 갱신하지 않는 SQL로 정리합니다.
- `apps/server/internal/db/media.sql.go`: SQL query 문자열을 동기화합니다.
- `apps/server/internal/domain/editor/media_service_test.go`: 별칭 아이콘 참조 미디어 삭제 차단/자동 해제 경로를 검증합니다.

## Local validation
- `cd apps/server && go test ./internal/domain/editor -run 'TestMediaService_(Delete_DetachesCharacterAliasIconReference|Delete_BlocksReferencesUntilDetachRequested|PreviewDelete_ReportsCharacterAliasIconReference)' -count=1` ✅
- `cd apps/server && go test ./internal/domain/editor -count=1` ✅
- `cd apps/server && go test ./cmd/server -count=1` ✅
- `git diff --check` ✅
- `scripts/mmp-local-ci.sh quick` ⚠️ 차단: unrelated Docker/testcontainers timeout in `TestService_DeleteTheme_ForbiddenForNonOwner` while starting postgres container. Focused/package tests above passed on the final source change.

## 운영 메모
- 현재 dev Docker backend hot reload는 `github.com/chai2010/webp` C dependency build error로 새 바이너리 반영에 실패했습니다. Source fix는 focused test로 검증했지만, 로컬 컨테이너 live 삭제 확인은 dev image dependency 정리 후 가능합니다.