### PR TITLE
fix: 역할지 리치 본문 Enter 저장 안정화

### DIFF
--- a/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
+++ b/apps/web/src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts
@@ -77,4 +77,49 @@ describe('richContentTrailingParagraph', () => {
 
     element.remove();
   });
+
+  it('does not treat the end of a middle paragraph as the editable end', () => {
+    const element = document.createElement('div');
+    element.contentEditable = 'true';
+    element.innerHTML =
+      '<p dir="auto"><span data-lexical-text="true">첫 문장</span></p><p dir="auto"><span data-lexical-text="true">둘째 문장</span></p>';
+    document.body.appendChild(element);
+
+    const firstParagraphText = element.querySelector('p')?.textContent;
+    const firstTextNode = element.querySelector('p span')?.firstChild;
+    expect(firstTextNode).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(firstTextNode!, firstParagraphText?.length ?? 0);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+
+    expect(isCollapsedSelectionAtEndOfElement(element)).toBe(false);
+
+    element.remove();
+  });
+
+  it('still detects the end of the last editor paragraph', () => {
+    const element = document.createElement('div');
+    element.contentEditable = 'true';
+    element.innerHTML =
+      '<p dir="auto"><span data-lexical-text="true">첫 문장</span></p><p dir="auto"><span data-lexical-text="true">둘째 문장</span></p>';
+    document.body.appendChild(element);
+
+    const lastParagraph = element.querySelectorAll('p')[1];
+    const lastTextNode = lastParagraph?.querySelector('span')?.firstChild;
+    expect(lastParagraph).not.toBeUndefined();
+    expect(lastTextNode).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(lastTextNode!, lastParagraph!.textContent?.length ?? 0);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+
+    expect(isCollapsedSelectionAtEndOfElement(element)).toBe(true);
+
+    element.remove();
+  });
 });

--- a/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
+++ b/apps/web/src/features/editor/components/content/richContentTrailingParagraph.ts
@@ -30,11 +30,34 @@ export function isCollapsedSelectionAtEndOfElement(element: HTMLElement) {
 
   const range = selection.getRangeAt(0);
   if (!element.contains(range.endContainer)) return false;
+  if (!isSelectionInLastEditableBlock(element, range)) return false;
 
   const afterSelection = range.cloneRange();
   afterSelection.selectNodeContents(element);
   afterSelection.setStart(range.endContainer, range.endOffset);
   return afterSelection.toString().length === 0 && !hasElementContentAfterRange(element, range);
+}
+
+const EDITABLE_BLOCK_SELECTOR = 'p,h1,h2,h3,h4,h5,h6,li';
+
+function isSelectionInLastEditableBlock(element: HTMLElement, range: Range) {
+  if (range.endContainer === element) return true;
+
+  const selectedBlock = findClosestEditableBlock(element, range.endContainer);
+  if (!selectedBlock) return true;
+
+  const editableBlocks = Array.from(
+    element.querySelectorAll<HTMLElement>(EDITABLE_BLOCK_SELECTOR)
+  ).filter((block) => !block.closest('[contenteditable="false"]'));
+  const lastBlock = editableBlocks.at(-1);
+
+  return !lastBlock || selectedBlock === lastBlock;
+}
+
+function findClosestEditableBlock(element: HTMLElement, node: Node) {
+  const candidate = node instanceof HTMLElement ? node : node.parentElement;
+  const block = candidate?.closest<HTMLElement>(EDITABLE_BLOCK_SELECTOR);
+  return block && element.contains(block) ? block : null;
 }
 
 function hasElementContentAfterRange(element: HTMLElement, range: Range) {

--- a/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterRoleSheetSection.tsx
@@ -112,9 +112,9 @@ export function CharacterRoleSheetSection({
             if (isSaveButtonTarget(relatedTarget)) {
               return;
             }
-            state.saveMarkdown(state.draft);
+            state.saveMarkdown();
           }}
-          onPreview={() => state.saveMarkdown(state.draft)}
+          onPreview={() => state.saveMarkdown()}
         />
       )}
     </section>

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -684,6 +684,10 @@ describe('CharacterAssignPanel', () => {
     fireEvent.change(roleSheet, { target: { value: '## 비밀\n범인은 아직 모른다.' } });
     fireEvent.click(screen.getByRole('button', { name: '미리보기' }));
 
+    expect(upsertRoleSheetMutateMock).toHaveBeenCalledWith(
+      { format: 'markdown', markdown: { body: '## 비밀\n범인은 아직 모른다.' } },
+      expect.any(Object)
+    );
     expect(screen.getByText('저장되었습니다.')).toBeDefined();
   });
 

--- a/apps/web/src/features/editor/components/design/useRoleSheetEditorState.ts
+++ b/apps/web/src/features/editor/components/design/useRoleSheetEditorState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import {
   useCharacterRoleSheet,
@@ -36,6 +36,7 @@ export function useRoleSheetEditorState({ characterId }: UseRoleSheetEditorState
     roleSheetError: roleSheetQuery.error,
   });
   const [draft, setDraft] = useState(sync.originalBody);
+  const draftRef = useRef(sync.originalBody);
   const [imagePages, setImagePages] = useState<ImageRoleSheetPageDraft[]>([]);
   const [imageDraft, setImageDraft] = useState('');
   const imageUrls = useMemo(
@@ -50,6 +51,7 @@ export function useRoleSheetEditorState({ characterId }: UseRoleSheetEditorState
   const [pdfMediaId, setPdfMediaId] = useState<string | undefined>(sync.pdfMediaId);
 
   useEffect(() => {
+    draftRef.current = sync.originalBody;
     setDraft(sync.originalBody);
     setSaveStatus('idle');
   }, [sync.originalBody, characterId]);
@@ -73,7 +75,7 @@ export function useRoleSheetEditorState({ characterId }: UseRoleSheetEditorState
 
   const saveMarkdown = useRoleSheetMarkdownSaver({
     data: roleSheetQuery.data,
-    draft,
+    getDraft: () => draftRef.current,
     originalBody: sync.originalBody,
     upsertContent,
     setSelectedFormat,
@@ -111,7 +113,10 @@ export function useRoleSheetEditorState({ characterId }: UseRoleSheetEditorState
     isUnsupportedFormat: sync.isUnsupportedFormat,
     pdfMediaId,
     upsertContent,
-    setDraft,
+    setDraft: (nextDraft: string) => {
+      draftRef.current = nextDraft;
+      setDraft(nextDraft);
+    },
     saveMarkdown,
     savePDFMedia,
     addImagePage: () => {
@@ -205,20 +210,20 @@ function useRoleSheetSync({
 
 function useRoleSheetMarkdownSaver({
   data,
-  draft,
+  getDraft,
   originalBody,
   upsertContent,
   setSelectedFormat,
   setSaveStatus,
 }: {
   data?: RoleSheetResponse;
-  draft: string;
+  getDraft: () => string;
   originalBody: string;
   upsertContent: UpsertRoleSheetMutation;
   setSelectedFormat: (format: EditableRoleSheetFormat) => void;
   setSaveStatus: (status: SaveStatus) => void;
 }) {
-  return (nextBody = draft) => {
+  return (nextBody = getDraft()) => {
     if (upsertContent.isPending) return;
     if (originalBody === nextBody && data?.format === 'markdown') {
       setSaveStatus('saved');


### PR DESCRIPTION
## 요약
- 역할지 Markdown 편집 중 Enter 직후 미리보기/blur 저장이 최신 draft를 사용하도록 ref 기반 저장 경로로 변경했습니다.
- RichContentEditor의 끝 빈 문단 보정이 중간 문단 Enter를 가로채지 않도록 마지막 편집 블록에서만 동작하게 제한했습니다.
- 중간 문단 끝/마지막 문단 끝 선택 회귀 테스트를 추가했습니다.

Closes #654

## Coverage Plan
- `useRoleSheetEditorState.ts`: blur/preview 저장이 stale React state 대신 최신 draft ref를 읽는 경로를 `CharacterAssignPanel.test.tsx`에서 payload assertion으로 확인했습니다.
- `CharacterRoleSheetSection.tsx`: blur/preview가 `saveMarkdown()` 기본 인자를 통해 최신 draft를 저장하는 경로를 기존 역할지 저장 테스트로 확인했습니다.
- `richContentTrailingParagraph.ts`: 중간 문단 끝 Enter는 false, 마지막 문단 끝 Enter는 true인 DOM selection 회귀 테스트를 추가했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx src/features/editor/components/content/__tests__/richContentTrailingParagraph.test.ts src/features/editor/components/content/__tests__/RichContentEditor.test.tsx` 통과
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web lint` 통과 (기존 warning 50개, error 0)
- `scripts/mmp-local-ci.sh quick` 통과
- cmux surface:3에서 중간 문단 Enter 이벤트가 `preventDefault=false`, markerDelta=0으로 확인됨

## 리뷰 메모
- PR 전 self-review에서 변경 범위가 역할지 저장 최신화와 RichContentEditor Enter 판별로 한정되어 있음을 확인했습니다.
- build 단계의 Rollup circular/chunk size 경고는 기존 경고이며 이번 변경 파일과 무관합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 편집기에서 중간 문단의 끝에 위치한 커서를 "편집 가능한 끝"으로 잘못 판별하는 문제를 수정했습니다.
  * 마크다운 역할지 저장 시 가장 최신의 초안 내용을 정확하게 적용하도록 개선했습니다.

* **Tests**
  * 편집기 내 선택 위치 판별에 관한 테스트 케이스를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->