### PR TITLE
chore: agentic delivery chain 하네스 정식화

### DIFF
--- a/.codex/agents/mmp-backend-engine-reviewer.toml
+++ b/.codex/agents/mmp-backend-engine-reviewer.toml
@@ -16,6 +16,8 @@ Check:
 4. Legacy data paths are preserved or migrated with tests; no silent data loss.
 5. Errors use project error conventions and do not leak internal details.
 6. Unit/integration tests cover runtime decisions and edge cases before relying on E2E.
+7. Confirm that final backend review is independent from the implementer and is rerun after the last fix.
+8. Do not spawn another agent. Return `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex to route.
 
 Output in Korean, under 500 words, with exactly these sections:
 - 발견

--- a/.codex/agents/mmp-backend-implementer.toml
+++ b/.codex/agents/mmp-backend-implementer.toml
@@ -23,6 +23,8 @@ Rules:
 - Do not change frontend adapters, route UI, PR metadata, labels, or merge state unless main Codex explicitly assigns that work.
 - Do not use mock-only behavior, TODO placeholders, skipped tests, force-push, reset, or destructive git commands.
 - If your assigned backend change requires a frontend/shared contract decision, stop and report the required contract decision instead of editing outside ownership.
+- Do not perform the final review or final validation for your own implementation. Recommend the next independent reviewer/validator instead.
+- Do not spawn another agent. Return handoff fields for main Codex to route because MMP agents run with `max_depth=1`.
 
 Final output must be Korean, under 600 words, with exactly these sections:
 - 발견
@@ -30,6 +32,7 @@ Final output must be Korean, under 600 words, with exactly these sections:
 - 판단
 - 미해결
 
-In `수행`, list changed file paths and validation commands/results. If no validation was possible, state the concrete reason and the smallest next check.
+In `수행`, list `changed_files`, validation commands/results, and `risk`. If no validation was possible, state the concrete reason and the smallest next check.
+In `미해결`, include `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex.
 """
 nickname_candidates = ["Duri", "Eun", "Garam"]

--- a/.codex/agents/mmp-ci-steward.toml
+++ b/.codex/agents/mmp-ci-steward.toml
@@ -8,6 +8,7 @@ Goal:
 - Keep one handed-off PR moving through CodeRabbit review cleanup and focused local validation.
 - Let the main Codex continue other issue work in a separate worktree without losing PR lifecycle ownership.
 - Make the lifecycle state observable: do not silently stop at a waiting state, and do not produce a final-looking report while the next autonomous action is still clear.
+- Steward only after main Codex creates the PR. PR creation, scope change, final merge, and merge-batch decisions remain main Codex owned.
 
 Allowed:
 1. Inspect the target PR, review threads, CodeRabbit comments, and existing check summaries.
@@ -36,6 +37,7 @@ Forbidden:
 - Do not add `ready-for-ci`, call `workflow_dispatch`, or use watcher flags that dispatch missing workflows.
 - Do not split steward fixes into extra PRs. Fix the handed-off PR branch unless main Codex explicitly changes the scope.
 - Do not inspect secrets or deployment credentials.
+- Do not spawn another agent. Return `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex to route because MMP agents run with `max_depth=1`.
 
 When blocked:
 - Report the blocker with exact PR number, failing check/thread, relevant log excerpt summary, and the next concrete action needed from main Codex or the user.
@@ -57,6 +59,7 @@ Final output must be Korean, under 600 words, with exactly these sections:
 
 If you changed files, include changed file paths and validation evidence in `수행`.
 Always include the PR head SHA you checked.
+In `미해결`, include `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex.
 If the PR is directly merge-ready, say `MERGE_READY` in `판단`; if only strict behind remains after quality gates are clear, say `MERGE_CANDIDATE`; otherwise say `BLOCKED` or `NEEDS_FIX`. Use `BLOCKED` for watcher timeout/no-progress states, not "waiting".
 """
 nickname_candidates = ["Mina", "Nuri", "Sia"]

--- a/.codex/agents/mmp-contract-integrator.toml
+++ b/.codex/agents/mmp-contract-integrator.toml
@@ -26,6 +26,8 @@ Rules:
 - Do not own broad UI polish or backend runtime implementation unless main Codex assigns those files.
 - Do not create PRs, labels, issues, merge commits, force-pushes, resets, or destructive git operations.
 - If a product or migration decision is ambiguous, stop and report options to main Codex.
+- Do not perform the final review or final validation for your own contract changes. Recommend the next independent reviewer/validator instead.
+- Do not spawn another agent. Return handoff fields for main Codex to route because MMP agents run with `max_depth=1`.
 
 Final output must be Korean, under 650 words, with exactly these sections:
 - 발견
@@ -33,6 +35,7 @@ Final output must be Korean, under 650 words, with exactly these sections:
 - 판단
 - 미해결
 
-In `수행`, list changed file paths, contract surfaces changed, and validation commands/results.
+In `수행`, list `changed_files`, contract surfaces changed, validation commands/results, and `risk`.
+In `미해결`, include `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex.
 """
 nickname_candidates = ["Miro", "Nara", "Oli"]

--- a/.codex/agents/mmp-contract-integrator.toml
+++ b/.codex/agents/mmp-contract-integrator.toml
@@ -29,7 +29,7 @@ Rules:
 - Do not perform the final review or final validation for your own contract changes. Recommend the next independent reviewer/validator instead.
 - Do not spawn another agent. Return handoff fields for main Codex to route because MMP agents run with `max_depth=1`.
 
-Final output must be Korean, under 650 words, with exactly these sections:
+Final output must be Korean, under 600 words, with exactly these sections:
 - 발견
 - 수행
 - 판단

--- a/.codex/agents/mmp-docs-wrap-steward.toml
+++ b/.codex/agents/mmp-docs-wrap-steward.toml
@@ -22,6 +22,7 @@ Rules:
 - Reject one-off observations without repeat evidence unless they prevent immediate damage.
 - Do not read docs/ops/self-improvement/archive by default.
 - Keep output actionable for main Codex to decide what to write or skip.
+- Do not spawn another agent. Return `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex to route because MMP agents run with `max_depth=1`.
 
 Output in Korean, under 700 words, with exactly these sections:
 - 발견
@@ -30,5 +31,6 @@ Output in Korean, under 700 words, with exactly these sections:
 - 미해결
 
 In `판단`, list only high-signal recommended updates and their target surfaces.
+In `미해결`, include `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex.
 """
 nickname_candidates = ["Lina", "Noa", "Sol"]

--- a/.codex/agents/mmp-frontend-editor-reviewer.toml
+++ b/.codex/agents/mmp-frontend-editor-reviewer.toml
@@ -15,7 +15,9 @@ Check:
 3. Components are reusable where the same search/select, entity picker, upload, or relation workflow appears more than once.
 4. Frontend does not fake backend runtime truth such as permissions, phase transitions, or clue effects.
 5. Use existing project UI conventions, Tailwind 4 direct styling, and lucide-react icons only.
-6. User-facing flows have E2E coverage or a documented substitute when E2E is not appropriate.
+6. User-facing flows have an E2E plan and cmux/browser QA evidence, or a documented substitute when E2E is not appropriate.
+7. Confirm that final frontend review is independent from the implementer and is rerun after the last fix.
+8. Do not spawn another agent. Return `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex to route.
 
 Output in Korean, under 500 words, with exactly these sections:
 - 발견

--- a/.codex/agents/mmp-frontend-implementer.toml
+++ b/.codex/agents/mmp-frontend-implementer.toml
@@ -24,6 +24,8 @@ Rules:
 - Do not use mock-only behavior, TODO placeholders, skipped tests, force-push, reset, or destructive git commands.
 - For multi-step assigned work, maintain a Markdown checkbox list and mark only verified completed items as `- [x]` in the final report.
 - If your assigned frontend change requires a backend/shared contract change, stop and report the required contract decision instead of editing the shared contract yourself.
+- Do not perform the final review or final validation for your own implementation. Recommend the next independent reviewer/validator instead.
+- Do not spawn another agent. Return handoff fields for main Codex to route because MMP agents run with `max_depth=1`.
 
 Final output must be Korean, under 600 words, with exactly these sections:
 - 발견
@@ -31,6 +33,7 @@ Final output must be Korean, under 600 words, with exactly these sections:
 - 판단
 - 미해결
 
-In `수행`, list changed file paths and validation commands/results. If no validation was possible, state the concrete reason and the smallest next check.
+In `수행`, list `changed_files`, validation commands/results, and `risk`. If no validation was possible, state the concrete reason and the smallest next check.
+In `미해결`, include `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex.
 """
 nickname_candidates = ["Ari", "Bora", "Cato"]

--- a/.codex/agents/mmp-issue-architect.toml
+++ b/.codex/agents/mmp-issue-architect.toml
@@ -23,18 +23,24 @@ Use this issue structure unless the parent agent asks for a narrower patch:
 6. 완료 조건
 7. Coverage Plan
 8. 검증 계획
-9. PR 묶음 제안
-10. 브레인스토밍 필요 여부
-11. 순서/의존성
-12. Deferred / Follow-up, if anything is intentionally left out
+9. Agent Handoff Contract
+10. PR 묶음 제안
+11. 브레인스토밍 필요 여부
+12. 순서/의존성
+13. Deferred / Follow-up, if anything is intentionally left out
 
 Rules:
 - Prefer read-heavy parallel audit first, then main-agent integration.
 - Name the concrete MMP agents when applicable: `mmp-parallel-coordinator`, `mmp-frontend-editor-reviewer`, `mmp-backend-engine-reviewer`, `mmp-test-coverage-reviewer`.
 - Do not assign two agents to edit the same file or contract boundary at the same time.
 - Put API DTO, frontend adapter/ViewModel mapping, migration decisions, labels, PR creation, and merge decisions under main-agent ownership.
+- State that `.codex/config.toml` has `max_depth=1`, so agents return `next_agent`, `handoff`, `checklist_delta`, and `evidence` instead of spawning the next agent.
+- Do not spawn another agent; main Codex owns all follow-up agent routing.
+- State that implementers cannot be final reviewers/validators, and that independent validation/review reruns after the last fix.
+- State that `mmp-ci-steward` stewards review/wait/fixes only after main Codex creates the PR; PR creation and merge remain main-agent owned.
 - Separate MVP scope from future scope. Do not add enterprise bloat.
 - Add a concrete Coverage Plan for code changes before suggesting PR creation: changed handlers/services/adapters/components must map to focused tests or an explicit E2E substitute.
+- For relevant UI work, include an E2E plan and cmux/browser QA evidence, or a documented substitute.
 - Write task lists, agent handoffs, and execution sequences as Markdown checkboxes (`- [ ]`). If the parent asks for progress tracking, preserve checked items as `- [x]` instead of rewriting them back to plain bullets.
 - Make PR grouping CI-cost aware. Group related same-scope workflow/config/doc changes into one PR, and split only when conflict risk, review ownership, or runtime blast radius justifies another CI cycle.
 - Any deferred/minimized work must be represented as an issue checklist item or follow-up GitHub issue, not only prose.

--- a/.codex/agents/mmp-local-validation-runner.toml
+++ b/.codex/agents/mmp-local-validation-runner.toml
@@ -22,6 +22,8 @@ Rules:
 - If a command produces large output, summarize the first failing test, root-cause evidence, and exact rerun command instead of pasting the full log.
 - If a command writes cache/build artifacts, report only tracked-file changes if any appear.
 - For multiple assigned validation steps, keep a Markdown checkbox list and mark only completed, evidenced checks as `- [x]`.
+- Do not validate your own source edits unless main Codex explicitly assigns a separate validation-fix task; final validation should be independent of the implementer.
+- Do not spawn another agent. Return handoff fields for main Codex to route because MMP agents run with `max_depth=1`.
 
 Final output must be Korean, under 550 words, with exactly these sections:
 - 발견
@@ -30,5 +32,6 @@ Final output must be Korean, under 550 words, with exactly these sections:
 - 미해결
 
 Always include exact command(s), exit status, and the smallest next action.
+In `미해결`, include `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex.
 """
 nickname_candidates = ["Hana", "Ivy", "Juno"]

--- a/.codex/agents/mmp-parallel-coordinator.toml
+++ b/.codex/agents/mmp-parallel-coordinator.toml
@@ -35,6 +35,9 @@ Rules:
 - Keep PR grouping CI-cost aware. Do not recommend many tiny PRs for same-scope changes just because tasks can run in parallel; group related low-conflict work when one validation cycle is enough.
 - Use checkbox task lists for execution order, validation gates, and main-agent integration checkpoints. Checked state (`- [x]`) means verified completion, not merely assigned work.
 - Split PRs when shared contracts, migration, runtime behavior, or review ownership would make one PR hard to verify.
+- Account for `.codex/config.toml` `max_depth=1`: agents must not spawn follow-up agents, so every lane needs `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex.
+- Include independent gates: implementers cannot be final reviewers/validators, and validation/review reruns after the last fix.
+- For relevant UI lanes, require E2E planning and cmux/browser QA evidence.
 - Do not perform code edits, PR creation, label changes, merge, deploy, secret access, or destructive commands.
 - Keep recommendations practical for current MMP Phase 25 issues.
 

--- a/.codex/agents/mmp-performance-reviewer.toml
+++ b/.codex/agents/mmp-performance-reviewer.toml
@@ -19,6 +19,8 @@ Rules:
 - Focus on concrete regressions and likely production symptoms, not theoretical micro-optimizations.
 - Include file/line references when possible.
 - If performance risk needs measurement, state the smallest focused benchmark, test, or log probe.
+- Confirm that performance review is independent from the implementer and is rerun after the last performance-relevant fix.
+- Do not spawn another agent. Return `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex to route.
 
 Output in Korean, under 600 words, with exactly these sections:
 - 발견

--- a/.codex/agents/mmp-security-reviewer.toml
+++ b/.codex/agents/mmp-security-reviewer.toml
@@ -21,6 +21,8 @@ Rules:
 - Prioritize high-confidence exploitable findings. Avoid noisy style feedback.
 - Include file/line references when possible.
 - If a finding depends on runtime behavior not visible in the diff, mark it as an open question with the exact verification needed.
+- Confirm that security review is independent from the implementer and is rerun after the last security-relevant fix.
+- Do not spawn another agent. Return `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex to route.
 
 Output in Korean, under 600 words, with exactly these sections:
 - 발견

--- a/.codex/agents/mmp-test-coverage-reviewer.toml
+++ b/.codex/agents/mmp-test-coverage-reviewer.toml
@@ -16,6 +16,9 @@ Check:
 6. Failed tests are root-caused; do not recommend skipping or weakening tests.
 7. Do not recommend `ready-for-ci`, workflow dispatch, or GitHub Actions worker waiting for the default development-minimum PR flow.
 8. Report exact commands that were run or should be run next.
+9. Confirm that final validation is independent from the implementer and is rerun after the last fix.
+10. Do not spawn another agent. Return `next_agent`, `handoff`, `checklist_delta`, and `evidence` for main Codex to route.
+11. For relevant UI work, require an E2E plan plus cmux/browser QA evidence, or a documented substitute.
 
 Output in Korean, under 500 words, with exactly these sections:
 - 발견

--- a/.codex/skills/mmp-agentic-delivery-chain/SKILL.md
+++ b/.codex/skills/mmp-agentic-delivery-chain/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: mmp-agentic-delivery-chain
+description: Use when MMP work requires OOO, subagents, harness engineering, strict role separation, independent review or validation, or issue-to-PR execution.
+---
+
+# MMP Agentic Delivery Chain
+
+This skill is the entrypoint for MMP work that must be executed through agent handoffs instead of direct main-thread implementation.
+
+## Trigger
+
+Use this when the user asks for OOO, subagents, harness engineering, strict role separation, issue-to-PR execution, or "do not review/validate your own work".
+
+## Chain
+
+1. Preflight:
+   - Run `scripts/mmp-workflow-preflight.sh` when practical.
+   - Work on a feature/chore branch or separate worktree.
+2. Requirements:
+   - Use `deep-interview` first when goal, scope, exclusions, constraints, or done criteria are unclear.
+   - Run OOO interview/refinement only after the deep-interview brief or an explicit safe default exists.
+   - Keep OOO bounded to the accepted brief; cancel or salvage if it widens scope.
+3. Tracking:
+   - Create or update a GitHub issue with `mmp-issue-planning`.
+   - Create/approve the local seed when PR guard requires it.
+   - The issue/seed must include objective, scope in/out, exclusions, done criteria, Coverage Plan, validation plan, and E2E/browser QA expectations when UI is involved.
+4. Delegation:
+   - Main Codex owns orchestration. `.codex/config.toml` uses `max_depth = 1`, so subagents must not spawn follow-up agents.
+   - Each agent returns `next_agent`, `handoff`, `checklist_delta`, and `evidence`; main Codex decides the next spawn.
+   - Use `mmp-parallel-coordinator` first for non-trivial splits.
+5. Implementation:
+   - Assign explicit file/module ownership.
+   - Implementers may run focused checks for their slice, but cannot be final reviewers or final validators for their own work.
+6. Review and validation:
+   - Run independent validation with `mmp-local-validation-runner` or a relevant reviewer lane.
+   - Run independent review by axis: frontend, backend, test coverage, security, performance, or docs/workflow.
+   - If fixes are needed, assign a different fixer where practical. For tiny one- or two-file urgent fixes, main Codex may patch directly and must state the exception.
+   - After the last fix, rerun independent validation and the relevant independent review before PR creation or merge judgment.
+7. PR:
+   - Main Codex creates PRs, decides scope, and merges.
+   - Use `mmp-pr-lifecycle`.
+   - `mmp-ci-steward` may handle CodeRabbit waiting, valid review fixes, and focused validation on a handed-off PR, but does not create or merge PRs.
+
+## Required Handoff Fields
+
+```md
+next_agent:
+handoff:
+checklist_delta:
+evidence:
+```
+
+`evidence` should name changed files, commands, exit status, browser surface, screenshots, logs, or review findings. For UI work, include the E2E plan and cmux/browser QA evidence or the documented substitute.
+
+## Stop Conditions
+
+- OOO or a subagent expands beyond accepted scope.
+- Two agents would edit the same file or shared contract at the same time.
+- An implementer is about to be used as final reviewer or final validator.
+- Final validation/review has not rerun after the last fix.
+- PR creation, label, or merge authority is being delegated away from main Codex.
+
+## Done
+
+- Issue/seed/checklist can reproduce the chain.
+- Each delegated result has the four handoff fields.
+- Final validation and review are independent and post-fix.
+- PR/merge ownership remains with main Codex.

--- a/.codex/skills/mmp-issue-planning/SKILL.md
+++ b/.codex/skills/mmp-issue-planning/SKILL.md
@@ -33,6 +33,7 @@ description: Use when creating, rewriting, prioritizing, or executing MMP GitHub
 2. Issue 생성/재작성 요청이 모호하면 `deep-interview` skill을 먼저 사용해 실행 브리프를 만든다.
    - 사용자에게 묻기 전에 repo 코드, 기존 Issue/PR, plan 문서, `memory/`에서 직접 확인 가능한 사실을 먼저 확인한다.
    - 인터뷰 대상은 목표, 포함 범위, 제외 범위, 제약, 완료 기준 중 실행을 막는 가장 큰 불확실성 하나로 좁힌다.
+   - OOO interview/refinement는 deep-interview 실행 브리프 또는 명시된 안전 기본값 이후에만 사용하고, accepted scope를 넓히지 않는다.
    - 마지막 실행 브리프의 목표/범위/제외/제약/완료 기준/열린 질문을 Issue 본문에 반영한다.
    - 바로 실행해도 안전한 기본값이 있고 사용자가 자율 진행을 허용한 상황이면 질문으로 멈추지 말고 권장 기본값을 명시해 진행한다.
 3. 각 Issue에는 가능한 한 아래 섹션을 포함한다.
@@ -44,6 +45,7 @@ description: Use when creating, rewriting, prioritizing, or executing MMP GitHub
    - `## 완료 조건`
    - `## Coverage Plan`
    - `## 검증 계획`
+   - `## Agent Handoff Contract`
    - `## PR 묶음 제안`
    - `## 브레인스토밍 필요 여부`
    - `## 순서/의존성`
@@ -59,27 +61,33 @@ description: Use when creating, rewriting, prioritizing, or executing MMP GitHub
    - `### 병렬 금지/주의 영역`: shared contract, migration, PR label/merge, 같은 파일 수정 위험을 적는다.
    - `### 취합 방식`: 각 subagent는 `발견 / 수행 / 판단 / 미해결`로 보고하고, 메인 Codex가 중복 제거와 최종 통합을 맡는다고 적는다.
    - `### 실행 체크리스트`: agent별 todo를 `- [ ]`로 적고, 메인 Codex가 취합하면서 완료 항목을 `- [x]`로 갱신한다고 적는다.
+   - `### Agent Handoff Contract`: `.codex/config.toml`의 `max_depth = 1` 제약을 적고, 각 agent가 다음 agent를 직접 부르지 않고 `next_agent / handoff / checklist_delta / evidence`를 반환한다고 적는다.
 6. 가능한 경우 실제 MMP agent 이름을 명시한다.
    - `mmp-parallel-coordinator`
    - `mmp-frontend-editor-reviewer`
    - `mmp-backend-engine-reviewer`
    - `mmp-test-coverage-reviewer`
 7. API DTO, frontend adapter/ViewModel mapping, migration 결정, PR 생성, label, merge는 메인 Codex 소유로 둔다.
+   - `mmp-ci-steward`는 main Codex가 만든 PR의 review/wait/fix stewardship만 맡고, PR 생성/merge 판단은 하지 않는다.
 8. 코드 작성/수정 이슈의 `## Coverage Plan`에는 변경 예상 파일/모듈별 테스트 책임을 적는다.
    - Backend handler/service: 성공 경로, validation, not found, ownership, conflict, delete-blocked 같은 실패 경로를 unit/integration test로 매핑한다.
    - Frontend adapter/hook/component: 저장 payload, dirty state, error UI, empty/loading state, direct URL/tab state를 Vitest/E2E로 매핑한다.
-   - E2E 제외 시에는 왜 E2E가 부적합한지와 대체 테스트를 적는다.
+   - UI 작업에는 E2E 계획과 cmux/browser QA evidence 항목을 넣는다. E2E 제외 시에는 왜 E2E가 부적합한지와 대체 테스트를 적는다.
    - Codecov patch coverage 70%를 PR 끝에서 처음 확인하는 흐름을 피하기 위해, issue 단계에서 미리 테스트 파일 후보를 지정한다.
-8. MVP와 후순위를 분리한다. 범위가 커지거나 구현 중 제외하는 항목이 생기면 `## Deferred / Follow-up`에 남긴다.
+9. 실행 순서에는 독립성 gate를 넣는다.
+   - 구현 agent는 자기 변경의 최종 review/validation owner가 될 수 없다.
+   - fix는 가능하면 구현 agent와 다른 owner에게 맡긴다. 작은 1~2파일 critical fix만 main Codex 예외를 허용한다.
+   - 마지막 fix 이후 독립 validation과 관련 review lane을 다시 실행한다.
+10. MVP와 후순위를 분리한다. 범위가 커지거나 구현 중 제외하는 항목이 생기면 `## Deferred / Follow-up`에 남긴다.
    - 같은 이슈 안에서 이어서 처리할 작은 항목이면 체크리스트로 둔다.
    - 독립 PR이 필요하거나 다른 owner/검증 범위를 갖는 항목이면 새 GitHub Issue를 만든다.
    - PR 본문에는 완료 범위는 `Closes #번호`, 후속/부분 범위는 `Refs #번호`로 연결한다.
-9. `## PR 묶음 제안`은 CI 비용까지 고려한다.
+11. `## PR 묶음 제안`은 CI 비용까지 고려한다.
    - 같은 이슈/같은 CI scope/같은 review surface의 repo-local workflow 변경은 하나의 PR로 묶는 것을 우선한다.
    - shared contract, migration, large UI route, backend API처럼 실패 blast radius가 큰 변경은 별도 PR로 분리한다.
    - “작게 쪼개기”는 기본값이 아니라 충돌·리뷰 위험을 줄일 때만 선택한다. CI를 여러 번 태우는 초소형 PR은 피한다.
-10. 에디터 이슈는 Uzu docs를 참고할 수 있지만, MMP runtime/gameplay 규칙이 최종 기준이다.
-11. 계획 문서나 Issue를 만들 때는 `완료 조건 선행` 방식으로 작성한다.
+12. 에디터 이슈는 Uzu docs를 참고할 수 있지만, MMP runtime/gameplay 규칙이 최종 기준이다.
+13. 계획 문서나 Issue를 만들 때는 `완료 조건 선행` 방식으로 작성한다.
    - 먼저 사용자가 체감할 완료 상태, 데이터/계약 완료 상태, 품질/검증 완료 상태를 분리해 적는다.
    - 이후 작업 체크리스트의 각 항목이 어떤 완료 조건을 만족시키는지 연결되게 쓴다.
    - 완료 조건을 만족시키지 않는 작업은 MVP에서 제외하거나 `Deferred / Follow-up`으로 분리한다.
@@ -95,7 +103,8 @@ description: Use when creating, rewriting, prioritizing, or executing MMP GitHub
 - 병렬 가능한 lane과 충돌 금지 영역이 둘 다 적혀 있다.
 - 완료 조건에 테스트 또는 테스트 대체 근거가 있다.
 - 완료 조건이 사용자 경험, 데이터/계약, 품질/검증으로 나뉘어 있고 작업 체크리스트가 그 조건을 만족하도록 구성되어 있다.
-- Coverage Plan에 변경 파일별 테스트 매핑이 있다.
+- Coverage Plan에 변경 파일별 테스트 매핑이 있고, 관련 UI 작업에는 E2E 계획과 cmux/browser QA evidence 요구가 있다.
+- Agent Handoff Contract에 `next_agent / handoff / checklist_delta / evidence`, `max_depth = 1`, 독립 review/validation gate가 보인다.
 - Deferred / Follow-up 판단이 추적 가능하거나, 후속 없음이 명확하다.
 - PR 묶음은 충돌 위험과 CI 비용을 함께 고려했고, 브레인스토밍 필요 여부가 명확하다.
 

--- a/.codex/skills/mmp-subagent-orchestration/SKILL.md
+++ b/.codex/skills/mmp-subagent-orchestration/SKILL.md
@@ -17,6 +17,12 @@ description: Use when executing MMP work under the user-approved main-Codex-as-o
    - goal, issue/plan link, scope, exclusions, Coverage Plan, file/module ownership, stop conditions, and validation gate.
    - Write executable work items as Markdown checkboxes (`- [ ]`) and update completed items to `- [x]` as agents report verified completion.
    - Include the checkbox ledger in subagent handoffs when the agent owns multiple steps, so the agent can report which items are done, blocked, or deferred.
+   - Because `.codex/config.toml` sets `max_depth = 1`, subagents must not call the next agent. They return `next_agent`, `handoff`, `checklist_delta`, and `evidence`; main Codex decides and spawns the next step.
+   - Standard handoff fields:
+     - `next_agent`: recommended next lane or `none`
+     - `handoff`: concise context and exact files/commands for the next lane
+     - `checklist_delta`: completed/blocked/deferred checkbox updates
+     - `evidence`: changed files, commands, exit status, browser surface, logs, or review findings
 2. Start with `mmp-parallel-coordinator` for non-trivial work:
    - use it to split read-heavy audits, write ownership, conflict risks, and integration checkpoints.
 3. Delegate implementation by ownership:
@@ -34,6 +40,7 @@ description: Use when executing MMP work under the user-approved main-Codex-as-o
    - when local browser QA is explicitly in cmux, instruct validation agents to use the `cmux-browse` skill/CLI first and to report a fallback only if cmux browser control is unavailable.
 6. Delegate PR waiting/fix loop:
    - use `mmp-ci-steward` for one handed-off PR after main Codex creates the PR.
+   - `mmp-ci-steward` owns review waiting and valid fix stewardship only; PR creation, PR scope changes, labels outside policy, and merge remain main Codex decisions.
 7. Delegate wrap-up:
    - use `mmp-docs-wrap-steward` after significant work to propose docs, automation, learning, and follow-up candidates.
 8. Main Codex integrates:
@@ -41,13 +48,19 @@ description: Use when executing MMP work under the user-approved main-Codex-as-o
    - decide which findings are valid
    - make PR/merge/user-facing decisions
    - close completed subagents after collecting final output
+9. Enforce independence gates:
+   - implementers do not provide the final review or final validation for their own changes.
+   - after the final fix, rerun independent validation plus the relevant review lane before PR creation or merge judgment.
+   - for relevant UI work, require an E2E plan and browser QA evidence; use cmux first when that is the active or requested browser surface, and record the fallback reason otherwise.
 
 ## Done
 
 - Assigned agents, ownership, and stop conditions are explicit.
 - The active task ledger uses checkboxes and completed items are checked off before final reporting.
 - Implementation agents changed only assigned files.
+- Subagents returned `next_agent`, `handoff`, `checklist_delta`, and `evidence` instead of spawning follow-up agents.
 - Review and validation evidence is summarized without raw log dumps.
+- Final validation/review was performed by an independent lane after the last fix.
 - PR creation/merge and product-risk decisions remain with main Codex.
 
 ## Avoid

--- a/.codex/skills/mmp-workflow-harness/SKILL.md
+++ b/.codex/skills/mmp-workflow-harness/SKILL.md
@@ -10,6 +10,7 @@ description: Use when starting or standardizing non-trivial MMP work from user r
 - A user request may turn into code, config, data, browser QA, PR, or merge work.
 - The request starts from a screen symptom, backend error, production-like data issue, or broad workflow improvement.
 - You need to keep the main Codex session as the decision and integration owner while preserving a clear execution ledger.
+- If the user explicitly requires OOO, subagent handoffs, independent review/validation, and PR stewardship as one routine, load `mmp-agentic-delivery-chain` as the narrower entrypoint.
 
 ## Do
 
@@ -35,8 +36,10 @@ description: Use when starting or standardizing non-trivial MMP work from user r
    - Backend: log, API response, DB state, ownership/auth, error type.
    - Workflow/CI: script path, exit code meaning, marker file, generated diff.
 5. Use interview/seed only where it adds control:
-   - Use `deep-interview` or OOO interview for ambiguous goals, UX decisions, data contracts, or destructive operations.
+   - Use `deep-interview` first when goals, scope, exclusions, constraints, or done criteria are materially unclear.
+   - Use OOO interview/refinement only after the deep-interview brief exists or a safe default is explicit; keep OOO bounded to refining the accepted brief.
    - Use Issue/Seed for trackable multi-step work.
+   - Before implementation, ensure the issue/seed captures objective, scope in/out, done criteria, Coverage Plan, validation plan, and E2E/browser QA expectations when UI is involved.
    - For small defects with clear evidence, proceed with a narrow plan and record assumptions in the final report.
 6. OOO run scope guard:
    - Stop or cancel OOO execution when it expands beyond the accepted scope, touches unrelated backend/API/DB/media areas, multiplies acceptance criteria without user approval, or stalls without new evidence.
@@ -45,15 +48,20 @@ description: Use when starting or standardizing non-trivial MMP work from user r
    - Use a feature/chore branch or separate worktree.
    - Do not mix unrelated dirty worktree changes.
    - Prefer existing project patterns and small direct changes.
+   - Main Codex orchestrates the chain because `.codex/config.toml` uses `max_depth = 1`; subagents return handoff fields and never spawn the next agent directly.
+   - Implementers must not review or validate their own work as the final gate. Assign independent review/validation after implementation.
 8. Validation:
    - Run focused tests first.
    - Add typecheck/lint/build when frontend or shared TS changes.
    - Use `scripts/mmp-local-ci.sh quick` for PR-bound code changes when practical.
+   - For relevant UI work, include an E2E plan plus browser QA evidence. If E2E is not appropriate, record the reason and substitute tests.
    - For cmux browser QA, report the surface, URL, user flow, assertion, and fallback reason if cmux is unavailable.
+   - After the last fix commit/change, rerun independent validation and review before PR creation or merge judgment.
 9. Review and PR:
    - Use `mmp-pr-lifecycle` before PR creation or merge.
    - Keep PR title/body in Korean.
    - Use CodeRabbit and unresolved-thread gates under the repo policy.
+   - PR creation and merge remain main Codex owned. `mmp-ci-steward` may steward review wait loops and valid fixes on a handed-off PR, but does not create or merge PRs.
 
 ## Browser Evidence Format
 


### PR DESCRIPTION
## 요약

- `mmp-agentic-delivery-chain` skill을 추가해 deep-interview → OOO refinement → issue/seed → delegated implementation → independent validation/review → final rerun → PR lifecycle 흐름을 한 곳에서 시작할 수 있게 했습니다.
- 기존 `mmp-workflow-harness`, `mmp-subagent-orchestration`, `mmp-issue-planning`에 `max_depth = 1` 기반 handoff 계약과 독립 review/validation gate를 반영했습니다.
- 기존 MMP subagent TOML들에 `next_agent / handoff / checklist_delta / evidence` 반환, 자기 작업 최종 리뷰/검증 금지, PR/merge main Codex 소유 경계를 명시했습니다.

## Coverage Plan

- Skill/template 변경: 새 skill 존재와 workflow keyword contract를 grep 기반으로 검증했습니다.
- Agent TOML 변경: handoff field, `max_depth`, 독립 final validation/review, `mmp-ci-steward`, E2E/cmux QA 문구가 `.codex/agents`와 `.codex/skills`에 반영됐는지 확인했습니다.
- 문서성 workflow 변경이라 앱 E2E는 대상이 아니며, UI 작업용 E2E/cmux evidence 요구사항 자체를 harness에 추가했습니다.

## Local validation

- `git diff --check -- .codex/skills .codex/agents` → pass
- `scripts/mmp-workflow-seed.sh validate --issue 682` → pass
- `rg -n "next_agent|handoff|checklist_delta|evidence|max_depth|deep-interview|OOO interview/refinement|final validation|final review|mmp-ci-steward|E2E plan|cmux/browser QA" .codex/skills .codex/agents` → pass
- `test -f .codex/skills/mmp-agentic-delivery-chain/SKILL.md` → pass

## Notes

- 이번 작업 중 긴 독립 리뷰 에이전트 2회가 timeout되어 종료됐고, 짧은 명령형 `mmp-local-validation-runner` 검증으로 재실행했습니다. 이 결과가 새 chain의 stop condition 필요성을 뒷받침합니다.
- Untracked `screenshots/issue-680-cmux/`는 이전 UI QA 산출물이라 이번 PR에 포함하지 않았습니다.

Closes #682


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 신규 에이전트 핸드오프 기반 배포 체인 기술 문서 추가
  * 이슈 계획 및 하위 에이전트 오케스트레이션 가이드 개선

* **Chores**
  * 워크플로우 에이전트 구성 최적화로 검증 및 리뷰 독립성 강화
  * 책임 분리 및 핸드오프 절차 표준화로 배포 프로세스 안정화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sabyunrepo/muder_platform/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->