### PR TITLE
feat: lazy-auth 라우트 foundation 추가

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -165,39 +165,42 @@ function AppContent() {
               <Route path="/editor/:id" element={<EditorPage />} />
               <Route path="/editor/:id/:tab" element={<EditorPage />} />
               <Route path="/editor/:id/design/:designTab" element={<EditorPage />} />
-              <Route element={<MainLayout />}>
-                <Route path="/" element={<LobbyPage />} />
-                <Route path="/lobby" element={<LobbyPage />} />
+            </Route>
+
+            <Route element={<MainLayout />}>
+              <Route path="/" element={<LobbyPage />} />
+              <Route path="/lobby" element={<LobbyPage />} />
+              <Route path="/users/:id" element={<PublicProfilePage />} />
+
+              {/* Shop */}
+              <Route path="/shop" element={<ShopPage />} />
+
+              {/* MainLayout 안의 인증 필요 페이지는 shell을 유지하고 안내 패널을 표시한다. */}
+              <Route element={<ProtectedRoute mode="prompt" />}>
                 <Route path="/profile" element={<ProfilePage />} />
                 <Route path="/room/:id" element={<RoomPage />} />
                 <Route path="/editor" element={<EditorPage />} />
                 <Route path="/social" element={<SocialPage />} />
-                <Route path="/users/:id" element={<PublicProfilePage />} />
-
-                {/* Shop */}
-                <Route path="/shop" element={<ShopPage />} />
                 <Route path="/shop/history" element={<ShopHistoryPage />} />
-
-                {/* My Themes */}
                 <Route path="/my-themes" element={<MyThemesPage />} />
+              </Route>
 
-                {/* Creator — creator 또는 admin 역할만 접근 가능 */}
-                <Route element={<RoleRoute roles={['creator', 'admin']} />}>
-                  <Route path="/creator" element={<CreatorDashboardPage />} />
-                  <Route path="/creator/:id/stats" element={<CreatorThemeStatsPage />} />
-                  <Route path="/creator/earnings" element={<CreatorEarningsPage />} />
-                  <Route path="/creator/settlements" element={<CreatorSettlementsPage />} />
-                </Route>
+              {/* Creator — creator 또는 admin 역할만 접근 가능 */}
+              <Route element={<RoleRoute roles={['creator', 'admin']} mode="prompt" />}>
+                <Route path="/creator" element={<CreatorDashboardPage />} />
+                <Route path="/creator/:id/stats" element={<CreatorThemeStatsPage />} />
+                <Route path="/creator/earnings" element={<CreatorEarningsPage />} />
+                <Route path="/creator/settlements" element={<CreatorSettlementsPage />} />
+              </Route>
 
-                {/* Admin — admin 역할만 접근 가능 */}
-                <Route element={<RoleRoute roles={['admin']} />}>
-                  <Route path="/admin" element={<AdminPage />} />
-                  <Route path="/admin/settlements" element={<AdminSettlementsPage />} />
-                  <Route path="/admin/revenue" element={<AdminRevenuePage />} />
-                  <Route path="/admin/packages" element={<AdminPackagesPage />} />
-                  <Route path="/admin/coins" element={<AdminCoinGrantPage />} />
-                  <Route path="/admin/reviews" element={<AdminReviewPage />} />
-                </Route>
+              {/* Admin — admin 역할만 접근 가능 */}
+              <Route element={<RoleRoute roles={['admin']} mode="prompt" />}>
+                <Route path="/admin" element={<AdminPage />} />
+                <Route path="/admin/settlements" element={<AdminSettlementsPage />} />
+                <Route path="/admin/revenue" element={<AdminRevenuePage />} />
+                <Route path="/admin/packages" element={<AdminPackagesPage />} />
+                <Route path="/admin/coins" element={<AdminCoinGrantPage />} />
+                <Route path="/admin/reviews" element={<AdminReviewPage />} />
               </Route>
             </Route>
 

--- a/apps/web/src/features/coin/api.ts
+++ b/apps/web/src/features/coin/api.ts
@@ -66,10 +66,11 @@ export const coinKeys = {
 // Queries
 // ---------------------------------------------------------------------------
 
-export function useBalance() {
+export function useBalance({ enabled = true }: { enabled?: boolean } = {}) {
   return useQuery<CoinBalance>({
     queryKey: coinKeys.balance(),
     queryFn: () => api.get<CoinBalance>("/v1/coins/balance"),
+    enabled,
   });
 }
 

--- a/apps/web/src/features/lobby/components/RoomList.tsx
+++ b/apps/web/src/features/lobby/components/RoomList.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router';
 import { DoorOpen } from 'lucide-react';
 import { Alert, Button, Badge, EmptyState, LoadingState, Table } from '@/shared/components/ui';
 import type { TableColumn } from '@/shared/components/ui';
+import { useAuthStore } from '@/stores/authStore';
 import { useRooms, useJoinRoom } from '../api';
 
 /** 방 상태별 Badge variant */
@@ -19,10 +20,17 @@ const statusLabel: Record<string, string> = {
 
 export function RoomList() {
   const navigate = useNavigate();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isAuthLoading = useAuthStore((s) => s.isLoading);
   const { data: rooms, isLoading, isError, refetch } = useRooms({ limit: 20 });
   const joinRoom = useJoinRoom();
 
   const handleJoin = (roomId: string) => {
+    if (isAuthLoading) return;
+    if (!isAuthenticated) {
+      navigate('/login');
+      return;
+    }
     joinRoom.mutate(roomId, {
       onSuccess: (data) => {
         navigate(`/room/${data.id}`);
@@ -83,7 +91,7 @@ export function RoomList() {
           <Button
             size="sm"
             variant="secondary"
-            disabled={effectiveStatus !== 'waiting'}
+            disabled={effectiveStatus !== 'waiting' || isAuthLoading}
             isLoading={joinRoom.isPending && joinRoom.variables === room.id}
             onClick={() => handleJoin(room.id)}
           >

--- a/apps/web/src/features/payment/components/CoinBalance.tsx
+++ b/apps/web/src/features/payment/components/CoinBalance.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router';
 import { Coins } from 'lucide-react';
 import { useBalance } from '@/features/coin/api';
+import { useAuthStore } from '@/stores/authStore';
 
 // ---------------------------------------------------------------------------
 // Nav 삽입용 잔액 위젯
@@ -8,9 +9,23 @@ import { useBalance } from '@/features/coin/api';
 
 export function CoinBalance() {
   const navigate = useNavigate();
-  const { data: balance } = useBalance();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const { data: balance } = useBalance({ enabled: isAuthenticated });
 
   const total = balance ? balance.total_coins : 0;
+
+  if (!isAuthenticated) {
+    return (
+      <button
+        type="button"
+        onClick={() => navigate('/login')}
+        className="flex items-center gap-1.5 rounded-lg border border-[var(--mmp-color-hairline)] px-3 py-1.5 text-sm font-medium text-[var(--mmp-color-charcoal)] transition-colors hover:bg-[var(--mmp-color-surface-soft)]"
+      >
+        <Coins className="h-4 w-4 text-[var(--mmp-color-primary)]" />
+        로그인하면 잔액을 볼 수 있어요
+      </button>
+    );
+  }
 
   return (
     <button

--- a/apps/web/src/features/payment/components/CoinPackageList.tsx
+++ b/apps/web/src/features/payment/components/CoinPackageList.tsx
@@ -56,10 +56,12 @@ function PackageCard({
 export function CoinPackageList() {
   const navigate = useNavigate();
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isAuthLoading = useAuthStore((s) => s.isLoading);
   const { data: packages, isLoading } = usePackages('WEB');
   const [selected, setSelected] = useState<CoinPackage | null>(null);
 
   function handleSelect(pkg: CoinPackage) {
+    if (isAuthLoading) return;
     if (!isAuthenticated) {
       navigate('/login');
       return;

--- a/apps/web/src/features/payment/components/CoinPackageList.tsx
+++ b/apps/web/src/features/payment/components/CoinPackageList.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 import { Coins, Sparkles } from 'lucide-react';
 import { Badge, Card, LoadingState } from '@/shared/components/ui';
 import { usePackages } from '@/features/payment/api';
 import type { CoinPackage } from '@/features/payment/api';
+import { useAuthStore } from '@/stores/authStore';
 import { PaymentModal } from './PaymentModal';
 
 // ---------------------------------------------------------------------------
@@ -52,8 +54,18 @@ function PackageCard({
 }
 
 export function CoinPackageList() {
+  const navigate = useNavigate();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const { data: packages, isLoading } = usePackages('WEB');
   const [selected, setSelected] = useState<CoinPackage | null>(null);
+
+  function handleSelect(pkg: CoinPackage) {
+    if (!isAuthenticated) {
+      navigate('/login');
+      return;
+    }
+    setSelected(pkg);
+  }
 
   if (isLoading) {
     return <LoadingState label="코인 패키지를 불러오는 중" className="py-20" />;
@@ -63,7 +75,7 @@ export function CoinPackageList() {
     <>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         {packages?.map((pkg) => (
-          <PackageCard key={pkg.id} pkg={pkg} onSelect={setSelected} />
+          <PackageCard key={pkg.id} pkg={pkg} onSelect={handleSelect} />
         ))}
       </div>
 

--- a/apps/web/src/features/payment/components/__tests__/CoinBalance.test.tsx
+++ b/apps/web/src/features/payment/components/__tests__/CoinBalance.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { useAuthStore } from "@/stores/authStore";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -30,7 +31,7 @@ vi.mock("react-router", async () => {
 // ---------------------------------------------------------------------------
 
 vi.mock("@/features/coin/api", () => ({
-  useBalance: () => useBalanceMock(),
+  useBalance: (options?: { enabled?: boolean }) => useBalanceMock(options),
 }));
 
 // ---------------------------------------------------------------------------
@@ -46,6 +47,13 @@ import { CoinBalance } from "../CoinBalance";
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  useAuthStore.setState({
+    user: null,
+    accessToken: null,
+    refreshToken: null,
+    isAuthenticated: false,
+    isLoading: false,
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -54,6 +62,7 @@ afterEach(() => {
 
 describe("CoinBalance", () => {
   it("base + bonus 합계를 포매팅하여 렌더링한다", () => {
+    useAuthStore.setState({ isAuthenticated: true });
     useBalanceMock.mockReturnValue({
       data: { base_coins: 1200, bonus_coins: 300, total_coins: 1500 },
     });
@@ -72,6 +81,7 @@ describe("CoinBalance", () => {
   });
 
   it("클릭 시 /shop 으로 네비게이션한다", () => {
+    useAuthStore.setState({ isAuthenticated: true });
     useBalanceMock.mockReturnValue({
       data: { base_coins: 500, bonus_coins: 0, total_coins: 500 },
     });
@@ -84,5 +94,21 @@ describe("CoinBalance", () => {
 
     fireEvent.click(screen.getByText("500"));
     expect(navigateMock).toHaveBeenCalledWith("/shop");
+  });
+
+  it("비로그인 상태에서는 잔액 API를 비활성화하고 로그인 이동을 제공한다", () => {
+    useBalanceMock.mockReturnValue({
+      data: undefined,
+    });
+
+    render(
+      <MemoryRouter>
+        <CoinBalance />
+      </MemoryRouter>,
+    );
+
+    expect(useBalanceMock).toHaveBeenCalledWith({ enabled: false });
+    fireEvent.click(screen.getByText("로그인하면 잔액을 볼 수 있어요"));
+    expect(navigateMock).toHaveBeenCalledWith("/login");
   });
 });

--- a/apps/web/src/features/payment/components/__tests__/CoinPackageList.test.tsx
+++ b/apps/web/src/features/payment/components/__tests__/CoinPackageList.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { useAuthStore } from "@/stores/authStore";
@@ -196,6 +196,25 @@ describe("CoinPackageList", () => {
     fireEvent.click(screen.getByText("프리미엄 팩"));
 
     expect(navigateMock).toHaveBeenCalledWith("/login");
+    expect(screen.queryByTestId("payment-modal")).toBeNull();
+  });
+
+  it("인증 초기화 중에는 패키지 클릭 시 로그인 이동이나 결제 모달을 열지 않는다", () => {
+    useAuthStore.setState({ isAuthenticated: false, isLoading: true });
+    usePackagesMock.mockReturnValue({
+      data: mockPackages,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <CoinPackageList />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("프리미엄 팩"));
+
+    expect(navigateMock).not.toHaveBeenCalled();
     expect(screen.queryByTestId("payment-modal")).toBeNull();
   });
 });

--- a/apps/web/src/features/payment/components/__tests__/CoinPackageList.test.tsx
+++ b/apps/web/src/features/payment/components/__tests__/CoinPackageList.test.tsx
@@ -1,13 +1,26 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { useAuthStore } from "@/stores/authStore";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { usePackagesMock } = vi.hoisted(() => ({
+const { usePackagesMock, navigateMock } = vi.hoisted(() => ({
   usePackagesMock: vi.fn(),
+  navigateMock: vi.fn(),
 }));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>(
+    "react-router",
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Mock: @/features/payment/api
@@ -79,6 +92,13 @@ const mockPackages = [
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  useAuthStore.setState({
+    user: null,
+    accessToken: null,
+    refreshToken: null,
+    isAuthenticated: false,
+    isLoading: false,
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -138,12 +158,17 @@ describe("CoinPackageList", () => {
   });
 
   it("카드 클릭 시 결제 모달을 연다", () => {
+    useAuthStore.setState({ isAuthenticated: true });
     usePackagesMock.mockReturnValue({
       data: mockPackages,
       isLoading: false,
     });
 
-    render(<CoinPackageList />);
+    render(
+      <MemoryRouter>
+        <CoinPackageList />
+      </MemoryRouter>,
+    );
 
     // 모달이 아직 없어야 한다
     expect(screen.queryByTestId("payment-modal")).toBeNull();
@@ -154,5 +179,23 @@ describe("CoinPackageList", () => {
     // 모달이 나타나야 한다
     expect(screen.getByTestId("payment-modal")).toBeDefined();
     expect(screen.getByTestId("payment-modal").textContent).toBe("프리미엄 팩");
+  });
+
+  it("비로그인 상태에서 패키지 클릭 시 결제 모달 대신 로그인으로 이동한다", () => {
+    usePackagesMock.mockReturnValue({
+      data: mockPackages,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <CoinPackageList />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("프리미엄 팩"));
+
+    expect(navigateMock).toHaveBeenCalledWith("/login");
+    expect(screen.queryByTestId("payment-modal")).toBeNull();
   });
 });

--- a/apps/web/src/pages/LobbyPage.tsx
+++ b/apps/web/src/pages/LobbyPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Plus, Hash } from 'lucide-react';
+import { useNavigate } from 'react-router';
 import {
   Alert,
   Button,
@@ -18,10 +19,15 @@ import {
   JoinByCodeModal,
 } from '@/features/lobby/components';
 import type { ThemeFilterValues } from '@/features/lobby/components';
+import { useAuthStore } from '@/stores/authStore';
 
 const THEMES_PER_PAGE = 12;
 
 export default function LobbyPage() {
+  const navigate = useNavigate();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isAuthLoading = useAuthStore((s) => s.isLoading);
+
   // 페이지네이션
   const [page, setPage] = useState(1);
 
@@ -61,10 +67,35 @@ export default function LobbyPage() {
   }, []);
 
   // 테마 카드 클릭 → 방 생성 모달
-  const handleThemeClick = useCallback((theme: ThemeSummary) => {
-    setSelectedTheme(theme);
-    setIsCreateOpen(true);
-  }, []);
+  const requireAuthenticatedAction = useCallback(() => {
+    if (isAuthLoading) return false;
+    if (!isAuthenticated) {
+      navigate('/login');
+      return false;
+    }
+    return true;
+  }, [isAuthLoading, isAuthenticated, navigate]);
+
+  const handleOpenCreateRoom = useCallback(
+    (theme: ThemeSummary | null = null) => {
+      if (!requireAuthenticatedAction()) return;
+      setSelectedTheme(theme);
+      setIsCreateOpen(true);
+    },
+    [requireAuthenticatedAction],
+  );
+
+  const handleOpenJoinByCode = useCallback(() => {
+    if (!requireAuthenticatedAction()) return;
+    setIsJoinOpen(true);
+  }, [requireAuthenticatedAction]);
+
+  const handleThemeClick = useCallback(
+    (theme: ThemeSummary) => {
+      handleOpenCreateRoom(theme);
+    },
+    [handleOpenCreateRoom],
+  );
 
   return (
     <PageShell
@@ -77,17 +108,16 @@ export default function LobbyPage() {
               <Button
                 variant="primary"
                 leftIcon={<Plus className="h-4 w-4" />}
-                onClick={() => {
-                  setSelectedTheme(null);
-                  setIsCreateOpen(true);
-                }}
+                disabled={isAuthLoading}
+                onClick={() => handleOpenCreateRoom()}
               >
                 방 만들기
               </Button>
               <Button
                 variant="secondary"
                 leftIcon={<Hash className="h-4 w-4" />}
-                onClick={() => setIsJoinOpen(true)}
+                disabled={isAuthLoading}
+                onClick={handleOpenJoinByCode}
               >
                 코드로 참가
               </Button>

--- a/apps/web/src/pages/__tests__/LobbyPage.test.tsx
+++ b/apps/web/src/pages/__tests__/LobbyPage.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { useAuthStore } from '@/stores/authStore';
+
+const { navigateMock, useThemesMock, useRoomsMock, useJoinRoomMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  useThemesMock: vi.fn(),
+  useRoomsMock: vi.fn(),
+  useJoinRoomMock: vi.fn(),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@/features/lobby/api', () => ({
+  useThemes: () => useThemesMock(),
+  useRooms: () => useRoomsMock(),
+  useJoinRoom: () => useJoinRoomMock(),
+  useCreateRoom: () => ({ mutate: vi.fn(), isPending: false }),
+  useRoomByCode: () => ({ data: undefined, isLoading: false, isError: false }),
+}));
+
+import LobbyPage from '../LobbyPage';
+
+const mockThemes = [
+  {
+    id: 'theme-1',
+    title: '초대받지 않은 손님',
+    slug: 'uninvited-guest',
+    description: '저택에서 벌어진 미스터리',
+    min_players: 4,
+    max_players: 6,
+    duration_min: 90,
+    cover_image: null,
+    coin_price: 0,
+  },
+];
+
+const mockRooms = [
+  {
+    id: 'room-1',
+    code: 'ABC123',
+    theme_id: 'theme-1',
+    theme_title: '초대받지 않은 손님',
+    host_id: 'host-1',
+    host_nickname: '호스트',
+    status: 'waiting',
+    player_count: 1,
+    max_players: 6,
+    is_private: false,
+    created_at: '2026-05-19T00:00:00Z',
+  },
+];
+
+function renderLobby() {
+  return render(
+    <MemoryRouter>
+      <LobbyPage />
+    </MemoryRouter>,
+  );
+}
+
+function mockLobbyData(joinMutate = vi.fn()) {
+  useThemesMock.mockReturnValue({
+    data: mockThemes,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  useRoomsMock.mockReturnValue({
+    data: mockRooms,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  useJoinRoomMock.mockReturnValue({
+    mutate: joinMutate,
+    isPending: false,
+    variables: undefined,
+  });
+  return joinMutate;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useAuthStore.setState({
+    user: null,
+    accessToken: null,
+    refreshToken: null,
+    isAuthenticated: false,
+    isLoading: false,
+  });
+});
+
+describe('LobbyPage lazy-auth gates', () => {
+  it('비로그인 사용자의 방 생성, 코드 참가, 테마 선택 액션을 로그인으로 보낸다', () => {
+    mockLobbyData();
+
+    renderLobby();
+
+    fireEvent.click(screen.getByRole('button', { name: /방 만들기/ }));
+    fireEvent.click(screen.getByRole('button', { name: /코드로 참가/ }));
+    fireEvent.click(screen.getAllByText('초대받지 않은 손님')[0]);
+
+    expect(navigateMock).toHaveBeenCalledTimes(3);
+    expect(navigateMock).toHaveBeenNthCalledWith(1, '/login');
+    expect(navigateMock).toHaveBeenNthCalledWith(2, '/login');
+    expect(navigateMock).toHaveBeenNthCalledWith(3, '/login');
+  });
+
+  it('비로그인 사용자의 공개 방 참가 액션은 join mutation 대신 로그인으로 보낸다', () => {
+    const joinMutate = mockLobbyData();
+
+    renderLobby();
+
+    fireEvent.click(screen.getByRole('button', { name: '참가' }));
+
+    expect(joinMutate).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/login');
+  });
+
+  it('인증 초기화 중에는 로비 write 액션을 실행하지 않는다', () => {
+    const joinMutate = mockLobbyData();
+    useAuthStore.setState({ isAuthenticated: false, isLoading: true });
+
+    renderLobby();
+
+    expect(screen.getByRole('button', { name: /방 만들기/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /코드로 참가/ })).toBeDisabled();
+
+    fireEvent.click(screen.getAllByText('초대받지 않은 손님')[0]);
+    fireEvent.click(screen.getByRole('button', { name: '참가' }));
+
+    expect(joinMutate).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/components/MainLayout.tsx
+++ b/apps/web/src/shared/components/MainLayout.tsx
@@ -3,14 +3,17 @@ import { Nav } from '@/shared/components/Nav';
 import { Sidebar } from '@/shared/components/Sidebar';
 import { useWsClient } from '@/hooks/useWsClient';
 import { useSocialSync } from '@/features/social/hooks/useSocialSync';
+import { useAuthStore } from '@/stores/authStore';
 
 // ---------------------------------------------------------------------------
 // 인증된 유저용 메인 레이아웃 (Nav + Sidebar + Outlet)
 // ---------------------------------------------------------------------------
 
 export function MainLayout() {
-  // Social WS: 인증된 모든 페이지에서 자동 연결
-  useWsClient({ endpoint: 'social' });
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  // Social WS: 인증된 shell에서만 자동 연결
+  useWsClient({ endpoint: 'social', autoConnect: isAuthenticated });
   useSocialSync();
 
   return (

--- a/apps/web/src/shared/components/ProtectedRoute.tsx
+++ b/apps/web/src/shared/components/ProtectedRoute.tsx
@@ -1,7 +1,48 @@
-import { Navigate, Outlet } from "react-router";
+import { Link, Navigate, Outlet } from "react-router";
 import { useAuthStore } from "@/stores/authStore";
 import { PublicThemeShell } from "@/shared/components/PublicThemeShell";
 import { Spinner } from "@/shared/components/ui";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type ProtectedRouteMode = "redirect" | "prompt";
+
+interface ProtectedRouteProps {
+  mode?: ProtectedRouteMode;
+}
+
+// ---------------------------------------------------------------------------
+// 로그인 안내 패널
+// ---------------------------------------------------------------------------
+
+export function LoginRequiredPanel() {
+  return (
+    <section
+      aria-labelledby="login-required-title"
+      className="mx-auto flex min-h-[360px] max-w-2xl flex-col items-center justify-center rounded-lg border border-[var(--mmp-color-hairline)] bg-[var(--mmp-color-surface)] px-6 py-12 text-center shadow-[var(--mmp-shadow-card)]"
+    >
+      <p className="mb-3 text-sm font-semibold text-[var(--mmp-color-primary)]">로그인 필요</p>
+      <h1
+        id="login-required-title"
+        className="text-2xl font-bold text-[var(--mmp-color-ink)]"
+      >
+        이 페이지는 로그인 후 이용할 수 있어요
+      </h1>
+      <p className="mt-3 max-w-md text-sm leading-6 text-[var(--mmp-color-charcoal)]">
+        프로필, 방 입장, 제작 도구처럼 내 계정 정보가 필요한 화면은 로그인한 사용자에게만
+        열립니다.
+      </p>
+      <Link
+        to="/login"
+        className="mt-6 rounded-md bg-[var(--mmp-color-primary)] px-5 py-2.5 text-sm font-semibold text-[var(--mmp-color-on-primary)] transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mmp-color-primary)] focus-visible:ring-offset-2"
+      >
+        로그인하러 가기
+      </Link>
+    </section>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // 컴포넌트
@@ -12,13 +53,13 @@ import { Spinner } from "@/shared/components/ui";
  *
  * 조건 분리:
  * - isLoading true → 스피너 (초기 토큰 갱신 대기)
- * - !isLoading && !isAuthenticated → /login 리다이렉트
+ * - !isLoading && !isAuthenticated → /login 리다이렉트 또는 인라인 안내
  * - !isLoading && isAuthenticated → 자식 렌더링 (Outlet)
  *
  * accessToken에 직접 의존하지 않음 — isAuthenticated를 단일 진실 공급원으로 사용.
  * 토큰 갱신 중에는 isLoading=true가 보장되므로 무한 스피너 방지.
  */
-function ProtectedRoute() {
+function ProtectedRoute({ mode = "redirect" }: ProtectedRouteProps) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isLoading = useAuthStore((s) => s.isLoading);
 
@@ -33,6 +74,9 @@ function ProtectedRoute() {
 
   // 로딩 완료 후 미인증 → 로그인으로 이동
   if (!isAuthenticated) {
+    if (mode === "prompt") {
+      return <LoginRequiredPanel />;
+    }
     return <Navigate to="/login" replace />;
   }
 

--- a/apps/web/src/shared/components/RoleRoute.test.tsx
+++ b/apps/web/src/shared/components/RoleRoute.test.tsx
@@ -9,14 +9,20 @@ import { useAuthStore } from "@/stores/authStore";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function renderWithRouter(roles: Array<"user" | "creator" | "admin"> = ["admin"]) {
+function renderWithRouter({
+  roles = ["admin"],
+  mode,
+}: {
+  roles?: Array<"user" | "creator" | "admin">;
+  mode?: "redirect" | "prompt";
+} = {}) {
   return render(
     <AppearanceProvider>
       <MemoryRouter initialEntries={["/protected"]}>
         <Routes>
           <Route path="/login" element={<div>로그인 페이지</div>} />
           <Route path="/" element={<div>홈 페이지</div>} />
-          <Route element={<RoleRoute roles={roles} />}>
+          <Route element={<RoleRoute roles={roles} mode={mode} />}>
             <Route path="/protected" element={<div>보호된 페이지</div>} />
           </Route>
         </Routes>
@@ -89,7 +95,7 @@ describe("RoleRoute", () => {
       },
     });
 
-    renderWithRouter(["admin"]);
+    renderWithRouter({ roles: ["admin"] });
 
     expect(screen.getByText("홈 페이지")).toBeDefined();
     expect(screen.queryByText("보호된 페이지")).toBeNull();
@@ -109,10 +115,26 @@ describe("RoleRoute", () => {
       },
     });
 
-    renderWithRouter(["admin"]);
+    renderWithRouter({ roles: ["admin"] });
 
     expect(screen.getByText("보호된 페이지")).toBeDefined();
     expect(screen.queryByText("로그인 페이지")).toBeNull();
     expect(screen.queryByText("홈 페이지")).toBeNull();
+  });
+
+  it("shows login prompt instead of redirect when unauthenticated in prompt mode", () => {
+    useAuthStore.setState({
+      isLoading: false,
+      isAuthenticated: false,
+      user: null,
+    });
+
+    renderWithRouter({ mode: "prompt" });
+
+    expect(
+      screen.getByRole("heading", { name: "이 페이지는 로그인 후 이용할 수 있어요" }),
+    ).toBeDefined();
+    expect(screen.queryByText("로그인 페이지")).toBeNull();
+    expect(screen.queryByText("보호된 페이지")).toBeNull();
   });
 });

--- a/apps/web/src/shared/components/RoleRoute.tsx
+++ b/apps/web/src/shared/components/RoleRoute.tsx
@@ -2,6 +2,7 @@ import { Navigate, Outlet } from "react-router";
 import { useAuthStore } from "@/stores/authStore";
 import type { User } from "@/stores/authStore";
 import { PublicThemeShell } from "@/shared/components/PublicThemeShell";
+import { LoginRequiredPanel } from "@/shared/components/ProtectedRoute";
 import { Spinner } from "@/shared/components/ui";
 
 // ---------------------------------------------------------------------------
@@ -10,6 +11,7 @@ import { Spinner } from "@/shared/components/ui";
 
 interface RoleRouteProps {
   roles: Array<User["role"]>;
+  mode?: "redirect" | "prompt";
 }
 
 // ---------------------------------------------------------------------------
@@ -19,14 +21,14 @@ interface RoleRouteProps {
 /**
  * 특정 역할(role)을 가진 사용자만 접근 가능한 라우트 가드.
  *
- * - 인증되지 않은 상태 → /login 리다이렉트
+ * - 인증되지 않은 상태 → /login 리다이렉트 또는 인라인 안내
  * - 인증됐지만 역할 없음(로딩 중) → 스피너 표시
  * - 역할이 허용 목록에 없음 → / 리다이렉트
  * - 역할이 허용 목록에 있음 → 자식 렌더링 (Outlet)
  *
- * ProtectedRoute 내부에 중첩해서 사용.
+ * MainLayout 안에서는 mode="prompt"로 사용해 shell을 유지한다.
  */
-function RoleRoute({ roles }: RoleRouteProps) {
+function RoleRoute({ roles, mode = "redirect" }: RoleRouteProps) {
   const user = useAuthStore((s) => s.user);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isLoading = useAuthStore((s) => s.isLoading);
@@ -42,6 +44,9 @@ function RoleRoute({ roles }: RoleRouteProps) {
 
   // 비로그인 상태
   if (!isAuthenticated || !user) {
+    if (mode === "prompt") {
+      return <LoginRequiredPanel />;
+    }
     return <Navigate to="/login" replace />;
   }
 

--- a/apps/web/src/shared/components/Sidebar.tsx
+++ b/apps/web/src/shared/components/Sidebar.tsx
@@ -29,6 +29,7 @@ interface MenuItem {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   roles?: Array<'user' | 'creator' | 'admin'>;
+  requiresAuth?: boolean;
 }
 
 interface MenuSection {
@@ -41,10 +42,10 @@ const menuSections: MenuSection[] = [
   {
     items: [
       { to: '/lobby', label: '로비', icon: Gamepad2 },
-      { to: '/social', label: '소셜', icon: MessageCircle },
+      { to: '/social', label: '소셜', icon: MessageCircle, requiresAuth: true },
       { to: '/shop', label: '상점', icon: Coins },
-      { to: '/my-themes', label: '내 테마', icon: Library },
-      { to: '/editor', label: '테마 제작', icon: Palette },
+      { to: '/my-themes', label: '내 테마', icon: Library, requiresAuth: true },
+      { to: '/editor', label: '테마 제작', icon: Palette, requiresAuth: true },
     ],
   },
   {
@@ -88,6 +89,7 @@ function navLinkClass({ isActive }: { isActive: boolean }): string {
 
 export function Sidebar() {
   const user = useAuthStore((s) => s.user);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
   const totalUnread = useSocialStore(selectTotalUnread);
@@ -99,7 +101,10 @@ export function Sidebar() {
     .filter((section) => !section.roles || section.roles.includes(userRole))
     .map((section) => ({
       ...section,
-      items: section.items.filter((item) => !item.roles || item.roles.includes(userRole)),
+      items: section.items.filter((item) => {
+        if (item.requiresAuth && !isAuthenticated) return false;
+        return !item.roles || item.roles.includes(userRole);
+      }),
     }))
     .filter((section) => section.items.length > 0);
 

--- a/apps/web/src/shared/components/__tests__/ProtectedRoute.test.tsx
+++ b/apps/web/src/shared/components/__tests__/ProtectedRoute.test.tsx
@@ -9,13 +9,19 @@ import { useAuthStore } from "@/stores/authStore";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function renderWithRouter(initialRoute = "/protected") {
+function renderWithRouter({
+  initialRoute = "/protected",
+  mode,
+}: {
+  initialRoute?: string;
+  mode?: "redirect" | "prompt";
+} = {}) {
   return render(
     <AppearanceProvider>
       <MemoryRouter initialEntries={[initialRoute]}>
         <Routes>
           <Route path="/login" element={<div>로그인 페이지</div>} />
-          <Route element={<ProtectedRoute />}>
+          <Route element={<ProtectedRoute mode={mode} />}>
             <Route
               path="/protected"
               element={<div>보호된 페이지</div>}
@@ -131,6 +137,43 @@ describe("ProtectedRoute", () => {
       const spinner = container.querySelector(".animate-spin");
       expect(spinner).not.toBeNull();
       expect(screen.queryByText("보호된 페이지")).toBeNull();
+    });
+  });
+
+  describe("prompt mode", () => {
+    it("미인증이면 로그인 안내 패널을 표시하고 자식 라우트를 숨긴다", () => {
+      renderWithRouter({ mode: "prompt" });
+
+      expect(
+        screen.getByRole("heading", { name: "이 페이지는 로그인 후 이용할 수 있어요" }),
+      ).toBeDefined();
+      expect(screen.getByRole("link", { name: "로그인하러 가기" }).getAttribute("href")).toBe(
+        "/login",
+      );
+      expect(screen.queryByText("보호된 페이지")).toBeNull();
+      expect(screen.queryByText("로그인 페이지")).toBeNull();
+    });
+
+    it("인증 완료 상태면 Outlet(자식 라우트)을 렌더링한다", () => {
+      useAuthStore.setState({
+        refreshToken: "refresh-token",
+        accessToken: "access-token",
+        isAuthenticated: true,
+        isLoading: false,
+        user: {
+          id: "user-1",
+          nickname: "TestUser",
+          email: "test@example.com",
+          profileImage: null,
+          role: "user",
+          provider: "google",
+        },
+      });
+
+      renderWithRouter({ mode: "prompt" });
+
+      expect(screen.getByText("보호된 페이지")).toBeDefined();
+      expect(screen.queryByText("이 페이지는 로그인 후 이용할 수 있어요")).toBeNull();
     });
   });
 });

--- a/apps/web/src/shared/components/__tests__/ShellSurfaces.test.tsx
+++ b/apps/web/src/shared/components/__tests__/ShellSurfaces.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { ComponentErrorBoundary, PageErrorBoundary } from '@/components/error';
+import { useWsClient } from '@/hooks/useWsClient';
+import { useSocialSync } from '@/features/social/hooks/useSocialSync';
 import { AppearanceProvider } from '@/shared/appearance';
 import { MainLayout } from '@/shared/components/MainLayout';
 import { NetworkBanner } from '@/shared/components/NetworkBanner';
@@ -48,7 +50,7 @@ describe('Shell surfaces', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the authenticated app shell with themed navigation chrome', () => {
+  it('renders the public app shell without auto-connecting social websocket', () => {
     const { container } = render(
       <AppearanceProvider>
         <MemoryRouter initialEntries={['/lobby']}>
@@ -63,9 +65,18 @@ describe('Shell surfaces', () => {
 
     expect(screen.getByText('MMP')).toBeDefined();
     expect(screen.getByText('로비')).toBeDefined();
+    expect(screen.getByText('상점')).toBeDefined();
     expect(screen.getByText('로비 콘텐츠')).toBeDefined();
+    expect(screen.queryByText('소셜')).toBeNull();
+    expect(screen.queryByText('내 테마')).toBeNull();
+    expect(screen.queryByText('테마 제작')).toBeNull();
     expect(screen.getAllByRole('group', { name: '화면 모드' })).toHaveLength(1);
     expect(screen.getAllByRole('button', { name: '다크' }).length).toBeGreaterThan(0);
+    expect(vi.mocked(useWsClient)).toHaveBeenCalledWith({
+      endpoint: 'social',
+      autoConnect: false,
+    });
+    expect(vi.mocked(useSocialSync)).toHaveBeenCalled();
     expect(container.firstElementChild?.className).toContain('var(--mmp-color-canvas)');
   });
 


### PR DESCRIPTION
## 요약

Refs #687

로그인하지 않아도 주요 shell 페이지를 볼 수 있도록 frontend lazy-auth foundation을 추가했습니다. 실제 계정 정보나 결제가 필요한 화면/액션은 로그인 안내 또는 로그인 이동으로 막습니다.

- `/`, `/lobby`, `/shop`, `/users/:id`를 public `MainLayout` route로 이동했습니다.
- `/profile`, `/room/:id`, `/editor`, `/social`, `/shop/history`, creator/admin route는 shell 안에서 로그인 안내 패널을 보여주는 `prompt` guard로 전환했습니다.
- `/game/:id`, `/editor/:id` 상세/탭 route는 기존 redirect-style `ProtectedRoute` 아래에 남겨 안전하게 보호했습니다.
- 비로그인 `MainLayout`에서는 social WebSocket이 자동 연결되지 않도록 `autoConnect: false`로 막았습니다.
- `/shop`은 패키지 목록은 공개 유지하되, 잔액 API는 비로그인에서 disabled, 패키지 클릭은 결제 모달 대신 `/login`으로 이동하게 했습니다.

## Coverage Plan

- `App.tsx`
  - public shell route와 protected fullscreen route의 분리 확인
  - private shell route는 `mode="prompt"` guard 아래 유지
- `ProtectedRoute.tsx`, `RoleRoute.tsx`
  - 기본 redirect 동작 유지
  - prompt mode에서 미인증 시 Outlet 미렌더 + 로그인 안내 표시
  - 인증/역할 충족 시 Outlet 렌더
- `MainLayout.tsx`, `Sidebar.tsx`
  - 미인증 shell에서 social WS autoConnect false
  - 미인증 sidebar는 public 메뉴만 표시
- `CoinBalance.tsx`, `CoinPackageList.tsx`, `coin/api.ts`
  - 미인증 shop 진입 시 balance API disabled
  - 미인증 패키지 클릭 시 PaymentModal 미오픈 + `/login` 이동

## Local validation

- `pnpm --filter @mmp/web test -- --run src/shared/components/__tests__/ProtectedRoute.test.tsx src/shared/components/RoleRoute.test.tsx src/shared/components/__tests__/ShellSurfaces.test.tsx src/features/payment/components/__tests__/CoinBalance.test.tsx src/features/payment/components/__tests__/CoinPackageList.test.tsx` PASS
  - 5 files / 24 tests passed
- `pnpm --filter @mmp/web typecheck` PASS
- `git diff --check` PASS
- `scripts/mmp-local-ci.sh quick` PASS on `9e203749`

## Review evidence

- `mmp-frontend-implementer`: route foundation 구현
- `mmp-security-reviewer`: `/shop` action gate 보완 후 blocker 없음
- `mmp-frontend-editor-reviewer`: UX/test readiness 기준 blocker 없음
- `mmp-local-validation-runner`: final `quick`, `diff --check`, tracked clean 검증

## E2E / Browser QA

이번 PR은 route guard와 shell/auth action gate foundation 변경이라 focused Vitest + typecheck + local-ci quick으로 검증했습니다. cmux/browser QA 또는 Playwright E2E는 다음 PR3 page-by-page rollout에서 실제 페이지별 smoke로 묶어 실행합니다.

## Deferred / Follow-up

- PR3에서 페이지별 lazy-auth rollout browser QA를 이어갑니다.
- #687의 SQL public-safe projection follow-up은 PR1에서 별도 추적한 상태를 유지합니다.
