### PR TITLE
fix: 리치 본문 끝 빈 문단 입력 보존

### DIFF
--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 import {
   BlockTypeSelect,
   BoldItalicUnderlineToggles,
@@ -30,6 +36,11 @@ import {
   type MediaEmbedAttributes,
 } from './mediaEmbedMarkdown';
 import { normalizeLegacyEscapedMarkdown } from './legacyMarkdown';
+import {
+  appendTrailingEmptyParagraph,
+  isCollapsedSelectionAtEndOfElement,
+  isPlainEnterKey,
+} from './richContentTrailingParagraph';
 
 export function RichContentEditor({
   themeId,
@@ -149,12 +160,30 @@ export function RichContentEditor({
     onClosePicker();
   }
 
+  function handleKeyDownCapture(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (!isPlainEnterKey(event.nativeEvent)) return;
+    const editable = findContentEditableElement(event.currentTarget);
+    if (!editable || !isCollapsedSelectionAtEndOfElement(editable)) return;
+
+    event.preventDefault();
+    const currentMarkdown = editorRef.current?.getMarkdown?.() || markdownRef.current;
+    const nextMarkdown = appendTrailingEmptyParagraph(currentMarkdown);
+    markdownRef.current = nextMarkdown;
+    onChangeRef.current(nextMarkdown);
+
+    window.requestAnimationFrame(() => {
+      editorRef.current?.setMarkdown?.(nextMarkdown);
+      editorRef.current?.focus?.(undefined, { defaultSelection: 'rootEnd', preventScroll: true });
+    });
+  }
+
   return (
     <div
       className="space-y-2"
       role="region"
       aria-label={ariaLabel}
       onBlurCapture={(event) => onBlurCapture?.(event.relatedTarget)}
+      onKeyDownCapture={handleKeyDownCapture}
     >
       <MediaEmbedPicker
         themeId={themeId}
@@ -179,6 +208,10 @@ export function RichContentEditor({
       </div>
     </div>
   );
+}
+
+function findContentEditableElement(root: HTMLElement) {
+  return root.querySelector<HTMLElement>('[contenteditable="true"]');
 }
 
 function createMediaEmbedDescriptor(

--- a/apps/web/src/features/editor/components/content/__tests__/RichContentEditor.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/RichContentEditor.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React, { useImperativeHandle, useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { useMediaListMock } = vi.hoisted(() => ({
+  useMediaListMock: vi.fn(),
+}));
+
+vi.mock('@/features/editor/mediaApi', () => ({
+  useMediaList: (...args: unknown[]) => useMediaListMock(...args),
+}));
+
+vi.mock('../MediaEmbedPicker', () => ({
+  MediaEmbedPicker: () => null,
+}));
+
+vi.mock('../MediaEmbedEditor', () => ({
+  MediaEmbedEditor: () => null,
+}));
+
+vi.mock('@mdxeditor/editor', () => {
+  const plugin = () => ({});
+  const MDXEditor = React.forwardRef(
+    (
+      {
+        markdown,
+        onChange,
+      }: {
+        markdown: string;
+        onChange: (markdown: string) => void;
+      },
+      ref
+    ) => {
+      const [value, setValue] = useState(markdown);
+      useImperativeHandle(
+        ref,
+        () => ({
+          getMarkdown: () => value,
+          setMarkdown: setValue,
+          insertMarkdown: (snippet: string) => {
+            const next = `${value}${snippet}`;
+            setValue(next);
+            onChange(next);
+          },
+          focus: vi.fn(),
+          getContentEditableHTML: () => value,
+          getSelectionMarkdown: () => '',
+        }),
+        [onChange, value]
+      );
+
+      return (
+        <div
+          role="textbox"
+          aria-label="mock markdown editor"
+          contentEditable
+          suppressContentEditableWarning
+        >
+          {value}
+        </div>
+      );
+    }
+  );
+
+  return {
+    MDXEditor,
+    BlockTypeSelect: () => null,
+    BoldItalicUnderlineToggles: () => null,
+    CreateLink: () => null,
+    ListsToggle: () => null,
+    UndoRedo: () => null,
+    headingsPlugin: plugin,
+    jsxPlugin: plugin,
+    linkPlugin: plugin,
+    listsPlugin: plugin,
+    markdownShortcutPlugin: plugin,
+    quotePlugin: plugin,
+    thematicBreakPlugin: plugin,
+    toolbarPlugin: plugin,
+  };
+});
+
+import { RichContentEditor } from '../RichContentEditor';
+import { TRAILING_EMPTY_PARAGRAPH_MARKDOWN } from '../richContentTrailingParagraph';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  document.getSelection()?.removeAllRanges();
+});
+
+describe('RichContentEditor', () => {
+  it('preserves a trailing empty paragraph when Enter is pressed at the end', () => {
+    useMediaListMock.mockReturnValue({ data: [] });
+    const onChange = vi.fn();
+
+    render(
+      <RichContentEditor
+        themeId="theme-1"
+        markdown="첫 문장"
+        onChange={onChange}
+        pickerType={null}
+        onOpenPicker={vi.fn()}
+        onClosePicker={vi.fn()}
+        ariaLabel="본문 작성기"
+      />
+    );
+
+    const editor = screen.getByRole('textbox', { name: 'mock markdown editor' });
+    const text = editor.firstChild;
+    expect(text).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(text!, editor.textContent?.length ?? 0);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+
+    fireEvent.keyDown(editor, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith(`첫 문장\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`);
+  });
+});

--- a/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
@@ -95,4 +95,15 @@ describe('RichContentViewer', () => {
     expect(container.querySelector('blockquote em')?.textContent).toBe('2008년 7월 28일 저녁');
     expect(container.querySelector('code')?.textContent?.trim()).toBe('\\*literal\\*');
   });
+
+  it('renders encoded trailing empty paragraphs as line breaks', () => {
+    useMediaListMock.mockReturnValue({ data: [] });
+
+    const { container } = render(
+      <RichContentViewer themeId="theme-1" markdown={['첫 문장', '', '<br />'].join('\n')} />
+    );
+
+    expect(screen.getByText('첫 문장')).not.toBeNull();
+    expect(container.querySelector('br')).not.toBeNull();
+  });
 });

--- a/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
+++ b/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendTrailingEmptyParagraph,
+  isCollapsedSelectionAtEndOfElement,
+  isPlainEnterKey,
+  TRAILING_EMPTY_PARAGRAPH_MARKDOWN,
+} from '../richContentTrailingParagraph';
+
+describe('richContentTrailingParagraph', () => {
+  it('encodes a trailing empty paragraph as markdown content that survives trimming', () => {
+    expect(appendTrailingEmptyParagraph('첫 문장')).toBe(
+      `첫 문장\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`
+    );
+    expect(appendTrailingEmptyParagraph('첫 문장\n\n')).toBe(
+      `첫 문장\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`
+    );
+  });
+
+  it('handles only unmodified Enter presses', () => {
+    expect(isPlainEnterKey(new KeyboardEvent('keydown', { key: 'Enter' }))).toBe(true);
+    expect(isPlainEnterKey(new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true }))).toBe(
+      false
+    );
+    expect(isPlainEnterKey(new KeyboardEvent('keydown', { key: 'a' }))).toBe(false);
+  });
+
+  it('detects a collapsed caret at the end of editable content', () => {
+    const element = document.createElement('div');
+    element.textContent = '첫 문장';
+    document.body.appendChild(element);
+
+    const text = element.firstChild;
+    expect(text).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(text!, element.textContent.length);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+
+    expect(isCollapsedSelectionAtEndOfElement(element)).toBe(true);
+
+    range.setStart(text!, 1);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+
+    expect(isCollapsedSelectionAtEndOfElement(element)).toBe(false);
+
+    element.remove();
+  });
+});

--- a/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
+++ b/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
@@ -1,0 +1,59 @@
+export const TRAILING_EMPTY_PARAGRAPH_MARKDOWN = '<br />';
+
+export function appendTrailingEmptyParagraph(markdown: string) {
+  const body = markdown.replace(/\s+$/, '');
+  return body
+    ? `${body}\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`
+    : TRAILING_EMPTY_PARAGRAPH_MARKDOWN;
+}
+
+export function isPlainEnterKey(
+  event: Pick<KeyboardEvent, 'key' | 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'isComposing'>
+) {
+  return (
+    event.key === 'Enter' &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    !event.isComposing
+  );
+}
+
+export function isCollapsedSelectionAtEndOfElement(element: HTMLElement) {
+  const selection = element.ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+
+  const range = selection.getRangeAt(0);
+  if (!element.contains(range.endContainer)) return false;
+
+  const afterSelection = range.cloneRange();
+  afterSelection.selectNodeContents(element);
+  afterSelection.setStart(range.endContainer, range.endOffset);
+  return afterSelection.toString().length === 0 && !hasElementContentAfterRange(element, range);
+}
+
+function hasElementContentAfterRange(element: HTMLElement, range: Range) {
+  const walker = element.ownerDocument.createTreeWalker(element, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      if (!(node instanceof HTMLElement)) return NodeFilter.FILTER_SKIP;
+      if (node === element) return NodeFilter.FILTER_SKIP;
+      if (!node.textContent?.trim() && node.childElementCount === 0) {
+        return NodeFilter.FILTER_SKIP;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  let node = walker.nextNode();
+  while (node) {
+    const nodeRange = element.ownerDocument.createRange();
+    nodeRange.selectNode(node);
+    if (range.compareBoundaryPoints(Range.END_TO_START, nodeRange) <= 0) {
+      return true;
+    }
+    node = walker.nextNode();
+  }
+
+  return false;
+}


### PR DESCRIPTION
Closes #648

## 요약

- `RichContentEditor` 공통 레이어에서 문서 끝 plain Enter를 감지해 trailing empty paragraph를 보존합니다.
- Markdown 문자열 계약을 유지하면서 끝 빈 문단을 `<br />`로 인코딩해 MDXEditor/Markdown trim 이후에도 사라지지 않게 했습니다.
- viewer 렌더링 경로에서 `<br />`가 안전하게 line break로 표시되는지 테스트를 추가했습니다.

## 실제 서비스 패턴 반영

ProseMirror/Tiptap 계열처럼 문서 끝에 계속 입력 가능한 trailing paragraph/node를 유지하는 방식을 공통 에디터 레이어에 적용했습니다. 백엔드 저장 trim 정책을 바꾸지 않고, 에디터 document-to-markdown 경계에서 보존 가능한 표현으로 변환합니다.

## Coverage Plan

- `richContentTrailingParagraph.ts`: 끝 빈 문단 인코딩, plain Enter 판별, 커서 끝 위치 판별을 unit test로 검증했습니다.
- `RichContentEditor.tsx`: 글 끝 Enter 입력 시 `onChange`가 `<br />` 포함 Markdown을 내보내는 component test를 추가했습니다.
- `RichContentViewer.tsx`: 인코딩된 `<br />`가 sanitizer/marked 렌더링 경로에서 line break로 남는지 검증했습니다.

## Local validation

- `pnpm --filter @mmp/web test -- src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts src/features/editor/components/content/__tests__/RichContentEditor.test.tsx src/features/editor/components/content/__tests__/RichContentViewer.test.tsx` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web lint` 통과, 기존 warning만 있음
- `git diff --check` 통과
- `scripts/mmp-local-ci.sh quick` 통과 (`81e44d96f327d3d9c058236c95d6bdccdf3f401d`)

## E2E 판단

이번 변경은 공통 리치 에디터의 keyboard serialization 경계 수정입니다. 사용자 흐름은 unit/component/viewer test와 quick local CI로 검증했고, 브라우저 E2E는 MDXEditor 내부 contenteditable 동작 의존성이 커서 이번 PR의 필수 gate에서는 제외했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 에디터의 Enter 키 입력 처리가 개선되었습니다.

* **Tests**
  * 리치 콘텐츠 에디터와 뷰어의 문단 처리, 키보드 입력 감지, 마크다운 렌더링 등 핵심 기능을 검증하는 포괄적인 테스트들이 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->