### PR TITLE
대기방 캐릭터 선택 게이트 추가

### DIFF
--- a/apps/server/cmd/server/routes_editor.go
+++ b/apps/server/cmd/server/routes_editor.go
@@ -77,9 +77,11 @@ func registerBaseRoutes(r chi.Router, deps authedDeps) {
 
 	// Rooms
 	r.Post("/rooms", deps.room.CreateRoom)
+	r.Get("/rooms/{id}/me", deps.room.GetRoomForCurrentUser)
 	r.Post("/rooms/{id}/join", deps.room.JoinRoom)
 	r.Post("/rooms/{id}/leave", deps.room.LeaveRoom)
 	r.Post("/rooms/{id}/ready", deps.room.SetReady)
+	r.Put("/rooms/{id}/character", deps.room.SelectCharacter)
 	r.Post("/rooms/{id}/start", deps.room.StartRoom)
 
 	// Payment endpoints (authed)

--- a/apps/server/db/migrations/00050_room_player_character_unique.sql
+++ b/apps/server/db/migrations/00050_room_player_character_unique.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM room_players
+    WHERE character_id IS NOT NULL
+    GROUP BY room_id, character_id
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'duplicate room_players.character_id values exist; clean up duplicate room character selections before applying unique index';
+  END IF;
+END $$;
+-- +goose StatementEnd
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_room_players_unique_character
+ON room_players(room_id, character_id)
+WHERE character_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_room_players_unique_character;

--- a/apps/server/db/queries/rooms.sql
+++ b/apps/server/db/queries/rooms.sql
@@ -55,3 +55,12 @@ DELETE FROM room_players WHERE room_id = $1 AND user_id = $2;
 
 -- name: SetPlayerReady :exec
 UPDATE room_players SET is_ready = $3 WHERE room_id = $1 AND user_id = $2;
+
+-- name: SetRoomPlayerCharacter :execrows
+UPDATE room_players
+SET character_id = $3
+FROM rooms
+WHERE room_players.room_id = $1
+  AND room_players.user_id = $2
+  AND rooms.id = room_players.room_id
+  AND rooms.status = 'WAITING';

--- a/apps/server/internal/db/rooms.sql.go
+++ b/apps/server/internal/db/rooms.sql.go
@@ -348,6 +348,30 @@ func (q *Queries) SetPlayerReady(ctx context.Context, arg SetPlayerReadyParams) 
 	return err
 }
 
+const setRoomPlayerCharacter = `-- name: SetRoomPlayerCharacter :execrows
+UPDATE room_players
+SET character_id = $3
+FROM rooms
+WHERE room_players.room_id = $1
+  AND room_players.user_id = $2
+  AND rooms.id = room_players.room_id
+  AND rooms.status = 'WAITING'
+`
+
+type SetRoomPlayerCharacterParams struct {
+	RoomID      uuid.UUID   `json:"room_id"`
+	UserID      uuid.UUID   `json:"user_id"`
+	CharacterID pgtype.UUID `json:"character_id"`
+}
+
+func (q *Queries) SetRoomPlayerCharacter(ctx context.Context, arg SetRoomPlayerCharacterParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setRoomPlayerCharacter, arg.RoomID, arg.UserID, arg.CharacterID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateRoomStatus = `-- name: UpdateRoomStatus :exec
 UPDATE rooms SET status = $2, updated_at = NOW() WHERE id = $1
 `

--- a/apps/server/internal/domain/room/handler.go
+++ b/apps/server/internal/domain/room/handler.go
@@ -75,6 +75,29 @@ func (h *Handler) GetRoom(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, resp)
 }
 
+// GetRoomForCurrentUser handles GET /rooms/{id}/me (authenticated participant).
+func (h *Handler) GetRoomForCurrentUser(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFrom(r.Context())
+	if userID == uuid.Nil {
+		apperror.WriteError(w, r, apperror.Unauthorized("authentication required"))
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	roomID, err := uuid.Parse(idStr)
+	if err != nil {
+		apperror.WriteError(w, r, apperror.BadRequest("invalid room ID"))
+		return
+	}
+
+	resp, err := h.svc.GetRoomForUser(r.Context(), roomID, userID)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
 // GetRoomByCode handles GET /rooms/code/{code} (public).
 func (h *Handler) GetRoomByCode(w http.ResponseWriter, r *http.Request) {
 	code := chi.URLParam(r, "code")
@@ -161,6 +184,34 @@ func (h *Handler) SetReady(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httputil.WriteJSON(w, http.StatusOK, map[string]string{"status": "ready updated"})
+}
+
+// SelectCharacter handles PUT /rooms/{id}/character (authenticated).
+func (h *Handler) SelectCharacter(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFrom(r.Context())
+	if userID == uuid.Nil {
+		apperror.WriteError(w, r, apperror.Unauthorized("authentication required"))
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	roomID, err := uuid.Parse(idStr)
+	if err != nil {
+		apperror.WriteError(w, r, apperror.BadRequest("invalid room ID"))
+		return
+	}
+
+	var req SelectCharacterRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	if err := h.svc.SelectCharacter(r.Context(), roomID, userID, req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, map[string]string{"status": "character selected"})
 }
 
 // StartRoom handles POST /rooms/{id}/start (authenticated, host only).

--- a/apps/server/internal/domain/room/handler_character_test.go
+++ b/apps/server/internal/domain/room/handler_character_test.go
@@ -1,0 +1,99 @@
+package room
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestSelectCharacter_Success(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	characterID := uuid.New()
+
+	svc := &mockService{
+		selectCharFn: func(_ context.Context, gotRoomID, gotUserID uuid.UUID, req SelectCharacterRequest) error {
+			if gotRoomID != roomID || gotUserID != userID || req.CharacterID != characterID {
+				t.Fatalf("SelectCharacter args mismatch: room=%s user=%s req=%+v", gotRoomID, gotUserID, req)
+			}
+			return nil
+		},
+	}
+	h := NewHandler(svc)
+
+	body, _ := json.Marshal(SelectCharacterRequest{CharacterID: characterID})
+	req := httptest.NewRequest(http.MethodPut, "/rooms/"+roomID.String()+"/character", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.SelectCharacter(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "character selected") {
+		t.Fatalf("expected success body, got %s", rec.Body.String())
+	}
+}
+
+func TestSelectCharacter_NoAuth(t *testing.T) {
+	h := NewHandler(&mockService{})
+	roomID := uuid.New()
+	characterID := uuid.New()
+	body, _ := json.Marshal(SelectCharacterRequest{CharacterID: characterID})
+
+	req := httptest.NewRequest(http.MethodPut, "/rooms/"+roomID.String()+"/character", bytes.NewReader(body))
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.SelectCharacter(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSelectCharacter_InvalidJSON(t *testing.T) {
+	h := NewHandler(&mockService{})
+	roomID := uuid.New()
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/rooms/"+roomID.String()+"/character", strings.NewReader(`not valid json`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.SelectCharacter(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSelectCharacter_InvalidRoomID(t *testing.T) {
+	h := NewHandler(&mockService{})
+	userID := uuid.New()
+	characterID := uuid.New()
+	body, _ := json.Marshal(SelectCharacterRequest{CharacterID: characterID})
+
+	req := httptest.NewRequest(http.MethodPut, "/rooms/not-a-uuid/character", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", "not-a-uuid")
+
+	rec := httptest.NewRecorder()
+	h.SelectCharacter(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/server/internal/domain/room/handler_test.go
+++ b/apps/server/internal/domain/room/handler_test.go
@@ -270,6 +270,59 @@ func TestGetRoom_Success(t *testing.T) {
 	}
 }
 
+func TestGetRoomForCurrentUser_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockService(ctrl)
+
+	roomID := uuid.New()
+	userID := uuid.New()
+	characterID := uuid.New()
+
+	mock.EXPECT().
+		GetRoomForUser(gomock.Any(), gomock.Eq(roomID), gomock.Eq(userID)).
+		Return(&room.RoomDetailResponse{
+			RoomResponse: room.RoomResponse{ID: roomID, Code: "XYZ789", Status: "WAITING"},
+			Players: []room.PlayerInfo{
+				{UserID: userID, CharacterID: &characterID, IsReady: true},
+			},
+		}, nil).Times(1)
+
+	h := room.NewHandler(mock)
+
+	req := httptest.NewRequest(http.MethodGet, "/rooms/"+roomID.String()+"/me", nil)
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.GetRoomForCurrentUser(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp room.RoomDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Players[0].CharacterID == nil || *resp.Players[0].CharacterID != characterID {
+		t.Fatalf("expected participant character_id, got %+v", resp.Players[0])
+	}
+}
+
+func TestGetRoomForCurrentUser_NoAuth(t *testing.T) {
+	h := room.NewHandler(mocks.NewMockService(gomock.NewController(t)))
+	roomID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/rooms/"+roomID.String()+"/me", nil)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.GetRoomForCurrentUser(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestGetRoom_NotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := mocks.NewMockService(ctrl)

--- a/apps/server/internal/domain/room/mock_shim_test.go
+++ b/apps/server/internal/domain/room/mock_shim_test.go
@@ -23,14 +23,16 @@ import (
 // mockService is a minimal hand-rolled stub for the room.Service interface,
 // used only in service_flag_test.go for white-box flag-dispatch testing.
 type mockService struct {
-	createRoomFn    func(ctx context.Context, hostID uuid.UUID, req CreateRoomRequest) (*RoomResponse, error)
-	getRoomFn       func(ctx context.Context, roomID uuid.UUID) (*RoomDetailResponse, error)
-	getRoomByCodeFn func(ctx context.Context, code string) (*RoomDetailResponse, error)
-	listWaitingFn   func(ctx context.Context, limit, offset int32) ([]RoomResponse, error)
-	joinRoomFn      func(ctx context.Context, roomID, userID uuid.UUID) error
-	leaveRoomFn     func(ctx context.Context, roomID, userID uuid.UUID) error
-	setReadyFn      func(ctx context.Context, roomID, userID uuid.UUID, ready bool) error
-	startRoomFn     func(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
+	createRoomFn     func(ctx context.Context, hostID uuid.UUID, req CreateRoomRequest) (*RoomResponse, error)
+	getRoomFn        func(ctx context.Context, roomID uuid.UUID) (*RoomDetailResponse, error)
+	getRoomForUserFn func(ctx context.Context, roomID, userID uuid.UUID) (*RoomDetailResponse, error)
+	getRoomByCodeFn  func(ctx context.Context, code string) (*RoomDetailResponse, error)
+	listWaitingFn    func(ctx context.Context, limit, offset int32) ([]RoomResponse, error)
+	joinRoomFn       func(ctx context.Context, roomID, userID uuid.UUID) error
+	leaveRoomFn      func(ctx context.Context, roomID, userID uuid.UUID) error
+	setReadyFn       func(ctx context.Context, roomID, userID uuid.UUID, ready bool) error
+	selectCharFn     func(ctx context.Context, roomID, userID uuid.UUID, req SelectCharacterRequest) error
+	startRoomFn      func(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
 }
 
 func (m *mockService) CreateRoom(ctx context.Context, hostID uuid.UUID, req CreateRoomRequest) (*RoomResponse, error) {
@@ -43,6 +45,13 @@ func (m *mockService) CreateRoom(ctx context.Context, hostID uuid.UUID, req Crea
 func (m *mockService) GetRoom(ctx context.Context, roomID uuid.UUID) (*RoomDetailResponse, error) {
 	if m.getRoomFn != nil {
 		return m.getRoomFn(ctx, roomID)
+	}
+	return nil, nil
+}
+
+func (m *mockService) GetRoomForUser(ctx context.Context, roomID, userID uuid.UUID) (*RoomDetailResponse, error) {
+	if m.getRoomForUserFn != nil {
+		return m.getRoomForUserFn(ctx, roomID, userID)
 	}
 	return nil, nil
 }
@@ -78,6 +87,13 @@ func (m *mockService) LeaveRoom(ctx context.Context, roomID, userID uuid.UUID) e
 func (m *mockService) SetReady(ctx context.Context, roomID, userID uuid.UUID, ready bool) error {
 	if m.setReadyFn != nil {
 		return m.setReadyFn(ctx, roomID, userID, ready)
+	}
+	return nil
+}
+
+func (m *mockService) SelectCharacter(ctx context.Context, roomID, userID uuid.UUID, req SelectCharacterRequest) error {
+	if m.selectCharFn != nil {
+		return m.selectCharFn(ctx, roomID, userID, req)
 	}
 	return nil
 }

--- a/apps/server/internal/domain/room/mocks/mock_service.go
+++ b/apps/server/internal/domain/room/mocks/mock_service.go
@@ -87,6 +87,21 @@ func (mr *MockServiceMockRecorder) GetRoomByCode(ctx, code any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomByCode", reflect.TypeOf((*MockService)(nil).GetRoomByCode), ctx, code)
 }
 
+// GetRoomForUser mocks base method.
+func (m *MockService) GetRoomForUser(ctx context.Context, roomID, userID uuid.UUID) (*room.RoomDetailResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRoomForUser", ctx, roomID, userID)
+	ret0, _ := ret[0].(*room.RoomDetailResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRoomForUser indicates an expected call of GetRoomForUser.
+func (mr *MockServiceMockRecorder) GetRoomForUser(ctx, roomID, userID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomForUser", reflect.TypeOf((*MockService)(nil).GetRoomForUser), ctx, roomID, userID)
+}
+
 // JoinRoom mocks base method.
 func (m *MockService) JoinRoom(ctx context.Context, roomID, userID uuid.UUID) error {
 	m.ctrl.T.Helper()
@@ -128,6 +143,20 @@ func (m *MockService) ListWaitingRooms(ctx context.Context, limit, offset int32)
 func (mr *MockServiceMockRecorder) ListWaitingRooms(ctx, limit, offset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWaitingRooms", reflect.TypeOf((*MockService)(nil).ListWaitingRooms), ctx, limit, offset)
+}
+
+// SelectCharacter mocks base method.
+func (m *MockService) SelectCharacter(ctx context.Context, roomID, userID uuid.UUID, req room.SelectCharacterRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectCharacter", ctx, roomID, userID, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SelectCharacter indicates an expected call of SelectCharacter.
+func (mr *MockServiceMockRecorder) SelectCharacter(ctx, roomID, userID, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectCharacter", reflect.TypeOf((*MockService)(nil).SelectCharacter), ctx, roomID, userID, req)
 }
 
 // SetReady mocks base method.

--- a/apps/server/internal/domain/room/service.go
+++ b/apps/server/internal/domain/room/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
@@ -70,11 +71,12 @@ type ThemeSummary struct {
 // 를 사용하므로 서버 SSOT 도 동일 필드를 직렬화한다. 기존 user_id/is_ready
 // 는 유지.
 type PlayerInfo struct {
-	UserID    uuid.UUID `json:"user_id"`
-	Nickname  string    `json:"nickname"`
-	AvatarURL *string   `json:"avatar_url,omitempty"`
-	IsHost    bool      `json:"is_host"`
-	IsReady   bool      `json:"is_ready"`
+	UserID      uuid.UUID  `json:"user_id"`
+	CharacterID *uuid.UUID `json:"character_id,omitempty"`
+	Nickname    string     `json:"nickname"`
+	AvatarURL   *string    `json:"avatar_url,omitempty"`
+	IsHost      bool       `json:"is_host"`
+	IsReady     bool       `json:"is_ready"`
 }
 
 // StartRoomRequest is the payload for POST /rooms/:id/start.
@@ -89,15 +91,22 @@ type SetReadyRequest struct {
 	IsReady bool `json:"is_ready"`
 }
 
+// SelectCharacterRequest is the payload for PUT /rooms/:id/character.
+type SelectCharacterRequest struct {
+	CharacterID uuid.UUID `json:"character_id"`
+}
+
 // Service defines the room domain operations.
 type Service interface {
 	CreateRoom(ctx context.Context, hostID uuid.UUID, req CreateRoomRequest) (*RoomResponse, error)
 	GetRoom(ctx context.Context, roomID uuid.UUID) (*RoomDetailResponse, error)
+	GetRoomForUser(ctx context.Context, roomID, userID uuid.UUID) (*RoomDetailResponse, error)
 	GetRoomByCode(ctx context.Context, code string) (*RoomDetailResponse, error)
 	ListWaitingRooms(ctx context.Context, limit, offset int32) ([]RoomResponse, error)
 	JoinRoom(ctx context.Context, roomID, userID uuid.UUID) error
 	LeaveRoom(ctx context.Context, roomID, userID uuid.UUID) error
 	SetReady(ctx context.Context, roomID, userID uuid.UUID, ready bool) error
+	SelectCharacter(ctx context.Context, roomID, userID uuid.UUID, req SelectCharacterRequest) error
 	StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
 }
 
@@ -259,7 +268,8 @@ func (s *service) CreateRoom(ctx context.Context, hostID uuid.UUID, req CreateRo
 	return &resp, nil
 }
 
-// GetRoom returns the room detail including player list.
+// GetRoom returns public room detail. Character selections are intentionally
+// redacted because public room/code lookups are available before joining.
 func (s *service) GetRoom(ctx context.Context, roomID uuid.UUID) (*RoomDetailResponse, error) {
 	room, err := s.queries.GetRoom(ctx, roomID)
 	if err != nil {
@@ -270,10 +280,32 @@ func (s *service) GetRoom(ctx context.Context, roomID uuid.UUID) (*RoomDetailRes
 		return nil, apperror.Internal("failed to get room")
 	}
 
-	return s.buildRoomDetail(ctx, room)
+	return s.buildRoomDetail(ctx, room, false)
 }
 
-// GetRoomByCode returns the room detail by its invite code.
+// GetRoomForUser returns room detail with participant-only pre-game state.
+func (s *service) GetRoomForUser(ctx context.Context, roomID, userID uuid.UUID) (*RoomDetailResponse, error) {
+	room, err := s.queries.GetRoom(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.New(apperror.ErrRoomNotFound, http.StatusNotFound, "room not found")
+		}
+		s.logger.Error().Err(err).Msg("failed to get room")
+		return nil, apperror.Internal("failed to get room")
+	}
+
+	resp, err := s.buildRoomDetail(ctx, room, true)
+	if err != nil {
+		return nil, err
+	}
+	if !hasPlayerInfo(resp.Players, userID) {
+		return nil, apperror.New(apperror.ErrPlayerNotInGame, http.StatusForbidden, "player is not in this room")
+	}
+	return resp, nil
+}
+
+// GetRoomByCode returns public room detail by its invite code. Character
+// selections are redacted until the caller joins and uses GetRoomForUser.
 func (s *service) GetRoomByCode(ctx context.Context, code string) (*RoomDetailResponse, error) {
 	room, err := s.queries.GetRoomByCode(ctx, code)
 	if err != nil {
@@ -284,7 +316,7 @@ func (s *service) GetRoomByCode(ctx context.Context, code string) (*RoomDetailRe
 		return nil, apperror.Internal("failed to get room")
 	}
 
-	return s.buildRoomDetail(ctx, room)
+	return s.buildRoomDetail(ctx, room, false)
 }
 
 // ListWaitingRooms returns public waiting rooms with player counts.
@@ -488,9 +520,86 @@ func (s *service) SetReady(ctx context.Context, roomID, userID uuid.UUID, ready 
 	return nil
 }
 
+// SelectCharacter persists a waiting-room participant's playable character
+// selection after validating room state, participant membership, and theme
+// ownership.
+func (s *service) SelectCharacter(ctx context.Context, roomID, userID uuid.UUID, req SelectCharacterRequest) error {
+	if req.CharacterID == uuid.Nil {
+		return apperror.BadRequest("character_id is required")
+	}
+
+	room, err := s.queries.GetRoom(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.New(apperror.ErrRoomNotFound, http.StatusNotFound, "room not found")
+		}
+		s.logger.Error().Err(err).Msg("SelectCharacter: failed to get room")
+		return apperror.Internal("failed to get room")
+	}
+	if room.Status != "WAITING" {
+		return apperror.New(apperror.ErrRoomNotWaiting, http.StatusConflict, "room is not in waiting state")
+	}
+
+	players, err := s.queries.GetRoomPlayers(ctx, roomID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("room_id", roomID).Msg("SelectCharacter: failed to get room players")
+		return apperror.Internal("failed to get room players")
+	}
+	if !hasRoomPlayer(players, userID) {
+		return apperror.New(apperror.ErrPlayerNotInGame, http.StatusForbidden, "player is not in this room")
+	}
+
+	character, err := s.queries.GetThemeCharacter(ctx, req.CharacterID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.NotFound("character not found")
+		}
+		s.logger.Error().Err(err).Stringer("character_id", req.CharacterID).Msg("SelectCharacter: failed to get character")
+		return apperror.Internal("failed to get character")
+	}
+	if character.ThemeID != room.ThemeID {
+		return apperror.BadRequest("character does not belong to this room theme")
+	}
+	if !character.IsPlayable {
+		return apperror.BadRequest("character is not playable")
+	}
+	for _, player := range players {
+		if player.UserID == userID || !player.CharacterID.Valid {
+			continue
+		}
+		if uuid.UUID(player.CharacterID.Bytes) == req.CharacterID {
+			return apperror.Conflict("character already selected")
+		}
+	}
+
+	rowsAffected, err := s.queries.SetRoomPlayerCharacter(ctx, db.SetRoomPlayerCharacterParams{
+		RoomID: roomID,
+		UserID: userID,
+		CharacterID: pgtype.UUID{
+			Bytes: req.CharacterID,
+			Valid: true,
+		},
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return apperror.Conflict("character already selected")
+		}
+		s.logger.Error().Err(err).Stringer("room_id", roomID).Stringer("user_id", userID).Stringer("character_id", req.CharacterID).Msg("SelectCharacter: failed to update character")
+		return apperror.Internal("failed to update character")
+	}
+	if rowsAffected == 0 {
+		latestRoom, latestErr := s.queries.GetRoom(ctx, roomID)
+		if latestErr == nil && latestRoom.Status != "WAITING" {
+			return apperror.New(apperror.ErrRoomNotWaiting, http.StatusConflict, "room is not in waiting state")
+		}
+		return apperror.New(apperror.ErrPlayerNotInGame, http.StatusForbidden, "player is not in this room")
+	}
+	return nil
+}
+
 // buildRoomDetail fetches players (with user JOIN) and assembles a
 // RoomDetailResponse. is_host 는 room.HostID 와 user_id 비교로 결정한다.
-func (s *service) buildRoomDetail(ctx context.Context, room db.Room) (*RoomDetailResponse, error) {
+func (s *service) buildRoomDetail(ctx context.Context, room db.Room, includeCharacterSelection bool) (*RoomDetailResponse, error) {
 	players, err := s.queries.GetRoomPlayersWithUser(ctx, room.ID)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to get room players")
@@ -511,6 +620,9 @@ func (s *service) buildRoomDetail(ctx context.Context, room db.Room) (*RoomDetai
 			IsHost:    p.UserID == room.HostID,
 			IsReady:   p.IsReady,
 		}
+		if includeCharacterSelection {
+			infos[i].CharacterID = pgUUIDToPtr(p.CharacterID)
+		}
 	}
 
 	resp := &RoomDetailResponse{
@@ -519,6 +631,14 @@ func (s *service) buildRoomDetail(ctx context.Context, room db.Room) (*RoomDetai
 		Theme:        mapThemeSummary(theme),
 	}
 	return resp, nil
+}
+
+func pgUUIDToPtr(value pgtype.UUID) *uuid.UUID {
+	if !value.Valid {
+		return nil
+	}
+	id := uuid.UUID(value.Bytes)
+	return &id
 }
 
 // textToPtr converts pgtype.Text to *string (nil when NULL).
@@ -533,12 +653,35 @@ func textToPtr(t pgtype.Text) *string {
 // delegates to GameStarter (game_runtime_v2 flag on) or returns a stub
 // response for the legacy path (flag off).
 func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error {
-	room, err := s.queries.GetRoom(ctx, roomID)
+	if s.pool == nil {
+		return s.startRoomLocked(ctx, s.queries, roomID, hostID, req)
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("StartRoom: failed to begin transaction")
+		return apperror.Internal("failed to start room")
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	qtx := s.queries.WithTx(tx)
+	if err := s.startRoomLocked(ctx, qtx, roomID, hostID, req); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		s.logger.Error().Err(err).Str("room_id", roomID.String()).Msg("StartRoom: failed to commit transaction")
+		return apperror.Internal("failed to start room")
+	}
+	return nil
+}
+
+func (s *service) startRoomLocked(ctx context.Context, q roomQueries, roomID, hostID uuid.UUID, req StartRoomRequest) error {
+	room, err := q.GetRoomForUpdate(ctx, roomID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperror.New(apperror.ErrRoomNotFound, http.StatusNotFound, "room not found")
 		}
-		s.logger.Error().Err(err).Msg("StartRoom: failed to get room")
+		s.logger.Error().Err(err).Msg("StartRoom: failed to lock room")
 		return apperror.Internal("failed to get room")
 	}
 
@@ -550,7 +693,7 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 		return apperror.New(apperror.ErrRoomNotWaiting, http.StatusConflict, "room is not in waiting state")
 	}
 
-	theme, err := s.queries.GetTheme(ctx, room.ThemeID)
+	theme, err := q.GetTheme(ctx, room.ThemeID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperror.New(apperror.ErrNotFound, http.StatusNotFound, "theme not found")
@@ -558,7 +701,7 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 		s.logger.Error().Err(err).Stringer("theme_id", room.ThemeID).Msg("StartRoom: failed to get theme")
 		return apperror.Internal("failed to get theme")
 	}
-	playerRows, err := s.queries.GetRoomPlayersWithUser(ctx, room.ID)
+	playerRows, err := q.GetRoomPlayersWithUser(ctx, room.ID)
 	if err != nil {
 		s.logger.Error().Err(err).Stringer("room_id", room.ID).Msg("StartRoom: failed to get room players")
 		return apperror.Internal("failed to get room players")
@@ -585,7 +728,7 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 		return err
 	}
 
-	if err := s.queries.UpdateRoomStatus(ctx, db.UpdateRoomStatusParams{
+	if err := q.UpdateRoomStatus(ctx, db.UpdateRoomStatusParams{
 		ID:     roomID,
 		Status: "PLAYING",
 	}); err != nil {
@@ -594,7 +737,7 @@ func (s *service) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req S
 	}
 	if err := s.gameStarter.Start(ctx, roomID, room.ThemeID, req.ConfigJSON, startPlayers); err != nil {
 		s.logger.Error().Err(err).Str("room_id", roomID.String()).Msg("StartRoom: gameStarter failed")
-		if rollbackErr := s.queries.UpdateRoomStatus(ctx, db.UpdateRoomStatusParams{
+		if rollbackErr := q.UpdateRoomStatus(ctx, db.UpdateRoomStatusParams{
 			ID:     roomID,
 			Status: "WAITING",
 		}); rollbackErr != nil {
@@ -615,6 +758,9 @@ func validateStartGate(room db.Room, theme db.Theme, players []db.RoomPlayer) er
 		return apperror.Conflict("not enough players to start")
 	}
 	for _, player := range players {
+		if !player.CharacterID.Valid {
+			return apperror.Conflict("all players must select a character")
+		}
 		if player.UserID == room.HostID {
 			continue
 		}
@@ -630,6 +776,9 @@ func validateStartGateRows(room db.Room, theme db.Theme, players []db.GetRoomPla
 		return apperror.Conflict("not enough players to start")
 	}
 	for _, player := range players {
+		if !player.CharacterID.Valid {
+			return apperror.Conflict("all players must select a character")
+		}
 		if player.UserID == room.HostID {
 			continue
 		}
@@ -640,7 +789,21 @@ func validateStartGateRows(room db.Room, theme db.Theme, players []db.GetRoomPla
 	return nil
 }
 
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
 func hasRoomPlayer(players []db.RoomPlayer, userID uuid.UUID) bool {
+	for _, player := range players {
+		if player.UserID == userID {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPlayerInfo(players []PlayerInfo, userID uuid.UUID) bool {
 	for _, player := range players {
 		if player.UserID == userID {
 			return true

--- a/apps/server/internal/domain/room/service_flag_test.go
+++ b/apps/server/internal/domain/room/service_flag_test.go
@@ -232,11 +232,13 @@ func TestValidateStartGate_MinPlayersNotMet(t *testing.T) {
 
 func TestValidateStartGate_NonHostNotReady(t *testing.T) {
 	hostID := uuid.New()
+	hostCharID := uuid.New()
+	guestCharID := uuid.New()
 	room := db.Room{HostID: hostID, Status: "WAITING"}
 	theme := db.Theme{MinPlayers: 2}
 	players := []db.RoomPlayer{
-		{UserID: hostID, IsReady: true},
-		{UserID: uuid.New(), IsReady: false},
+		{UserID: hostID, CharacterID: pgtype.UUID{Bytes: hostCharID, Valid: true}, IsReady: true},
+		{UserID: uuid.New(), CharacterID: pgtype.UUID{Bytes: guestCharID, Valid: true}, IsReady: false},
 	}
 
 	err := validateStartGate(room, theme, players)
@@ -245,11 +247,13 @@ func TestValidateStartGate_NonHostNotReady(t *testing.T) {
 
 func TestValidateStartGate_HostReadyIgnored(t *testing.T) {
 	hostID := uuid.New()
+	hostCharID := uuid.New()
+	guestCharID := uuid.New()
 	room := db.Room{HostID: hostID, Status: "WAITING"}
 	theme := db.Theme{MinPlayers: 2}
 	players := []db.RoomPlayer{
-		{UserID: hostID, IsReady: false},
-		{UserID: uuid.New(), IsReady: true},
+		{UserID: hostID, CharacterID: pgtype.UUID{Bytes: hostCharID, Valid: true}, IsReady: false},
+		{UserID: uuid.New(), CharacterID: pgtype.UUID{Bytes: guestCharID, Valid: true}, IsReady: true},
 	}
 
 	if err := validateStartGate(room, theme, players); err != nil {
@@ -262,14 +266,27 @@ func TestValidateStartGate_AllNonHostReadyPasses(t *testing.T) {
 	room := db.Room{HostID: hostID, Status: "WAITING"}
 	theme := db.Theme{MinPlayers: 3}
 	players := []db.RoomPlayer{
-		{UserID: hostID},
-		{UserID: uuid.New(), IsReady: true},
-		{UserID: uuid.New(), IsReady: true},
+		{UserID: hostID, CharacterID: pgtype.UUID{Bytes: uuid.New(), Valid: true}},
+		{UserID: uuid.New(), CharacterID: pgtype.UUID{Bytes: uuid.New(), Valid: true}, IsReady: true},
+		{UserID: uuid.New(), CharacterID: pgtype.UUID{Bytes: uuid.New(), Valid: true}, IsReady: true},
 	}
 
 	if err := validateStartGate(room, theme, players); err != nil {
 		t.Fatalf("expected start gate to pass, got %v", err)
 	}
+}
+
+func TestValidateStartGate_AllPlayersNeedCharacter(t *testing.T) {
+	hostID := uuid.New()
+	room := db.Room{HostID: hostID, Status: "WAITING"}
+	theme := db.Theme{MinPlayers: 2}
+	players := []db.RoomPlayer{
+		{UserID: hostID, IsReady: false},
+		{UserID: uuid.New(), CharacterID: pgtype.UUID{Bytes: uuid.New(), Valid: true}, IsReady: true},
+	}
+
+	err := validateStartGate(room, theme, players)
+	assertAppError(t, err, http.StatusConflict)
 }
 
 func assertAppError(t *testing.T, err error, status int) {

--- a/apps/server/internal/domain/room/service_pregame_test.go
+++ b/apps/server/internal/domain/room/service_pregame_test.go
@@ -1,7 +1,9 @@
 package room
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
 
 	"github.com/mmp-platform/server/internal/db"
@@ -16,6 +19,7 @@ import (
 
 type fakeRoomQueries struct {
 	room                     db.Room
+	roomAfterCharacterNoRows *db.Room
 	roomErr                  error
 	players                  []db.RoomPlayer
 	playersErr               error
@@ -25,13 +29,19 @@ type fakeRoomQueries struct {
 	playersWithUserErr       error
 	characters               []db.ThemeCharacter
 	charactersErr            error
+	character                db.ThemeCharacter
+	characterErr             error
 	setReadyParams           *db.SetPlayerReadyParams
 	setReadyErr              error
+	setCharacterParams       *db.SetRoomPlayerCharacterParams
+	setCharacterErr          error
+	setCharacterRowsAffected *int64
 	updateRoomStatusParams   *db.UpdateRoomStatusParams
 	statusUpdates            []db.UpdateRoomStatusParams
 	updateRoomStatusErr      error
 	getRoomPlayersCalled     bool
 	getPlayersWithUserCalled bool
+	getRoomForUpdateCalled   bool
 	getThemeCalled           bool
 }
 
@@ -44,6 +54,9 @@ func (f *fakeRoomQueries) CreateRoom(context.Context, db.CreateRoomParams) (db.R
 }
 
 func (f *fakeRoomQueries) GetRoom(context.Context, uuid.UUID) (db.Room, error) {
+	if f.setCharacterParams != nil && f.roomAfterCharacterNoRows != nil {
+		return *f.roomAfterCharacterNoRows, f.roomErr
+	}
 	return f.room, f.roomErr
 }
 
@@ -52,7 +65,8 @@ func (f *fakeRoomQueries) GetRoomByCode(context.Context, string) (db.Room, error
 }
 
 func (f *fakeRoomQueries) GetRoomForUpdate(context.Context, uuid.UUID) (db.Room, error) {
-	panic("unexpected GetRoomForUpdate call")
+	f.getRoomForUpdateCalled = true
+	return f.room, f.roomErr
 }
 
 func (f *fakeRoomQueries) GetRoomPlayerCount(context.Context, uuid.UUID) (int64, error) {
@@ -78,6 +92,10 @@ func (f *fakeRoomQueries) GetThemeCharacters(context.Context, uuid.UUID) ([]db.T
 	return f.characters, f.charactersErr
 }
 
+func (f *fakeRoomQueries) GetThemeCharacter(context.Context, uuid.UUID) (db.ThemeCharacter, error) {
+	return f.character, f.characterErr
+}
+
 func (f *fakeRoomQueries) ListWaitingRoomsWithCount(context.Context, db.ListWaitingRoomsWithCountParams) ([]db.ListWaitingRoomsWithCountRow, error) {
 	panic("unexpected ListWaitingRoomsWithCount call")
 }
@@ -89,6 +107,17 @@ func (f *fakeRoomQueries) RemoveRoomPlayer(context.Context, db.RemoveRoomPlayerP
 func (f *fakeRoomQueries) SetPlayerReady(_ context.Context, arg db.SetPlayerReadyParams) error {
 	f.setReadyParams = &arg
 	return f.setReadyErr
+}
+
+func (f *fakeRoomQueries) SetRoomPlayerCharacter(_ context.Context, arg db.SetRoomPlayerCharacterParams) (int64, error) {
+	f.setCharacterParams = &arg
+	if f.setCharacterErr != nil {
+		return 0, f.setCharacterErr
+	}
+	if f.setCharacterRowsAffected != nil {
+		return *f.setCharacterRowsAffected, nil
+	}
+	return 1, nil
 }
 
 func (f *fakeRoomQueries) UpdateRoomStatus(_ context.Context, arg db.UpdateRoomStatusParams) error {
@@ -187,11 +216,293 @@ func TestSetReadyServiceBranches(t *testing.T) {
 	}
 }
 
+func TestSelectCharacterServiceBranches(t *testing.T) {
+	roomID := uuid.New()
+	themeID := uuid.New()
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	charID := uuid.New()
+	otherCharID := uuid.New()
+	waitingRoom := db.Room{ID: roomID, ThemeID: themeID, Status: "WAITING"}
+	playingRoom := db.Room{ID: roomID, ThemeID: themeID, Status: "PLAYING"}
+	participant := db.RoomPlayer{RoomID: roomID, UserID: userID}
+	playableChar := db.ThemeCharacter{ID: charID, ThemeID: themeID, IsPlayable: true}
+	zeroRows := int64(0)
+
+	tests := []struct {
+		name        string
+		queries     *fakeRoomQueries
+		wantStatus  int
+		wantUpdated bool
+	}{
+		{
+			name:       "room missing",
+			queries:    &fakeRoomQueries{roomErr: pgx.ErrNoRows},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "room not waiting",
+			queries:    &fakeRoomQueries{room: db.Room{ID: roomID, ThemeID: themeID, Status: "PLAYING"}},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name: "caller is not participant",
+			queries: &fakeRoomQueries{
+				room:    waitingRoom,
+				players: []db.RoomPlayer{{RoomID: roomID, UserID: otherUserID}},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "character missing",
+			queries: &fakeRoomQueries{
+				room:         waitingRoom,
+				players:      []db.RoomPlayer{participant},
+				characterErr: pgx.ErrNoRows,
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "character belongs to another theme",
+			queries: &fakeRoomQueries{
+				room:      waitingRoom,
+				players:   []db.RoomPlayer{participant},
+				character: db.ThemeCharacter{ID: charID, ThemeID: uuid.New(), IsPlayable: true},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "character is not playable",
+			queries: &fakeRoomQueries{
+				room:      waitingRoom,
+				players:   []db.RoomPlayer{participant},
+				character: db.ThemeCharacter{ID: charID, ThemeID: themeID, IsPlayable: false},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "character already selected by another player",
+			queries: &fakeRoomQueries{
+				room: waitingRoom,
+				players: []db.RoomPlayer{
+					participant,
+					{
+						RoomID: roomID,
+						UserID: otherUserID,
+						CharacterID: pgtype.UUID{
+							Bytes: charID,
+							Valid: true,
+						},
+					},
+				},
+				character: playableChar,
+			},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name: "same player reselecting same character is harmless",
+			queries: &fakeRoomQueries{
+				room: waitingRoom,
+				players: []db.RoomPlayer{{
+					RoomID: roomID,
+					UserID: userID,
+					CharacterID: pgtype.UUID{
+						Bytes: charID,
+						Valid: true,
+					},
+				}},
+				character: playableChar,
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "success changes from previous character",
+			queries: &fakeRoomQueries{
+				room: waitingRoom,
+				players: []db.RoomPlayer{{
+					RoomID: roomID,
+					UserID: userID,
+					CharacterID: pgtype.UUID{
+						Bytes: otherCharID,
+						Valid: true,
+					},
+				}},
+				character: playableChar,
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "update failure",
+			queries: &fakeRoomQueries{
+				room:            waitingRoom,
+				players:         []db.RoomPlayer{participant},
+				character:       playableChar,
+				setCharacterErr: errors.New("db update failed"),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "room starts before final update",
+			queries: &fakeRoomQueries{
+				room:                     waitingRoom,
+				roomAfterCharacterNoRows: &playingRoom,
+				players:                  []db.RoomPlayer{participant},
+				character:                playableChar,
+				setCharacterRowsAffected: &zeroRows,
+			},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name: "participant leaves before final update",
+			queries: &fakeRoomQueries{
+				room:                     waitingRoom,
+				players:                  []db.RoomPlayer{participant},
+				character:                playableChar,
+				setCharacterRowsAffected: &zeroRows,
+			},
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &service{queries: tt.queries, logger: zerolog.Nop()}
+
+			err := svc.SelectCharacter(context.Background(), roomID, userID, SelectCharacterRequest{CharacterID: charID})
+
+			if tt.wantStatus != 0 {
+				assertAppError(t, err, tt.wantStatus)
+				return
+			}
+			if err != nil {
+				t.Fatalf("SelectCharacter returned error: %v", err)
+			}
+			if tt.wantUpdated {
+				if tt.queries.setCharacterParams == nil {
+					t.Fatal("expected SetRoomPlayerCharacter to be called")
+				}
+				if tt.queries.setCharacterParams.RoomID != roomID ||
+					tt.queries.setCharacterParams.UserID != userID ||
+					!tt.queries.setCharacterParams.CharacterID.Valid ||
+					uuid.UUID(tt.queries.setCharacterParams.CharacterID.Bytes) != charID {
+					t.Fatalf("SetRoomPlayerCharacter params mismatch: %+v", tt.queries.setCharacterParams)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildRoomDetailIncludesNullableCharacterID(t *testing.T) {
+	roomID := uuid.New()
+	themeID := uuid.New()
+	hostID := uuid.New()
+	guestID := uuid.New()
+	charID := uuid.New()
+	queries := &fakeRoomQueries{
+		room:  db.Room{ID: roomID, ThemeID: themeID, HostID: hostID, Status: "WAITING"},
+		theme: db.Theme{ID: themeID, Title: "테마", Slug: "theme"},
+		playersWithUser: []db.GetRoomPlayersWithUserRow{
+			{
+				UserID: hostID,
+				CharacterID: pgtype.UUID{
+					Bytes: charID,
+					Valid: true,
+				},
+				Nickname: "호스트",
+			},
+			{
+				UserID:   guestID,
+				Nickname: "게스트",
+			},
+		},
+	}
+	svc := &service{queries: queries, logger: zerolog.Nop()}
+
+	resp, err := svc.buildRoomDetail(context.Background(), queries.room, true)
+	if err != nil {
+		t.Fatalf("buildRoomDetail returned error: %v", err)
+	}
+	if len(resp.Players) != 2 {
+		t.Fatalf("players len = %d, want 2", len(resp.Players))
+	}
+	if resp.Players[0].CharacterID == nil || *resp.Players[0].CharacterID != charID {
+		t.Fatalf("host character_id mismatch: %+v", resp.Players[0])
+	}
+	if resp.Players[1].CharacterID != nil {
+		t.Fatalf("guest character_id should be nil: %+v", resp.Players[1])
+	}
+
+	body, err := json.Marshal(resp.Players[1])
+	if err != nil {
+		t.Fatalf("marshal player: %v", err)
+	}
+	if bytes.Contains(body, []byte(`"character_id"`)) {
+		t.Fatalf("expected empty character_id to be omitted in JSON, got %s", body)
+	}
+}
+
+func TestBuildRoomDetailRedactsCharacterIDForPublicDetail(t *testing.T) {
+	roomID := uuid.New()
+	themeID := uuid.New()
+	hostID := uuid.New()
+	charID := uuid.New()
+	queries := &fakeRoomQueries{
+		room:  db.Room{ID: roomID, ThemeID: themeID, HostID: hostID, Status: "WAITING"},
+		theme: db.Theme{ID: themeID, Title: "테마", Slug: "theme"},
+		playersWithUser: []db.GetRoomPlayersWithUserRow{
+			{
+				UserID: hostID,
+				CharacterID: pgtype.UUID{
+					Bytes: charID,
+					Valid: true,
+				},
+				Nickname: "호스트",
+			},
+		},
+	}
+	svc := &service{queries: queries, logger: zerolog.Nop()}
+
+	resp, err := svc.buildRoomDetail(context.Background(), queries.room, false)
+	if err != nil {
+		t.Fatalf("buildRoomDetail returned error: %v", err)
+	}
+	if resp.Players[0].CharacterID != nil {
+		t.Fatalf("public room detail should redact character_id: %+v", resp.Players[0])
+	}
+	body, err := json.Marshal(resp.Players[0])
+	if err != nil {
+		t.Fatalf("marshal public player: %v", err)
+	}
+	if bytes.Contains(body, []byte(`"character_id"`)) {
+		t.Fatalf("public room detail should omit character_id, got %s", body)
+	}
+}
+
+func TestGetRoomForUserRejectsNonParticipant(t *testing.T) {
+	roomID := uuid.New()
+	themeID := uuid.New()
+	hostID := uuid.New()
+	queries := &fakeRoomQueries{
+		room:  db.Room{ID: roomID, ThemeID: themeID, HostID: hostID, Status: "WAITING"},
+		theme: db.Theme{ID: themeID, Title: "테마", Slug: "theme"},
+		playersWithUser: []db.GetRoomPlayersWithUserRow{
+			{UserID: hostID, Nickname: "호스트"},
+		},
+	}
+	svc := &service{queries: queries, logger: zerolog.Nop()}
+
+	_, err := svc.GetRoomForUser(context.Background(), roomID, uuid.New())
+
+	assertAppError(t, err, http.StatusForbidden)
+}
+
 func TestStartRoomServiceGateWiring(t *testing.T) {
 	roomID := uuid.New()
 	themeID := uuid.New()
 	hostID := uuid.New()
 	guestID := uuid.New()
+	hostCharID := uuid.New()
+	guestCharID := uuid.New()
 	room := db.Room{ID: roomID, ThemeID: themeID, HostID: hostID, Status: "WAITING"}
 	theme := db.Theme{ID: themeID, MinPlayers: 2}
 
@@ -251,8 +562,8 @@ func TestStartRoomServiceGateWiring(t *testing.T) {
 			room:  room,
 			theme: theme,
 			playersWithUser: []db.GetRoomPlayersWithUserRow{
-				{UserID: hostID, Nickname: "호스트", IsReady: false, JoinedAt: joinedAt},
-				{UserID: guestID, Nickname: "참가자", IsReady: true, JoinedAt: joinedAt.Add(time.Second)},
+				{UserID: hostID, CharacterID: pgtype.UUID{Bytes: hostCharID, Valid: true}, Nickname: "호스트", IsReady: false, JoinedAt: joinedAt},
+				{UserID: guestID, CharacterID: pgtype.UUID{Bytes: guestCharID, Valid: true}, Nickname: "참가자", IsReady: true, JoinedAt: joinedAt.Add(time.Second)},
 			},
 		}
 		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
@@ -269,14 +580,23 @@ func TestStartRoomServiceGateWiring(t *testing.T) {
 		if starter.players[0].UserID != hostID || !starter.players[0].IsHost {
 			t.Fatalf("host roster mismatch: %+v", starter.players[0])
 		}
+		if starter.players[0].CharacterID == nil || *starter.players[0].CharacterID != hostCharID {
+			t.Fatalf("host character roster mismatch: %+v", starter.players[0])
+		}
 		if starter.players[1].UserID != guestID || !starter.players[1].IsReady {
 			t.Fatalf("guest roster mismatch: %+v", starter.players[1])
+		}
+		if starter.players[1].CharacterID == nil || *starter.players[1].CharacterID != guestCharID {
+			t.Fatalf("guest character roster mismatch: %+v", starter.players[1])
 		}
 		if queries.updateRoomStatusParams == nil {
 			t.Fatal("expected room status to be updated after successful game start")
 		}
 		if queries.updateRoomStatusParams.ID != roomID || queries.updateRoomStatusParams.Status != "PLAYING" {
 			t.Fatalf("room status update mismatch: %+v", queries.updateRoomStatusParams)
+		}
+		if !queries.getRoomForUpdateCalled {
+			t.Fatal("expected StartRoom to lock room before reading players")
 		}
 	})
 
@@ -286,8 +606,8 @@ func TestStartRoomServiceGateWiring(t *testing.T) {
 			room:  room,
 			theme: theme,
 			playersWithUser: []db.GetRoomPlayersWithUserRow{
-				{UserID: hostID, Nickname: "호스트", IsReady: false},
-				{UserID: guestID, Nickname: "참가자", IsReady: true},
+				{UserID: hostID, CharacterID: pgtype.UUID{Bytes: hostCharID, Valid: true}, Nickname: "호스트", IsReady: false},
+				{UserID: guestID, CharacterID: pgtype.UUID{Bytes: guestCharID, Valid: true}, Nickname: "참가자", IsReady: true},
 			},
 			updateRoomStatusErr: errors.New("status update failed"),
 		}
@@ -310,8 +630,8 @@ func TestStartRoomServiceGateWiring(t *testing.T) {
 			room:  room,
 			theme: theme,
 			playersWithUser: []db.GetRoomPlayersWithUserRow{
-				{UserID: hostID, Nickname: "호스트", IsReady: false},
-				{UserID: guestID, Nickname: "참가자", IsReady: true},
+				{UserID: hostID, CharacterID: pgtype.UUID{Bytes: hostCharID, Valid: true}, Nickname: "호스트", IsReady: false},
+				{UserID: guestID, CharacterID: pgtype.UUID{Bytes: guestCharID, Valid: true}, Nickname: "참가자", IsReady: true},
 			},
 		}
 		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
@@ -326,6 +646,29 @@ func TestStartRoomServiceGateWiring(t *testing.T) {
 		}
 		if queries.statusUpdates[0].Status != "PLAYING" || queries.statusUpdates[1].Status != "WAITING" {
 			t.Fatalf("status update order mismatch: %+v", queries.statusUpdates)
+		}
+	})
+
+	t.Run("missing host character stops before game starter", func(t *testing.T) {
+		starter := &fakeGameStarter{}
+		queries := &fakeRoomQueries{
+			room:  room,
+			theme: theme,
+			playersWithUser: []db.GetRoomPlayersWithUserRow{
+				{UserID: hostID, Nickname: "호스트", IsReady: false},
+				{UserID: guestID, CharacterID: pgtype.UUID{Bytes: guestCharID, Valid: true}, Nickname: "참가자", IsReady: true},
+			},
+		}
+		svc := &service{queries: queries, logger: zerolog.Nop(), gameStarter: starter}
+
+		err := svc.StartRoom(context.Background(), roomID, hostID, StartRoomRequest{})
+
+		assertAppError(t, err, http.StatusConflict)
+		if starter.called {
+			t.Fatal("expected missing character gate to stop before GameStarter.Start")
+		}
+		if queries.updateRoomStatusParams != nil {
+			t.Fatalf("room status should not update when character gate fails: %+v", queries.updateRoomStatusParams)
 		}
 	})
 }

--- a/apps/server/internal/domain/room/service_queries.go
+++ b/apps/server/internal/domain/room/service_queries.go
@@ -19,9 +19,11 @@ type roomQueries interface {
 	GetRoomPlayers(ctx context.Context, roomID uuid.UUID) ([]db.RoomPlayer, error)
 	GetRoomPlayersWithUser(ctx context.Context, roomID uuid.UUID) ([]db.GetRoomPlayersWithUserRow, error)
 	GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error)
+	GetThemeCharacter(ctx context.Context, id uuid.UUID) (db.ThemeCharacter, error)
 	GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.ThemeCharacter, error)
 	ListWaitingRoomsWithCount(ctx context.Context, arg db.ListWaitingRoomsWithCountParams) ([]db.ListWaitingRoomsWithCountRow, error)
 	RemoveRoomPlayer(ctx context.Context, arg db.RemoveRoomPlayerParams) error
+	SetRoomPlayerCharacter(ctx context.Context, arg db.SetRoomPlayerCharacterParams) (int64, error)
 	SetPlayerReady(ctx context.Context, arg db.SetPlayerReadyParams) error
 	UpdateRoomStatus(ctx context.Context, arg db.UpdateRoomStatusParams) error
 	WithTx(tx pgx.Tx) *db.Queries

--- a/apps/web/src/features/lobby/api.test.tsx
+++ b/apps/web/src/features/lobby/api.test.tsx
@@ -1,24 +1,33 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, renderHook } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 
 const invalidateSpy = vi.fn();
 
-vi.mock("@/services/api", () => ({
+vi.mock('@/services/api', () => ({
   api: {
+    get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
   },
 }));
 
-vi.mock("@/services/queryClient", () => ({
+vi.mock('@/services/queryClient', () => ({
   queryClient: {
     invalidateQueries: (...args: unknown[]) => invalidateSpy(...args),
   },
 }));
 
-import { api } from "@/services/api";
-import { roomKeys, useSetReady, useStartRoom } from "./api";
+import { api } from '@/services/api';
+import {
+  roomKeys,
+  useRoom,
+  useSelectRoomCharacter,
+  useSetReady,
+  useStartRoom,
+  useThemeCharacters,
+} from './api';
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -41,37 +50,97 @@ afterEach(() => {
   cleanup();
 });
 
-describe("lobby pregame mutations", () => {
-  it("useSetReady posts is_ready and invalidates room detail/list", async () => {
-    vi.mocked(api.post).mockResolvedValueOnce({ status: "ready updated" });
-    const { result } = renderHook(() => useSetReady(), { wrapper: makeWrapper() });
+describe('lobby pregame mutations', () => {
+  it('useRoom fetches participant-only room detail', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      id: 'room-1',
+      code: 'ABC123',
+      players: [],
+    });
+    const { result } = renderHook(() => useRoom('room-1'), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(api.get).toHaveBeenCalledWith('/v1/rooms/room-1/me');
+  });
+
+  it('useThemeCharacters fetches public theme character summaries', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce([
+      {
+        id: 'character-1',
+        name: '탐정',
+        description: '진실을 좇는 손님',
+        image_url: null,
+        image_media_id: null,
+        sort_order: 1,
+      },
+    ]);
+    const { result } = renderHook(() => useThemeCharacters('theme-1'), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(api.get).toHaveBeenCalledWith('/v1/themes/theme-1/characters');
+    expect(result.current.data?.[0]?.name).toBe('탐정');
+  });
+
+  it('useSelectRoomCharacter puts character_id and invalidates room detail/list', async () => {
+    vi.mocked(api.put).mockResolvedValueOnce({ status: 'selected' });
+    const { result } = renderHook(() => useSelectRoomCharacter(), {
+      wrapper: makeWrapper(),
+    });
 
     await act(async () => {
-      await result.current.mutateAsync({ roomId: "room-1", is_ready: true });
+      await result.current.mutateAsync({
+        roomId: 'room-1',
+        characterId: 'character-1',
+      });
     });
 
-    expect(api.post).toHaveBeenCalledWith("/v1/rooms/room-1/ready", {
-      is_ready: true,
+    expect(api.put).toHaveBeenCalledWith('/v1/rooms/room-1/character', {
+      character_id: 'character-1',
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: roomKeys.detail("room-1"),
+      queryKey: roomKeys.detail('room-1'),
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: roomKeys.list(),
     });
   });
 
-  it("useStartRoom posts to start endpoint and invalidates room detail/list", async () => {
-    vi.mocked(api.post).mockResolvedValueOnce({ status: "started" });
+  it('useSetReady posts is_ready and invalidates room detail/list', async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({ status: 'ready updated' });
+    const { result } = renderHook(() => useSetReady(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({ roomId: 'room-1', is_ready: true });
+    });
+
+    expect(api.post).toHaveBeenCalledWith('/v1/rooms/room-1/ready', {
+      is_ready: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: roomKeys.detail('room-1'),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: roomKeys.list(),
+    });
+  });
+
+  it('useStartRoom posts to start endpoint and invalidates room detail/list', async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({ status: 'started' });
     const { result } = renderHook(() => useStartRoom(), { wrapper: makeWrapper() });
 
     await act(async () => {
-      await result.current.mutateAsync("room-1");
+      await result.current.mutateAsync('room-1');
     });
 
-    expect(api.post).toHaveBeenCalledWith("/v1/rooms/room-1/start", {});
+    expect(api.post).toHaveBeenCalledWith('/v1/rooms/room-1/start', {});
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: roomKeys.detail("room-1"),
+      queryKey: roomKeys.detail('room-1'),
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: roomKeys.list(),

--- a/apps/web/src/features/lobby/api.ts
+++ b/apps/web/src/features/lobby/api.ts
@@ -1,6 +1,6 @@
-import { useQuery, useMutation } from "@tanstack/react-query";
-import { api } from "@/services/api";
-import { queryClient } from "@/services/queryClient";
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { api } from '@/services/api';
+import { queryClient } from '@/services/queryClient';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -37,6 +37,15 @@ export interface ThemeRole {
   is_murderer: boolean;
 }
 
+export interface ThemeCharacterSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  image_url?: string | null;
+  image_media_id?: string | null;
+  sort_order: number;
+}
+
 export interface RoomResponse {
   id: string;
   code: string;
@@ -56,6 +65,10 @@ export interface RoomDetailResponse extends RoomResponse {
   theme?: ThemeSummary | null;
 }
 
+export interface PublicRoomLookupResponse extends RoomResponse {
+  theme?: ThemeSummary | null;
+}
+
 export interface RoomPlayer {
   id?: string;
   user_id: string;
@@ -63,6 +76,7 @@ export interface RoomPlayer {
   avatar_url?: string | null;
   is_host: boolean;
   is_ready: boolean;
+  character_id?: string | null;
   joined_at?: string;
 }
 
@@ -76,6 +90,11 @@ export interface SetReadyRequest {
   is_ready: boolean;
 }
 
+export interface SelectRoomCharacterRequest {
+  roomId: string;
+  characterId: string;
+}
+
 export interface PaginationParams {
   limit?: number;
   offset?: number;
@@ -86,18 +105,17 @@ export interface PaginationParams {
 // ---------------------------------------------------------------------------
 
 export const themeKeys = {
-  all: ["themes"] as const,
-  list: (params?: PaginationParams) =>
-    [...themeKeys.all, "list", params ?? {}] as const,
+  all: ['themes'] as const,
+  list: (params?: PaginationParams) => [...themeKeys.all, 'list', params ?? {}] as const,
   detail: (id: string) => [...themeKeys.all, id] as const,
+  characters: (id: string) => [...themeKeys.all, id, 'characters'] as const,
 };
 
 export const roomKeys = {
-  all: ["rooms"] as const,
-  list: (params?: PaginationParams) =>
-    [...roomKeys.all, "list", params ?? {}] as const,
+  all: ['rooms'] as const,
+  list: (params?: PaginationParams) => [...roomKeys.all, 'list', params ?? {}] as const,
   detail: (id: string) => [...roomKeys.all, id] as const,
-  byCode: (code: string) => [...roomKeys.all, "code", code] as const,
+  byCode: (code: string) => [...roomKeys.all, 'code', code] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -106,13 +124,13 @@ export const roomKeys = {
 
 export function useThemes(params?: PaginationParams) {
   const searchParams = new URLSearchParams();
-  if (params?.limit != null) searchParams.set("limit", String(params.limit));
-  if (params?.offset != null) searchParams.set("offset", String(params.offset));
+  if (params?.limit != null) searchParams.set('limit', String(params.limit));
+  if (params?.offset != null) searchParams.set('offset', String(params.offset));
   const qs = searchParams.toString();
 
   return useQuery<ThemeSummary[]>({
     queryKey: themeKeys.list(params),
-    queryFn: () => api.get<ThemeSummary[]>(`/v1/themes${qs ? `?${qs}` : ""}`),
+    queryFn: () => api.get<ThemeSummary[]>(`/v1/themes${qs ? `?${qs}` : ''}`),
   });
 }
 
@@ -124,34 +142,42 @@ export function useTheme(id: string) {
   });
 }
 
+export function useThemeCharacters(themeId: string) {
+  return useQuery<ThemeCharacterSummary[]>({
+    queryKey: themeKeys.characters(themeId),
+    queryFn: () => api.get<ThemeCharacterSummary[]>(`/v1/themes/${themeId}/characters`),
+    enabled: !!themeId,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Room Queries
 // ---------------------------------------------------------------------------
 
 export function useRooms(params?: PaginationParams) {
   const searchParams = new URLSearchParams();
-  if (params?.limit != null) searchParams.set("limit", String(params.limit));
-  if (params?.offset != null) searchParams.set("offset", String(params.offset));
+  if (params?.limit != null) searchParams.set('limit', String(params.limit));
+  if (params?.offset != null) searchParams.set('offset', String(params.offset));
   const qs = searchParams.toString();
 
   return useQuery<RoomResponse[]>({
     queryKey: roomKeys.list(params),
-    queryFn: () => api.get<RoomResponse[]>(`/v1/rooms${qs ? `?${qs}` : ""}`),
+    queryFn: () => api.get<RoomResponse[]>(`/v1/rooms${qs ? `?${qs}` : ''}`),
   });
 }
 
 export function useRoom(id: string) {
   return useQuery<RoomDetailResponse>({
     queryKey: roomKeys.detail(id),
-    queryFn: () => api.get<RoomDetailResponse>(`/v1/rooms/${id}`),
+    queryFn: () => api.get<RoomDetailResponse>(`/v1/rooms/${id}/me`),
     enabled: !!id,
   });
 }
 
 export function useRoomByCode(code: string) {
-  return useQuery<RoomDetailResponse>({
+  return useQuery<PublicRoomLookupResponse>({
     queryKey: roomKeys.byCode(code),
-    queryFn: () => api.get<RoomDetailResponse>(`/v1/rooms/code/${code}`),
+    queryFn: () => api.get<PublicRoomLookupResponse>(`/v1/rooms/code/${code}`),
     enabled: !!code,
   });
 }
@@ -162,8 +188,7 @@ export function useRoomByCode(code: string) {
 
 export function useCreateRoom() {
   return useMutation<RoomDetailResponse, Error, CreateRoomRequest>({
-    mutationFn: (body) =>
-      api.post<RoomDetailResponse>("/v1/rooms", body),
+    mutationFn: (body) => api.post<RoomDetailResponse>('/v1/rooms', body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: roomKeys.all });
     },
@@ -172,8 +197,7 @@ export function useCreateRoom() {
 
 export function useJoinRoom() {
   return useMutation<unknown, Error, string>({
-    mutationFn: (roomId) =>
-      api.post<unknown>(`/v1/rooms/${roomId}/join`),
+    mutationFn: (roomId) => api.post<unknown>(`/v1/rooms/${roomId}/join`),
     onSuccess: (_data, roomId) => {
       queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
       queryClient.invalidateQueries({ queryKey: roomKeys.list() });
@@ -195,6 +219,19 @@ export function useSetReady() {
   return useMutation<unknown, Error, SetReadyRequest>({
     mutationFn: ({ roomId, is_ready }) =>
       api.post<unknown>(`/v1/rooms/${roomId}/ready`, { is_ready }),
+    onSuccess: (_data, { roomId }) => {
+      queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
+      queryClient.invalidateQueries({ queryKey: roomKeys.list() });
+    },
+  });
+}
+
+export function useSelectRoomCharacter() {
+  return useMutation<unknown, Error, SelectRoomCharacterRequest>({
+    mutationFn: ({ roomId, characterId }) =>
+      api.put<unknown>(`/v1/rooms/${roomId}/character`, {
+        character_id: characterId,
+      }),
     onSuccess: (_data, { roomId }) => {
       queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
       queryClient.invalidateQueries({ queryKey: roomKeys.list() });

--- a/apps/web/src/features/room/components/CharacterSelectionPanel.tsx
+++ b/apps/web/src/features/room/components/CharacterSelectionPanel.tsx
@@ -1,0 +1,123 @@
+import { CheckCircle, LockKeyhole, UserRound } from 'lucide-react';
+
+import type { ThemeCharacterSummary } from '@/features/lobby/api';
+import { Badge, Button, Card } from '@/shared/components/ui';
+
+interface CharacterSelectionPanelProps {
+  characters: ThemeCharacterSummary[];
+  selectedCharacterId?: string | null;
+  selectedByOtherPlayerIds: Set<string>;
+  isLoading?: boolean;
+  isError?: boolean;
+  isSelecting?: boolean;
+  onSelect: (characterId: string) => void;
+}
+
+export function CharacterSelectionPanel({
+  characters,
+  selectedCharacterId,
+  selectedByOtherPlayerIds,
+  isLoading = false,
+  isError = false,
+  isSelecting = false,
+  onSelect,
+}: CharacterSelectionPanelProps) {
+  if (isLoading) {
+    return (
+      <Card className="p-4">
+        <h2 className="text-base font-semibold text-[var(--mmp-color-ink)]">캐릭터 선택</h2>
+        <p className="mt-2 text-sm text-[var(--mmp-color-steel)]">
+          선택 가능한 캐릭터를 불러오는 중입니다.
+        </p>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card className="p-4">
+        <h2 className="text-base font-semibold text-[var(--mmp-color-ink)]">캐릭터 선택</h2>
+        <p className="mt-2 text-sm text-[var(--mmp-color-error)]">
+          캐릭터 목록을 불러올 수 없습니다.
+        </p>
+      </Card>
+    );
+  }
+
+  if (characters.length === 0) {
+    return (
+      <Card className="p-4">
+        <h2 className="text-base font-semibold text-[var(--mmp-color-ink)]">캐릭터 선택</h2>
+        <p className="mt-2 text-sm text-[var(--mmp-color-steel)]">
+          선택할 수 있는 캐릭터가 아직 없습니다.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-[var(--mmp-color-ink)]">캐릭터 선택</h2>
+          <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">
+            게임을 시작하려면 각 참가자가 서로 다른 캐릭터를 선택해야 합니다.
+          </p>
+        </div>
+        {selectedCharacterId && (
+          <Badge variant="success" size="sm">
+            <CheckCircle className="mr-1 h-3 w-3" />
+            선택 완료
+          </Badge>
+        )}
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        {characters.map((character) => {
+          const isSelected = character.id === selectedCharacterId;
+          const isTakenByOther = selectedByOtherPlayerIds.has(character.id);
+          const isDisabled = isSelecting || isSelected || isTakenByOther;
+
+          return (
+            <Button
+              key={character.id}
+              variant={isSelected ? 'primary' : 'secondary'}
+              disabled={isDisabled}
+              onClick={() => onSelect(character.id)}
+              className="min-h-[104px] w-full items-stretch justify-start p-0 text-left"
+            >
+              <span className="flex w-full gap-3 p-3">
+                <span className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--mmp-color-muted)] text-[var(--mmp-color-charcoal)]">
+                  {character.image_url ? (
+                    <img src={character.image_url} alt="" className="h-full w-full object-cover" />
+                  ) : (
+                    <UserRound className="h-5 w-5" aria-hidden="true" />
+                  )}
+                </span>
+                <span className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="flex flex-wrap items-center gap-2">
+                    <span className="truncate font-semibold">{character.name}</span>
+                    {isSelected && (
+                      <Badge variant="success" size="sm">
+                        선택됨
+                      </Badge>
+                    )}
+                    {isTakenByOther && (
+                      <Badge variant="warning" size="sm">
+                        <LockKeyhole className="mr-1 h-3 w-3" />
+                        다른 참가자 선택
+                      </Badge>
+                    )}
+                  </span>
+                  <span className="line-clamp-2 text-xs font-normal opacity-80">
+                    {character.description || '캐릭터 설명이 없습니다.'}
+                  </span>
+                </span>
+              </span>
+            </Button>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/features/room/components/HostControls.tsx
+++ b/apps/web/src/features/room/components/HostControls.tsx
@@ -1,5 +1,5 @@
-import { Play, XCircle } from "lucide-react";
-import { Button } from "@/shared/components/ui";
+import { Play, XCircle } from 'lucide-react';
+import { Button } from '@/shared/components/ui';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -12,6 +12,8 @@ interface HostControlsProps {
   allReady: boolean;
   /** 최소 인원 충족 여부 */
   hasMinPlayers: boolean;
+  /** 전원 캐릭터 선택 여부 */
+  allCharactersSelected: boolean;
   /** 게임 시작 핸들러 */
   onStartGame: () => void;
   /** 방 닫기 핸들러 */
@@ -30,6 +32,7 @@ export function HostControls({
   isHost,
   allReady,
   hasMinPlayers,
+  allCharactersSelected,
   onStartGame,
   onCloseRoom,
   isStarting = false,
@@ -38,7 +41,7 @@ export function HostControls({
   // 호스트가 아니면 렌더링하지 않음
   if (!isHost) return null;
 
-  const canStart = allReady && hasMinPlayers;
+  const canStart = allReady && hasMinPlayers && allCharactersSelected;
 
   return (
     <div className="flex flex-col gap-2 pt-2">
@@ -57,15 +60,15 @@ export function HostControls({
       {!canStart && (
         <p className="text-center text-xs text-[var(--mmp-color-steel)]">
           {!hasMinPlayers
-            ? "최소 인원이 충족되지 않았습니다."
-            : "모든 참가자가 준비해야 시작할 수 있습니다."}
+            ? '최소 인원이 충족되지 않았습니다.'
+            : !allCharactersSelected
+              ? '모든 참가자가 캐릭터를 선택해야 시작할 수 있습니다.'
+              : '모든 참가자가 준비해야 시작할 수 있습니다.'}
         </p>
       )}
 
       {startErrorMessage && (
-        <p className="text-center text-xs text-[var(--mmp-color-error)]">
-          {startErrorMessage}
-        </p>
+        <p className="text-center text-xs text-[var(--mmp-color-error)]">{startErrorMessage}</p>
       )}
 
       <Button

--- a/apps/web/src/features/room/components/PlayerList.tsx
+++ b/apps/web/src/features/room/components/PlayerList.tsx
@@ -1,35 +1,39 @@
-import { Crown, CheckCircle, Circle, UserPlus } from "lucide-react";
-import { Card, Badge } from "@/shared/components/ui";
+import { Crown, CheckCircle, Circle, UserPlus } from 'lucide-react';
+import { Card, Badge } from '@/shared/components/ui';
+import type { RoomPlayer } from '@/features/lobby/api';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface RoomPlayer {
-  id?: string;
-  user_id: string;
-  nickname: string;
-  avatar_url?: string | null;
-  is_host: boolean;
-  is_ready: boolean;
-  joined_at?: string;
-}
-
 interface PlayerListProps {
   players: RoomPlayer[];
   maxPlayers: number;
+  characterNameById?: Map<string, string>;
 }
 
 // ---------------------------------------------------------------------------
 // 플레이어 카드
 // ---------------------------------------------------------------------------
 
-function PlayerCard({ player, index }: { player: RoomPlayer; index: number }) {
+function PlayerCard({
+  player,
+  index,
+  characterName,
+}: {
+  player: RoomPlayer;
+  index: number;
+  characterName?: string;
+}) {
   return (
     <Card
       className="motion-safe:animate-fade-slide-up flex items-center gap-3 p-3"
       style={
-        { "--stagger-index": index, animationDelay: `calc(var(--stagger-index) * 50ms)`, animationFillMode: "backwards" } as React.CSSProperties
+        {
+          '--stagger-index': index,
+          animationDelay: `calc(var(--stagger-index) * 50ms)`,
+          animationFillMode: 'backwards',
+        } as React.CSSProperties
       }
     >
       {/* 아바타 */}
@@ -41,9 +45,7 @@ function PlayerCard({ player, index }: { player: RoomPlayer; index: number }) {
             className="h-full w-full rounded-full object-cover"
           />
         ) : (
-          <span className="text-sm font-bold">
-            {player.nickname.charAt(0).toUpperCase()}
-          </span>
+          <span className="text-sm font-bold">{player.nickname.charAt(0).toUpperCase()}</span>
         )}
       </div>
 
@@ -56,6 +58,11 @@ function PlayerCard({ player, index }: { player: RoomPlayer; index: number }) {
           <Badge variant="warning" size="sm">
             <Crown className="mr-1 h-3 w-3" />
             호스트
+          </Badge>
+        )}
+        {characterName && (
+          <Badge variant="info" size="sm">
+            {characterName}
           </Badge>
         )}
       </div>
@@ -89,13 +96,20 @@ function EmptySlot() {
 // PlayerList
 // ---------------------------------------------------------------------------
 
-export function PlayerList({ players, maxPlayers }: PlayerListProps) {
+export function PlayerList({ players, maxPlayers, characterNameById }: PlayerListProps) {
   const emptySlots = Math.max(0, maxPlayers - players.length);
 
   return (
     <div className="flex flex-col gap-2">
       {players.map((player, index) => (
-        <PlayerCard key={player.id ?? player.user_id} player={player} index={index} />
+        <PlayerCard
+          key={player.id ?? player.user_id}
+          player={player}
+          index={index}
+          characterName={
+            player.character_id ? characterNameById?.get(player.character_id) : undefined
+          }
+        />
       ))}
       {Array.from({ length: emptySlots }, (_, i) => (
         <EmptySlot key={`empty-${i}`} />

--- a/apps/web/src/features/room/components/index.ts
+++ b/apps/web/src/features/room/components/index.ts
@@ -1,4 +1,5 @@
-export { PlayerList } from "./PlayerList";
-export { RoomHeader } from "./RoomHeader";
-export { HostControls } from "./HostControls";
-export { RoomChat } from "./RoomChat";
+export { PlayerList } from './PlayerList';
+export { RoomHeader } from './RoomHeader';
+export { HostControls } from './HostControls';
+export { RoomChat } from './RoomChat';
+export { CharacterSelectionPanel } from './CharacterSelectionPanel';

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -1,19 +1,27 @@
-import { useState, useCallback } from "react";
-import { useParams, useNavigate } from "react-router";
-import { LogOut, Shield, Users, MessageSquare } from "lucide-react";
+import { useState, useCallback, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import { LogOut, Shield, Users, MessageSquare } from 'lucide-react';
 
-import { useRoom, useLeaveRoom, useSetReady, useStartRoom } from "@/features/lobby/api";
-import { WsEventType } from "@mmp/shared";
-import { useWsClient } from "@/hooks/useWsClient";
-import { useWsEvent } from "@/hooks/useWsEvent";
-import { useAuthStore, selectUser } from "@/stores/authStore";
-import { Alert, Button, LoadingState, PageShell } from "@/shared/components/ui";
+import {
+  useRoom,
+  useLeaveRoom,
+  useSelectRoomCharacter,
+  useSetReady,
+  useStartRoom,
+  useThemeCharacters,
+} from '@/features/lobby/api';
+import { WsEventType } from '@mmp/shared';
+import { useWsClient } from '@/hooks/useWsClient';
+import { useWsEvent } from '@/hooks/useWsEvent';
+import { useAuthStore, selectUser } from '@/stores/authStore';
+import { Alert, Button, LoadingState, PageShell } from '@/shared/components/ui';
 import {
   PlayerList,
   RoomHeader,
   HostControls,
   RoomChat,
-} from "@/features/room/components";
+  CharacterSelectionPanel,
+} from '@/features/room/components';
 
 // ---------------------------------------------------------------------------
 // WS 이벤트 페이로드 타입 (인라인)
@@ -39,6 +47,7 @@ interface SessionStatePayload {
     avatar_url: string | null;
     is_host: boolean;
     is_ready: boolean;
+    character_id?: string | null;
     joined_at: string;
   }>;
 }
@@ -47,7 +56,7 @@ interface SessionStatePayload {
 // 모바일 탭
 // ---------------------------------------------------------------------------
 
-type MobileTab = "players" | "chat";
+type MobileTab = 'players' | 'chat';
 
 // ---------------------------------------------------------------------------
 // RoomPage
@@ -59,58 +68,75 @@ export default function RoomPage() {
   const currentUser = useAuthStore(selectUser);
 
   // 방 정보 쿼리
-  const { data: room, isLoading, isError, refetch } = useRoom(id ?? "");
+  const { data: room, isLoading, isError, refetch } = useRoom(id ?? '');
 
   // WS 연결
   const { send } = useWsClient({
-    endpoint: "game",
+    endpoint: 'game',
     sessionId: id,
     autoConnect: !!id,
   });
 
   // 방 나가기
   const leaveRoom = useLeaveRoom();
+  const themeCharacters = useThemeCharacters(room?.theme_id ?? '');
+  const selectRoomCharacter = useSelectRoomCharacter();
   const setReady = useSetReady();
   const startRoom = useStartRoom();
 
   // 로컬 상태
-  const [mobileTab, setMobileTab] = useState<MobileTab>("players");
+  const [mobileTab, setMobileTab] = useState<MobileTab>('players');
   const [startErrorMessage, setStartErrorMessage] = useState<string | null>(null);
 
   // ------ WS 이벤트 구독 → 쿼리 갱신 ------
 
-  useWsEvent<PlayerJoinedPayload>("game", WsEventType.PLAYER_JOINED, () => {
+  useWsEvent<PlayerJoinedPayload>('game', WsEventType.PLAYER_JOINED, () => {
     refetch();
   });
 
-  useWsEvent<PlayerLeftPayload>("game", WsEventType.PLAYER_LEFT, () => {
+  useWsEvent<PlayerLeftPayload>('game', WsEventType.PLAYER_LEFT, () => {
     refetch();
   });
 
-  useWsEvent<SessionStatePayload>("game", WsEventType.SESSION_STATE, () => {
+  useWsEvent<SessionStatePayload>('game', WsEventType.SESSION_STATE, () => {
     refetch();
   });
 
   // ------ 파생 상태 ------
 
-  const players = room?.players ?? [];
+  const players = useMemo(() => room?.players ?? [], [room?.players]);
   const currentPlayer = currentUser
     ? players.find((player) => player.user_id === currentUser.id)
     : undefined;
   const isReady = currentPlayer?.is_ready ?? false;
   const isHost = currentUser ? room?.host_id === currentUser.id : false;
   const nonHostPlayers = players.filter((p) => !p.is_host);
-  const allReady =
-    nonHostPlayers.length > 0 && nonHostPlayers.every((p) => p.is_ready);
+  const allReady = nonHostPlayers.length > 0 && nonHostPlayers.every((p) => p.is_ready);
   const minPlayers = room?.theme?.min_players;
   const hasMinPlayers = minPlayers != null && players.length >= minPlayers;
+  const allCharactersSelected =
+    players.length > 0 && players.every((player) => Boolean(player.character_id));
+  const characterNameById = useMemo(
+    () => new Map((themeCharacters.data ?? []).map((character) => [character.id, character.name])),
+    [themeCharacters.data]
+  );
+  const selectedByOtherPlayerIds = useMemo(
+    () =>
+      new Set(
+        players
+          .filter((player) => player.user_id !== currentUser?.id)
+          .map((player) => player.character_id)
+          .filter((characterId): characterId is string => Boolean(characterId))
+      ),
+    [currentUser?.id, players]
+  );
 
   // ------ 핸들러 ------
 
   const handleLeave = useCallback(() => {
     if (!id) return;
     leaveRoom.mutate(id, {
-      onSuccess: () => navigate("/lobby"),
+      onSuccess: () => navigate('/lobby'),
     });
   }, [id, leaveRoom, navigate]);
 
@@ -122,9 +148,24 @@ export default function RoomPage() {
         onSuccess: () => {
           refetch();
         },
-      },
+      }
     );
   }, [id, isReady, refetch, setReady]);
+
+  const handleSelectCharacter = useCallback(
+    (characterId: string) => {
+      if (!id) return;
+      selectRoomCharacter.mutate(
+        { roomId: id, characterId },
+        {
+          onSuccess: () => {
+            refetch();
+          },
+        }
+      );
+    },
+    [id, refetch, selectRoomCharacter]
+  );
 
   const handleStartGame = useCallback(() => {
     if (!id) return;
@@ -134,15 +175,15 @@ export default function RoomPage() {
         navigate(`/game/${id}`);
       },
       onError: (error) => {
-        const reason = error instanceof Error ? error.message : "알 수 없는 오류";
+        const reason = error instanceof Error ? error.message : '알 수 없는 오류';
         setStartErrorMessage(`게임 시작에 실패했습니다. ${reason}`);
       },
     });
   }, [id, navigate, startRoom]);
 
   const handleCloseRoom = useCallback(() => {
-    send(WsEventType.GAME_ACTION, { type: "close" });
-    navigate("/lobby");
+    send(WsEventType.GAME_ACTION, { type: 'close' });
+    navigate('/lobby');
   }, [send, navigate]);
 
   // ------ 로딩 / 에러 ------
@@ -160,7 +201,7 @@ export default function RoomPage() {
       <PageShell>
         <Alert tone="error" title="방 정보를 불러올 수 없습니다">
           <div className="mt-3">
-            <Button variant="secondary" onClick={() => navigate("/lobby")}>
+            <Button variant="secondary" onClick={() => navigate('/lobby')}>
               로비로 돌아가기
             </Button>
           </div>
@@ -174,89 +215,103 @@ export default function RoomPage() {
   return (
     <PageShell className="min-h-[calc(100vh-4rem)]">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
-      {/* 헤더 */}
-      <RoomHeader
-        themeTitle={room.theme_title ?? room.theme?.title ?? "대기방"}
-        roomCode={room.code}
-        playerCount={room.player_count}
-        maxPlayers={room.max_players}
-        status={room.status}
-      />
+        {/* 헤더 */}
+        <RoomHeader
+          themeTitle={room.theme_title ?? room.theme?.title ?? '대기방'}
+          roomCode={room.code}
+          playerCount={room.player_count}
+          maxPlayers={room.max_players}
+          status={room.status}
+        />
 
-      {/* 모바일 탭 전환 */}
-      <div className="flex gap-2 md:hidden">
-        <Button
-          variant={mobileTab === "players" ? "primary" : "ghost"}
-          size="sm"
-          leftIcon={<Users className="h-4 w-4" />}
-          onClick={() => setMobileTab("players")}
-          className="flex-1"
-        >
-          참가자
-        </Button>
-        <Button
-          variant={mobileTab === "chat" ? "primary" : "ghost"}
-          size="sm"
-          leftIcon={<MessageSquare className="h-4 w-4" />}
-          onClick={() => setMobileTab("chat")}
-          className="flex-1"
-        >
-          채팅
-        </Button>
-      </div>
-
-      {/* 2컬럼 레이아웃 (데스크탑) / 탭 전환 (모바일) */}
-      <div className="grid gap-4 md:grid-cols-[1fr_1fr]">
-        {/* 왼쪽: 참가자 + 호스트 컨트롤 */}
-        <div
-          className={`flex flex-col gap-4 ${
-            mobileTab !== "players" ? "hidden md:flex" : "flex"
-          }`}
-        >
-          <PlayerList players={players} maxPlayers={room.max_players} />
-          <HostControls
-            isHost={isHost}
-            allReady={allReady}
-            hasMinPlayers={hasMinPlayers}
-            onStartGame={handleStartGame}
-            onCloseRoom={handleCloseRoom}
-            isStarting={startRoom.isPending}
-            startErrorMessage={startErrorMessage}
-          />
-        </div>
-
-        {/* 오른쪽: 채팅 */}
-        <div
-          className={`h-[400px] md:h-[500px] ${
-            mobileTab !== "chat" ? "hidden md:block" : "block"
-          }`}
-        >
-          <RoomChat roomId={id} send={send} />
-        </div>
-      </div>
-
-      {/* 하단: 레디 + 나가기 */}
-      <div className="flex items-center justify-between gap-3 border-t border-[var(--mmp-color-hairline)] pt-4">
-        <Button
-          variant="ghost"
-          leftIcon={<LogOut className="h-4 w-4" />}
-          onClick={handleLeave}
-          isLoading={leaveRoom.isPending}
-        >
-          나가기
-        </Button>
-
-        {!isHost && (
+        {/* 모바일 탭 전환 */}
+        <div className="flex gap-2 md:hidden">
           <Button
-            variant={isReady ? "secondary" : "primary"}
-            leftIcon={<Shield className="h-4 w-4" />}
-            onClick={handleToggleReady}
-            isLoading={setReady.isPending}
+            variant={mobileTab === 'players' ? 'primary' : 'ghost'}
+            size="sm"
+            leftIcon={<Users className="h-4 w-4" />}
+            onClick={() => setMobileTab('players')}
+            className="flex-1"
           >
-            {isReady ? "준비 취소" : "준비 완료"}
+            참가자
           </Button>
-        )}
-      </div>
+          <Button
+            variant={mobileTab === 'chat' ? 'primary' : 'ghost'}
+            size="sm"
+            leftIcon={<MessageSquare className="h-4 w-4" />}
+            onClick={() => setMobileTab('chat')}
+            className="flex-1"
+          >
+            채팅
+          </Button>
+        </div>
+
+        {/* 2컬럼 레이아웃 (데스크탑) / 탭 전환 (모바일) */}
+        <div className="grid gap-4 md:grid-cols-[1fr_1fr]">
+          {/* 왼쪽: 참가자 + 호스트 컨트롤 */}
+          <div
+            className={`flex flex-col gap-4 ${mobileTab !== 'players' ? 'hidden md:flex' : 'flex'}`}
+          >
+            <PlayerList
+              players={players}
+              maxPlayers={room.max_players}
+              characterNameById={characterNameById}
+            />
+            {currentPlayer && (
+              <CharacterSelectionPanel
+                characters={themeCharacters.data ?? []}
+                selectedCharacterId={currentPlayer.character_id}
+                selectedByOtherPlayerIds={selectedByOtherPlayerIds}
+                isLoading={themeCharacters.isLoading}
+                isError={themeCharacters.isError}
+                isSelecting={selectRoomCharacter.isPending}
+                onSelect={handleSelectCharacter}
+              />
+            )}
+            <HostControls
+              isHost={isHost}
+              allReady={allReady}
+              hasMinPlayers={hasMinPlayers}
+              allCharactersSelected={allCharactersSelected}
+              onStartGame={handleStartGame}
+              onCloseRoom={handleCloseRoom}
+              isStarting={startRoom.isPending}
+              startErrorMessage={startErrorMessage}
+            />
+          </div>
+
+          {/* 오른쪽: 채팅 */}
+          <div
+            className={`h-[400px] md:h-[500px] ${
+              mobileTab !== 'chat' ? 'hidden md:block' : 'block'
+            }`}
+          >
+            <RoomChat roomId={id} send={send} />
+          </div>
+        </div>
+
+        {/* 하단: 레디 + 나가기 */}
+        <div className="flex items-center justify-between gap-3 border-t border-[var(--mmp-color-hairline)] pt-4">
+          <Button
+            variant="ghost"
+            leftIcon={<LogOut className="h-4 w-4" />}
+            onClick={handleLeave}
+            isLoading={leaveRoom.isPending}
+          >
+            나가기
+          </Button>
+
+          {!isHost && (
+            <Button
+              variant={isReady ? 'secondary' : 'primary'}
+              leftIcon={<Shield className="h-4 w-4" />}
+              onClick={handleToggleReady}
+              isLoading={setReady.isPending}
+            >
+              {isReady ? '준비 취소' : '준비 완료'}
+            </Button>
+          )}
+        </div>
       </div>
     </PageShell>
   );

--- a/apps/web/src/pages/__tests__/RoomPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RoomPage.test.tsx
@@ -10,8 +10,10 @@ const {
   sendMock,
   useRoomMock,
   useLeaveRoomMock,
+  useSelectRoomCharacterMock,
   useSetReadyMock,
   useStartRoomMock,
+  useThemeCharactersMock,
   useWsEventMock,
 } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
@@ -19,8 +21,10 @@ const {
   sendMock: vi.fn(),
   useRoomMock: vi.fn(),
   useLeaveRoomMock: vi.fn(),
+  useSelectRoomCharacterMock: vi.fn(),
   useSetReadyMock: vi.fn(),
   useStartRoomMock: vi.fn(),
+  useThemeCharactersMock: vi.fn(),
   useWsEventMock: vi.fn(),
 }));
 
@@ -36,8 +40,10 @@ vi.mock('react-router', async () => {
 vi.mock('@/features/lobby/api', () => ({
   useRoom: () => useRoomMock(),
   useLeaveRoom: () => useLeaveRoomMock(),
+  useSelectRoomCharacter: () => useSelectRoomCharacterMock(),
   useSetReady: () => useSetReadyMock(),
   useStartRoom: () => useStartRoomMock(),
+  useThemeCharacters: (themeId: string) => useThemeCharactersMock(themeId),
 }));
 
 vi.mock('@/hooks/useWsClient', () => ({
@@ -81,6 +87,7 @@ const baseRoom = {
       avatar_url: null,
       is_host: true,
       is_ready: true,
+      character_id: 'character-detective',
       joined_at: '2026-05-19T00:00:00Z',
     },
     {
@@ -90,27 +97,58 @@ const baseRoom = {
       avatar_url: null,
       is_host: false,
       is_ready: true,
+      character_id: 'character-doctor',
       joined_at: '2026-05-19T00:00:00Z',
     },
   ],
 };
 
+const baseCharacters = [
+  {
+    id: 'character-detective',
+    name: '탐정',
+    description: '사건의 진실을 좇는 손님',
+    image_url: null,
+    image_media_id: null,
+    sort_order: 1,
+  },
+  {
+    id: 'character-doctor',
+    name: '의사',
+    description: '저택의 비밀을 알고 있는 인물',
+    image_url: null,
+    image_media_id: null,
+    sort_order: 2,
+  },
+  {
+    id: 'character-chef',
+    name: '요리사',
+    description: '마지막 만찬을 준비한 사람',
+    image_url: null,
+    image_media_id: null,
+    sort_order: 3,
+  },
+];
+
 function renderRoom() {
   return render(
     <MemoryRouter>
       <RoomPage />
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
-function mockRoomPage(overrides: {
-  room?: typeof baseRoom;
-  readyMutate?: ReturnType<typeof vi.fn>;
-  startMutate?: ReturnType<typeof vi.fn>;
-  leaveMutate?: ReturnType<typeof vi.fn>;
-  readyPending?: boolean;
-  startPending?: boolean;
-} = {}) {
+function mockRoomPage(
+  overrides: {
+    room?: typeof baseRoom;
+    readyMutate?: ReturnType<typeof vi.fn>;
+    selectMutate?: ReturnType<typeof vi.fn>;
+    startMutate?: ReturnType<typeof vi.fn>;
+    leaveMutate?: ReturnType<typeof vi.fn>;
+    readyPending?: boolean;
+    startPending?: boolean;
+  } = {}
+) {
   useRoomMock.mockReturnValue({
     data: overrides.room ?? baseRoom,
     isLoading: false,
@@ -119,6 +157,15 @@ function mockRoomPage(overrides: {
   });
   useLeaveRoomMock.mockReturnValue({
     mutate: overrides.leaveMutate ?? vi.fn(),
+    isPending: false,
+  });
+  useThemeCharactersMock.mockReturnValue({
+    data: baseCharacters,
+    isLoading: false,
+    isError: false,
+  });
+  useSelectRoomCharacterMock.mockReturnValue({
+    mutate: overrides.selectMutate ?? vi.fn(),
     isPending: false,
   });
   useSetReadyMock.mockReturnValue({
@@ -161,7 +208,7 @@ describe('RoomPage pregame controls', () => {
 
     expect(readyMutate).toHaveBeenCalledWith(
       { roomId: 'room-1', is_ready: false },
-      expect.objectContaining({ onSuccess: expect.any(Function) }),
+      expect.objectContaining({ onSuccess: expect.any(Function) })
     );
     await waitFor(() => expect(refetchMock).toHaveBeenCalled());
   });
@@ -175,7 +222,7 @@ describe('RoomPage pregame controls', () => {
       room: {
         ...baseRoom,
         players: baseRoom.players.map((player) =>
-          player.user_id === 'user-1' ? { ...player, is_ready: false } : player,
+          player.user_id === 'user-1' ? { ...player, is_ready: false } : player
         ),
       },
       readyPending: true,
@@ -202,7 +249,7 @@ describe('RoomPage pregame controls', () => {
 
     expect(startMutate).toHaveBeenCalledWith(
       'room-1',
-      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
     );
     expect(navigateMock).toHaveBeenCalledWith('/game/room-1');
   });
@@ -279,7 +326,7 @@ describe('RoomPage pregame controls', () => {
     expect(sendMock).toHaveBeenCalledWith('chat:send', { room_id: 'room-1', text: '준비됐어요' });
     expect(leaveMutate).toHaveBeenCalledWith(
       'room-1',
-      expect.objectContaining({ onSuccess: expect.any(Function) }),
+      expect.objectContaining({ onSuccess: expect.any(Function) })
     );
     expect(navigateMock).toHaveBeenCalledWith('/lobby');
   });
@@ -299,7 +346,75 @@ describe('RoomPage pregame controls', () => {
     fireEvent.click(screen.getByRole('button', { name: /게임 시작/ }));
 
     expect(screen.getByText(/게임 시작에 실패했습니다/)).toHaveTextContent(
-      '아직 모든 참가자가 준비하지 않았습니다.',
+      '아직 모든 참가자가 준비하지 않았습니다.'
     );
+  });
+
+  it('대기방에서 테마 캐릭터 목록을 표시하고 현재 선택을 구분한다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    expect(useThemeCharactersMock).toHaveBeenCalledWith('theme-1');
+    expect(screen.getByRole('heading', { name: '캐릭터 선택' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /의사/ })).toHaveTextContent('선택됨');
+    expect(screen.getByRole('button', { name: /요리사/ })).toBeEnabled();
+    expect(screen.getAllByText('참가자').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('의사').length).toBeGreaterThan(0);
+  });
+
+  it('다른 참가자가 선택한 캐릭터는 비활성화하고 내 선택 mutation을 보낸다', () => {
+    const selectMutate = vi.fn((_variables, options) => {
+      options?.onSuccess?.();
+    });
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({ selectMutate });
+
+    renderRoom();
+
+    expect(screen.getByRole('button', { name: /탐정/ })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /요리사/ }));
+
+    expect(selectMutate).toHaveBeenCalledWith(
+      { roomId: 'room-1', characterId: 'character-chef' },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    expect(refetchMock).toHaveBeenCalled();
+  });
+
+  it('캐릭터를 선택하지 않은 참가자가 있으면 호스트 시작 버튼을 비활성화하고 사유를 표시한다', () => {
+    const startMutate = vi.fn();
+    useAuthStore.setState({
+      user: { id: 'host-1', email: 'host@example.com', nickname: '호스트', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({
+      room: {
+        ...baseRoom,
+        players: baseRoom.players.map((player) =>
+          player.user_id === 'user-1' ? { ...player, character_id: null } : player
+        ),
+      },
+      startMutate,
+    });
+
+    renderRoom();
+
+    const startButton = screen.getByRole('button', { name: /게임 시작/ });
+    expect(startButton).toBeDisabled();
+    expect(
+      screen.getByText('모든 참가자가 캐릭터를 선택해야 시작할 수 있습니다.')
+    ).toBeInTheDocument();
+
+    fireEvent.click(startButton);
+
+    expect(startMutate).not.toHaveBeenCalled();
   });
 });

--- a/docs/plans/2026-05-19-pregame-slice2-character-selection-plan.md
+++ b/docs/plans/2026-05-19-pregame-slice2-character-selection-plan.md
@@ -1,0 +1,64 @@
+# 로비/대기방 Slice 2: 캐릭터 선택 계획
+
+## 목표
+
+- [x] 대기방에서 현재 테마의 공개 캐릭터 목록을 확인할 수 있다.
+- [x] 참가자가 캐릭터를 선택/변경하면 `room_players.character_id`에 저장된다.
+- [x] 같은 방 안에서 같은 캐릭터를 두 명이 선택할 수 없다.
+- [x] 방의 테마와 다른 캐릭터, 플레이 불가 캐릭터, 참가자가 아닌 사용자의 선택을 거부한다.
+- [x] 호스트는 모든 참가자가 캐릭터를 선택해야 게임 시작을 요청할 수 있고, 실패 사유를 볼 수 있다.
+
+## 범위
+
+### 포함
+
+- [x] `PUT /v1/rooms/{id}/character` 인증 API 추가
+- [x] `room_players.character_id` 저장 쿼리와 중복 방지 migration 추가
+- [x] Room detail `players[].character_id` 응답 확장
+- [x] `StartRoom`의 캐릭터 선택 완료 gate 추가
+- [x] 프론트 공개 캐릭터 목록 query와 캐릭터 선택 mutation 추가
+- [x] 대기방 캐릭터 선택 패널과 참가자 캐릭터 배지 추가
+- [x] backend/frontend focused tests와 browser QA
+
+### 이번 Slice 2 제외
+
+- [ ] 친구 초대/초대 링크 UX
+- [ ] 대기방 음성 채팅
+- [ ] 게임 본편 character select WebSocket runtime 교체
+- [ ] 모바일 전용 레이아웃 고도화
+
+## 결정
+
+- [x] 저장 계약은 HTTP `PUT /rooms/{id}/character`를 사용한다. ready/start와 같은 pre-game write path라서 REST API가 사용자 행동과 테스트를 더 명확히 만든다.
+- [x] 캐릭터 중복 정책은 방 단위 unique로 고정한다. 머더미스터리 캐릭터는 역할/정보 배정의 기준이므로 중복 선택을 허용하면 시작 후 역할지와 단서 공개가 깨진다.
+- [x] 공개 캐릭터 목록은 기존 `GET /themes/{id}/characters`만 사용한다. 에디터 API는 스포일러와 권한 경계가 달라 플레이어 대기방에 사용하지 않는다.
+
+## Coverage Plan
+
+- [x] Backend service: 성공, 방 없음, 대기 상태 아님, 참가자 아님, 다른 테마 캐릭터, 플레이 불가 캐릭터, 이미 선택된 캐릭터, 캐릭터 미선택 start gate
+- [x] Backend handler: 인증 없음, 잘못된 room ID, 잘못된 body/character ID, 성공
+- [x] SQL/generated: `SetRoomPlayerCharacter`, partial unique index migration, `sqlc generate`
+- [x] Frontend API: `useThemeCharacters`, `useSelectRoomCharacter`
+- [x] RoomPage: 캐릭터 목록 표시, 선택 mutation, 이미 선택된 캐릭터 disabled, 캐릭터 미선택 시 start disabled/사유 표시
+- [x] Browser QA: 로그인 후 대기방에서 캐릭터 선택, 화면 반영, 시작 버튼 조건 확인
+
+## Validation Plan
+
+- [x] `cd apps/server && go test ./internal/domain/room ./cmd/server`
+- [x] `pnpm --filter @mmp/web test -- RoomPage.test.tsx api.test.tsx`
+- [x] `pnpm --filter @mmp/web typecheck`
+- [x] 대기방 브라우저 QA
+- [x] `scripts/mmp-local-ci.sh quick`
+
+## 실행 원장
+
+- [x] Slice 1 PR #692 merge 확인
+- [x] backend/frontend read-only audit subagent 결과 회수
+- [x] Slice 2 branch `feat/issue-691-character-selection` 생성
+- [x] Slice 2 계획 문서 작성
+- [x] backend character API/service/sqlc/migration 구현
+- [x] frontend API/UI/tests 구현
+- [x] focused validation
+- [x] independent review/validation
+- [ ] PR 생성 및 Codex review
+- [ ] merge 후 #691 다음 Slice 진행


### PR DESCRIPTION
## 요약

- 대기방 참가자용 캐릭터 선택 API와 UI를 추가했습니다.
- `room_players.character_id` 저장/중복 방지 migration을 추가하고, 게임 시작 gate에 캐릭터 선택 완료 조건을 넣었습니다.
- 참가자 전용 방 조회 `/rooms/{id}/me`를 사용해 공개 방 조회와 대기방 상세 조회의 응답 경계를 분리했습니다.

## Coverage Plan

- Backend service: 선택 성공, 방 없음, 대기 상태 아님, 참가자 아님, 테마 불일치, 플레이 불가 캐릭터, 이미 선택된 캐릭터, 캐릭터 미선택 start gate
- Backend handler: 인증 없음, 잘못된 room ID/body/character ID, 성공
- SQL/migration: `SetRoomPlayerCharacter`, partial unique index, `sqlc generate`
- Frontend API/UI: `useThemeCharacters`, `useSelectRoomCharacter`, 선택 패널, 참가자 캐릭터 배지, start disabled reason

## Local validation

- `scripts/mmp-local-ci.sh quick` 성공 (HEAD `afe98074a95ce1b7dd549687f5d36674c8c51cb2`)
- `cd apps/server && go test -count=1 ./internal/domain/room ./cmd/server` 성공
- `pnpm --filter @mmp/web test -- RoomPage.test.tsx api.test.tsx` 성공 (16 tests)
- `pnpm --filter @mmp/web typecheck` 성공
- `pnpm --filter @mmp/web lint` 성공, 기존 warning only
- Browser QA: 로그인 후 기존 공개 대기방 진입, 캐릭터 목록 로딩, `PUT /rooms/:id/character` 200, 선택 완료 표시, 참가자 목록 캐릭터 반영, 준비 상태 전환 확인

## Notes

- Browser QA 중 방 생성은 dev fixture의 기존 `rooms_code_key` / `AAAAAA` 중복으로 500을 반환했습니다. 이번 캐릭터 선택 변경의 회귀가 아니라 dev DB fixture/code generation 상태 문제로 분리했습니다.
- Refs #691
