### PR TITLE
fix: lazy-auth 전환 전 public/auth 경계 강화

### DIFF
--- a/apps/server/internal/domain/theme/service.go
+++ b/apps/server/internal/domain/theme/service.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mmp-platform/server/internal/engine"
 )
 
+const publishedStatus = "PUBLISHED"
+
 // ThemeSummary is the compact representation used in list endpoints.
 type ThemeSummary struct {
 	ID          uuid.UUID `json:"id"`
@@ -82,7 +84,7 @@ func (s *service) GetTheme(ctx context.Context, themeID uuid.UUID) (*ThemeRespon
 		s.logger.Error().Err(err).Stringer("theme_id", themeID).Msg("failed to get theme")
 		return nil, apperror.Internal("failed to get theme")
 	}
-	return toThemeResponse(theme), nil
+	return toPublicThemeResponse(theme)
 }
 
 func (s *service) GetThemeBySlug(ctx context.Context, slug string) (*ThemeResponse, error) {
@@ -94,7 +96,7 @@ func (s *service) GetThemeBySlug(ctx context.Context, slug string) (*ThemeRespon
 		s.logger.Error().Err(err).Str("slug", slug).Msg("failed to get theme by slug")
 		return nil, apperror.Internal("failed to get theme")
 	}
-	return toThemeResponse(theme), nil
+	return toPublicThemeResponse(theme)
 }
 
 func (s *service) ListPublished(ctx context.Context, limit, offset int32) ([]ThemeSummary, error) {
@@ -115,6 +117,18 @@ func (s *service) ListPublished(ctx context.Context, limit, offset int32) ([]The
 }
 
 func (s *service) GetCharacters(ctx context.Context, themeID uuid.UUID) ([]CharacterResponse, error) {
+	theme, err := s.queries.GetTheme(ctx, themeID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.NotFound("theme not found")
+		}
+		s.logger.Error().Err(err).Stringer("theme_id", themeID).Msg("failed to get theme")
+		return nil, apperror.Internal("failed to get characters")
+	}
+	if theme.Status != publishedStatus {
+		return nil, apperror.NotFound("theme not found")
+	}
+
 	chars, err := s.queries.GetThemeCharacters(ctx, themeID)
 	if err != nil {
 		s.logger.Error().Err(err).Stringer("theme_id", themeID).Msg("failed to get theme characters")
@@ -174,6 +188,15 @@ func toThemeResponse(t db.Theme) *ThemeResponse {
 		PublishedAt:  timestampToPtr(t.PublishedAt),
 		CreatedAt:    t.CreatedAt,
 	}
+}
+
+func toPublicThemeResponse(t db.Theme) (*ThemeResponse, error) {
+	if t.Status != publishedStatus {
+		return nil, apperror.NotFound("theme not found")
+	}
+	resp := toThemeResponse(t)
+	resp.ConfigJson = nil
+	return resp, nil
 }
 
 func textToPtr(t pgtype.Text) *string {

--- a/apps/server/internal/domain/theme/service_test.go
+++ b/apps/server/internal/domain/theme/service_test.go
@@ -7,7 +7,115 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+
+	"github.com/mmp-platform/server/internal/apperror"
 )
+
+func TestGetTheme_HidesUnpublishedThemes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID, _ := f.createThemeForUserWithStatus(t, creatorID, "DRAFT", json.RawMessage(`{"private":"draft"}`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	_, err := svc.GetTheme(ctx, themeID)
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != apperror.ErrNotFound {
+		t.Fatalf("expected NOT_FOUND, got %s", appErr.Code)
+	}
+}
+
+func TestGetThemeBySlug_HidesUnpublishedThemes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	_, slug := f.createThemeForUserWithStatus(t, creatorID, "DRAFT", json.RawMessage(`{"private":"draft"}`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	_, err := svc.GetThemeBySlug(ctx, slug)
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != apperror.ErrNotFound {
+		t.Fatalf("expected NOT_FOUND, got %s", appErr.Code)
+	}
+}
+
+func TestGetTheme_ReturnsPublishedThemeWithoutConfigJson(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID, _ := f.createThemeForUserWithStatus(t, creatorID, "PUBLISHED", json.RawMessage(`{"private":"published-runtime-config"}`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	got, err := svc.GetTheme(ctx, themeID)
+	if err != nil {
+		t.Fatalf("GetTheme: %v", err)
+	}
+	if got.ID != themeID {
+		t.Fatalf("theme id = %s, want %s", got.ID, themeID)
+	}
+	if got.Status != "PUBLISHED" {
+		t.Fatalf("status = %s, want PUBLISHED", got.Status)
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal theme: %v", err)
+	}
+	if jsonObjectContainsKey(t, raw, "config_json") {
+		t.Fatalf("public theme response leaked config_json: %s", string(raw))
+	}
+}
+
+func TestGetThemeBySlug_ReturnsPublishedThemeWithoutConfigJson(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	_, slug := f.createThemeForUserWithStatus(t, creatorID, "PUBLISHED", json.RawMessage(`{"private":"published-runtime-config"}`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	got, err := svc.GetThemeBySlug(ctx, slug)
+	if err != nil {
+		t.Fatalf("GetThemeBySlug: %v", err)
+	}
+	if got.Slug != slug {
+		t.Fatalf("slug = %s, want %s", got.Slug, slug)
+	}
+	if got.Status != "PUBLISHED" {
+		t.Fatalf("status = %s, want PUBLISHED", got.Status)
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal theme: %v", err)
+	}
+	if jsonObjectContainsKey(t, raw, "config_json") {
+		t.Fatalf("public theme response leaked config_json: %s", string(raw))
+	}
+}
 
 func TestGetCharacters_UsesBackendDisplayResolverWithoutLeakingAliasRules(t *testing.T) {
 	if testing.Short() {
@@ -16,7 +124,7 @@ func TestGetCharacters_UsesBackendDisplayResolverWithoutLeakingAliasRules(t *tes
 	f := setupThemeFixture(t)
 	ctx := context.Background()
 	creatorID := f.createUser(t)
-	themeID := f.createThemeForUser(t, creatorID)
+	themeID, _ := f.createThemeForUserWithStatus(t, creatorID, "PUBLISHED", json.RawMessage(`{}`))
 
 	charID := f.createCharacter(t, themeID, "홍길동", json.RawMessage(`[{
 		"id":"alias-1",
@@ -46,6 +154,31 @@ func TestGetCharacters_UsesBackendDisplayResolverWithoutLeakingAliasRules(t *tes
 	}
 }
 
+func TestGetCharacters_HidesUnpublishedThemes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID, _ := f.createThemeForUserWithStatus(t, creatorID, "DRAFT", json.RawMessage(`{}`))
+	f.createCharacter(t, themeID, "비공개 캐릭터", json.RawMessage(`[]`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	_, err := svc.GetCharacters(ctx, themeID)
+	assertNotFound(t, err)
+}
+
+func jsonObjectContainsKey(t *testing.T, raw []byte, key string) bool {
+	t.Helper()
+	var row map[string]any
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatalf("unmarshal row: %v", err)
+	}
+	_, ok := row[key]
+	return ok
+}
+
 func jsonContainsKey(t *testing.T, raw []byte, key string) bool {
 	t.Helper()
 	var rows []map[string]any
@@ -58,6 +191,20 @@ func jsonContainsKey(t *testing.T, raw []byte, key string) bool {
 		}
 	}
 	return false
+}
+
+func assertNotFound(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != apperror.ErrNotFound {
+		t.Fatalf("expected NOT_FOUND, got %s", appErr.Code)
+	}
 }
 
 func (f *themeFixture) createCharacter(t *testing.T, themeID uuid.UUID, name string, aliasRules json.RawMessage) uuid.UUID {

--- a/apps/server/internal/domain/theme/test_fixture_test.go
+++ b/apps/server/internal/domain/theme/test_fixture_test.go
@@ -3,6 +3,7 @@ package theme
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -70,13 +71,27 @@ func (f *themeFixture) createUser(t *testing.T) uuid.UUID {
 
 func (f *themeFixture) createThemeForUser(t *testing.T, creatorID uuid.UUID) uuid.UUID {
 	t.Helper()
+	id, _ := f.createThemeForUserWithStatus(t, creatorID, "DRAFT", json.RawMessage(`{}`))
+	return id
+}
+
+func (f *themeFixture) createThemeForUserWithStatus(t *testing.T, creatorID uuid.UUID, status string, config json.RawMessage) (uuid.UUID, string) {
+	t.Helper()
+	slug := fmt.Sprintf("theme-%s", uuid.New().String()[:8])
 	var id uuid.UUID
 	if err := f.pool.QueryRow(context.Background(), `
-		INSERT INTO themes (creator_id, title, slug, min_players, max_players, duration_min, config_json)
-		VALUES ($1, 'Theme', $2, 2, 6, 60, '{}')
+		INSERT INTO themes (creator_id, title, slug, min_players, max_players, duration_min, status, config_json)
+		VALUES ($1, 'Theme', $2, 2, 6, 60, $3, $4)
 		RETURNING id
-	`, creatorID, fmt.Sprintf("theme-%s", uuid.New().String()[:8])).Scan(&id); err != nil {
+	`, creatorID, slug, status, config).Scan(&id); err != nil {
 		t.Fatalf("create theme: %v", err)
 	}
-	return id
+	if status == "PUBLISHED" {
+		if _, err := f.pool.Exec(context.Background(), `
+			UPDATE themes SET published_at = NOW() WHERE id = $1
+		`, id); err != nil {
+			t.Fatalf("publish theme timestamp: %v", err)
+		}
+	}
+	return id, slug
 }

--- a/apps/server/internal/middleware/auth.go
+++ b/apps/server/internal/middleware/auth.go
@@ -52,6 +52,10 @@ func Auth(cfg JWTConfig) func(http.Handler) http.Handler {
 				apperror.WriteError(w, r, apperror.Unauthorized("invalid token claims"))
 				return
 			}
+			if tokenType, _ := claims["type"].(string); tokenType == "refresh" {
+				apperror.WriteError(w, r, apperror.New(apperror.ErrAuthTokenInvalid, http.StatusUnauthorized, "refresh token cannot be used for HTTP auth"))
+				return
+			}
 
 			sub, _ := claims.GetSubject()
 			userID, err := uuid.Parse(sub)

--- a/apps/server/internal/middleware/auth_test.go
+++ b/apps/server/internal/middleware/auth_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	authdomain "github.com/mmp-platform/server/internal/domain/auth"
 	"github.com/mmp-platform/server/internal/middleware"
 )
 
@@ -55,6 +56,37 @@ func TestAuth_ValidToken(t *testing.T) {
 	}
 	if gotRole != "HOST" {
 		t.Fatalf("expected role HOST, got %s", gotRole)
+	}
+}
+
+func TestAuth_RejectsRefreshTokenBearer(t *testing.T) {
+	userID := uuid.New()
+	tokenStr, _, err := authdomain.GenerateRefreshToken(userID, []byte(testSecret))
+	if err != nil {
+		t.Fatalf("generate refresh token: %v", err)
+	}
+
+	handler := middleware.Auth(middleware.JWTConfig{Secret: []byte(testSecret)})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("handler should not be called")
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	if body["code"] != "AUTH_TOKEN_INVALID" {
+		t.Fatalf("expected code AUTH_TOKEN_INVALID, got %v", body["code"])
 	}
 }
 


### PR DESCRIPTION
## 요약

Refs #687

Lazy-auth 전환 전에 로그인 없이 볼 수 있는 public API 경계를 먼저 막았습니다.

- HTTP 보호 라우트에서 refresh token을 Bearer token으로 사용할 수 없도록 `AUTH_TOKEN_INVALID`로 거절합니다.
- public theme detail/id, slug 조회는 `PUBLISHED` 상태만 응답하고 `config_json`을 제거합니다.
- public theme characters 조회도 `PUBLISHED` theme에서만 가능하도록 막아 draft/private theme character 노출을 차단합니다.

## Coverage Plan

- `apps/server/internal/middleware/auth.go`
  - access token 기반 인증 기존 경로 유지
  - refresh token을 Bearer로 넣은 경우 401 + `AUTH_TOKEN_INVALID` 검증
- `apps/server/internal/domain/theme/service.go`
  - `GetTheme`, `GetThemeBySlug`: unpublished theme은 NotFound, published theme은 `config_json` redaction 검증
  - `GetCharacters`: unpublished theme은 NotFound, published theme character 응답은 기존 public-safe resolver 경로 검증
- `apps/server/internal/domain/theme/test_fixture_test.go`
  - DRAFT/PUBLISHED fixture를 명시적으로 생성할 수 있게 보강

## Local validation

- `go test -count=1 ./internal/middleware ./internal/domain/theme` PASS
- `git diff --check` PASS
- `scripts/mmp-local-ci.sh quick` PASS on `51f88f92da23d8c41461104bd94fd284e2748038`
  - Go tests, lint/typecheck/test/build 통과
  - Web test: 207 files / 1890 tests passed
  - 기존 lint 경고 41개와 Vite/Rollup chunk warning은 있었지만 exit 0

## Review evidence

- `mmp-backend-implementer`: backend hardening 구현
- `mmp-security-reviewer`: 최종 High/Medium blocker 없음
- `mmp-backend-engine-reviewer`: refresh token error code 보정 후 blocker 없음
- `mmp-local-validation-runner`: final `quick`, `diff --check`, tracked clean 검증

## Deferred / Follow-up

- SQL 단계에서 public-safe projection을 분리하는 후속 hardening은 #687 댓글로 추적했습니다.
- 이번 PR은 lazy-auth rollout 전 실제 사용자 노출 위험을 service/response 경계에서 먼저 막는 PR1입니다.
