### PR TITLE
에디터 디자인 잔존 스타일과 가독성 보정

### DIFF
--- a/apps/web/src/features/editor/design-system/editorNotionTheme.css
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.css
@@ -224,6 +224,7 @@
   --accentText: var(--mmp-editor-color-primary);
   --accentTextContrast: var(--mmp-editor-color-primary-pressed);
   --baseBorder: var(--mmp-editor-color-hairline);
+
   background: var(--mmp-editor-color-canvas);
   color: var(--mmp-editor-color-charcoal);
 }

--- a/apps/web/src/features/editor/design-system/editorNotionTheme.css
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.css
@@ -15,11 +15,11 @@
   --mmp-editor-color-hairline-strong: #c8c4be;
   --mmp-editor-color-ink: #1a1a1a;
   --mmp-editor-color-charcoal: #37352f;
-  --mmp-editor-color-slate: #5d5b54;
-  --mmp-editor-color-steel: #787671;
-  --mmp-editor-color-muted: #bbb8b1;
+  --mmp-editor-color-slate: #4f4d47;
+  --mmp-editor-color-steel: #5d5b54;
+  --mmp-editor-color-muted: #8f8a83;
   --mmp-editor-color-success: #1aae39;
-  --mmp-editor-color-warning: #dd5b00;
+  --mmp-editor-color-warning: #a84600;
   --mmp-editor-color-error: #e03131;
   --mmp-editor-color-tint-peach: #ffe8d4;
   --mmp-editor-color-tint-rose: #fde0ec;
@@ -207,6 +207,50 @@
   line-height: 1.4;
 }
 
+.mmp-editor-design-scope .mmp-rich-content-surface {
+  border-color: var(--mmp-editor-color-hairline);
+  background: var(--mmp-editor-color-canvas);
+}
+
+.mmp-editor-design-scope .mmp-mdx-editor {
+  --baseBg: var(--mmp-editor-color-canvas);
+  --baseText: var(--mmp-editor-color-charcoal);
+  --baseTextContrast: var(--mmp-editor-color-ink);
+  --basePageBg: var(--mmp-editor-color-canvas);
+  --baseBgHover: var(--mmp-editor-color-surface);
+  --baseBgSubtle: var(--mmp-editor-color-surface-soft);
+  --accentBase: var(--mmp-editor-color-primary);
+  --accentBgSubtle: color-mix(in srgb, var(--mmp-editor-color-primary) 10%, var(--mmp-editor-color-canvas));
+  --accentText: var(--mmp-editor-color-primary);
+  --accentTextContrast: var(--mmp-editor-color-primary-pressed);
+  --baseBorder: var(--mmp-editor-color-hairline);
+  background: var(--mmp-editor-color-canvas);
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-toolbar {
+  border-bottom-color: var(--mmp-editor-color-hairline);
+  background: var(--mmp-editor-color-surface-soft);
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-toolbar button,
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-toolbar select,
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-toolbar [role='button'],
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-toolbar svg {
+  color: var(--mmp-editor-color-charcoal);
+}
+
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-toolbar button:hover,
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-toolbar [role='button']:hover {
+  background: var(--mmp-editor-color-surface);
+}
+
+.mmp-editor-design-scope .mmp-mdx-editor .mdxeditor-root-contenteditable {
+  background: var(--mmp-editor-color-canvas);
+  color: var(--mmp-editor-color-charcoal);
+}
+
 /*
  * Legacy Tailwind bridge for editor-only screens.
  *
@@ -221,10 +265,15 @@
   background-color: var(--mmp-editor-color-canvas);
 }
 
+.mmp-editor-design-scope .bg-slate-900\/80,
 .mmp-editor-design-scope .bg-slate-900\/70,
 .mmp-editor-design-scope .bg-slate-900\/60,
 .mmp-editor-design-scope .bg-slate-900\/55,
 .mmp-editor-design-scope .bg-slate-900\/50,
+.mmp-editor-design-scope .bg-slate-950\/80,
+.mmp-editor-design-scope .bg-slate-950\/70,
+.mmp-editor-design-scope .bg-slate-950\/60,
+.mmp-editor-design-scope .bg-slate-950\/40,
 .mmp-editor-design-scope .bg-slate-800\/90,
 .mmp-editor-design-scope .bg-slate-800\/70,
 .mmp-editor-design-scope .bg-slate-800\/60,
@@ -316,6 +365,21 @@
 
 .mmp-editor-design-scope .bg-amber-500\/10 {
   background-color: color-mix(in srgb, var(--mmp-editor-color-primary) 9%, var(--mmp-editor-color-canvas));
+}
+
+.mmp-editor-design-scope .bg-amber-500\/5,
+.mmp-editor-design-scope .bg-amber-500\/15,
+.mmp-editor-design-scope .bg-amber-500\/20,
+.mmp-editor-design-scope .bg-amber-500\/25,
+.mmp-editor-design-scope .bg-amber-950\/30 {
+  background-color: color-mix(in srgb, var(--mmp-editor-color-primary) 12%, var(--mmp-editor-color-canvas));
+}
+
+.mmp-editor-design-scope .text-amber-100,
+.mmp-editor-design-scope .text-amber-100\/90,
+.mmp-editor-design-scope .text-amber-200,
+.mmp-editor-design-scope .text-amber-200\/70 {
+  color: var(--mmp-editor-color-primary);
 }
 
 .mmp-editor-design-scope .focus\:ring-amber-500\/30:focus,


### PR DESCRIPTION
## 요약
- 에디터 전용 디자인 토큰의 보조 텍스트 대비를 올렸습니다.
- `.mmp-editor-design-scope` 안에서만 기존 slate/amber Tailwind 잔존 스타일을 Notion 계열 토큰으로 흡수했습니다.
- rich content/MDX editor 표면이 에디터 화면에서 어두운 배경으로 남지 않도록 editor-scoped override를 추가했습니다.

Closes #638

## Coverage Plan
- `apps/web/src/features/editor/design-system/editorNotionTheme.css`
  - 에디터 route scope인 `.mmp-editor-design-scope` 내부만 수정해 non-editor 페이지 스타일 누수를 막습니다.
  - 기능 로직 변경이 없으므로 unit test 추가 대신 typecheck, cmux 스크린샷, contrast probe로 검증합니다.

## Local validation
- `git diff --check`: 통과
- `pnpm --filter @mmp/web typecheck`: 통과
- cmux 브라우저 스크린샷 확인: `/tmp/mmp-design-audit-after/{storyMap,info,story,characters,clues,design,questions,endings,locations,media,overview,advanced}.png`
- contrast probe: 주요 에디터 탭 `storyMap/info/story/characters/clues/design/questions/endings/locations/media/overview/advanced`에서 확인 대상 텍스트 저대비 항목 없음
- `scripts/mmp-local-ci.sh quick`: 실패
  - 실패 위치: `github.com/mmp-platform/server/internal/domain/editor`
  - 실패 원인: `TestFindMediaReferencesInReadingSections_JSONBIntegration`의 testcontainers/Postgres reaper mapped port 확인 중 `invalid port`/Docker socket timeout
  - 판단: 이번 PR은 CSS 한 파일의 에디터 표시 보정이며, 실패 지점은 백엔드 통합 테스트 컨테이너 기동 문제라 변경과 직접 관련 없음

## Notes
- backend/API/DB/payload 변경 없음
- non-editor page 변경 없음
- ready-for-ci 라벨/수동 workflow dispatch 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 에디터 컬러 팔레트 업데이트로 시각적 일관성 개선
  * 에디터 컴포넌트의 배경, 테두리, 텍스트 색상 스타일 확장
  * 툴바 및 본문 영역의 호버 및 액센트 색상 재정의

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->