### PR TITLE
feat: 캐릭터 공개 소개 자동저장 편집 지원

### DIFF
--- a/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterAssignPanel.tsx
@@ -1,9 +1,10 @@
 import { useState, useCallback, useMemo } from "react";
 import { Edit3, Trash2 } from "lucide-react";
-import type { CharacterAliasRule, EditorCharacterResponse, EditorThemeResponse, MysteryRole } from "@/features/editor/api";
+import type { CharacterAliasRule, EditorCharacterResponse, EditorThemeResponse, MysteryRole, UpdateCharacterRequest } from "@/features/editor/api";
 import { useEditorCharacters, useEditorClues, useUpdateCharacter } from "@/features/editor/api";
 import { useFlowGraph } from "@/features/editor/flowApi";
 import { useCharacterConfigDebounce } from "@/features/editor/hooks/useCharacterConfigDebounce";
+import { useEditorAutosaveToast } from "@/features/editor/hooks/useEditorAutosaveToast";
 import { CharacterDetailPanel } from "./CharacterDetailPanel";
 import { EntityEditorShell } from "@/features/editor/entities/shell/EntityEditorShell";
 import {
@@ -15,6 +16,7 @@ import {
   writePlayerKillCharacterEnabled,
 } from "@/features/editor/utils/configShape";
 import {
+  buildCharacterDescriptionUpdatePayload,
   buildCharacterAliasRulesUpdatePayload,
   buildCharacterVisibilityUpdatePayload,
   buildCharacterProfileImageMediaUpdatePayload,
@@ -105,13 +107,32 @@ export function CharacterAssignPanel({
   );
 
   const { saveConfig, flush } = useCharacterConfigDebounce(themeId, theme.config_json);
+  const {
+    schedule: scheduleCharacterDescriptionSave,
+    flush: flushCharacterDescriptionSave,
+  } = useEditorAutosaveToast<{
+    characterId: string;
+    body: UpdateCharacterRequest;
+  }>({
+    debounceMs: 1000,
+    messages: {
+      toastId: 'character-description-autosave',
+      loading: '캐릭터 소개를 저장 중입니다',
+      success: '캐릭터 소개가 저장되었습니다',
+      error: '캐릭터 소개 저장에 실패했습니다',
+    },
+    mutate: (payload, opts) => {
+      updateCharacter.mutate(payload, opts);
+    },
+  });
 
   const handleSelectChar = useCallback(
     (id: string) => {
       flush();
+      flushCharacterDescriptionSave();
       setSelectedCharId(id);
     },
-    [flush],
+    [flush, flushCharacterDescriptionSave],
   );
 
   const handleClueToggleForChar = useCallback(
@@ -223,6 +244,19 @@ export function CharacterAssignPanel({
     [characters, updateCharacter],
   );
 
+  const handleDescriptionChangeForChar = useCallback(
+    (characterId: string, description: string) => {
+      const selected = characters?.find((char) => char.id === characterId);
+      if (!selected) return;
+
+      scheduleCharacterDescriptionSave({
+        characterId: selected.id,
+        body: buildCharacterDescriptionUpdatePayload(selected, description),
+      });
+    },
+    [characters, scheduleCharacterDescriptionSave],
+  );
+
   if (charsLoading) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center overflow-hidden">
@@ -254,7 +288,10 @@ export function CharacterAssignPanel({
       onBlur={(e) => {
         // Flush pending config when focus leaves the panel entirely. `relatedTarget`
         // is null when the user clicks outside React's focus tree (e.g. tab switch).
-        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) flush();
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+          flush();
+          flushCharacterDescriptionSave();
+        }
       }}
     >
       <EntityEditorShell
@@ -314,6 +351,8 @@ export function CharacterAssignPanel({
             showPlayerKillSettings={isPlayerKillEnabled}
             isKillable={playerKillConfig.killableCharacterIds.includes(char.id)}
             onKillableChange={(checked) => handleKillableChangeForChar(char.id, checked)}
+            onDescriptionChange={(description) => handleDescriptionChangeForChar(char.id, description)}
+            onDescriptionBlur={flushCharacterDescriptionSave}
             onAliasRulesSave={
               updateCharacter.isPending
                 ? undefined

--- a/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
+++ b/apps/web/src/features/editor/components/design/CharacterDetailPanel.tsx
@@ -68,6 +68,8 @@ interface CharacterDetailPanelProps {
   showPlayerKillSettings?: boolean;
   isKillable?: boolean;
   onKillableChange?: (value: boolean) => void;
+  onDescriptionChange?: (description: string) => void;
+  onDescriptionBlur?: () => void;
   onAliasRulesSave?: (rules: CharacterAliasRule[]) => void;
   onProfileImageChange?: (imageMediaId: string | null) => void;
 }
@@ -94,16 +96,20 @@ export function CharacterDetailPanel({
   showPlayerKillSettings = false,
   isKillable = false,
   onKillableChange,
+  onDescriptionChange,
+  onDescriptionBlur,
   onAliasRulesSave,
   onProfileImageChange,
 }: CharacterDetailPanelProps) {
   const [aliasDrafts, setAliasDrafts] = useState<CharacterAliasRule[]>([]);
+  const [descriptionDraft, setDescriptionDraft] = useState('');
   const aliasDraftCharacterIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (aliasDraftCharacterIdRef.current === (selectedChar?.id ?? null)) return;
     aliasDraftCharacterIdRef.current = selectedChar?.id ?? null;
     setAliasDrafts(normalizeCharacterAliasRules(selectedChar?.alias_rules));
+    setDescriptionDraft(selectedChar?.description ?? '');
   }, [selectedChar]);
 
   if (!selectedChar) {
@@ -221,10 +227,26 @@ export function CharacterDetailPanel({
                     </div>
                   </div>
                   <div>
-                    <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-600">공개 소개</p>
-                    <p className="mt-2 min-h-24 rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-xs leading-5 text-slate-400">
-                      {selectedChar.description || '공개 소개가 없습니다.'}
-                    </p>
+                    <label
+                      htmlFor={`character-description-${selectedChar.id}`}
+                      className="text-[10px] font-semibold uppercase tracking-widest text-slate-600"
+                    >
+                      공개 소개
+                    </label>
+                    <textarea
+                      id={`character-description-${selectedChar.id}`}
+                      value={descriptionDraft}
+                      maxLength={2000}
+                      disabled={!onDescriptionChange}
+                      placeholder="공개 소개가 없습니다."
+                      onChange={(event) => {
+                        const next = event.currentTarget.value;
+                        setDescriptionDraft(next);
+                        onDescriptionChange?.(next);
+                      }}
+                      onBlur={onDescriptionBlur}
+                      className="mt-2 min-h-24 w-full resize-y rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-xs leading-5 text-slate-300 outline-none transition focus:border-amber-500/60 focus:ring-2 focus:ring-amber-500/20 disabled:cursor-not-allowed disabled:text-slate-500"
+                    />
                   </div>
                 </div>
                 <div>

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -612,6 +612,59 @@ describe('CharacterAssignPanel', () => {
     });
   });
 
+  it('기본 정보의 공개 소개를 수정하면 기존 자동저장 로직으로 저장한다', async () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
+
+    fireEvent.change(screen.getByLabelText('공개 소개'), {
+      target: { value: '정직하고 내성적인 호텔 직원' },
+    });
+    await act(async () => { vi.advanceTimersByTime(1000); });
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith(
+      {
+        characterId: 'char-1',
+        body: {
+          name: '홍길동',
+          description: '정직하고 내성적인 호텔 직원',
+          image_url: undefined,
+          is_culprit: true,
+          mystery_role: 'culprit',
+          sort_order: 0,
+          is_playable: true,
+          show_in_intro: true,
+          can_speak_in_reading: true,
+          is_voting_candidate: true,
+          is_victim: false,
+          alias_rules: [],
+        },
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it('공개 소개 입력 후 blur 되면 대기 중인 자동저장을 즉시 실행한다', async () => {
+    renderPanel();
+    const descriptionInput = screen.getByLabelText('공개 소개');
+
+    fireEvent.change(descriptionInput, { target: { value: '성실한 청년' } });
+    fireEvent.blur(descriptionInput);
+
+    expect(updateCharacterMutateMock).toHaveBeenCalledOnce();
+    expect(updateCharacterMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        characterId: 'char-1',
+        body: expect.objectContaining({ description: '성실한 청년' }),
+      }),
+      expect.any(Object),
+    );
+    await act(async () => { vi.advanceTimersByTime(1000); });
+    expect(updateCharacterMutateMock).toHaveBeenCalledOnce();
+  });
+
 
   it('선택한 캐릭터가 목록에서 사라지면 현재 상세 캐릭터 ID로 저장한다', async () => {
     let currentCharacters = mockCharacters;

--- a/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
+++ b/apps/web/src/features/editor/entities/character/characterEditorAdapter.ts
@@ -194,6 +194,16 @@ export function buildCharacterRoleUpdatePayload(
   };
 }
 
+export function buildCharacterDescriptionUpdatePayload(
+  character: EditorCharacterResponse,
+  description: string,
+): UpdateCharacterRequest {
+  return {
+    ...buildCharacterBaseUpdatePayload(character),
+    description: description.trim() || undefined,
+  };
+}
+
 export function buildCharacterVisibilityUpdatePayload(
   character: EditorCharacterResponse,
   field: CharacterVisibilityField,


### PR DESCRIPTION
## 요약
- 캐릭터 기본 정보 Accordion의 `공개 소개`를 읽기 전용 문단에서 바로 수정 가능한 textarea로 변경했습니다.
- 기존 공통 자동저장 훅 `useEditorAutosaveToast`를 사용해 debounce 저장, blur 즉시 저장, 토스트 상태 표시, 실패 시 재시도 흐름을 재사용했습니다.
- 캐릭터 설명 변경 전용 payload builder와 자동저장/blur 테스트를 추가했습니다.

## Coverage Plan
- `CharacterDetailPanel.tsx`: 공개 소개 입력 UI, blur flush 연결을 `CharacterAssignPanel.test.tsx`에서 사용자 입력으로 검증했습니다.
- `CharacterAssignPanel.tsx`: 기존 자동저장 훅을 통한 `useUpdateCharacter` payload 호출, 캐릭터 전환/패널 blur 시 flush 경로를 테스트와 local-ci로 검증했습니다.
- `characterEditorAdapter.ts`: 기존 캐릭터 update payload 구조를 유지한 채 description만 교체하는 builder를 자동저장 payload 테스트로 검증했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- CharacterAssignPanel.test.tsx` 통과: 41 tests
- `pnpm --filter @mmp/web typecheck` 통과
- `pnpm --filter @mmp/web lint -- ...` 통과: 0 errors, 기존 repo-wide warnings 47개
- `git diff --check` 통과
- `scripts/mmp-local-ci.sh quick` 통과

## CI policy
- `ready-for-ci` 라벨을 붙이지 않았고 workflow dispatch도 실행하지 않았습니다.
