### PR TITLE
로비/대기방 Slice 1 UX와 ready/start 계약 정렬

### DIFF
--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -283,6 +283,8 @@ func main() {
 	gameStarter := session.NewGameStarter(sessionMgr, broadcaster, cfg.GameRuntimeV2, mediaSvc, logger)
 	roomSvc := room.NewServiceWithStarter(pool, queries, logger, gameStarter)
 	roomHandler := room.NewHandler(roomSvc)
+	lobbyChatWSHandler := room.NewLobbyChatWSHandler(queries, wsHub, logger)
+	wsRouter.Handle("chat", lobbyChatWSHandler.HandleChat)
 
 	// 11.3. Sound WS Handler
 	soundWSHandler := sound.NewWSHandler(wsHub, logger)
@@ -390,7 +392,7 @@ func main() {
 		AllowedOrigins: cfg.CORSOrigins,
 		DevMode:        cfg.IsDevelopment(),
 	}
-	gameUpgrade := ws.UpgradeHandler(wsHub, ws.DefaultPlayerIDExtractor, wsCfg, logger)
+	gameUpgrade := ws.UpgradeHandler(wsHub, ws.JWTPlayerIDExtractor([]byte(cfg.JWTSecret)), wsCfg, logger)
 	r.Get("/ws/game", gameUpgrade)
 
 	socialExtractor := ws.JWTPlayerIDExtractor([]byte(cfg.JWTSecret))

--- a/apps/server/cmd/server/routes_editor.go
+++ b/apps/server/cmd/server/routes_editor.go
@@ -79,6 +79,7 @@ func registerBaseRoutes(r chi.Router, deps authedDeps) {
 	r.Post("/rooms", deps.room.CreateRoom)
 	r.Post("/rooms/{id}/join", deps.room.JoinRoom)
 	r.Post("/rooms/{id}/leave", deps.room.LeaveRoom)
+	r.Post("/rooms/{id}/ready", deps.room.SetReady)
 	r.Post("/rooms/{id}/start", deps.room.StartRoom)
 
 	// Payment endpoints (authed)

--- a/apps/server/internal/domain/room/handler.go
+++ b/apps/server/internal/domain/room/handler.go
@@ -135,6 +135,34 @@ func (h *Handler) LeaveRoom(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, map[string]string{"status": "left"})
 }
 
+// SetReady handles POST /rooms/{id}/ready (authenticated).
+func (h *Handler) SetReady(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFrom(r.Context())
+	if userID == uuid.Nil {
+		apperror.WriteError(w, r, apperror.Unauthorized("authentication required"))
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	roomID, err := uuid.Parse(idStr)
+	if err != nil {
+		apperror.WriteError(w, r, apperror.BadRequest("invalid room ID"))
+		return
+	}
+
+	var req SetReadyRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	if err := h.svc.SetReady(r.Context(), roomID, userID, req.IsReady); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, map[string]string{"status": "ready updated"})
+}
+
 // StartRoom handles POST /rooms/{id}/start (authenticated, host only).
 // It enforces a 256 KiB body limit to protect the configJson trust boundary.
 func (h *Handler) StartRoom(w http.ResponseWriter, r *http.Request) {

--- a/apps/server/internal/domain/room/handler_ready_test.go
+++ b/apps/server/internal/domain/room/handler_ready_test.go
@@ -1,0 +1,100 @@
+package room
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestSetReady_Success(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+
+	var gotReady bool
+	svc := &mockService{
+		setReadyFn: func(_ context.Context, gotRoomID, gotUserID uuid.UUID, ready bool) error {
+			if gotRoomID != roomID {
+				t.Fatalf("roomID = %s, want %s", gotRoomID, roomID)
+			}
+			if gotUserID != userID {
+				t.Fatalf("userID = %s, want %s", gotUserID, userID)
+			}
+			gotReady = ready
+			return nil
+		},
+	}
+	h := NewHandler(svc)
+
+	body, _ := json.Marshal(SetReadyRequest{IsReady: true})
+	req := httptest.NewRequest(http.MethodPost, "/rooms/"+roomID.String()+"/ready", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.SetReady(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !gotReady {
+		t.Fatal("expected is_ready=true to be passed to service")
+	}
+}
+
+func TestSetReady_NoAuth(t *testing.T) {
+	h := NewHandler(&mockService{})
+	roomID := uuid.New()
+
+	body, _ := json.Marshal(SetReadyRequest{IsReady: true})
+	req := httptest.NewRequest(http.MethodPost, "/rooms/"+roomID.String()+"/ready", bytes.NewReader(body))
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.SetReady(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSetReady_InvalidJSON(t *testing.T) {
+	h := NewHandler(&mockService{})
+	roomID := uuid.New()
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/rooms/"+roomID.String()+"/ready", strings.NewReader(`not json`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.SetReady(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSetReady_InvalidRoomID(t *testing.T) {
+	h := NewHandler(&mockService{})
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/rooms/not-a-uuid/ready", strings.NewReader(`{"is_ready":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", "not-a-uuid")
+
+	rec := httptest.NewRecorder()
+	h.SetReady(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/server/internal/domain/room/mock_shim_test.go
+++ b/apps/server/internal/domain/room/mock_shim_test.go
@@ -29,6 +29,7 @@ type mockService struct {
 	listWaitingFn   func(ctx context.Context, limit, offset int32) ([]RoomResponse, error)
 	joinRoomFn      func(ctx context.Context, roomID, userID uuid.UUID) error
 	leaveRoomFn     func(ctx context.Context, roomID, userID uuid.UUID) error
+	setReadyFn      func(ctx context.Context, roomID, userID uuid.UUID, ready bool) error
 	startRoomFn     func(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
 }
 
@@ -70,6 +71,13 @@ func (m *mockService) JoinRoom(ctx context.Context, roomID, userID uuid.UUID) er
 func (m *mockService) LeaveRoom(ctx context.Context, roomID, userID uuid.UUID) error {
 	if m.leaveRoomFn != nil {
 		return m.leaveRoomFn(ctx, roomID, userID)
+	}
+	return nil
+}
+
+func (m *mockService) SetReady(ctx context.Context, roomID, userID uuid.UUID, ready bool) error {
+	if m.setReadyFn != nil {
+		return m.setReadyFn(ctx, roomID, userID, ready)
 	}
 	return nil
 }

--- a/apps/server/internal/domain/room/mocks/mock_service.go
+++ b/apps/server/internal/domain/room/mocks/mock_service.go
@@ -130,6 +130,20 @@ func (mr *MockServiceMockRecorder) ListWaitingRooms(ctx, limit, offset any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWaitingRooms", reflect.TypeOf((*MockService)(nil).ListWaitingRooms), ctx, limit, offset)
 }
 
+// SetReady mocks base method.
+func (m *MockService) SetReady(ctx context.Context, roomID, userID uuid.UUID, ready bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetReady", ctx, roomID, userID, ready)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetReady indicates an expected call of SetReady.
+func (mr *MockServiceMockRecorder) SetReady(ctx, roomID, userID, ready any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReady", reflect.TypeOf((*MockService)(nil).SetReady), ctx, roomID, userID, ready)
+}
+
 // StartRoom mocks base method.
 func (m *MockService) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req room.StartRoomRequest) error {
 	m.ctrl.T.Helper()

--- a/apps/server/internal/domain/room/service.go
+++ b/apps/server/internal/domain/room/service.go
@@ -46,6 +46,22 @@ type RoomResponse struct {
 type RoomDetailResponse struct {
 	RoomResponse
 	Players []PlayerInfo `json:"players"`
+	Theme   ThemeSummary `json:"theme"`
+}
+
+// ThemeSummary is the compact theme representation embedded in room detail.
+type ThemeSummary struct {
+	ID          uuid.UUID `json:"id"`
+	Title       string    `json:"title"`
+	Slug        string    `json:"slug"`
+	Description *string   `json:"description,omitempty"`
+	CoverImage  *string   `json:"cover_image,omitempty"`
+	MinPlayers  int32     `json:"min_players"`
+	MaxPlayers  int32     `json:"max_players"`
+	DurationMin int32     `json:"duration_min"`
+	Price       int32     `json:"price"`
+	CoinPrice   int32     `json:"coin_price"`
+	CreatorID   uuid.UUID `json:"creator_id"`
 }
 
 // PlayerInfo is the public representation of a player in a room.
@@ -68,6 +84,11 @@ type StartRoomRequest struct {
 	ConfigJSON []byte `json:"configJson,omitempty"`
 }
 
+// SetReadyRequest is the payload for POST /rooms/:id/ready.
+type SetReadyRequest struct {
+	IsReady bool `json:"is_ready"`
+}
+
 // Service defines the room domain operations.
 type Service interface {
 	CreateRoom(ctx context.Context, hostID uuid.UUID, req CreateRoomRequest) (*RoomResponse, error)
@@ -76,6 +97,7 @@ type Service interface {
 	ListWaitingRooms(ctx context.Context, limit, offset int32) ([]RoomResponse, error)
 	JoinRoom(ctx context.Context, roomID, userID uuid.UUID) error
 	LeaveRoom(ctx context.Context, roomID, userID uuid.UUID) error
+	SetReady(ctx context.Context, roomID, userID uuid.UUID, ready bool) error
 	StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
 }
 
@@ -103,7 +125,7 @@ type GameStarter interface {
 
 type service struct {
 	pool        *pgxpool.Pool
-	queries     *db.Queries
+	queries     roomQueries
 	logger      zerolog.Logger
 	gameStarter GameStarter // nil → legacy (flag off)
 }
@@ -432,6 +454,40 @@ func (s *service) LeaveRoom(ctx context.Context, roomID, userID uuid.UUID) error
 	return nil
 }
 
+// SetReady updates a participant's pre-game ready state.
+func (s *service) SetReady(ctx context.Context, roomID, userID uuid.UUID, ready bool) error {
+	room, err := s.queries.GetRoom(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.New(apperror.ErrRoomNotFound, http.StatusNotFound, "room not found")
+		}
+		s.logger.Error().Err(err).Msg("SetReady: failed to get room")
+		return apperror.Internal("failed to get room")
+	}
+	if room.Status != "WAITING" {
+		return apperror.New(apperror.ErrRoomNotWaiting, http.StatusConflict, "room is not in waiting state")
+	}
+
+	players, err := s.queries.GetRoomPlayers(ctx, roomID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("room_id", roomID).Msg("SetReady: failed to get room players")
+		return apperror.Internal("failed to get room players")
+	}
+	if !hasRoomPlayer(players, userID) {
+		return apperror.New(apperror.ErrPlayerNotInGame, http.StatusForbidden, "player is not in this room")
+	}
+
+	if err := s.queries.SetPlayerReady(ctx, db.SetPlayerReadyParams{
+		RoomID:  roomID,
+		UserID:  userID,
+		IsReady: ready,
+	}); err != nil {
+		s.logger.Error().Err(err).Stringer("room_id", roomID).Stringer("user_id", userID).Msg("SetReady: failed to update ready state")
+		return apperror.Internal("failed to update ready state")
+	}
+	return nil
+}
+
 // buildRoomDetail fetches players (with user JOIN) and assembles a
 // RoomDetailResponse. is_host 는 room.HostID 와 user_id 비교로 결정한다.
 func (s *service) buildRoomDetail(ctx context.Context, room db.Room) (*RoomDetailResponse, error) {
@@ -439,6 +495,11 @@ func (s *service) buildRoomDetail(ctx context.Context, room db.Room) (*RoomDetai
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to get room players")
 		return nil, apperror.Internal("failed to get room players")
+	}
+	theme, err := s.queries.GetTheme(ctx, room.ThemeID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("theme_id", room.ThemeID).Msg("failed to get room theme")
+		return nil, apperror.Internal("failed to get room theme")
 	}
 
 	infos := make([]PlayerInfo, len(players))
@@ -455,6 +516,7 @@ func (s *service) buildRoomDetail(ctx context.Context, room db.Room) (*RoomDetai
 	resp := &RoomDetailResponse{
 		RoomResponse: mapRoomResponse(room, len(players)),
 		Players:      infos,
+		Theme:        mapThemeSummary(theme),
 	}
 	return resp, nil
 }
@@ -488,6 +550,23 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 		return apperror.New(apperror.ErrRoomNotWaiting, http.StatusConflict, "room is not in waiting state")
 	}
 
+	theme, err := s.queries.GetTheme(ctx, room.ThemeID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.New(apperror.ErrNotFound, http.StatusNotFound, "theme not found")
+		}
+		s.logger.Error().Err(err).Stringer("theme_id", room.ThemeID).Msg("StartRoom: failed to get theme")
+		return apperror.Internal("failed to get theme")
+	}
+	playerRows, err := s.queries.GetRoomPlayersWithUser(ctx, room.ID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("room_id", room.ID).Msg("StartRoom: failed to get room players")
+		return apperror.Internal("failed to get room players")
+	}
+	if err := validateStartGateRows(room, theme, playerRows); err != nil {
+		return err
+	}
+
 	if s.gameStarter == nil {
 		// Feature flag off — return 503 so clients get an explicit signal
 		// rather than a false success. (M-9 early fix)
@@ -501,13 +580,26 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 		)
 	}
 
-	players, err := s.buildGameStartPlayers(ctx, room)
+	startPlayers, err := s.buildGameStartPlayers(ctx, room, playerRows)
 	if err != nil {
 		return err
 	}
 
-	if err := s.gameStarter.Start(ctx, roomID, room.ThemeID, req.ConfigJSON, players); err != nil {
+	if err := s.queries.UpdateRoomStatus(ctx, db.UpdateRoomStatusParams{
+		ID:     roomID,
+		Status: "PLAYING",
+	}); err != nil {
+		s.logger.Error().Err(err).Str("room_id", roomID.String()).Msg("StartRoom: failed to mark room as playing")
+		return apperror.Internal("failed to update room status")
+	}
+	if err := s.gameStarter.Start(ctx, roomID, room.ThemeID, req.ConfigJSON, startPlayers); err != nil {
 		s.logger.Error().Err(err).Str("room_id", roomID.String()).Msg("StartRoom: gameStarter failed")
+		if rollbackErr := s.queries.UpdateRoomStatus(ctx, db.UpdateRoomStatusParams{
+			ID:     roomID,
+			Status: "WAITING",
+		}); rollbackErr != nil {
+			s.logger.Error().Err(rollbackErr).Str("room_id", roomID.String()).Msg("StartRoom: failed to roll back room status after gameStarter failure")
+		}
 		return err
 	}
 
@@ -518,12 +610,46 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 	return nil
 }
 
-func (s *service) buildGameStartPlayers(ctx context.Context, room db.Room) ([]GameStartPlayer, error) {
-	rows, err := s.queries.GetRoomPlayersWithUser(ctx, room.ID)
-	if err != nil {
-		s.logger.Error().Err(err).Stringer("room_id", room.ID).Msg("StartRoom: failed to get room players")
-		return nil, apperror.Internal("failed to get room players")
+func validateStartGate(room db.Room, theme db.Theme, players []db.RoomPlayer) error {
+	if int32(len(players)) < theme.MinPlayers {
+		return apperror.Conflict("not enough players to start")
 	}
+	for _, player := range players {
+		if player.UserID == room.HostID {
+			continue
+		}
+		if !player.IsReady {
+			return apperror.Conflict("all non-host players must be ready")
+		}
+	}
+	return nil
+}
+
+func validateStartGateRows(room db.Room, theme db.Theme, players []db.GetRoomPlayersWithUserRow) error {
+	if int32(len(players)) < theme.MinPlayers {
+		return apperror.Conflict("not enough players to start")
+	}
+	for _, player := range players {
+		if player.UserID == room.HostID {
+			continue
+		}
+		if !player.IsReady {
+			return apperror.Conflict("all non-host players must be ready")
+		}
+	}
+	return nil
+}
+
+func hasRoomPlayer(players []db.RoomPlayer, userID uuid.UUID) bool {
+	for _, player := range players {
+		if player.UserID == userID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *service) buildGameStartPlayers(ctx context.Context, room db.Room, rows []db.GetRoomPlayersWithUserRow) ([]GameStartPlayer, error) {
 	chars, err := s.queries.GetThemeCharacters(ctx, room.ThemeID)
 	if err != nil {
 		s.logger.Error().Err(err).Stringer("theme_id", room.ThemeID).Msg("StartRoom: failed to get theme characters")
@@ -587,5 +713,21 @@ func mapRoomResponse(r db.Room, playerCount int) RoomResponse {
 		IsPrivate:   r.IsPrivate,
 		PlayerCount: playerCount,
 		CreatedAt:   r.CreatedAt,
+	}
+}
+
+func mapThemeSummary(t db.Theme) ThemeSummary {
+	return ThemeSummary{
+		ID:          t.ID,
+		Title:       t.Title,
+		Slug:        t.Slug,
+		Description: textToPtr(t.Description),
+		CoverImage:  textToPtr(t.CoverImage),
+		MinPlayers:  t.MinPlayers,
+		MaxPlayers:  t.MaxPlayers,
+		DurationMin: t.DurationMin,
+		Price:       t.Price,
+		CoinPrice:   t.CoinPrice,
+		CreatorID:   t.CreatorID,
 	}
 }

--- a/apps/server/internal/domain/room/service_flag_test.go
+++ b/apps/server/internal/domain/room/service_flag_test.go
@@ -24,10 +24,12 @@ import (
 type fakeGameStarter struct {
 	called    bool
 	returnErr error
+	players   []GameStartPlayer
 }
 
-func (f *fakeGameStarter) Start(_ context.Context, _, _ uuid.UUID, _ []byte, _ []GameStartPlayer) error {
+func (f *fakeGameStarter) Start(_ context.Context, _, _ uuid.UUID, _ []byte, players []GameStartPlayer) error {
 	f.called = true
+	f.players = players
 	return f.returnErr
 }
 
@@ -213,6 +215,75 @@ func TestNewService_GameStarterNil(t *testing.T) {
 		t.Error("NewServiceWithStarter should set gameStarter")
 	}
 
+}
+
+func TestValidateStartGate_MinPlayersNotMet(t *testing.T) {
+	hostID := uuid.New()
+	room := db.Room{HostID: hostID, Status: "WAITING"}
+	theme := db.Theme{MinPlayers: 3}
+	players := []db.RoomPlayer{
+		{UserID: hostID},
+		{UserID: uuid.New(), IsReady: true},
+	}
+
+	err := validateStartGate(room, theme, players)
+	assertAppError(t, err, http.StatusConflict)
+}
+
+func TestValidateStartGate_NonHostNotReady(t *testing.T) {
+	hostID := uuid.New()
+	room := db.Room{HostID: hostID, Status: "WAITING"}
+	theme := db.Theme{MinPlayers: 2}
+	players := []db.RoomPlayer{
+		{UserID: hostID, IsReady: true},
+		{UserID: uuid.New(), IsReady: false},
+	}
+
+	err := validateStartGate(room, theme, players)
+	assertAppError(t, err, http.StatusConflict)
+}
+
+func TestValidateStartGate_HostReadyIgnored(t *testing.T) {
+	hostID := uuid.New()
+	room := db.Room{HostID: hostID, Status: "WAITING"}
+	theme := db.Theme{MinPlayers: 2}
+	players := []db.RoomPlayer{
+		{UserID: hostID, IsReady: false},
+		{UserID: uuid.New(), IsReady: true},
+	}
+
+	if err := validateStartGate(room, theme, players); err != nil {
+		t.Fatalf("expected host readiness to be ignored, got %v", err)
+	}
+}
+
+func TestValidateStartGate_AllNonHostReadyPasses(t *testing.T) {
+	hostID := uuid.New()
+	room := db.Room{HostID: hostID, Status: "WAITING"}
+	theme := db.Theme{MinPlayers: 3}
+	players := []db.RoomPlayer{
+		{UserID: hostID},
+		{UserID: uuid.New(), IsReady: true},
+		{UserID: uuid.New(), IsReady: true},
+	}
+
+	if err := validateStartGate(room, theme, players); err != nil {
+		t.Fatalf("expected start gate to pass, got %v", err)
+	}
+}
+
+func assertAppError(t *testing.T, err error, status int) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ae *apperror.AppError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *apperror.AppError, got %T", err)
+	}
+	if ae.Status != status {
+		t.Fatalf("status = %d, want %d", ae.Status, status)
+	}
 }
 
 func TestMapGameStartPlayers_UsesAssignedCharacterDisplayMetadata(t *testing.T) {

--- a/apps/server/internal/domain/room/service_pregame_test.go
+++ b/apps/server/internal/domain/room/service_pregame_test.go
@@ -1,0 +1,331 @@
+package room
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/mmp-platform/server/internal/db"
+)
+
+type fakeRoomQueries struct {
+	room                     db.Room
+	roomErr                  error
+	players                  []db.RoomPlayer
+	playersErr               error
+	theme                    db.Theme
+	themeErr                 error
+	playersWithUser          []db.GetRoomPlayersWithUserRow
+	playersWithUserErr       error
+	characters               []db.ThemeCharacter
+	charactersErr            error
+	setReadyParams           *db.SetPlayerReadyParams
+	setReadyErr              error
+	updateRoomStatusParams   *db.UpdateRoomStatusParams
+	statusUpdates            []db.UpdateRoomStatusParams
+	updateRoomStatusErr      error
+	getRoomPlayersCalled     bool
+	getPlayersWithUserCalled bool
+	getThemeCalled           bool
+}
+
+func (f *fakeRoomQueries) AddRoomPlayer(context.Context, db.AddRoomPlayerParams) error {
+	panic("unexpected AddRoomPlayer call")
+}
+
+func (f *fakeRoomQueries) CreateRoom(context.Context, db.CreateRoomParams) (db.Room, error) {
+	panic("unexpected CreateRoom call")
+}
+
+func (f *fakeRoomQueries) GetRoom(context.Context, uuid.UUID) (db.Room, error) {
+	return f.room, f.roomErr
+}
+
+func (f *fakeRoomQueries) GetRoomByCode(context.Context, string) (db.Room, error) {
+	panic("unexpected GetRoomByCode call")
+}
+
+func (f *fakeRoomQueries) GetRoomForUpdate(context.Context, uuid.UUID) (db.Room, error) {
+	panic("unexpected GetRoomForUpdate call")
+}
+
+func (f *fakeRoomQueries) GetRoomPlayerCount(context.Context, uuid.UUID) (int64, error) {
+	panic("unexpected GetRoomPlayerCount call")
+}
+
+func (f *fakeRoomQueries) GetRoomPlayers(context.Context, uuid.UUID) ([]db.RoomPlayer, error) {
+	f.getRoomPlayersCalled = true
+	return f.players, f.playersErr
+}
+
+func (f *fakeRoomQueries) GetRoomPlayersWithUser(context.Context, uuid.UUID) ([]db.GetRoomPlayersWithUserRow, error) {
+	f.getPlayersWithUserCalled = true
+	return f.playersWithUser, f.playersWithUserErr
+}
+
+func (f *fakeRoomQueries) GetTheme(context.Context, uuid.UUID) (db.Theme, error) {
+	f.getThemeCalled = true
+	return f.theme, f.themeErr
+}
+
+func (f *fakeRoomQueries) GetThemeCharacters(context.Context, uuid.UUID) ([]db.ThemeCharacter, error) {
+	return f.characters, f.charactersErr
+}
+
+func (f *fakeRoomQueries) ListWaitingRoomsWithCount(context.Context, db.ListWaitingRoomsWithCountParams) ([]db.ListWaitingRoomsWithCountRow, error) {
+	panic("unexpected ListWaitingRoomsWithCount call")
+}
+
+func (f *fakeRoomQueries) RemoveRoomPlayer(context.Context, db.RemoveRoomPlayerParams) error {
+	panic("unexpected RemoveRoomPlayer call")
+}
+
+func (f *fakeRoomQueries) SetPlayerReady(_ context.Context, arg db.SetPlayerReadyParams) error {
+	f.setReadyParams = &arg
+	return f.setReadyErr
+}
+
+func (f *fakeRoomQueries) UpdateRoomStatus(_ context.Context, arg db.UpdateRoomStatusParams) error {
+	f.updateRoomStatusParams = &arg
+	f.statusUpdates = append(f.statusUpdates, arg)
+	return f.updateRoomStatusErr
+}
+
+func (f *fakeRoomQueries) WithTx(pgx.Tx) *db.Queries {
+	panic("unexpected WithTx call")
+}
+
+func TestSetReadyServiceBranches(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	waitingRoom := db.Room{ID: roomID, Status: "WAITING"}
+
+	tests := []struct {
+		name        string
+		queries     *fakeRoomQueries
+		wantStatus  int
+		wantUpdated bool
+	}{
+		{
+			name:       "room missing",
+			queries:    &fakeRoomQueries{roomErr: pgx.ErrNoRows},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "room lookup failure",
+			queries:    &fakeRoomQueries{roomErr: errors.New("db unavailable")},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "room not waiting",
+			queries:    &fakeRoomQueries{room: db.Room{ID: roomID, Status: "PLAYING"}},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name: "player lookup failure",
+			queries: &fakeRoomQueries{
+				room:       waitingRoom,
+				playersErr: errors.New("db unavailable"),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "user is not a participant",
+			queries: &fakeRoomQueries{
+				room:    waitingRoom,
+				players: []db.RoomPlayer{{RoomID: roomID, UserID: uuid.New()}},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "ready update failure",
+			queries: &fakeRoomQueries{
+				room:        waitingRoom,
+				players:     []db.RoomPlayer{{RoomID: roomID, UserID: userID}},
+				setReadyErr: errors.New("db update failed"),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "success",
+			queries: &fakeRoomQueries{
+				room:    waitingRoom,
+				players: []db.RoomPlayer{{RoomID: roomID, UserID: userID}},
+			},
+			wantUpdated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &service{queries: tt.queries, logger: zerolog.Nop()}
+
+			err := svc.SetReady(context.Background(), roomID, userID, true)
+
+			if tt.wantStatus != 0 {
+				assertAppError(t, err, tt.wantStatus)
+				return
+			}
+			if err != nil {
+				t.Fatalf("SetReady returned error: %v", err)
+			}
+			if tt.wantUpdated {
+				if tt.queries.setReadyParams == nil {
+					t.Fatal("expected SetPlayerReady to be called")
+				}
+				if tt.queries.setReadyParams.RoomID != roomID || tt.queries.setReadyParams.UserID != userID || !tt.queries.setReadyParams.IsReady {
+					t.Fatalf("SetPlayerReady params mismatch: %+v", tt.queries.setReadyParams)
+				}
+			}
+		})
+	}
+}
+
+func TestStartRoomServiceGateWiring(t *testing.T) {
+	roomID := uuid.New()
+	themeID := uuid.New()
+	hostID := uuid.New()
+	guestID := uuid.New()
+	room := db.Room{ID: roomID, ThemeID: themeID, HostID: hostID, Status: "WAITING"}
+	theme := db.Theme{ID: themeID, MinPlayers: 2}
+
+	t.Run("gate failure stops before game starter", func(t *testing.T) {
+		starter := &fakeGameStarter{}
+		queries := &fakeRoomQueries{
+			room: room,
+			playersWithUser: []db.GetRoomPlayersWithUserRow{
+				{UserID: hostID, Nickname: "호스트", IsReady: false},
+				{UserID: guestID, Nickname: "참가자", IsReady: false},
+			},
+			theme: theme,
+		}
+		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
+
+		err := svc.StartRoom(context.Background(), roomID, hostID, StartRoomRequest{})
+
+		assertAppError(t, err, http.StatusConflict)
+		if starter.called {
+			t.Fatal("expected gate failure to stop before GameStarter.Start")
+		}
+		if !queries.getPlayersWithUserCalled || !queries.getThemeCalled {
+			t.Fatal("expected StartRoom to load players and theme before gate validation")
+		}
+	})
+
+	t.Run("minimum player gate stops before game starter and status update", func(t *testing.T) {
+		starter := &fakeGameStarter{}
+		queries := &fakeRoomQueries{
+			room:  room,
+			theme: db.Theme{ID: themeID, MinPlayers: 3},
+			playersWithUser: []db.GetRoomPlayersWithUserRow{
+				{UserID: hostID, Nickname: "호스트", IsReady: false},
+				{UserID: guestID, Nickname: "참가자", IsReady: true},
+			},
+		}
+		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
+
+		err := svc.StartRoom(context.Background(), roomID, hostID, StartRoomRequest{})
+
+		assertAppError(t, err, http.StatusConflict)
+		if starter.called {
+			t.Fatal("expected minimum player gate to stop before GameStarter.Start")
+		}
+		if queries.updateRoomStatusParams != nil {
+			t.Fatalf("room status should not update when minimum player gate fails: %+v", queries.updateRoomStatusParams)
+		}
+		if !queries.getPlayersWithUserCalled || !queries.getThemeCalled {
+			t.Fatal("expected StartRoom to load players and theme before minimum player gate validation")
+		}
+	})
+
+	t.Run("gate pass calls game starter with roster", func(t *testing.T) {
+		starter := &fakeGameStarter{}
+		joinedAt := time.Unix(1700, 0)
+		queries := &fakeRoomQueries{
+			room:  room,
+			theme: theme,
+			playersWithUser: []db.GetRoomPlayersWithUserRow{
+				{UserID: hostID, Nickname: "호스트", IsReady: false, JoinedAt: joinedAt},
+				{UserID: guestID, Nickname: "참가자", IsReady: true, JoinedAt: joinedAt.Add(time.Second)},
+			},
+		}
+		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
+
+		if err := svc.StartRoom(context.Background(), roomID, hostID, StartRoomRequest{}); err != nil {
+			t.Fatalf("StartRoom returned error: %v", err)
+		}
+		if !starter.called {
+			t.Fatal("expected GameStarter.Start to be called")
+		}
+		if len(starter.players) != 2 {
+			t.Fatalf("starter players len = %d, want 2", len(starter.players))
+		}
+		if starter.players[0].UserID != hostID || !starter.players[0].IsHost {
+			t.Fatalf("host roster mismatch: %+v", starter.players[0])
+		}
+		if starter.players[1].UserID != guestID || !starter.players[1].IsReady {
+			t.Fatalf("guest roster mismatch: %+v", starter.players[1])
+		}
+		if queries.updateRoomStatusParams == nil {
+			t.Fatal("expected room status to be updated after successful game start")
+		}
+		if queries.updateRoomStatusParams.ID != roomID || queries.updateRoomStatusParams.Status != "PLAYING" {
+			t.Fatalf("room status update mismatch: %+v", queries.updateRoomStatusParams)
+		}
+	})
+
+	t.Run("status update failure stops before game starter", func(t *testing.T) {
+		starter := &fakeGameStarter{}
+		queries := &fakeRoomQueries{
+			room:  room,
+			theme: theme,
+			playersWithUser: []db.GetRoomPlayersWithUserRow{
+				{UserID: hostID, Nickname: "호스트", IsReady: false},
+				{UserID: guestID, Nickname: "참가자", IsReady: true},
+			},
+			updateRoomStatusErr: errors.New("status update failed"),
+		}
+		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
+
+		err := svc.StartRoom(context.Background(), roomID, hostID, StartRoomRequest{})
+
+		assertAppError(t, err, http.StatusInternalServerError)
+		if starter.called {
+			t.Fatal("expected status update failure to stop before GameStarter.Start")
+		}
+		if len(queries.statusUpdates) != 1 || queries.statusUpdates[0].Status != "PLAYING" {
+			t.Fatalf("status update attempt mismatch: %+v", queries.statusUpdates)
+		}
+	})
+
+	t.Run("starter failure rolls room status back to waiting", func(t *testing.T) {
+		starter := &fakeGameStarter{returnErr: errors.New("runtime unavailable")}
+		queries := &fakeRoomQueries{
+			room:  room,
+			theme: theme,
+			playersWithUser: []db.GetRoomPlayersWithUserRow{
+				{UserID: hostID, Nickname: "호스트", IsReady: false},
+				{UserID: guestID, Nickname: "참가자", IsReady: true},
+			},
+		}
+		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
+
+		err := svc.StartRoom(context.Background(), roomID, hostID, StartRoomRequest{})
+
+		if err == nil {
+			t.Fatal("expected GameStarter failure")
+		}
+		if len(queries.statusUpdates) != 2 {
+			t.Fatalf("status updates len = %d, want 2: %+v", len(queries.statusUpdates), queries.statusUpdates)
+		}
+		if queries.statusUpdates[0].Status != "PLAYING" || queries.statusUpdates[1].Status != "WAITING" {
+			t.Fatalf("status update order mismatch: %+v", queries.statusUpdates)
+		}
+	})
+}

--- a/apps/server/internal/domain/room/service_queries.go
+++ b/apps/server/internal/domain/room/service_queries.go
@@ -1,0 +1,28 @@
+package room
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mmp-platform/server/internal/db"
+)
+
+type roomQueries interface {
+	AddRoomPlayer(ctx context.Context, arg db.AddRoomPlayerParams) error
+	CreateRoom(ctx context.Context, arg db.CreateRoomParams) (db.Room, error)
+	GetRoom(ctx context.Context, id uuid.UUID) (db.Room, error)
+	GetRoomByCode(ctx context.Context, code string) (db.Room, error)
+	GetRoomForUpdate(ctx context.Context, id uuid.UUID) (db.Room, error)
+	GetRoomPlayerCount(ctx context.Context, roomID uuid.UUID) (int64, error)
+	GetRoomPlayers(ctx context.Context, roomID uuid.UUID) ([]db.RoomPlayer, error)
+	GetRoomPlayersWithUser(ctx context.Context, roomID uuid.UUID) ([]db.GetRoomPlayersWithUserRow, error)
+	GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error)
+	GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.ThemeCharacter, error)
+	ListWaitingRoomsWithCount(ctx context.Context, arg db.ListWaitingRoomsWithCountParams) ([]db.ListWaitingRoomsWithCountRow, error)
+	RemoveRoomPlayer(ctx context.Context, arg db.RemoveRoomPlayerParams) error
+	SetPlayerReady(ctx context.Context, arg db.SetPlayerReadyParams) error
+	UpdateRoomStatus(ctx context.Context, arg db.UpdateRoomStatusParams) error
+	WithTx(tx pgx.Tx) *db.Queries
+}

--- a/apps/server/internal/domain/room/ws_chat.go
+++ b/apps/server/internal/domain/room/ws_chat.go
@@ -1,0 +1,118 @@
+package room
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/ws"
+	"github.com/rs/zerolog"
+)
+
+type roomChatQueries interface {
+	GetRoom(ctx context.Context, id uuid.UUID) (db.Room, error)
+	GetRoomPlayersWithUser(ctx context.Context, roomID uuid.UUID) ([]db.GetRoomPlayersWithUserRow, error)
+}
+
+type roomChatBroadcaster interface {
+	SendToPlayer(playerID uuid.UUID, env *ws.Envelope)
+}
+
+type LobbyChatWSHandler struct {
+	queries     roomChatQueries
+	broadcaster roomChatBroadcaster
+	logger      zerolog.Logger
+}
+
+type lobbyChatSendPayload struct {
+	RoomID string `json:"room_id"`
+	Text   string `json:"text"`
+}
+
+type lobbyChatMessagePayload struct {
+	Sender   string `json:"sender"`
+	Nickname string `json:"nickname"`
+	Text     string `json:"text"`
+	TS       int64  `json:"ts"`
+}
+
+func NewLobbyChatWSHandler(queries roomChatQueries, broadcaster roomChatBroadcaster, logger zerolog.Logger) *LobbyChatWSHandler {
+	return &LobbyChatWSHandler{
+		queries:     queries,
+		broadcaster: broadcaster,
+		logger:      logger.With().Str("component", "room.lobby_chat_ws").Logger(),
+	}
+}
+
+func (h *LobbyChatWSHandler) HandleChat(c *ws.Client, env *ws.Envelope) {
+	if env.Type != "chat:send" {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "unknown chat event type: "+env.Type))
+		return
+	}
+
+	var payload lobbyChatSendPayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "invalid chat:send payload"))
+		return
+	}
+
+	roomID, err := uuid.Parse(payload.RoomID)
+	if err != nil {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "invalid room_id"))
+		return
+	}
+
+	text := strings.TrimSpace(payload.Text)
+	if text == "" {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "empty message"))
+		return
+	}
+	if len([]rune(text)) > 500 {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "message too long"))
+		return
+	}
+
+	room, err := h.queries.GetRoom(context.Background(), roomID)
+	if err != nil {
+		h.logger.Error().Err(err).Stringer("roomID", roomID).Msg("failed to load room for lobby chat")
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeInternalError, "failed to send message"))
+		return
+	}
+	if room.Status != "WAITING" {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeBadMessage, "room chat is closed"))
+		return
+	}
+
+	players, err := h.queries.GetRoomPlayersWithUser(context.Background(), roomID)
+	if err != nil {
+		h.logger.Error().Err(err).Stringer("roomID", roomID).Msg("failed to load room players for lobby chat")
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeInternalError, "failed to send message"))
+		return
+	}
+
+	senderNickname := ""
+	for _, player := range players {
+		if player.UserID == c.ID {
+			senderNickname = player.Nickname
+			break
+		}
+	}
+	if senderNickname == "" {
+		c.SendMessage(ws.NewErrorEnvelope(ws.ErrCodeUnauthorized, "player not in room"))
+		return
+	}
+
+	message := lobbyChatMessagePayload{
+		Sender:   c.ID.String(),
+		Nickname: senderNickname,
+		Text:     text,
+		TS:       time.Now().UnixMilli(),
+	}
+	out := ws.MustEnvelope("chat:message", message)
+	for _, player := range players {
+		h.broadcaster.SendToPlayer(player.UserID, out)
+	}
+}

--- a/apps/server/internal/domain/room/ws_chat_test.go
+++ b/apps/server/internal/domain/room/ws_chat_test.go
@@ -1,0 +1,127 @@
+package room
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/ws"
+	"github.com/rs/zerolog"
+)
+
+type fakeLobbyChatQueries struct {
+	room    db.Room
+	roomErr error
+	roomID  uuid.UUID
+	players []db.GetRoomPlayersWithUserRow
+	err     error
+}
+
+func (f *fakeLobbyChatQueries) GetRoom(_ context.Context, roomID uuid.UUID) (db.Room, error) {
+	f.roomID = roomID
+	return f.room, f.roomErr
+}
+
+func (f *fakeLobbyChatQueries) GetRoomPlayersWithUser(_ context.Context, roomID uuid.UUID) ([]db.GetRoomPlayersWithUserRow, error) {
+	f.roomID = roomID
+	return f.players, f.err
+}
+
+type sentLobbyChatMessage struct {
+	playerID uuid.UUID
+	env      *ws.Envelope
+}
+
+type fakeLobbyChatBroadcaster struct {
+	sent []sentLobbyChatMessage
+}
+
+func (f *fakeLobbyChatBroadcaster) SendToPlayer(playerID uuid.UUID, env *ws.Envelope) {
+	f.sent = append(f.sent, sentLobbyChatMessage{playerID: playerID, env: env})
+}
+
+func TestLobbyChatWSHandlerBroadcastsToRoomParticipants(t *testing.T) {
+	roomID := uuid.New()
+	senderID := uuid.New()
+	otherID := uuid.New()
+	queries := &fakeLobbyChatQueries{
+		room: db.Room{ID: roomID, Status: "WAITING"},
+		players: []db.GetRoomPlayersWithUserRow{
+			{RoomID: roomID, UserID: senderID, Nickname: "참가자", AvatarUrl: pgtype.Text{}},
+			{RoomID: roomID, UserID: otherID, Nickname: "다른 참가자", AvatarUrl: pgtype.Text{}},
+		},
+	}
+	broadcaster := &fakeLobbyChatBroadcaster{}
+	handler := NewLobbyChatWSHandler(queries, broadcaster, zerolog.Nop())
+
+	handler.HandleChat(&ws.Client{ID: senderID}, ws.MustEnvelope("chat:send", map[string]string{
+		"room_id": roomID.String(),
+		"text":    "  준비됐어요  ",
+	}))
+
+	if queries.roomID != roomID {
+		t.Fatalf("loaded room id %s, want %s", queries.roomID, roomID)
+	}
+	if len(broadcaster.sent) != 2 {
+		t.Fatalf("sent messages = %d, want 2", len(broadcaster.sent))
+	}
+	if broadcaster.sent[0].playerID != senderID || broadcaster.sent[1].playerID != otherID {
+		t.Fatalf("sent recipients = %v, %v", broadcaster.sent[0].playerID, broadcaster.sent[1].playerID)
+	}
+	var payload lobbyChatMessagePayload
+	if err := json.Unmarshal(broadcaster.sent[0].env.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if broadcaster.sent[0].env.Type != "chat:message" {
+		t.Fatalf("event type = %q, want chat:message", broadcaster.sent[0].env.Type)
+	}
+	if payload.Sender != senderID.String() || payload.Nickname != "참가자" || payload.Text != "준비됐어요" {
+		t.Fatalf("payload = %+v", payload)
+	}
+}
+
+func TestLobbyChatWSHandlerRejectsNonParticipant(t *testing.T) {
+	roomID := uuid.New()
+	queries := &fakeLobbyChatQueries{
+		room: db.Room{ID: roomID, Status: "WAITING"},
+		players: []db.GetRoomPlayersWithUserRow{
+			{RoomID: roomID, UserID: uuid.New(), Nickname: "참가자", AvatarUrl: pgtype.Text{}},
+		},
+	}
+	broadcaster := &fakeLobbyChatBroadcaster{}
+	handler := NewLobbyChatWSHandler(queries, broadcaster, zerolog.Nop())
+
+	handler.HandleChat(&ws.Client{ID: uuid.New()}, ws.MustEnvelope("chat:send", map[string]string{
+		"room_id": roomID.String(),
+		"text":    "hello",
+	}))
+
+	if len(broadcaster.sent) != 0 {
+		t.Fatalf("sent messages = %d, want 0", len(broadcaster.sent))
+	}
+}
+
+func TestLobbyChatWSHandlerRejectsNonWaitingRoom(t *testing.T) {
+	roomID := uuid.New()
+	senderID := uuid.New()
+	queries := &fakeLobbyChatQueries{
+		room: db.Room{ID: roomID, Status: "PLAYING"},
+		players: []db.GetRoomPlayersWithUserRow{
+			{RoomID: roomID, UserID: senderID, Nickname: "참가자", AvatarUrl: pgtype.Text{}},
+		},
+	}
+	broadcaster := &fakeLobbyChatBroadcaster{}
+	handler := NewLobbyChatWSHandler(queries, broadcaster, zerolog.Nop())
+
+	handler.HandleChat(&ws.Client{ID: senderID}, ws.MustEnvelope("chat:send", map[string]string{
+		"room_id": roomID.String(),
+		"text":    "hello",
+	}))
+
+	if len(broadcaster.sent) != 0 {
+		t.Fatalf("sent messages = %d, want 0", len(broadcaster.sent))
+	}
+}

--- a/apps/server/internal/ws/upgrade.go
+++ b/apps/server/internal/ws/upgrade.go
@@ -87,6 +87,9 @@ func JWTPlayerIDExtractor(secret []byte) PlayerIDExtractor {
 		if !ok {
 			return uuid.Nil, ErrQueryAuthNotAllowed
 		}
+		if tokenType, _ := claims["type"].(string); tokenType == "refresh" {
+			return uuid.Nil, ErrQueryAuthNotAllowed
+		}
 
 		sub, _ := claims.GetSubject()
 		return uuid.Parse(sub)

--- a/apps/server/internal/ws/upgrade_test.go
+++ b/apps/server/internal/ws/upgrade_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
@@ -32,6 +33,40 @@ func setupTestServer(t *testing.T, cfg UpgradeConfig) (*httptest.Server, *Hub) {
 
 func wsURL(srv *httptest.Server, path string) string {
 	return "ws" + strings.TrimPrefix(srv.URL, "http") + path
+}
+
+func setupJWTTestServer(t *testing.T, secret []byte, cfg UpgradeConfig) (*httptest.Server, *Hub) {
+	t.Helper()
+	logger := zerolog.Nop()
+	router := NewRouter(logger)
+	hub := NewHub(router, NoopPubSub{}, logger)
+	handler := UpgradeHandler(hub, JWTPlayerIDExtractor(secret), cfg, logger)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws/game", handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		hub.Stop()
+		srv.Close()
+	})
+	return srv, hub
+}
+
+func mintUpgradeToken(t *testing.T, userID uuid.UUID, secret []byte, tokenType string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"sub": userID.String(),
+		"exp": jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"iat": jwt.NewNumericDate(time.Now()),
+	}
+	if tokenType != "" {
+		claims["type"] = tokenType
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(secret)
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	return token
 }
 
 func TestUpgrade_Success(t *testing.T) {
@@ -103,6 +138,45 @@ func TestUpgrade_InvalidPlayerID(t *testing.T) {
 	}
 	if resp != nil && resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestJWTPlayerIDExtractorRejectsRefreshToken(t *testing.T) {
+	secret := []byte("test-secret")
+	srv, _ := setupJWTTestServer(t, secret, UpgradeConfig{DevMode: true})
+
+	refreshToken := mintUpgradeToken(t, uuid.New(), secret, "refresh")
+	url := wsURL(srv, "/ws/game") + "?token=" + refreshToken
+
+	_, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if err == nil {
+		t.Fatal("expected dial error for refresh token")
+	}
+	if resp != nil && resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestJWTPlayerIDExtractorAcceptsAccessToken(t *testing.T) {
+	secret := []byte("test-secret")
+	srv, hub := setupJWTTestServer(t, secret, UpgradeConfig{DevMode: true})
+
+	playerID := uuid.New()
+	accessToken := mintUpgradeToken(t, playerID, secret, "")
+	url := wsURL(srv, "/ws/game") + "?token=" + accessToken
+
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected 101, got %d", resp.StatusCode)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := hub.ClientCount(); got != 1 {
+		t.Errorf("ClientCount() = %d, want 1", got)
 	}
 }
 

--- a/apps/web/src/features/lobby/api.test.tsx
+++ b/apps/web/src/features/lobby/api.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const invalidateSpy = vi.fn();
+
+vi.mock("@/services/api", () => ({
+  api: {
+    post: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/queryClient", () => ({
+  queryClient: {
+    invalidateQueries: (...args: unknown[]) => invalidateSpy(...args),
+  },
+}));
+
+import { api } from "@/services/api";
+import { roomKeys, useSetReady, useStartRoom } from "./api";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateSpy.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("lobby pregame mutations", () => {
+  it("useSetReady posts is_ready and invalidates room detail/list", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({ status: "ready updated" });
+    const { result } = renderHook(() => useSetReady(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({ roomId: "room-1", is_ready: true });
+    });
+
+    expect(api.post).toHaveBeenCalledWith("/v1/rooms/room-1/ready", {
+      is_ready: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: roomKeys.detail("room-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: roomKeys.list(),
+    });
+  });
+
+  it("useStartRoom posts to start endpoint and invalidates room detail/list", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({ status: "started" });
+    const { result } = renderHook(() => useStartRoom(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync("room-1");
+    });
+
+    expect(api.post).toHaveBeenCalledWith("/v1/rooms/room-1/start", {});
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: roomKeys.detail("room-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: roomKeys.list(),
+    });
+  });
+});

--- a/apps/web/src/features/lobby/api.ts
+++ b/apps/web/src/features/lobby/api.ts
@@ -41,9 +41,9 @@ export interface RoomResponse {
   id: string;
   code: string;
   theme_id: string;
-  theme_title: string;
+  theme_title?: string;
   host_id: string;
-  host_nickname: string;
+  host_nickname?: string;
   status: string;
   player_count: number;
   max_players: number;
@@ -53,22 +53,27 @@ export interface RoomResponse {
 
 export interface RoomDetailResponse extends RoomResponse {
   players: RoomPlayer[];
-  theme: ThemeSummary;
+  theme?: ThemeSummary | null;
 }
 
 export interface RoomPlayer {
-  id: string;
+  id?: string;
   user_id: string;
   nickname: string;
-  avatar_url: string | null;
+  avatar_url?: string | null;
   is_host: boolean;
   is_ready: boolean;
-  joined_at: string;
+  joined_at?: string;
 }
 
 export interface CreateRoomRequest {
   theme_id: string;
   is_private?: boolean;
+}
+
+export interface SetReadyRequest {
+  roomId: string;
+  is_ready: boolean;
 }
 
 export interface PaginationParams {
@@ -166,9 +171,9 @@ export function useCreateRoom() {
 }
 
 export function useJoinRoom() {
-  return useMutation<RoomDetailResponse, Error, string>({
+  return useMutation<unknown, Error, string>({
     mutationFn: (roomId) =>
-      api.post<RoomDetailResponse>(`/v1/rooms/${roomId}/join`),
+      api.post<unknown>(`/v1/rooms/${roomId}/join`),
     onSuccess: (_data, roomId) => {
       queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
       queryClient.invalidateQueries({ queryKey: roomKeys.list() });
@@ -179,6 +184,27 @@ export function useJoinRoom() {
 export function useLeaveRoom() {
   return useMutation<void, Error, string>({
     mutationFn: (roomId) => api.postVoid(`/v1/rooms/${roomId}/leave`),
+    onSuccess: (_data, roomId) => {
+      queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
+      queryClient.invalidateQueries({ queryKey: roomKeys.list() });
+    },
+  });
+}
+
+export function useSetReady() {
+  return useMutation<unknown, Error, SetReadyRequest>({
+    mutationFn: ({ roomId, is_ready }) =>
+      api.post<unknown>(`/v1/rooms/${roomId}/ready`, { is_ready }),
+    onSuccess: (_data, { roomId }) => {
+      queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
+      queryClient.invalidateQueries({ queryKey: roomKeys.list() });
+    },
+  });
+}
+
+export function useStartRoom() {
+  return useMutation<unknown, Error, string>({
+    mutationFn: (roomId) => api.post<unknown>(`/v1/rooms/${roomId}/start`, {}),
     onSuccess: (_data, roomId) => {
       queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
       queryClient.invalidateQueries({ queryKey: roomKeys.list() });

--- a/apps/web/src/features/lobby/components/JoinByCodeModal.tsx
+++ b/apps/web/src/features/lobby/components/JoinByCodeModal.tsx
@@ -23,10 +23,10 @@ export function JoinByCodeModal({ isOpen, onClose }: JoinByCodeModalProps) {
   const handleJoin = () => {
     if (!room) return;
     joinRoom.mutate(room.id, {
-      onSuccess: (data) => {
+      onSuccess: () => {
         onClose();
         setCode('');
-        navigate(`/room/${data.id}`);
+        navigate(`/room/${room.id}`);
       },
     });
   };
@@ -43,7 +43,7 @@ export function JoinByCodeModal({ isOpen, onClose }: JoinByCodeModalProps) {
   } else if (isCodeValid && isNotFound) {
     statusMessage = '해당 코드의 방을 찾을 수 없습니다.';
   } else if (room) {
-    statusMessage = `${room.theme_title} — ${room.host_nickname}의 방 (${room.player_count}/${room.max_players})`;
+    statusMessage = `${room.theme_title ?? '테마 정보 없음'} — ${room.host_nickname ?? '호스트'}의 방 (${room.player_count}/${room.max_players})`;
   }
 
   return (

--- a/apps/web/src/features/lobby/components/RoomList.tsx
+++ b/apps/web/src/features/lobby/components/RoomList.tsx
@@ -4,6 +4,7 @@ import { Alert, Button, Badge, EmptyState, LoadingState, Table } from '@/shared/
 import type { TableColumn } from '@/shared/components/ui';
 import { useAuthStore } from '@/stores/authStore';
 import { useRooms, useJoinRoom } from '../api';
+import { normalizeRoomStatus } from '../roomStatus';
 
 /** 방 상태별 Badge variant */
 const statusVariant: Record<string, 'success' | 'warning' | 'danger'> = {
@@ -32,8 +33,8 @@ export function RoomList() {
       return;
     }
     joinRoom.mutate(roomId, {
-      onSuccess: (data) => {
-        navigate(`/room/${data.id}`);
+      onSuccess: () => {
+        navigate(`/room/${roomId}`);
       },
     });
   };
@@ -66,14 +67,15 @@ export function RoomList() {
 
   const columns: TableColumn<(typeof rooms)[number]>[] = [
     { id: 'code', header: '코드', render: (room) => <span className="font-mono text-xs text-[var(--mmp-color-steel)]">{room.code}</span> },
-    { id: 'theme', header: '테마', render: (room) => room.theme_title },
-    { id: 'host', header: '호스트', render: (room) => <span className="text-[var(--mmp-color-charcoal)]">{room.host_nickname}</span> },
+    { id: 'theme', header: '테마', render: (room) => room.theme_title ?? '테마 정보 없음' },
+    { id: 'host', header: '호스트', render: (room) => <span className="text-[var(--mmp-color-charcoal)]">{room.host_nickname ?? '호스트'}</span> },
     { id: 'players', header: '인원', render: (room) => `${room.player_count}/${room.max_players}` },
     {
       id: 'status',
       header: '상태',
       render: (room) => {
-        const effectiveStatus = room.player_count >= room.max_players ? 'full' : room.status;
+        const normalizedStatus = normalizeRoomStatus(room.status);
+        const effectiveStatus = room.player_count >= room.max_players ? 'full' : normalizedStatus;
         return (
           <Badge variant={statusVariant[effectiveStatus] ?? 'default'}>
             {statusLabel[effectiveStatus] ?? effectiveStatus}
@@ -86,7 +88,8 @@ export function RoomList() {
       header: '',
       align: 'right',
       render: (room) => {
-        const effectiveStatus = room.player_count >= room.max_players ? 'full' : room.status;
+        const normalizedStatus = normalizeRoomStatus(room.status);
+        const effectiveStatus = room.player_count >= room.max_players ? 'full' : normalizedStatus;
         return (
           <Button
             size="sm"

--- a/apps/web/src/features/lobby/roomStatus.ts
+++ b/apps/web/src/features/lobby/roomStatus.ts
@@ -1,0 +1,5 @@
+type RoomStatus = 'waiting' | 'playing' | 'full' | string;
+
+export function normalizeRoomStatus(status: string): RoomStatus {
+  return status.toLowerCase();
+}

--- a/apps/web/src/features/room/components/HostControls.tsx
+++ b/apps/web/src/features/room/components/HostControls.tsx
@@ -18,6 +18,8 @@ interface HostControlsProps {
   onCloseRoom: () => void;
   /** 로딩 상태 */
   isStarting?: boolean;
+  /** 시작 실패 메시지 */
+  startErrorMessage?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -31,6 +33,7 @@ export function HostControls({
   onStartGame,
   onCloseRoom,
   isStarting = false,
+  startErrorMessage,
 }: HostControlsProps) {
   // 호스트가 아니면 렌더링하지 않음
   if (!isHost) return null;
@@ -56,6 +59,12 @@ export function HostControls({
           {!hasMinPlayers
             ? "최소 인원이 충족되지 않았습니다."
             : "모든 참가자가 준비해야 시작할 수 있습니다."}
+        </p>
+      )}
+
+      {startErrorMessage && (
+        <p className="text-center text-xs text-[var(--mmp-color-error)]">
+          {startErrorMessage}
         </p>
       )}
 

--- a/apps/web/src/features/room/components/PlayerList.tsx
+++ b/apps/web/src/features/room/components/PlayerList.tsx
@@ -6,13 +6,13 @@ import { Card, Badge } from "@/shared/components/ui";
 // ---------------------------------------------------------------------------
 
 interface RoomPlayer {
-  id: string;
+  id?: string;
   user_id: string;
   nickname: string;
-  avatar_url: string | null;
+  avatar_url?: string | null;
   is_host: boolean;
   is_ready: boolean;
-  joined_at: string;
+  joined_at?: string;
 }
 
 interface PlayerListProps {
@@ -95,7 +95,7 @@ export function PlayerList({ players, maxPlayers }: PlayerListProps) {
   return (
     <div className="flex flex-col gap-2">
       {players.map((player, index) => (
-        <PlayerCard key={player.id} player={player} index={index} />
+        <PlayerCard key={player.id ?? player.user_id} player={player} index={index} />
       ))}
       {Array.from({ length: emptySlots }, (_, i) => (
         <EmptySlot key={`empty-${i}`} />

--- a/apps/web/src/features/room/components/RoomChat.tsx
+++ b/apps/web/src/features/room/components/RoomChat.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Send } from "lucide-react";
+import { WsEventType } from "@mmp/shared";
 import { Button, Input, Panel } from "@/shared/components/ui";
 import { useWsEvent } from "@/hooks/useWsEvent";
 
@@ -16,6 +17,7 @@ interface ChatMessage {
 }
 
 interface RoomChatProps {
+  roomId: string;
   /** WS send 함수 */
   send: <T>(type: string, payload: T) => void;
 }
@@ -24,7 +26,7 @@ interface RoomChatProps {
 // RoomChat
 // ---------------------------------------------------------------------------
 
-export function RoomChat({ send }: RoomChatProps) {
+export function RoomChat({ roomId, send }: RoomChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputText, setInputText] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -39,7 +41,7 @@ export function RoomChat({ send }: RoomChatProps) {
   }, [messages, scrollToBottom]);
 
   // WS 이벤트 구독: 채팅 메시지 수신
-  useWsEvent<ChatMessage>("game", "chat:message", (payload) => {
+  useWsEvent<ChatMessage>("game", WsEventType.CHAT_MESSAGE, (payload) => {
     setMessages((prev) => {
       const next = [...prev, payload];
       return next.length > 500 ? next.slice(-500) : next;
@@ -51,7 +53,7 @@ export function RoomChat({ send }: RoomChatProps) {
     const trimmed = inputText.trim();
     if (!trimmed) return;
 
-    send("chat:message", { text: trimmed });
+    send(WsEventType.CHAT_SEND, { room_id: roomId, text: trimmed });
     setInputText("");
   };
 

--- a/apps/web/src/features/room/components/RoomHeader.tsx
+++ b/apps/web/src/features/room/components/RoomHeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Copy, Check, Users } from "lucide-react";
 import { Badge, Button, Panel } from "@/shared/components/ui";
+import { normalizeRoomStatus } from "@/features/lobby/roomStatus";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -47,7 +48,8 @@ export function RoomHeader({
     }
   };
 
-  const { label, variant } = statusConfig[status] ?? {
+  const normalizedStatus = normalizeRoomStatus(status);
+  const { label, variant } = statusConfig[normalizedStatus] ?? {
     label: status,
     variant: "info" as const,
   };

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router";
 import { LogOut, Shield, Users, MessageSquare } from "lucide-react";
 
-import { useRoom, useLeaveRoom } from "@/features/lobby/api";
+import { useRoom, useLeaveRoom, useSetReady, useStartRoom } from "@/features/lobby/api";
 import { WsEventType } from "@mmp/shared";
 import { useWsClient } from "@/hooks/useWsClient";
 import { useWsEvent } from "@/hooks/useWsEvent";
@@ -70,10 +70,12 @@ export default function RoomPage() {
 
   // 방 나가기
   const leaveRoom = useLeaveRoom();
+  const setReady = useSetReady();
+  const startRoom = useStartRoom();
 
   // 로컬 상태
-  const [isReady, setIsReady] = useState(false);
   const [mobileTab, setMobileTab] = useState<MobileTab>("players");
+  const [startErrorMessage, setStartErrorMessage] = useState<string | null>(null);
 
   // ------ WS 이벤트 구독 → 쿼리 갱신 ------
 
@@ -89,6 +91,20 @@ export default function RoomPage() {
     refetch();
   });
 
+  // ------ 파생 상태 ------
+
+  const players = room?.players ?? [];
+  const currentPlayer = currentUser
+    ? players.find((player) => player.user_id === currentUser.id)
+    : undefined;
+  const isReady = currentPlayer?.is_ready ?? false;
+  const isHost = currentUser ? room?.host_id === currentUser.id : false;
+  const nonHostPlayers = players.filter((p) => !p.is_host);
+  const allReady =
+    nonHostPlayers.length > 0 && nonHostPlayers.every((p) => p.is_ready);
+  const minPlayers = room?.theme?.min_players;
+  const hasMinPlayers = minPlayers != null && players.length >= minPlayers;
+
   // ------ 핸들러 ------
 
   const handleLeave = useCallback(() => {
@@ -99,28 +115,35 @@ export default function RoomPage() {
   }, [id, leaveRoom, navigate]);
 
   const handleToggleReady = useCallback(() => {
-    const next = !isReady;
-    setIsReady(next);
-    send(WsEventType.GAME_ACTION, { type: "ready", ready: next });
-  }, [isReady, send]);
+    if (!id) return;
+    setReady.mutate(
+      { roomId: id, is_ready: !isReady },
+      {
+        onSuccess: () => {
+          refetch();
+        },
+      },
+    );
+  }, [id, isReady, refetch, setReady]);
 
   const handleStartGame = useCallback(() => {
-    send(WsEventType.GAME_ACTION, { type: "start" });
-  }, [send]);
+    if (!id) return;
+    setStartErrorMessage(null);
+    startRoom.mutate(id, {
+      onSuccess: () => {
+        navigate(`/game/${id}`);
+      },
+      onError: (error) => {
+        const reason = error instanceof Error ? error.message : "알 수 없는 오류";
+        setStartErrorMessage(`게임 시작에 실패했습니다. ${reason}`);
+      },
+    });
+  }, [id, navigate, startRoom]);
 
   const handleCloseRoom = useCallback(() => {
     send(WsEventType.GAME_ACTION, { type: "close" });
     navigate("/lobby");
   }, [send, navigate]);
-
-  // ------ 파생 상태 ------
-
-  const players = room?.players ?? [];
-  const isHost = currentUser ? room?.host_id === currentUser.id : false;
-  const nonHostPlayers = players.filter((p) => !p.is_host);
-  const allReady =
-    nonHostPlayers.length > 0 && nonHostPlayers.every((p) => p.is_ready);
-  const hasMinPlayers = players.length >= (room?.theme.min_players ?? 2);
 
   // ------ 로딩 / 에러 ------
 
@@ -153,7 +176,7 @@ export default function RoomPage() {
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
       {/* 헤더 */}
       <RoomHeader
-        themeTitle={room.theme_title}
+        themeTitle={room.theme_title ?? room.theme?.title ?? "대기방"}
         roomCode={room.code}
         playerCount={room.player_count}
         maxPlayers={room.max_players}
@@ -197,6 +220,8 @@ export default function RoomPage() {
             hasMinPlayers={hasMinPlayers}
             onStartGame={handleStartGame}
             onCloseRoom={handleCloseRoom}
+            isStarting={startRoom.isPending}
+            startErrorMessage={startErrorMessage}
           />
         </div>
 
@@ -206,7 +231,7 @@ export default function RoomPage() {
             mobileTab !== "chat" ? "hidden md:block" : "block"
           }`}
         >
-          <RoomChat send={send} />
+          <RoomChat roomId={id} send={send} />
         </div>
       </div>
 
@@ -226,6 +251,7 @@ export default function RoomPage() {
             variant={isReady ? "secondary" : "primary"}
             leftIcon={<Shield className="h-4 w-4" />}
             onClick={handleToggleReady}
+            isLoading={setReady.isPending}
           >
             {isReady ? "준비 취소" : "준비 완료"}
           </Button>

--- a/apps/web/src/pages/__tests__/LobbyPage.test.tsx
+++ b/apps/web/src/pages/__tests__/LobbyPage.test.tsx
@@ -142,4 +142,35 @@ describe('LobbyPage lazy-auth gates', () => {
     expect(joinMutate).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
+
+  it('대문자 WAITING 방도 대기 중으로 표시하고 참가할 수 있다', () => {
+    const joinMutate = mockLobbyData();
+    useRoomsMock.mockReturnValue({
+      data: [{ ...mockRooms[0], status: 'WAITING' }],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    renderLobby();
+
+    expect(screen.getByText('대기 중')).toBeInTheDocument();
+    const joinButton = screen.getByRole('button', { name: '참가' });
+    expect(joinButton).not.toBeDisabled();
+
+    fireEvent.click(joinButton);
+
+    expect(joinMutate).toHaveBeenCalledWith(
+      'room-1',
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    const [, options] = joinMutate.mock.calls[0];
+    options.onSuccess();
+    expect(navigateMock).toHaveBeenCalledWith('/room/room-1');
+  });
 });

--- a/apps/web/src/pages/__tests__/RoomPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RoomPage.test.tsx
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { useAuthStore } from '@/stores/authStore';
+
+const {
+  navigateMock,
+  refetchMock,
+  sendMock,
+  useRoomMock,
+  useLeaveRoomMock,
+  useSetReadyMock,
+  useStartRoomMock,
+  useWsEventMock,
+} = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  refetchMock: vi.fn(),
+  sendMock: vi.fn(),
+  useRoomMock: vi.fn(),
+  useLeaveRoomMock: vi.fn(),
+  useSetReadyMock: vi.fn(),
+  useStartRoomMock: vi.fn(),
+  useWsEventMock: vi.fn(),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => ({ id: 'room-1' }),
+  };
+});
+
+vi.mock('@/features/lobby/api', () => ({
+  useRoom: () => useRoomMock(),
+  useLeaveRoom: () => useLeaveRoomMock(),
+  useSetReady: () => useSetReadyMock(),
+  useStartRoom: () => useStartRoomMock(),
+}));
+
+vi.mock('@/hooks/useWsClient', () => ({
+  useWsClient: () => ({ send: sendMock }),
+}));
+
+vi.mock('@/hooks/useWsEvent', () => ({
+  useWsEvent: (...args: unknown[]) => useWsEventMock(...args),
+}));
+
+import RoomPage from '../RoomPage';
+
+const baseRoom = {
+  id: 'room-1',
+  code: 'ABC123',
+  theme_id: 'theme-1',
+  theme_title: '초대받지 않은 손님',
+  host_id: 'host-1',
+  host_nickname: '호스트',
+  status: 'WAITING',
+  player_count: 2,
+  max_players: 6,
+  is_private: false,
+  created_at: '2026-05-19T00:00:00Z',
+  theme: {
+    id: 'theme-1',
+    title: '초대받지 않은 손님',
+    slug: 'uninvited-guest',
+    description: '저택에서 벌어진 미스터리',
+    min_players: 2,
+    max_players: 6,
+    duration_min: 90,
+    cover_image: null,
+    coin_price: 0,
+  },
+  players: [
+    {
+      id: 'player-host',
+      user_id: 'host-1',
+      nickname: '호스트',
+      avatar_url: null,
+      is_host: true,
+      is_ready: true,
+      joined_at: '2026-05-19T00:00:00Z',
+    },
+    {
+      id: 'player-user',
+      user_id: 'user-1',
+      nickname: '참가자',
+      avatar_url: null,
+      is_host: false,
+      is_ready: true,
+      joined_at: '2026-05-19T00:00:00Z',
+    },
+  ],
+};
+
+function renderRoom() {
+  return render(
+    <MemoryRouter>
+      <RoomPage />
+    </MemoryRouter>,
+  );
+}
+
+function mockRoomPage(overrides: {
+  room?: typeof baseRoom;
+  readyMutate?: ReturnType<typeof vi.fn>;
+  startMutate?: ReturnType<typeof vi.fn>;
+  leaveMutate?: ReturnType<typeof vi.fn>;
+  readyPending?: boolean;
+  startPending?: boolean;
+} = {}) {
+  useRoomMock.mockReturnValue({
+    data: overrides.room ?? baseRoom,
+    isLoading: false,
+    isError: false,
+    refetch: refetchMock,
+  });
+  useLeaveRoomMock.mockReturnValue({
+    mutate: overrides.leaveMutate ?? vi.fn(),
+    isPending: false,
+  });
+  useSetReadyMock.mockReturnValue({
+    mutate: overrides.readyMutate ?? vi.fn(),
+    isPending: overrides.readyPending ?? false,
+  });
+  useStartRoomMock.mockReturnValue({
+    mutate: overrides.startMutate ?? vi.fn(),
+    isPending: overrides.startPending ?? false,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useAuthStore.setState({
+    user: null,
+    accessToken: null,
+    refreshToken: null,
+    isAuthenticated: false,
+    isLoading: false,
+  });
+});
+
+describe('RoomPage pregame controls', () => {
+  it('현재 사용자의 준비 상태를 room.players에서 읽고 HTTP ready mutation에 is_ready를 보낸다', async () => {
+    const readyMutate = vi.fn((_variables, options) => {
+      options?.onSuccess?.();
+    });
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({ readyMutate });
+
+    renderRoom();
+
+    const readyButton = screen.getByRole('button', { name: /준비 취소/ });
+    fireEvent.click(readyButton);
+
+    expect(readyMutate).toHaveBeenCalledWith(
+      { roomId: 'room-1', is_ready: false },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    await waitFor(() => expect(refetchMock).toHaveBeenCalled());
+  });
+
+  it('ready mutation 중에는 준비 버튼을 비활성화한다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({
+      room: {
+        ...baseRoom,
+        players: baseRoom.players.map((player) =>
+          player.user_id === 'user-1' ? { ...player, is_ready: false } : player,
+        ),
+      },
+      readyPending: true,
+    });
+
+    renderRoom();
+
+    expect(screen.getByRole('button', { name: /준비 완료/ })).toBeDisabled();
+  });
+
+  it('호스트가 게임 시작에 성공하면 game route로 이동한다', () => {
+    const startMutate = vi.fn((_roomId, options) => {
+      options?.onSuccess?.();
+    });
+    useAuthStore.setState({
+      user: { id: 'host-1', email: 'host@example.com', nickname: '호스트', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({ startMutate });
+
+    renderRoom();
+
+    fireEvent.click(screen.getByRole('button', { name: /게임 시작/ }));
+
+    expect(startMutate).toHaveBeenCalledWith(
+      'room-1',
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+    expect(navigateMock).toHaveBeenCalledWith('/game/room-1');
+  });
+
+  it('대기방 헤더에서 uppercase WAITING 상태를 대기 중으로 표시한다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    expect(screen.getByText('대기 중')).toBeInTheDocument();
+  });
+
+  it('theme 객체가 없는 실제 방 상세 응답도 대기방으로 렌더링한다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    const roomWithoutTheme = { ...baseRoom } as Partial<typeof baseRoom>;
+    delete roomWithoutTheme.theme;
+    delete roomWithoutTheme.theme_title;
+    delete roomWithoutTheme.host_nickname;
+    mockRoomPage({ room: roomWithoutTheme as typeof baseRoom });
+
+    renderRoom();
+
+    expect(screen.getByRole('heading', { name: '대기방' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /준비 취소/ })).toBeInTheDocument();
+  });
+
+  it('호스트도 theme 최소 인원 정보가 없으면 게임 시작을 서버에 요청하지 않는다', () => {
+    const startMutate = vi.fn();
+    useAuthStore.setState({
+      user: { id: 'host-1', email: 'host@example.com', nickname: '호스트', role: 'user' },
+      isAuthenticated: true,
+    });
+    const roomWithoutTheme = { ...baseRoom } as Partial<typeof baseRoom>;
+    delete roomWithoutTheme.theme;
+    mockRoomPage({ room: roomWithoutTheme as typeof baseRoom, startMutate });
+
+    renderRoom();
+
+    const startButton = screen.getByRole('button', { name: /게임 시작/ });
+    expect(startButton).toBeDisabled();
+    expect(screen.getByText('최소 인원이 충족되지 않았습니다.')).toBeInTheDocument();
+
+    fireEvent.click(startButton);
+
+    expect(startMutate).not.toHaveBeenCalled();
+  });
+
+  it('기존 채팅 탭과 나가기 동작을 유지한다', () => {
+    const leaveMutate = vi.fn((_roomId, options) => {
+      options?.onSuccess?.();
+    });
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({ leaveMutate });
+
+    renderRoom();
+
+    expect(screen.getByRole('button', { name: /채팅/ })).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('메시지를 입력하세요...'), {
+      target: { value: '준비됐어요' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /메시지 전송/ }));
+    fireEvent.click(screen.getByRole('button', { name: /나가기/ }));
+
+    expect(sendMock).toHaveBeenCalledWith('chat:send', { room_id: 'room-1', text: '준비됐어요' });
+    expect(leaveMutate).toHaveBeenCalledWith(
+      'room-1',
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    expect(navigateMock).toHaveBeenCalledWith('/lobby');
+  });
+
+  it('호스트 게임 시작 실패 사유를 컨트롤 근처에 표시한다', () => {
+    const startMutate = vi.fn((_roomId, options) => {
+      options?.onError?.(new Error('아직 모든 참가자가 준비하지 않았습니다.'));
+    });
+    useAuthStore.setState({
+      user: { id: 'host-1', email: 'host@example.com', nickname: '호스트', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({ startMutate });
+
+    renderRoom();
+
+    fireEvent.click(screen.getByRole('button', { name: /게임 시작/ }));
+
+    expect(screen.getByText(/게임 시작에 실패했습니다/)).toHaveTextContent(
+      '아직 모든 참가자가 준비하지 않았습니다.',
+    );
+  });
+});

--- a/docs/plans/2026-05-19-pregame-slice1-plan.md
+++ b/docs/plans/2026-05-19-pregame-slice1-plan.md
@@ -1,0 +1,176 @@
+# Pre-game Slice 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use the MMP agentic delivery chain. Implementers must not be final reviewers or final validators. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the first #691 slice: lobby/room entry/waiting-room UX and ready/start contract alignment.
+
+**Architecture:** Keep public room discovery and room entry as existing HTTP flows. Use authenticated HTTP mutations as the canonical write path for pre-game ready/start state, then refresh room detail and rely on existing WebSocket/session events where available for live invalidation. Add the minimal room text chat bridge needed for the waiting room to be usable. Defer character selection, friend invite, and voice to later #691 slices.
+
+**Tech Stack:** Go room handler/service/sqlc, React 19, TanStack Query, React Router, Vitest/Testing Library, focused Go tests.
+
+---
+
+## Scope
+
+- [x] Add an authenticated room ready mutation path using `{"is_ready": boolean}`.
+- [x] Make host start use `POST /v1/rooms/{id}/start` instead of the stubbed `game.action` path.
+- [x] Add backend start gating for minimum players and non-host ready state.
+- [x] Make room status labels robust to backend uppercase status values.
+- [x] Add minimal waiting-room text chat over the existing authenticated game WebSocket.
+- [x] Keep character selection, friend invite, and voice expansion out of this PR except for preserving existing UI hooks.
+
+## Files
+
+- Modify: `apps/server/internal/domain/room/service.go`
+- Add: `apps/server/internal/domain/room/service_queries.go`
+- Modify: `apps/server/internal/domain/room/handler.go`
+- Modify: `apps/server/internal/domain/room/mock_shim_test.go`
+- Modify: `apps/server/internal/domain/room/mocks/mock_service.go` if generated mocks are refreshed
+- Add: `apps/server/internal/domain/room/ws_chat.go`
+- Modify: `apps/server/cmd/server/routes_editor.go`
+- Test: `apps/server/internal/domain/room/handler_ready_test.go`
+- Test: `apps/server/internal/domain/room/service_pregame_test.go`
+- Test: `apps/server/internal/domain/room/ws_chat_test.go`
+- Modify: `apps/web/src/features/lobby/api.ts`
+- Add: `apps/web/src/features/lobby/roomStatus.ts`
+- Modify: `apps/web/src/pages/RoomPage.tsx`
+- Modify: `apps/web/src/features/room/components/HostControls.tsx`
+- Modify: `apps/web/src/features/room/components/RoomHeader.tsx`
+- Modify: `apps/web/src/features/lobby/components/RoomList.tsx`
+- Test: `apps/web/src/pages/__tests__/RoomPage.test.tsx`
+- Test: `apps/web/src/pages/__tests__/LobbyPage.test.tsx`
+- Test: `apps/web/src/features/lobby/api.test.tsx`
+
+## Task 1: Backend Ready Endpoint
+
+- [x] **Step 1: Write failing handler tests**
+  - Add tests for `POST /rooms/{id}/ready` success, unauthenticated request, invalid room id, and invalid JSON.
+  - Expected before implementation: compile failure because handler/service method is missing.
+  - Run: `cd apps/server && go test ./internal/domain/room -run 'TestSetReady'`
+
+- [x] **Step 2: Add service contract**
+  - Add `SetReady(ctx, roomID, userID uuid.UUID, ready bool) error` to `Service`.
+  - Add a request type equivalent to:
+    ```go
+    type SetReadyRequest struct {
+        IsReady bool `json:"is_ready"`
+    }
+    ```
+
+- [x] **Step 3: Implement handler**
+  - Parse auth user, room id, and JSON body.
+  - Call `svc.SetReady`.
+  - Return `{"status":"ready_updated"}`.
+
+- [x] **Step 4: Implement service**
+  - Lock room with `GetRoomForUpdate`.
+  - Reject missing room with `ErrRoomNotFound`.
+  - Reject non-`WAITING` room with `ErrRoomNotWaiting`.
+  - Verify user is in `room_players`.
+  - Persist with `SetPlayerReady`.
+
+- [x] **Step 5: Register route**
+  - Add `r.Post("/rooms/{id}/ready", deps.room.SetReady)` in authenticated room routes.
+
+- [x] **Step 6: Verify**
+  - Run: `cd apps/server && go test ./internal/domain/room -run 'TestSetReady|TestStartRoom'`
+
+## Task 2: Backend Start Gating
+
+- [x] **Step 1: Write failing service tests**
+  - Add tests for `validateStartRoster` or equivalent helper:
+    - minimum players not met
+    - non-host player not ready
+    - host readiness is ignored
+    - all non-host players ready passes
+  - Expected before implementation: helper is missing or behavior fails.
+  - Run: `cd apps/server && go test ./internal/domain/room -run 'TestValidateStart'`
+
+- [x] **Step 2: Implement small validation helper**
+  - Inputs: `room`, theme min players, roster rows.
+  - Return `apperror.ErrValidation` or `apperror.ErrConflict` with user-readable detail.
+  - Do not add character selection checks in this PR.
+
+- [x] **Step 3: Call helper in `StartRoom`**
+  - Load theme or min players before `buildGameStartPlayers`.
+  - Validate room status, host ownership, minimum players, non-host readiness.
+  - Keep existing `game runtime not enabled` behavior for flag-off path.
+
+- [x] **Step 4: Verify**
+  - Run: `cd apps/server && go test ./internal/domain/room -run 'TestValidateStart|TestStartRoom|TestMapGameStartPlayers'`
+
+## Task 3: Frontend API Mutations
+
+- [x] **Step 1: Write failing frontend tests**
+  - `RoomPage` non-host ready button calls `useSetReady` with server truth.
+  - host start button calls `useStartRoom` and shows a failure message on mutation error.
+  - Expected before implementation: mocks/functions missing or `game.action` send is called.
+  - Run: `pnpm --filter @mmp/web test -- RoomPage.test.tsx`
+
+- [x] **Step 2: Add lobby API mutations**
+  - Add `SetReadyRequest` with `is_ready`.
+  - Add `useSetReady`.
+  - Add `useStartRoom`.
+  - Invalidate room detail/list on success.
+
+- [x] **Step 3: Update `RoomPage`**
+  - Derive `isReady` from current user’s `room.players`.
+  - Use `useSetReady` for ready toggle.
+  - Use `useStartRoom` for host start.
+  - On start success navigate to `/game/${room.id}`.
+  - On mutation error show a Korean `Alert` near host controls.
+
+- [x] **Step 4: Verify**
+  - Run: `pnpm --filter @mmp/web test -- RoomPage.test.tsx`
+
+## Task 4: Frontend Status and UX Hardening
+
+- [x] **Step 1: Write failing component/page tests**
+  - `RoomList` treats `WAITING` as joinable and labels it `대기 중`.
+  - `RoomHeader` treats `WAITING` as `대기 중`.
+  - Expected before implementation: uppercase status is shown raw or disables join.
+  - Run: `pnpm --filter @mmp/web test -- LobbyPage.test.tsx RoomPage.test.tsx`
+
+- [x] **Step 2: Normalize room status**
+  - Add a small feature-local helper if needed.
+  - Use it in `RoomList` and `RoomHeader`.
+
+- [x] **Step 3: Improve waiting-room clarity**
+  - Keep the existing two-column desktop structure.
+  - Show server-driven ready state and host start disabled reason.
+  - Do not introduce character/invite/voice controls in this PR.
+
+- [x] **Step 4: Verify**
+  - Run: `pnpm --filter @mmp/web test -- LobbyPage.test.tsx RoomPage.test.tsx`
+
+## Task 5: Focused Validation and Review Gate
+
+- [x] **Step 1: Run focused backend tests**
+  - `cd apps/server && go test ./internal/domain/room`
+  - Final blocker-fix evidence: `cd apps/server && go test ./internal/domain/room ./cmd/server ./internal/ws` passed after adding WS refresh-token rejection and StartRoom status compensation tests.
+
+- [x] **Step 2: Run focused frontend tests**
+  - `pnpm --filter @mmp/web test -- RoomPage.test.tsx LobbyPage.test.tsx api.test.tsx`
+  - `pnpm --filter @mmp/web typecheck`
+  - Evidence after final blocker fixes: 3 files / 14 tests passed; TypeScript `tsc --noEmit` passed.
+
+- [x] **Step 3: Run local quick validation if focused checks pass**
+  - `scripts/mmp-local-ci.sh quick`
+  - Independent validation runner evidence: quick passed, including server Go tests, web lint/typecheck/test/build, and web test 210 files / 1910 tests passed.
+  - Main final evidence after all blocker fixes: `scripts/mmp-local-ci.sh quick` passed. Existing web lint warnings remained warnings only: 40 problems, 0 errors.
+
+- [x] **Step 4: Browser QA**
+  - With backend `:8080` and web `:3000`, verify host/player ready/start behavior manually or document why two-account QA could not run.
+  - Evidence: Playwright opened `/room/c2c3ffc2-a70e-4cd1-b994-dcbceec0ea6c`, confirmed no render crash, `POST /ready` returned `200`, WebSocket `/ws/game` upgraded with `200`, and lobby chat sent/received `브라우저 채팅 확인` in the room UI.
+
+- [x] **Step 5: Independent review**
+  - Frontend reviewer: no blocker.
+  - Test coverage reviewer: requested actual `StartRoom` min-player wiring coverage; fixed with `minimum player gate stops before game starter and status update`.
+  - Backend reviewer: requested WS refresh-token rejection and StartRoom status/runtime consistency; fixed with JWT extractor token-type check and status transition compensation.
+  - Final backend re-review: no blocker; targeted WS JWT and `StartRoom` wiring tests passed.
+
+## Self-review
+
+- [x] Spec coverage: #691 Slice 1 only; character/invite/voice are deliberately excluded.
+- [x] No placeholder implementation steps remain.
+- [x] Shared contracts are sequentially owned by main Codex or one backend implementer, not parallel writers.


### PR DESCRIPTION
## 요약
- 로비/대기방 Slice 1 범위에서 ready/start를 HTTP 계약으로 정렬했습니다.
- 대기방 상세 응답에 theme 요약을 포함하고, 최소 인원/준비 조건을 backend StartRoom gate로 강제했습니다.
- 대기방 텍스트 채팅을 기존 authenticated game WebSocket에 연결하고, 참가자/WAITING 상태에서만 허용했습니다.
- `/ws/game` query token 인증이 refresh token을 거부하도록 맞췄습니다.

## 범위
- Refs #691
- 이번 PR은 #691의 Slice 1입니다.
- 캐릭터 선택, 친구 초대, 음성 채팅은 #691 후속 slice로 남깁니다.

## Coverage Plan
- Backend ready endpoint: handler success/auth/invalid JSON/error path, service room status/participant/update failure path.
- Backend start gate: 실제 `StartRoom` wiring에서 최소 인원 부족, 비호스트 미준비, status update failure, starter failure rollback, 성공 status transition을 검증.
- Backend chat/auth: room chat participant/status gate와 WS refresh-token rejection/access-token success를 검증.
- Frontend lobby/room: `RoomPage`, `LobbyPage`, lobby API mutation tests로 ready/start mutation, uppercase status normalization, missing theme/min_players safety, join navigation, chat payload를 검증.

## Local validation
- `cd apps/server && go test ./internal/domain/room ./cmd/server ./internal/ws` 통과.
- `pnpm --filter @mmp/web test -- RoomPage.test.tsx LobbyPage.test.tsx api.test.tsx` 통과: 3 files / 14 tests.
- `pnpm --filter @mmp/web typecheck` 통과.
- `scripts/mmp-local-ci.sh quick` 통과 on HEAD `08a317baeceb54b972f629f5696f7d26026280f0`.
- Browser QA: `/room/c2c3ffc2-a70e-4cd1-b994-dcbceec0ea6c`에서 대기방 렌더링, `POST /ready` 200, room detail theme 포함, 텍스트 채팅 송수신 확인.

## Review evidence
- Frontend reviewer: blocker 없음.
- Test coverage reviewer: StartRoom min-player wiring gap 지적, 테스트 추가 후 해소.
- Backend reviewer: WS refresh-token rejection과 StartRoom status/runtime consistency 지적, 수정 후 backend re-review no blocker.

## Deferred / Follow-up
- #691 후속 slice: 테마별 캐릭터 선택, 친구 초대, 음성 채팅, 전체 pre-game polish.