### PR TITLE
feat: 대기방 음성 채팅 연결

### DIFF
--- a/apps/server/internal/domain/voice/service.go
+++ b/apps/server/internal/domain/voice/service.go
@@ -8,7 +8,8 @@ import (
 
 // TokenRequest is the payload for requesting a voice room token.
 type TokenRequest struct {
-	SessionID string `json:"session_id" validate:"required"`
+	SessionID string `json:"session_id" validate:"omitempty"`
+	RoomID    string `json:"room_id"    validate:"omitempty"`
 	RoomType  string `json:"room_type"  validate:"required,oneof=main whisper"`
 	RoomName  string `json:"room_name"  validate:"omitempty,max=64"`
 }

--- a/apps/server/internal/domain/voice/service_impl.go
+++ b/apps/server/internal/domain/voice/service_impl.go
@@ -26,9 +26,15 @@ var roomNameRe = regexp.MustCompile(`^[a-zA-Z0-9\-]{1,64}$`)
 
 type serviceImpl struct {
 	provider VoiceProvider
-	queries  *db.Queries
+	queries  voiceQueries
 	lkURL    string
 	logger   zerolog.Logger
+}
+
+type voiceQueries interface {
+	GetSessionPlayers(ctx context.Context, sessionID uuid.UUID) ([]db.SessionPlayer, error)
+	GetRoom(ctx context.Context, id uuid.UUID) (db.Room, error)
+	GetRoomPlayers(ctx context.Context, roomID uuid.UUID) ([]db.RoomPlayer, error)
 }
 
 // NewService creates a new voice service.
@@ -44,35 +50,14 @@ func NewService(provider VoiceProvider, queries *db.Queries, lkURL string, logge
 // GetToken validates the request, ensures the LiveKit room exists, and returns
 // a signed token the client can use to connect.
 func (s *serviceImpl) GetToken(ctx context.Context, userID uuid.UUID, req TokenRequest) (*TokenResponse, error) {
-	// C3: Validate session_id as UUID.
-	sessionID, err := uuid.Parse(req.SessionID)
-	if err != nil {
-		return nil, apperror.BadRequest("session_id must be a valid UUID")
-	}
-
 	// C3: Validate room_name format when provided.
 	if req.RoomName != "" && !roomNameRe.MatchString(req.RoomName) {
 		return nil, apperror.BadRequest("room_name must contain only alphanumerics and hyphens, max 64 characters")
 	}
 
-	// C2: Verify the user is a participant of the session.
-	players, err := s.queries.GetSessionPlayers(ctx, sessionID)
+	target, err := s.resolveTokenTarget(ctx, userID, req)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apperror.Forbidden("not a participant of this session")
-		}
-		s.logger.Error().Err(err).Str("session_id", req.SessionID).Msg("failed to get session players")
-		return nil, apperror.Internal("failed to verify session participation")
-	}
-	found := false
-	for _, p := range players {
-		if p.UserID == userID {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, apperror.Forbidden("not a participant of this session")
+		return nil, err
 	}
 
 	var ttl time.Duration
@@ -86,7 +71,7 @@ func (s *serviceImpl) GetToken(ctx context.Context, userID uuid.UUID, req TokenR
 			fmt.Sprintf("invalid room_type %q: must be \"main\" or \"whisper\"", req.RoomType))
 	}
 
-	roomName := s.buildRoomName(req)
+	roomName := s.buildRoomName(req, target)
 
 	if err := s.provider.CreateRoom(ctx, roomName); err != nil {
 		s.logger.Error().Err(err).Str("room", roomName).Msg("failed to create voice room")
@@ -112,6 +97,7 @@ func (s *serviceImpl) GetToken(ctx context.Context, userID uuid.UUID, req TokenR
 		Str("room", roomName).
 		Str("user_id", userID.String()).
 		Str("room_type", req.RoomType).
+		Str("target_kind", target.kind).
 		Msg("voice token issued")
 
 	return &TokenResponse{
@@ -121,10 +107,87 @@ func (s *serviceImpl) GetToken(ctx context.Context, userID uuid.UUID, req TokenR
 	}, nil
 }
 
+type tokenTarget struct {
+	kind string
+	id   uuid.UUID
+}
+
+func (s *serviceImpl) resolveTokenTarget(ctx context.Context, userID uuid.UUID, req TokenRequest) (tokenTarget, error) {
+	hasSessionID := req.SessionID != ""
+	hasRoomID := req.RoomID != ""
+	if hasSessionID == hasRoomID {
+		return tokenTarget{}, apperror.BadRequest("exactly one of session_id or room_id is required")
+	}
+	if hasRoomID {
+		return s.resolveWaitingRoomTarget(ctx, userID, req)
+	}
+	return s.resolveSessionTarget(ctx, userID, req)
+}
+
+func (s *serviceImpl) resolveSessionTarget(ctx context.Context, userID uuid.UUID, req TokenRequest) (tokenTarget, error) {
+	sessionID, err := uuid.Parse(req.SessionID)
+	if err != nil {
+		return tokenTarget{}, apperror.BadRequest("session_id must be a valid UUID")
+	}
+
+	players, err := s.queries.GetSessionPlayers(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return tokenTarget{}, apperror.Forbidden("not a participant of this session")
+		}
+		s.logger.Error().Err(err).Str("session_id", req.SessionID).Msg("failed to get session players")
+		return tokenTarget{}, apperror.Internal("failed to verify session participation")
+	}
+	for _, p := range players {
+		if p.UserID == userID {
+			return tokenTarget{kind: "session", id: sessionID}, nil
+		}
+	}
+	return tokenTarget{}, apperror.Forbidden("not a participant of this session")
+}
+
+func (s *serviceImpl) resolveWaitingRoomTarget(ctx context.Context, userID uuid.UUID, req TokenRequest) (tokenTarget, error) {
+	if req.RoomType != "main" {
+		return tokenTarget{}, apperror.BadRequest("waiting room voice only supports main room_type")
+	}
+	roomID, err := uuid.Parse(req.RoomID)
+	if err != nil {
+		return tokenTarget{}, apperror.BadRequest("room_id must be a valid UUID")
+	}
+
+	room, err := s.queries.GetRoom(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return tokenTarget{}, apperror.Forbidden("not a participant of this room")
+		}
+		s.logger.Error().Err(err).Str("room_id", req.RoomID).Msg("failed to get waiting room")
+		return tokenTarget{}, apperror.Internal("failed to verify room participation")
+	}
+	if room.Status != "WAITING" {
+		return tokenTarget{}, apperror.New(apperror.ErrRoomNotWaiting, http.StatusConflict, "room is not in waiting state")
+	}
+
+	players, err := s.queries.GetRoomPlayers(ctx, roomID)
+	if err != nil {
+		s.logger.Error().Err(err).Str("room_id", req.RoomID).Msg("failed to get waiting room players")
+		return tokenTarget{}, apperror.Internal("failed to verify room participation")
+	}
+	for _, p := range players {
+		if p.UserID == userID {
+			return tokenTarget{kind: "room", id: roomID}, nil
+		}
+	}
+	return tokenTarget{}, apperror.Forbidden("not a participant of this room")
+}
+
 // buildRoomName constructs the LiveKit room name from the request.
-// main:    {sessionID}_main
-// whisper: {sessionID}_{roomName}
-func (s *serviceImpl) buildRoomName(req TokenRequest) string {
+// session main:      {sessionID}_main
+// session whisper:   {sessionID}_{roomName}
+// waiting room main: room-{roomID}-main
+func (s *serviceImpl) buildRoomName(req TokenRequest, target tokenTarget) string {
+	if target.kind == "room" {
+		return fmt.Sprintf("room-%s-%s", target.id.String(), req.RoomType)
+	}
 	if req.RoomType == "whisper" && req.RoomName != "" {
 		return fmt.Sprintf("%s_%s", req.SessionID, req.RoomName)
 	}

--- a/apps/server/internal/domain/voice/service_impl_test.go
+++ b/apps/server/internal/domain/voice/service_impl_test.go
@@ -1,0 +1,265 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/mmp-platform/server/internal/apperror"
+	"github.com/mmp-platform/server/internal/db"
+)
+
+type fakeVoiceQueries struct {
+	sessionPlayers []db.SessionPlayer
+	sessionErr     error
+	room           db.Room
+	roomErr        error
+	roomPlayers    []db.RoomPlayer
+	roomPlayersErr error
+}
+
+func (f *fakeVoiceQueries) GetSessionPlayers(_ context.Context, sessionID uuid.UUID) ([]db.SessionPlayer, error) {
+	if f.sessionErr != nil {
+		return nil, f.sessionErr
+	}
+	return f.sessionPlayers, nil
+}
+
+func (f *fakeVoiceQueries) GetRoom(_ context.Context, id uuid.UUID) (db.Room, error) {
+	if f.roomErr != nil {
+		return db.Room{}, f.roomErr
+	}
+	return f.room, nil
+}
+
+func (f *fakeVoiceQueries) GetRoomPlayers(_ context.Context, roomID uuid.UUID) ([]db.RoomPlayer, error) {
+	if f.roomPlayersErr != nil {
+		return nil, f.roomPlayersErr
+	}
+	return f.roomPlayers, nil
+}
+
+type fakeVoiceProvider struct {
+	createdRoom string
+	tokenRoom   string
+	createErr   error
+	tokenErr    error
+}
+
+func (f *fakeVoiceProvider) GenerateToken(_ context.Context, params TokenParams) (string, error) {
+	f.tokenRoom = params.RoomName
+	if f.tokenErr != nil {
+		return "", f.tokenErr
+	}
+	return "voice-token", nil
+}
+
+func (f *fakeVoiceProvider) CreateRoom(_ context.Context, name string) error {
+	f.createdRoom = name
+	return f.createErr
+}
+
+func (f *fakeVoiceProvider) DestroyRoom(context.Context, string) error {
+	return nil
+}
+
+func TestGetTokenForWaitingRoomUsesRoomPlayers(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	provider := &fakeVoiceProvider{}
+	svc := &serviceImpl{
+		provider: provider,
+		queries: &fakeVoiceQueries{
+			room:        db.Room{ID: roomID, Status: "WAITING"},
+			roomPlayers: []db.RoomPlayer{{RoomID: roomID, UserID: userID}},
+		},
+		lkURL:  "ws://livekit",
+		logger: zerolog.Nop(),
+	}
+
+	resp, err := svc.GetToken(context.Background(), userID, TokenRequest{
+		RoomID:   roomID.String(),
+		RoomType: "main",
+	})
+
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	wantRoomName := "room-" + roomID.String() + "-main"
+	if resp.Token != "voice-token" || resp.URL != "ws://livekit" || resp.RoomName != wantRoomName {
+		t.Fatalf("response mismatch: %+v", resp)
+	}
+	if provider.createdRoom != wantRoomName || provider.tokenRoom != wantRoomName {
+		t.Fatalf("provider room mismatch: create=%q token=%q want %q", provider.createdRoom, provider.tokenRoom, wantRoomName)
+	}
+}
+
+func TestGetTokenForWaitingRoomRequiresParticipant(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	svc := &serviceImpl{
+		provider: &fakeVoiceProvider{},
+		queries: &fakeVoiceQueries{
+			room:        db.Room{ID: roomID, Status: "WAITING"},
+			roomPlayers: []db.RoomPlayer{{RoomID: roomID, UserID: uuid.New()}},
+		},
+		logger: zerolog.Nop(),
+	}
+
+	_, err := svc.GetToken(context.Background(), userID, TokenRequest{
+		RoomID:   roomID.String(),
+		RoomType: "main",
+	})
+
+	assertVoiceAppError(t, err, http.StatusForbidden)
+}
+
+func TestGetTokenForWaitingRoomRequiresWaitingStatus(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	svc := &serviceImpl{
+		provider: &fakeVoiceProvider{},
+		queries: &fakeVoiceQueries{
+			room:        db.Room{ID: roomID, Status: "PLAYING"},
+			roomPlayers: []db.RoomPlayer{{RoomID: roomID, UserID: userID}},
+		},
+		logger: zerolog.Nop(),
+	}
+
+	_, err := svc.GetToken(context.Background(), userID, TokenRequest{
+		RoomID:   roomID.String(),
+		RoomType: "main",
+	})
+
+	assertVoiceAppError(t, err, http.StatusConflict)
+}
+
+func TestGetTokenForWaitingRoomRejectsWhisper(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	svc := &serviceImpl{
+		provider: &fakeVoiceProvider{},
+		queries:  &fakeVoiceQueries{},
+		logger:   zerolog.Nop(),
+	}
+
+	_, err := svc.GetToken(context.Background(), userID, TokenRequest{
+		RoomID:   roomID.String(),
+		RoomType: "whisper",
+		RoomName: "side",
+	})
+
+	assertVoiceAppError(t, err, http.StatusBadRequest)
+}
+
+func TestGetTokenRequiresExactlyOneTarget(t *testing.T) {
+	svc := &serviceImpl{
+		provider: &fakeVoiceProvider{},
+		queries:  &fakeVoiceQueries{},
+		logger:   zerolog.Nop(),
+	}
+
+	_, err := svc.GetToken(context.Background(), uuid.New(), TokenRequest{RoomType: "main"})
+	assertVoiceAppError(t, err, http.StatusBadRequest)
+
+	_, err = svc.GetToken(context.Background(), uuid.New(), TokenRequest{
+		SessionID: uuid.New().String(),
+		RoomID:    uuid.New().String(),
+		RoomType:  "main",
+	})
+	assertVoiceAppError(t, err, http.StatusBadRequest)
+}
+
+func TestGetTokenForSessionStillUsesSessionPlayers(t *testing.T) {
+	sessionID := uuid.New()
+	userID := uuid.New()
+	provider := &fakeVoiceProvider{}
+	svc := &serviceImpl{
+		provider: provider,
+		queries: &fakeVoiceQueries{
+			sessionPlayers: []db.SessionPlayer{{SessionID: sessionID, UserID: userID}},
+		},
+		lkURL:  "ws://livekit",
+		logger: zerolog.Nop(),
+	}
+
+	resp, err := svc.GetToken(context.Background(), userID, TokenRequest{
+		SessionID: sessionID.String(),
+		RoomType:  "main",
+	})
+
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if resp.RoomName != sessionID.String()+"_main" {
+		t.Fatalf("room_name = %q", resp.RoomName)
+	}
+}
+
+func TestGetTokenProviderFailures(t *testing.T) {
+	roomID := uuid.New()
+	userID := uuid.New()
+	baseQueries := &fakeVoiceQueries{
+		room:        db.Room{ID: roomID, Status: "WAITING"},
+		roomPlayers: []db.RoomPlayer{{RoomID: roomID, UserID: userID}},
+	}
+
+	tests := []struct {
+		name     string
+		provider *fakeVoiceProvider
+	}{
+		{name: "create room", provider: &fakeVoiceProvider{createErr: errors.New("livekit unavailable")}},
+		{name: "generate token", provider: &fakeVoiceProvider{tokenErr: errors.New("sign failed")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &serviceImpl{
+				provider: tt.provider,
+				queries:  baseQueries,
+				logger:   zerolog.Nop(),
+			}
+
+			_, err := svc.GetToken(context.Background(), userID, TokenRequest{
+				RoomID:   roomID.String(),
+				RoomType: "main",
+			})
+
+			assertVoiceAppError(t, err, http.StatusInternalServerError)
+		})
+	}
+}
+
+func TestGetTokenWaitingRoomMissing(t *testing.T) {
+	svc := &serviceImpl{
+		provider: &fakeVoiceProvider{},
+		queries:  &fakeVoiceQueries{roomErr: pgx.ErrNoRows},
+		logger:   zerolog.Nop(),
+	}
+
+	_, err := svc.GetToken(context.Background(), uuid.New(), TokenRequest{
+		RoomID:   uuid.New().String(),
+		RoomType: "main",
+	})
+
+	assertVoiceAppError(t, err, http.StatusForbidden)
+}
+
+func assertVoiceAppError(t *testing.T, err error, wantStatus int) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error status %d, got nil", wantStatus)
+	}
+	var appErr *apperror.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected AppError, got %T: %v", err, err)
+	}
+	if appErr.Status != wantStatus {
+		t.Fatalf("status = %d, want %d: %v", appErr.Status, wantStatus, err)
+	}
+}

--- a/apps/web/src/features/room/components/RoomVoicePanel.tsx
+++ b/apps/web/src/features/room/components/RoomVoicePanel.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo } from 'react';
+import { Mic, MicOff, Phone, PhoneOff, Volume2, VolumeX } from 'lucide-react';
+
+import { useVoiceConnection } from '@/hooks/useVoiceConnection';
+import { useVoiceStore, selectIsMuted, selectIsSpeakerMuted, selectVoiceConnectionState } from '@/stores/voiceStore';
+import { Button, Panel } from '@/shared/components/ui';
+
+interface RoomVoicePanelProps {
+  roomId: string;
+  isActive: boolean;
+}
+
+const stateLabel = {
+  disconnected: '연결 안 됨',
+  connecting: '연결 중',
+  connected: '연결됨',
+  error: '연결 실패',
+} as const;
+
+export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
+  const connectionState = useVoiceStore(selectVoiceConnectionState);
+  const isMuted = useVoiceStore(selectIsMuted);
+  const isSpeakerMuted = useVoiceStore(selectIsSpeakerMuted);
+  const resetVoice = useVoiceStore((state) => state.reset);
+  const { participants, localParticipant, connect, disconnect, toggleMute, toggleSpeakerMute } =
+    useVoiceConnection({
+      roomId,
+      roomType: 'main',
+      autoConnect: false,
+    });
+
+  useEffect(() => {
+    if (isActive) return;
+    void disconnect();
+    resetVoice();
+  }, [disconnect, isActive, resetVoice]);
+
+  useEffect(() => {
+    return () => {
+      void disconnect();
+      resetVoice();
+    };
+  }, [disconnect, resetVoice]);
+
+  const participantCount = participants.length + (localParticipant ? 1 : 0);
+  const canDisconnect = connectionState === 'connected' || connectionState === 'connecting';
+  const helperText = useMemo(() => {
+    if (!isActive) return '게임 시작 또는 방 나가기 중에는 음성 연결을 정리합니다.';
+    if (connectionState === 'error') return '음성 서버 연결에 실패했습니다. 잠시 후 다시 시도해 주세요.';
+    if (connectionState === 'connected') return `${participantCount}명이 음성 채팅에 연결되어 있습니다.`;
+    return '대기방 참가자만 음성 채팅에 들어갈 수 있습니다.';
+  }, [connectionState, isActive, participantCount]);
+
+  return (
+    <Panel className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[var(--mmp-color-ink)]">
+            <Mic className="h-4 w-4" />
+            음성 채팅
+          </h2>
+          <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">{stateLabel[connectionState]}</p>
+        </div>
+        {canDisconnect ? (
+          <Button
+            size="sm"
+            variant="secondary"
+            leftIcon={<PhoneOff className="h-4 w-4" />}
+            onClick={() => void disconnect()}
+          >
+            나가기
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            leftIcon={<Phone className="h-4 w-4" />}
+            onClick={() => void connect()}
+            isLoading={connectionState === 'connecting'}
+            disabled={!isActive}
+          >
+            입장
+          </Button>
+        )}
+      </div>
+
+      <p
+        className={`text-sm ${
+          connectionState === 'error'
+            ? 'font-medium text-[var(--mmp-color-error)]'
+            : 'text-[var(--mmp-color-steel)]'
+        }`}
+      >
+        {helperText}
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant={isMuted ? 'danger' : 'secondary'}
+          leftIcon={isMuted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+          onClick={() => void toggleMute()}
+          disabled={connectionState !== 'connected'}
+        >
+          {isMuted ? '마이크 켜기' : '마이크 끄기'}
+        </Button>
+        <Button
+          size="sm"
+          variant={isSpeakerMuted ? 'danger' : 'secondary'}
+          leftIcon={isSpeakerMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
+          onClick={toggleSpeakerMute}
+          disabled={connectionState !== 'connected'}
+        >
+          {isSpeakerMuted ? '스피커 켜기' : '스피커 끄기'}
+        </Button>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/web/src/features/room/components/index.ts
+++ b/apps/web/src/features/room/components/index.ts
@@ -1,6 +1,7 @@
 export { PlayerList } from './PlayerList';
 export { RoomHeader } from './RoomHeader';
 export { RoomInvitePanel } from './RoomInvitePanel';
+export { RoomVoicePanel } from './RoomVoicePanel';
 export { HostControls } from './HostControls';
 export { RoomChat } from './RoomChat';
 export { CharacterSelectionPanel } from './CharacterSelectionPanel';

--- a/apps/web/src/hooks/__tests__/useVoiceConnection.test.ts
+++ b/apps/web/src/hooks/__tests__/useVoiceConnection.test.ts
@@ -1,0 +1,92 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useVoiceConnection } from "@/hooks/useVoiceConnection";
+import { voiceApi } from "@/services/voiceApi";
+import { useVoiceStore } from "@/stores/voiceStore";
+
+const roomConnectMock = vi.fn();
+const roomDisconnectMock = vi.fn();
+const roomOnMock = vi.fn();
+
+vi.mock("livekit-client", () => ({
+  RoomEvent: {
+    Connected: "connected",
+    Disconnected: "disconnected",
+    Reconnecting: "reconnecting",
+    ParticipantConnected: "participantConnected",
+    ParticipantDisconnected: "participantDisconnected",
+  },
+  Room: vi.fn().mockImplementation(() => ({
+    connect: roomConnectMock,
+    disconnect: roomDisconnectMock,
+    on: roomOnMock,
+    remoteParticipants: new Map(),
+    localParticipant: { setMicrophoneEnabled: vi.fn() },
+  })),
+}));
+
+vi.mock("@/services/voiceApi", () => ({
+  voiceApi: {
+    getTokenForTarget: vi.fn(),
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useVoiceStore.getState().reset();
+});
+
+describe("useVoiceConnection", () => {
+  it("does not connect a stale manual connection after disconnect cleanup", async () => {
+    const token = deferred<{
+      token: string;
+      room_name: string;
+      livekit_url: string;
+    }>();
+    vi.mocked(voiceApi.getTokenForTarget).mockReturnValue(token.promise);
+
+    const { result } = renderHook(() =>
+      useVoiceConnection({
+        roomId: "room-1",
+        roomType: "main",
+        autoConnect: false,
+      }),
+    );
+
+    void act(() => {
+      void result.current.connect();
+    });
+
+    expect(useVoiceStore.getState().connectionState).toBe("connecting");
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    await act(async () => {
+      token.resolve({
+        token: "late-token",
+        room_name: "room-room-1-main",
+        livekit_url: "ws://livekit",
+      });
+      await token.promise;
+    });
+
+    await waitFor(() => {
+      expect(roomConnectMock).not.toHaveBeenCalled();
+    });
+    expect(useVoiceStore.getState().connectionState).toBe("disconnected");
+  });
+});

--- a/apps/web/src/hooks/useVoiceConnection.ts
+++ b/apps/web/src/hooks/useVoiceConnection.ts
@@ -16,8 +16,9 @@ import { useVoiceStore } from "@/stores/voiceStore";
 export type VoiceParticipant = LocalParticipant | RemoteParticipant;
 
 interface UseVoiceConnectionOptions {
-  sessionId: string;
-  roomType: string;
+  sessionId?: string;
+  roomId?: string;
+  roomType: "main" | "whisper";
   roomName?: string;
   /** mount 시 자동 연결 여부 (기본값: true) */
   autoConnect?: boolean;
@@ -40,16 +41,17 @@ interface UseVoiceConnectionReturn {
 export function useVoiceConnection(
   options: UseVoiceConnectionOptions,
 ): UseVoiceConnectionReturn {
-  const { sessionId, roomType, roomName, autoConnect = true } = options;
+  const { sessionId, roomId, roomType, roomName, autoConnect = true } = options;
 
   const setConnectionState = useVoiceStore((s) => s.setConnectionState);
   const setCurrentChannel = useVoiceStore((s) => s.setCurrentChannel);
   const isMuted = useVoiceStore((s) => s.isMuted);
   const isSpeakerMuted = useVoiceStore((s) => s.isSpeakerMuted);
-  const storToggleMute = useVoiceStore((s) => s.toggleMute);
+  const storeToggleMute = useVoiceStore((s) => s.toggleMute);
   const storeToggleSpeakerMute = useVoiceStore((s) => s.toggleSpeakerMute);
 
   const roomRef = useRef<Room | null>(null);
+  const connectionGenerationRef = useRef(0);
   const [participants, setParticipants] = useState<RemoteParticipant[]>([]);
   const [localParticipant, setLocalParticipant] =
     useState<LocalParticipant | null>(null);
@@ -70,6 +72,9 @@ export function useVoiceConnection(
   };
 
   const connect = useCallback(async () => {
+    const generation = connectionGenerationRef.current + 1;
+    connectionGenerationRef.current = generation;
+
     if (roomRef.current) {
       await roomRef.current.disconnect();
       roomRef.current = null;
@@ -78,19 +83,28 @@ export function useVoiceConnection(
     setConnectionState("connecting");
 
     try {
-      const { sessionId: sid, roomType: rt, roomName: rn } = optsRef.current;
-      const tokenData = await voiceApi.getToken(sid, rt, rn);
+      const { sessionId: sid, roomId: rid, roomType: rt, roomName: rn } = optsRef.current;
+      const tokenData = await voiceApi.getTokenForTarget({
+        sessionId: sid,
+        roomId: rid,
+        roomType: rt,
+        roomName: rn,
+      });
+
+      if (connectionGenerationRef.current !== generation) return;
 
       const room = new Room();
       roomRef.current = room;
 
       room.on(RoomEvent.Connected, () => {
+        if (connectionGenerationRef.current !== generation) return;
         setConnectionState("connected");
         setCurrentChannel(tokenData.room_name);
         syncParticipants(room);
       });
 
       room.on(RoomEvent.Disconnected, () => {
+        if (connectionGenerationRef.current !== generation) return;
         setConnectionState("disconnected");
         setCurrentChannel(null);
         setParticipants([]);
@@ -98,24 +112,37 @@ export function useVoiceConnection(
       });
 
       room.on(RoomEvent.Reconnecting, () => {
+        if (connectionGenerationRef.current !== generation) return;
         setConnectionState("connecting");
       });
 
       room.on(RoomEvent.ParticipantConnected, () => {
+        if (connectionGenerationRef.current !== generation) return;
         syncParticipants(room);
       });
 
       room.on(RoomEvent.ParticipantDisconnected, () => {
+        if (connectionGenerationRef.current !== generation) return;
         syncParticipants(room);
       });
 
       await room.connect(tokenData.livekit_url, tokenData.token);
+
+      if (connectionGenerationRef.current !== generation) {
+        void room.disconnect();
+        if (roomRef.current === room) {
+          roomRef.current = null;
+        }
+      }
     } catch {
-      setConnectionState("error");
+      if (connectionGenerationRef.current === generation) {
+        setConnectionState("error");
+      }
     }
   }, [setConnectionState, setCurrentChannel]);
 
   const disconnect = useCallback(async () => {
+    connectionGenerationRef.current += 1;
     if (roomRef.current) {
       await roomRef.current.disconnect();
       roomRef.current = null;
@@ -130,9 +157,13 @@ export function useVoiceConnection(
     const room = roomRef.current;
     if (!room) return;
     const nextMuted = !isMutedRef.current;
-    await room.localParticipant.setMicrophoneEnabled(!nextMuted);
-    storToggleMute();
-  }, [storToggleMute]);
+    try {
+      await room.localParticipant.setMicrophoneEnabled(!nextMuted);
+      storeToggleMute();
+    } catch {
+      setConnectionState("error");
+    }
+  }, [setConnectionState, storeToggleMute]);
 
   const toggleSpeakerMute = useCallback(() => {
     const room = roomRef.current;
@@ -162,8 +193,13 @@ export function useVoiceConnection(
       setConnectionState("connecting");
 
       try {
-        const { sessionId: sid, roomType: rt, roomName: rn } = optsRef.current;
-        const tokenData = await voiceApi.getToken(sid, rt, rn);
+        const { sessionId: sid, roomId: rid, roomType: rt, roomName: rn } = optsRef.current;
+        const tokenData = await voiceApi.getTokenForTarget({
+          sessionId: sid,
+          roomId: rid,
+          roomType: rt,
+          roomName: rn,
+        });
 
         if (stale) return;
 
@@ -220,7 +256,7 @@ export function useVoiceConnection(
       setConnectionState("disconnected");
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoConnect, sessionId, roomType, roomName]);
+  }, [autoConnect, sessionId, roomId, roomType, roomName]);
 
   return {
     room: roomRef.current,

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -19,6 +19,7 @@ import {
   PlayerList,
   RoomHeader,
   RoomInvitePanel,
+  RoomVoicePanel,
   HostControls,
   RoomChat,
   CharacterSelectionPanel,
@@ -260,6 +261,9 @@ export default function RoomPage() {
             />
             {id && room.status.toLowerCase() === 'waiting' && (
               <RoomInvitePanel roomId={id} isHost={isHost} />
+            )}
+            {id && (
+              <RoomVoicePanel roomId={id} isActive={room.status.toLowerCase() === 'waiting'} />
             )}
             {currentPlayer && (
               <CharacterSelectionPanel

--- a/apps/web/src/pages/__tests__/RoomPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RoomPage.test.tsx
@@ -15,6 +15,7 @@ const {
   useSetReadyMock,
   useStartRoomMock,
   useThemeCharactersMock,
+  useVoiceConnectionMock,
   useWsEventMock,
 } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
@@ -27,6 +28,7 @@ const {
   useSetReadyMock: vi.fn(),
   useStartRoomMock: vi.fn(),
   useThemeCharactersMock: vi.fn(),
+  useVoiceConnectionMock: vi.fn(),
   useWsEventMock: vi.fn(),
 }));
 
@@ -80,6 +82,10 @@ vi.mock('@/hooks/useWsClient', () => ({
 
 vi.mock('@/hooks/useWsEvent', () => ({
   useWsEvent: (...args: unknown[]) => useWsEventMock(...args),
+}));
+
+vi.mock('@/hooks/useVoiceConnection', () => ({
+  useVoiceConnection: (options: unknown) => useVoiceConnectionMock(options),
 }));
 
 import RoomPage from '../RoomPage';
@@ -211,6 +217,14 @@ function mockRoomPage(
   useStartRoomMock.mockReturnValue({
     mutate: overrides.startMutate ?? vi.fn(),
     isPending: overrides.startPending ?? false,
+  });
+  useVoiceConnectionMock.mockReturnValue({
+    participants: [],
+    localParticipant: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    toggleMute: vi.fn(),
+    toggleSpeakerMute: vi.fn(),
   });
 }
 
@@ -506,5 +520,32 @@ describe('RoomPage pregame controls', () => {
     renderRoom();
 
     expect(screen.getByText('초대 0명 전송, 0명 건너뜀')).toBeInTheDocument();
+  });
+
+  it('대기방 음성 채팅 패널을 room_id 기반으로 연결한다', () => {
+    const connect = vi.fn();
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+    useVoiceConnectionMock.mockReturnValue({
+      participants: [],
+      localParticipant: null,
+      connect,
+      disconnect: vi.fn(),
+      toggleMute: vi.fn(),
+      toggleSpeakerMute: vi.fn(),
+    });
+
+    renderRoom();
+
+    expect(useVoiceConnectionMock).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      roomType: 'main',
+      autoConnect: false,
+    });
+    fireEvent.click(screen.getByRole('button', { name: '입장' }));
+    expect(connect).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/services/voiceApi.ts
+++ b/apps/web/src/services/voiceApi.ts
@@ -10,6 +10,13 @@ export interface TokenResponse {
   livekit_url: string;
 }
 
+export interface VoiceTokenRequest {
+  sessionId?: string;
+  roomId?: string;
+  roomType: "main" | "whisper";
+  roomName?: string;
+}
+
 // ---------------------------------------------------------------------------
 // API
 // ---------------------------------------------------------------------------
@@ -18,6 +25,13 @@ export const voiceApi = {
   getToken: (sessionId: string, roomType: string, roomName?: string) =>
     api.post<TokenResponse>("/v1/voice/token", {
       session_id: sessionId,
+      room_type: roomType,
+      room_name: roomName,
+    }),
+  getTokenForTarget: ({ sessionId, roomId, roomType, roomName }: VoiceTokenRequest) =>
+    api.post<TokenResponse>("/v1/voice/token", {
+      session_id: sessionId,
+      room_id: roomId,
       room_type: roomType,
       room_name: roomName,
     }),

--- a/docs/plans/2026-05-20-pregame-lobby-room/checklist.md
+++ b/docs/plans/2026-05-20-pregame-lobby-room/checklist.md
@@ -26,7 +26,7 @@ Checklist:
 - [x] Handle incoming `room:invite` event in social sync.
 - [x] Add focused tests.
 - [x] Run focused validation and browser QA.
-- [ ] Create PR, request Codex review, resolve findings, merge.
+- [x] Create PR, request Codex review, resolve findings, merge.
 
 Open Decisions:
 - Durable offline invite table: excluded from Slice 3.
@@ -38,3 +38,39 @@ Validation Notes:
 - Frontend type/lint: `pnpm --filter @mmp/web typecheck`, `pnpm --filter @mmp/web lint` (existing warnings only).
 - Browser QA: `127.0.0.1:3000` host room invite, `POST /api/v1/rooms/7b6bb5d7-f98b-4c5c-8d3b-b3062cb69103/invites => 200`, UI displayed `초대 1명 전송, 0명 건너뜀`; temp DB rows cleaned.
 - `scripts/mmp-local-ci.sh quick` reached full `go test -race ./...` but failed in existing `internal/domain/flow` testcontainer setup with Docker socket `context deadline exceeded`; changed room package passed.
+
+## Slice 4: Waiting Room Voice
+
+Scope:
+- Keep the existing in-game voice session flow compatible with `session_id`.
+- Add a waiting-room voice token path based on `room_id` and server-owned room participant checks.
+- Surface a usable waiting-room voice panel before game start, including join/leave, mic mute, speaker mute, connection state, and cleanup on leave/start navigation.
+- Exclude durable voice preferences, channel moderation, and push-to-talk from this slice.
+
+Coverage Plan:
+- Backend voice service: exactly one target (`session_id` or `room_id`), room UUID validation, waiting-room status gate, room participant authorization, unsupported whisper rejection, session compatibility path, provider failure handling.
+- Frontend voice API/hook: target-based token request while preserving existing `getToken(sessionId, ...)` compatibility, LiveKit mic toggle side effect, room cleanup.
+- Room page UI: waiting-room voice panel renders with the current room ID and invokes manual connect through `useVoiceConnection`.
+- Focused validation: `go test` for voice service, RoomPage component test, frontend typecheck/lint, and browser smoke where local services allow it.
+
+Checklist:
+- [x] Start Slice 4 branch from latest `main`.
+- [x] Run read-only coordinator for waiting-room voice architecture.
+- [x] Add backend `room_id` token contract and authorization tests.
+- [x] Add target-based frontend voice API/hook path.
+- [x] Add waiting-room voice panel to `RoomPage`.
+- [x] Run focused validation.
+- [x] Run independent review agents and resolve findings.
+- [ ] Create PR, request Codex review, resolve findings, merge.
+
+Open Decisions:
+- Waiting-room voice only supports the main room channel in this slice; whisper remains session-only.
+- LiveKit room naming uses `room-{roomID}-main` for pregame voice and keeps existing `session-{sessionID}-...` names for gameplay.
+- Issued LiveKit tokens are checked at request time; immediate token revocation on later room status changes is outside this slice.
+
+Validation Notes:
+- Focused backend: `cd apps/server && go test -count=1 ./internal/domain/voice ./internal/domain/room ./cmd/server`.
+- Focused frontend: `pnpm --filter @mmp/web test -- src/hooks/__tests__/useVoiceConnection.test.ts src/pages/__tests__/RoomPage.test.tsx`.
+- Frontend type/lint: `pnpm --filter @mmp/web typecheck`, `pnpm --filter @mmp/web lint` (existing 39 warnings only).
+- Browser QA: `127.0.0.1:3000/room/a3cb2e27-6894-4b7d-9fbd-8206bda5ce26` rendered the voice panel; clicking `입장` sent `POST /api/v1/voice/token => 200` with `room_name=room-a3cb2e27-6894-4b7d-9fbd-8206bda5ce26-main`; mock voice provider left `livekit_url` empty, so UI correctly showed `연결 실패`. Temp room/user rows cleaned.
+- Independent review: backend and security reviewers found no blocker; frontend reviewer found a stale manual-connect race, fixed with a connection generation guard and covered by `useVoiceConnection` test.


### PR DESCRIPTION
## 요약
- 대기방 voice token 발급을 `room_id` 기반으로 확장하고 `room_players` 참여자와 `WAITING` 상태를 서버에서 검증합니다.
- RoomPage에 음성 채팅 패널을 추가해 입장/나가기, 마이크/스피커 토글, 연결 실패 상태를 제공합니다.
- 수동 연결 중 방 이탈/게임 시작 cleanup race를 connection generation guard와 테스트로 막았습니다.

Closes #691

## Coverage Plan
- Backend voice service: `session_id` 기존 호환, `room_id` validation, room participant authorization, `WAITING` 상태, unsupported whisper rejection, provider failure를 검증합니다.
- Frontend voice API/hook: target 기반 token request, manual connect stale guard, LiveKit mic toggle, cleanup을 검증합니다.
- Room UI: RoomPage voice panel이 현재 `room_id`로 렌더링되고 수동 connect를 호출하는지 검증합니다.

## Local validation
- `scripts/mmp-local-ci.sh quick` — passed on HEAD `b4b046a6`.
- `cd apps/server && go test -count=1 ./internal/domain/voice ./internal/domain/room ./cmd/server` — passed.
- `pnpm --filter @mmp/web test -- src/hooks/__tests__/useVoiceConnection.test.ts src/pages/__tests__/RoomPage.test.tsx` — passed.
- `pnpm --filter @mmp/web typecheck` — passed.
- `pnpm --filter @mmp/web lint` — passed with existing 39 warnings, 0 errors.
- Browser QA: temp waiting room `/room/a3cb2e27-6894-4b7d-9fbd-8206bda5ce26`에서 음성 채팅 패널 렌더링을 확인했고, `POST /api/v1/voice/token`이 200과 `room-a3cb2e27-6894-4b7d-9fbd-8206bda5ce26-main`을 반환했습니다. 로컬 mock LiveKit URL이 비어 있어 UI는 예상대로 `연결 실패`를 표시했고, temp DB row는 정리했습니다.

## Review
- Backend reviewer: blocker 없음.
- Security reviewer: blocker 없음. 방 상태 변경 뒤 이미 발급된 LiveKit token revoke는 이번 slice 밖 residual risk로 plan에 기록했습니다.
- Frontend reviewer: manual connect cleanup race를 발견했고, generation guard와 `useVoiceConnection` 테스트로 수정했습니다.
