### PR TITLE
feat: 에디터 상세 화면 다크/라이트 모드 추가

### DIFF
--- a/apps/web/e2e/editor-appearance.spec.ts
+++ b/apps/web/e2e/editor-appearance.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+import {
+  BASE,
+  THEME_ID,
+  freshState,
+  loginAsE2EUser,
+  mockCommonApis,
+} from './helpers/editor-golden-path-fixtures';
+import { EDITOR_APPEARANCE_STORAGE_KEY } from '../src/features/editor/design-system/useEditorAppearance';
+
+test.describe('editor appearance mode', () => {
+  test('에디터 상세 화면에서 다크 모드를 선택하면 저장되고 새로고침 뒤에도 유지된다', async ({
+    page,
+  }) => {
+    const state = freshState();
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    const editorScope = page.locator('.mmp-editor-design-scope');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+    await expect(page.getByRole('button', { name: '시스템 설정 사용' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    await page.getByRole('button', { name: '다크 모드' }).click();
+
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expect(page.getByRole('button', { name: '다크 모드' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect
+      .poll(() =>
+        page.evaluate((key) => window.localStorage.getItem(key), EDITOR_APPEARANCE_STORAGE_KEY)
+      )
+      .toBe('dark');
+
+    await page.reload();
+
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expect(page.getByRole('button', { name: '다크 모드' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  test('시스템 설정 모드는 브라우저 색상 설정을 따라간다', async ({ page }) => {
+    const state = freshState();
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    const editorScope = page.locator('.mmp-editor-design-scope');
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+
+    await page.getByRole('button', { name: '라이트 모드' }).click();
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+
+    await page.getByRole('button', { name: '시스템 설정 사용' }).click();
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+  });
+});

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -1,20 +1,24 @@
-import { Suspense, useEffect, useState, useMemo } from "react";
-import { useNavigate } from "react-router";
-import { ArrowLeft, ChevronRight } from "lucide-react";
-import { Spinner } from "@/shared/components/ui";
-import type { EditorThemeResponse } from "@/features/editor/api";
-import { useEditorUI } from "@/features/editor/stores/editorUIStore";
-import { SaveIndicator } from "./SaveIndicator";
-import { EditorTabNav } from "./EditorTabNav";
-import { TabContent } from "./TabContent";
-import { ValidationPanel } from "./ValidationPanel";
-import { STATUS_LABEL } from "@/features/editor/constants";
-import type { EditorTab } from "@/features/editor/constants";
-import type { DesignWarning } from "@/features/editor/validation";
-import type { SaveStatus } from "@/features/editor/hooks/useAutoSave";
-import { readEnabledModuleIds } from "@/features/editor/utils/configShape";
-import { readEditorTabFromRouteSegment } from "@/features/editor/routeSegments";
-import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
+import { Suspense, useEffect, useState, useMemo } from 'react';
+import { useNavigate } from 'react-router';
+import { ArrowLeft, ChevronRight, Monitor, Moon, Sun } from 'lucide-react';
+import { Spinner } from '@/shared/components/ui';
+import type { EditorThemeResponse } from '@/features/editor/api';
+import type {
+  EditorAppearancePreference,
+  EditorResolvedAppearance,
+} from '@/features/editor/design-system/useEditorAppearance';
+import { useEditorUI } from '@/features/editor/stores/editorUIStore';
+import { SaveIndicator } from './SaveIndicator';
+import { EditorTabNav } from './EditorTabNav';
+import { TabContent } from './TabContent';
+import { ValidationPanel } from './ValidationPanel';
+import { STATUS_LABEL } from '@/features/editor/constants';
+import type { EditorTab } from '@/features/editor/constants';
+import type { DesignWarning } from '@/features/editor/validation';
+import type { SaveStatus } from '@/features/editor/hooks/useAutoSave';
+import { readEnabledModuleIds } from '@/features/editor/utils/configShape';
+import { readEditorTabFromRouteSegment } from '@/features/editor/routeSegments';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 // ---------------------------------------------------------------------------
 // EditorLayout
@@ -31,12 +35,15 @@ interface EditorLayoutProps {
   onValidate?: () => DesignWarning[];
   validationWarnings?: DesignWarning[];
   routeSegment?: string;
+  appearancePreference?: EditorAppearancePreference;
+  resolvedAppearance?: EditorResolvedAppearance;
+  onAppearancePreferenceChange?: (preference: EditorAppearancePreference) => void;
 }
 
 export function EditorLayout({
   theme,
   themeId,
-  saveStatus = "idle",
+  saveStatus = 'idle',
   lastSaved,
   onSave,
   onRetry,
@@ -44,19 +51,19 @@ export function EditorLayout({
   onValidate,
   validationWarnings: externalWarnings,
   routeSegment,
+  appearancePreference = 'system',
+  resolvedAppearance = 'light',
+  onAppearancePreferenceChange,
 }: EditorLayoutProps) {
   const navigate = useNavigate();
   const { activeTab } = useEditorUI();
   const [validationResult, setValidationResult] = useState<DesignWarning[] | null>(null);
   const [dismissed, setDismissed] = useState(false);
 
-  const activeModules = useMemo(
-    () => readEnabledModuleIds(theme.config_json),
-    [theme.config_json],
-  );
+  const activeModules = useMemo(() => readEnabledModuleIds(theme.config_json), [theme.config_json]);
   const routeTab = useMemo(
     () => (routeSegment ? readEditorTabFromRouteSegment(routeSegment) : undefined),
-    [routeSegment],
+    [routeSegment]
   );
   const effectiveTab = routeTab ?? activeTab;
   const usesInternalScroll = INTERNAL_SCROLL_TABS.has(effectiveTab);
@@ -72,22 +79,26 @@ export function EditorLayout({
   // Save on Ctrl+S / Cmd+S
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
         onSave?.();
       }
     };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
   }, [onSave]);
 
   return (
-    <div className={`fixed inset-0 flex flex-col overflow-hidden ${editorDesignClassNames.surface}`}>
+    <div
+      className={`fixed inset-0 flex flex-col overflow-hidden ${editorDesignClassNames.surface}`}
+    >
       {/* ── Top bar ── */}
-      <header className={`sticky top-0 z-50 flex h-12 shrink-0 items-center gap-2 px-2 shadow-sm sm:gap-3 sm:px-3 ${editorDesignClassNames.topBar}`}>
+      <header
+        className={`sticky top-0 z-50 flex h-12 shrink-0 items-center gap-2 px-2 shadow-sm sm:gap-3 sm:px-3 ${editorDesignClassNames.topBar}`}
+      >
         <button
           type="button"
-          onClick={() => navigate("/editor")}
+          onClick={() => navigate('/editor')}
           className="rounded-md p-1.5 text-[var(--mmp-editor-color-slate)] transition-colors hover:bg-[var(--mmp-editor-color-surface)] hover:text-[var(--mmp-editor-color-charcoal)]"
           aria-label="에디터 목록으로 돌아가기"
         >
@@ -97,22 +108,52 @@ export function EditorLayout({
         <div className="h-5 w-px bg-[var(--mmp-editor-color-hairline)]" />
 
         <div className="flex min-w-0 flex-1 items-center gap-1.5 sm:gap-2">
-          <span className="hidden shrink-0 text-xs text-[var(--mmp-editor-color-steel)] sm:inline">에디터</span>
+          <span className="hidden shrink-0 text-xs text-[var(--mmp-editor-color-steel)] sm:inline">
+            에디터
+          </span>
           <ChevronRight className="hidden h-3.5 w-3.5 shrink-0 text-[var(--mmp-editor-color-muted)] sm:block" />
           <span className="truncate text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">
             {theme.title}
           </span>
-          <span className={`hidden shrink-0 px-1.5 py-0.5 text-[10px] sm:inline ${editorDesignClassNames.tag}`}>
+          <span
+            className={`hidden shrink-0 px-1.5 py-0.5 text-[10px] sm:inline ${editorDesignClassNames.tag}`}
+          >
             {STATUS_LABEL[theme.status] ?? theme.status}
           </span>
         </div>
 
         <div className="hidden sm:block">
-          <SaveIndicator
-            status={saveStatus}
-            lastSaved={lastSaved}
-            onRetry={onRetry}
-          />
+          <SaveIndicator status={saveStatus} lastSaved={lastSaved} onRetry={onRetry} />
+        </div>
+
+        <div className="hidden h-5 w-px bg-[var(--mmp-editor-color-hairline)] sm:block" />
+
+        <div
+          role="group"
+          aria-label="에디터 화면 모드"
+          data-editor-resolved-theme={resolvedAppearance}
+          className="flex items-center gap-0.5 rounded-lg border border-[var(--mmp-editor-color-hairline)] bg-[var(--mmp-editor-color-surface-soft)] p-0.5"
+        >
+          {APPEARANCE_OPTIONS.map(({ value, label, Icon }) => {
+            const isActive = appearancePreference === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                aria-label={label}
+                aria-pressed={isActive}
+                title={label}
+                onClick={() => onAppearancePreferenceChange?.(value)}
+                className={`inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+                  isActive
+                    ? 'bg-[var(--mmp-editor-color-canvas)] text-[var(--mmp-editor-color-primary)] shadow-sm'
+                    : 'text-[var(--mmp-editor-color-slate)] hover:bg-[var(--mmp-editor-color-surface)] hover:text-[var(--mmp-editor-color-charcoal)]'
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            );
+          })}
         </div>
 
         <div className="hidden h-5 w-px bg-[var(--mmp-editor-color-hairline)] sm:block" />
@@ -127,7 +168,7 @@ export function EditorLayout({
         <button
           type="button"
           onClick={onPublish}
-          disabled={theme.status === "PUBLISHED"}
+          disabled={theme.status === 'PUBLISHED'}
           className={`h-8 px-2 text-xs transition-colors hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:px-3 ${editorDesignClassNames.primaryAction}`}
         >
           출판
@@ -135,18 +176,17 @@ export function EditorLayout({
       </header>
 
       {/* ── Tab nav ── */}
-      <EditorTabNav
-        themeId={themeId}
-        activeModules={activeModules}
-        forcedVisibleTab={routeTab}
-      />
+      <EditorTabNav themeId={themeId} activeModules={activeModules} forcedVisibleTab={routeTab} />
 
       {/* ── Validation panel ── */}
       {!dismissed && (validationResult ?? externalWarnings) && (
         <div className="shrink-0 border-b border-[var(--mmp-editor-color-hairline)] px-3 py-2">
           <ValidationPanel
             warnings={validationResult ?? externalWarnings ?? []}
-            onClose={() => { setValidationResult(null); setDismissed(true); }}
+            onClose={() => {
+              setValidationResult(null);
+              setDismissed(true);
+            }}
           />
         </div>
       )}
@@ -156,7 +196,7 @@ export function EditorLayout({
         role="tabpanel"
         id={`tabpanel-${effectiveTab}`}
         aria-labelledby={`tab-${effectiveTab}`}
-        className={usesInternalScroll ? "min-h-0 flex-1 overflow-hidden" : "flex-1 overflow-y-auto"}
+        className={usesInternalScroll ? 'min-h-0 flex-1 overflow-hidden' : 'flex-1 overflow-y-auto'}
       >
         <Suspense
           fallback={
@@ -178,13 +218,23 @@ export function EditorLayout({
 }
 
 const INTERNAL_SCROLL_TABS = new Set<EditorTab>([
-  "storyMap",
-  "info",
-  "characters",
-  "clues",
-  "design",
-  "questions",
-  "endings",
-  "locations",
-  "media",
+  'storyMap',
+  'info',
+  'characters',
+  'clues',
+  'design',
+  'questions',
+  'endings',
+  'locations',
+  'media',
 ]);
+
+const APPEARANCE_OPTIONS: Array<{
+  value: EditorAppearancePreference;
+  label: string;
+  Icon: typeof Monitor;
+}> = [
+  { value: 'system', label: '시스템 설정 사용', Icon: Monitor },
+  { value: 'light', label: '라이트 모드', Icon: Sun },
+  { value: 'dark', label: '다크 모드', Icon: Moon },
+];

--- a/apps/web/src/features/editor/components/ThemeEditor.tsx
+++ b/apps/web/src/features/editor/components/ThemeEditor.tsx
@@ -1,11 +1,15 @@
-import { useCallback } from "react";
-import { Spinner } from "@/shared/components/ui";
-import { useEditorTheme } from "@/features/editor/api";
-import { useEditorClues } from "@/features/editor/editorClueApi";
-import { validateGameDesign, validateClueGraph } from "@/features/editor/validation";
-import { useClueEdges } from "@/features/editor/clueEdgeApi";
-import { isApiHttpError } from "@/lib/api-error";
-import { EditorLayout } from "./EditorLayout";
+import { useCallback } from 'react';
+import { Spinner } from '@/shared/components/ui';
+import { useEditorTheme } from '@/features/editor/api';
+import { useEditorClues } from '@/features/editor/editorClueApi';
+import { validateGameDesign, validateClueGraph } from '@/features/editor/validation';
+import { useClueEdges } from '@/features/editor/clueEdgeApi';
+import type {
+  EditorAppearancePreference,
+  EditorResolvedAppearance,
+} from '@/features/editor/design-system/useEditorAppearance';
+import { isApiHttpError } from '@/lib/api-error';
+import { EditorLayout } from './EditorLayout';
 
 // ---------------------------------------------------------------------------
 // FullPage helpers
@@ -30,40 +34,41 @@ function FullPageError({ message, detail }: { message: string; detail?: string }
   );
 }
 
-const uuidLikeRe =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uuidLikeRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function buildThemeLoadError(themeId: string, error?: unknown) {
   if (isApiHttpError(error)) {
     if (error.status === 400) {
       return {
-        message: "테마 주소 형식이 올바르지 않습니다",
-        detail: "주소에는 테마 UUID 또는 영문 소문자, 숫자, 하이픈으로 된 slug만 사용할 수 있습니다.",
+        message: '테마 주소 형식이 올바르지 않습니다',
+        detail:
+          '주소에는 테마 UUID 또는 영문 소문자, 숫자, 하이픈으로 된 slug만 사용할 수 있습니다.',
       };
     }
     if (error.status === 403) {
       return {
-        message: "테마 편집 권한이 없습니다",
-        detail: "현재 로그인한 계정으로는 이 테마를 편집할 수 없습니다. 다른 계정으로 로그인했는지 확인하세요.",
+        message: '테마 편집 권한이 없습니다',
+        detail:
+          '현재 로그인한 계정으로는 이 테마를 편집할 수 없습니다. 다른 계정으로 로그인했는지 확인하세요.',
       };
     }
     if (error.status === 404) {
       return {
-        message: "테마를 찾을 수 없습니다",
-        detail: "삭제됐거나 현재 계정에서 접근할 수 없는 테마일 수 있습니다.",
+        message: '테마를 찾을 수 없습니다',
+        detail: '삭제됐거나 현재 계정에서 접근할 수 없는 테마일 수 있습니다.',
       };
     }
   }
   if (uuidLikeRe.test(themeId)) {
     return {
-      message: "테마를 찾을 수 없습니다",
-      detail: "삭제됐거나 현재 계정에 편집 권한이 없는 테마일 수 있습니다.",
+      message: '테마를 찾을 수 없습니다',
+      detail: '삭제됐거나 현재 계정에 편집 권한이 없는 테마일 수 있습니다.',
     };
   }
   return {
-    message: "샘플 또는 slug 테마를 찾을 수 없습니다",
+    message: '샘플 또는 slug 테마를 찾을 수 없습니다',
     detail:
-      "이 주소는 UUID가 아닌 slug로 열린 주소입니다. 로컬 샘플이라면 e2e-test-theme seed가 적용됐는지 확인하세요.",
+      '이 주소는 UUID가 아닌 slug로 열린 주소입니다. 로컬 샘플이라면 e2e-test-theme seed가 적용됐는지 확인하세요.',
   };
 }
 
@@ -74,11 +79,20 @@ function buildThemeLoadError(themeId: string, error?: unknown) {
 interface ThemeEditorProps {
   themeId: string;
   routeSegment?: string;
+  appearancePreference?: EditorAppearancePreference;
+  resolvedAppearance?: EditorResolvedAppearance;
+  onAppearancePreferenceChange?: (preference: EditorAppearancePreference) => void;
 }
 
-export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
+export function ThemeEditor({
+  themeId,
+  routeSegment,
+  appearancePreference = 'system',
+  resolvedAppearance = 'light',
+  onAppearancePreferenceChange,
+}: ThemeEditorProps) {
   const { data: theme, error, isLoading, isError } = useEditorTheme(themeId);
-  const resolvedThemeId = theme?.id ?? "";
+  const resolvedThemeId = theme?.id ?? '';
   const { data: clues } = useEditorClues(resolvedThemeId);
   const { data: clueEdgeGroups } = useClueEdges(resolvedThemeId);
 
@@ -97,11 +111,11 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
         sourceId: src,
         targetId: g.targetId,
         mode: g.mode,
-      })),
+      }))
     );
     const graphWarnings = validateClueGraph(
       flatRelations,
-      (clues ?? []).map((c) => ({ id: c.id, name: c.name })),
+      (clues ?? []).map((c) => ({ id: c.id, name: c.name }))
     );
     return [...gameWarnings, ...graphWarnings];
   }, [theme, clues, clueEdgeGroups]);
@@ -118,6 +132,9 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
       themeId={resolvedThemeId}
       routeSegment={routeSegment}
       onValidate={handleValidate}
+      appearancePreference={appearancePreference}
+      resolvedAppearance={resolvedAppearance}
+      onAppearancePreferenceChange={onAppearancePreferenceChange}
     />
   );
 }

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -1,7 +1,8 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { EditorThemeResponse } from '@/features/editor/api';
 import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
+import type { EditorAppearancePreference } from '@/features/editor/design-system/useEditorAppearance';
 
 const { mockNavigate, mockSetActiveTab, mockActiveTab } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
@@ -50,9 +51,33 @@ const baseTheme: EditorThemeResponse = {
   reviewed_by: null,
 };
 
+function createStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+  };
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: createStorage(),
+    configurable: true,
+  });
+});
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  window.localStorage.clear();
   mockActiveTab.current = 'storyMap';
 });
 
@@ -68,17 +93,25 @@ describe('EditorLayout', () => {
         saveStatus="dirty"
         onValidate={onValidate}
         onPublish={onPublish}
-      />,
+      />
     );
 
     expect(screen.getByText('좁은 모바일 화면용 테스트 테마')).toBeDefined();
     expect(screen.getByText('초안')).toBeDefined();
     expect(screen.getByText('변경사항 있음')).toBeDefined();
     expect(screen.getByText('초안').className).toContain(editorDesignClassNames.tag);
-    expect((screen.getByRole('button', { name: '검증' }) as HTMLButtonElement).disabled).toBe(false);
-    expect((screen.getByRole('button', { name: '출판' }) as HTMLButtonElement).disabled).toBe(false);
-    expect(screen.getByRole('button', { name: '검증' }).className).toContain(editorDesignClassNames.secondaryAction);
-    expect(screen.getByRole('button', { name: '출판' }).className).toContain(editorDesignClassNames.primaryAction);
+    expect((screen.getByRole('button', { name: '검증' }) as HTMLButtonElement).disabled).toBe(
+      false
+    );
+    expect((screen.getByRole('button', { name: '출판' }) as HTMLButtonElement).disabled).toBe(
+      false
+    );
+    expect(screen.getByRole('button', { name: '검증' }).className).toContain(
+      editorDesignClassNames.secondaryAction
+    );
+    expect(screen.getByRole('button', { name: '출판' }).className).toContain(
+      editorDesignClassNames.primaryAction
+    );
 
     fireEvent.click(screen.getByRole('button', { name: '검증' }));
     fireEvent.click(screen.getByRole('button', { name: '출판' }));
@@ -87,13 +120,56 @@ describe('EditorLayout', () => {
     expect(onPublish).toHaveBeenCalledTimes(1);
   });
 
-  it('뒤로가기와 출판 완료 테마의 비활성 상태를 유지한다', () => {
+  it.each([
+    ['시스템 설정 사용', 'system'],
+    ['라이트 모드', 'light'],
+    ['다크 모드', 'dark'],
+  ] as const)(
+    '에디터 상세 화면 모드에서 %s 버튼을 누르면 preference 변경을 요청한다',
+    (label, mode) => {
+      const onAppearancePreferenceChange = vi.fn();
+      render(
+        <EditorLayout
+          theme={baseTheme}
+          themeId="theme-1"
+          appearancePreference="system"
+          onAppearancePreferenceChange={onAppearancePreferenceChange}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: label }));
+
+      expect(onAppearancePreferenceChange).toHaveBeenCalledWith(
+        mode satisfies EditorAppearancePreference
+      );
+    }
+  );
+
+  it('에디터 상세 화면 모드 버튼은 현재 선택값과 실제 적용 테마를 표시한다', () => {
     render(
       <EditorLayout
-        theme={{ ...baseTheme, status: 'PUBLISHED' }}
+        theme={baseTheme}
         themeId="theme-1"
-      />,
+        appearancePreference="dark"
+        resolvedAppearance="dark"
+      />
     );
+
+    expect(
+      screen
+        .getByRole('group', { name: '에디터 화면 모드' })
+        .getAttribute('data-editor-resolved-theme')
+    ).toBe('dark');
+    expect(screen.getByRole('button', { name: '다크 모드' }).getAttribute('aria-pressed')).toBe(
+      'true'
+    );
+    expect(screen.getByRole('button', { name: '라이트 모드' }).getAttribute('aria-pressed')).toBe(
+      'false'
+    );
+  });
+
+  it('뒤로가기와 출판 완료 테마의 비활성 상태를 유지한다', () => {
+    render(<EditorLayout theme={{ ...baseTheme, status: 'PUBLISHED' }} themeId="theme-1" />);
 
     fireEvent.click(screen.getByLabelText('에디터 목록으로 돌아가기'));
 
@@ -105,23 +181,13 @@ describe('EditorLayout', () => {
   it('저장 상태별 표시와 재시도 액션을 헤더 안에서 유지한다', () => {
     const onRetry = vi.fn();
     const { rerender } = render(
-      <EditorLayout
-        theme={baseTheme}
-        themeId="theme-1"
-        saveStatus="saving"
-        onRetry={onRetry}
-      />,
+      <EditorLayout theme={baseTheme} themeId="theme-1" saveStatus="saving" onRetry={onRetry} />
     );
 
     expect(screen.getByText('저장 중...')).toBeDefined();
 
     rerender(
-      <EditorLayout
-        theme={baseTheme}
-        themeId="theme-1"
-        saveStatus="error"
-        onRetry={onRetry}
-      />,
+      <EditorLayout theme={baseTheme} themeId="theme-1" saveStatus="error" onRetry={onRetry} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: /저장 실패/ }));
@@ -138,13 +204,7 @@ describe('EditorLayout', () => {
       { type: 'warning' as const, category: 'modules', message: '모듈 설정을 확인하세요' },
     ]);
 
-    render(
-      <EditorLayout
-        theme={baseTheme}
-        themeId="theme-1"
-        onValidate={onValidate}
-      />,
-    );
+    render(<EditorLayout theme={baseTheme} themeId="theme-1" onValidate={onValidate} />);
 
     fireEvent.click(screen.getByRole('button', { name: '검증' }));
 
@@ -158,13 +218,7 @@ describe('EditorLayout', () => {
   it('Ctrl+S와 Cmd+S 저장 단축키만 저장 액션을 실행한다', () => {
     const onSave = vi.fn();
 
-    render(
-      <EditorLayout
-        theme={baseTheme}
-        themeId="theme-1"
-        onSave={onSave}
-      />,
-    );
+    render(<EditorLayout theme={baseTheme} themeId="theme-1" onSave={onSave} />);
 
     fireEvent.keyDown(window, { key: 'a', ctrlKey: true });
     fireEvent.keyDown(window, { key: 's', ctrlKey: true });

--- a/apps/web/src/features/editor/design-system/editorNotionTheme.css
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.css
@@ -27,6 +27,8 @@
   --mmp-editor-color-tint-lavender: #e6e0f5;
   --mmp-editor-color-tint-sky: #dcecfa;
   --mmp-editor-color-tint-yellow: #fef7d6;
+  --mmp-editor-color-tag-bg: var(--mmp-editor-color-tint-lavender);
+  --mmp-editor-color-tag-text: #391c57;
   --mmp-editor-radius-xs: 4px;
   --mmp-editor-radius-sm: 6px;
   --mmp-editor-radius-md: 8px;
@@ -42,8 +44,47 @@
   --mmp-editor-shadow-card: rgba(15, 15, 15, 0.08) 0 4px 12px 0;
   --mmp-editor-shadow-modal: rgba(15, 15, 15, 0.16) 0 16px 48px -8px;
   font-family:
-    "Notion Sans", var(--font-sans, "Inter", ui-sans-serif, system-ui, -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif);
+    'Notion Sans',
+    var(
+      --font-sans,
+      'Inter',
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      sans-serif
+    );
+}
+
+.mmp-editor-design-scope[data-editor-theme='dark'] {
+  --mmp-editor-color-primary: #a99cff;
+  --mmp-editor-color-primary-pressed: #c5bdff;
+  --mmp-editor-color-on-primary: #171421;
+  --mmp-editor-color-canvas: #191919;
+  --mmp-editor-color-surface: #242424;
+  --mmp-editor-color-surface-soft: #202020;
+  --mmp-editor-color-hairline: #3a3a38;
+  --mmp-editor-color-hairline-strong: #4a4a46;
+  --mmp-editor-color-ink: #f4f4f2;
+  --mmp-editor-color-charcoal: #e5e4df;
+  --mmp-editor-color-slate: #c9c6bd;
+  --mmp-editor-color-steel: #aaa79f;
+  --mmp-editor-color-muted: #8f8b82;
+  --mmp-editor-color-success: #44c767;
+  --mmp-editor-color-warning: #ffb86b;
+  --mmp-editor-color-error: #ff6b6b;
+  --mmp-editor-color-tint-peach: #4a3126;
+  --mmp-editor-color-tint-rose: #4a2638;
+  --mmp-editor-color-tint-mint: #243f31;
+  --mmp-editor-color-tint-lavender: #30294a;
+  --mmp-editor-color-tint-sky: #24384a;
+  --mmp-editor-color-tint-yellow: #473d23;
+  --mmp-editor-color-tag-bg: #30294a;
+  --mmp-editor-color-tag-text: #ded6ff;
+  --mmp-editor-shadow-card: rgba(0, 0, 0, 0.3) 0 8px 24px 0;
+  --mmp-editor-shadow-modal: rgba(0, 0, 0, 0.44) 0 20px 56px -10px;
+  color-scheme: dark;
 }
 
 .mmp-editor-design-scope .mmp-editor-surface {
@@ -61,7 +102,11 @@
 
 .mmp-editor-design-scope .mmp-editor-top-bar {
   border-bottom: 1px solid var(--mmp-editor-color-hairline);
-  background: color-mix(in srgb, var(--mmp-editor-color-canvas) 94%, var(--mmp-editor-color-surface));
+  background: color-mix(
+    in srgb,
+    var(--mmp-editor-color-canvas) 94%,
+    var(--mmp-editor-color-surface)
+  );
   color: var(--mmp-editor-color-charcoal);
 }
 
@@ -101,8 +146,16 @@
 }
 
 .mmp-editor-design-scope .mmp-editor-list-item-active {
-  border-color: color-mix(in srgb, var(--mmp-editor-color-primary) 58%, var(--mmp-editor-color-hairline));
-  background: color-mix(in srgb, var(--mmp-editor-color-primary) 9%, var(--mmp-editor-color-canvas));
+  border-color: color-mix(
+    in srgb,
+    var(--mmp-editor-color-primary) 58%,
+    var(--mmp-editor-color-hairline)
+  );
+  background: color-mix(
+    in srgb,
+    var(--mmp-editor-color-primary) 9%,
+    var(--mmp-editor-color-canvas)
+  );
 }
 
 .mmp-editor-design-scope .mmp-editor-subtle-panel {
@@ -113,7 +166,8 @@
 }
 
 .mmp-editor-design-scope .mmp-editor-error-panel {
-  border: 1px solid color-mix(in srgb, var(--mmp-editor-color-error) 45%, var(--mmp-editor-color-hairline));
+  border: 1px solid
+    color-mix(in srgb, var(--mmp-editor-color-error) 45%, var(--mmp-editor-color-hairline));
   border-radius: var(--mmp-editor-radius-md);
   background: color-mix(in srgb, var(--mmp-editor-color-error) 7%, var(--mmp-editor-color-canvas));
   color: var(--mmp-editor-color-error);
@@ -138,7 +192,8 @@
 }
 
 .mmp-editor-design-scope .mmp-editor-danger-action {
-  border: 1px solid color-mix(in srgb, var(--mmp-editor-color-error) 42%, var(--mmp-editor-color-hairline));
+  border: 1px solid
+    color-mix(in srgb, var(--mmp-editor-color-error) 42%, var(--mmp-editor-color-hairline));
   border-radius: var(--mmp-editor-radius-md);
   background: color-mix(in srgb, var(--mmp-editor-color-error) 7%, var(--mmp-editor-color-canvas));
   color: var(--mmp-editor-color-error);
@@ -200,8 +255,8 @@
 
 .mmp-editor-design-scope .mmp-editor-tag {
   border-radius: var(--mmp-editor-radius-sm);
-  background: var(--mmp-editor-color-tint-lavender);
-  color: #391c57;
+  background: var(--mmp-editor-color-tag-bg);
+  color: var(--mmp-editor-color-tag-text);
   font-size: 13px;
   font-weight: 600;
   line-height: 1.4;
@@ -220,7 +275,11 @@
   --baseBgHover: var(--mmp-editor-color-surface);
   --baseBgSubtle: var(--mmp-editor-color-surface-soft);
   --accentBase: var(--mmp-editor-color-primary);
-  --accentBgSubtle: color-mix(in srgb, var(--mmp-editor-color-primary) 10%, var(--mmp-editor-color-canvas));
+  --accentBgSubtle: color-mix(
+    in srgb,
+    var(--mmp-editor-color-primary) 10%,
+    var(--mmp-editor-color-canvas)
+  );
   --accentText: var(--mmp-editor-color-primary);
   --accentTextContrast: var(--mmp-editor-color-primary-pressed);
   --baseBorder: var(--mmp-editor-color-hairline);
@@ -365,7 +424,11 @@
 }
 
 .mmp-editor-design-scope .bg-amber-500\/10 {
-  background-color: color-mix(in srgb, var(--mmp-editor-color-primary) 9%, var(--mmp-editor-color-canvas));
+  background-color: color-mix(
+    in srgb,
+    var(--mmp-editor-color-primary) 9%,
+    var(--mmp-editor-color-canvas)
+  );
 }
 
 .mmp-editor-design-scope .bg-amber-500\/5,
@@ -373,7 +436,11 @@
 .mmp-editor-design-scope .bg-amber-500\/20,
 .mmp-editor-design-scope .bg-amber-500\/25,
 .mmp-editor-design-scope .bg-amber-950\/30 {
-  background-color: color-mix(in srgb, var(--mmp-editor-color-primary) 12%, var(--mmp-editor-color-canvas));
+  background-color: color-mix(
+    in srgb,
+    var(--mmp-editor-color-primary) 12%,
+    var(--mmp-editor-color-canvas)
+  );
 }
 
 .mmp-editor-design-scope .text-amber-100,

--- a/apps/web/src/features/editor/design-system/editorNotionTheme.test.ts
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.test.ts
@@ -23,4 +23,13 @@ describe('editorNotionTheme legacy bridge', () => {
     expect(css).toContain('var(--mmp-editor-color-primary)');
     expect(css).toContain('var(--mmp-editor-color-on-primary)');
   });
+
+  it('keeps light and dark mode tokens inside the editor boundary', () => {
+    const css = readFileSync(cssPath, 'utf8');
+
+    expect(css).toContain(".mmp-editor-design-scope[data-editor-theme='dark']");
+    expect(css).toContain('--mmp-editor-color-tag-bg');
+    expect(css).toContain('color-scheme: dark');
+    expect(css).not.toMatch(/(^|\n)\[data-editor-theme='dark'\][,\s{]/);
+  });
 });

--- a/apps/web/src/features/editor/design-system/useEditorAppearance.test.ts
+++ b/apps/web/src/features/editor/design-system/useEditorAppearance.test.ts
@@ -1,0 +1,124 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  EDITOR_APPEARANCE_STORAGE_KEY,
+  type EditorAppearancePreference,
+  readStoredEditorAppearance,
+  resolveEditorAppearancePreference,
+  useEditorAppearance,
+  writeStoredEditorAppearance,
+} from './useEditorAppearance';
+
+type MediaListener = (event: { matches: boolean }) => void;
+
+let mediaMatches = false;
+let mediaListeners: MediaListener[] = [];
+let storageItems: Record<string, string> = {};
+
+beforeEach(() => {
+  mediaMatches = false;
+  mediaListeners = [];
+  storageItems = {};
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: vi.fn((key: string) => storageItems[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        storageItems[key] = value;
+      }),
+      clear: vi.fn(() => {
+        storageItems = {};
+      }),
+    },
+  });
+  window.localStorage.clear();
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((media: string) => ({
+      matches: mediaMatches,
+      media,
+      onchange: null,
+      addEventListener: vi.fn((_event: 'change', listener: MediaListener) => {
+        mediaListeners.push(listener);
+      }),
+      removeEventListener: vi.fn((_event: 'change', listener: MediaListener) => {
+        mediaListeners = mediaListeners.filter((candidate) => candidate !== listener);
+      }),
+      addListener: vi.fn((listener: MediaListener) => {
+        mediaListeners.push(listener);
+      }),
+      removeListener: vi.fn((listener: MediaListener) => {
+        mediaListeners = mediaListeners.filter((candidate) => candidate !== listener);
+      }),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useEditorAppearance', () => {
+  it('저장값이 없으면 시스템 설정을 기본값으로 사용한다', () => {
+    const { result } = renderHook(() => useEditorAppearance());
+
+    expect(result.current.preference).toBe('system');
+    expect(result.current.resolvedTheme).toBe('light');
+  });
+
+  it('잘못 저장된 값은 무시한다', () => {
+    window.localStorage.setItem(EDITOR_APPEARANCE_STORAGE_KEY, 'sepia');
+
+    expect(readStoredEditorAppearance()).toBe('system');
+  });
+
+  it.each(['system', 'light', 'dark'] as const)(
+    '사용자가 %s appearance 값을 선택하면 저장하고 즉시 반영한다',
+    (mode: EditorAppearancePreference) => {
+      const { result } = renderHook(() => useEditorAppearance());
+
+      act(() => result.current.setPreference(mode));
+
+      expect(result.current.preference).toBe(mode);
+      expect(result.current.resolvedTheme).toBe(mode === 'dark' ? 'dark' : 'light');
+      expect(window.localStorage.getItem(EDITOR_APPEARANCE_STORAGE_KEY)).toBe(mode);
+    }
+  );
+
+  it('시스템 모드는 운영체제 색상 변경을 따라간다', () => {
+    const { result } = renderHook(() => useEditorAppearance());
+
+    act(() => {
+      mediaMatches = true;
+      mediaListeners.forEach((listener) => listener({ matches: true }));
+    });
+
+    expect(result.current.preference).toBe('system');
+    expect(result.current.resolvedTheme).toBe('dark');
+  });
+});
+
+describe('editor appearance helpers', () => {
+  it('preference와 시스템 dark 여부로 실제 테마를 해석한다', () => {
+    expect(resolveEditorAppearancePreference('system', false)).toBe('light');
+    expect(resolveEditorAppearancePreference('system', true)).toBe('dark');
+    expect(resolveEditorAppearancePreference('light', true)).toBe('light');
+    expect(resolveEditorAppearancePreference('dark', false)).toBe('dark');
+  });
+
+  it('storage 접근이 실패해도 기본값으로 동작한다', () => {
+    const blockedStorage = {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('blocked');
+      },
+    };
+
+    expect(readStoredEditorAppearance(blockedStorage)).toBe('system');
+    expect(() => writeStoredEditorAppearance('dark', blockedStorage)).not.toThrow();
+  });
+});

--- a/apps/web/src/features/editor/design-system/useEditorAppearance.ts
+++ b/apps/web/src/features/editor/design-system/useEditorAppearance.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export const EDITOR_APPEARANCE_STORAGE_KEY = 'mmp.editor.appearance';
+
+export type EditorAppearancePreference = 'system' | 'light' | 'dark';
+export type EditorResolvedAppearance = 'light' | 'dark';
+
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+export function isEditorAppearancePreference(value: unknown): value is EditorAppearancePreference {
+  return value === 'system' || value === 'light' || value === 'dark';
+}
+
+export function resolveEditorAppearancePreference(
+  preference: EditorAppearancePreference,
+  prefersDark: boolean
+): EditorResolvedAppearance {
+  if (preference === 'system') {
+    return prefersDark ? 'dark' : 'light';
+  }
+  return preference;
+}
+
+export function readStoredEditorAppearance(
+  storage: Pick<Storage, 'getItem'> | null | undefined = getLocalStorage()
+): EditorAppearancePreference {
+  try {
+    const stored = storage?.getItem(EDITOR_APPEARANCE_STORAGE_KEY);
+    return isEditorAppearancePreference(stored) ? stored : 'system';
+  } catch {
+    return 'system';
+  }
+}
+
+export function writeStoredEditorAppearance(
+  preference: EditorAppearancePreference,
+  storage: Pick<Storage, 'setItem'> | null | undefined = getLocalStorage()
+): void {
+  try {
+    storage?.setItem(EDITOR_APPEARANCE_STORAGE_KEY, preference);
+  } catch {
+    /* localStorage may be unavailable in private or embedded browsers. */
+  }
+}
+
+export function useEditorAppearance() {
+  const [preference, setPreferenceState] = useState<EditorAppearancePreference>(() =>
+    readStoredEditorAppearance()
+  );
+  const [prefersDark, setPrefersDark] = useState(readSystemPrefersDark);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const query = window.matchMedia(SYSTEM_DARK_QUERY);
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      setPrefersDark(event.matches);
+    };
+
+    handleChange(query);
+
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', handleChange);
+      return () => query.removeEventListener('change', handleChange);
+    }
+
+    query.addListener(handleChange);
+    return () => query.removeListener(handleChange);
+  }, []);
+
+  const setPreference = useCallback((nextPreference: EditorAppearancePreference) => {
+    writeStoredEditorAppearance(nextPreference);
+    setPreferenceState(nextPreference);
+  }, []);
+
+  const resolvedTheme = useMemo(
+    () => resolveEditorAppearancePreference(preference, prefersDark),
+    [preference, prefersDark]
+  );
+
+  return {
+    preference,
+    resolvedTheme,
+    setPreference,
+  };
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readSystemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(SYSTEM_DARK_QUERY).matches;
+}

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -1,11 +1,12 @@
-import { useEffect } from "react";
-import { useLocation, useParams } from "react-router";
-import { EditorDashboard } from "@/features/editor/components";
-import { ThemeEditor } from "@/features/editor/components";
-import "@/features/editor/design-system/editorNotionTheme.css";
-import { EDITOR_DESIGN_SCOPE_CLASS } from "@/features/editor/design-system/editorDesignTokens";
-import { readEditorTabFromRouteSegment } from "@/features/editor/routeSegments";
-import { useEditorUI } from "@/features/editor/stores/editorUIStore";
+import { useEffect } from 'react';
+import { useLocation, useParams } from 'react-router';
+import { EditorDashboard } from '@/features/editor/components';
+import { ThemeEditor } from '@/features/editor/components';
+import '@/features/editor/design-system/editorNotionTheme.css';
+import { EDITOR_DESIGN_SCOPE_CLASS } from '@/features/editor/design-system/editorDesignTokens';
+import { useEditorAppearance } from '@/features/editor/design-system/useEditorAppearance';
+import { readEditorTabFromRouteSegment } from '@/features/editor/routeSegments';
+import { useEditorUI } from '@/features/editor/stores/editorUIStore';
 
 export default function EditorPage() {
   const { id } = useParams<{
@@ -13,7 +14,7 @@ export default function EditorPage() {
   }>();
   const location = useLocation();
   const setActiveTab = useEditorUI((state) => state.setActiveTab);
-  const routeSegment = location.pathname.split("/").filter(Boolean).slice(2).join("/") || undefined;
+  const routeSegment = location.pathname.split('/').filter(Boolean).slice(2).join('/') || undefined;
   const activeTabRouteSegment = routeSegment;
 
   useEffect(() => {
@@ -21,16 +22,34 @@ export default function EditorPage() {
   }, [setActiveTab, activeTabRouteSegment]);
 
   if (id) {
-    return (
-      <div className={EDITOR_DESIGN_SCOPE_CLASS}>
-        <ThemeEditor themeId={id} routeSegment={routeSegment} />
-      </div>
-    );
+    return <EditorDetailPageFrame themeId={id} routeSegment={routeSegment} />;
   }
 
+  return <EditorDashboard />;
+}
+
+function EditorDetailPageFrame({
+  themeId,
+  routeSegment,
+}: {
+  themeId: string;
+  routeSegment?: string;
+}) {
+  const { preference, resolvedTheme, setPreference } = useEditorAppearance();
+
   return (
-    <div className={EDITOR_DESIGN_SCOPE_CLASS}>
-      <EditorDashboard />
+    <div
+      className={EDITOR_DESIGN_SCOPE_CLASS}
+      data-editor-theme={resolvedTheme}
+      data-editor-theme-preference={preference}
+    >
+      <ThemeEditor
+        themeId={themeId}
+        routeSegment={routeSegment}
+        appearancePreference={preference}
+        resolvedAppearance={resolvedTheme}
+        onAppearancePreferenceChange={setPreference}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 const { locationPathMock, paramsMock, setActiveTabMock } = vi.hoisted(() => ({
   locationPathMock: vi.fn(() => '/editor'),
@@ -19,15 +19,27 @@ vi.mock('@/features/editor/stores/editorUIStore', () => ({
 
 vi.mock('@/features/editor/components', () => ({
   EditorDashboard: () => <div>에디터 대시보드</div>,
-  ThemeEditor: ({ themeId, routeSegment }: { themeId: string; routeSegment?: string }) => (
+  ThemeEditor: ({
+    themeId,
+    routeSegment,
+    appearancePreference,
+    resolvedAppearance,
+  }: {
+    themeId: string;
+    routeSegment?: string;
+    appearancePreference?: string;
+    resolvedAppearance?: string;
+  }) => (
     <div>
-      테마 에디터 {themeId} {routeSegment ?? 'no-segment'}
+      테마 에디터 {themeId} {routeSegment ?? 'no-segment'} {appearancePreference}{' '}
+      {resolvedAppearance}
     </div>
   ),
 }));
 
 import EditorPage from '../EditorPage';
 import { EDITOR_DESIGN_SCOPE_CLASS } from '@/features/editor/design-system/editorDesignTokens';
+import { EDITOR_APPEARANCE_STORAGE_KEY } from '@/features/editor/design-system/useEditorAppearance';
 
 const routeMatrixCases = [
   ['직접 URL /editor/:id', { id: 'theme-1' }, 'no-segment', 'storyMap'],
@@ -90,9 +102,33 @@ const routeMatrixCases = [
   ['직접 URL /editor/:id/endings', { id: 'theme-1', tab: 'endings' }, 'endings', 'endings'],
 ] as const;
 
+function createStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+  };
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: createStorage(),
+    configurable: true,
+  });
+});
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  window.localStorage.clear();
   locationPathMock.mockReturnValue('/editor');
 });
 
@@ -101,12 +137,10 @@ describe('EditorPage', () => {
     paramsMock.mockReturnValue({});
     locationPathMock.mockReturnValue('/editor');
 
-    render(<EditorPage />);
+    const { container } = render(<EditorPage />);
 
     expect(screen.getByText('에디터 대시보드')).toBeDefined();
-    expect(screen.getByText('에디터 대시보드').parentElement?.className).toContain(
-      EDITOR_DESIGN_SCOPE_CLASS
-    );
+    expect(container.querySelector(`.${EDITOR_DESIGN_SCOPE_CLASS}`)).toBeNull();
     expect(setActiveTabMock).toHaveBeenCalledWith('storyMap');
   });
 
@@ -116,11 +150,26 @@ describe('EditorPage', () => {
 
     render(<EditorPage />);
 
-    expect(screen.getByText(/테마 에디터 theme-1 characters/)).toBeDefined();
-    expect(screen.getByText(/테마 에디터 theme-1 characters/).parentElement?.className).toContain(
-      EDITOR_DESIGN_SCOPE_CLASS
-    );
+    const detail = screen.getByText(/테마 에디터 theme-1 characters system light/);
+    expect(detail).toBeDefined();
+    expect(detail.parentElement?.className).toContain(EDITOR_DESIGN_SCOPE_CLASS);
+    expect(detail.parentElement?.getAttribute('data-editor-theme')).toBe('light');
+    expect(detail.parentElement?.getAttribute('data-editor-theme-preference')).toBe('system');
     expect(setActiveTabMock).toHaveBeenCalledWith('characters');
+  });
+
+  it('에디터 상세 초기화 시 localStorage에 저장된 valid appearance mode를 복원한다', () => {
+    window.localStorage.setItem(EDITOR_APPEARANCE_STORAGE_KEY, 'dark');
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: 'characters' });
+    locationPathMock.mockReturnValue('/editor/theme-1/characters');
+
+    render(<EditorPage />);
+
+    const detail = screen.getByText(/테마 에디터 theme-1 characters dark dark/);
+    expect(detail).toBeDefined();
+    expect(detail.parentElement?.className).toContain(EDITOR_DESIGN_SCOPE_CLASS);
+    expect(detail.parentElement?.getAttribute('data-editor-theme')).toBe('dark');
+    expect(detail.parentElement?.getAttribute('data-editor-theme-preference')).toBe('dark');
   });
 
   it.each(routeMatrixCases)(


### PR DESCRIPTION
## 요약
- 에디터 상세 화면(`/editor/:id...`)에 `system / light / dark` appearance 모드를 추가했습니다.
- `/editor` 대시보드는 새 디자인 scope에서 제외해 기존 화면 스타일을 유지했습니다.
- appearance 저장/복원, 시스템 색상 감지, CSS token dark mode, 상단 아이콘 세그먼트 컨트롤을 추가했습니다.

Closes #640

## Coverage Plan
- `EditorPage.tsx`: `/editor`는 scope 없음, `/editor/:id`는 scope와 `data-editor-theme`를 갖는지 테스트
- `useEditorAppearance`: 기본값, 저장/복원, 잘못된 저장값 무시, `prefers-color-scheme` 변경 반영 테스트
- `EditorLayout`: 세그먼트 버튼 렌더링, 선택 상태, preference callback 테스트
- `editorNotionTheme.css`: dark token이 editor boundary 안에만 존재하는지 테스트
- E2E: mocked backend로 다크 모드 저장/새로고침 복원, 시스템 dark 모드 반영 확인

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/__tests__/EditorLayout.test.tsx src/pages/__tests__/EditorPage.test.tsx src/features/editor/design-system/useEditorAppearance.test.ts src/features/editor/design-system/editorNotionTheme.test.ts` — pass, 58 tests
- `pnpm --filter @mmp/web typecheck` — pass
- `pnpm --filter @mmp/web exec playwright test e2e/editor-appearance.spec.ts --project=chromium` — pass, 2 tests
- `pnpm --filter @mmp/web lint` — pass with existing warnings only
- `scripts/mmp-local-ci.sh quick` — pass

## Notes
- Backend/API/DB 변경은 없습니다.
- 계정 단위 appearance 저장과 플레이어 런타임 연동은 issue #640의 Deferred / Follow-up으로 남겼습니다.
