### PR TITLE
대기방 친구 초대 추가

### DIFF
--- a/apps/server/cmd/server/adapters.go
+++ b/apps/server/cmd/server/adapters.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/google/uuid"
+	"github.com/mmp-platform/server/internal/domain/room"
 	"github.com/mmp-platform/server/internal/session"
 	"github.com/mmp-platform/server/internal/ws"
 )
@@ -62,4 +64,17 @@ func (b *hubBroadcaster) BroadcastToSession(sessionID uuid.UUID, env session.Bro
 		Payload: env.Payload,
 	}
 	b.hub.BroadcastToSession(sessionID, wsEnv)
+}
+
+// roomInviteNotifier adapts the social websocket hub to room.Service without
+// coupling the room domain package to ws internals.
+type roomInviteNotifier struct {
+	hub *ws.SocialHub
+}
+
+func (n *roomInviteNotifier) NotifyRoomInvite(_ context.Context, userID uuid.UUID, payload room.RoomInviteNotification) (bool, error) {
+	if n == nil || n.hub == nil {
+		return false, nil
+	}
+	return n.hub.SendToUser(userID, ws.MustEnvelope("room:invite", payload)), nil
 }

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -281,8 +281,6 @@ func main() {
 	// 11.2. GameStarter for room service.
 	broadcaster := &hubBroadcaster{hub: wsHub}
 	gameStarter := session.NewGameStarter(sessionMgr, broadcaster, cfg.GameRuntimeV2, mediaSvc, logger)
-	roomSvc := room.NewServiceWithStarter(pool, queries, logger, gameStarter)
-	roomHandler := room.NewHandler(roomSvc)
 	lobbyChatWSHandler := room.NewLobbyChatWSHandler(queries, wsHub, logger)
 	wsRouter.Handle("chat", lobbyChatWSHandler.HandleChat)
 
@@ -302,6 +300,15 @@ func main() {
 	socialRouter.Handle("chat", socialWSHandler.HandleChat)
 	socialRouter.Handle("friend", socialWSHandler.HandleFriend)
 	socialRouter.Handle("presence", socialWSHandler.HandlePresence)
+
+	roomSvc := room.NewServiceWithStarterAndInviteNotifier(
+		pool,
+		queries,
+		logger,
+		gameStarter,
+		&roomInviteNotifier{hub: socialHub},
+	)
+	roomHandler := room.NewHandler(roomSvc)
 
 	// 11.6. PR-9 WS Auth Protocol wiring.
 	//

--- a/apps/server/cmd/server/routes_editor.go
+++ b/apps/server/cmd/server/routes_editor.go
@@ -82,6 +82,7 @@ func registerBaseRoutes(r chi.Router, deps authedDeps) {
 	r.Post("/rooms/{id}/leave", deps.room.LeaveRoom)
 	r.Post("/rooms/{id}/ready", deps.room.SetReady)
 	r.Put("/rooms/{id}/character", deps.room.SelectCharacter)
+	r.Post("/rooms/{id}/invites", deps.room.InviteFriends)
 	r.Post("/rooms/{id}/start", deps.room.StartRoom)
 
 	// Payment endpoints (authed)

--- a/apps/server/internal/domain/room/handler.go
+++ b/apps/server/internal/domain/room/handler.go
@@ -214,6 +214,35 @@ func (h *Handler) SelectCharacter(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, map[string]string{"status": "character selected"})
 }
 
+// InviteFriends handles POST /rooms/{id}/invites (authenticated).
+func (h *Handler) InviteFriends(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFrom(r.Context())
+	if userID == uuid.Nil {
+		apperror.WriteError(w, r, apperror.Unauthorized("authentication required"))
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	roomID, err := uuid.Parse(idStr)
+	if err != nil {
+		apperror.WriteError(w, r, apperror.BadRequest("invalid room ID"))
+		return
+	}
+
+	var req RoomInviteRequest
+	if err := httputil.ReadJSON(r, &req); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	resp, err := h.svc.InviteFriends(r.Context(), roomID, userID, req)
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
 // StartRoom handles POST /rooms/{id}/start (authenticated, host only).
 // It enforces a 256 KiB body limit to protect the configJson trust boundary.
 func (h *Handler) StartRoom(w http.ResponseWriter, r *http.Request) {

--- a/apps/server/internal/domain/room/handler_invite_test.go
+++ b/apps/server/internal/domain/room/handler_invite_test.go
@@ -1,0 +1,101 @@
+package room
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestInviteFriends_Success(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	friendID := uuid.New()
+
+	svc := &mockService{
+		inviteFriendsFn: func(_ context.Context, gotRoomID, gotUserID uuid.UUID, req RoomInviteRequest) (*RoomInviteResponse, error) {
+			if gotRoomID != roomID || gotUserID != userID {
+				t.Fatalf("InviteFriends ids mismatch: room=%s user=%s", gotRoomID, gotUserID)
+			}
+			if len(req.FriendIDs) != 1 || req.FriendIDs[0] != friendID {
+				t.Fatalf("FriendIDs = %+v, want [%s]", req.FriendIDs, friendID)
+			}
+			return &RoomInviteResponse{
+				Sent: []RoomInviteSent{{FriendID: friendID, Nickname: "Ada", Online: true}},
+			}, nil
+		},
+	}
+	h := NewHandler(svc)
+
+	body, _ := json.Marshal(RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}})
+	req := httptest.NewRequest(http.MethodPost, "/rooms/"+roomID.String()+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.InviteFriends(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"online":true`) {
+		t.Fatalf("expected invite response body, got %s", rec.Body.String())
+	}
+}
+
+func TestInviteFriends_NoAuth(t *testing.T) {
+	h := NewHandler(&mockService{})
+	roomID := uuid.New()
+	body, _ := json.Marshal(RoomInviteRequest{FriendIDs: []uuid.UUID{uuid.New()}})
+
+	req := httptest.NewRequest(http.MethodPost, "/rooms/"+roomID.String()+"/invites", bytes.NewReader(body))
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.InviteFriends(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInviteFriends_InvalidRoomID(t *testing.T) {
+	h := NewHandler(&mockService{})
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/rooms/not-a-uuid/invites", strings.NewReader(`{"friend_ids":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", "not-a-uuid")
+
+	rec := httptest.NewRecorder()
+	h.InviteFriends(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInviteFriends_InvalidJSON(t *testing.T) {
+	h := NewHandler(&mockService{})
+	roomID := uuid.New()
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/rooms/"+roomID.String()+"/invites", strings.NewReader(`not json`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAuth(req, userID)
+	req = withChiParam(req, "id", roomID.String())
+
+	rec := httptest.NewRecorder()
+	h.InviteFriends(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/server/internal/domain/room/mock_shim_test.go
+++ b/apps/server/internal/domain/room/mock_shim_test.go
@@ -32,6 +32,7 @@ type mockService struct {
 	leaveRoomFn      func(ctx context.Context, roomID, userID uuid.UUID) error
 	setReadyFn       func(ctx context.Context, roomID, userID uuid.UUID, ready bool) error
 	selectCharFn     func(ctx context.Context, roomID, userID uuid.UUID, req SelectCharacterRequest) error
+	inviteFriendsFn  func(ctx context.Context, roomID, inviterID uuid.UUID, req RoomInviteRequest) (*RoomInviteResponse, error)
 	startRoomFn      func(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
 }
 
@@ -96,6 +97,13 @@ func (m *mockService) SelectCharacter(ctx context.Context, roomID, userID uuid.U
 		return m.selectCharFn(ctx, roomID, userID, req)
 	}
 	return nil
+}
+
+func (m *mockService) InviteFriends(ctx context.Context, roomID, inviterID uuid.UUID, req RoomInviteRequest) (*RoomInviteResponse, error) {
+	if m.inviteFriendsFn != nil {
+		return m.inviteFriendsFn(ctx, roomID, inviterID, req)
+	}
+	return &RoomInviteResponse{}, nil
 }
 
 func (m *mockService) StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error {

--- a/apps/server/internal/domain/room/mocks/mock_service.go
+++ b/apps/server/internal/domain/room/mocks/mock_service.go
@@ -102,6 +102,21 @@ func (mr *MockServiceMockRecorder) GetRoomForUser(ctx, roomID, userID any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomForUser", reflect.TypeOf((*MockService)(nil).GetRoomForUser), ctx, roomID, userID)
 }
 
+// InviteFriends mocks base method.
+func (m *MockService) InviteFriends(ctx context.Context, roomID, inviterID uuid.UUID, req room.RoomInviteRequest) (*room.RoomInviteResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InviteFriends", ctx, roomID, inviterID, req)
+	ret0, _ := ret[0].(*room.RoomInviteResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InviteFriends indicates an expected call of InviteFriends.
+func (mr *MockServiceMockRecorder) InviteFriends(ctx, roomID, inviterID, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InviteFriends", reflect.TypeOf((*MockService)(nil).InviteFriends), ctx, roomID, inviterID, req)
+}
+
 // JoinRoom mocks base method.
 func (m *MockService) JoinRoom(ctx context.Context, roomID, userID uuid.UUID) error {
 	m.ctrl.T.Helper()
@@ -223,4 +238,43 @@ func (m *MockGameStarter) Start(ctx context.Context, roomID, themeID uuid.UUID, 
 func (mr *MockGameStarterMockRecorder) Start(ctx, roomID, themeID, configJSON, players any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockGameStarter)(nil).Start), ctx, roomID, themeID, configJSON, players)
+}
+
+// MockRoomInviteNotifier is a mock of RoomInviteNotifier interface.
+type MockRoomInviteNotifier struct {
+	ctrl     *gomock.Controller
+	recorder *MockRoomInviteNotifierMockRecorder
+	isgomock struct{}
+}
+
+// MockRoomInviteNotifierMockRecorder is the mock recorder for MockRoomInviteNotifier.
+type MockRoomInviteNotifierMockRecorder struct {
+	mock *MockRoomInviteNotifier
+}
+
+// NewMockRoomInviteNotifier creates a new mock instance.
+func NewMockRoomInviteNotifier(ctrl *gomock.Controller) *MockRoomInviteNotifier {
+	mock := &MockRoomInviteNotifier{ctrl: ctrl}
+	mock.recorder = &MockRoomInviteNotifierMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRoomInviteNotifier) EXPECT() *MockRoomInviteNotifierMockRecorder {
+	return m.recorder
+}
+
+// NotifyRoomInvite mocks base method.
+func (m *MockRoomInviteNotifier) NotifyRoomInvite(ctx context.Context, userID uuid.UUID, payload room.RoomInviteNotification) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NotifyRoomInvite", ctx, userID, payload)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NotifyRoomInvite indicates an expected call of NotifyRoomInvite.
+func (mr *MockRoomInviteNotifierMockRecorder) NotifyRoomInvite(ctx, userID, payload any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyRoomInvite", reflect.TypeOf((*MockRoomInviteNotifier)(nil).NotifyRoomInvite), ctx, userID, payload)
 }

--- a/apps/server/internal/domain/room/service.go
+++ b/apps/server/internal/domain/room/service.go
@@ -96,6 +96,42 @@ type SelectCharacterRequest struct {
 	CharacterID uuid.UUID `json:"character_id"`
 }
 
+// RoomInviteRequest is the payload for POST /rooms/:id/invites.
+type RoomInviteRequest struct {
+	FriendIDs []uuid.UUID `json:"friend_ids"`
+}
+
+// RoomInviteSent reports a target that passed all validation and was eligible
+// for realtime delivery.
+type RoomInviteSent struct {
+	FriendID uuid.UUID `json:"friend_id"`
+	Nickname string    `json:"nickname"`
+	Online   bool      `json:"online"`
+}
+
+// RoomInviteSkipped reports a target that could not receive this invite.
+type RoomInviteSkipped struct {
+	FriendID uuid.UUID `json:"friend_id"`
+	Reason   string    `json:"reason"`
+}
+
+// RoomInviteResponse is the room invite MVP response. No durable invite row is
+// written; callers should treat Sent.Online=false as "eligible but no online
+// realtime delivery was confirmed".
+type RoomInviteResponse struct {
+	Sent    []RoomInviteSent    `json:"sent"`
+	Skipped []RoomInviteSkipped `json:"skipped"`
+}
+
+// RoomInviteNotification is the payload handed to the online social notifier.
+type RoomInviteNotification struct {
+	RoomID          uuid.UUID `json:"room_id"`
+	Code            string    `json:"code"`
+	ThemeTitle      string    `json:"theme_title"`
+	InviterID       uuid.UUID `json:"inviter_id"`
+	InviterNickname string    `json:"inviter_nickname"`
+}
+
 // Service defines the room domain operations.
 type Service interface {
 	CreateRoom(ctx context.Context, hostID uuid.UUID, req CreateRoomRequest) (*RoomResponse, error)
@@ -107,6 +143,7 @@ type Service interface {
 	LeaveRoom(ctx context.Context, roomID, userID uuid.UUID) error
 	SetReady(ctx context.Context, roomID, userID uuid.UUID, ready bool) error
 	SelectCharacter(ctx context.Context, roomID, userID uuid.UUID, req SelectCharacterRequest) error
+	InviteFriends(ctx context.Context, roomID, inviterID uuid.UUID, req RoomInviteRequest) (*RoomInviteResponse, error)
 	StartRoom(ctx context.Context, roomID, hostID uuid.UUID, req StartRoomRequest) error
 }
 
@@ -132,11 +169,18 @@ type GameStarter interface {
 	Start(ctx context.Context, roomID, themeID uuid.UUID, configJSON []byte, players []GameStartPlayer) error
 }
 
+// RoomInviteNotifier is intentionally tiny so main wiring can adapt the social
+// WebSocket hub without coupling room service to ws/social packages.
+type RoomInviteNotifier interface {
+	NotifyRoomInvite(ctx context.Context, userID uuid.UUID, payload RoomInviteNotification) (online bool, err error)
+}
+
 type service struct {
-	pool        *pgxpool.Pool
-	queries     roomQueries
-	logger      zerolog.Logger
-	gameStarter GameStarter // nil → legacy (flag off)
+	pool           *pgxpool.Pool
+	queries        roomQueries
+	logger         zerolog.Logger
+	gameStarter    GameStarter // nil → legacy (flag off)
+	inviteNotifier RoomInviteNotifier
 }
 
 // NewService creates a new room service.
@@ -156,6 +200,29 @@ func NewServiceWithStarter(pool *pgxpool.Pool, queries *db.Queries, logger zerol
 		queries:     queries,
 		logger:      logger.With().Str("domain", "room").Logger(),
 		gameStarter: starter,
+	}
+}
+
+// NewServiceWithInviteNotifier creates a room service with realtime invite
+// delivery enabled. Kept separate from NewService so existing wiring remains
+// unchanged until main Codex wires the social hub adapter.
+func NewServiceWithInviteNotifier(pool *pgxpool.Pool, queries *db.Queries, logger zerolog.Logger, notifier RoomInviteNotifier) Service {
+	return &service{
+		pool:           pool,
+		queries:        queries,
+		logger:         logger.With().Str("domain", "room").Logger(),
+		inviteNotifier: notifier,
+	}
+}
+
+// NewServiceWithStarterAndInviteNotifier wires both optional runtime adapters.
+func NewServiceWithStarterAndInviteNotifier(pool *pgxpool.Pool, queries *db.Queries, logger zerolog.Logger, starter GameStarter, notifier RoomInviteNotifier) Service {
+	return &service{
+		pool:           pool,
+		queries:        queries,
+		logger:         logger.With().Str("domain", "room").Logger(),
+		gameStarter:    starter,
+		inviteNotifier: notifier,
 	}
 }
 
@@ -595,6 +662,153 @@ func (s *service) SelectCharacter(ctx context.Context, roomID, userID uuid.UUID,
 		return apperror.New(apperror.ErrPlayerNotInGame, http.StatusForbidden, "player is not in this room")
 	}
 	return nil
+}
+
+// InviteFriends validates friend targets for a waiting-room participant and
+// pushes online notifications. This MVP deliberately does not persist invites;
+// when no notifier is wired, eligible targets are returned as sent with
+// online=false so the API stays usable during staged integration.
+func (s *service) InviteFriends(ctx context.Context, roomID, inviterID uuid.UUID, req RoomInviteRequest) (*RoomInviteResponse, error) {
+	if len(req.FriendIDs) == 0 {
+		return nil, apperror.BadRequest("friend_ids is required")
+	}
+
+	room, err := s.queries.GetRoom(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.New(apperror.ErrRoomNotFound, http.StatusNotFound, "room not found")
+		}
+		s.logger.Error().Err(err).Msg("InviteFriends: failed to get room")
+		return nil, apperror.Internal("failed to get room")
+	}
+	if room.Status != "WAITING" {
+		return nil, apperror.New(apperror.ErrRoomNotWaiting, http.StatusConflict, "room is not in waiting state")
+	}
+	if room.HostID != inviterID {
+		return nil, apperror.New(apperror.ErrForbidden, http.StatusForbidden, "only the host can invite friends")
+	}
+
+	players, err := s.queries.GetRoomPlayers(ctx, roomID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("room_id", roomID).Msg("InviteFriends: failed to get room players")
+		return nil, apperror.Internal("failed to get room players")
+	}
+	if !hasRoomPlayer(players, inviterID) {
+		return nil, apperror.New(apperror.ErrPlayerNotInGame, http.StatusForbidden, "player is not in this room")
+	}
+
+	theme, err := s.queries.GetTheme(ctx, room.ThemeID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apperror.New(apperror.ErrNotFound, http.StatusNotFound, "theme not found")
+		}
+		s.logger.Error().Err(err).Stringer("theme_id", room.ThemeID).Msg("InviteFriends: failed to get theme")
+		return nil, apperror.Internal("failed to get theme")
+	}
+	inviter, err := s.queries.GetUser(ctx, inviterID)
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("inviter_id", inviterID).Msg("InviteFriends: failed to get inviter")
+		return nil, apperror.Internal("failed to invite friends")
+	}
+
+	resp := &RoomInviteResponse{
+		Sent:    []RoomInviteSent{},
+		Skipped: []RoomInviteSkipped{},
+	}
+	participantIDs := make(map[uuid.UUID]struct{}, len(players))
+	for _, player := range players {
+		participantIDs[player.UserID] = struct{}{}
+	}
+	seen := make(map[uuid.UUID]struct{}, len(req.FriendIDs))
+	payload := RoomInviteNotification{
+		RoomID:          room.ID,
+		Code:            room.Code,
+		ThemeTitle:      theme.Title,
+		InviterID:       inviterID,
+		InviterNickname: inviter.Nickname,
+	}
+
+	for _, friendID := range req.FriendIDs {
+		if friendID == uuid.Nil {
+			resp.Skipped = append(resp.Skipped, RoomInviteSkipped{FriendID: friendID, Reason: "invalid_friend_id"})
+			continue
+		}
+		if _, exists := seen[friendID]; exists {
+			resp.Skipped = append(resp.Skipped, RoomInviteSkipped{FriendID: friendID, Reason: "duplicate"})
+			continue
+		}
+		seen[friendID] = struct{}{}
+		if _, inRoom := participantIDs[friendID]; inRoom {
+			resp.Skipped = append(resp.Skipped, RoomInviteSkipped{FriendID: friendID, Reason: "already_participant"})
+			continue
+		}
+
+		target, skipReason, err := s.validateInviteTarget(ctx, inviterID, friendID)
+		if err != nil {
+			return nil, err
+		}
+		if skipReason != "" {
+			resp.Skipped = append(resp.Skipped, RoomInviteSkipped{FriendID: friendID, Reason: skipReason})
+			continue
+		}
+
+		online := false
+		if s.inviteNotifier != nil {
+			online, err = s.inviteNotifier.NotifyRoomInvite(ctx, friendID, payload)
+			if err != nil {
+				s.logger.Error().Err(err).Stringer("friend_id", friendID).Msg("InviteFriends: notifier failed")
+				resp.Skipped = append(resp.Skipped, RoomInviteSkipped{FriendID: friendID, Reason: "notification_failed"})
+				continue
+			}
+		}
+		resp.Sent = append(resp.Sent, RoomInviteSent{FriendID: friendID, Nickname: target.Nickname, Online: online})
+	}
+	return resp, nil
+}
+
+func (s *service) validateInviteTarget(ctx context.Context, inviterID, friendID uuid.UUID) (db.User, string, error) {
+	friendship, err := s.queries.GetFriendshipBetween(ctx, db.GetFriendshipBetweenParams{
+		RequesterID: inviterID,
+		AddresseeID: friendID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.User{}, "not_friend", nil
+		}
+		s.logger.Error().Err(err).Stringer("friend_id", friendID).Msg("InviteFriends: failed to get friendship")
+		return db.User{}, "", apperror.Internal("failed to validate invite target")
+	}
+	if friendship.Status != "ACCEPTED" {
+		return db.User{}, "not_friend", nil
+	}
+
+	blocked, err := s.queries.IsBlocked(ctx, db.IsBlockedParams{BlockerID: inviterID, BlockedID: friendID})
+	if err != nil {
+		s.logger.Error().Err(err).Stringer("friend_id", friendID).Msg("InviteFriends: failed to check block")
+		return db.User{}, "", apperror.Internal("failed to validate invite target")
+	}
+	if blocked {
+		return db.User{}, "blocked", nil
+	}
+
+	prefs, err := s.queries.GetNotificationPrefs(ctx, friendID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		s.logger.Error().Err(err).Stringer("friend_id", friendID).Msg("InviteFriends: failed to get notification prefs")
+		return db.User{}, "", apperror.Internal("failed to validate invite target")
+	}
+	if err == nil && !prefs.GameInvite {
+		return db.User{}, "notification_disabled", nil
+	}
+
+	target, err := s.queries.GetUser(ctx, friendID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.User{}, "not_friend", nil
+		}
+		s.logger.Error().Err(err).Stringer("friend_id", friendID).Msg("InviteFriends: failed to get target user")
+		return db.User{}, "", apperror.Internal("failed to validate invite target")
+	}
+	return target, "", nil
 }
 
 // buildRoomDetail fetches players (with user JOIN) and assembles a

--- a/apps/server/internal/domain/room/service_invite_test.go
+++ b/apps/server/internal/domain/room/service_invite_test.go
@@ -1,0 +1,230 @@
+package room
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/mmp-platform/server/internal/db"
+)
+
+type fakeRoomInviteNotifier struct {
+	onlineByUser map[uuid.UUID]bool
+	calls        []RoomInviteNotification
+	err          error
+}
+
+func (f *fakeRoomInviteNotifier) NotifyRoomInvite(_ context.Context, userID uuid.UUID, payload RoomInviteNotification) (bool, error) {
+	f.calls = append(f.calls, payload)
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.onlineByUser[userID], nil
+}
+
+func TestInviteFriendsServiceValidationBranches(t *testing.T) {
+	roomID := uuid.New()
+	themeID := uuid.New()
+	inviterID := uuid.New()
+	friendID := uuid.New()
+	waitingRoom := db.Room{ID: roomID, ThemeID: themeID, HostID: inviterID, Code: "ABC234", Status: "WAITING"}
+
+	tests := []struct {
+		name       string
+		req        RoomInviteRequest
+		queries    *fakeRoomQueries
+		notifier   RoomInviteNotifier
+		wantStatus int
+		wantSent   int
+		wantReason string
+	}{
+		{
+			name:       "empty friend list",
+			req:        RoomInviteRequest{},
+			queries:    &fakeRoomQueries{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "room missing",
+			req:        RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries:    &fakeRoomQueries{roomErr: pgx.ErrNoRows},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "room lookup failure",
+			req:        RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries:    &fakeRoomQueries{roomErr: errors.New("db unavailable")},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "room not waiting",
+			req:        RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries:    &fakeRoomQueries{room: db.Room{ID: roomID, Status: "PLAYING"}},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name: "inviter is not host",
+			req:  RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries: &fakeRoomQueries{
+				room:    db.Room{ID: roomID, ThemeID: themeID, HostID: uuid.New(), Code: "ABC234", Status: "WAITING"},
+				players: []db.RoomPlayer{{RoomID: roomID, UserID: inviterID}},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "inviter is not participant",
+			req:  RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries: &fakeRoomQueries{
+				room:    waitingRoom,
+				players: []db.RoomPlayer{{RoomID: roomID, UserID: uuid.New()}},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "target is not accepted friend",
+			req:  RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries: inviteFakeQueries(waitingRoom, inviterID, map[uuid.UUID]db.Friendship{
+				friendID: {RequesterID: inviterID, AddresseeID: friendID, Status: "PENDING"},
+			}),
+			wantReason: "not_friend",
+		},
+		{
+			name: "invalid friend id is skipped",
+			req:  RoomInviteRequest{FriendIDs: []uuid.UUID{uuid.Nil}},
+			queries: inviteFakeQueries(waitingRoom, inviterID, map[uuid.UUID]db.Friendship{
+				friendID: {RequesterID: inviterID, AddresseeID: friendID, Status: "ACCEPTED"},
+			}),
+			wantReason: "invalid_friend_id",
+		},
+		{
+			name:       "duplicate friend id is skipped after first send",
+			req:        RoomInviteRequest{FriendIDs: []uuid.UUID{friendID, friendID}},
+			queries:    inviteFakeQueries(waitingRoom, inviterID, acceptedFriend(inviterID, friendID)),
+			wantSent:   1,
+			wantReason: "duplicate",
+		},
+		{
+			name: "blocked target is skipped",
+			req:  RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries: func() *fakeRoomQueries {
+				q := inviteFakeQueries(waitingRoom, inviterID, acceptedFriend(inviterID, friendID))
+				q.blockedUsers = map[uuid.UUID]bool{friendID: true}
+				return q
+			}(),
+			wantReason: "blocked",
+		},
+		{
+			name: "existing participant is skipped",
+			req:  RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries: func() *fakeRoomQueries {
+				q := inviteFakeQueries(waitingRoom, inviterID, acceptedFriend(inviterID, friendID))
+				q.players = append(q.players, db.RoomPlayer{RoomID: roomID, UserID: friendID})
+				return q
+			}(),
+			wantReason: "already_participant",
+		},
+		{
+			name: "notification opt out is skipped",
+			req:  RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries: func() *fakeRoomQueries {
+				q := inviteFakeQueries(waitingRoom, inviterID, acceptedFriend(inviterID, friendID))
+				q.gameInvitePrefs = map[uuid.UUID]bool{friendID: false}
+				return q
+			}(),
+			wantReason: "notification_disabled",
+		},
+		{
+			name:       "nil notifier returns eligible invite as offline sent",
+			req:        RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries:    inviteFakeQueries(waitingRoom, inviterID, acceptedFriend(inviterID, friendID)),
+			wantSent:   1,
+			wantReason: "",
+		},
+		{
+			name:       "notifier failure skips eligible invite",
+			req:        RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}},
+			queries:    inviteFakeQueries(waitingRoom, inviterID, acceptedFriend(inviterID, friendID)),
+			notifier:   &fakeRoomInviteNotifier{onlineByUser: map[uuid.UUID]bool{friendID: true}, err: errors.New("ws unavailable")},
+			wantReason: "notification_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &service{queries: tt.queries, logger: zerolog.Nop(), inviteNotifier: tt.notifier}
+
+			resp, err := svc.InviteFriends(context.Background(), roomID, inviterID, tt.req)
+
+			if tt.wantStatus != 0 {
+				assertAppError(t, err, tt.wantStatus)
+				return
+			}
+			if err != nil {
+				t.Fatalf("InviteFriends returned error: %v", err)
+			}
+			if resp.Sent == nil || resp.Skipped == nil {
+				t.Fatalf("sent/skipped must be non-nil arrays: %+v", resp)
+			}
+			if len(resp.Sent) != tt.wantSent {
+				t.Fatalf("sent len = %d, want %d: %+v", len(resp.Sent), tt.wantSent, resp)
+			}
+			if tt.wantReason != "" {
+				if len(resp.Skipped) != 1 || resp.Skipped[0].Reason != tt.wantReason {
+					t.Fatalf("skipped = %+v, want reason %q", resp.Skipped, tt.wantReason)
+				}
+			}
+		})
+	}
+}
+
+func TestInviteFriendsServiceNotifiesOnlineFriends(t *testing.T) {
+	roomID := uuid.New()
+	themeID := uuid.New()
+	inviterID := uuid.New()
+	friendID := uuid.New()
+	roomRow := db.Room{ID: roomID, ThemeID: themeID, HostID: inviterID, Code: "ABC234", Status: "WAITING"}
+	queries := inviteFakeQueries(roomRow, inviterID, acceptedFriend(inviterID, friendID))
+	notifier := &fakeRoomInviteNotifier{onlineByUser: map[uuid.UUID]bool{friendID: true}}
+	svc := &service{queries: queries, logger: zerolog.Nop(), inviteNotifier: notifier}
+
+	resp, err := svc.InviteFriends(context.Background(), roomID, inviterID, RoomInviteRequest{FriendIDs: []uuid.UUID{friendID}})
+
+	if err != nil {
+		t.Fatalf("InviteFriends returned error: %v", err)
+	}
+	if len(resp.Sent) != 1 || resp.Sent[0].FriendID != friendID || resp.Sent[0].Nickname != "friend" || !resp.Sent[0].Online {
+		t.Fatalf("sent mismatch: %+v", resp.Sent)
+	}
+	if len(notifier.calls) != 1 {
+		t.Fatalf("notifier calls = %d, want 1", len(notifier.calls))
+	}
+	payload := notifier.calls[0]
+	if payload.RoomID != roomID || payload.Code != "ABC234" || payload.ThemeTitle != "Mystery" || payload.InviterID != inviterID || payload.InviterNickname != "host" {
+		t.Fatalf("payload mismatch: %+v", payload)
+	}
+}
+
+func inviteFakeQueries(roomRow db.Room, inviterID uuid.UUID, friendships map[uuid.UUID]db.Friendship) *fakeRoomQueries {
+	users := map[uuid.UUID]db.User{inviterID: {ID: inviterID, Nickname: "host"}}
+	for friendID := range friendships {
+		users[friendID] = db.User{ID: friendID, Nickname: "friend"}
+	}
+	return &fakeRoomQueries{
+		room:        roomRow,
+		theme:       db.Theme{ID: roomRow.ThemeID, Title: "Mystery"},
+		players:     []db.RoomPlayer{{RoomID: roomRow.ID, UserID: inviterID}},
+		users:       users,
+		friendships: friendships,
+	}
+}
+
+func acceptedFriend(inviterID, friendID uuid.UUID) map[uuid.UUID]db.Friendship {
+	return map[uuid.UUID]db.Friendship{
+		friendID: {RequesterID: inviterID, AddresseeID: friendID, Status: "ACCEPTED"},
+	}
+}

--- a/apps/server/internal/domain/room/service_pregame_test.go
+++ b/apps/server/internal/domain/room/service_pregame_test.go
@@ -31,6 +31,14 @@ type fakeRoomQueries struct {
 	charactersErr            error
 	character                db.ThemeCharacter
 	characterErr             error
+	users                    map[uuid.UUID]db.User
+	userErr                  error
+	friendships              map[uuid.UUID]db.Friendship
+	friendshipErr            error
+	blockedUsers             map[uuid.UUID]bool
+	blockErr                 error
+	gameInvitePrefs          map[uuid.UUID]bool
+	notificationPrefsErr     error
 	setReadyParams           *db.SetPlayerReadyParams
 	setReadyErr              error
 	setCharacterParams       *db.SetRoomPlayerCharacterParams
@@ -94,6 +102,52 @@ func (f *fakeRoomQueries) GetThemeCharacters(context.Context, uuid.UUID) ([]db.T
 
 func (f *fakeRoomQueries) GetThemeCharacter(context.Context, uuid.UUID) (db.ThemeCharacter, error) {
 	return f.character, f.characterErr
+}
+
+func (f *fakeRoomQueries) GetUser(_ context.Context, id uuid.UUID) (db.User, error) {
+	if f.userErr != nil {
+		return db.User{}, f.userErr
+	}
+	if f.users != nil {
+		if user, ok := f.users[id]; ok {
+			return user, nil
+		}
+	}
+	return db.User{}, pgx.ErrNoRows
+}
+
+func (f *fakeRoomQueries) GetFriendshipBetween(_ context.Context, arg db.GetFriendshipBetweenParams) (db.Friendship, error) {
+	if f.friendshipErr != nil {
+		return db.Friendship{}, f.friendshipErr
+	}
+	if f.friendships != nil {
+		if friendship, ok := f.friendships[arg.AddresseeID]; ok {
+			return friendship, nil
+		}
+		if friendship, ok := f.friendships[arg.RequesterID]; ok {
+			return friendship, nil
+		}
+	}
+	return db.Friendship{}, pgx.ErrNoRows
+}
+
+func (f *fakeRoomQueries) IsBlocked(_ context.Context, arg db.IsBlockedParams) (bool, error) {
+	if f.blockErr != nil {
+		return false, f.blockErr
+	}
+	return f.blockedUsers[arg.BlockedID], nil
+}
+
+func (f *fakeRoomQueries) GetNotificationPrefs(_ context.Context, userID uuid.UUID) (db.NotificationPreference, error) {
+	if f.notificationPrefsErr != nil {
+		return db.NotificationPreference{}, f.notificationPrefsErr
+	}
+	if f.gameInvitePrefs != nil {
+		if enabled, ok := f.gameInvitePrefs[userID]; ok {
+			return db.NotificationPreference{UserID: userID, GameInvite: enabled}, nil
+		}
+	}
+	return db.NotificationPreference{}, pgx.ErrNoRows
 }
 
 func (f *fakeRoomQueries) ListWaitingRoomsWithCount(context.Context, db.ListWaitingRoomsWithCountParams) ([]db.ListWaitingRoomsWithCountRow, error) {

--- a/apps/server/internal/domain/room/service_queries.go
+++ b/apps/server/internal/domain/room/service_queries.go
@@ -21,6 +21,10 @@ type roomQueries interface {
 	GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error)
 	GetThemeCharacter(ctx context.Context, id uuid.UUID) (db.ThemeCharacter, error)
 	GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.ThemeCharacter, error)
+	GetUser(ctx context.Context, id uuid.UUID) (db.User, error)
+	GetFriendshipBetween(ctx context.Context, arg db.GetFriendshipBetweenParams) (db.Friendship, error)
+	GetNotificationPrefs(ctx context.Context, userID uuid.UUID) (db.NotificationPreference, error)
+	IsBlocked(ctx context.Context, arg db.IsBlockedParams) (bool, error)
 	ListWaitingRoomsWithCount(ctx context.Context, arg db.ListWaitingRoomsWithCountParams) ([]db.ListWaitingRoomsWithCountRow, error)
 	RemoveRoomPlayer(ctx context.Context, arg db.RemoveRoomPlayerParams) error
 	SetRoomPlayerCharacter(ctx context.Context, arg db.SetRoomPlayerCharacterParams) (int64, error)

--- a/apps/web/src/features/lobby/api.test.tsx
+++ b/apps/web/src/features/lobby/api.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/services/queryClient', () => ({
 import { api } from '@/services/api';
 import {
   roomKeys,
+  useInviteRoomFriends,
   useRoom,
   useSelectRoomCharacter,
   useSetReady,
@@ -144,6 +145,25 @@ describe('lobby pregame mutations', () => {
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: roomKeys.list(),
+    });
+  });
+
+  it('useInviteRoomFriends posts friend_ids to room invites endpoint', async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({
+      sent: [{ friend_id: 'friend-1', nickname: '민재', online: true }],
+      skipped: [{ friend_id: 'friend-2', reason: 'already_invited' }],
+    });
+    const { result } = renderHook(() => useInviteRoomFriends(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        roomId: 'room-1',
+        friend_ids: ['friend-1', 'friend-2'],
+      });
+    });
+
+    expect(api.post).toHaveBeenCalledWith('/v1/rooms/room-1/invites', {
+      friend_ids: ['friend-1', 'friend-2'],
     });
   });
 });

--- a/apps/web/src/features/lobby/api.ts
+++ b/apps/web/src/features/lobby/api.ts
@@ -95,6 +95,27 @@ export interface SelectRoomCharacterRequest {
   characterId: string;
 }
 
+export interface InviteRoomFriendsRequest {
+  roomId: string;
+  friend_ids: string[];
+}
+
+export interface RoomInviteSent {
+  friend_id: string;
+  nickname: string;
+  online: boolean;
+}
+
+export interface RoomInviteSkipped {
+  friend_id: string;
+  reason: string;
+}
+
+export interface InviteRoomFriendsResponse {
+  sent: RoomInviteSent[];
+  skipped: RoomInviteSkipped[];
+}
+
 export interface PaginationParams {
   limit?: number;
   offset?: number;
@@ -246,5 +267,12 @@ export function useStartRoom() {
       queryClient.invalidateQueries({ queryKey: roomKeys.detail(roomId) });
       queryClient.invalidateQueries({ queryKey: roomKeys.list() });
     },
+  });
+}
+
+export function useInviteRoomFriends() {
+  return useMutation<InviteRoomFriendsResponse, Error, InviteRoomFriendsRequest>({
+    mutationFn: ({ roomId, friend_ids }) =>
+      api.post<InviteRoomFriendsResponse>(`/v1/rooms/${roomId}/invites`, { friend_ids }),
   });
 }

--- a/apps/web/src/features/room/components/RoomInvitePanel.tsx
+++ b/apps/web/src/features/room/components/RoomInvitePanel.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+import { Send, UserPlus } from 'lucide-react';
+
+import { useInviteRoomFriends } from '@/features/lobby/api';
+import { useFriends } from '@/features/social/api';
+import { Alert, Button, Panel } from '@/shared/components/ui';
+
+interface RoomInvitePanelProps {
+  roomId: string;
+  isHost: boolean;
+}
+
+export function RoomInvitePanel({ roomId, isHost }: RoomInvitePanelProps) {
+  const friends = useFriends();
+  const inviteFriends = useInviteRoomFriends();
+  const [selectedFriendIds, setSelectedFriendIds] = useState<string[]>([]);
+
+  const selectedCount = selectedFriendIds.length;
+  const inviteResult = inviteFriends.data;
+  const statusMessage = useMemo(() => {
+    if (!inviteResult) return null;
+    return `초대 ${inviteResult.sent?.length ?? 0}명 전송, ${inviteResult.skipped?.length ?? 0}명 건너뜀`;
+  }, [inviteResult]);
+
+  const toggleFriend = (friendId: string) => {
+    setSelectedFriendIds((current) =>
+      current.includes(friendId) ? current.filter((id) => id !== friendId) : [...current, friendId]
+    );
+  };
+
+  const handleInvite = () => {
+    if (!selectedCount) return;
+    inviteFriends.mutate({
+      roomId,
+      friend_ids: selectedFriendIds,
+    });
+  };
+
+  return (
+    <Panel className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[var(--mmp-color-ink)]">
+            <UserPlus className="h-4 w-4" />
+            친구 초대
+          </h2>
+          <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">
+            방 코드는 헤더에서 복사할 수 있습니다.
+          </p>
+        </div>
+        {isHost && (
+          <Button
+            size="sm"
+            leftIcon={<Send className="h-4 w-4" />}
+            onClick={handleInvite}
+            disabled={selectedCount === 0}
+            isLoading={inviteFriends.isPending}
+          >
+            선택한 친구 초대
+          </Button>
+        )}
+      </div>
+
+      {!isHost ? (
+        <p className="text-sm text-[var(--mmp-color-steel)]">
+          친구 초대는 방장만 보낼 수 있습니다.
+        </p>
+      ) : friends.isLoading ? (
+        <p className="text-sm text-[var(--mmp-color-steel)]">친구 목록을 불러오는 중입니다.</p>
+      ) : friends.isError ? (
+        <Alert tone="error" title="친구 목록을 불러올 수 없습니다" />
+      ) : (friends.data?.length ?? 0) === 0 ? (
+        <p className="text-sm text-[var(--mmp-color-steel)]">
+          아직 초대할 친구가 없습니다. 친구를 추가한 뒤 다시 시도해 주세요.
+        </p>
+      ) : (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {(friends.data ?? []).map((friend) => (
+            <label
+              key={friend.id}
+              className="flex min-h-10 items-center gap-2 rounded-md border border-[var(--mmp-color-hairline)] px-3 py-2 text-sm text-[var(--mmp-color-charcoal)]"
+            >
+              <input
+                type="checkbox"
+                checked={selectedFriendIds.includes(friend.id)}
+                onChange={() => toggleFriend(friend.id)}
+                className="h-4 w-4 accent-[var(--mmp-color-primary)]"
+              />
+              <span className="font-medium text-[var(--mmp-color-ink)]">{friend.nickname}</span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      {statusMessage && (
+        <p className="text-sm font-medium text-[var(--mmp-color-success)]">{statusMessage}</p>
+      )}
+      {inviteFriends.isError && (
+        <p className="text-sm font-medium text-[var(--mmp-color-error)]">
+          초대를 보내지 못했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+      )}
+    </Panel>
+  );
+}

--- a/apps/web/src/features/room/components/index.ts
+++ b/apps/web/src/features/room/components/index.ts
@@ -1,5 +1,6 @@
 export { PlayerList } from './PlayerList';
 export { RoomHeader } from './RoomHeader';
+export { RoomInvitePanel } from './RoomInvitePanel';
 export { HostControls } from './HostControls';
 export { RoomChat } from './RoomChat';
 export { CharacterSelectionPanel } from './CharacterSelectionPanel';

--- a/apps/web/src/features/social/hooks/useSocialSync.test.tsx
+++ b/apps/web/src/features/social/hooks/useSocialSync.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
+import { toast } from 'sonner';
+
+import { queryClient } from '@/services/queryClient';
+import { useConnectionStore } from '@/stores/connectionStore';
+import { useSocialStore } from '@/stores/socialStore';
+import { socialKeys } from '../api';
+import { useSocialSync } from './useSocialSync';
+
+vi.mock('sonner', () => ({
+  toast: vi.fn(),
+}));
+
+function makeClient() {
+  const handlers = new Map<string, (payload: unknown) => void>();
+  return {
+    handlers,
+    client: {
+      on: vi.fn((event: string, handler: (payload: unknown) => void) => {
+        handlers.set(event, handler);
+        return vi.fn();
+      }),
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  useConnectionStore.setState({ socialClient: null });
+  useSocialStore.getState().reset();
+  queryClient.clear();
+});
+
+describe('useSocialSync room invites', () => {
+  it('room:invite 이벤트를 받으면 새로고침 없이 방으로 이동하는 액션이 있는 toast를 표시한다', () => {
+    const { client, handlers } = makeClient();
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+    useConnectionStore.setState({ socialClient: client as never });
+
+    renderHook(() => useSocialSync());
+
+    handlers.get('room:invite')?.({
+      room_id: 'room-1',
+      code: 'ABC123',
+      theme_title: '초대받지 않은 손님',
+      inviter_id: 'host-1',
+      inviter_nickname: '호스트',
+    });
+
+    expect(toast).toHaveBeenCalledWith(
+      '호스트님이 초대받지 않은 손님 방에 초대했습니다.',
+      expect.objectContaining({
+        description: '방 코드 ABC123',
+        action: expect.objectContaining({ label: '입장' }),
+      })
+    );
+    const options = vi.mocked(toast).mock.calls[0]?.[1] as { action?: { onClick?: () => void } };
+    options.action?.onClick?.();
+    expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/room/room-1');
+    expect(dispatchEventSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'popstate' }));
+  });
+});
+
+describe('useSocialSync existing social events', () => {
+  it('friend online/offline 이벤트를 social store에 반영한다', () => {
+    const { client, handlers } = makeClient();
+    useConnectionStore.setState({ socialClient: client as never });
+
+    renderHook(() => useSocialSync());
+
+    handlers.get('friend:online')?.({ user_id: 'friend-1' });
+    expect(useSocialStore.getState().onlineFriends.has('friend-1')).toBe(true);
+
+    handlers.get('friend:offline')?.({ user_id: 'friend-1' });
+    expect(useSocialStore.getState().onlineFriends.has('friend-1')).toBe(false);
+  });
+
+  it('chat message/read receipt 이벤트가 unread와 query invalidation을 유지한다', () => {
+    const { client, handlers } = makeClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    useConnectionStore.setState({ socialClient: client as never });
+
+    renderHook(() => useSocialSync());
+
+    handlers.get('chat:message')?.({ chat_room_id: 'chat-1', sender_id: 'friend-1' });
+    expect(useSocialStore.getState().unreadCounts.get('chat-1')).toBe(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: socialKeys.messages('chat-1') });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: socialKeys.chatRooms() });
+
+    handlers.get('chat:read_receipt')?.({});
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: socialKeys.chatRooms() });
+  });
+});

--- a/apps/web/src/features/social/hooks/useSocialSync.ts
+++ b/apps/web/src/features/social/hooks/useSocialSync.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { WsClient } from "@mmp/ws-client";
+import { toast } from "sonner";
 
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useSocialStore } from "@/stores/socialStore";
@@ -23,13 +24,17 @@ interface ChatMessagePayload {
   sender_id: string;
 }
 
-interface ChatReadPayload {
-  chat_room_id: string;
-}
-
 interface ChatTypingPayload {
   room_id: string;
   user_id: string;
+}
+
+interface RoomInvitePayload {
+  room_id: string;
+  code: string;
+  theme_title: string;
+  inviter_id: string;
+  inviter_nickname: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -44,6 +49,7 @@ const SOCIAL_EVENT = {
   CHAT_MESSAGE: "chat:message",
   CHAT_READ_RECEIPT: "chat:read_receipt",
   CHAT_TYPING_INDICATOR: "chat:typing_indicator",
+  ROOM_INVITE: "room:invite",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -118,10 +124,10 @@ export function useSocialSync(): void {
     );
 
     // chat:read_receipt → invalidate room queries
-    subscribe<ChatReadPayload>(
+    subscribe<Record<string, never>>(
       client,
       SOCIAL_EVENT.CHAT_READ_RECEIPT,
-      (payload) => {
+      () => {
         queryClient.invalidateQueries({
           queryKey: socialKeys.chatRooms(),
         });
@@ -163,6 +169,27 @@ export function useSocialSync(): void {
         queryClient.invalidateQueries({
           queryKey: socialKeys.friends(),
         });
+      },
+    );
+
+    // room:invite → surface a direct room entry action
+    subscribe<RoomInvitePayload>(
+      client,
+      SOCIAL_EVENT.ROOM_INVITE,
+      (payload) => {
+        toast(
+          `${payload.inviter_nickname}님이 ${payload.theme_title} 방에 초대했습니다.`,
+          {
+            description: `방 코드 ${payload.code}`,
+            action: {
+              label: "입장",
+              onClick: () => {
+                window.history.pushState({}, "", `/room/${payload.room_id}`);
+                window.dispatchEvent(new Event("popstate"));
+              },
+            },
+          },
+        );
       },
     );
 

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -18,6 +18,7 @@ import { Alert, Button, LoadingState, PageShell } from '@/shared/components/ui';
 import {
   PlayerList,
   RoomHeader,
+  RoomInvitePanel,
   HostControls,
   RoomChat,
   CharacterSelectionPanel,
@@ -257,6 +258,9 @@ export default function RoomPage() {
               maxPlayers={room.max_players}
               characterNameById={characterNameById}
             />
+            {id && room.status.toLowerCase() === 'waiting' && (
+              <RoomInvitePanel roomId={id} isHost={isHost} />
+            )}
             {currentPlayer && (
               <CharacterSelectionPanel
                 characters={themeCharacters.data ?? []}

--- a/apps/web/src/pages/__tests__/RoomPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RoomPage.test.tsx
@@ -9,6 +9,7 @@ const {
   refetchMock,
   sendMock,
   useRoomMock,
+  useInviteRoomFriendsMock,
   useLeaveRoomMock,
   useSelectRoomCharacterMock,
   useSetReadyMock,
@@ -20,6 +21,7 @@ const {
   refetchMock: vi.fn(),
   sendMock: vi.fn(),
   useRoomMock: vi.fn(),
+  useInviteRoomFriendsMock: vi.fn(),
   useLeaveRoomMock: vi.fn(),
   useSelectRoomCharacterMock: vi.fn(),
   useSetReadyMock: vi.fn(),
@@ -39,11 +41,37 @@ vi.mock('react-router', async () => {
 
 vi.mock('@/features/lobby/api', () => ({
   useRoom: () => useRoomMock(),
+  useInviteRoomFriends: () => useInviteRoomFriendsMock(),
   useLeaveRoom: () => useLeaveRoomMock(),
   useSelectRoomCharacter: () => useSelectRoomCharacterMock(),
   useSetReady: () => useSetReadyMock(),
   useStartRoom: () => useStartRoomMock(),
   useThemeCharacters: (themeId: string) => useThemeCharactersMock(themeId),
+}));
+
+vi.mock('@/features/social/api', () => ({
+  useFriends: () => ({
+    data: [
+      {
+        id: 'friend-1',
+        nickname: '민재',
+        avatar_url: null,
+        role: 'user',
+        friendship_id: 'friendship-1',
+        since: '2026-05-19T00:00:00Z',
+      },
+      {
+        id: 'friend-2',
+        nickname: '하윤',
+        avatar_url: null,
+        role: 'user',
+        friendship_id: 'friendship-2',
+        since: '2026-05-19T00:00:00Z',
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
 }));
 
 vi.mock('@/hooks/useWsClient', () => ({
@@ -145,6 +173,9 @@ function mockRoomPage(
     selectMutate?: ReturnType<typeof vi.fn>;
     startMutate?: ReturnType<typeof vi.fn>;
     leaveMutate?: ReturnType<typeof vi.fn>;
+    inviteMutate?: ReturnType<typeof vi.fn>;
+    inviteData?: unknown;
+    invitePending?: boolean;
     readyPending?: boolean;
     startPending?: boolean;
   } = {}
@@ -158,6 +189,11 @@ function mockRoomPage(
   useLeaveRoomMock.mockReturnValue({
     mutate: overrides.leaveMutate ?? vi.fn(),
     isPending: false,
+  });
+  useInviteRoomFriendsMock.mockReturnValue({
+    mutate: overrides.inviteMutate ?? vi.fn(),
+    data: overrides.inviteData,
+    isPending: overrides.invitePending ?? false,
   });
   useThemeCharactersMock.mockReturnValue({
     data: baseCharacters,
@@ -416,5 +452,59 @@ describe('RoomPage pregame controls', () => {
     fireEvent.click(startButton);
 
     expect(startMutate).not.toHaveBeenCalled();
+  });
+
+  it('호스트는 대기방에서 친구를 선택해 방 초대를 보낼 수 있다', () => {
+    const inviteMutate = vi.fn();
+    useAuthStore.setState({
+      user: { id: 'host-1', email: 'host@example.com', nickname: '호스트', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({ inviteMutate });
+
+    renderRoom();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /민재/ }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /하윤/ }));
+    fireEvent.click(screen.getByRole('button', { name: /선택한 친구 초대/ }));
+
+    expect(inviteMutate).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      friend_ids: ['friend-1', 'friend-2'],
+    });
+  });
+
+  it('초대 성공 후 전송/건너뜀 결과 수를 표시한다', () => {
+    useAuthStore.setState({
+      user: { id: 'host-1', email: 'host@example.com', nickname: '호스트', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({
+      inviteData: {
+        sent: [{ friend_id: 'friend-1', nickname: '민재', online: true }],
+        skipped: [{ friend_id: 'friend-2', reason: 'already_in_room' }],
+      },
+    });
+
+    renderRoom();
+
+    expect(screen.getByText('초대 1명 전송, 1명 건너뜀')).toBeInTheDocument();
+  });
+
+  it('초대 응답의 sent/skipped가 null이어도 결과 영역이 깨지지 않는다', () => {
+    useAuthStore.setState({
+      user: { id: 'host-1', email: 'host@example.com', nickname: '호스트', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage({
+      inviteData: {
+        sent: null,
+        skipped: null,
+      },
+    });
+
+    renderRoom();
+
+    expect(screen.getByText('초대 0명 전송, 0명 건너뜀')).toBeInTheDocument();
   });
 });

--- a/docs/plans/2026-05-20-pregame-lobby-room/checklist.md
+++ b/docs/plans/2026-05-20-pregame-lobby-room/checklist.md
@@ -1,0 +1,40 @@
+# Issue #691 Pregame Lobby/Room Workflow
+
+## Slice 3: Room Invites
+
+Scope:
+- Existing room code/link sharing remains the canonical invite entry.
+- Hosts can invite accepted friends from the waiting room.
+- Online invitees receive a social WebSocket `room:invite` event with the room code and room route.
+- Offline durable notification storage is excluded from this slice; add a follow-up only if product requires invite history.
+
+Coverage Plan:
+- Backend handler: auth required, invalid room ID, request decode, service delegation.
+- Backend service: inviter must be participant, room must be `WAITING`, target must be accepted friend, blocked/already-in-room/notification-disabled targets are skipped, notifier result is reflected.
+- Frontend API/UI: room link copy, friend picker states, successful/partial invite status.
+- Social sync: `room:invite` shows a toast with join action and does not break existing friend/chat events.
+- Browser QA: host invites a friend or simulated social event opens `/room/:id` or code join path.
+
+Checklist:
+- [x] Diagnose stalled workflow and avoid stale sub-agent close path.
+- [x] Merge Slice 2 character selection/start gate PR.
+- [x] Start Slice 3 branch from latest `main`.
+- [x] Run read-only parallel coordinator for invite architecture.
+- [x] Implement backend invite API and validation.
+- [x] Wire room invite notifier to social WebSocket hub.
+- [x] Implement frontend room link copy and friend invite picker.
+- [x] Handle incoming `room:invite` event in social sync.
+- [x] Add focused tests.
+- [x] Run focused validation and browser QA.
+- [ ] Create PR, request Codex review, resolve findings, merge.
+
+Open Decisions:
+- Durable offline invite table: excluded from Slice 3.
+- Private room access policy: unchanged; invite shares the existing room code/link and join gate remains server-owned.
+
+Validation Notes:
+- Focused backend: `cd apps/server && go test -count=1 ./internal/domain/room ./cmd/server`.
+- Focused frontend: `pnpm --filter @mmp/web test -- src/features/social/hooks/useSocialSync.test.tsx src/pages/__tests__/RoomPage.test.tsx src/features/lobby/api.test.tsx`.
+- Frontend type/lint: `pnpm --filter @mmp/web typecheck`, `pnpm --filter @mmp/web lint` (existing warnings only).
+- Browser QA: `127.0.0.1:3000` host room invite, `POST /api/v1/rooms/7b6bb5d7-f98b-4c5c-8d3b-b3062cb69103/invites => 200`, UI displayed `초대 1명 전송, 0명 건너뜀`; temp DB rows cleaned.
+- `scripts/mmp-local-ci.sh quick` reached full `go test -race ./...` but failed in existing `internal/domain/flow` testcontainer setup with Docker socket `context deadline exceeded`; changed room package passed.


### PR DESCRIPTION
## 요약
- 대기방 호스트가 수락된 친구를 선택해 방 초대를 보낼 수 있게 추가했습니다.
- 서버에서 host-only, WAITING 상태, 참가자 여부, 친구/차단/알림 preference를 검증하고 online 대상에게 `room:invite` social WS payload를 전송합니다.
- 초대 toast의 입장 액션은 전체 새로고침 대신 SPA route 이동으로 처리해 인증 상태를 유지합니다.

## Coverage Plan
- Backend handler: auth required, invalid room ID, invalid JSON, service delegation.
- Backend service: host-only, participant check, WAITING room, accepted friend, invalid/duplicate/already participant/blocked/notification disabled/notifier failure skip.
- Frontend API/UI: invite mutation, host friend picker, null sent/skipped response safety, existing room controls.
- Social sync: `room:invite` toast action plus existing friend/chat/read receipt event regression.
- Browser QA: host room invite click against local dev server.

## Local validation
- `cd apps/server && go test -count=1 ./internal/domain/room ./cmd/server` ✅
- `pnpm --filter @mmp/web test -- src/features/social/hooks/useSocialSync.test.tsx src/pages/__tests__/RoomPage.test.tsx src/features/lobby/api.test.tsx` ✅
- `pnpm --filter @mmp/web typecheck` ✅
- `pnpm --filter @mmp/web lint` ✅ (기존 warning 39개, 이번 변경 파일 신규 warning 없음)
- Browser QA ✅: `127.0.0.1:3000`에서 host가 `테스터` 친구 선택 → `POST /api/v1/rooms/7b6bb5d7-f98b-4c5c-8d3b-b3062cb69103/invites => 200` → UI `초대 1명 전송, 0명 건너뜀` 확인. 임시 DB row cleanup 완료.

## Local CI note
- `scripts/mmp-local-ci.sh quick`는 생성물 drift 없이 `go test -race ./...`까지 진행했지만, 기존 `internal/domain/flow` testcontainer setup에서 Docker socket `context deadline exceeded`로 실패했습니다.
- 변경 범위인 `internal/domain/room`, `cmd/server`, web invite/social sync focused 검증은 통과했습니다.

Refs #691
