### PR TITLE
feat: 에디터 리치 본문 미리보기 수정 UX 통일

### DIFF
--- a/apps/web/e2e/editor-phase-ending.spec.ts
+++ b/apps/web/e2e/editor-phase-ending.spec.ts
@@ -81,26 +81,29 @@ test.describe("Phase 24 페이즈/결말 entity smoke", () => {
   test("페이즈 흐름 안내와 결말 목록을 볼 수 있다", async ({ page }) => {
     await page.goto(`${BASE}/editor/${THEME_ID}/flow`);
 
-    await expect(page.getByText("페이즈 흐름")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText(/페이즈는 게임 진행 순서를 화살표로 연결합니다/)).toBeVisible();
+    await expect(page.getByRole("heading", { name: "게임 진행 플로우" })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("region", { name: "게임 진행 플로우" })).toBeVisible();
 
-    await page.getByRole("button", { name: /결말/ }).click();
+    await page.getByRole("tab", { name: /결말 관리/ }).click();
 
     await expect(page.getByRole("heading", { name: "결말 목록" })).toBeVisible();
     await expect(page.getByLabel("결말 판정 준비")).toBeVisible();
     await expect(page.getByLabel("결말 판정 준비").getByText("본문 작성", { exact: true })).toBeVisible();
     await expect(page.getByText("진실").first()).toBeVisible();
     await expect(page.getByLabel("결말 이름")).toHaveValue("진실");
-    await expect(page.getByLabel("결말 본문")).toHaveValue("범인은 밝혀졌다.");
+    await expect(page.getByRole("region", { name: "결말 본문 보기" })).toContainText("범인은 밝혀졌다.");
+    await page.getByRole("button", { name: "결말 수정" }).click();
+    await expect(page.getByRole("region", { name: "결말 본문 작성기" })).toBeVisible();
 
     await expect(page.getByRole("heading", { name: "결말 판정 설정" })).toBeVisible();
+    await page.getByRole("tab", { name: "질문 관리" }).click();
+    await expect(page.getByRole("heading", { name: "질문 관리", level: 3 })).toBeVisible();
     await expect(page.getByLabel("질문 1 내용")).toHaveValue("범인은 누구인가?");
-    await page.getByLabel("질문 1 내용").fill("진범은 누구인가?");
 
     const configRequest = page.waitForRequest((request) =>
       request.method() === "PUT" && request.url().includes(`/v1/editor/themes/${THEME_ID}/config`),
     );
-    await page.getByRole("button", { name: "판정 설정 저장" }).click();
+    await page.getByLabel("질문 1 내용").fill("진범은 누구인가?");
     const request = await configRequest;
     expect(request.postDataJSON()).toMatchObject({
       version: 1,

--- a/apps/web/e2e/phase24-editor-character-role.spec.ts
+++ b/apps/web/e2e/phase24-editor-character-role.spec.ts
@@ -209,6 +209,8 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
     await expect(page.getByRole("region", { name: "캐릭터 목록" })).toBeVisible();
     await page.getByRole("button", { name: "탐정 A 선택" }).click();
     await page.getByRole("button", { name: /^역할지/ }).click();
+    await expect(page.getByRole("region", { name: "역할지 본문 보기" })).toBeVisible();
+    await page.getByRole("button", { name: "역할지 수정" }).click();
 
     const block = page.getByRole("group", { name: "역할지 이미지 미디어 블록" });
     await expect(block).toBeVisible();
@@ -230,7 +232,7 @@ test.describe("Phase 24 에디터 캐릭터 역할 저장", () => {
         request.method() === "PUT" &&
         request.url().includes("/v1/editor/characters/char-1/role-sheet"),
     );
-    await page.getByRole("button", { name: "역할지 저장" }).click();
+    await page.getByRole("button", { name: "미리보기" }).click();
     const roleSheetRequest = await roleSheetRequestPromise;
 
     const body = roleSheetRequest.postDataJSON();

--- a/apps/web/src/features/editor/components/content/RichContentDocumentField.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentDocumentField.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useState } from 'react';
+import { Edit3, Eye } from 'lucide-react';
+
+import type { MediaType } from '@/features/editor/mediaApi';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
+import { RichContentEditor } from './RichContentEditor';
+import { RichContentViewer } from './RichContentViewer';
+import { hasDisplayableRichContent } from './richContentDisplay';
+
+interface RichContentDocumentFieldProps {
+  themeId: string;
+  markdown: string;
+  onChange: (markdown: string) => void;
+  previewAriaLabel: string;
+  editorAriaLabel: string;
+  editButtonLabel: string;
+  previewButtonLabel?: string;
+  emptyPreviewMessage?: string;
+  imageButtonLabel?: string;
+  videoButtonLabel?: string;
+  imagePickerTitle?: string;
+  videoPickerTitle?: string;
+  onBlurCapture?: (relatedTarget: EventTarget | null) => void;
+  onRequestPreview?: () => void;
+}
+
+export function RichContentDocumentField({
+  themeId,
+  markdown,
+  onChange,
+  previewAriaLabel,
+  editorAriaLabel,
+  editButtonLabel,
+  previewButtonLabel = '미리보기',
+  emptyPreviewMessage = '아직 작성된 본문이 없습니다.',
+  imageButtonLabel,
+  videoButtonLabel,
+  imagePickerTitle,
+  videoPickerTitle,
+  onBlurCapture,
+  onRequestPreview,
+}: RichContentDocumentFieldProps) {
+  const [pickerType, setPickerType] = useState<MediaType | null>(null);
+  const [mode, setMode] = useState<'preview' | 'edit'>(() =>
+    hasDisplayableRichContent(markdown) ? 'preview' : 'edit',
+  );
+  const openedEditorRef = useRef(false);
+  const editorInteractedRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      !openedEditorRef.current &&
+      !editorInteractedRef.current &&
+      mode === 'edit' &&
+      hasDisplayableRichContent(markdown)
+    ) {
+      setMode('preview');
+    }
+  }, [markdown, mode]);
+
+  if (mode === 'preview' && hasDisplayableRichContent(markdown)) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-end">
+          <button
+            type="button"
+            onClick={() => {
+              openedEditorRef.current = true;
+              setMode('edit');
+            }}
+            className={`inline-flex items-center justify-center gap-1.5 px-3 py-2 ${editorDesignClassNames.secondaryAction}`}
+          >
+            <Edit3 className="h-4 w-4" />
+            {editButtonLabel}
+          </button>
+        </div>
+        <div role="region" aria-label={previewAriaLabel}>
+          <RichContentViewer themeId={themeId} markdown={markdown} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          data-rich-content-control="true"
+          onClick={() => {
+            onRequestPreview?.();
+            if (hasDisplayableRichContent(markdown)) {
+              openedEditorRef.current = false;
+              setMode('preview');
+            }
+          }}
+          className={`inline-flex items-center justify-center gap-1.5 px-3 py-2 ${editorDesignClassNames.secondaryAction}`}
+        >
+          <Eye className="h-4 w-4" />
+          {previewButtonLabel}
+        </button>
+      </div>
+      <div
+        onKeyDownCapture={() => {
+          editorInteractedRef.current = true;
+        }}
+        onPointerDownCapture={() => {
+          editorInteractedRef.current = true;
+        }}
+      >
+        <RichContentEditor
+          themeId={themeId}
+          markdown={markdown}
+          onChange={onChange}
+          pickerType={pickerType}
+          onOpenPicker={setPickerType}
+          onClosePicker={() => setPickerType(null)}
+          ariaLabel={editorAriaLabel}
+          imageButtonLabel={imageButtonLabel}
+          videoButtonLabel={videoButtonLabel}
+          imagePickerTitle={imagePickerTitle}
+          videoPickerTitle={videoPickerTitle}
+          onBlurCapture={onBlurCapture}
+        />
+      </div>
+      {!hasDisplayableRichContent(markdown) ? (
+        <p className="text-xs leading-5 text-[var(--mmp-editor-color-slate)]">
+          {emptyPreviewMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/editor/components/content/richContentDisplay.ts
+++ b/apps/web/src/features/editor/components/content/richContentDisplay.ts
@@ -1,0 +1,3 @@
+export function hasDisplayableRichContent(markdown: string | null | undefined) {
+  return Boolean(markdown?.trim());
+}

--- a/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { ChevronLeft, ChevronRight, FileText, FileUp, Save } from 'lucide-react';
+import { ChevronLeft, ChevronRight, FileText, FileUp } from 'lucide-react';
 import { Button } from '@/shared/components/ui/Button';
 import { Spinner } from '@/shared/components/ui/Spinner';
-import { useMediaDownloadUrl, type MediaResponse, type MediaType } from '@/features/editor/mediaApi';
+import { useMediaDownloadUrl, type MediaResponse } from '@/features/editor/mediaApi';
 import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
-import { RichContentEditor } from '@/features/editor/components/content/RichContentEditor';
+import { RichContentDocumentField } from '@/features/editor/components/content/RichContentDocumentField';
 import { ImageRoleSheetPanel } from './ImageRoleSheetPanel';
 import { useRoleSheetEditorState } from './useRoleSheetEditorState';
 
@@ -100,37 +100,21 @@ export function CharacterRoleSheetSection({
       ) : (
         <MarkdownRoleSheetEditor
           themeId={themeId}
+          documentKey={`${characterId}:${state.roleSheetQuery.data?.format ?? 'missing'}:${state.roleSheetQuery.data?.markdown?.body ?? ''}`}
           draft={state.draft}
           saveStatus={state.saveStatus}
           isMissingDocument={state.isMissingDocument}
-          isPending={state.upsertContent.isPending}
           onDraftChange={(next) => {
             state.setDraft(next);
             state.setSaveStatus('idle');
           }}
           onBlur={(relatedTarget) => {
             if (isSaveButtonTarget(relatedTarget)) {
-              state.manualSaveRef.current = true;
               return;
             }
-            if (state.manualSaveRef.current) return;
             state.saveMarkdown(state.draft);
           }}
-          onSaveMouseDown={() => {
-            state.manualSaveRef.current = true;
-          }}
-          onSaveKeyDown={() => {
-            state.manualSaveRef.current = true;
-          }}
-          onSave={() => {
-            state.saveMarkdown(state.draft);
-            window.setTimeout(() => {
-              state.manualSaveRef.current = false;
-            }, 0);
-          }}
-          onSaveBlur={() => {
-            state.manualSaveRef.current = false;
-          }}
+          onPreview={() => state.saveMarkdown(state.draft)}
         />
       )}
     </section>
@@ -155,7 +139,7 @@ function UnsupportedRoleSheetFormatNotice({ characterName }: { characterName: st
 function isSaveButtonTarget(target: EventTarget | null) {
   return (
     target instanceof HTMLElement &&
-    target.closest('[data-role-sheet-save="true"], [data-rich-content-control="true"]') !== null
+    target.closest('[data-rich-content-control="true"]') !== null
   );
 }
 
@@ -220,49 +204,43 @@ function FormatButton({
 
 function MarkdownRoleSheetEditor({
   themeId,
+  documentKey,
   draft,
   saveStatus,
   isMissingDocument,
-  isPending,
   onDraftChange,
   onBlur,
-  onSaveMouseDown,
-  onSaveKeyDown,
-  onSave,
-  onSaveBlur,
+  onPreview,
 }: {
   themeId: string;
+  documentKey: string;
   draft: string;
   saveStatus: 'idle' | 'saved' | 'failed';
   isMissingDocument: boolean;
-  isPending: boolean;
   onDraftChange: (body: string) => void;
   onBlur: (relatedTarget: EventTarget | null) => void;
-  onSaveMouseDown: () => void;
-  onSaveKeyDown: () => void;
-  onSave: () => void;
-  onSaveBlur: () => void;
+  onPreview: () => void;
 }) {
-  const [pickerType, setPickerType] = useState<MediaType | null>(null);
-
   return (
     <div className="space-y-3">
-      <RichContentEditor
+      <RichContentDocumentField
+        key={documentKey}
         themeId={themeId}
         markdown={draft}
         onChange={onDraftChange}
-        pickerType={pickerType}
-        onOpenPicker={setPickerType}
-        onClosePicker={() => setPickerType(null)}
-        ariaLabel="역할지 Markdown"
+        previewAriaLabel="역할지 본문 보기"
+        editorAriaLabel="역할지 Markdown"
+        editButtonLabel="역할지 수정"
         imageButtonLabel="역할지 이미지 삽입"
         videoButtonLabel="역할지 영상 삽입"
         imagePickerTitle="역할지 이미지 선택"
         videoPickerTitle="역할지 영상 선택"
+        emptyPreviewMessage="아직 저장된 역할지가 없습니다."
+        onRequestPreview={onPreview}
         onBlurCapture={onBlur}
       />
 
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center justify-start">
         <p
           className={`text-xs ${
             saveStatus === 'failed'
@@ -274,24 +252,12 @@ function MarkdownRoleSheetEditor({
         >
           {saveStatus === 'failed'
             ? '저장하지 못했습니다. 다시 시도해 주세요.'
-            : saveStatus === 'saved'
-              ? '저장되었습니다.'
-              : isMissingDocument
-                ? '아직 저장된 역할지가 없습니다.'
+              : saveStatus === 'saved'
+                ? '저장되었습니다.'
+                : isMissingDocument
+                  ? '아직 저장된 역할지가 없습니다.'
                 : '수정 후 포커스를 벗어나면 자동 저장됩니다.'}
         </p>
-        <Button
-          size="sm"
-          data-role-sheet-save="true"
-          onMouseDown={onSaveMouseDown}
-          onKeyDown={onSaveKeyDown}
-          onClick={onSave}
-          onBlur={onSaveBlur}
-          disabled={isPending}
-        >
-          <Save className="mr-1.5 h-3.5 w-3.5" />
-          역할지 저장
-        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
+++ b/apps/web/src/features/editor/components/design/EndingEntityDetail.tsx
@@ -1,9 +1,8 @@
-import { useId, useState, type ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 import type { Node } from "@xyflow/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEditorAutosaveToast } from "@/features/editor/hooks/useEditorAutosaveToast";
-import { RichContentEditor } from "@/features/editor/components/content/RichContentEditor";
-import type { MediaType } from "@/features/editor/mediaApi";
+import { RichContentDocumentField } from "@/features/editor/components/content/RichContentDocumentField";
 import { useUpdateFlowNode } from "../../flowApi";
 import {
   flowKeys,
@@ -28,7 +27,6 @@ export function EndingEntityDetail({
   rulesSlot,
 }: EndingEntityDetailProps) {
   const fieldIdPrefix = useId();
-  const [pickerType, setPickerType] = useState<MediaType | null>(null);
   const data = node.data as FlowNodeData;
   const updateNode = useUpdateFlowNode(themeId);
   const queryClient = useQueryClient();
@@ -101,18 +99,19 @@ export function EndingEntityDetail({
         <p className="text-sm font-medium text-[var(--mmp-editor-color-charcoal)]" id={`${fieldIdPrefix}-content-label`}>
           결말 본문
         </p>
-        <RichContentEditor
+        <RichContentDocumentField
+          key={node.id}
           themeId={themeId}
           markdown={data.endingContent ?? ""}
           onChange={(markdown) => handleChange({ endingContent: markdown })}
-          pickerType={pickerType}
-          onOpenPicker={setPickerType}
-          onClosePicker={() => setPickerType(null)}
-          ariaLabel="결말 본문 작성기"
+          previewAriaLabel="결말 본문 보기"
+          editorAriaLabel="결말 본문 작성기"
+          editButtonLabel="결말 수정"
           imageButtonLabel="결말 이미지 삽입"
           videoButtonLabel="결말 영상 삽입"
           imagePickerTitle="결말 이미지 선택"
           videoPickerTitle="결말 영상 선택"
+          onRequestPreview={debouncer.flush}
           onBlurCapture={() => debouncer.flush()}
         />
         <p className="text-xs leading-5 text-[var(--mmp-editor-color-slate)]">

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -680,10 +680,29 @@ describe('CharacterAssignPanel', () => {
     openRoleSheetSection();
 
     const roleSheet = getRoleSheetEditor();
+    fireEvent.pointerDown(roleSheet);
     fireEvent.change(roleSheet, { target: { value: '## 비밀\n범인은 아직 모른다.' } });
-    fireEvent.click(screen.getByRole('button', { name: '역할지 저장' }));
+    fireEvent.click(screen.getByRole('button', { name: '미리보기' }));
 
     expect(screen.getByText('저장되었습니다.')).toBeDefined();
+  });
+
+  it('저장된 역할지는 먼저 읽기 미리보기로 표시하고 수정 버튼으로 편집한다', () => {
+    useCharacterRoleSheetMock.mockReturnValue({ data: { format: 'markdown', markdown: { body: '기존 역할지' } }, isLoading: false });
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+    openRoleSheetSection();
+
+    expect(screen.getByRole('region', { name: '역할지 본문 보기' })).toHaveProperty(
+      'textContent',
+      expect.stringContaining('기존 역할지'),
+    );
+    expect(screen.queryByRole('region', { name: '역할지 Markdown' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: '역할지 수정' }));
+
+    expect((getRoleSheetEditor() as HTMLTextAreaElement).value).toBe('기존 역할지');
   });
 
   it('역할지 작성기는 미디어 관리 이미지를 mediaId embed로 삽입하고 편집기 안에 표시한다', () => {
@@ -691,6 +710,7 @@ describe('CharacterAssignPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
 
+    fireEvent.pointerDown(getRoleSheetEditor());
     fireEvent.click(screen.getByRole('button', { name: '역할지 이미지 삽입' }));
     expect(screen.getByText('filter:IMAGE')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: '캐릭터 이미지 선택' }));
@@ -711,6 +731,7 @@ describe('CharacterAssignPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
 
+    fireEvent.pointerDown(getRoleSheetEditor());
     fireEvent.click(screen.getByRole('button', { name: '역할지 영상 삽입' }));
     expect(screen.getByText('filter:VIDEO')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: '역할지 영상 선택' }));
@@ -742,7 +763,7 @@ describe('CharacterAssignPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
 
-    expect(screen.getByText('아직 저장된 역할지가 없습니다.')).toBeDefined();
+    expect(screen.getAllByText('아직 저장된 역할지가 없습니다.').length).toBeGreaterThanOrEqual(1);
     expect((getRoleSheetEditor() as HTMLTextAreaElement).value).toBe('');
   });
 
@@ -776,23 +797,24 @@ describe('CharacterAssignPanel', () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
-    fireEvent.click(screen.getByRole('button', { name: '역할지 저장' }));
+    fireEvent.click(screen.getByRole('button', { name: '역할지 수정' }));
+    fireEvent.click(screen.getByRole('button', { name: '미리보기' }));
 
     expect(upsertRoleSheetMutateMock).not.toHaveBeenCalled();
     expect(screen.getByText('저장되었습니다.')).toBeDefined();
   });
 
-  it('역할지 저장 버튼 클릭 시 blur 자동 저장과 중복 호출하지 않는다', async () => {
+  it('역할지 미리보기 전환 시 blur 자동 저장과 중복 호출하지 않는다', async () => {
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
     openRoleSheetSection();
 
     const roleSheet = getRoleSheetEditor();
-    const saveButton = screen.getByRole('button', { name: '역할지 저장' });
+    const previewButton = screen.getByRole('button', { name: '미리보기' });
+    fireEvent.pointerDown(roleSheet);
     fireEvent.change(roleSheet, { target: { value: '수정된 역할지' } });
-    fireEvent.mouseDown(saveButton);
-    fireEvent.blur(roleSheet);
-    fireEvent.click(saveButton);
+    fireEvent.blur(roleSheet, { relatedTarget: previewButton });
+    fireEvent.click(previewButton);
 
     expect(upsertRoleSheetMutateMock).toHaveBeenCalledTimes(1);
     await act(async () => { vi.advanceTimersByTime(1500); });

--- a/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx
@@ -400,6 +400,11 @@ describe("EndingEntitySubTab", () => {
   it("다른 결말을 선택하면 본문 작성기가 선택한 결말의 본문으로 바뀐다", () => {
     renderWithClient(<EndingEntitySubTab themeId="theme-1" theme={theme} />);
 
+    expect(screen.getByRole("region", { name: "결말 본문 보기" })).toHaveProperty(
+      "textContent",
+      expect.stringContaining("범인은 밝혀졌다."),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "결말 수정" }));
     expect((screen.getByLabelText("editable markdown") as HTMLTextAreaElement).value).toBe("범인은 밝혀졌다.");
 
     fireEvent.click(screen.getByRole("button", { name: "오판 선택" }));
@@ -426,6 +431,9 @@ describe("EndingEntitySubTab", () => {
     expect(screen.queryByLabelText("공개 범위")).toBeNull();
     expect(screen.queryByLabelText("스포일러 안내")).toBeNull();
     expect(screen.queryByLabelText("감상 공유 문구")).toBeNull();
+    expect(screen.getByRole("region", { name: "결말 본문 보기" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "결말 수정" })).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "결말 수정" }));
     expect(screen.getByRole("region", { name: "결말 본문 작성기" })).toBeDefined();
     expect(screen.getByRole("button", { name: "결말 이미지 삽입" })).toBeDefined();
     expect(screen.getByRole("button", { name: "결말 영상 삽입" })).toBeDefined();

--- a/apps/web/src/features/editor/components/design/useRoleSheetEditorState.ts
+++ b/apps/web/src/features/editor/components/design/useRoleSheetEditorState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import {
   useCharacterRoleSheet,
@@ -31,10 +31,9 @@ export function useRoleSheetEditorState({
   const [selectedFormat, setSelectedFormat] = useState<EditableRoleSheetFormat>('markdown');
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const [page, setPage] = useState(1);
-  const manualSaveRef = useRef(false);
 
   const sync = useRoleSheetSync({ roleSheet: roleSheetQuery.data, roleSheetError: roleSheetQuery.error });
-  const [draft, setDraft] = useState('');
+  const [draft, setDraft] = useState(sync.originalBody);
   const [imagePages, setImagePages] = useState<ImageRoleSheetPageDraft[]>([]);
   const [imageDraft, setImageDraft] = useState('');
   const imageUrls = useMemo(() => imagePages.flatMap((imagePage) => imagePage.kind === 'url' ? [imagePage.url] : []), [imagePages]);
@@ -99,7 +98,6 @@ export function useRoleSheetEditorState({
     imagePages,
     imageDraft,
     setImageDraft,
-    manualSaveRef,
     isMissingDocument: sync.isMissingDocument,
     isUnsupportedFormat: sync.isUnsupportedFormat,
     pdfMediaId,

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -15,6 +15,7 @@ import { InfoDeliverySettingsCard } from './InfoDeliverySettingsCard';
 import { InfoBodyPreview } from './InfoBodyPreview';
 import { InfoMarkdownEditor } from './InfoMarkdownEditor';
 import { useAutosavedDraft } from '@/features/editor/hooks/useAutosavedDraft';
+import { hasDisplayableRichContent } from '@/features/editor/components/content/richContentDisplay';
 import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 
 interface InfoTabProps {
@@ -328,7 +329,7 @@ function toEditableInfo(info: StoryInfoResponse) {
 }
 
 function hasDisplayableBody(info: StoryInfoResponse) {
-  return info.body.trim().length > 0;
+  return hasDisplayableRichContent(info.body);
 }
 
 function hasEditableChanges(current: StoryInfoResponse, baseline: StoryInfoResponse) {


### PR DESCRIPTION
Closes #642

## 요약
- 저장된 리치 본문은 먼저 미리보기로 보여주고, 필요할 때만 수정 버튼으로 에디터를 여는 `RichContentDocumentField`를 추가했습니다.
- 결말 본문과 캐릭터 역할지에 같은 preview-first UX를 적용하고, 역할지의 별도 수동 저장 버튼은 자동저장 흐름과 충돌하지 않도록 제거했습니다.
- 정보 관리의 본문 표시 여부 판정을 공용 helper로 분리해 같은 기준을 재사용하게 했습니다.

## Coverage Plan
- `RichContentDocumentField`: 저장된 markdown은 preview-first, 빈 markdown은 edit-first, 사용자가 수정 버튼을 누른 경우에는 명시적으로 편집 모드 유지.
- `EndingEntityDetail`: 결말 본문 미리보기, 수정 전환, 자동저장 debounce flush 경로.
- `CharacterRoleSheetSection`: 역할지 미리보기, 수정 전환, 미디어 삽입 후 저장, 수동 저장 버튼 제거.
- `InfoTab`: 본문 존재 판정이 공용 rich-content 기준과 동일하게 동작.
- E2E: 결말 관리와 캐릭터 역할지 실제 에디터 흐름에서 미리보기/수정/저장 경로 확인.

## Local validation
- `pnpm --filter @mmp/web test -- --run src/features/editor/components/design/__tests__/EndingEntitySubTab.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/content/__tests__/RichContentViewer.test.tsx` 통과: 4 files, 80 tests.
- `pnpm --filter @mmp/web typecheck` 통과.
- `pnpm --filter @mmp/web lint` 통과: 0 errors, 기존 warning만 남음.
- `pnpm --filter @mmp/web exec playwright test e2e/editor-phase-ending.spec.ts e2e/phase24-editor-character-role.spec.ts --project=chromium` 통과: 6 tests.
- `scripts/mmp-local-ci.sh quick` 통과: Go tests, web lint/typecheck/test/build 포함.

## Notes
- `ready-for-ci` 라벨과 workflow dispatch는 사용하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 결말 및 역할지 편집 시 리치 콘텐츠 미리보기 기능 추가

* **Improvements**
  * 결말 편집 UI 개선 - 본문 미리보기와 편집 모드를 명확하게 전환
  * 역할지 편집 흐름 개선 - 미리보기 버튼을 통한 편집 모드 전환 지원
  * 편집기 상호작용 감지 안정성 향상

* **Bug Fixes**
  * 미리보기 전환 시 자동 저장 중복 호출 방지

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->