### PR TITLE
fix: 에디터 저장 오류 토스트 통일

### DIFF
--- a/apps/web/src/features/editor/components/ConfigJsonTab.tsx
+++ b/apps/web/src/features/editor/components/ConfigJsonTab.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from "react";
-import { toast } from "sonner";
+import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
 
-import { Button, Badge } from "@/shared/components/ui";
-import type { EditorThemeResponse } from "@/features/editor/api";
-import { useUpdateConfigJson } from "@/features/editor/api";
+import { Button, Badge } from '@/shared/components/ui';
+import type { EditorThemeResponse } from '@/features/editor/api';
+import { useUpdateConfigJson } from '@/features/editor/api';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,17 +47,17 @@ export function ConfigJsonTab({ themeId, theme }: ConfigJsonTabProps) {
     try {
       parsed = JSON.parse(text) as Record<string, unknown>;
     } catch {
-      setParseError("유효하지 않은 JSON 형식입니다");
+      setParseError('유효하지 않은 JSON 형식입니다');
       return;
     }
     setParseError(null);
 
     updateConfig.mutate(parsed, {
       onSuccess: () => {
-        toast.success("설정이 저장되었습니다");
+        toast.success('설정이 저장되었습니다');
       },
-      onError: () => {
-        toast.error("설정 저장에 실패했습니다");
+      onError: (error) => {
+        showUnknownErrorToast(error, '설정 저장에 실패했습니다');
       },
     });
   };
@@ -86,9 +87,7 @@ export function ConfigJsonTab({ themeId, theme }: ConfigJsonTabProps) {
       />
 
       {/* Validation error */}
-      {parseError && (
-        <p className="text-sm text-red-400">{parseError}</p>
-      )}
+      {parseError && <p className="text-sm text-red-400">{parseError}</p>}
 
       {/* Actions */}
       <div className="flex items-center gap-3">

--- a/apps/web/src/features/editor/components/ModulesTab.tsx
+++ b/apps/web/src/features/editor/components/ModulesTab.tsx
@@ -1,13 +1,14 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
-import { toast } from "sonner";
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { toast } from 'sonner';
 
-import { Button, Badge } from "@/shared/components/ui";
-import type { EditorThemeResponse } from "@/features/editor/api";
-import { useUpdateConfigJson } from "@/features/editor/api";
-import { MODULE_CATEGORIES, REQUIRED_MODULE_IDS } from "@/features/editor/constants";
-import type { ModuleCategory } from "@/features/editor/constants";
-import { readEnabledModuleIds, writeModuleEnabled } from "@/features/editor/utils/configShape";
+import { Button, Badge } from '@/shared/components/ui';
+import type { EditorThemeResponse } from '@/features/editor/api';
+import { useUpdateConfigJson } from '@/features/editor/api';
+import { MODULE_CATEGORIES, REQUIRED_MODULE_IDS } from '@/features/editor/constants';
+import type { ModuleCategory } from '@/features/editor/constants';
+import { readEnabledModuleIds, writeModuleEnabled } from '@/features/editor/utils/configShape';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -42,9 +43,7 @@ function CategorySection({
   const [expanded, setExpanded] = useState(true);
 
   const categoryModuleIds = category.modules.map((m) => m.id);
-  const selectedCount = categoryModuleIds.filter((id) =>
-    selectedModules.includes(id),
-  ).length;
+  const selectedCount = categoryModuleIds.filter((id) => selectedModules.includes(id)).length;
   const allSelected = selectedCount === category.modules.length;
 
   return (
@@ -64,7 +63,7 @@ function CategorySection({
           <span className="text-sm font-medium uppercase tracking-wider text-slate-300">
             {category.label}
           </span>
-          <Badge variant={selectedCount > 0 ? "warning" : "default"} size="sm">
+          <Badge variant={selectedCount > 0 ? 'warning' : 'default'} size="sm">
             {selectedCount}/{category.modules.length}
           </Badge>
         </div>
@@ -119,15 +118,17 @@ function CategorySection({
                     <span className="block text-sm font-medium text-slate-200">
                       {mod.name}
                       {isRequired && (
-                        <span className="ml-1.5 text-[10px] font-normal text-amber-500/60">(필수)</span>
+                        <span className="ml-1.5 text-[10px] font-normal text-amber-500/60">
+                          (필수)
+                        </span>
                       )}
                       {!mod.supported && !isRequired && (
-                        <span className="ml-1.5 text-[10px] font-normal text-slate-600">(미지원)</span>
+                        <span className="ml-1.5 text-[10px] font-normal text-slate-600">
+                          (미지원)
+                        </span>
                       )}
                     </span>
-                    <span className="block text-xs text-slate-400">
-                      {mod.description}
-                    </span>
+                    <span className="block text-xs text-slate-400">{mod.description}</span>
                   </div>
                 </label>
               );
@@ -147,7 +148,7 @@ export function ModulesTab({ themeId, theme }: ModulesTabProps) {
   const configJson = useMemo(() => theme.config_json ?? {}, [theme.config_json]);
   const serverModules = useMemo(
     () => Array.from(new Set([...REQUIRED_MODULE_IDS, ...readEnabledModuleIds(configJson)])),
-    [configJson],
+    [configJson]
   );
 
   const [selectedModules, setSelectedModules] = useState<string[]>(serverModules);
@@ -158,49 +159,37 @@ export function ModulesTab({ themeId, theme }: ModulesTabProps) {
     setSelectedModules(serverModules);
   }, [serverModules]);
 
-  const isDirty = JSON.stringify(selectedModules.slice().sort()) !== JSON.stringify(serverModules.slice().sort());
+  const isDirty =
+    JSON.stringify(selectedModules.slice().sort()) !== JSON.stringify(serverModules.slice().sort());
 
-  const handleToggle = useCallback(
-    (moduleId: string) => {
-      // 필수 모듈은 토글 불가
-      if (REQUIRED_MODULE_IDS.includes(moduleId)) return;
-      setSelectedModules((prev) =>
-        prev.includes(moduleId)
-          ? prev.filter((id) => id !== moduleId)
-          : [...prev, moduleId],
-      );
-    },
-    [],
-  );
+  const handleToggle = useCallback((moduleId: string) => {
+    // 필수 모듈은 토글 불가
+    if (REQUIRED_MODULE_IDS.includes(moduleId)) return;
+    setSelectedModules((prev) =>
+      prev.includes(moduleId) ? prev.filter((id) => id !== moduleId) : [...prev, moduleId]
+    );
+  }, []);
 
-  const handleSelectAll = useCallback(
-    (moduleIds: string[]) => {
-      setSelectedModules((prev) =>
-        Array.from(new Set([...prev, ...moduleIds])),
-      );
-    },
-    [],
-  );
+  const handleSelectAll = useCallback((moduleIds: string[]) => {
+    setSelectedModules((prev) => Array.from(new Set([...prev, ...moduleIds])));
+  }, []);
 
-  const handleDeselectAll = useCallback(
-    (moduleIds: string[]) => {
-      setSelectedModules((prev) =>
-        // 필수 모듈은 해제 불가
-        prev.filter((id) => !moduleIds.includes(id) || REQUIRED_MODULE_IDS.includes(id)),
-      );
-    },
-    [],
-  );
+  const handleDeselectAll = useCallback((moduleIds: string[]) => {
+    setSelectedModules((prev) =>
+      // 필수 모듈은 해제 불가
+      prev.filter((id) => !moduleIds.includes(id) || REQUIRED_MODULE_IDS.includes(id))
+    );
+  }, []);
 
   function handleSave() {
     const allModuleIds = MODULE_CATEGORIES.flatMap((cat) => cat.modules.map((mod) => mod.id));
     const nextConfig = allModuleIds.reduce(
       (acc, moduleId) => writeModuleEnabled(acc, moduleId, selectedModules.includes(moduleId)),
-      configJson,
+      configJson
     );
     updateConfig.mutate(nextConfig, {
-      onSuccess: () => toast.success("모듈 설정이 저장되었습니다"),
-      onError: () => toast.error("모듈 설정 저장에 실패했습니다"),
+      onSuccess: () => toast.success('모듈 설정이 저장되었습니다'),
+      onError: (error) => showUnknownErrorToast(error, '모듈 설정 저장에 실패했습니다'),
     });
   }
 
@@ -209,10 +198,7 @@ export function ModulesTab({ themeId, theme }: ModulesTabProps) {
   }
 
   const totalSelected = selectedModules.length;
-  const totalModules = MODULE_CATEGORIES.reduce(
-    (sum, cat) => sum + cat.modules.length,
-    0,
-  );
+  const totalModules = MODULE_CATEGORIES.reduce((sum, cat) => sum + cat.modules.length, 0);
 
   return (
     <div className="space-y-4">
@@ -220,7 +206,7 @@ export function ModulesTab({ themeId, theme }: ModulesTabProps) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h2 className="text-lg font-semibold text-slate-100">모듈 선택</h2>
-          <Badge variant={totalSelected > 0 ? "warning" : "default"}>
+          <Badge variant={totalSelected > 0 ? 'warning' : 'default'}>
             {totalSelected}/{totalModules} 모듈 선택됨
           </Badge>
           {isDirty && <Badge variant="warning">변경사항 있음</Badge>}

--- a/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueEntityWorkspace.tsx
@@ -33,14 +33,10 @@ import type {
   ClueRuntimeEffectDraftState,
 } from './ClueRuntimeEffectCard';
 import { ClueBasicInfoCard } from './ClueBasicInfoCard';
-import type {
-  ClueBasicInfoCardHandle,
-  ClueBasicInfoDraftState,
-} from './ClueBasicInfoCard';
-import {
-  buildProgressNodeRevealOptions,
-} from '@/features/editor/entities/reveal/revealTimingOptions';
+import type { ClueBasicInfoCardHandle, ClueBasicInfoDraftState } from './ClueBasicInfoCard';
+import { buildProgressNodeRevealOptions } from '@/features/editor/entities/reveal/revealTimingOptions';
 import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 const CLUE_DETAIL_AUTOSAVE_MS = 1500;
 const CLUE_AUTOSAVE_TOAST_ID = 'clue-detail-autosave';
@@ -102,41 +98,37 @@ export function ClueEntityWorkspace({
     [configJson, clues, locations, characters]
   );
   const sceneOptions = useMemo(
-    () => buildProgressNodeRevealOptions(
-      flowNodes,
-      clues.flatMap((clue) => [
-        clue.reveal_scene_id,
-        clue.hide_scene_id,
-      ]),
-      { scope: 'investigation_phase' },
-    ),
-    [flowNodes, clues],
+    () =>
+      buildProgressNodeRevealOptions(
+        flowNodes,
+        clues.flatMap((clue) => [clue.reveal_scene_id, clue.hide_scene_id]),
+        { scope: 'investigation_phase' }
+      ),
+    [flowNodes, clues]
   );
   const isPlayerKillEnabled = useMemo(
     () => readEnabledModuleIds(configJson).includes(PLAYER_KILL_MODULE_ID),
-    [configJson],
+    [configJson]
   );
   const enabledModuleIds = useMemo(() => readEnabledModuleIds(configJson), [configJson]);
   const isDeckInvestigationEnabled = enabledModuleIds.includes(DECK_INVESTIGATION_MODULE_ID);
   const deckInvestigationDraft = useMemo(
     () => readDeckInvestigationConfig(configJson),
-    [configJson],
+    [configJson]
   );
   const cluePlacement = useMemo(() => readCluePlacement(configJson), [configJson]);
   const locationById = useMemo(
     () => new Map(locations.map((location) => [location.id, location])),
-    [locations],
+    [locations]
   );
   const getClueLocationContext = useCallback(
     (clue: ClueResponse) => {
       const placedLocationId = cluePlacement[clue.id] ?? clue.location_id ?? null;
-      const placedLocation = placedLocationId ? locationById.get(placedLocationId) ?? null : null;
-      const locationName = placedLocation
-        ? getLocationPathLabel(placedLocation, locations)
-        : null;
+      const placedLocation = placedLocationId ? (locationById.get(placedLocationId) ?? null) : null;
+      const locationName = placedLocation ? getLocationPathLabel(placedLocation, locations) : null;
       return { placedLocationId, locationName };
     },
-    [cluePlacement, locationById, locations],
+    [cluePlacement, locationById, locations]
   );
   const buildListBadges = useCallback(
     (clue: ClueResponse) => {
@@ -151,17 +143,22 @@ export function ClueEntityWorkspace({
         if ((effect.defensePower ?? 0) > 0) badges.push(`방어력 ${effect.defensePower}`);
       }
       if (isDeckInvestigationEnabled && placedLocationId) {
-        const cost = readLocationClueInvestigationCost(deckInvestigationDraft, placedLocationId, clue.id);
-        badges.push(cost.mode === 'free' ? '조사권 무료' : `조사권 ${Math.max(1, cost.tokenCost)}개`);
+        const cost = readLocationClueInvestigationCost(
+          deckInvestigationDraft,
+          placedLocationId,
+          clue.id
+        );
+        badges.push(
+          cost.mode === 'free' ? '조사권 무료' : `조사권 ${Math.max(1, cost.tokenCost)}개`
+        );
       }
       return badges;
     },
-    [configJson, deckInvestigationDraft, getClueLocationContext, isDeckInvestigationEnabled],
+    [configJson, deckInvestigationDraft, getClueLocationContext, isDeckInvestigationEnabled]
   );
   const saveDetailBody = useCallback(
     (body: ClueDetailAutosaveBody, opts?: { onError?: (error?: unknown) => void }) => {
-      const saveOperations =
-        (body.rowBody ? 1 : 0) + (body.nextConfig && onConfigChange ? 1 : 0);
+      const saveOperations = (body.rowBody ? 1 : 0) + (body.nextConfig && onConfigChange ? 1 : 0);
       if (saveOperations === 0) return;
 
       toast.loading('단서 자동저장 중...', { id: CLUE_AUTOSAVE_TOAST_ID });
@@ -197,25 +194,27 @@ export function ClueEntityWorkspace({
         });
       }
     },
-    [onConfigChange, onUpdate],
+    [onConfigChange, onUpdate]
   );
 
-  const showFailureToast = useCallback((body: ClueDetailAutosaveBody | null) => {
-    toast.error('단서 자동저장에 실패했습니다', {
-      id: CLUE_AUTOSAVE_TOAST_ID,
-      duration: 6000,
-      action: body
-        ? {
-            label: '재시도',
-            onClick: () => {
-              saveDetailBody(body, {
-                onError: () => showFailureToast(body),
-              });
-            },
-          }
-        : undefined,
-    });
-  }, [saveDetailBody]);
+  const showFailureToast = useCallback(
+    (body: ClueDetailAutosaveBody | null, error?: unknown) => {
+      showUnknownErrorToast(error, '단서 자동저장에 실패했습니다', {
+        id: CLUE_AUTOSAVE_TOAST_ID,
+        action: body
+          ? {
+              label: '재시도',
+              onClick: () => {
+                saveDetailBody(body, {
+                  onError: (retryError) => showFailureToast(body, retryError),
+                });
+              },
+            }
+          : undefined,
+      });
+    },
+    [saveDetailBody]
+  );
 
   const { schedule, flush } = useDebouncedMutation<ClueDetailAutosaveBody>({
     debounceMs: CLUE_DETAIL_AUTOSAVE_MS,
@@ -223,7 +222,7 @@ export function ClueEntityWorkspace({
       saveDetailBody(body, {
         onError: (error) => {
           opts.onError(error);
-          showFailureToast(body);
+          showFailureToast(body, error);
         },
       });
     },
@@ -254,7 +253,7 @@ export function ClueEntityWorkspace({
       };
       return body.rowBody || body.nextConfig ? body : null;
     },
-    [configJson],
+    [configJson]
   );
 
   const scheduleAutosave = useCallback(
@@ -265,7 +264,7 @@ export function ClueEntityWorkspace({
       if (!body) return;
       schedule(body);
     },
-    [basicInfoState, buildAutosaveBody, runtimeEffectState, schedule],
+    [basicInfoState, buildAutosaveBody, runtimeEffectState, schedule]
   );
 
   const selectedClue = clues.find((clue) => clue.id === selectedId) ?? clues[0];
@@ -279,7 +278,7 @@ export function ClueEntityWorkspace({
       flush();
       setSelectedId(id);
     },
-    [flush],
+    [flush]
   );
 
   const handleFlushAutosave = useCallback(() => {
@@ -300,13 +299,13 @@ export function ClueEntityWorkspace({
   const handleBasicInfoStateChange = useCallback((state: ClueBasicInfoDraftState) => {
     setDraftRevision((revision) => revision + 1);
     setBasicInfoState((current) =>
-      current.dirty === state.dirty && current.valid === state.valid ? current : state,
+      current.dirty === state.dirty && current.valid === state.valid ? current : state
     );
   }, []);
   const handleRuntimeEffectStateChange = useCallback((state: ClueRuntimeEffectDraftState) => {
     setDraftRevision((revision) => revision + 1);
     setRuntimeEffectState((current) =>
-      current.dirty === state.dirty && current.valid === state.valid ? current : state,
+      current.dirty === state.dirty && current.valid === state.valid ? current : state
     );
   }, []);
 
@@ -325,7 +324,9 @@ export function ClueEntityWorkspace({
       renderDetail={(clue) => {
         const { placedLocationId, locationName } = getClueLocationContext(clue);
         const discovery = placedLocationId
-          ? readLocationDiscoveries(configJson, placedLocationId).find((item) => item.clueId === clue.id)
+          ? readLocationDiscoveries(configJson, placedLocationId).find(
+              (item) => item.clueId === clue.id
+            )
           : undefined;
         return (
           <div className="space-y-4">
@@ -341,7 +342,11 @@ export function ClueEntityWorkspace({
                 enabled: isDeckInvestigationEnabled,
                 tokens: deckInvestigationDraft.tokens,
                 cost: placedLocationId
-                  ? readLocationClueInvestigationCost(deckInvestigationDraft, placedLocationId, clue.id)
+                  ? readLocationClueInvestigationCost(
+                      deckInvestigationDraft,
+                      placedLocationId,
+                      clue.id
+                    )
                   : null,
                 locationId: placedLocationId,
                 locationName,

--- a/apps/web/src/features/editor/components/clues/ClueListView.tsx
+++ b/apps/web/src/features/editor/components/clues/ClueListView.tsx
@@ -108,7 +108,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
           options.onError(err);
           return;
         }
-        toast.error('단서 설정 저장에 실패했습니다');
+        showUnknownErrorToast(err, '단서 설정 저장에 실패했습니다');
       },
     });
   }
@@ -170,11 +170,7 @@ export function ClueListView({ themeId }: ClueListViewProps) {
         isConfigSaving={updateConfig.isPending}
       />
 
-      <ClueForm
-        themeId={themeId}
-        isOpen={isFormOpen}
-        onClose={handleFormClose}
-      />
+      <ClueForm themeId={themeId} isOpen={isFormOpen} onClose={handleFormClose} />
 
       <Modal
         isOpen={!!deletingClue}

--- a/apps/web/src/features/editor/components/design/CluePlacementPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CluePlacementPanel.tsx
@@ -3,12 +3,9 @@ import { toast } from 'sonner';
 import { Package, MapPin, X } from 'lucide-react';
 import { Spinner } from '@/shared/components/ui/Spinner';
 import type { EditorThemeResponse } from '@/features/editor/api';
-import {
-  useEditorClues,
-  useEditorLocations,
-  useUpdateConfigJson,
-} from '@/features/editor/api';
+import { useEditorClues, useEditorLocations, useUpdateConfigJson } from '@/features/editor/api';
 import { readCluePlacement, writeCluePlacement } from '@/features/editor/utils/configShape';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -32,7 +29,7 @@ export function CluePlacementPanel({ themeId, theme }: CluePlacementPanelProps) 
 
   const unplacedClues = useMemo(
     () => (clues ?? []).filter((c) => !placement[c.id]),
-    [clues, placement],
+    [clues, placement]
   );
 
   const placedByLocation = useMemo(() => {
@@ -49,7 +46,7 @@ export function CluePlacementPanel({ themeId, theme }: CluePlacementPanelProps) 
   function savePlacement(next: Record<string, string>) {
     updateConfig.mutate(writeCluePlacement(theme.config_json, next), {
       onSuccess: () => toast.success('배치가 저장되었습니다'),
-      onError: () => toast.error('배치 저장에 실패했습니다'),
+      onError: (error) => showUnknownErrorToast(error, '배치 저장에 실패했습니다'),
     });
   }
 
@@ -106,15 +103,10 @@ export function CluePlacementPanel({ themeId, theme }: CluePlacementPanelProps) 
         ) : (
           <div className="space-y-2">
             {unplacedClues.map((clue) => (
-              <div
-                key={clue.id}
-                className="rounded-sm border border-slate-800 bg-slate-900 p-2"
-              >
+              <div key={clue.id} className="rounded-sm border border-slate-800 bg-slate-900 p-2">
                 <div className="mb-1.5 flex items-center gap-1.5">
                   <Package className="h-3 w-3 shrink-0 text-slate-600" />
-                  <span className="text-xs font-medium text-slate-300 truncate">
-                    {clue.name}
-                  </span>
+                  <span className="text-xs font-medium text-slate-300 truncate">{clue.name}</span>
                 </div>
                 <select
                   aria-label={`${clue.name} 장소 선택`}
@@ -152,12 +144,8 @@ export function CluePlacementPanel({ themeId, theme }: CluePlacementPanelProps) 
               <div key={loc.id}>
                 <div className="mb-2 flex items-center gap-1.5">
                   <MapPin className="h-3.5 w-3.5 text-amber-500/70" />
-                  <span className="text-xs font-semibold text-slate-400">
-                    {loc.name}
-                  </span>
-                  <span className="ml-1 text-[10px] text-slate-600">
-                    ({placed.length})
-                  </span>
+                  <span className="text-xs font-semibold text-slate-400">{loc.name}</span>
+                  <span className="ml-1 text-[10px] text-slate-600">({placed.length})</span>
                 </div>
 
                 {placed.length === 0 ? (
@@ -172,9 +160,7 @@ export function CluePlacementPanel({ themeId, theme }: CluePlacementPanelProps) 
                         className="group flex items-center gap-2 rounded-sm border border-slate-800 bg-slate-900 px-3 py-1.5"
                       >
                         <Package className="h-3 w-3 shrink-0 text-slate-600" />
-                        <span className="flex-1 truncate text-xs text-slate-300">
-                          {clue.name}
-                        </span>
+                        <span className="flex-1 truncate text-xs text-slate-300">{clue.name}</span>
                         <button
                           type="button"
                           aria-label={`${clue.name} 배치 해제`}

--- a/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
+++ b/apps/web/src/features/editor/components/design/EndingBranchRulesPanel.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from "react";
-import { AlertTriangle, CheckCircle2 } from "lucide-react";
-import { toast } from "sonner";
-import type { Node } from "@xyflow/react";
-import type { EditorCharacterResponse, EditorThemeResponse } from "@/features/editor/api";
-import { useUpdateConfigJson } from "@/features/editor/editorConfigApi";
-import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
+import { AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { toast } from 'sonner';
+import type { Node } from '@xyflow/react';
+import type { EditorCharacterResponse, EditorThemeResponse } from '@/features/editor/api';
+import { useUpdateConfigJson } from '@/features/editor/editorConfigApi';
+import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 import {
   createEndingBranchQuestion,
   readChoiceCondition,
@@ -13,16 +14,16 @@ import {
   writeEndingBranchConfig,
   type EndingBranchConfig,
   type EndingBranchQuestion,
-} from "../../entities/ending/endingBranchAdapter";
-import { EndingBranchOutcomeRules } from "./EndingBranchOutcomeRules";
-import { EndingBranchQuestionList } from "./EndingBranchQuestionList";
+} from '../../entities/ending/endingBranchAdapter';
+import { EndingBranchOutcomeRules } from './EndingBranchOutcomeRules';
+import { EndingBranchQuestionList } from './EndingBranchQuestionList';
 
 interface EndingBranchRulesPanelProps {
   themeId: string;
   theme: EditorThemeResponse;
   endingNodes: Node[];
   characters: EditorCharacterResponse[];
-  section: "questions" | "endings";
+  section: 'questions' | 'endings';
   selectedEndingId?: string;
   embedded?: boolean;
   settingsOnly?: boolean;
@@ -35,18 +36,21 @@ interface AutosaveBody {
 const ENDING_BRANCH_AUTOSAVE_MS = 1500;
 
 function reorderPriorities(config: EndingBranchConfig): EndingBranchConfig {
-  return { ...config, matrix: config.matrix.map((row, index) => ({ ...row, priority: index + 1 })) };
+  return {
+    ...config,
+    matrix: config.matrix.map((row, index) => ({ ...row, priority: index + 1 })),
+  };
 }
 
 function updateQuestionAt(
   config: EndingBranchConfig,
   questionId: string,
-  updater: (question: EndingBranchQuestion) => EndingBranchQuestion,
+  updater: (question: EndingBranchQuestion) => EndingBranchQuestion
 ): EndingBranchConfig {
   return {
     ...config,
     questions: config.questions.map((question) =>
-      question.id === questionId ? updater(question) : question,
+      question.id === questionId ? updater(question) : question
     ),
   };
 }
@@ -54,11 +58,13 @@ function updateQuestionAt(
 function hasDuplicateChoice(
   question: EndingBranchQuestion,
   choiceIndex: number,
-  value: string,
+  value: string
 ): boolean {
   const normalized = value.trim();
   if (!normalized) return false;
-  return question.choices.some((choice, index) => index !== choiceIndex && choice.trim() === normalized);
+  return question.choices.some(
+    (choice, index) => index !== choiceIndex && choice.trim() === normalized
+  );
 }
 
 function createUniqueChoiceLabel(question: EndingBranchQuestion): string {
@@ -75,7 +81,7 @@ function createUniqueChoiceLabel(question: EndingBranchQuestion): string {
 function updateChoiceValues(
   question: EndingBranchQuestion,
   choiceIndex: number,
-  value: string,
+  value: string
 ): string[] {
   if (hasDuplicateChoice(question, choiceIndex, value)) return question.choices;
   return question.choices.map((choice, index) => (index === choiceIndex ? value : choice));
@@ -83,7 +89,8 @@ function updateChoiceValues(
 
 function hasInvalidSpecificPlayerTarget(config: EndingBranchConfig): boolean {
   return config.questions.some(
-    (question) => question.target.type === "specific_players" && question.target.characterIds.length === 0,
+    (question) =>
+      question.target.type === 'specific_players' && question.target.characterIds.length === 0
   );
 }
 
@@ -91,18 +98,34 @@ function endingBranchConfigEqual(left: EndingBranchConfig, right: EndingBranchCo
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
-export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters, section, selectedEndingId, embedded = false, settingsOnly = false }: EndingBranchRulesPanelProps) {
+export function EndingBranchRulesPanel({
+  themeId,
+  theme,
+  endingNodes,
+  characters,
+  section,
+  selectedEndingId,
+  embedded = false,
+  settingsOnly = false,
+}: EndingBranchRulesPanelProps) {
   const panelRef = useRef<HTMLElement | null>(null);
   const updateConfig = useUpdateConfigJson(themeId);
-  const serverConfig = useMemo(() => readEndingBranchConfig(theme.config_json), [theme.config_json]);
+  const serverConfig = useMemo(
+    () => readEndingBranchConfig(theme.config_json),
+    [theme.config_json]
+  );
   const [draft, setDraft] = useState<EndingBranchConfig>(serverConfig);
   const [dirty, setDirty] = useState(false);
   const draftRef = useRef(draft);
-  const isQuestions = section === "questions";
-  const toastId = isQuestions ? "ending-questions-autosave" : "ending-rules-autosave";
-  const loadingMessage = isQuestions ? "질문 설정 자동저장 중..." : "결말 판정 규칙 자동저장 중...";
-  const successMessage = isQuestions ? "질문 설정이 자동저장되었습니다" : "결말 판정 규칙이 자동저장되었습니다";
-  const failureMessage = isQuestions ? "질문 설정 자동저장에 실패했습니다" : "결말 판정 규칙 자동저장에 실패했습니다";
+  const isQuestions = section === 'questions';
+  const toastId = isQuestions ? 'ending-questions-autosave' : 'ending-rules-autosave';
+  const loadingMessage = isQuestions ? '질문 설정 자동저장 중...' : '결말 판정 규칙 자동저장 중...';
+  const successMessage = isQuestions
+    ? '질문 설정이 자동저장되었습니다'
+    : '결말 판정 규칙이 자동저장되었습니다';
+  const failureMessage = isQuestions
+    ? '질문 설정 자동저장에 실패했습니다'
+    : '결말 판정 규칙 자동저장에 실패했습니다';
 
   useEffect(() => {
     if (dirty) return;
@@ -115,42 +138,48 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
   }, [draft]);
 
   const viewModel = useMemo(
-    () => toEndingBranchEditorViewModel(writeEndingBranchConfig(theme.config_json, draft), endingNodes),
-    [draft, endingNodes, theme.config_json],
+    () =>
+      toEndingBranchEditorViewModel(writeEndingBranchConfig(theme.config_json, draft), endingNodes),
+    [draft, endingNodes, theme.config_json]
   );
-  const branchQuestions = draft.questions.filter((question) => question.impact === "branch");
-  const canAddRule = endingNodes.length > 0 && (
-    branchQuestions.some((question) => question.choices.length > 0) ||
-    characters.length > 0
+  const branchQuestions = draft.questions.filter((question) => question.impact === 'branch');
+  const canAddRule =
+    endingNodes.length > 0 &&
+    (branchQuestions.some((question) => question.choices.length > 0) || characters.length > 0);
+
+  const saveBody = useCallback(
+    (body: AutosaveBody, opts?: { onError?: (error?: unknown) => void }) => {
+      const submittedDraft = body.draft;
+      toast.loading(loadingMessage, { id: toastId });
+      updateConfig.mutate(
+        { ...writeEndingBranchConfig(theme.config_json, submittedDraft), version: theme.version },
+        {
+          onSuccess: () => {
+            if (draftRef.current === submittedDraft) {
+              setDirty(false);
+            }
+            toast.success(successMessage, { id: toastId, duration: 1200 });
+          },
+          onError: opts?.onError,
+        }
+      );
+    },
+    [loadingMessage, successMessage, theme.config_json, theme.version, toastId, updateConfig]
   );
 
-  const saveBody = useCallback((body: AutosaveBody, opts?: { onError?: (error?: unknown) => void }) => {
-    const submittedDraft = body.draft;
-    toast.loading(loadingMessage, { id: toastId });
-    updateConfig.mutate(
-      { ...writeEndingBranchConfig(theme.config_json, submittedDraft), version: theme.version },
-      {
-        onSuccess: () => {
-          if (draftRef.current === submittedDraft) {
-            setDirty(false);
-          }
-          toast.success(successMessage, { id: toastId, duration: 1200 });
+  const showFailureToast = useCallback(
+    (body: AutosaveBody, error?: unknown) => {
+      showUnknownErrorToast(error, failureMessage, {
+        id: toastId,
+        action: {
+          label: '재시도',
+          onClick: () =>
+            saveBody(body, { onError: (retryError) => showFailureToast(body, retryError) }),
         },
-        onError: opts?.onError,
-      },
-    );
-  }, [loadingMessage, successMessage, theme.config_json, theme.version, toastId, updateConfig]);
-
-  const showFailureToast = useCallback((body: AutosaveBody) => {
-    toast.error(failureMessage, {
-      id: toastId,
-      duration: 6000,
-      action: {
-        label: "재시도",
-        onClick: () => saveBody(body, { onError: () => showFailureToast(body) }),
-      },
-    });
-  }, [failureMessage, saveBody, toastId]);
+      });
+    },
+    [failureMessage, saveBody, toastId]
+  );
 
   const { schedule, flush, cancel } = useDebouncedMutation<AutosaveBody>({
     debounceMs: ENDING_BRANCH_AUTOSAVE_MS,
@@ -158,104 +187,143 @@ export function EndingBranchRulesPanel({ themeId, theme, endingNodes, characters
       saveBody(body, {
         onError: (error) => {
           opts.onError(error);
-          showFailureToast(body);
+          showFailureToast(body, error);
         },
       });
     },
   });
 
-  const applyDraft = useCallback((next: EndingBranchConfig) => {
-    setDraft(next);
-    draftRef.current = next;
-    if (endingBranchConfigEqual(next, serverConfig)) {
-      setDirty(false);
-      cancel();
-      return;
-    }
-    setDirty(true);
-    if (hasInvalidSpecificPlayerTarget(next)) {
-      cancel();
-      toast.error("특정 플레이어 질문은 받을 캐릭터를 1명 이상 선택해야 합니다");
-      return;
-    }
-    schedule({ draft: next });
-  }, [cancel, schedule, serverConfig]);
+  const applyDraft = useCallback(
+    (next: EndingBranchConfig) => {
+      setDraft(next);
+      draftRef.current = next;
+      if (endingBranchConfigEqual(next, serverConfig)) {
+        setDirty(false);
+        cancel();
+        return;
+      }
+      setDirty(true);
+      if (hasInvalidSpecificPlayerTarget(next)) {
+        cancel();
+        toast.error('특정 플레이어 질문은 받을 캐릭터를 1명 이상 선택해야 합니다');
+        return;
+      }
+      schedule({ draft: next });
+    },
+    [cancel, schedule, serverConfig]
+  );
 
-  const handlePanelBlur = useCallback((event: FocusEvent<HTMLElement>) => {
-    const nextTarget = event.relatedTarget;
-    if (nextTarget instanceof Node && panelRef.current?.contains(nextTarget)) return;
-    flush();
-  }, [flush]);
+  const handlePanelBlur = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      const nextTarget = event.relatedTarget;
+      if (nextTarget instanceof Node && panelRef.current?.contains(nextTarget)) return;
+      flush();
+    },
+    [flush]
+  );
 
   const handleRemoveQuestion = (questionId: string) => {
-    applyDraft(reorderPriorities({
-      ...draft,
-      questions: draft.questions.filter((question) => question.id !== questionId),
-      matrix: draft.matrix.filter((row) => readChoiceCondition(row.condition)?.questionId !== questionId),
-    }));
+    applyDraft(
+      reorderPriorities({
+        ...draft,
+        questions: draft.questions.filter((question) => question.id !== questionId),
+        matrix: draft.matrix.filter(
+          (row) => readChoiceCondition(row.condition)?.questionId !== questionId
+        ),
+      })
+    );
   };
 
   const handleChoiceChange = (questionId: string, choiceIndex: number, value: string) => {
-    applyDraft(updateQuestionAt(draft, questionId, (question) => {
-      const choices = updateChoiceValues(question, choiceIndex, value);
-      return {
-        ...question,
-        choices,
-        scoreMap: question.scoreMap
-          ? Object.fromEntries(choices.map((choice, index) => [choice, question.scoreMap?.[question.choices[index]] ?? 0]))
-          : undefined,
-      };
-    }));
+    applyDraft(
+      updateQuestionAt(draft, questionId, (question) => {
+        const choices = updateChoiceValues(question, choiceIndex, value);
+        return {
+          ...question,
+          choices,
+          scoreMap: question.scoreMap
+            ? Object.fromEntries(
+                choices.map((choice, index) => [
+                  choice,
+                  question.scoreMap?.[question.choices[index]] ?? 0,
+                ])
+              )
+            : undefined,
+        };
+      })
+    );
   };
 
   const handleRemoveChoice = (questionId: string, choice: string) => {
-    applyDraft(reorderPriorities({
-      ...updateQuestionAt(draft, questionId, (question) => ({
-        ...question,
-        choices: question.choices.filter((item) => item !== choice),
-        scoreMap: question.scoreMap
-          ? Object.fromEntries(Object.entries(question.scoreMap).filter(([key]) => key !== choice))
-          : undefined,
-      })),
-      matrix: draft.matrix.filter((row) => {
-        const parsed = readChoiceCondition(row.condition);
-        return !(parsed?.questionId === questionId && parsed.choice === choice);
-      }),
-    }));
+    applyDraft(
+      reorderPriorities({
+        ...updateQuestionAt(draft, questionId, (question) => ({
+          ...question,
+          choices: question.choices.filter((item) => item !== choice),
+          scoreMap: question.scoreMap
+            ? Object.fromEntries(
+                Object.entries(question.scoreMap).filter(([key]) => key !== choice)
+              )
+            : undefined,
+        })),
+        matrix: draft.matrix.filter((row) => {
+          const parsed = readChoiceCondition(row.condition);
+          return !(parsed?.questionId === questionId && parsed.choice === choice);
+        }),
+      })
+    );
   };
 
   return (
     <section
       ref={panelRef}
-      className={embedded ? "text-sm text-slate-300" : "rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300"}
-      aria-label={section === "questions" ? "질문 관리" : "결말 판정 규칙"}
+      className={
+        embedded
+          ? 'text-sm text-slate-300'
+          : 'rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300'
+      }
+      aria-label={section === 'questions' ? '질문 관리' : '결말 판정 규칙'}
       onBlur={handlePanelBlur}
     >
       <Header section={section} embedded={embedded} settingsOnly={settingsOnly} />
       <Warnings warnings={viewModel.warnings} />
       <div className="mt-5">
-        {section === "questions" ? (
-        <EndingBranchQuestionList
-          questions={draft.questions}
-          characters={characters}
-          onAddQuestion={() => applyDraft({ ...draft, questions: [...draft.questions, createEndingBranchQuestion(draft.questions.length)] })}
-          onRemoveQuestion={handleRemoveQuestion}
-          onChangeQuestion={(questionId, updater) => applyDraft(updateQuestionAt(draft, questionId, updater))}
-          onChangeChoice={handleChoiceChange}
-          onAddChoice={(questionId) => applyDraft(updateQuestionAt(draft, questionId, (question) => ({ ...question, choices: [...question.choices, createUniqueChoiceLabel(question)] })))}
-          onRemoveChoice={handleRemoveChoice}
-        />
+        {section === 'questions' ? (
+          <EndingBranchQuestionList
+            questions={draft.questions}
+            characters={characters}
+            onAddQuestion={() =>
+              applyDraft({
+                ...draft,
+                questions: [...draft.questions, createEndingBranchQuestion(draft.questions.length)],
+              })
+            }
+            onRemoveQuestion={handleRemoveQuestion}
+            onChangeQuestion={(questionId, updater) =>
+              applyDraft(updateQuestionAt(draft, questionId, updater))
+            }
+            onChangeChoice={handleChoiceChange}
+            onAddChoice={(questionId) =>
+              applyDraft(
+                updateQuestionAt(draft, questionId, (question) => ({
+                  ...question,
+                  choices: [...question.choices, createUniqueChoiceLabel(question)],
+                }))
+              )
+            }
+            onRemoveChoice={handleRemoveChoice}
+          />
         ) : (
-        <EndingBranchOutcomeRules
-          draft={draft}
-          endingNodes={endingNodes}
-          branchQuestions={branchQuestions}
-          characters={characters}
-          canAddRule={canAddRule}
-          selectedEndingId={selectedEndingId}
-          display={settingsOnly ? "settings" : selectedEndingId ? "rules" : "all"}
-          onChange={applyDraft}
-        />
+          <EndingBranchOutcomeRules
+            draft={draft}
+            endingNodes={endingNodes}
+            branchQuestions={branchQuestions}
+            characters={characters}
+            canAddRule={canAddRule}
+            selectedEndingId={selectedEndingId}
+            display={settingsOnly ? 'settings' : selectedEndingId ? 'rules' : 'all'}
+            onChange={applyDraft}
+          />
         )}
       </div>
     </section>
@@ -267,26 +335,34 @@ function Header({
   embedded,
   settingsOnly,
 }: {
-  section: "questions" | "endings";
+  section: 'questions' | 'endings';
   embedded: boolean;
   settingsOnly: boolean;
 }) {
-  const isQuestions = section === "questions";
+  const isQuestions = section === 'questions';
   return (
     <div>
       <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-400">Ending Rules</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-400">
+          Ending Rules
+        </p>
         <h3 className="mt-1 text-lg font-semibold text-slate-100">
-          {isQuestions ? "질문 관리" : settingsOnly ? "결말 판정 설정" : embedded ? "이 결말로 가는 조건" : "결말 판정 규칙"}
+          {isQuestions
+            ? '질문 관리'
+            : settingsOnly
+              ? '결말 판정 설정'
+              : embedded
+                ? '이 결말로 가는 조건'
+                : '결말 판정 규칙'}
         </h3>
         <p className="mt-1 text-sm leading-6 text-slate-400">
           {isQuestions
-            ? "플레이어에게 진행할 최종 질문과 선택지를 설정합니다."
+            ? '플레이어에게 진행할 최종 질문과 선택지를 설정합니다.'
             : settingsOnly
-              ? "규칙에 맞는 결말이 없을 때 보여줄 기본 결말과 복수 선택 기준을 설정합니다."
+              ? '규칙에 맞는 결말이 없을 때 보여줄 기본 결말과 복수 선택 기준을 설정합니다.'
               : embedded
-              ? "조건 그룹 중 하나라도 만족하면 이 결말이 플레이어에게 공개됩니다."
-              : "질문 답변이 어떤 결말로 이어지는지 설정합니다. 내부 판정식은 자동으로 만들어집니다."}
+                ? '조건 그룹 중 하나라도 만족하면 이 결말이 플레이어에게 공개됩니다.'
+                : '질문 답변이 어떤 결말로 이어지는지 설정합니다. 내부 판정식은 자동으로 만들어집니다.'}
         </p>
       </div>
     </div>
@@ -309,7 +385,9 @@ function Warnings({ warnings }: { warnings: string[] }) {
         <div>
           <p className="font-medium">저장 전 확인할 점</p>
           <ul className="mt-1 list-disc space-y-1 pl-4 text-xs leading-5">
-            {warnings.map((warning) => <li key={warning}>{warning}</li>)}
+            {warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
           </ul>
         </div>
       </div>

--- a/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationAccessPolicyPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/features/editor/entities/location/locationEntityAdapter';
 import { useEditorCharacters, useUpdateLocation } from '@/features/editor/api';
 import { getDisplayErrorMessage } from '@/lib/display-error';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 interface LocationAccessPolicyPanelProps {
   themeId: string;
@@ -41,7 +42,7 @@ export function LocationAccessPolicyPanel({ themeId, location }: LocationAccessP
           hide_scene_id: location.hide_scene_id ?? null,
         },
       },
-      { onError: () => toast.error('접근 제한 저장에 실패했습니다') }
+      { onError: (error) => showUnknownErrorToast(error, '접근 제한 저장에 실패했습니다') }
     );
   }
 

--- a/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationClueAssignPanel.tsx
@@ -24,6 +24,7 @@ import {
   type InvestigationCostDraft,
 } from '@/features/editor/entities/deckInvestigation/locationClueInvestigationCost';
 import { getLocationPathLabel } from '@/features/editor/entities/location/locationHierarchy';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 import { ClueSearchMultiSelect, type ClueSearchSelectItem } from './ClueSearchMultiSelect';
 import { LocationSelectedClueItem } from './LocationSelectedClueItem';
 
@@ -93,7 +94,8 @@ export function LocationClueAssignPanel({
   const assignedSet = useMemo(() => new Set(assignedIds), [assignedIds]);
   const clueById = useMemo(() => new Map(clues.map((clue) => [clue.id, clue])), [clues]);
   const selectedClues = clues.filter((clue) => assignedSet.has(clue.id));
-  const activeClue = selectedClues.find((clue) => clue.id === activeClueId) ?? selectedClues[0] ?? null;
+  const activeClue =
+    selectedClues.find((clue) => clue.id === activeClueId) ?? selectedClues[0] ?? null;
   const clueSearchItems = useMemo(() => clues.map(toClueSearchItem), [clues]);
   const locationPathLabel = useMemo(
     () => getLocationPathLabel(location, allLocations ?? [location]),
@@ -101,14 +103,16 @@ export function LocationClueAssignPanel({
   );
 
   function readLatestConfigJson() {
-    return queryClient.getQueryData<EditorThemeResponse>(editorKeys.theme(themeId))?.config_json
-      ?? theme.config_json;
+    return (
+      queryClient.getQueryData<EditorThemeResponse>(editorKeys.theme(themeId))?.config_json ??
+      theme.config_json
+    );
   }
 
   function commit(
     next: LocationDiscoveryConfig[],
     deckDraft?: typeof investigationDraft,
-    baseConfig = theme.config_json,
+    baseConfig = theme.config_json
   ) {
     const locationConfig = writeLocationDiscoveries(baseConfig, location.id, next);
     const nextConfig = deckDraft
@@ -127,9 +131,9 @@ export function LocationClueAssignPanel({
         toast.success('단서 조사가 저장되었습니다');
         onChange?.(nextIds);
       },
-      onError: () => {
+      onError: (error) => {
         if (previous) queryClient.setQueryData(cacheKey, previous);
-        toast.error('단서 조사 저장에 실패했습니다');
+        showUnknownErrorToast(error, '단서 조사 저장에 실패했습니다');
       },
     });
   }
@@ -263,7 +267,9 @@ export function LocationClueAssignPanel({
     >
       <header className="mb-3 flex flex-wrap items-center gap-2">
         <MapPin className="h-3.5 w-3.5 text-[var(--mmp-editor-color-primary)]" />
-        <h4 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">{locationPathLabel} 단서 조사</h4>
+        <h4 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">
+          {locationPathLabel} 단서 조사
+        </h4>
         <span className="text-xs text-[var(--mmp-editor-color-steel)]">
           ({assignedIds.length}/{clues.length})
         </span>

--- a/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/LocationDetailPanel.tsx
@@ -22,6 +22,7 @@ import { LocationHierarchyList } from './LocationHierarchyList';
 import { LocationImageMediaField } from './LocationImageMediaField';
 import { LocationStructurePanel } from './LocationStructurePanel';
 import { useEditorAutosaveToast } from '@/features/editor/hooks/useEditorAutosaveToast';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 interface LocationDetailPanelProps {
   themeId: string;
@@ -62,8 +63,7 @@ export function LocationDetailPanel({
   onSelectLocation,
   onDeleteLocation,
 }: LocationDetailPanelProps) {
-  const [pendingDeleteLocation, setPendingDeleteLocation] =
-    useState<LocationResponse | null>(null);
+  const [pendingDeleteLocation, setPendingDeleteLocation] = useState<LocationResponse | null>(null);
   const updateLocation = useUpdateLocation(themeId);
 
   if (!selectedMap) return <LocationEmptyState message="좌측에서 맵을 선택하세요" />;
@@ -106,7 +106,7 @@ export function LocationDetailPanel({
       },
       {
         onSuccess: () => toast.success('장소 위치가 저장되었습니다'),
-        onError: () => toast.error('장소 위치 저장에 실패했습니다'),
+        onError: (error) => showUnknownErrorToast(error, '장소 위치 저장에 실패했습니다'),
       }
     );
   }
@@ -259,17 +259,16 @@ function SelectedLocationDetail({
         onError: (error) => {
           options.onError?.(error);
           if (!options.suppressErrorToast) {
-            toast.error(options.onErrorMessage ?? '장소 저장에 실패했습니다');
+            showUnknownErrorToast(error, options.onErrorMessage ?? '장소 저장에 실패했습니다');
           }
         },
       }
     );
   }
 
-  const {
-    schedule: scheduleBasicInfoSave,
-    cancel: cancelBasicInfoSave,
-  } = useEditorAutosaveToast<Partial<LocationResponse>>({
+  const { schedule: scheduleBasicInfoSave, cancel: cancelBasicInfoSave } = useEditorAutosaveToast<
+    Partial<LocationResponse>
+  >({
     debounceMs: 1000,
     messages: {
       toastId: `location-basic-autosave-${location.id}`,
@@ -355,7 +354,7 @@ function SelectedLocationDetail({
     );
     updateConfig.mutate(nextConfig, {
       onSuccess: () => toast.success('장소 단서 순서가 저장되었습니다'),
-      onError: () => toast.error('장소 단서 순서 저장에 실패했습니다'),
+      onError: (error) => showUnknownErrorToast(error, '장소 단서 순서 저장에 실패했습니다'),
     });
   }
 
@@ -368,9 +367,7 @@ function SelectedLocationDetail({
               장소 상세
             </p>
             <h3 className="mt-1 text-xl font-semibold text-slate-100">{viewModel.name}</h3>
-            <p className="mt-1 text-xs text-slate-500">
-              소속 맵: {map.name}
-            </p>
+            <p className="mt-1 text-xs text-slate-500">소속 맵: {map.name}</p>
             <p className="mt-1 text-xs text-slate-400">{viewModel.roundLabel}</p>
           </div>
           <div className="rounded-lg border border-slate-800 bg-slate-900/80 px-3 py-2 text-xs text-slate-400">
@@ -595,8 +592,12 @@ function LocationInvestigationStructurePanel({
 
   function moveDiscovery(sourceClueId: string, targetClueId: string) {
     if (sourceClueId === targetClueId || isSaving) return;
-    const sourceIndex = sortedDiscoveries.findIndex((discovery) => discovery.clueId === sourceClueId);
-    const targetIndex = sortedDiscoveries.findIndex((discovery) => discovery.clueId === targetClueId);
+    const sourceIndex = sortedDiscoveries.findIndex(
+      (discovery) => discovery.clueId === sourceClueId
+    );
+    const targetIndex = sortedDiscoveries.findIndex(
+      (discovery) => discovery.clueId === targetClueId
+    );
     if (sourceIndex < 0 || targetIndex < 0) return;
     const next = [...sortedDiscoveries];
     const [moved] = next.splice(sourceIndex, 1);
@@ -677,8 +678,8 @@ function LocationInvestigationStructurePanel({
         </ol>
       ) : (
         <p className="rounded-md border border-dashed border-slate-800 px-3 py-4 text-xs leading-5 text-slate-500">
-          아직 배치된 단서가 없습니다. 아래 단서 배치에서 단서를 추가하면 이 장소에서
-          획득할 수 있습니다.
+          아직 배치된 단서가 없습니다. 아래 단서 배치에서 단서를 추가하면 이 장소에서 획득할 수
+          있습니다.
         </p>
       )}
     </section>

--- a/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/LocationsSubTab.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/features/editor/api';
 import { useFlowGraph } from '@/features/editor/flowApi';
 import { buildProgressNodeRevealOptions } from '@/features/editor/entities/reveal/revealTimingOptions';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 import { AddNameInput } from './AddNameInput';
 import { LocationDetailPanel } from './LocationDetailPanel';
 
@@ -73,7 +74,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           setSelectedMapId(newMap.id);
           setSelectedLocationId(null);
         },
-        onError: () => toast.error('맵 추가에 실패했습니다'),
+        onError: (error) => showUnknownErrorToast(error, '맵 추가에 실패했습니다'),
       }
     );
   }
@@ -87,7 +88,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           setSelectedLocationId(null);
         }
       },
-      onError: () => toast.error('맵 삭제에 실패했습니다'),
+      onError: (error) => showUnknownErrorToast(error, '맵 삭제에 실패했습니다'),
     });
   }
 
@@ -101,7 +102,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
           setAddingLocationParentId(null);
           setSelectedLocationId(newLocation.id);
         },
-        onError: () => toast.error('장소 추가에 실패했습니다'),
+        onError: (error) => showUnknownErrorToast(error, '장소 추가에 실패했습니다'),
       }
     );
   }
@@ -112,7 +113,7 @@ export function LocationsSubTab({ themeId, theme }: LocationsSubTabProps) {
         toast.success('장소가 삭제되었습니다');
         if (selectedLocationId === locationId) setSelectedLocationId(null);
       },
-      onError: () => toast.error('장소 삭제에 실패했습니다'),
+      onError: (error) => showUnknownErrorToast(error, '장소 삭제에 실패했습니다'),
     });
   }
 

--- a/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
+++ b/apps/web/src/features/editor/components/design/ModulesSubTab.tsx
@@ -29,6 +29,7 @@ import {
   type LocationInvestigationMode,
   type PlayerKillConfig,
 } from '@/features/editor/utils/configShape';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -68,7 +69,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
       nextConfig: Record<string, unknown>,
       successMsg: string,
       errorMsg: string,
-      onRollback?: () => void,
+      onRollback?: () => void
     ) => {
       if (updateConfig.isPending) {
         return;
@@ -83,13 +84,13 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
             setConflictBannerDismissed(false);
             toast.success(successMsg);
           },
-          onError: () => {
+          onError: (error) => {
             if (conflictRef.current) {
               setConflictDraft(nextConfig);
               setConflictBannerDismissed(false);
             } else {
               onRollback?.();
-              toast.error(errorMsg);
+              showUnknownErrorToast(error, errorMsg);
             }
           },
         }
@@ -154,7 +155,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
           writeModuleEnabled(activeConfig, moduleId, enabled),
           '모듈 설정이 저장되었습니다',
           '모듈 설정 저장에 실패했습니다',
-          () => setSelectedModules(prev),
+          () => setSelectedModules(prev)
         );
 
         return next;
@@ -191,10 +192,7 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
   );
 
   const handleLocationInvestigationChange = useCallback(
-    (settings: {
-      investigationMode: LocationInvestigationMode;
-      deckOrder: LocationDeckOrder;
-    }) => {
+    (settings: { investigationMode: LocationInvestigationMode; deckOrder: LocationDeckOrder }) => {
       if (updateConfig.isPending) {
         return;
       }
@@ -331,14 +329,14 @@ export function ModulesSubTab({ themeId, theme }: ModulesSubTabProps) {
                       mod.id !== LOCATION_MODULE_ID &&
                       mod.id !== PLAYER_KILL_MODULE_ID &&
                       schema && (
-                      <div className="border-t border-slate-700 px-3 py-3">
-                        <SchemaDrivenForm
-                          schema={schema}
-                          values={moduleConfigs[mod.id] ?? {}}
-                          onChange={(path, value) => handleConfigChange(mod.id, path, value)}
-                        />
-                      </div>
-                    )}
+                        <div className="border-t border-slate-700 px-3 py-3">
+                          <SchemaDrivenForm
+                            schema={schema}
+                            values={moduleConfigs[mod.id] ?? {}}
+                            onChange={(path, value) => handleConfigChange(mod.id, path, value)}
+                          />
+                        </div>
+                      )}
                   </div>
                 );
               })}
@@ -359,7 +357,11 @@ function PlayerKillSettingsPanel({
   isSaving: boolean;
   onChange: (settings: PlayerKillConfig) => void;
 }) {
-  const modes: Array<{ value: PlayerKillConfig['killResolutionMode']; label: string; description: string }> = [
+  const modes: Array<{
+    value: PlayerKillConfig['killResolutionMode'];
+    label: string;
+    description: string;
+  }> = [
     {
       value: 'all_weapons_vs_all_armor',
       label: '무기 모두 vs 방어구 모두',
@@ -418,9 +420,7 @@ function PlayerKillSettingsPanel({
           aria-label="살해시 마이크 끔"
           checked={settings.muteOnKilled}
           disabled={isSaving}
-          onChange={(event) =>
-            onChange({ ...settings, muteOnKilled: event.currentTarget.checked })
-          }
+          onChange={(event) => onChange({ ...settings, muteOnKilled: event.currentTarget.checked })}
           className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-amber-500 focus:ring-amber-500"
         />
         <span>

--- a/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
+++ b/apps/web/src/features/editor/components/design/PhaseNodePanel.tsx
@@ -1,37 +1,34 @@
-import { useCallback, type ReactNode } from "react";
-import type { Edge, Node } from "@xyflow/react";
-import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { useEditorMaps } from "../../editorMapApi";
-import { useUpdateConfigJson } from "../../editorConfigApi";
-import { useUpdateFlowNode } from "../../flowApi";
-import type { EditorThemeResponse } from "../../api";
-import { editorKeys } from "../../api";
-import type {
-  FlowGraphResponse,
-  FlowNodeData,
-  PhaseAction,
-} from "../../flowTypes";
-import { flowKeys } from "../../flowTypes";
-import { useEditorAutosaveToast } from "@/features/editor/hooks/useEditorAutosaveToast";
-import { ActionListEditor, hasIncompletePresentationCueActions } from "./ActionListEditor";
-import { PhasePanelBasicInfo } from "./PhasePanelBasicInfo";
-import { normalizePhaseType } from "./phaseTypeOptions";
-import { InvestigationPhasePanel } from "./InvestigationPhasePanel";
-import { DiscussionPhasePanel } from "./DiscussionPhasePanel";
-import { VotingQuestionPhasePanel } from "./VotingQuestionPhasePanel";
-import { ReadingPhasePanel } from "./ReadingPhasePanel";
+import { useCallback, type ReactNode } from 'react';
+import type { Edge, Node } from '@xyflow/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useEditorMaps } from '../../editorMapApi';
+import { useUpdateConfigJson } from '../../editorConfigApi';
+import { useUpdateFlowNode } from '../../flowApi';
+import type { EditorThemeResponse } from '../../api';
+import { editorKeys } from '../../api';
+import type { FlowGraphResponse, FlowNodeData, PhaseAction } from '../../flowTypes';
+import { flowKeys } from '../../flowTypes';
+import { useEditorAutosaveToast } from '@/features/editor/hooks/useEditorAutosaveToast';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
+import { ActionListEditor, hasIncompletePresentationCueActions } from './ActionListEditor';
+import { PhasePanelBasicInfo } from './PhasePanelBasicInfo';
+import { normalizePhaseType } from './phaseTypeOptions';
+import { InvestigationPhasePanel } from './InvestigationPhasePanel';
+import { DiscussionPhasePanel } from './DiscussionPhasePanel';
+import { VotingQuestionPhasePanel } from './VotingQuestionPhasePanel';
+import { ReadingPhasePanel } from './ReadingPhasePanel';
 import {
   PLAYER_KILL_MODULE_ID,
   readEnabledModuleIds,
   readPlayerKillConfig,
   writePlayerKillSceneEnabled,
-} from "../../utils/configShape";
+} from '../../utils/configShape';
 import {
   createSceneActionDefaultParams,
   getSceneActionOptions,
-} from "../../entities/sceneAction/sceneActionRegistry";
-import { readDeckInvestigationConfig } from "../../entities/deckInvestigation/deckInvestigationAdapter";
+} from '../../entities/sceneAction/sceneActionRegistry';
+import { readDeckInvestigationConfig } from '../../entities/deckInvestigation/deckInvestigationAdapter';
 
 interface PhaseNodePanelProps {
   node: Node;
@@ -47,12 +44,7 @@ const toastWithLoading = toast as typeof toast & {
   loading?: (message: string, options?: Record<string, unknown>) => void;
 };
 
-export function PhaseNodePanel({
-  node,
-  themeId,
-  onUpdate,
-  headerActions,
-}: PhaseNodePanelProps) {
+export function PhaseNodePanel({ node, themeId, onUpdate, headerActions }: PhaseNodePanelProps) {
   const updateNode = useUpdateFlowNode(themeId);
   const updateConfig = useUpdateConfigJson(themeId);
   const { data: maps = [], isLoading: mapsLoading } = useEditorMaps(themeId);
@@ -70,7 +62,7 @@ export function PhaseNodePanel({
     (type: string) => {
       const params = createSceneActionDefaultParams(type);
       if (
-        (type === "GRANT_INVESTIGATION_TOKEN" || type === "RESET_INVESTIGATION_TOKEN") &&
+        (type === 'GRANT_INVESTIGATION_TOKEN' || type === 'RESET_INVESTIGATION_TOKEN') &&
         params &&
         !params.tokenId &&
         investigationTokens[0]?.id
@@ -79,22 +71,21 @@ export function PhaseNodePanel({
       }
       return params;
     },
-    [investigationTokens],
+    [investigationTokens]
   );
   const playerKillConfig = readPlayerKillConfig(configJson);
   const sceneKillEnabled = playerKillConfig.allowedSceneIds.includes(node.id);
-  const isPhaseSceneNode = node.type === "phase";
+  const isPhaseSceneNode = node.type === 'phase';
 
   const debouncer = useEditorAutosaveToast<FlowNodeData>({
     debounceMs: SAVE_DEBOUNCE_MS,
     messages: {
       toastId: `phase-node-autosave-${node.id}`,
-      loading: "장면 설정을 저장 중입니다",
-      success: "장면 설정이 저장되었습니다",
-      error: "저장에 실패했습니다",
+      loading: '장면 설정을 저장 중입니다',
+      success: '장면 설정이 저장되었습니다',
+      error: '저장에 실패했습니다',
     },
-    mutate: (body, opts) =>
-      updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
+    mutate: (body, opts) => updateNode.mutate({ nodeId: node.id, body: { data: body } }, opts),
     applyOptimistic: (body) => {
       const cacheKey = flowKeys.graph(themeId);
       const previous = queryClient.getQueryData<FlowGraphResponse>(cacheKey);
@@ -102,7 +93,7 @@ export function PhaseNodePanel({
       queryClient.setQueryData<FlowGraphResponse>(cacheKey, {
         ...previous,
         nodes: previous.nodes.map((n) =>
-          n.id === node.id ? { ...n, data: { ...n.data, ...body } } : n,
+          n.id === node.id ? { ...n, data: { ...n.data, ...body } } : n
         ),
       });
       return () => queryClient.setQueryData(cacheKey, previous);
@@ -114,45 +105,37 @@ export function PhaseNodePanel({
     onUpdate(node.id, patch);
     const nextData = { ...data, ...patch };
     if (hasIncompleteActionPatch(nextData)) return;
-    debouncer.schedule(
-      nextData,
-      (prev) => ({ ...data, ...(prev ?? {}), ...patch }),
-    );
+    debouncer.schedule(nextData, (prev) => ({ ...data, ...(prev ?? {}), ...patch }));
   };
 
   const handleSceneKillToggle = (enabled: boolean) => {
     if (!theme || updateConfig.isPending || !isPhaseSceneNode) return;
     const nextConfig = writePlayerKillSceneEnabled(configJson, node.id, enabled);
-    toastWithLoading.loading?.("장면 설정을 저장 중입니다", {
+    toastWithLoading.loading?.('장면 설정을 저장 중입니다', {
       id: `phase-kill-autosave-${node.id}`,
     });
     updateConfig.mutate(
       { ...nextConfig, version: theme.version },
       {
         onSuccess: () =>
-          toast.success("장면 설정이 저장되었습니다", {
+          toast.success('장면 설정이 저장되었습니다', {
             id: `phase-kill-autosave-${node.id}`,
             duration: 1200,
           }),
-        onError: () =>
-          toast.error("장면 설정 저장에 실패했습니다", {
+        onError: (error) =>
+          showUnknownErrorToast(error, '장면 설정 저장에 실패했습니다', {
             id: `phase-kill-autosave-${node.id}`,
-            duration: 6000,
           }),
-      },
+      }
     );
   };
 
   return (
     <div className="flex flex-col gap-3 p-4">
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-          장면 설정
-        </h3>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">장면 설정</h3>
         {headerActions ? (
-          <div className="flex shrink-0 items-center gap-1.5">
-            {headerActions}
-          </div>
+          <div className="flex shrink-0 items-center gap-1.5">{headerActions}</div>
         ) : null}
       </div>
 
@@ -214,7 +197,7 @@ export function PhaseNodePanel({
           />
         </section>
       ) : null}
-      {phaseType === "investigation" ? (
+      {phaseType === 'investigation' ? (
         <>
           <InvestigationMapField
             mapId={data.investigationMapId}
@@ -230,7 +213,7 @@ export function PhaseNodePanel({
           />
         </>
       ) : null}
-      {phaseType === "discussion" ? (
+      {phaseType === 'discussion' ? (
         <DiscussionPhasePanel
           duration={data.duration}
           policy={data.discussionRoomPolicy}
@@ -238,14 +221,14 @@ export function PhaseNodePanel({
           onFlush={flush}
         />
       ) : null}
-      {phaseType === "voting" ? (
+      {phaseType === 'voting' ? (
         <VotingQuestionPhasePanel
           duration={data.duration}
           onChange={handleChange}
           onFlush={flush}
         />
       ) : null}
-      {phaseType === "story_progression" ? (
+      {phaseType === 'story_progression' ? (
         <ReadingPhasePanel
           key={node.id}
           themeId={themeId}
@@ -277,18 +260,14 @@ function InvestigationMapField({
     <label className="flex flex-col gap-1">
       <span className="text-[11px] text-slate-400">사용할 맵</span>
       <select
-        value={mapId ?? ""}
+        value={mapId ?? ''}
         disabled={isLoading}
         aria-label="사용할 맵"
-        onChange={(event) =>
-          onChange({ investigationMapId: event.target.value || undefined })
-        }
+        onChange={(event) => onChange({ investigationMapId: event.target.value || undefined })}
         onBlur={onFlush}
         className="rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-200 focus:border-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-60"
       >
-        <option value="">
-          {maps.length === 0 ? "등록된 맵 없음" : "맵 선택"}
-        </option>
+        <option value="">{maps.length === 0 ? '등록된 맵 없음' : '맵 선택'}</option>
         {maps.map((map) => (
           <option key={map.id} value={map.id}>
             {map.name}

--- a/apps/web/src/features/editor/components/design/useRoleSheetEditorState.ts
+++ b/apps/web/src/features/editor/components/design/useRoleSheetEditorState.ts
@@ -7,6 +7,7 @@ import {
 } from '@/features/editor/api';
 import type { MediaResponse } from '@/features/editor/mediaApi';
 import { isApiHttpError } from '@/lib/api-error';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 type EditableRoleSheetFormat = 'markdown' | 'pdf' | 'images';
 type ResolvedRoleSheetFormat = EditableRoleSheetFormat | null;
@@ -23,21 +24,29 @@ interface UseRoleSheetEditorStateParams {
   characterName: string;
 }
 
-export function useRoleSheetEditorState({
-  characterId,
-}: UseRoleSheetEditorStateParams) {
+export function useRoleSheetEditorState({ characterId }: UseRoleSheetEditorStateParams) {
   const roleSheetQuery = useCharacterRoleSheet(characterId);
   const upsertContent = useUpsertCharacterRoleSheet(characterId);
   const [selectedFormat, setSelectedFormat] = useState<EditableRoleSheetFormat>('markdown');
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const [page, setPage] = useState(1);
 
-  const sync = useRoleSheetSync({ roleSheet: roleSheetQuery.data, roleSheetError: roleSheetQuery.error });
+  const sync = useRoleSheetSync({
+    roleSheet: roleSheetQuery.data,
+    roleSheetError: roleSheetQuery.error,
+  });
   const [draft, setDraft] = useState(sync.originalBody);
   const [imagePages, setImagePages] = useState<ImageRoleSheetPageDraft[]>([]);
   const [imageDraft, setImageDraft] = useState('');
-  const imageUrls = useMemo(() => imagePages.flatMap((imagePage) => imagePage.kind === 'url' ? [imagePage.url] : []), [imagePages]);
-  const imageMediaIds = useMemo(() => imagePages.flatMap((imagePage) => imagePage.kind === 'media' ? [imagePage.mediaId] : []), [imagePages]);
+  const imageUrls = useMemo(
+    () => imagePages.flatMap((imagePage) => (imagePage.kind === 'url' ? [imagePage.url] : [])),
+    [imagePages]
+  );
+  const imageMediaIds = useMemo(
+    () =>
+      imagePages.flatMap((imagePage) => (imagePage.kind === 'media' ? [imagePage.mediaId] : [])),
+    [imagePages]
+  );
   const [pdfMediaId, setPdfMediaId] = useState<string | undefined>(sync.pdfMediaId);
 
   useEffect(() => {
@@ -120,7 +129,10 @@ export function useRoleSheetEditorState({
     },
     addImageMediaPage: (mediaId: string) => {
       setImagePages((current) => {
-        if (current.some((imagePage) => imagePage.kind === 'media' && imagePage.mediaId === mediaId)) return current;
+        if (
+          current.some((imagePage) => imagePage.kind === 'media' && imagePage.mediaId === mediaId)
+        )
+          return current;
         setPage(current.length + 1);
         return [...current, { kind: 'media', mediaId }];
       });
@@ -172,13 +184,18 @@ function useRoleSheetSync({
   roleSheetError: unknown;
 }) {
   const isMissingDocument = isApiHttpError(roleSheetError) && roleSheetError.status === 404;
-  const isUnsupportedFormat = Boolean(roleSheet?.format && !resolveEditableFormat(roleSheet.format));
+  const isUnsupportedFormat = Boolean(
+    roleSheet?.format && !resolveEditableFormat(roleSheet.format)
+  );
   const originalBody = isMissingDocument ? '' : (roleSheet?.markdown?.body ?? '');
   const pdfMediaId = roleSheet?.format === 'pdf' ? roleSheet.pdf?.media_id : undefined;
   const imagePages = useMemo<ImageRoleSheetPageDraft[]>(() => {
     if (roleSheet?.format !== 'images') return [];
     return [
-      ...(roleSheet.images?.image_media_ids ?? []).map((mediaId) => ({ kind: 'media' as const, mediaId })),
+      ...(roleSheet.images?.image_media_ids ?? []).map((mediaId) => ({
+        kind: 'media' as const,
+        mediaId,
+      })),
       ...(roleSheet.images?.image_urls ?? []).map((url) => ({ kind: 'url' as const, url })),
     ];
   }, [roleSheet?.format, roleSheet?.images?.image_media_ids, roleSheet?.images?.image_urls]);
@@ -216,11 +233,11 @@ function useRoleSheetMarkdownSaver({
           setSaveStatus('saved');
           toast.success('역할지가 저장되었습니다');
         },
-        onError: () => {
+        onError: (error) => {
           setSaveStatus('failed');
-          toast.error('역할지 저장에 실패했습니다');
+          showUnknownErrorToast(error, '역할지 저장에 실패했습니다');
         },
-      },
+      }
     );
   };
 }
@@ -240,8 +257,12 @@ function useRoleSheetImagesSaver({
 }) {
   return () => {
     if (upsertContent.isPending) return;
-    const imageUrls = imagePages.flatMap((imagePage) => imagePage.kind === 'url' ? [imagePage.url] : []);
-    const imageMediaIds = imagePages.flatMap((imagePage) => imagePage.kind === 'media' ? [imagePage.mediaId] : []);
+    const imageUrls = imagePages.flatMap((imagePage) =>
+      imagePage.kind === 'url' ? [imagePage.url] : []
+    );
+    const imageMediaIds = imagePages.flatMap((imagePage) =>
+      imagePage.kind === 'media' ? [imagePage.mediaId] : []
+    );
     if (imageUrls.length === 0 && imageMediaIds.length === 0) {
       setSaveStatus('failed');
       toast.error('이미지 페이지를 1개 이상 추가해 주세요');
@@ -257,11 +278,11 @@ function useRoleSheetImagesSaver({
           setSaveStatus('saved');
           toast.success('이미지 롤지가 저장되었습니다');
         },
-        onError: () => {
+        onError: (error) => {
           setSaveStatus('failed');
-          toast.error('이미지 롤지 저장에 실패했습니다');
+          showUnknownErrorToast(error, '이미지 롤지 저장에 실패했습니다');
         },
-      },
+      }
     );
   };
 }
@@ -302,10 +323,10 @@ function useRoleSheetPdfMediaSaver({
           setPdfMediaId(media.id);
           toast.success('PDF 역할지가 연결되었습니다');
         },
-        onError: () => {
-          toast.error('PDF 역할지 연결에 실패했습니다');
+        onError: (error) => {
+          showUnknownErrorToast(error, 'PDF 역할지 연결에 실패했습니다');
         },
-      },
+      }
     );
   };
 }

--- a/apps/web/src/features/editor/components/info/InfoDeliverySettingsCard.tsx
+++ b/apps/web/src/features/editor/components/info/InfoDeliverySettingsCard.tsx
@@ -1,21 +1,25 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from "react";
-import { CheckCircle2, Users } from "lucide-react";
-import { toast } from "sonner";
+import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
+import { CheckCircle2, Users } from 'lucide-react';
+import { toast } from 'sonner';
 
-import { useEditorCharacters } from "@/features/editor/api";
-import { SceneSelectField } from "@/features/editor/components/SceneSelectField";
-import { OptionList, type OptionItem } from "@/features/editor/components/design/InformationDeliveryOptionList";
-import { useFlowGraph, useUpdateFlowNode } from "@/features/editor/flowApi";
-import type { FlowNodeResponse } from "@/features/editor/flowTypes";
-import { editorDesignClassNames } from "@/features/editor/design-system/editorDesignTokens";
+import { useEditorCharacters } from '@/features/editor/api';
+import { SceneSelectField } from '@/features/editor/components/SceneSelectField';
+import {
+  OptionList,
+  type OptionItem,
+} from '@/features/editor/components/design/InformationDeliveryOptionList';
+import { useFlowGraph, useUpdateFlowNode } from '@/features/editor/flowApi';
+import type { FlowNodeResponse } from '@/features/editor/flowTypes';
+import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
 import {
   normalizeTarget,
   readInfoDeliveryTarget,
   targetsEqual,
   writeInfoDeliveryTarget,
   type InfoDeliveryTargetDraft,
-} from "@/features/editor/entities/info/infoDeliverySettingsAdapter";
-import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+} from '@/features/editor/entities/info/infoDeliverySettingsAdapter';
+import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 interface InfoDeliverySettingsCardProps {
   themeId: string;
@@ -34,16 +38,17 @@ interface AutosaveBody {
 }
 
 const INFO_DELIVERY_AUTOSAVE_MS = 1500;
-const INFO_DELIVERY_AUTOSAVE_TOAST_ID = "info-delivery-autosave";
-const ALL_CHARACTERS_ID = "__all_characters__";
+const INFO_DELIVERY_AUTOSAVE_TOAST_ID = 'info-delivery-autosave';
+const ALL_CHARACTERS_ID = '__all_characters__';
 
-export function InfoDeliverySettingsCard({
-  themeId,
-  storyInfoId,
-}: InfoDeliverySettingsCardProps) {
+export function InfoDeliverySettingsCard({ themeId, storyInfoId }: InfoDeliverySettingsCardProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
-  const { data: flowGraph, isLoading: flowLoading, isError: flowError, refetch: refetchFlow } =
-    useFlowGraph(themeId);
+  const {
+    data: flowGraph,
+    isLoading: flowLoading,
+    isError: flowError,
+    refetch: refetchFlow,
+  } = useFlowGraph(themeId);
   const {
     data: characters = [],
     isLoading: charactersLoading,
@@ -55,39 +60,44 @@ export function InfoDeliverySettingsCard({
   const phaseOptions = useMemo(
     () =>
       (flowGraph?.nodes ?? [])
-        .filter((node) => node.type === "phase")
-        .map((node, index): PhaseOption => ({
-          id: node.id,
-          label: node.data.label?.trim() || `장면 ${index + 1}`,
-          node,
-        })),
-    [flowGraph?.nodes],
+        .filter((node) => node.type === 'phase')
+        .map(
+          (node, index): PhaseOption => ({
+            id: node.id,
+            label: node.data.label?.trim() || `장면 ${index + 1}`,
+            node,
+          })
+        ),
+    [flowGraph?.nodes]
   );
   const sceneOptions = useMemo(
     () => phaseOptions.map((phase) => ({ value: phase.id, label: phase.label })),
-    [phaseOptions],
+    [phaseOptions]
   );
   const [selectedPhaseId, setSelectedPhaseId] = useState<string | null>(null);
   const selectedPhase = useMemo(
     () => phaseOptions.find((phase) => phase.id === selectedPhaseId) ?? phaseOptions[0] ?? null,
-    [phaseOptions, selectedPhaseId],
+    [phaseOptions, selectedPhaseId]
   );
   const savedTarget = useMemo(
-    () => selectedPhase ? readInfoDeliveryTarget(selectedPhase.node.data, storyInfoId) : { mode: "none" as const, characterIds: [] },
-    [selectedPhase, storyInfoId],
+    () =>
+      selectedPhase
+        ? readInfoDeliveryTarget(selectedPhase.node.data, storyInfoId)
+        : { mode: 'none' as const, characterIds: [] },
+    [selectedPhase, storyInfoId]
   );
   const [draftTarget, setDraftTarget] = useState<InfoDeliveryTargetDraft>(savedTarget);
   const normalizedDraft = normalizeTarget(draftTarget);
   const deliveryItems = useMemo<OptionItem[]>(
     () => [
-      { id: ALL_CHARACTERS_ID, name: "전체 캐릭터", summary: "장면 시작 시 모든 캐릭터에게 배포" },
+      { id: ALL_CHARACTERS_ID, name: '전체 캐릭터', summary: '장면 시작 시 모든 캐릭터에게 배포' },
       ...characters.map((character) => ({ id: character.id, name: character.name })),
     ],
-    [characters],
+    [characters]
   );
   const selectedDeliveryIds = useMemo(() => {
-    if (normalizedDraft.mode === "all_players") return [ALL_CHARACTERS_ID];
-    if (normalizedDraft.mode === "characters") return normalizedDraft.characterIds;
+    if (normalizedDraft.mode === 'all_players') return [ALL_CHARACTERS_ID];
+    if (normalizedDraft.mode === 'characters') return normalizedDraft.characterIds;
     return [];
   }, [normalizedDraft]);
 
@@ -107,43 +117,52 @@ export function InfoDeliverySettingsCard({
     (body: AutosaveBody, opts?: { onError?: (error?: unknown) => void }) => {
       const phase = phaseOptions.find((item) => item.id === body.phaseId);
       if (!phase) {
-        opts?.onError?.(new Error("Selected phase is no longer available"));
+        opts?.onError?.(new Error('Selected phase is no longer available'));
         return;
       }
 
-      toast.loading("정보 배포 설정 저장 중...", { id: INFO_DELIVERY_AUTOSAVE_TOAST_ID });
-      updateNode.mutateAsync({
-        nodeId: phase.id,
-        body: {
-          data: {
-            ...phase.node.data,
-            ...writeInfoDeliveryTarget(phase.node.data, storyInfoId, normalizeTarget(body.target)),
+      toast.loading('정보 배포 설정 저장 중...', { id: INFO_DELIVERY_AUTOSAVE_TOAST_ID });
+      updateNode
+        .mutateAsync({
+          nodeId: phase.id,
+          body: {
+            data: {
+              ...phase.node.data,
+              ...writeInfoDeliveryTarget(
+                phase.node.data,
+                storyInfoId,
+                normalizeTarget(body.target)
+              ),
+            },
           },
-        },
-      }).then(() => {
-        toast.success("정보 배포 설정이 자동저장되었습니다", {
-          id: INFO_DELIVERY_AUTOSAVE_TOAST_ID,
-          duration: 1200,
+        })
+        .then(() => {
+          toast.success('정보 배포 설정이 자동저장되었습니다', {
+            id: INFO_DELIVERY_AUTOSAVE_TOAST_ID,
+            duration: 1200,
+          });
+        })
+        .catch((error) => {
+          opts?.onError?.(error);
         });
-      }).catch((error) => {
-        opts?.onError?.(error);
-      });
     },
-    [phaseOptions, storyInfoId, updateNode],
+    [phaseOptions, storyInfoId, updateNode]
   );
 
-  const showFailureToast = useCallback((body: AutosaveBody) => {
-    toast.error("정보 배포 설정 저장에 실패했습니다", {
-      id: INFO_DELIVERY_AUTOSAVE_TOAST_ID,
-      duration: 6000,
-      action: {
-        label: "재시도",
-        onClick: () => {
-          saveBody(body, { onError: () => showFailureToast(body) });
+  const showFailureToast = useCallback(
+    (body: AutosaveBody, error?: unknown) => {
+      showUnknownErrorToast(error, '정보 배포 설정 저장에 실패했습니다', {
+        id: INFO_DELIVERY_AUTOSAVE_TOAST_ID,
+        action: {
+          label: '재시도',
+          onClick: () => {
+            saveBody(body, { onError: (retryError) => showFailureToast(body, retryError) });
+          },
         },
-      },
-    });
-  }, [saveBody]);
+      });
+    },
+    [saveBody]
+  );
 
   const { schedule, flush, cancel } = useDebouncedMutation<AutosaveBody>({
     debounceMs: INFO_DELIVERY_AUTOSAVE_MS,
@@ -151,7 +170,7 @@ export function InfoDeliverySettingsCard({
       saveBody(body, {
         onError: (error) => {
           opts.onError(error);
-          showFailureToast(body);
+          showFailureToast(body, error);
         },
       });
     },
@@ -168,7 +187,7 @@ export function InfoDeliverySettingsCard({
         cancel();
       }
     },
-    [cancel, savedTarget, schedule, selectedPhase],
+    [cancel, savedTarget, schedule, selectedPhase]
   );
 
   const handleSceneChange = useCallback(
@@ -176,37 +195,45 @@ export function InfoDeliverySettingsCard({
       flush();
       setSelectedPhaseId(sceneId);
     },
-    [flush],
+    [flush]
   );
 
-  const handleBlur = useCallback((event: FocusEvent<HTMLDivElement>) => {
-    const nextTarget = event.relatedTarget;
-    if (nextTarget instanceof Node && panelRef.current?.contains(nextTarget)) return;
-    flush();
-  }, [flush]);
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLDivElement>) => {
+      const nextTarget = event.relatedTarget;
+      if (nextTarget instanceof Node && panelRef.current?.contains(nextTarget)) return;
+      flush();
+    },
+    [flush]
+  );
 
   const handleDeliveryToggle = useCallback(
     (id: string) => {
       if (id === ALL_CHARACTERS_ID) {
         updateDraftTarget(
-          normalizedDraft.mode === "all_players"
-            ? { mode: "none", characterIds: [] }
-            : { mode: "all_players", characterIds: [] },
+          normalizedDraft.mode === 'all_players'
+            ? { mode: 'none', characterIds: [] }
+            : { mode: 'all_players', characterIds: [] }
         );
         return;
       }
-      const currentIds = normalizedDraft.mode === "characters" ? normalizedDraft.characterIds : [];
+      const currentIds = normalizedDraft.mode === 'characters' ? normalizedDraft.characterIds : [];
       const nextIds = toggleId(currentIds, id);
-      updateDraftTarget({ mode: nextIds.length > 0 ? "characters" : "none", characterIds: nextIds });
+      updateDraftTarget({
+        mode: nextIds.length > 0 ? 'characters' : 'none',
+        characterIds: nextIds,
+      });
     },
-    [normalizedDraft, updateDraftTarget],
+    [normalizedDraft, updateDraftTarget]
   );
 
   return (
     <section className={`p-4 ${editorDesignClassNames.panel}`} aria-label="정보 배포 설정">
       <div className="flex flex-col gap-2 border-b border-[var(--mmp-editor-color-hairline)] pb-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h3 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">장면 시작 배포</h3>
+          <h3 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">
+            장면 시작 배포
+          </h3>
           <p className="mt-1 text-xs text-[var(--mmp-editor-color-slate)]">
             선택한 장면이 시작될 때 이 정보를 누구에게 보여줄지 정합니다.
           </p>
@@ -226,7 +253,9 @@ export function InfoDeliverySettingsCard({
       </div>
 
       {isLoading ? (
-        <p className="py-4 text-xs text-[var(--mmp-editor-color-slate)]">장면과 캐릭터를 불러오는 중입니다.</p>
+        <p className="py-4 text-xs text-[var(--mmp-editor-color-slate)]">
+          장면과 캐릭터를 불러오는 중입니다.
+        </p>
       ) : isError ? (
         <p className="py-4 text-xs text-rose-300">배포 설정을 불러오지 못했습니다.</p>
       ) : phaseOptions.length === 0 ? (
@@ -249,13 +278,15 @@ export function InfoDeliverySettingsCard({
             <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
               <div>
                 <h4 className="text-sm font-medium text-[var(--mmp-editor-color-charcoal)]">
-                  {selectedPhase?.label ?? "장면 선택"}
+                  {selectedPhase?.label ?? '장면 선택'}
                 </h4>
                 <p className="mt-0.5 text-xs text-[var(--mmp-editor-color-slate)]">
                   {targetSummary(normalizedDraft, characters)}
                 </p>
               </div>
-              <span className={`inline-flex items-center gap-1 self-start px-2 py-1 text-[11px] ${editorDesignClassNames.tag}`}>
+              <span
+                className={`inline-flex items-center gap-1 self-start px-2 py-1 text-[11px] ${editorDesignClassNames.tag}`}
+              >
                 <CheckCircle2 className="h-3.5 w-3.5" />
                 변경하면 자동저장
               </span>
@@ -264,10 +295,10 @@ export function InfoDeliverySettingsCard({
             <div className="mt-3 grid gap-3">
               <button
                 type="button"
-                onClick={() => updateDraftTarget({ mode: "none", characterIds: [] })}
-                aria-pressed={normalizedDraft.mode === "none"}
+                onClick={() => updateDraftTarget({ mode: 'none', characterIds: [] })}
+                aria-pressed={normalizedDraft.mode === 'none'}
                 className={`flex min-h-10 items-center gap-2 px-3 py-2 text-left text-xs transition-colors ${
-                  normalizedDraft.mode === "none"
+                  normalizedDraft.mode === 'none'
                     ? editorDesignClassNames.listItemActive
                     : editorDesignClassNames.listItem
                 }`}
@@ -280,7 +311,7 @@ export function InfoDeliverySettingsCard({
                 emptyText="등록된 캐릭터가 없습니다."
                 items={deliveryItems}
                 selectedIds={selectedDeliveryIds}
-                getMeta={(item) => item.id === ALL_CHARACTERS_ID ? "전체" : undefined}
+                getMeta={(item) => (item.id === ALL_CHARACTERS_ID ? '전체' : undefined)}
                 onToggle={handleDeliveryToggle}
                 allItems={deliveryItems}
               />
@@ -292,16 +323,19 @@ export function InfoDeliverySettingsCard({
   );
 }
 
-function targetSummary(target: InfoDeliveryTargetDraft, characters: Array<{ id: string; name: string }>): string {
+function targetSummary(
+  target: InfoDeliveryTargetDraft,
+  characters: Array<{ id: string; name: string }>
+): string {
   const normalized = normalizeTarget(target);
-  if (normalized.mode === "all_players") return "현재 전체 캐릭터에게 공개됩니다.";
-  if (normalized.mode === "characters") {
+  if (normalized.mode === 'all_players') return '현재 전체 캐릭터에게 공개됩니다.';
+  if (normalized.mode === 'characters') {
     const names = normalized.characterIds
-      .map((id) => characters.find((character) => character.id === id)?.name ?? "이름 없는 캐릭터")
-      .join(", ");
+      .map((id) => characters.find((character) => character.id === id)?.name ?? '이름 없는 캐릭터')
+      .join(', ');
     return `현재 ${names}에게 공개됩니다.`;
   }
-  return "현재 이 장면에서는 공개되지 않습니다.";
+  return '현재 이 장면에서는 공개되지 않습니다.';
 }
 
 function toggleId(ids: string[], id: string): string[] {

--- a/apps/web/src/features/editor/components/info/InfoTab.tsx
+++ b/apps/web/src/features/editor/components/info/InfoTab.tsx
@@ -17,6 +17,7 @@ import { InfoMarkdownEditor } from './InfoMarkdownEditor';
 import { useAutosavedDraft } from '@/features/editor/hooks/useAutosavedDraft';
 import { hasDisplayableRichContent } from '@/features/editor/components/content/richContentDisplay';
 import { editorDesignClassNames } from '@/features/editor/design-system/editorDesignTokens';
+import { getDisplayErrorMessage } from '@/lib/display-error';
 
 interface InfoTabProps {
   themeId: string;
@@ -74,9 +75,13 @@ export function InfoTab({ themeId }: InfoTabProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className={`flex items-center justify-between px-4 py-3 ${editorDesignClassNames.topBar}`}>
+      <div
+        className={`flex items-center justify-between px-4 py-3 ${editorDesignClassNames.topBar}`}
+      >
         <div>
-          <h2 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">정보 관리</h2>
+          <h2 className="text-sm font-semibold text-[var(--mmp-editor-color-charcoal)]">
+            정보 관리
+          </h2>
           <p className="mt-1 text-xs text-[var(--mmp-editor-color-slate)]">
             장면에서 공개할 정보를 대사와 분리해 카드로 관리합니다.
           </p>
@@ -148,7 +153,7 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
   const toInfoDraft = useCallback((value: StoryInfoResponse) => toEditableInfo(value), []);
   const isSameInfoDraft = useCallback(
     (left: StoryInfoResponse, right: StoryInfoResponse) => !hasEditableChanges(left, right),
-    [],
+    []
   );
   const saveInfo = useCallback(
     (body: StoryInfoResponse) =>
@@ -165,7 +170,7 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
           version: body.version,
         },
       }),
-    [info.id, updateInfo],
+    [info.id, updateInfo]
   );
   const buildInfoSaveBody = useCallback((current: StoryInfoResponse) => current, []);
   const mergeSavedInfoDraft = useCallback(
@@ -181,13 +186,13 @@ function InfoEditor({ themeId, info }: { themeId: string; info: StoryInfoRespons
       hasEditableChanges(currentDraft, submittedDraft)
         ? { ...currentDraft, version: savedDraft.version }
         : savedDraft,
-    [],
+    []
   );
-  const {
-    draft,
-    setDraft,
-    baseline,
-  } = useAutosavedDraft<StoryInfoResponse, StoryInfoResponse, StoryInfoResponse>({
+  const { draft, setDraft, baseline } = useAutosavedDraft<
+    StoryInfoResponse,
+    StoryInfoResponse,
+    StoryInfoResponse
+  >({
     serverValue: info,
     serverKey: info.id,
     debounceMs: 1000,
@@ -341,5 +346,5 @@ function hasEditableChanges(current: StoryInfoResponse, baseline: StoryInfoRespo
 }
 
 function errorMessage(err: unknown, fallback: string) {
-  return err instanceof Error && err.message ? err.message : fallback;
+  return getDisplayErrorMessage(err, fallback);
 }

--- a/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
+++ b/apps/web/src/features/editor/components/info/__tests__/InfoTab.test.tsx
@@ -69,7 +69,12 @@ vi.mock('@mdxeditor/editor', () => ({
       onChange: (markdown: string) => void;
       plugins?: Array<{
         markdownShortcuts?: boolean;
-        jsxComponentDescriptors?: Array<{ name: string; Editor: ComponentType<{ mdastNode: { attributes: Array<{ name: string; value: string }> } }> }>;
+        jsxComponentDescriptors?: Array<{
+          name: string;
+          Editor: ComponentType<{
+            mdastNode: { attributes: Array<{ name: string; value: string }> };
+          }>;
+        }>;
       }>;
     }
   >(({ markdown, onChange, plugins = [] }, ref) => {
@@ -289,10 +294,34 @@ beforeEach(() => {
   });
   useMediaListMock.mockReturnValue({
     data: [
-      { id: 'image-1', name: '기존 이미지', type: 'IMAGE', source_type: 'FILE', url: 'http://localhost:8080/media/image-1.png' },
-      { id: 'image-2', name: '새 이미지', type: 'IMAGE', source_type: 'FILE', url: 'http://localhost:8080/media/image-2.png' },
-      { id: 'video-1', name: 'CCTV', type: 'VIDEO', source_type: 'FILE', url: 'http://localhost:8080/media/video-1.mp4' },
-      { id: 'video-2', name: 'CCTV 후속', type: 'VIDEO', source_type: 'FILE', url: 'http://localhost:8080/media/video-2.mp4' },
+      {
+        id: 'image-1',
+        name: '기존 이미지',
+        type: 'IMAGE',
+        source_type: 'FILE',
+        url: 'http://localhost:8080/media/image-1.png',
+      },
+      {
+        id: 'image-2',
+        name: '새 이미지',
+        type: 'IMAGE',
+        source_type: 'FILE',
+        url: 'http://localhost:8080/media/image-2.png',
+      },
+      {
+        id: 'video-1',
+        name: 'CCTV',
+        type: 'VIDEO',
+        source_type: 'FILE',
+        url: 'http://localhost:8080/media/video-1.mp4',
+      },
+      {
+        id: 'video-2',
+        name: 'CCTV 후속',
+        type: 'VIDEO',
+        source_type: 'FILE',
+        url: 'http://localhost:8080/media/video-2.mp4',
+      },
     ],
   });
   useMediaDownloadUrlMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
@@ -316,7 +345,7 @@ describe('InfoTab', () => {
     expect(screen.getByRole('heading', { name: '피해자의 비밀' })).toBeDefined();
     expect(screen.getByRole('region', { name: '정보 본문 보기' })).toHaveProperty(
       'textContent',
-      expect.stringContaining('처음 공개되는 정보'),
+      expect.stringContaining('처음 공개되는 정보')
     );
     expect(screen.queryByLabelText('정보 제목')).toBeNull();
     expect(screen.queryByRole('region', { name: '정보 본문 작성기' })).toBeNull();
@@ -329,10 +358,10 @@ describe('InfoTab', () => {
     expect(screen.queryByRole('region', { name: '정보 카드 프리뷰' })).toBeNull();
     expect(screen.getByRole('region', { name: '정보 배포 설정' })).toHaveProperty(
       'textContent',
-      expect.stringContaining('오프닝'),
+      expect.stringContaining('오프닝')
     );
     expect(screen.getByRole('region', { name: '정보 배포 설정' }).className).toContain(
-      'mmp-editor-panel',
+      'mmp-editor-panel'
     );
     expect(screen.getByText('현재 전체 캐릭터에게 공개됩니다.')).toBeDefined();
   });
@@ -380,9 +409,11 @@ describe('InfoTab', () => {
     const preview = screen.getByRole('region', { name: '정보 본문 보기' });
     expect(within(preview).getByRole('img', { name: '증거 사진' })).toHaveProperty(
       'src',
-      'http://localhost:8080/media/evidence.png',
+      'http://localhost:8080/media/evidence.png'
     );
-    expect(within(preview).getByTestId('media-embed-display').querySelector('figcaption')).toBeNull();
+    expect(
+      within(preview).getByTestId('media-embed-display').querySelector('figcaption')
+    ).toBeNull();
     expect(within(preview).queryByText('증거 사진')).toBeNull();
     expect(within(preview).queryByText('이미지 블록')).toBeNull();
   });
@@ -454,7 +485,10 @@ describe('InfoTab', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /정보 추가/ }));
 
-    expect(await screen.findByRole('alert')).toHaveProperty('textContent', '서버 오류');
+    expect(await screen.findByRole('alert')).toHaveProperty(
+      'textContent',
+      '정보 생성에 실패했습니다'
+    );
   });
 
   it('saves title/body without exposing image or reference fields', async () => {
@@ -523,8 +557,14 @@ describe('InfoTab', () => {
         },
       },
     });
-    expect(toastLoadingMock).toHaveBeenCalledWith('정보 배포 설정 저장 중...', expect.objectContaining({ id: 'info-delivery-autosave' }));
-    expect(toastSuccessMock).toHaveBeenCalledWith('정보 배포 설정이 자동저장되었습니다', expect.objectContaining({ id: 'info-delivery-autosave' }));
+    expect(toastLoadingMock).toHaveBeenCalledWith(
+      '정보 배포 설정 저장 중...',
+      expect.objectContaining({ id: 'info-delivery-autosave' })
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      '정보 배포 설정이 자동저장되었습니다',
+      expect.objectContaining({ id: 'info-delivery-autosave' })
+    );
     expect(within(deliverySettings).queryByRole('button', { name: /배포 적용/ })).toBeNull();
   });
 
@@ -553,7 +593,7 @@ describe('InfoTab', () => {
       expect.objectContaining({
         id: 'info-delivery-autosave',
         action: expect.objectContaining({ label: '재시도' }),
-      }),
+      })
     );
     const [, errorOptions] = toastErrorMock.mock.calls[0];
     errorOptions.action.onClick();
@@ -582,7 +622,7 @@ describe('InfoTab', () => {
 
     expect(screen.getByRole('alert')).toHaveProperty(
       'textContent',
-      expect.stringContaining('failed to update story info'),
+      expect.stringContaining('저장에 실패했습니다')
     );
 
     act(() => {
@@ -640,7 +680,9 @@ describe('InfoTab', () => {
 
     expect(getInfoBodyEditor()).toHaveProperty(
       'value',
-      expect.stringContaining('<MediaEmbed mediaId="video-1" type="video" align="center" width="medium" />')
+      expect.stringContaining(
+        '<MediaEmbed mediaId="video-1" type="video" align="center" width="medium" />'
+      )
     );
     const editorSurface = screen.getByTestId('mdx-editor-surface');
     const embedEditor = within(editorSurface).getByTestId('media-embed-editor');
@@ -653,7 +695,9 @@ describe('InfoTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'CCTV 후속 선택' }));
     expect(getInfoBodyEditor()).toHaveProperty(
       'value',
-      expect.stringContaining('<MediaEmbed mediaId="video-2" type="video" align="center" width="medium" />')
+      expect.stringContaining(
+        '<MediaEmbed mediaId="video-2" type="video" align="center" width="medium" />'
+      )
     );
     expect(within(editorSurface).getByLabelText('CCTV 후속 영상')).toBeDefined();
     expect(within(editorSurface).getByRole('button', { name: 'CCTV 후속 교체' })).toBeDefined();
@@ -663,7 +707,9 @@ describe('InfoTab', () => {
     expect(updateMutate).toHaveBeenCalledWith({
       id: 'info-1',
       patch: expect.objectContaining({
-        body: expect.stringContaining('<MediaEmbed mediaId="video-2" type="video" align="center" width="medium" />'),
+        body: expect.stringContaining(
+          '<MediaEmbed mediaId="video-2" type="video" align="center" width="medium" />'
+        ),
       }),
     });
   });

--- a/apps/web/src/features/editor/hooks/__tests__/useAutosavedDraft.test.tsx
+++ b/apps/web/src/features/editor/hooks/__tests__/useAutosavedDraft.test.tsx
@@ -1,7 +1,18 @@
-import { act, cleanup, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { ApiError } from '@mmp/shared';
+import { toast } from 'sonner';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useAutosavedDraft } from "../useAutosavedDraft";
+import { ApiHttpError } from '@/lib/api-error';
+import { useAutosavedDraft } from '../useAutosavedDraft';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    loading: vi.fn(),
+    success: vi.fn(),
+  },
+}));
 
 interface ServerValue {
   id: string;
@@ -22,9 +33,21 @@ function isEqual(left: DraftValue, right: DraftValue) {
   return left.title === right.title && left.version === right.version;
 }
 
-describe("useAutosavedDraft", () => {
+function apiError(overrides: Partial<ApiError>): ApiError {
+  return {
+    type: 'about:blank',
+    title: 'Internal Server Error',
+    status: 500,
+    detail: 'raw backend failure',
+    code: 'INTERNAL_ERROR',
+    ...overrides,
+  };
+}
+
+describe('useAutosavedDraft', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -32,8 +55,8 @@ describe("useAutosavedDraft", () => {
     vi.useRealTimers();
   });
 
-  it("preserves a dirty draft when the same entity refetches stale server data", () => {
-    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "지도", version: 2 });
+  it('preserves a dirty draft when the same entity refetches stale server data', () => {
+    const save = vi.fn().mockResolvedValue({ id: 'info-1', title: '지도', version: 2 });
     const { result, rerender } = renderHook(
       ({ serverValue }: { serverValue: ServerValue }) =>
         useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
@@ -47,22 +70,22 @@ describe("useAutosavedDraft", () => {
         }),
       {
         initialProps: {
-          serverValue: { id: "info-1", title: "지", version: 1 },
+          serverValue: { id: 'info-1', title: '지', version: 1 },
         },
-      },
+      }
     );
 
     act(() => {
-      result.current.setDraft({ title: "지도", version: 1 });
+      result.current.setDraft({ title: '지도', version: 1 });
     });
-    rerender({ serverValue: { id: "info-1", title: "지", version: 1 } });
+    rerender({ serverValue: { id: 'info-1', title: '지', version: 1 } });
 
-    expect(result.current.draft.title).toBe("지도");
+    expect(result.current.draft.title).toBe('지도');
     expect(result.current.isDirty).toBe(true);
   });
 
-  it("accepts server data when there are no local changes", () => {
-    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "지도", version: 2 });
+  it('accepts server data when there are no local changes', () => {
+    const save = vi.fn().mockResolvedValue({ id: 'info-1', title: '지도', version: 2 });
     const { result, rerender } = renderHook(
       ({ serverValue }: { serverValue: ServerValue }) =>
         useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
@@ -76,68 +99,68 @@ describe("useAutosavedDraft", () => {
         }),
       {
         initialProps: {
-          serverValue: { id: "info-1", title: "지", version: 1 },
+          serverValue: { id: 'info-1', title: '지', version: 1 },
         },
-      },
+      }
     );
 
-    rerender({ serverValue: { id: "info-1", title: "지도", version: 2 } });
+    rerender({ serverValue: { id: 'info-1', title: '지도', version: 2 } });
 
-    expect(result.current.draft).toEqual({ title: "지도", version: 2 });
-    expect(result.current.baseline).toEqual({ title: "지도", version: 2 });
+    expect(result.current.draft).toEqual({ title: '지도', version: 2 });
+    expect(result.current.baseline).toEqual({ title: '지도', version: 2 });
     expect(result.current.isDirty).toBe(false);
   });
 
-  it("clears dirty state only for the draft that was submitted", async () => {
-    const serverValue = { id: "info-1", title: "", version: 1 };
-    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "지", version: 2 });
+  it('clears dirty state only for the draft that was submitted', async () => {
+    const serverValue = { id: 'info-1', title: '', version: 1 };
+    const save = vi.fn().mockResolvedValue({ id: 'info-1', title: '지', version: 2 });
     const { result } = renderHook(() =>
       useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
         serverValue,
-        serverKey: "info-1",
+        serverKey: 'info-1',
         debounceMs: 1000,
         toDraft,
         isEqual,
         buildSaveBody: (draft) => draft,
         save,
-      }),
+      })
     );
 
     act(() => {
-      result.current.setDraft({ title: "지", version: 1 });
+      result.current.setDraft({ title: '지', version: 1 });
     });
     act(() => {
       vi.advanceTimersByTime(1000);
     });
     act(() => {
-      result.current.setDraft({ title: "지도", version: 1 });
+      result.current.setDraft({ title: '지도', version: 1 });
     });
     await act(async () => {
       await Promise.resolve();
     });
 
     expect(save).toHaveBeenCalledTimes(1);
-    expect(result.current.draft.title).toBe("지도");
+    expect(result.current.draft.title).toBe('지도');
     expect(result.current.isDirty).toBe(true);
   });
 
-  it("saveNow flushes the current draft immediately", async () => {
-    const serverValue = { id: "info-1", title: "", version: 1 };
-    const save = vi.fn().mockResolvedValue({ id: "info-1", title: "즉시 저장", version: 2 });
+  it('saveNow flushes the current draft immediately', async () => {
+    const serverValue = { id: 'info-1', title: '', version: 1 };
+    const save = vi.fn().mockResolvedValue({ id: 'info-1', title: '즉시 저장', version: 2 });
     const { result } = renderHook(() =>
       useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
         serverValue,
-        serverKey: "info-1",
+        serverKey: 'info-1',
         debounceMs: 1000,
         toDraft,
         isEqual,
         buildSaveBody: (draft) => draft,
         save,
-      }),
+      })
     );
 
     act(() => {
-      result.current.setDraft({ title: "즉시 저장", version: 1 });
+      result.current.setDraft({ title: '즉시 저장', version: 1 });
     });
     act(() => {
       result.current.saveNow();
@@ -147,6 +170,56 @@ describe("useAutosavedDraft", () => {
       await Promise.resolve();
     });
     expect(save).toHaveBeenCalledTimes(1);
-    expect(save).toHaveBeenCalledWith({ title: "즉시 저장", version: 1 });
+    expect(save).toHaveBeenCalledWith({ title: '즉시 저장', version: 1 });
+  });
+
+  it('shows ApiHttpError user message and reference when autosave fails', async () => {
+    const serverValue = { id: 'info-1', title: '', version: 1 };
+    const save = vi.fn().mockRejectedValue(
+      new ApiHttpError(
+        apiError({
+          user_message: '정보 저장 중 충돌이 발생했습니다. 새로고침 후 다시 시도해주세요.',
+          request_id: 'request-autosave-123',
+          severity: 'high',
+        })
+      )
+    );
+    const { result } = renderHook(() =>
+      useAutosavedDraft<ServerValue, DraftValue, DraftValue>({
+        serverValue,
+        serverKey: 'info-1',
+        debounceMs: 1000,
+        toDraft,
+        isEqual,
+        buildSaveBody: (draft) => draft,
+        save,
+        messages: {
+          toastId: 'info-autosave',
+          loading: '정보를 저장 중입니다',
+          success: '정보가 저장되었습니다',
+          error: '정보 저장에 실패했습니다',
+        },
+      })
+    );
+
+    act(() => {
+      result.current.setDraft({ title: '지도', version: 1 });
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      '정보 저장 중 충돌이 발생했습니다. 새로고침 후 다시 시도해주세요.',
+      expect.objectContaining({
+        id: 'info-autosave',
+        description: '오류 ID: request-',
+        duration: Infinity,
+        action: expect.objectContaining({ label: '재시도' }),
+      })
+    );
   });
 });

--- a/apps/web/src/features/editor/hooks/__tests__/useEditorAutosaveToast.test.tsx
+++ b/apps/web/src/features/editor/hooks/__tests__/useEditorAutosaveToast.test.tsx
@@ -1,0 +1,86 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { ApiError } from '@mmp/shared';
+import { toast } from 'sonner';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiHttpError } from '@/lib/api-error';
+import { useEditorAutosaveToast } from '../useEditorAutosaveToast';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    loading: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function apiError(overrides: Partial<ApiError>): ApiError {
+  return {
+    type: 'about:blank',
+    title: 'Internal Server Error',
+    status: 500,
+    detail: 'raw backend failure',
+    code: 'INTERNAL_ERROR',
+    ...overrides,
+  };
+}
+
+describe('useEditorAutosaveToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('uses ApiHttpError user message and keeps retry action on autosave failure', async () => {
+    const mutate = vi.fn(
+      (_body: { title: string }, opts: { onError: (error?: unknown) => void }) => {
+        opts.onError(
+          new ApiHttpError(
+            apiError({
+              user_message: '장면 설정을 저장하지 못했습니다. 최신 내용으로 다시 시도해주세요.',
+              request_id: 'request-scene-save',
+              severity: 'high',
+            })
+          )
+        );
+      }
+    );
+    const { result } = renderHook(() =>
+      useEditorAutosaveToast<{ title: string }>({
+        debounceMs: 500,
+        messages: {
+          toastId: 'scene-autosave',
+          loading: '장면 설정을 저장 중입니다',
+          success: '장면 설정이 저장되었습니다',
+          error: '장면 설정 저장에 실패했습니다',
+        },
+        mutate,
+      })
+    );
+
+    act(() => {
+      result.current.schedule({ title: '오프닝' });
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      '장면 설정을 저장하지 못했습니다. 최신 내용으로 다시 시도해주세요.',
+      expect.objectContaining({
+        id: 'scene-autosave',
+        description: '오류 ID: request-',
+        duration: Infinity,
+        action: expect.objectContaining({ label: '재시도' }),
+      })
+    );
+  });
+});

--- a/apps/web/src/features/editor/hooks/useAutosavedDraft.ts
+++ b/apps/web/src/features/editor/hooks/useAutosavedDraft.ts
@@ -6,10 +6,11 @@ import {
   useState,
   type Dispatch,
   type SetStateAction,
-} from "react";
-import { toast } from "sonner";
+} from 'react';
+import { toast } from 'sonner';
 
-import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
+import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 const toastWithLoading = toast as typeof toast & {
   loading?: (message: string, options?: Record<string, unknown>) => void;
@@ -65,6 +66,18 @@ function defaultMergeSavedDraft<TDraft>({
   return isEqual(currentDraft, submittedDraft) ? savedDraft : currentDraft;
 }
 
+function showAutosaveFailureToast<TSaveBody, TDraft>(
+  error: unknown,
+  messages: AutosavedDraftToastMessages,
+  payload: { body: TSaveBody; submittedDraft: TDraft },
+  retry: (payload: { body: TSaveBody; submittedDraft: TDraft }) => void
+): void {
+  showUnknownErrorToast(error, messages.error, {
+    id: messages.toastId,
+    action: { label: '재시도', onClick: () => retry(payload) },
+  });
+}
+
 export function useAutosavedDraft<TServer, TDraft, TSaveBody>({
   serverValue,
   serverKey,
@@ -95,9 +108,7 @@ export function useAutosavedDraft<TServer, TDraft, TSaveBody>({
   const setDraft = useCallback<Dispatch<SetStateAction<TDraft>>>((next) => {
     setDraftState((current) => {
       const resolved =
-        typeof next === "function"
-          ? (next as (current: TDraft) => TDraft)(current)
-          : next;
+        typeof next === 'function' ? (next as (current: TDraft) => TDraft)(current) : next;
       draftRef.current = resolved;
       return resolved;
     });
@@ -136,7 +147,7 @@ export function useAutosavedDraft<TServer, TDraft, TSaveBody>({
       });
       onSaved?.(saved);
     },
-    [isEqual, mergeSavedDraft, onSaved, setDraft, toDraft],
+    [isEqual, mergeSavedDraft, onSaved, setDraft, toDraft]
   );
 
   const retrySave = useCallback(
@@ -155,14 +166,10 @@ export function useAutosavedDraft<TServer, TDraft, TSaveBody>({
         })
         .catch((error) => {
           onError?.(error);
-          toast.error(messages.error, {
-            id: messages.toastId,
-            duration: 6000,
-            action: { label: "재시도", onClick: () => retrySave(payload) },
-          });
+          showAutosaveFailureToast(error, messages, payload, retrySave);
         });
     },
-    [acceptSavedValue, messages, onError, save],
+    [acceptSavedValue, messages, onError, save]
   );
 
   const { schedule, flush, cancel } = useDebouncedMutation<{
@@ -189,11 +196,7 @@ export function useAutosavedDraft<TServer, TDraft, TSaveBody>({
     onFailure: (error, payload) => {
       onError?.(error);
       if (!messages) return;
-      toast.error(messages.error, {
-        id: messages.toastId,
-        duration: 6000,
-        action: { label: "재시도", onClick: () => retrySave(payload) },
-      });
+      showAutosaveFailureToast(error, messages, payload, retrySave);
     },
   });
 

--- a/apps/web/src/features/editor/hooks/useCharacterConfigDebounce.ts
+++ b/apps/web/src/features/editor/hooks/useCharacterConfigDebounce.ts
@@ -1,10 +1,11 @@
-import { useCallback, useRef } from "react";
-import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
-import type { EditorThemeResponse } from "@/features/editor/api";
-import { editorKeys, useUpdateConfigJson } from "@/features/editor/api";
-import { useDebouncedMutation } from "@/hooks/useDebouncedMutation";
-import { normalizeConfigForSave } from "@/features/editor/utils/configShape";
+import { useCallback, useRef } from 'react';
+import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
+import type { EditorThemeResponse } from '@/features/editor/api';
+import { editorKeys, useUpdateConfigJson } from '@/features/editor/api';
+import { useDebouncedMutation } from '@/hooks/useDebouncedMutation';
+import { normalizeConfigForSave } from '@/features/editor/utils/configShape';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 /** Debounce window for config saves (W2 PR-5: 500→1500ms). */
 const SAVE_DEBOUNCE_MS = 1500;
@@ -33,7 +34,7 @@ export interface UseCharacterConfigDebounceReturn {
  */
 export function useCharacterConfigDebounce(
   themeId: string,
-  themeConfigJson: Record<string, unknown> | undefined,
+  themeConfigJson: Record<string, unknown> | undefined
 ): UseCharacterConfigDebounceReturn {
   const updateConfig = useUpdateConfigJson(themeId);
   const queryClient = useQueryClient();
@@ -50,7 +51,7 @@ export function useCharacterConfigDebounce(
     mutate: (body, opts) =>
       updateConfig.mutate(body, {
         onSuccess: () => {
-          toast.success("저장되었습니다");
+          toast.success('저장되었습니다');
           pendingSnapshotRef.current = undefined;
         },
         onError: (err) => {
@@ -64,7 +65,7 @@ export function useCharacterConfigDebounce(
       const cacheKey = editorKeys.theme(themeId);
       return () => queryClient.setQueryData(cacheKey, previous);
     },
-    onError: () => toast.error("저장에 실패했습니다"),
+    onError: (error) => showUnknownErrorToast(error, '저장에 실패했습니다'),
   });
 
   const saveConfig = useCallback(
@@ -72,8 +73,7 @@ export function useCharacterConfigDebounce(
       const cacheKey = editorKeys.theme(themeId);
 
       if (!pendingSnapshotRef.current) {
-        pendingSnapshotRef.current =
-          queryClient.getQueryData<EditorThemeResponse>(cacheKey);
+        pendingSnapshotRef.current = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
       }
 
       const cacheNow = queryClient.getQueryData<EditorThemeResponse>(cacheKey);
@@ -88,8 +88,7 @@ export function useCharacterConfigDebounce(
       // theme.config_json. Prevents loss of earlier edits made within the
       // same debounce window on different keys.
       debouncer.schedule(updates, (prev) => {
-        const cached =
-          queryClient.getQueryData<EditorThemeResponse>(cacheKey)?.config_json;
+        const cached = queryClient.getQueryData<EditorThemeResponse>(cacheKey)?.config_json;
         const basis = prev ?? cached ?? themeConfigJson ?? {};
         return normalizeConfigForSave({ ...basis, ...updates });
       });
@@ -97,7 +96,7 @@ export function useCharacterConfigDebounce(
     // `themeConfigJson` is deliberately in deps as the *last-resort* merge
     // basis — even though pending/cached fallbacks usually win, capturing the
     // latest prop identity keeps the rare cold-start path correct.
-    [debouncer, queryClient, themeConfigJson, themeId],
+    [debouncer, queryClient, themeConfigJson, themeId]
   );
 
   return { saveConfig, flush: debouncer.flush };

--- a/apps/web/src/features/editor/hooks/useEditorAutosaveToast.ts
+++ b/apps/web/src/features/editor/hooks/useEditorAutosaveToast.ts
@@ -1,10 +1,11 @@
-import { useCallback } from "react";
-import { toast } from "sonner";
+import { useCallback } from 'react';
+import { toast } from 'sonner';
 
 import {
   useDebouncedMutation,
   type UseDebouncedMutationReturn,
-} from "@/hooks/useDebouncedMutation";
+} from '@/hooks/useDebouncedMutation';
+import { showUnknownErrorToast } from '@/lib/show-error-toast';
 
 const toastWithLoading = toast as typeof toast & {
   loading?: (message: string, options?: Record<string, unknown>) => void;
@@ -22,11 +23,26 @@ interface EditorAutosaveToastOptions<TBody> {
   messages: EditorAutosaveToastMessages;
   mutate: (
     body: TBody,
-    opts: { onError: (error?: unknown) => void; onSuccess?: () => void },
+    opts: { onError: (error?: unknown) => void; onSuccess?: () => void }
   ) => void;
   applyOptimistic?: (body: TBody) => (() => void) | null;
   onSuccess?: (body: TBody) => void;
   onError?: (error?: unknown) => void;
+}
+
+function showAutosaveFailureToast<TBody>(
+  error: unknown,
+  body: TBody,
+  messages: EditorAutosaveToastMessages,
+  retry: (body: TBody) => void
+): void {
+  showUnknownErrorToast(error, messages.error, {
+    id: messages.toastId,
+    action: {
+      label: '재시도',
+      onClick: () => retry(body),
+    },
+  });
 }
 
 export function useEditorAutosaveToast<TBody>({
@@ -47,18 +63,11 @@ export function useEditorAutosaveToast<TBody>({
         },
         onError: (error) => {
           onError?.(error);
-          toast.error(messages.error, {
-            id: messages.toastId,
-            duration: 6000,
-            action: {
-              label: "재시도",
-              onClick: () => retryMutation(body),
-            },
-          });
+          showAutosaveFailureToast(error, body, messages, retryMutation);
         },
       });
     },
-    [messages, mutate, onError, onSuccess],
+    [messages, mutate, onError, onSuccess]
   );
 
   return useDebouncedMutation<TBody>({
@@ -74,14 +83,7 @@ export function useEditorAutosaveToast<TBody>({
     },
     onFailure: (error, body) => {
       onError?.(error);
-      toast.error(messages.error, {
-        id: messages.toastId,
-        duration: 6000,
-        action: {
-          label: "재시도",
-          onClick: () => retryMutation(body),
-        },
-      });
+      showAutosaveFailureToast(error, body, messages, retryMutation);
     },
   });
 }

--- a/apps/web/src/lib/show-error-toast.test.ts
+++ b/apps/web/src/lib/show-error-toast.test.ts
@@ -3,7 +3,8 @@ import type { ApiError } from '@mmp/shared';
 import { toast } from 'sonner';
 
 import { captureApiError } from '@/lib/sentry';
-import { getErrorReference, showErrorToast } from '@/lib/show-error-toast';
+import { getErrorReference, showErrorToast, showUnknownErrorToast } from '@/lib/show-error-toast';
+import { ApiHttpError } from '@/lib/api-error';
 
 vi.mock('sonner', () => ({
   toast: {
@@ -116,6 +117,37 @@ describe('showErrorToast', () => {
       {
         description: '오류 ID: request-',
         duration: Infinity,
+      }
+    );
+  });
+
+  it('공통 unknown toast는 ApiHttpError 메시지와 호출자 액션을 함께 표시한다', () => {
+    const retry = vi.fn();
+
+    showUnknownErrorToast(
+      new ApiHttpError(
+        apiError({
+          status: 409,
+          code: 'EDITOR_CONFIG_VERSION_MISMATCH',
+          detail: 'version conflict',
+          request_id: 'request-conflict-1',
+          severity: 'high',
+        })
+      ),
+      '저장에 실패했습니다',
+      {
+        id: 'autosave-toast',
+        action: { label: '재시도', onClick: retry },
+      }
+    );
+
+    expect(toast.error).toHaveBeenCalledWith(
+      '다른 변경사항과 충돌했습니다. 최신 내용으로 새로고침 후 다시 저장해주세요.',
+      {
+        id: 'autosave-toast',
+        description: '오류 ID: request-',
+        duration: 8000,
+        action: { label: '재시도', onClick: retry },
       }
     );
   });

--- a/apps/web/src/lib/show-error-toast.ts
+++ b/apps/web/src/lib/show-error-toast.ts
@@ -5,12 +5,23 @@ import { getUserMessage } from '@/lib/error-messages';
 import { getErrorRecoveryStrategy } from '@/lib/error-recovery';
 import { captureApiError } from '@/lib/sentry';
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+interface ErrorToastOptions {
+  id?: string;
+  duration?: number;
+  action?: ToastAction;
+}
+
 /**
  * API 에러를 sonner 토스트로 표시한다.
  * - recovery strategy가 login이면 로그인 페이지로 리다이렉트
  * - severity/retryability에 따라 표시 시간과 Sentry 캡처를 결정
  */
-export function showErrorToast(error: ApiError): void {
+export function showErrorToast(error: ApiError, options?: ErrorToastOptions): void {
   const strategy = getErrorRecoveryStrategy(error);
 
   // 401은 토스트 대신 리다이렉트 (로그인 페이지에서는 루프 방지)
@@ -27,18 +38,27 @@ export function showErrorToast(error: ApiError): void {
     captureApiError(new Error(error.detail), error);
   }
 
-  toast.error(message, {
-    description,
-    duration: strategy.duration,
-  });
+  toast.error(
+    message,
+    buildToastOptions({ ...options, description, duration: options?.duration ?? strategy.duration })
+  );
 }
 
-export function showUnknownErrorToast(error: unknown, fallback: string): void {
+export function showUnknownErrorToast(
+  error: unknown,
+  fallback: string,
+  options?: ErrorToastOptions
+): void {
   if (isApiHttpError(error)) {
-    showErrorToast(error.apiError);
+    showErrorToast(error.apiError, options);
     return;
   }
 
+  const toastOptions = buildToastOptions(options);
+  if (toastOptions) {
+    toast.error(fallback, toastOptions);
+    return;
+  }
   toast.error(fallback);
 }
 
@@ -48,4 +68,15 @@ export function getErrorReference(error: ApiError): string | undefined {
   const correlationId = error.correlation_id?.trim();
   const id = requestId || traceId || correlationId;
   return id ? id.slice(0, 8) : undefined;
+}
+
+function buildToastOptions(
+  options?: ErrorToastOptions & { description?: string }
+): Record<string, unknown> | undefined {
+  const toastOptions: Record<string, unknown> = {};
+  if (options?.id) toastOptions.id = options.id;
+  if (options?.description) toastOptions.description = options.description;
+  if (options?.duration !== undefined) toastOptions.duration = options.duration;
+  if (options?.action) toastOptions.action = options.action;
+  return Object.keys(toastOptions).length > 0 ? toastOptions : undefined;
 }


### PR DESCRIPTION
Closes #645

## 요약

- `showErrorToast` / `showUnknownErrorToast`가 `ApiHttpError`의 사용자 메시지, 오류 ID, 재시도 액션을 함께 보존하도록 확장했습니다.
- 에디터 자동저장 훅(`useAutosavedDraft`, `useEditorAutosaveToast`)이 공통 오류 토스트를 사용하도록 바꿨습니다.
- 정보, 장소, 장면, 결말, 단서, 역할지, 모듈 설정 등 에디터 저장/삭제 실패 경로의 raw/generic 토스트를 공통 처리로 교체했습니다.

## Coverage Plan

- `apps/web/src/lib/show-error-toast.ts`: API 오류 메시지, 오류 ID, action 전달, non-API fallback 동작을 unit test로 확인했습니다.
- `apps/web/src/features/editor/hooks/useAutosavedDraft.ts`, `useEditorAutosaveToast.ts`: 자동저장 실패 시 서버 사용자 메시지와 재시도 action이 유지되는지 hook test로 확인했습니다.
- 에디터 화면 회귀: `InfoTab`, `PhaseNodePanelDebounce`, `ClueEntityWorkspace`, `ModulesSubTab`, `LocationClueAssignPanel`, `LocationAccessPolicyPanel` component tests로 주요 저장/삭제 흐름을 확인했습니다.
- 전체 회귀: 최종 커밋 기준 `scripts/mmp-local-ci.sh quick`로 install, wsgen drift, playeraware lint, Go tests, web lint/typecheck/test/build를 확인했습니다.

## Local validation

- `pnpm --filter @mmp/web test -- src/lib/show-error-toast.test.ts src/features/editor/hooks/__tests__/useAutosavedDraft.test.tsx src/features/editor/hooks/__tests__/useEditorAutosaveToast.test.tsx src/features/editor/components/design/__tests__/PhaseNodePanelDebounce.test.tsx src/features/editor/components/clues/ClueEntityWorkspace.test.tsx src/features/editor/components/info/__tests__/InfoTab.test.tsx src/features/editor/components/design/__tests__/ModulesSubTab.test.tsx src/features/editor/components/design/__tests__/LocationClueAssignPanel.test.tsx src/features/editor/components/design/__tests__/LocationAccessPolicyPanel.test.tsx` 통과 (9 files, 100 tests)
- `pnpm --filter @mmp/web typecheck` 통과
- `git diff --check` 통과
- `scripts/mmp-local-ci.sh quick` 통과 (`277f27e47774b0f2d4d375bd8be6eb3bb7a5c9b5`)

## E2E 판단

이번 PR은 저장 실패 표시 helper와 기존 에디터 component/hook 경로 교체가 중심이라 인증/스토리지 의존 E2E보다 focused unit/component test가 더 직접적입니다. `quick` 검증으로 전체 web test와 build까지 함께 확인했습니다.

## Deferred / Follow-up

- 비에디터 직접 fetch 정리(`profileApi.ts` 등), 관리자/소셜/결제 화면 raw `err.message` 정리, 내부용 `docs/error-codes.md`는 Issue #645의 Deferred 항목으로 남겨두었습니다.