### PR TITLE
fix: MDXEditor 빈 문단 끝 입력 판별 보정

### DIFF
--- a/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
+++ b/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
@@ -60,4 +60,21 @@ describe('richContentTrailingParagraph', () => {
 
     element.remove();
   });
+
+  it('treats MDXEditor empty paragraphs as the editable end', () => {
+    const element = document.createElement('div');
+    element.contentEditable = 'true';
+    element.innerHTML = '<p dir="auto"><br></p>';
+    document.body.appendChild(element);
+
+    const range = document.createRange();
+    range.setStart(element, element.childNodes.length);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+
+    expect(isCollapsedSelectionAtEndOfElement(element)).toBe(true);
+
+    element.remove();
+  });
 });

--- a/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
+++ b/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
@@ -42,7 +42,8 @@ function hasElementContentAfterRange(element: HTMLElement, range: Range) {
     acceptNode(node) {
       if (!(node instanceof HTMLElement)) return NodeFilter.FILTER_SKIP;
       if (node === element) return NodeFilter.FILTER_SKIP;
-      if (!node.textContent?.trim() && node.childElementCount === 0) {
+      if (node.contains(range.endContainer)) return NodeFilter.FILTER_SKIP;
+      if (isEmptyEditorParagraph(node)) {
         return NodeFilter.FILTER_SKIP;
       }
       return NodeFilter.FILTER_ACCEPT;
@@ -60,4 +61,10 @@ function hasElementContentAfterRange(element: HTMLElement, range: Range) {
   }
 
   return false;
+}
+
+function isEmptyEditorParagraph(node: HTMLElement) {
+  if (node.textContent?.trim()) return false;
+  if (node.tagName !== 'P') return node.childElementCount === 0;
+  return node.childElementCount === 0 || Array.from(node.children).every((child) => child.tagName === 'BR');
 }


### PR DESCRIPTION
## 요약
- MDXEditor가 끝 빈 줄을 `<p><br></p>`로 렌더링하는 실제 DOM을 끝 위치로 인정하도록 보정했습니다.
- 커서가 현재 빈 문단 안에 있거나 MDXEditor 빈 문단만 남은 경우를 `hasElementContentAfterRange`에서 뒤 콘텐츠로 오판하지 않게 했습니다.
- 해당 DOM 형태를 `richContentTrailingParagraph.test.ts`에 회귀 테스트로 추가했습니다.

Closes #652

## 원인
cmux surface:3 실제 화면에서 역할지 편집기를 열고 끝에 커서를 둔 뒤 Enter를 누르자 기존 패치에서는 DOM이 그대로였습니다. 진단 결과 selection의 `range.endContainer`는 루트 `DIV`, 마지막 요소는 `<p dir="auto"><br></p>`였고, 기존 판별 함수가 이 빈 문단을 커서 뒤 콘텐츠로 오판했습니다.

## cmux 실증
- 대상: `surface:3`, `/editor/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/characters`
- 패치 후: 역할지 편집기 끝에서 Enter 입력 시 `defaultPrevented=true`
- 패치 후 DOM tail: `<p dir="auto"><span data-lexical-text="true">​</span></p>`
- 결과: 빈 줄을 의미하는 zero-width marker가 실제 편집 DOM에 남음

## Coverage Plan
- `richContentTrailingParagraph.ts`: MDXEditor 빈 끝 문단 `<p><br></p>`를 끝 위치로 취급하는 분기 보정
- `richContentTrailingParagraph.test.ts`: 실제 DOM 형태를 회귀 테스트로 추가
- `RichContentEditor.test.tsx`: 기존 Enter 입력 보존 테스트 회귀 확인
- `RichContentViewer.test.tsx`: marker 표시/숨김 회귀 확인

## Local validation
- PASS: cmux surface:3 실제 역할지 편집기 Enter 입력 검증
- PASS: `pnpm --filter @mmp/web test -- src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts src/features/editor/components/content/__tests__/RichContentEditor.test.tsx src/features/editor/components/content/__tests__/RichContentViewer.test.tsx`
- PASS: `pnpm --filter @mmp/web typecheck`
- PASS: `pnpm --filter @mmp/web lint` (기존 warning만, error 0)
- PASS: `git diff --check`
- PASS: `scripts/mmp-local-ci.sh quick`

## 제외
- 자동저장 훅, 저장 API, MDXEditor wrapper 구조는 변경하지 않았습니다.
