### PR TITLE
feat: 대기방 LiveKit React 음성 foundation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@livekit/components-react": "^2.9.21",
     "@mdxeditor/editor": "3.55.0",
     "@mmp/game-logic": "workspace:*",
     "@mmp/shared": "workspace:*",
@@ -30,7 +31,7 @@
     "@tanstack/react-query": "^5.96.2",
     "@xyflow/react": "^12.10.2",
     "dompurify": "^3.3.3",
-    "livekit-client": "^2.18.1",
+    "livekit-client": "^2.19.0",
     "lucide-react": "^0.468.0",
     "marked": "^17.0.6",
     "react": "^19.0.0",

--- a/apps/web/src/features/room/components/RoomVoicePanel.tsx
+++ b/apps/web/src/features/room/components/RoomVoicePanel.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useMemo } from 'react';
+import {
+  LiveKitRoom,
+  RoomAudioRenderer,
+  useLocalParticipant,
+  useParticipants,
+} from '@livekit/components-react';
 import { Mic, MicOff, Phone, PhoneOff, Volume2, VolumeX } from 'lucide-react';
 
 import { useVoiceConnection } from '@/hooks/useVoiceConnection';
@@ -22,7 +28,14 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
   const isMuted = useVoiceStore(selectIsMuted);
   const isSpeakerMuted = useVoiceStore(selectIsSpeakerMuted);
   const resetVoice = useVoiceStore((state) => state.reset);
-  const { participants, localParticipant, connect, disconnect, toggleMute, toggleSpeakerMute } =
+  const {
+    connectionDetails,
+    connect,
+    disconnect,
+    handleConnected,
+    handleDisconnected,
+    handleError,
+  } =
     useVoiceConnection({
       roomId,
       roomType: 'main',
@@ -42,14 +55,13 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
     };
   }, [disconnect, resetVoice]);
 
-  const participantCount = participants.length + (localParticipant ? 1 : 0);
   const canDisconnect = connectionState === 'connected' || connectionState === 'connecting';
   const helperText = useMemo(() => {
     if (!isActive) return '게임 시작 또는 방 나가기 중에는 음성 연결을 정리합니다.';
     if (connectionState === 'error') return '음성 서버 연결에 실패했습니다. 잠시 후 다시 시도해 주세요.';
-    if (connectionState === 'connected') return `${participantCount}명이 음성 채팅에 연결되어 있습니다.`;
+    if (connectionState === 'connected') return '음성 채팅에 연결되어 있습니다.';
     return '대기방 참가자만 음성 채팅에 들어갈 수 있습니다.';
-  }, [connectionState, isActive, participantCount]);
+  }, [connectionState, isActive]);
 
   return (
     <Panel className="flex flex-col gap-3">
@@ -93,12 +105,78 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
         {helperText}
       </p>
 
+      {connectionDetails ? (
+        <LiveKitRoom
+          serverUrl={connectionDetails.serverUrl}
+          token={connectionDetails.token}
+          connect
+          audio
+          video={false}
+          onConnected={handleConnected}
+          onDisconnected={handleDisconnected}
+          onError={handleError}
+          className="contents"
+        >
+          <RoomAudioRenderer muted={isSpeakerMuted} />
+          <LiveKitVoiceControls />
+        </LiveKitRoom>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant={isMuted ? 'danger' : 'secondary'}
+            leftIcon={isMuted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+            disabled
+          >
+            {isMuted ? '마이크 켜기' : '마이크 끄기'}
+          </Button>
+          <Button
+            size="sm"
+            variant={isSpeakerMuted ? 'danger' : 'secondary'}
+            leftIcon={isSpeakerMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
+            disabled
+          >
+            {isSpeakerMuted ? '스피커 켜기' : '스피커 끄기'}
+          </Button>
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+function LiveKitVoiceControls() {
+  const participants = useParticipants();
+  const { localParticipant } = useLocalParticipant();
+  const connectionState = useVoiceStore(selectVoiceConnectionState);
+  const isMuted = useVoiceStore(selectIsMuted);
+  const isSpeakerMuted = useVoiceStore(selectIsSpeakerMuted);
+  const toggleStoreMute = useVoiceStore((state) => state.toggleMute);
+  const toggleStoreSpeakerMute = useVoiceStore((state) => state.toggleSpeakerMute);
+  const setConnectionState = useVoiceStore((state) => state.setConnectionState);
+
+  const handleToggleMute = async () => {
+    const nextMuted = !isMuted;
+    try {
+      await localParticipant.setMicrophoneEnabled(!nextMuted);
+      toggleStoreMute();
+    } catch {
+      setConnectionState('error');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {connectionState === 'connected' && (
+        <p className="text-xs text-[var(--mmp-color-steel)]">
+          {participants.length}명이 음성 채팅에 연결되어 있습니다.
+        </p>
+      )}
       <div className="flex flex-wrap gap-2">
         <Button
           size="sm"
           variant={isMuted ? 'danger' : 'secondary'}
           leftIcon={isMuted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
-          onClick={() => void toggleMute()}
+          onClick={() => void handleToggleMute()}
           disabled={connectionState !== 'connected'}
         >
           {isMuted ? '마이크 켜기' : '마이크 끄기'}
@@ -107,12 +185,12 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
           size="sm"
           variant={isSpeakerMuted ? 'danger' : 'secondary'}
           leftIcon={isSpeakerMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
-          onClick={toggleSpeakerMute}
+          onClick={toggleStoreSpeakerMute}
           disabled={connectionState !== 'connected'}
         >
           {isSpeakerMuted ? '스피커 켜기' : '스피커 끄기'}
         </Button>
       </div>
-    </Panel>
+    </div>
   );
 }

--- a/apps/web/src/features/room/components/__tests__/RoomVoicePanel.test.tsx
+++ b/apps/web/src/features/room/components/__tests__/RoomVoicePanel.test.tsx
@@ -1,0 +1,120 @@
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { voiceApi } from '@/services/voiceApi';
+import { useVoiceStore } from '@/stores/voiceStore';
+import { RoomVoicePanel } from '../RoomVoicePanel';
+
+const {
+  liveKitRoomProps,
+  microphoneEnabledMock,
+  participantsMock,
+} = vi.hoisted(() => ({
+  liveKitRoomProps: { current: null as null | {
+    onConnected?: () => void;
+    onDisconnected?: () => void;
+    onError?: (error: Error) => void;
+  } },
+  microphoneEnabledMock: vi.fn(),
+  participantsMock: [
+    { identity: 'local-user' },
+    { identity: 'remote-user' },
+  ],
+}));
+
+vi.mock('@livekit/components-react', () => ({
+  LiveKitRoom: (props: {
+    children: ReactNode;
+    onConnected?: () => void;
+    onDisconnected?: () => void;
+    onError?: (error: Error) => void;
+  }) => {
+    liveKitRoomProps.current = props;
+    return <div data-testid="livekit-room">{props.children}</div>;
+  },
+  RoomAudioRenderer: ({ muted }: { muted?: boolean }) => (
+    <div data-muted={muted ? 'true' : 'false'} data-testid="room-audio-renderer" />
+  ),
+  useParticipants: () => participantsMock,
+  useLocalParticipant: () => ({
+    localParticipant: {
+      setMicrophoneEnabled: microphoneEnabledMock,
+    },
+  }),
+}));
+
+vi.mock('@/services/voiceApi', () => ({
+  voiceApi: {
+    getTokenForTarget: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  liveKitRoomProps.current = null;
+  useVoiceStore.getState().reset();
+});
+
+describe('RoomVoicePanel', () => {
+  it('wires LiveKit callbacks to reconnectable voice state', async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: 'token-1',
+      room_name: 'room-room-1-main',
+      livekit_url: 'ws://livekit',
+    });
+
+    render(<RoomVoicePanel roomId="room-1" isActive />);
+
+    fireEvent.click(screen.getByRole('button', { name: /입장/ }));
+
+    await screen.findByTestId('livekit-room');
+    expect(screen.getByTestId('room-audio-renderer')).toHaveAttribute('data-muted', 'false');
+    expect(screen.queryByText('2명이 음성 채팅에 연결되어 있습니다.')).not.toBeInTheDocument();
+
+    act(() => {
+      liveKitRoomProps.current?.onConnected?.();
+    });
+
+    expect(await screen.findByText('2명이 음성 채팅에 연결되어 있습니다.')).toBeInTheDocument();
+
+    act(() => {
+      liveKitRoomProps.current?.onDisconnected?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('livekit-room')).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /입장/ })).toBeEnabled();
+  });
+
+  it('uses LiveKit participant controls for microphone and speaker state', async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: 'token-1',
+      room_name: 'room-room-1-main',
+      livekit_url: 'ws://livekit',
+    });
+
+    render(<RoomVoicePanel roomId="room-1" isActive />);
+
+    fireEvent.click(screen.getByRole('button', { name: /입장/ }));
+    await screen.findByTestId('livekit-room');
+
+    act(() => {
+      liveKitRoomProps.current?.onConnected?.();
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /마이크 끄기/ }));
+
+    await waitFor(() => {
+      expect(microphoneEnabledMock).toHaveBeenCalledWith(false);
+    });
+    expect(await screen.findByRole('button', { name: /마이크 켜기/ })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /스피커 끄기/ }));
+
+    expect(screen.getByTestId('room-audio-renderer')).toHaveAttribute('data-muted', 'true');
+  });
+});

--- a/apps/web/src/hooks/__tests__/useVoiceConnection.test.ts
+++ b/apps/web/src/hooks/__tests__/useVoiceConnection.test.ts
@@ -5,27 +5,6 @@ import { useVoiceConnection } from "@/hooks/useVoiceConnection";
 import { voiceApi } from "@/services/voiceApi";
 import { useVoiceStore } from "@/stores/voiceStore";
 
-const roomConnectMock = vi.fn();
-const roomDisconnectMock = vi.fn();
-const roomOnMock = vi.fn();
-
-vi.mock("livekit-client", () => ({
-  RoomEvent: {
-    Connected: "connected",
-    Disconnected: "disconnected",
-    Reconnecting: "reconnecting",
-    ParticipantConnected: "participantConnected",
-    ParticipantDisconnected: "participantDisconnected",
-  },
-  Room: vi.fn().mockImplementation(() => ({
-    connect: roomConnectMock,
-    disconnect: roomDisconnectMock,
-    on: roomOnMock,
-    remoteParticipants: new Map(),
-    localParticipant: { setMicrophoneEnabled: vi.fn() },
-  })),
-}));
-
 vi.mock("@/services/voiceApi", () => ({
   voiceApi: {
     getTokenForTarget: vi.fn(),
@@ -49,7 +28,7 @@ afterEach(() => {
 });
 
 describe("useVoiceConnection", () => {
-  it("does not connect a stale manual connection after disconnect cleanup", async () => {
+  it("does not expose stale LiveKit connection details after disconnect cleanup", async () => {
     const token = deferred<{
       token: string;
       room_name: string;
@@ -85,8 +64,106 @@ describe("useVoiceConnection", () => {
     });
 
     await waitFor(() => {
-      expect(roomConnectMock).not.toHaveBeenCalled();
+      expect(result.current.connectionDetails).toBeNull();
     });
     expect(useVoiceStore.getState().connectionState).toBe("disconnected");
+  });
+
+  it("keeps token fetching separate from LiveKit connected state", async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: "token-1",
+      room_name: "room-room-1-main",
+      livekit_url: "ws://livekit",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceConnection({
+        roomId: "room-1",
+        roomType: "main",
+        autoConnect: false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.connectionDetails).toEqual({
+      token: "token-1",
+      roomName: "room-room-1-main",
+      serverUrl: "ws://livekit",
+    });
+    expect(useVoiceStore.getState().connectionState).toBe("connecting");
+
+    act(() => {
+      result.current.handleConnected();
+    });
+
+    expect(useVoiceStore.getState().connectionState).toBe("connected");
+    expect(useVoiceStore.getState().currentChannel).toBe("room-room-1-main");
+  });
+
+  it("ignores stale LiveKit callbacks after a user disconnect", async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: "token-1",
+      room_name: "room-room-1-main",
+      livekit_url: "ws://livekit",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceConnection({
+        roomId: "room-1",
+        roomType: "main",
+        autoConnect: false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+      await result.current.disconnect();
+    });
+
+    act(() => {
+      result.current.handleConnected();
+      result.current.handleError(new Error("late failure"));
+    });
+
+    expect(result.current.connectionDetails).toBeNull();
+    expect(useVoiceStore.getState().connectionState).toBe("disconnected");
+    expect(useVoiceStore.getState().currentChannel).toBeNull();
+  });
+
+  it("clears LiveKit connection details when the room disconnects", async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: "token-1",
+      room_name: "room-room-1-main",
+      livekit_url: "ws://livekit",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceConnection({
+        roomId: "room-1",
+        roomType: "main",
+        autoConnect: false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    act(() => {
+      result.current.handleConnected();
+    });
+
+    expect(useVoiceStore.getState().connectionState).toBe("connected");
+
+    act(() => {
+      result.current.handleDisconnected();
+    });
+
+    expect(result.current.connectionDetails).toBeNull();
+    expect(useVoiceStore.getState().connectionState).toBe("disconnected");
+    expect(useVoiceStore.getState().currentChannel).toBeNull();
   });
 });

--- a/apps/web/src/hooks/useVoiceConnection.ts
+++ b/apps/web/src/hooks/useVoiceConnection.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  LocalParticipant,
-  RemoteParticipant,
-  Room,
-  RoomEvent,
-} from "livekit-client";
+import type { LocalParticipant, RemoteParticipant } from "livekit-client";
 
-import { voiceApi } from "@/services/voiceApi";
+import { voiceApi, type TokenResponse } from "@/services/voiceApi";
 import { useVoiceStore } from "@/stores/voiceStore";
 
 // ---------------------------------------------------------------------------
@@ -14,6 +9,12 @@ import { useVoiceStore } from "@/stores/voiceStore";
 // ---------------------------------------------------------------------------
 
 export type VoiceParticipant = LocalParticipant | RemoteParticipant;
+
+export interface VoiceConnectionDetails {
+  token: string;
+  roomName: string;
+  serverUrl: string;
+}
 
 interface UseVoiceConnectionOptions {
   sessionId?: string;
@@ -25,13 +26,16 @@ interface UseVoiceConnectionOptions {
 }
 
 interface UseVoiceConnectionReturn {
-  room: Room | null;
+  connectionDetails: VoiceConnectionDetails | null;
   participants: RemoteParticipant[];
   localParticipant: LocalParticipant | null;
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
   toggleMute: () => Promise<void>;
   toggleSpeakerMute: () => void;
+  handleConnected: () => void;
+  handleDisconnected: () => void;
+  handleError: (error: Error) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -45,13 +49,12 @@ export function useVoiceConnection(
 
   const setConnectionState = useVoiceStore((s) => s.setConnectionState);
   const setCurrentChannel = useVoiceStore((s) => s.setCurrentChannel);
-  const isMuted = useVoiceStore((s) => s.isMuted);
-  const isSpeakerMuted = useVoiceStore((s) => s.isSpeakerMuted);
-  const storeToggleMute = useVoiceStore((s) => s.toggleMute);
-  const storeToggleSpeakerMute = useVoiceStore((s) => s.toggleSpeakerMute);
 
-  const roomRef = useRef<Room | null>(null);
   const connectionGenerationRef = useRef(0);
+  const activeConnectionRef = useRef(false);
+  const pendingRoomNameRef = useRef<string | null>(null);
+  const [connectionDetails, setConnectionDetails] =
+    useState<VoiceConnectionDetails | null>(null);
   const [participants, setParticipants] = useState<RemoteParticipant[]>([]);
   const [localParticipant, setLocalParticipant] =
     useState<LocalParticipant | null>(null);
@@ -60,26 +63,13 @@ export function useVoiceConnection(
   const optsRef = useRef(options);
   optsRef.current = options;
 
-  // Keep latest mute state accessible in callbacks
-  const isMutedRef = useRef(isMuted);
-  isMutedRef.current = isMuted;
-  const isSpeakerMutedRef = useRef(isSpeakerMuted);
-  isSpeakerMutedRef.current = isSpeakerMuted;
-
-  const syncParticipants = (room: Room) => {
-    setParticipants(Array.from(room.remoteParticipants.values()));
-    setLocalParticipant(room.localParticipant);
-  };
-
   const connect = useCallback(async () => {
     const generation = connectionGenerationRef.current + 1;
     connectionGenerationRef.current = generation;
 
-    if (roomRef.current) {
-      await roomRef.current.disconnect();
-      roomRef.current = null;
-    }
-
+    activeConnectionRef.current = false;
+    setConnectionDetails(null);
+    pendingRoomNameRef.current = null;
     setConnectionState("connecting");
 
     try {
@@ -93,60 +83,21 @@ export function useVoiceConnection(
 
       if (connectionGenerationRef.current !== generation) return;
 
-      const room = new Room();
-      roomRef.current = room;
-
-      room.on(RoomEvent.Connected, () => {
-        if (connectionGenerationRef.current !== generation) return;
-        setConnectionState("connected");
-        setCurrentChannel(tokenData.room_name);
-        syncParticipants(room);
-      });
-
-      room.on(RoomEvent.Disconnected, () => {
-        if (connectionGenerationRef.current !== generation) return;
-        setConnectionState("disconnected");
-        setCurrentChannel(null);
-        setParticipants([]);
-        setLocalParticipant(null);
-      });
-
-      room.on(RoomEvent.Reconnecting, () => {
-        if (connectionGenerationRef.current !== generation) return;
-        setConnectionState("connecting");
-      });
-
-      room.on(RoomEvent.ParticipantConnected, () => {
-        if (connectionGenerationRef.current !== generation) return;
-        syncParticipants(room);
-      });
-
-      room.on(RoomEvent.ParticipantDisconnected, () => {
-        if (connectionGenerationRef.current !== generation) return;
-        syncParticipants(room);
-      });
-
-      await room.connect(tokenData.livekit_url, tokenData.token);
-
-      if (connectionGenerationRef.current !== generation) {
-        void room.disconnect();
-        if (roomRef.current === room) {
-          roomRef.current = null;
-        }
-      }
+      pendingRoomNameRef.current = tokenData.room_name;
+      activeConnectionRef.current = true;
+      setConnectionDetails(toConnectionDetails(tokenData));
     } catch {
       if (connectionGenerationRef.current === generation) {
         setConnectionState("error");
       }
     }
-  }, [setConnectionState, setCurrentChannel]);
+  }, [setConnectionState]);
 
   const disconnect = useCallback(async () => {
     connectionGenerationRef.current += 1;
-    if (roomRef.current) {
-      await roomRef.current.disconnect();
-      roomRef.current = null;
-    }
+    activeConnectionRef.current = false;
+    pendingRoomNameRef.current = null;
+    setConnectionDetails(null);
     setConnectionState("disconnected");
     setCurrentChannel(null);
     setParticipants([]);
@@ -154,117 +105,69 @@ export function useVoiceConnection(
   }, [setConnectionState, setCurrentChannel]);
 
   const toggleMute = useCallback(async () => {
-    const room = roomRef.current;
-    if (!room) return;
-    const nextMuted = !isMutedRef.current;
-    try {
-      await room.localParticipant.setMicrophoneEnabled(!nextMuted);
-      storeToggleMute();
-    } catch {
-      setConnectionState("error");
-    }
-  }, [setConnectionState, storeToggleMute]);
+    // Media control is handled by components rendered under LiveKitRoom.
+  }, []);
 
   const toggleSpeakerMute = useCallback(() => {
-    const room = roomRef.current;
-    if (!room) return;
-    const nextSpeakerMuted = !isSpeakerMutedRef.current;
-    for (const participant of room.remoteParticipants.values()) {
-      for (const pub of participant.audioTrackPublications.values()) {
-        if (pub.audioTrack) {
-          pub.audioTrack.setMuted(nextSpeakerMuted);
-        }
-      }
-    }
-    storeToggleSpeakerMute();
-  }, [storeToggleSpeakerMute]);
+    // Speaker mute is handled by RoomAudioRenderer in the room component tree.
+  }, []);
+
+  const handleConnected = useCallback(() => {
+    if (!activeConnectionRef.current) return;
+    setConnectionState("connected");
+    setCurrentChannel(pendingRoomNameRef.current);
+  }, [setConnectionState, setCurrentChannel]);
+
+  const handleDisconnected = useCallback(() => {
+    if (!activeConnectionRef.current) return;
+    activeConnectionRef.current = false;
+    pendingRoomNameRef.current = null;
+    setConnectionDetails(null);
+    setConnectionState("disconnected");
+    setCurrentChannel(null);
+    setParticipants([]);
+    setLocalParticipant(null);
+  }, [setConnectionState, setCurrentChannel]);
+
+  const handleError = useCallback(
+    (_error: Error) => {
+      if (!activeConnectionRef.current) return;
+      activeConnectionRef.current = false;
+      setConnectionDetails(null);
+      pendingRoomNameRef.current = null;
+      setConnectionState("error");
+      setCurrentChannel(null);
+    },
+    [setConnectionState, setCurrentChannel],
+  );
 
   useEffect(() => {
     if (!autoConnect) return;
-
-    let stale = false;
-
-    const run = async () => {
-      if (roomRef.current) {
-        await roomRef.current.disconnect();
-        roomRef.current = null;
-      }
-
-      setConnectionState("connecting");
-
-      try {
-        const { sessionId: sid, roomId: rid, roomType: rt, roomName: rn } = optsRef.current;
-        const tokenData = await voiceApi.getTokenForTarget({
-          sessionId: sid,
-          roomId: rid,
-          roomType: rt,
-          roomName: rn,
-        });
-
-        if (stale) return;
-
-        const room = new Room();
-        roomRef.current = room;
-
-        room.on(RoomEvent.Connected, () => {
-          if (stale) return;
-          setConnectionState("connected");
-          setCurrentChannel(tokenData.room_name);
-          syncParticipants(room);
-        });
-
-        room.on(RoomEvent.Disconnected, () => {
-          setConnectionState("disconnected");
-          setCurrentChannel(null);
-          setParticipants([]);
-          setLocalParticipant(null);
-        });
-
-        room.on(RoomEvent.Reconnecting, () => {
-          setConnectionState("connecting");
-        });
-
-        room.on(RoomEvent.ParticipantConnected, () => {
-          syncParticipants(room);
-        });
-
-        room.on(RoomEvent.ParticipantDisconnected, () => {
-          syncParticipants(room);
-        });
-
-        await room.connect(tokenData.livekit_url, tokenData.token);
-
-        if (stale) {
-          void room.disconnect();
-          roomRef.current = null;
-        }
-      } catch {
-        if (!stale) {
-          setConnectionState("error");
-        }
-      }
-    };
-
-    void run();
+    void connect();
 
     return () => {
-      stale = true;
-      if (roomRef.current) {
-        void roomRef.current.disconnect();
-        roomRef.current = null;
-      }
-      setConnectionState("disconnected");
+      void disconnect();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoConnect, sessionId, roomId, roomType, roomName]);
+  }, [autoConnect, connect, disconnect, sessionId, roomId, roomType, roomName]);
 
   return {
-    room: roomRef.current,
+    connectionDetails,
     participants,
     localParticipant,
     connect,
     disconnect,
     toggleMute,
     toggleSpeakerMute,
+    handleConnected,
+    handleDisconnected,
+    handleError,
+  };
+}
+
+function toConnectionDetails(tokenData: TokenResponse): VoiceConnectionDetails {
+  return {
+    token: tokenData.token,
+    roomName: tokenData.room_name,
+    serverUrl: tokenData.livekit_url,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@livekit/components-react':
+        specifier: ^2.9.21
+        version: 2.9.21(livekit-client@2.19.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tslib@2.8.1)
       '@mdxeditor/editor':
         specifier: 3.55.0
         version: 3.55.0(@codemirror/language@6.12.3)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
@@ -51,8 +54,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       livekit-client:
-        specifier: ^2.18.1
-        version: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+        specifier: ^2.19.0
+        version: 2.19.0(@types/dom-mediacapture-record@1.0.22)
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
@@ -1444,6 +1447,9 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
@@ -1666,11 +1672,31 @@ packages:
   '@lezer/yaml@1.0.4':
     resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
 
+  '@livekit/components-core@0.12.13':
+    resolution: {integrity: sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      livekit-client: ^2.17.2
+      tslib: ^2.6.2
+
+  '@livekit/components-react@2.9.21':
+    resolution: {integrity: sha512-6hU9VucJJL+gAhilNGe4MBCDCZVk64qyjP9Ck86krvOIdVU76WeWksddg1MYUP10AlUwwrfD7davz41pJTcMJw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@livekit/krisp-noise-filter': ^0.2.12 || ^0.3.0
+      livekit-client: ^2.18.2
+      react: '>=18'
+      react-dom: '>=18'
+      tslib: ^2.6.2
+    peerDependenciesMeta:
+      '@livekit/krisp-noise-filter':
+        optional: true
+
   '@livekit/mutex@1.1.1':
     resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
 
-  '@livekit/protocol@1.44.0':
-    resolution: {integrity: sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==}
+  '@livekit/protocol@1.45.8':
+    resolution: {integrity: sha512-Q+l57E7w/xxOBFVWzdX5rkAZO7ffyF+rlDzNUYq2SU114+5aTyCq+PK4unaEVDNd4952Af7wteKr3sOgasGuaA==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -2886,6 +2912,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   cm6-theme-basic-light@0.2.0:
     resolution: {integrity: sha512-1prg2gv44sYfpHscP26uLT/ePrh0mlmVwMSoSd3zYKQ92Ab3jPRLzyCnpyOCQLJbK+YdNs4HvMRqMNYdy4pMhA==}
     peerDependencies:
@@ -3850,8 +3880,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  livekit-client@2.18.1:
-    resolution: {integrity: sha512-nGjuEEV1mVN01EcAMwGIwG3J1gpBMqwn2V4R6W/8zz9Rah1CaAohIm6AMLG7BdctQpyeh34dfAOLfDodIsWyYA==}
+  livekit-client@2.19.0:
+    resolution: {integrity: sha512-aolY1XDAtx0nHKBNm29W9OhzBnSz1CP5kq3phvRhFfi1NbvMXs8tcACjAkZTnIKgihkp+BiJScZZ3tZv0Gz8sA==}
     peerDependencies:
       '@types/dom-mediacapture-record': ^1
 
@@ -3874,6 +3904,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  loglevel@1.9.1:
+    resolution: {integrity: sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==}
+    engines: {node: '>= 0.6.0'}
 
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
@@ -4989,6 +5023,12 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  usehooks-ts@3.1.1:
+    resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
+    engines: {node: '>=16.15.0'}
+    peerDependencies:
+      react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
     engines: {node: '>=8'}
@@ -5128,8 +5168,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  webrtc-adapter@9.0.4:
-    resolution: {integrity: sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==}
+  webrtc-adapter@9.0.5:
+    resolution: {integrity: sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==}
     engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
   whatwg-encoding@3.1.1:
@@ -6676,6 +6716,11 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
@@ -7012,9 +7057,29 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
+  '@livekit/components-core@0.12.13(livekit-client@2.19.0(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      livekit-client: 2.19.0(@types/dom-mediacapture-record@1.0.22)
+      loglevel: 1.9.1
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@livekit/components-react@2.9.21(livekit-client@2.19.0(@types/dom-mediacapture-record@1.0.22))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tslib@2.8.1)':
+    dependencies:
+      '@livekit/components-core': 0.12.13(livekit-client@2.19.0(@types/dom-mediacapture-record@1.0.22))(tslib@2.8.1)
+      clsx: 2.1.1
+      events: 3.3.0
+      jose: 6.2.2
+      livekit-client: 2.19.0(@types/dom-mediacapture-record@1.0.22)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+      usehooks-ts: 3.1.1(react@19.2.4)
+
   '@livekit/mutex@1.1.1': {}
 
-  '@livekit/protocol@1.44.0':
+  '@livekit/protocol@1.45.8':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
@@ -8283,6 +8348,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   cm6-theme-basic-light@0.2.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.42.0)(@lezer/highlight@1.2.3):
     dependencies:
       '@codemirror/language': 6.12.3
@@ -9372,10 +9439,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  livekit-client@2.18.1(@types/dom-mediacapture-record@1.0.22):
+  livekit-client@2.19.0(@types/dom-mediacapture-record@1.0.22):
     dependencies:
       '@livekit/mutex': 1.1.1
-      '@livekit/protocol': 1.44.0
+      '@livekit/protocol': 1.45.8
       '@types/dom-mediacapture-record': 1.0.22
       events: 3.3.0
       jose: 6.2.2
@@ -9383,7 +9450,7 @@ snapshots:
       sdp-transform: 2.15.0
       tslib: 2.8.1
       typed-emitter: 2.1.0
-      webrtc-adapter: 9.0.4
+      webrtc-adapter: 9.0.5
 
   load-tsconfig@0.2.5: {}
 
@@ -9398,6 +9465,8 @@ snapshots:
   lodash.sortby@4.7.0: {}
 
   lodash@4.18.1: {}
+
+  loglevel@1.9.1: {}
 
   loglevel@1.9.2: {}
 
@@ -10264,7 +10333,6 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   sade@1.8.1:
     dependencies:
@@ -10803,6 +10871,11 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  usehooks-ts@3.1.1(react@19.2.4):
+    dependencies:
+      lodash.debounce: 4.0.8
+      react: 19.2.4
+
   uvu@0.5.6:
     dependencies:
       dequal: 2.0.3
@@ -10955,7 +11028,7 @@ snapshots:
   webidl-conversions@8.0.1:
     optional: true
 
-  webrtc-adapter@9.0.4:
+  webrtc-adapter@9.0.5:
     dependencies:
       sdp: 3.2.2
 


### PR DESCRIPTION
## 요약
- v3 대기방 음성 UI를 `@livekit/components-react`의 `LiveKitRoom` 기반으로 표준화했습니다.
- `useVoiceConnection`은 토큰 발급, 연결 상세, disconnect race guard만 담당하도록 정리했습니다.
- `RoomVoicePanel`은 `RoomAudioRenderer`, `useParticipants`, `useLocalParticipant`로 실제 음성 UI 상태를 표시하고 mic/speaker 제어를 처리합니다.

## 이슈
Closes #696
Refs #697
Refs #698
Refs #699

## Coverage Plan
- `apps/web/src/hooks/useVoiceConnection.ts`: token fetch, disconnect cleanup, stale connected/error callback, LiveKit disconnected cleanup을 `useVoiceConnection.test.ts`로 검증했습니다.
- `apps/web/src/features/room/components/RoomVoicePanel.tsx`: LiveKit callbacks, reconnect UI, `RoomAudioRenderer` muted, mic/speaker controls를 `RoomVoicePanel.test.tsx`로 검증했습니다.
- `apps/web/src/pages/RoomPage.tsx` 연동 회귀: 기존 `RoomPage.test.tsx`로 voice panel render/useVoiceConnection contract를 검증했습니다.
- E2E 제외 사유: 이 PR은 LiveKit React provider foundation 변경이며 실제 마이크 권한/LiveKit 서버가 필요한 브라우저 음성 E2E는 #699 hardening에서 수행합니다. 이번 PR은 component/unit + quick local CI로 대체했습니다.

## Local validation
- `pnpm --config.store-dir=.pnpm-store --filter @mmp/web test -- src/hooks/__tests__/useVoiceConnection.test.ts src/features/room/components/__tests__/RoomVoicePanel.test.tsx src/pages/__tests__/RoomPage.test.tsx` - 3 files / 21 tests passed
- `pnpm --config.store-dir=.pnpm-store --filter @mmp/web typecheck` - passed
- `scripts/mmp-local-ci.sh quick` - passed at `fb14cdf9`; web tests 213 files / 1930 tests passed; build passed; existing lint/build warnings remain non-blocking

## CI policy
- `ready-for-ci` 라벨을 추가하지 않았습니다.
