### PR TITLE
fix: 리치 본문 끝 빈 줄 편집 상태 보정

### DIFF
--- a/apps/web/src/features/editor/components/content/RichContentEditor.tsx
+++ b/apps/web/src/features/editor/components/content/RichContentEditor.tsx
@@ -40,6 +40,7 @@ import {
   appendTrailingEmptyParagraph,
   isCollapsedSelectionAtEndOfElement,
   isPlainEnterKey,
+  normalizeTrailingEmptyParagraphInput,
 } from './richContentTrailingParagraph';
 
 export function RichContentEditor({
@@ -160,6 +161,12 @@ export function RichContentEditor({
     onClosePicker();
   }
 
+  function handleChange(nextMarkdown: string) {
+    const normalizedNextMarkdown = normalizeTrailingEmptyParagraphInput(nextMarkdown);
+    markdownRef.current = normalizedNextMarkdown;
+    onChangeRef.current(normalizedNextMarkdown);
+  }
+
   function handleKeyDownCapture(event: ReactKeyboardEvent<HTMLDivElement>) {
     if (!isPlainEnterKey(event.nativeEvent)) return;
     const editable = findContentEditableElement(event.currentTarget);
@@ -200,7 +207,7 @@ export function RichContentEditor({
         <MDXEditor
           ref={editorRef}
           markdown={normalizedMarkdown}
-          onChange={onChange}
+          onChange={handleChange}
           plugins={plugins}
           className="mmp-mdx-editor"
           contentEditableClassName="text-sm leading-6 text-slate-100"

--- a/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
+++ b/apps/web/src/features/editor/components/content/__tests__/RichContentViewer.test.tsx
@@ -96,14 +96,14 @@ describe('RichContentViewer', () => {
     expect(container.querySelector('code')?.textContent?.trim()).toBe('\\*literal\\*');
   });
 
-  it('renders encoded trailing empty paragraphs as line breaks', () => {
+  it('renders encoded trailing empty paragraphs as an empty paragraph', () => {
     useMediaListMock.mockReturnValue({ data: [] });
 
     const { container } = render(
-      <RichContentViewer themeId="theme-1" markdown={['첫 문장', '', '<br />'].join('\n')} />
+      <RichContentViewer themeId="theme-1" markdown={['첫 문장', '', '\u200B'].join('\n')} />
     );
 
     expect(screen.getByText('첫 문장')).not.toBeNull();
-    expect(container.querySelector('br')).not.toBeNull();
+    expect(container.querySelectorAll('p')).toHaveLength(2);
   });
 });

--- a/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
+++ b/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
@@ -4,6 +4,7 @@ import {
   appendTrailingEmptyParagraph,
   isCollapsedSelectionAtEndOfElement,
   isPlainEnterKey,
+  normalizeTrailingEmptyParagraphInput,
   TRAILING_EMPTY_PARAGRAPH_MARKDOWN,
 } from '../richContentTrailingParagraph';
 
@@ -14,6 +15,15 @@ describe('richContentTrailingParagraph', () => {
     );
     expect(appendTrailingEmptyParagraph('첫 문장\n\n')).toBe(
       `첫 문장\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`
+    );
+  });
+
+  it('removes the empty paragraph marker once the user types real content on that line', () => {
+    expect(normalizeTrailingEmptyParagraphInput(`첫 문장\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`)).toBe(
+      `첫 문장\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`
+    );
+    expect(normalizeTrailingEmptyParagraphInput(`첫 문장\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}다음 문장`)).toBe(
+      '첫 문장\n\n다음 문장'
     );
   });
 

--- a/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
+++ b/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
@@ -1,10 +1,14 @@
-export const TRAILING_EMPTY_PARAGRAPH_MARKDOWN = '<br />';
+export const TRAILING_EMPTY_PARAGRAPH_MARKDOWN = '\u200B';
 
 export function appendTrailingEmptyParagraph(markdown: string) {
   const body = markdown.replace(/\s+$/, '');
   return body
     ? `${body}\n\n${TRAILING_EMPTY_PARAGRAPH_MARKDOWN}`
     : TRAILING_EMPTY_PARAGRAPH_MARKDOWN;
+}
+
+export function normalizeTrailingEmptyParagraphInput(markdown: string) {
+  return markdown.replace(/(^|\n)\u200B(?=[^\n]*\S)/g, '$1');
 }
 
 export function isPlainEnterKey(

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -95,6 +95,7 @@ body {
 
 .mmp-mdx-editor [contenteditable='true'] p,
 .mmp-mdx-editor [contenteditable='true'] li {
+  min-height: 1.5em;
   color: rgb(226 232 240);
 }
 


### PR DESCRIPTION
Closes #650

## 요약

- `RichContentEditor` 공통 레이어에서 trailing empty paragraph를 실제 편집 가능한 invisible paragraph marker로 보존하도록 보정했습니다.
- 사용자가 marker 줄에 실제 글자를 입력하면 저장값에서 marker를 자동 제거합니다.
- 빈 문단에서도 커서 높이가 확보되도록 리치 에디터 paragraph 최소 높이를 지정했습니다.

## 원인

PR #649의 `<br />` 방식은 Markdown/viewer 보존에는 맞았지만, MDXEditor 편집 화면에서 새 입력 문단처럼 안정적으로 체감되지 않을 수 있었습니다. 실제 서비스형 에디터의 trailing paragraph/node 패턴에 맞춰 공통 editor serialization 레이어에서 보이지 않는 paragraph marker를 유지하는 방식으로 바꿨습니다.

## Coverage Plan

- `richContentTrailingParagraph.ts`: marker 보존, 실제 입력 시 marker 제거, plain Enter/end-caret 판별을 테스트했습니다.
- `RichContentEditor.tsx`: 끝 Enter 입력 시 marker 기반 Markdown을 내보내는 component test를 유지했습니다.
- `RichContentViewer.tsx`: marker paragraph가 빈 문단으로 렌더링되는지 검증했습니다.
- `apps/web/src/index.css`: 빈 paragraph의 최소 높이만 추가해 layout side effect를 최소화했습니다.

## Local validation

- `pnpm --filter @mmp/web test -- src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts src/features/editor/components/content/__tests__/RichContentEditor.test.tsx src/features/editor/components/content/__tests__/RichContentViewer.test.tsx` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web lint` 통과, 기존 warning만 있음
- `git diff --check` 통과
- `scripts/mmp-local-ci.sh quick` 통과 (`6c5deb10a911c6af6b141b12e572cd0de2f3baa8`)

## E2E 판단

이번 변경은 공통 리치 에디터의 keyboard serialization과 paragraph 렌더링 보정입니다. focused DOM component test와 전체 quick CI로 검증했고, 외부 MDXEditor contenteditable 내부 구현에 강하게 묶이는 별도 E2E는 이번 gate에서 제외했습니다.