### PR TITLE
feat: 에디터 appearance 시스템 동기화 검증

### DIFF
--- a/apps/web/e2e/editor-appearance.spec.ts
+++ b/apps/web/e2e/editor-appearance.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import {
   BASE,
   THEME_ID,
@@ -8,7 +9,94 @@ import {
 } from './helpers/editor-golden-path-fixtures';
 import { EDITOR_APPEARANCE_STORAGE_KEY } from '../src/features/editor/design-system/useEditorAppearance';
 
+async function expectDarkEditorTokens(page: Page) {
+  const tokens = await page.locator('.mmp-editor-design-scope').evaluate((scope) => {
+    const scopeStyle = window.getComputedStyle(scope);
+    const surface = scope.querySelector('.mmp-editor-surface');
+    const surfaceStyle = surface ? window.getComputedStyle(surface) : null;
+
+    return {
+      canvas: scopeStyle.getPropertyValue('--mmp-editor-color-canvas').trim(),
+      ink: scopeStyle.getPropertyValue('--mmp-editor-color-ink').trim(),
+      colorScheme: scopeStyle.colorScheme,
+      surfaceBackground: surfaceStyle?.backgroundColor ?? '',
+      surfaceColor: surfaceStyle?.color ?? '',
+    };
+  });
+
+  expect(tokens).toEqual(
+    expect.objectContaining({
+      canvas: '#191919',
+      ink: '#f4f4f2',
+      colorScheme: 'dark',
+      surfaceBackground: 'rgb(32, 32, 32)',
+      surfaceColor: 'rgb(244, 244, 242)',
+    })
+  );
+}
+
+async function expectLightEditorTokens(page: Page) {
+  const tokens = await page.locator('.mmp-editor-design-scope').evaluate((scope) => {
+    const scopeStyle = window.getComputedStyle(scope);
+    const surface = scope.querySelector('.mmp-editor-surface');
+    const surfaceStyle = surface ? window.getComputedStyle(surface) : null;
+
+    return {
+      canvas: scopeStyle.getPropertyValue('--mmp-editor-color-canvas').trim(),
+      ink: scopeStyle.getPropertyValue('--mmp-editor-color-ink').trim(),
+      surfaceBackground: surfaceStyle?.backgroundColor ?? '',
+      surfaceColor: surfaceStyle?.color ?? '',
+    };
+  });
+
+  expect(tokens).toEqual(
+    expect.objectContaining({
+      canvas: '#ffffff',
+      ink: '#1a1a1a',
+      surfaceBackground: 'rgb(250, 250, 249)',
+      surfaceColor: 'rgb(26, 26, 26)',
+    })
+  );
+}
+
 test.describe('editor appearance mode', () => {
+  test('/editor 대시보드는 저장된 appearance mode와 무관하게 legacy design으로 남는다', async ({
+    page,
+  }) => {
+    const state = freshState();
+    await page.setViewportSize({ width: 1440, height: 960 });
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.addInitScript(
+      ({ storageKey }) => {
+        window.localStorage.setItem(storageKey, 'dark');
+      },
+      { storageKey: EDITOR_APPEARANCE_STORAGE_KEY }
+    );
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor`);
+
+    await expect(page.getByRole('heading', { name: '테마 에디터' })).toBeVisible();
+    await expect(page.getByText('E2E 골든패스')).toBeVisible();
+    await expect(page.locator('.mmp-editor-design-scope')).toHaveCount(0);
+    await expect(page.locator('[data-editor-theme]')).toHaveCount(0);
+    await expect(page.locator('[data-editor-theme-preference]')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: '시스템 설정 사용' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: '다크 모드' })).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate((key) => window.localStorage.getItem(key), EDITOR_APPEARANCE_STORAGE_KEY)
+      )
+      .toBe('dark');
+
+    const screenshot = await page.screenshot({
+      fullPage: true,
+      path: 'test-results/editor-dashboard-legacy-design.png',
+    });
+    expect(screenshot.length).toBeGreaterThan(0);
+  });
+
   test('에디터 상세 화면에서 다크 모드를 선택하면 저장되고 새로고침 뒤에도 유지된다', async ({
     page,
   }) => {
@@ -28,6 +116,7 @@ test.describe('editor appearance mode', () => {
     await page.getByRole('button', { name: '다크 모드' }).click();
 
     await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expectDarkEditorTokens(page);
     await expect(page.getByRole('button', { name: '다크 모드' })).toHaveAttribute(
       'aria-pressed',
       'true'
@@ -41,6 +130,7 @@ test.describe('editor appearance mode', () => {
     await page.reload();
 
     await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expectDarkEditorTokens(page);
     await expect(page.getByRole('button', { name: '다크 모드' })).toHaveAttribute(
       'aria-pressed',
       'true'
@@ -58,11 +148,175 @@ test.describe('editor appearance mode', () => {
     const editorScope = page.locator('.mmp-editor-design-scope');
     await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
     await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expectDarkEditorTokens(page);
 
     await page.getByRole('button', { name: '라이트 모드' }).click();
     await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
 
     await page.getByRole('button', { name: '시스템 설정 사용' }).click();
     await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+  });
+
+  test('에디터 상세 화면의 system appearance 스크린샷을 캡처한다', async ({ page }) => {
+    const state = freshState();
+    await page.setViewportSize({ width: 1440, height: 960 });
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.addInitScript(
+      ({ storageKey }) => {
+        window.localStorage.setItem(storageKey, 'system');
+      },
+      { storageKey: EDITOR_APPEARANCE_STORAGE_KEY }
+    );
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    const editorScope = page.locator('.mmp-editor-design-scope');
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expect(page.getByRole('button', { name: '시스템 설정 사용' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expectDarkEditorTokens(page);
+
+    const screenshot = await page.screenshot({
+      fullPage: true,
+      path: 'test-results/editor-detail-system-appearance.png',
+    });
+    expect(screenshot.length).toBeGreaterThan(0);
+  });
+
+  test('에디터 상세 화면의 light appearance 스크린샷을 캡처한다', async ({ page }) => {
+    const state = freshState();
+    await page.setViewportSize({ width: 1440, height: 960 });
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.addInitScript(
+      ({ storageKey }) => {
+        window.localStorage.setItem(storageKey, 'light');
+      },
+      { storageKey: EDITOR_APPEARANCE_STORAGE_KEY }
+    );
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    const editorScope = page.locator('.mmp-editor-design-scope');
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'light');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+    await expect(page.getByRole('button', { name: '라이트 모드' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expectLightEditorTokens(page);
+
+    const screenshot = await page.screenshot({
+      fullPage: true,
+      path: 'test-results/editor-detail-light-appearance.png',
+    });
+    expect(screenshot.length).toBeGreaterThan(0);
+  });
+
+  test('에디터 상세 화면의 dark appearance 스크린샷을 캡처한다', async ({ page }) => {
+    const state = freshState();
+    await page.setViewportSize({ width: 1440, height: 960 });
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.addInitScript(
+      ({ storageKey }) => {
+        window.localStorage.setItem(storageKey, 'dark');
+      },
+      { storageKey: EDITOR_APPEARANCE_STORAGE_KEY }
+    );
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}`);
+
+    const editorScope = page.locator('.mmp-editor-design-scope');
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'dark');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expect(page.getByRole('button', { name: '다크 모드' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expectDarkEditorTokens(page);
+
+    const screenshot = await page.screenshot({
+      fullPage: true,
+      path: 'test-results/editor-detail-dark-appearance.png',
+    });
+    expect(screenshot.length).toBeGreaterThan(0);
+  });
+
+  test('에디터 상세 화면에서 라이트 모드를 선택하면 시스템 dark 설정보다 우선한다', async ({
+    page,
+  }) => {
+    const state = freshState();
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
+
+    const editorScope = page.locator('.mmp-editor-design-scope');
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+
+    await page.getByRole('button', { name: '라이트 모드' }).click();
+
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'light');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+    await expect(page.getByRole('button', { name: '라이트 모드' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect
+      .poll(() =>
+        page.evaluate((key) => window.localStorage.getItem(key), EDITOR_APPEARANCE_STORAGE_KEY)
+      )
+      .toBe('light');
+
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+
+    await page.reload();
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'light');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+    await expect(page.getByRole('button', { name: '라이트 모드' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  test('시스템 설정 모드는 열린 에디터 상세 화면에서 브라우저 색상 변경을 즉시 반영한다', async ({
+    page,
+  }) => {
+    const state = freshState();
+    await page.emulateMedia({ colorScheme: 'light' });
+    await mockCommonApis(page, state);
+    await loginAsE2EUser(page);
+
+    await page.goto(`${BASE}/editor/${THEME_ID}/characters`);
+
+    const editorScope = page.locator('.mmp-editor-design-scope');
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+    await expect(page.getByRole('button', { name: '시스템 설정 사용' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    await page.emulateMedia({ colorScheme: 'dark' });
+
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
+    await expectDarkEditorTokens(page);
+
+    await page.emulateMedia({ colorScheme: 'light' });
+
+    await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
+    await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
   });
 });

--- a/apps/web/e2e/editor-appearance.spec.ts
+++ b/apps/web/e2e/editor-appearance.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import type { Page } from '@playwright/test';
+import type { Page, TestInfo } from '@playwright/test';
 import {
   BASE,
   THEME_ID,
@@ -44,6 +44,7 @@ async function expectLightEditorTokens(page: Page) {
     return {
       canvas: scopeStyle.getPropertyValue('--mmp-editor-color-canvas').trim(),
       ink: scopeStyle.getPropertyValue('--mmp-editor-color-ink').trim(),
+      colorScheme: scopeStyle.colorScheme,
       surfaceBackground: surfaceStyle?.backgroundColor ?? '',
       surfaceColor: surfaceStyle?.color ?? '',
     };
@@ -53,6 +54,7 @@ async function expectLightEditorTokens(page: Page) {
     expect.objectContaining({
       canvas: '#ffffff',
       ink: '#1a1a1a',
+      colorScheme: 'light',
       surfaceBackground: 'rgb(250, 250, 249)',
       surfaceColor: 'rgb(26, 26, 26)',
     })
@@ -62,7 +64,7 @@ async function expectLightEditorTokens(page: Page) {
 test.describe('editor appearance mode', () => {
   test('/editor 대시보드는 저장된 appearance mode와 무관하게 legacy design으로 남는다', async ({
     page,
-  }) => {
+  }, testInfo: TestInfo) => {
     const state = freshState();
     await page.setViewportSize({ width: 1440, height: 960 });
     await page.emulateMedia({ colorScheme: 'dark' });
@@ -92,7 +94,7 @@ test.describe('editor appearance mode', () => {
 
     const screenshot = await page.screenshot({
       fullPage: true,
-      path: 'test-results/editor-dashboard-legacy-design.png',
+      path: testInfo.outputPath('editor-dashboard-legacy-design.png'),
     });
     expect(screenshot.length).toBeGreaterThan(0);
   });
@@ -157,7 +159,10 @@ test.describe('editor appearance mode', () => {
     await expect(editorScope).toHaveAttribute('data-editor-theme', 'dark');
   });
 
-  test('에디터 상세 화면의 system appearance 스크린샷을 캡처한다', async ({ page }) => {
+  test('에디터 상세 화면의 system appearance 스크린샷을 캡처한다', async (
+    { page },
+    testInfo: TestInfo
+  ) => {
     const state = freshState();
     await page.setViewportSize({ width: 1440, height: 960 });
     await page.emulateMedia({ colorScheme: 'dark' });
@@ -183,12 +188,15 @@ test.describe('editor appearance mode', () => {
 
     const screenshot = await page.screenshot({
       fullPage: true,
-      path: 'test-results/editor-detail-system-appearance.png',
+      path: testInfo.outputPath('editor-detail-system-appearance.png'),
     });
     expect(screenshot.length).toBeGreaterThan(0);
   });
 
-  test('에디터 상세 화면의 light appearance 스크린샷을 캡처한다', async ({ page }) => {
+  test('에디터 상세 화면의 light appearance 스크린샷을 캡처한다', async (
+    { page },
+    testInfo: TestInfo
+  ) => {
     const state = freshState();
     await page.setViewportSize({ width: 1440, height: 960 });
     await page.emulateMedia({ colorScheme: 'dark' });
@@ -214,12 +222,15 @@ test.describe('editor appearance mode', () => {
 
     const screenshot = await page.screenshot({
       fullPage: true,
-      path: 'test-results/editor-detail-light-appearance.png',
+      path: testInfo.outputPath('editor-detail-light-appearance.png'),
     });
     expect(screenshot.length).toBeGreaterThan(0);
   });
 
-  test('에디터 상세 화면의 dark appearance 스크린샷을 캡처한다', async ({ page }) => {
+  test('에디터 상세 화면의 dark appearance 스크린샷을 캡처한다', async (
+    { page },
+    testInfo: TestInfo
+  ) => {
     const state = freshState();
     await page.setViewportSize({ width: 1440, height: 960 });
     await page.emulateMedia({ colorScheme: 'light' });
@@ -245,7 +256,7 @@ test.describe('editor appearance mode', () => {
 
     const screenshot = await page.screenshot({
       fullPage: true,
-      path: 'test-results/editor-detail-dark-appearance.png',
+      path: testInfo.outputPath('editor-detail-dark-appearance.png'),
     });
     expect(screenshot.length).toBeGreaterThan(0);
   });
@@ -318,5 +329,6 @@ test.describe('editor appearance mode', () => {
 
     await expect(editorScope).toHaveAttribute('data-editor-theme-preference', 'system');
     await expect(editorScope).toHaveAttribute('data-editor-theme', 'light');
+    await expectLightEditorTokens(page);
   });
 });

--- a/apps/web/src/features/editor/design-system/editorNotionTheme.css
+++ b/apps/web/src/features/editor/design-system/editorNotionTheme.css
@@ -43,6 +43,7 @@
   --mmp-editor-space-xxl: 32px;
   --mmp-editor-shadow-card: rgba(15, 15, 15, 0.08) 0 4px 12px 0;
   --mmp-editor-shadow-modal: rgba(15, 15, 15, 0.16) 0 16px 48px -8px;
+  color-scheme: light;
   font-family:
     'Notion Sans',
     var(

--- a/apps/web/src/features/editor/design-system/useEditorAppearance.test.ts
+++ b/apps/web/src/features/editor/design-system/useEditorAppearance.test.ts
@@ -5,6 +5,7 @@ import {
   type EditorAppearancePreference,
   readStoredEditorAppearance,
   resolveEditorAppearancePreference,
+  subscribeToSystemEditorAppearance,
   useEditorAppearance,
   writeStoredEditorAppearance,
 } from './useEditorAppearance';
@@ -68,8 +69,37 @@ describe('useEditorAppearance', () => {
     expect(result.current.resolvedTheme).toBe('light');
   });
 
-  it('잘못 저장된 값은 무시한다', () => {
-    window.localStorage.setItem(EDITOR_APPEARANCE_STORAGE_KEY, 'sepia');
+  it.each([
+    ['system', true, 'dark'],
+    ['light', true, 'light'],
+    ['dark', false, 'dark'],
+  ] as const)(
+    '저장된 %s appearance 값을 첫 렌더에서 복원한다',
+    (storedPreference, systemPrefersDark, expectedResolvedTheme) => {
+      mediaMatches = systemPrefersDark;
+      window.localStorage.setItem(EDITOR_APPEARANCE_STORAGE_KEY, storedPreference);
+
+      const { result } = renderHook(() => useEditorAppearance());
+
+      expect(result.current.preference).toBe(storedPreference);
+      expect(result.current.resolvedTheme).toBe(expectedResolvedTheme);
+    }
+  );
+
+  it('시스템 모드는 첫 렌더부터 운영체제 dark 설정을 반영한다', () => {
+    mediaMatches = true;
+
+    const { result } = renderHook(() => useEditorAppearance());
+
+    expect(result.current.preference).toBe('system');
+    expect(result.current.resolvedTheme).toBe('dark');
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['unsupported mode', 'sepia'],
+  ])('저장된 appearance 값이 %s이면 기본 시스템 설정으로 되돌린다', (_label, storedValue) => {
+    window.localStorage.setItem(EDITOR_APPEARANCE_STORAGE_KEY, storedValue);
 
     expect(readStoredEditorAppearance()).toBe('system');
   });
@@ -98,15 +128,74 @@ describe('useEditorAppearance', () => {
     expect(result.current.preference).toBe('system');
     expect(result.current.resolvedTheme).toBe('dark');
   });
+
+  it.each([
+    ['light', false, true],
+    ['dark', true, false],
+  ] as const)(
+    '%s 모드는 운영체제 색상 변경 이벤트를 무시하고 선택한 테마를 유지한다',
+    (mode, initialSystemPrefersDark, nextSystemPrefersDark) => {
+      mediaMatches = initialSystemPrefersDark;
+      const { result } = renderHook(() => useEditorAppearance());
+
+      act(() => result.current.setPreference(mode));
+
+      expect(result.current.preference).toBe(mode);
+      expect(result.current.resolvedTheme).toBe(mode);
+
+      act(() => {
+        mediaMatches = nextSystemPrefersDark;
+        mediaListeners.forEach((listener) => listener({ matches: nextSystemPrefersDark }));
+      });
+
+      expect(result.current.preference).toBe(mode);
+      expect(result.current.resolvedTheme).toBe(mode);
+    }
+  );
 });
 
 describe('editor appearance helpers', () => {
-  it('preference와 시스템 dark 여부로 실제 테마를 해석한다', () => {
-    expect(resolveEditorAppearancePreference('system', false)).toBe('light');
-    expect(resolveEditorAppearancePreference('system', true)).toBe('dark');
-    expect(resolveEditorAppearancePreference('light', true)).toBe('light');
-    expect(resolveEditorAppearancePreference('dark', false)).toBe('dark');
+  it('시스템 색상 변경 이벤트를 실제 light/dark 값으로 변환해 전달한다', () => {
+    const listeners: MediaListener[] = [];
+    const removeEventListener = vi.fn((_event: 'change', listener: MediaListener) => {
+      const index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    });
+    const matchMedia = vi.fn((media: string) => ({
+      matches: false,
+      media,
+      addEventListener: vi.fn((_event: 'change', listener: MediaListener) => {
+        listeners.push(listener);
+      }),
+      removeEventListener,
+    }));
+    const onResolvedThemeChange = vi.fn();
+
+    const unsubscribe = subscribeToSystemEditorAppearance(onResolvedThemeChange, matchMedia);
+
+    listeners.forEach((listener) => listener({ matches: true }));
+    listeners.forEach((listener) => listener({ matches: false }));
+    unsubscribe();
+
+    expect(onResolvedThemeChange).toHaveBeenNthCalledWith(1, 'dark');
+    expect(onResolvedThemeChange).toHaveBeenNthCalledWith(2, 'light');
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(listeners).toHaveLength(0);
   });
+
+  it.each([
+    ['system', false, 'light'],
+    ['system', true, 'dark'],
+    ['light', true, 'light'],
+    ['dark', false, 'dark'],
+  ] as const)(
+    '%s preference와 system dark=%s 입력을 %s resolved theme으로 해석한다',
+    (preference, prefersDark, expectedResolvedTheme) => {
+      expect(resolveEditorAppearancePreference(preference, prefersDark)).toBe(expectedResolvedTheme);
+    }
+  );
 
   it('storage 접근이 실패해도 기본값으로 동작한다', () => {
     const blockedStorage = {

--- a/apps/web/src/features/editor/design-system/useEditorAppearance.ts
+++ b/apps/web/src/features/editor/design-system/useEditorAppearance.ts
@@ -4,6 +4,23 @@ export const EDITOR_APPEARANCE_STORAGE_KEY = 'mmp.editor.appearance';
 
 export type EditorAppearancePreference = 'system' | 'light' | 'dark';
 export type EditorResolvedAppearance = 'light' | 'dark';
+export type EditorSystemAppearanceListener = (resolvedTheme: EditorResolvedAppearance) => void;
+
+type SystemColorSchemeChangeTarget = {
+  matches: boolean;
+  addEventListener?: (
+    event: 'change',
+    listener: (event: { matches: boolean }) => void
+  ) => void;
+  removeEventListener?: (
+    event: 'change',
+    listener: (event: { matches: boolean }) => void
+  ) => void;
+  addListener?: (listener: (event: { matches: boolean }) => void) => void;
+  removeListener?: (listener: (event: { matches: boolean }) => void) => void;
+};
+
+type MatchSystemColorScheme = (query: string) => SystemColorSchemeChangeTarget;
 
 const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
 
@@ -43,6 +60,28 @@ export function writeStoredEditorAppearance(
   }
 }
 
+export function subscribeToSystemEditorAppearance(
+  listener: EditorSystemAppearanceListener,
+  matchSystemColorScheme: MatchSystemColorScheme | null | undefined = getMatchMedia()
+): () => void {
+  if (!matchSystemColorScheme) {
+    return () => {};
+  }
+
+  const query = matchSystemColorScheme(SYSTEM_DARK_QUERY);
+  const handleChange = (event: { matches: boolean }) => {
+    listener(event.matches ? 'dark' : 'light');
+  };
+
+  if (typeof query.addEventListener === 'function') {
+    query.addEventListener('change', handleChange);
+    return () => query.removeEventListener?.('change', handleChange);
+  }
+
+  query.addListener?.(handleChange);
+  return () => query.removeListener?.(handleChange);
+}
+
 export function useEditorAppearance() {
   const [preference, setPreferenceState] = useState<EditorAppearancePreference>(() =>
     readStoredEditorAppearance()
@@ -50,24 +89,9 @@ export function useEditorAppearance() {
   const [prefersDark, setPrefersDark] = useState(readSystemPrefersDark);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return;
-    }
-
-    const query = window.matchMedia(SYSTEM_DARK_QUERY);
-    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
-      setPrefersDark(event.matches);
-    };
-
-    handleChange(query);
-
-    if (typeof query.addEventListener === 'function') {
-      query.addEventListener('change', handleChange);
-      return () => query.removeEventListener('change', handleChange);
-    }
-
-    query.addListener(handleChange);
-    return () => query.removeListener(handleChange);
+    return subscribeToSystemEditorAppearance((nextResolvedTheme) => {
+      setPrefersDark(nextResolvedTheme === 'dark');
+    });
   }, []);
 
   const setPreference = useCallback((nextPreference: EditorAppearancePreference) => {
@@ -98,9 +122,17 @@ function getLocalStorage(): Storage | null {
   }
 }
 
-function readSystemPrefersDark(): boolean {
+function getMatchMedia(): MatchSystemColorScheme | null {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return null;
+  }
+  return window.matchMedia.bind(window);
+}
+
+function readSystemPrefersDark(): boolean {
+  const matchMedia = getMatchMedia();
+  if (!matchMedia) {
     return false;
   }
-  return window.matchMedia(SYSTEM_DARK_QUERY).matches;
+  return matchMedia(SYSTEM_DARK_QUERY).matches;
 }

--- a/apps/web/src/pages/__tests__/EditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/EditorPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 const { locationPathMock, paramsMock, setActiveTabMock } = vi.hoisted(() => ({
@@ -118,6 +118,39 @@ function createStorage() {
   };
 }
 
+function createMatchMediaController(initialMatches = false) {
+  let matches = initialMatches;
+  let listeners: Array<(event: { matches: boolean }) => void> = [];
+  const matchMedia = vi.fn((media: string) => ({
+    matches,
+    media,
+    onchange: null,
+    addEventListener: vi.fn((_event: 'change', listener: (event: { matches: boolean }) => void) => {
+      listeners.push(listener);
+    }),
+    removeEventListener: vi.fn(
+      (_event: 'change', listener: (event: { matches: boolean }) => void) => {
+        listeners = listeners.filter((candidate) => candidate !== listener);
+      }
+    ),
+    addListener: vi.fn((listener: (event: { matches: boolean }) => void) => {
+      listeners.push(listener);
+    }),
+    removeListener: vi.fn((listener: (event: { matches: boolean }) => void) => {
+      listeners = listeners.filter((candidate) => candidate !== listener);
+    }),
+    dispatchEvent: vi.fn(),
+  }));
+
+  return {
+    matchMedia,
+    setMatches(nextMatches: boolean) {
+      matches = nextMatches;
+      listeners.forEach((listener) => listener({ matches: nextMatches }));
+    },
+  };
+}
+
 beforeAll(() => {
   Object.defineProperty(window, 'localStorage', {
     value: createStorage(),
@@ -128,6 +161,7 @@ beforeAll(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
   window.localStorage.clear();
   locationPathMock.mockReturnValue('/editor');
 });
@@ -144,6 +178,23 @@ describe('EditorPage', () => {
     expect(setActiveTabMock).toHaveBeenCalledWith('storyMap');
   });
 
+  it('/editor dashboard는 저장된 appearance mode와 시스템 dark 설정에도 legacy design으로 남는다', () => {
+    const systemTheme = createMatchMediaController(true);
+    vi.stubGlobal('matchMedia', systemTheme.matchMedia);
+    window.localStorage.setItem(EDITOR_APPEARANCE_STORAGE_KEY, 'dark');
+    paramsMock.mockReturnValue({});
+    locationPathMock.mockReturnValue('/editor');
+
+    const { container } = render(<EditorPage />);
+
+    expect(screen.getByText('에디터 대시보드')).toBeDefined();
+    expect(screen.queryByText(/테마 에디터/)).toBeNull();
+    expect(container.querySelector(`.${EDITOR_DESIGN_SCOPE_CLASS}`)).toBeNull();
+    expect(container.querySelector('[data-editor-theme]')).toBeNull();
+    expect(container.querySelector('[data-editor-theme-preference]')).toBeNull();
+    expect(systemTheme.matchMedia).not.toHaveBeenCalled();
+  });
+
   it('characters 라우트 segment를 characters 탭으로 매핑한다', () => {
     paramsMock.mockReturnValue({ id: 'theme-1', tab: 'characters' });
     locationPathMock.mockReturnValue('/editor/theme-1/characters');
@@ -156,6 +207,71 @@ describe('EditorPage', () => {
     expect(detail.parentElement?.getAttribute('data-editor-theme')).toBe('light');
     expect(detail.parentElement?.getAttribute('data-editor-theme-preference')).toBe('system');
     expect(setActiveTabMock).toHaveBeenCalledWith('characters');
+  });
+
+  it('에디터 상세 첫 로드에서 system appearance를 운영체제 dark 설정으로 해석한다', () => {
+    const systemTheme = createMatchMediaController(true);
+    vi.stubGlobal('matchMedia', systemTheme.matchMedia);
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: 'characters' });
+    locationPathMock.mockReturnValue('/editor/theme-1/characters');
+
+    render(<EditorPage />);
+
+    const detail = screen.getByText(/테마 에디터 theme-1 characters system dark/);
+    expect(detail).toBeDefined();
+    expect(detail.parentElement?.className).toContain(EDITOR_DESIGN_SCOPE_CLASS);
+    expect(detail.parentElement?.getAttribute('data-editor-theme')).toBe('dark');
+    expect(detail.parentElement?.getAttribute('data-editor-theme-preference')).toBe('system');
+  });
+
+  it.each([
+    ['system', false, 'light'],
+    ['system', true, 'dark'],
+    ['light', true, 'light'],
+    ['dark', false, 'dark'],
+  ] as const)(
+    '%s appearance는 editor detail data-editor-theme에 concrete %s 값을 쓴다',
+    (storedPreference, systemPrefersDark, expectedTheme) => {
+      const systemTheme = createMatchMediaController(systemPrefersDark);
+      vi.stubGlobal('matchMedia', systemTheme.matchMedia);
+      window.localStorage.setItem(EDITOR_APPEARANCE_STORAGE_KEY, storedPreference);
+      paramsMock.mockReturnValue({ id: 'theme-1', tab: 'characters' });
+      locationPathMock.mockReturnValue('/editor/theme-1/characters');
+
+      render(<EditorPage />);
+
+      const detail = screen.getByText(
+        new RegExp(`테마 에디터 theme-1 characters ${storedPreference} ${expectedTheme}`)
+      );
+      expect(detail.parentElement?.className).toContain(EDITOR_DESIGN_SCOPE_CLASS);
+      expect(detail.parentElement?.getAttribute('data-editor-theme')).toBe(expectedTheme);
+      expect(detail.parentElement?.getAttribute('data-editor-theme')).not.toBe('system');
+      expect(detail.parentElement?.getAttribute('data-editor-theme-preference')).toBe(
+        storedPreference
+      );
+    }
+  );
+
+  it('system appearance는 reload 없이 운영체제 색상 변경을 에디터 상세 wrapper에 반영한다', () => {
+    const systemTheme = createMatchMediaController(false);
+    vi.stubGlobal('matchMedia', systemTheme.matchMedia);
+    paramsMock.mockReturnValue({ id: 'theme-1', tab: 'characters' });
+    locationPathMock.mockReturnValue('/editor/theme-1/characters');
+
+    render(<EditorPage />);
+
+    let detail = screen.getByText(/테마 에디터 theme-1 characters system light/);
+    const editorScope = detail.parentElement;
+    expect(editorScope?.getAttribute('data-editor-theme')).toBe('light');
+
+    act(() => {
+      systemTheme.setMatches(true);
+    });
+
+    detail = screen.getByText(/테마 에디터 theme-1 characters system dark/);
+    expect(detail.parentElement).toBe(editorScope);
+    expect(editorScope?.getAttribute('data-editor-theme')).toBe('dark');
+    expect(editorScope?.getAttribute('data-editor-theme-preference')).toBe('system');
   });
 
   it('에디터 상세 초기화 시 localStorage에 저장된 valid appearance mode를 복원한다', () => {


### PR DESCRIPTION
## 요약
- 에디터 상세 화면의 system appearance가 브라우저 색상 변경 이벤트를 즉시 따라가도록 구독 로직을 분리했습니다.
- /editor 대시보드는 기존 legacy design으로 남고, /editor/:id 상세 화면에만 appearance scope가 적용되는지 보강했습니다.
- 라이트/다크/system 모드의 토큰, 저장 복원, 새로고침 유지, E2E 스크린샷 검증을 추가했습니다.

## Coverage Plan
- apps/web/src/features/editor/design-system/useEditorAppearance.ts: matchMedia 구독/해제, 저장값 복원, system/light/dark 해석을 Vitest로 검증.
- apps/web/src/pages/__tests__/EditorPage.test.tsx: /editor legacy 유지, /editor/:id 상세 wrapper theme attribute, system 변경 이벤트 반영을 컴포넌트 테스트로 검증.
- apps/web/e2e/editor-appearance.spec.ts: 실제 에디터 진입 후 appearance 선택, 저장 유지, system 변경 반영, 대시보드 미적용을 Playwright로 검증.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/design-system/useEditorAppearance.test.ts src/pages/__tests__/EditorPage.test.tsx
- pnpm --filter @mmp/web exec playwright test e2e/editor-appearance.spec.ts --project=chromium
- scripts/mmp-local-ci.sh quick

## Deferred / Follow-up
- 없음.

Issue: 추적 이슈 없는 소규모 에디터 appearance 검증 보강 PR입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 에디터 테마 전환 및 시스템 색상 설정 감지 기능에 대한 검증을 강화했습니다.
  * 다크/라이트 모드 전환 시나리오와 CSS 토큰 값 검증을 추가하여 테마 기능의 안정성을 개선했습니다.

* **Chores**
  * 에디터 외형 설정 로직을 리팩토링하여 코드 유지보수성을 향상했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->