### PR TITLE
feat: 대기방 데스크톱 레이아웃 재구성

### DIFF
--- a/apps/web/src/features/room/components/HostControls.tsx
+++ b/apps/web/src/features/room/components/HostControls.tsx
@@ -1,5 +1,5 @@
-import { Play, XCircle } from 'lucide-react';
-import { Button } from '@/shared/components/ui';
+import { CheckCircle, Circle, Play, XCircle } from 'lucide-react';
+import { Button, Panel } from '@/shared/components/ui';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -22,6 +22,18 @@ interface HostControlsProps {
   isStarting?: boolean;
   /** 시작 실패 메시지 */
   startErrorMessage?: string | null;
+  /** 현재 인원 */
+  playerCount?: number;
+  /** 최소 인원 */
+  minPlayers?: number | null;
+  /** 준비 완료 인원 */
+  readyPlayerCount?: number;
+  /** 준비 대상 인원 */
+  readyTargetCount?: number;
+  /** 캐릭터 선택 완료 인원 */
+  selectedCharacterCount?: number;
+  /** 캐릭터 선택 대상 인원 */
+  characterTargetCount?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -37,14 +49,64 @@ export function HostControls({
   onCloseRoom,
   isStarting = false,
   startErrorMessage,
+  playerCount = 0,
+  minPlayers,
+  readyPlayerCount = 0,
+  readyTargetCount = 0,
+  selectedCharacterCount = 0,
+  characterTargetCount = 0,
 }: HostControlsProps) {
   // 호스트가 아니면 렌더링하지 않음
   if (!isHost) return null;
 
   const canStart = allReady && hasMinPlayers && allCharactersSelected;
 
+  const startChecks = [
+    {
+      label: minPlayers != null ? `최소 인원 ${minPlayers}명` : '최소 인원 정보',
+      detail: minPlayers != null ? `${playerCount}/${minPlayers}` : '테마 정보 없음',
+      passed: hasMinPlayers,
+    },
+    {
+      label: '참가자 준비',
+      detail: `${readyPlayerCount}/${readyTargetCount}`,
+      passed: allReady,
+    },
+    {
+      label: '캐릭터 선택',
+      detail: `${selectedCharacterCount}/${characterTargetCount}`,
+      passed: allCharactersSelected,
+    },
+  ];
+
   return (
-    <div className="flex flex-col gap-2 pt-2">
+    <Panel className="flex flex-col gap-3">
+      <div>
+        <h2 className="text-base font-semibold text-[var(--mmp-color-ink)]">시작 조건</h2>
+        <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">
+          조건이 모두 충족되면 게임을 시작할 수 있습니다.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        {startChecks.map((check) => (
+          <div
+            key={check.label}
+            className="flex items-center justify-between gap-3 rounded-md border border-[var(--mmp-color-hairline)] px-3 py-2"
+          >
+            <span className="flex items-center gap-2 text-sm text-[var(--mmp-color-charcoal)]">
+              {check.passed ? (
+                <CheckCircle className="h-4 w-4 text-[var(--mmp-color-success)]" />
+              ) : (
+                <Circle className="h-4 w-4 text-[var(--mmp-color-muted)]" />
+              )}
+              {check.label}
+            </span>
+            <span className="text-xs font-medium text-[var(--mmp-color-steel)]">{check.detail}</span>
+          </div>
+        ))}
+      </div>
+
       <Button
         variant="primary"
         size="lg"
@@ -80,6 +142,6 @@ export function HostControls({
       >
         방 닫기
       </Button>
-    </div>
+    </Panel>
   );
 }

--- a/apps/web/src/features/room/components/PlayerList.tsx
+++ b/apps/web/src/features/room/components/PlayerList.tsx
@@ -1,5 +1,5 @@
 import { Crown, CheckCircle, Circle, UserPlus } from 'lucide-react';
-import { Card, Badge } from '@/shared/components/ui';
+import { Badge } from '@/shared/components/ui';
 import type { RoomPlayer } from '@/features/lobby/api';
 
 // ---------------------------------------------------------------------------
@@ -10,6 +10,7 @@ interface PlayerListProps {
   players: RoomPlayer[];
   maxPlayers: number;
   characterNameById?: Map<string, string>;
+  currentUserId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -20,14 +21,18 @@ function PlayerCard({
   player,
   index,
   characterName,
+  isCurrentUser,
 }: {
   player: RoomPlayer;
   index: number;
   characterName?: string;
+  isCurrentUser?: boolean;
 }) {
+  const readyLabel = player.is_ready ? '준비 완료' : '미준비';
+
   return (
-    <Card
-      className="motion-safe:animate-fade-slide-up flex items-center gap-3 p-3"
+    <div
+      className="motion-safe:animate-fade-slide-up flex items-center gap-3 rounded-lg border border-[var(--mmp-color-hairline)] bg-[var(--mmp-color-surface)] p-3"
       style={
         {
           '--stagger-index': index,
@@ -49,31 +54,53 @@ function PlayerCard({
         )}
       </div>
 
-      {/* 닉네임 + 역할 */}
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        <span className="truncate text-sm font-medium text-[var(--mmp-color-ink)]">
-          {player.nickname}
-        </span>
-        {player.is_host && (
-          <Badge variant="warning" size="sm">
-            <Crown className="mr-1 h-3 w-3" />
-            호스트
-          </Badge>
-        )}
-        {characterName && (
-          <Badge variant="info" size="sm">
-            {characterName}
-          </Badge>
-        )}
+      {/* 닉네임 + 상태 */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-medium text-[var(--mmp-color-ink)]">
+            {player.nickname}
+          </span>
+          {isCurrentUser && (
+            <span className="text-[10px] font-medium text-[var(--mmp-color-primary)]">나</span>
+          )}
+          {player.is_host && (
+            <Badge variant="warning" size="sm">
+              <Crown className="mr-1 h-3 w-3" />
+              호스트
+            </Badge>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {characterName ? (
+            <Badge variant="info" size="sm">
+              {characterName}
+            </Badge>
+          ) : (
+            <Badge variant="default" size="sm">
+              캐릭터 미선택
+            </Badge>
+          )}
+          {!player.is_host && (
+            <Badge variant={player.is_ready ? 'success' : 'default'} size="sm">
+              {readyLabel}
+            </Badge>
+          )}
+        </div>
       </div>
 
       {/* 레디 상태 */}
       {player.is_host ? null : player.is_ready ? (
-        <CheckCircle className="h-5 w-5 shrink-0 text-[var(--mmp-color-success)]" />
+        <CheckCircle
+          aria-label={readyLabel}
+          className="h-5 w-5 shrink-0 text-[var(--mmp-color-success)]"
+        />
       ) : (
-        <Circle className="h-5 w-5 shrink-0 text-[var(--mmp-color-muted)]" />
+        <Circle
+          aria-label={readyLabel}
+          className="h-5 w-5 shrink-0 text-[var(--mmp-color-muted)]"
+        />
       )}
-    </Card>
+    </div>
   );
 }
 
@@ -96,7 +123,12 @@ function EmptySlot() {
 // PlayerList
 // ---------------------------------------------------------------------------
 
-export function PlayerList({ players, maxPlayers, characterNameById }: PlayerListProps) {
+export function PlayerList({
+  players,
+  maxPlayers,
+  characterNameById,
+  currentUserId,
+}: PlayerListProps) {
   const emptySlots = Math.max(0, maxPlayers - players.length);
 
   return (
@@ -109,6 +141,7 @@ export function PlayerList({ players, maxPlayers, characterNameById }: PlayerLis
           characterName={
             player.character_id ? characterNameById?.get(player.character_id) : undefined
           }
+          isCurrentUser={player.user_id === currentUserId}
         />
       ))}
       {Array.from({ length: emptySlots }, (_, i) => (

--- a/apps/web/src/features/room/components/__tests__/PlayerList.test.tsx
+++ b/apps/web/src/features/room/components/__tests__/PlayerList.test.tsx
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { RoomPlayer } from '@/features/lobby/api';
+import { PlayerList } from '../PlayerList';
+
+afterEach(() => {
+  cleanup();
+});
+
+const players: RoomPlayer[] = [
+  {
+    id: 'player-host',
+    user_id: 'host-1',
+    nickname: '호스트',
+    avatar_url: null,
+    is_host: true,
+    is_ready: true,
+    character_id: 'detective',
+    joined_at: '2026-05-19T00:00:00Z',
+  },
+  {
+    id: 'player-current',
+    user_id: 'user-1',
+    nickname: '나참가자',
+    avatar_url: null,
+    is_host: false,
+    is_ready: true,
+    character_id: 'doctor',
+    joined_at: '2026-05-19T00:00:00Z',
+  },
+  {
+    id: 'player-pending',
+    user_id: 'user-2',
+    nickname: '미정참가자',
+    avatar_url: null,
+    is_host: false,
+    is_ready: false,
+    character_id: null,
+    joined_at: '2026-05-19T00:00:00Z',
+  },
+];
+
+describe('PlayerList', () => {
+  it('renders player role, current user, character, ready state, and empty slots', () => {
+    render(
+      <PlayerList
+        players={players}
+        maxPlayers={4}
+        currentUserId="user-1"
+        characterNameById={
+          new Map([
+            ['detective', '탐정'],
+            ['doctor', '의사'],
+          ])
+        }
+      />
+    );
+
+    expect(screen.getAllByText('호스트')).toHaveLength(2);
+    expect(screen.getAllByText('나').length).toBeGreaterThan(0);
+    expect(screen.getByText('탐정')).toBeInTheDocument();
+    expect(screen.getByText('의사')).toBeInTheDocument();
+    expect(screen.getByText('캐릭터 미선택')).toBeInTheDocument();
+    expect(screen.getByText('준비 완료')).toBeInTheDocument();
+    expect(screen.getByText('미준비')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('준비 완료')).toHaveLength(1);
+    expect(screen.getAllByLabelText('미준비')).toHaveLength(1);
+    expect(screen.getByText('빈 자리')).toBeInTheDocument();
+    expect(screen.queryByText('대기')).not.toBeInTheDocument();
+    expect(screen.queryByText('음소거')).not.toBeInTheDocument();
+    expect(screen.queryByText('말하는 중')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -14,7 +14,7 @@ import { WsEventType } from '@mmp/shared';
 import { useWsClient } from '@/hooks/useWsClient';
 import { useWsEvent } from '@/hooks/useWsEvent';
 import { useAuthStore, selectUser } from '@/stores/authStore';
-import { Alert, Button, LoadingState, PageShell } from '@/shared/components/ui';
+import { Alert, Button, LoadingState, PageShell, Panel } from '@/shared/components/ui';
 import {
   PlayerList,
   RoomHeader,
@@ -114,10 +114,12 @@ export default function RoomPage() {
   const isHost = currentUser ? room?.host_id === currentUser.id : false;
   const nonHostPlayers = players.filter((p) => !p.is_host);
   const allReady = nonHostPlayers.length > 0 && nonHostPlayers.every((p) => p.is_ready);
+  const readyPlayerCount = nonHostPlayers.filter((p) => p.is_ready).length;
   const minPlayers = room?.theme?.min_players;
   const hasMinPlayers = minPlayers != null && players.length >= minPlayers;
   const allCharactersSelected =
     players.length > 0 && players.every((player) => Boolean(player.character_id));
+  const selectedCharacterCount = players.filter((player) => Boolean(player.character_id)).length;
   const characterNameById = useMemo(
     () => new Map((themeCharacters.data ?? []).map((character) => [character.id, character.name])),
     [themeCharacters.data]
@@ -216,7 +218,7 @@ export default function RoomPage() {
 
   return (
     <PageShell className="min-h-[calc(100vh-4rem)]">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4">
         {/* 헤더 */}
         <RoomHeader
           themeTitle={room.theme_title ?? room.theme?.title ?? '대기방'}
@@ -248,23 +250,87 @@ export default function RoomPage() {
           </Button>
         </div>
 
-        {/* 2컬럼 레이아웃 (데스크탑) / 탭 전환 (모바일) */}
-        <div className="grid gap-4 md:grid-cols-[1fr_1fr]">
-          {/* 왼쪽: 참가자 + 호스트 컨트롤 */}
-          <div
+        {/* 데스크톱 3영역 레이아웃 / 모바일 탭 전환 */}
+        <div className="grid gap-4 lg:grid-cols-[minmax(260px,0.85fr)_minmax(360px,1.15fr)_minmax(320px,1fr)]">
+          {/* 참가자 상태 */}
+          <section
+            aria-labelledby="room-participants-heading"
             className={`flex flex-col gap-4 ${mobileTab !== 'players' ? 'hidden md:flex' : 'flex'}`}
           >
-            <PlayerList
-              players={players}
-              maxPlayers={room.max_players}
-              characterNameById={characterNameById}
-            />
-            {id && room.status.toLowerCase() === 'waiting' && (
-              <RoomInvitePanel roomId={id} isHost={isHost} />
-            )}
-            {id && (
-              <RoomVoicePanel roomId={id} isActive={room.status.toLowerCase() === 'waiting'} />
-            )}
+            <Panel className="flex flex-col gap-3">
+              <div>
+                <h2
+                  id="room-participants-heading"
+                  className="text-base font-semibold text-[var(--mmp-color-ink)]"
+                >
+                  참가자 상태
+                </h2>
+                <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">
+                  준비 상태와 캐릭터 선택을 한 번에 확인합니다.
+                </p>
+              </div>
+              <PlayerList
+                players={players}
+                maxPlayers={room.max_players}
+                characterNameById={characterNameById}
+                currentUserId={currentUser?.id}
+              />
+            </Panel>
+
+            <Panel className="flex flex-col gap-3">
+              <div className="grid grid-cols-3 gap-2 text-center">
+                <div className="rounded-md border border-[var(--mmp-color-hairline)] px-2 py-2">
+                  <p className="text-xs text-[var(--mmp-color-steel)]">인원</p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--mmp-color-ink)]">
+                    {players.length}/{room.max_players}
+                  </p>
+                </div>
+                <div className="rounded-md border border-[var(--mmp-color-hairline)] px-2 py-2">
+                  <p className="text-xs text-[var(--mmp-color-steel)]">준비</p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--mmp-color-ink)]">
+                    {readyPlayerCount}/{nonHostPlayers.length}
+                  </p>
+                </div>
+                <div className="rounded-md border border-[var(--mmp-color-hairline)] px-2 py-2">
+                  <p className="text-xs text-[var(--mmp-color-steel)]">캐릭터</p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--mmp-color-ink)]">
+                    {selectedCharacterCount}/{players.length}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between gap-3">
+                <Button
+                  variant="ghost"
+                  leftIcon={<LogOut className="h-4 w-4" />}
+                  onClick={handleLeave}
+                  isLoading={leaveRoom.isPending}
+                >
+                  나가기
+                </Button>
+
+                {!isHost && (
+                  <Button
+                    variant={isReady ? 'secondary' : 'primary'}
+                    leftIcon={<Shield className="h-4 w-4" />}
+                    onClick={handleToggleReady}
+                    isLoading={setReady.isPending}
+                  >
+                    {isReady ? '준비 취소' : '준비 완료'}
+                  </Button>
+                )}
+              </div>
+            </Panel>
+          </section>
+
+          {/* 준비 설정 */}
+          <section
+            aria-labelledby="room-setup-heading"
+            className={`flex flex-col gap-4 ${mobileTab !== 'players' ? 'hidden md:flex' : 'flex'}`}
+          >
+            <h2 id="room-setup-heading" className="sr-only">
+              준비 설정
+            </h2>
             {currentPlayer && (
               <CharacterSelectionPanel
                 characters={themeCharacters.data ?? []}
@@ -285,40 +351,35 @@ export default function RoomPage() {
               onCloseRoom={handleCloseRoom}
               isStarting={startRoom.isPending}
               startErrorMessage={startErrorMessage}
+              playerCount={players.length}
+              minPlayers={minPlayers}
+              readyPlayerCount={readyPlayerCount}
+              readyTargetCount={nonHostPlayers.length}
+              selectedCharacterCount={selectedCharacterCount}
+              characterTargetCount={players.length}
             />
-          </div>
+          </section>
 
-          {/* 오른쪽: 채팅 */}
-          <div
-            className={`h-[400px] md:h-[500px] ${
-              mobileTab !== 'chat' ? 'hidden md:block' : 'block'
+          {/* 채팅 + 음성 */}
+          <section
+            aria-labelledby="room-communication-heading"
+            className={`flex flex-col gap-4 ${
+              mobileTab !== 'chat' ? 'hidden md:flex' : 'flex'
             }`}
           >
-            <RoomChat roomId={id} send={send} />
-          </div>
-        </div>
-
-        {/* 하단: 레디 + 나가기 */}
-        <div className="flex items-center justify-between gap-3 border-t border-[var(--mmp-color-hairline)] pt-4">
-          <Button
-            variant="ghost"
-            leftIcon={<LogOut className="h-4 w-4" />}
-            onClick={handleLeave}
-            isLoading={leaveRoom.isPending}
-          >
-            나가기
-          </Button>
-
-          {!isHost && (
-            <Button
-              variant={isReady ? 'secondary' : 'primary'}
-              leftIcon={<Shield className="h-4 w-4" />}
-              onClick={handleToggleReady}
-              isLoading={setReady.isPending}
-            >
-              {isReady ? '준비 취소' : '준비 완료'}
-            </Button>
-          )}
+            <h2 id="room-communication-heading" className="sr-only">
+              채팅과 음성
+            </h2>
+            <div className="h-[420px] lg:h-[560px]">
+              <RoomChat roomId={id} send={send} />
+            </div>
+            {id && (
+              <RoomVoicePanel roomId={id} isActive={room.status.toLowerCase() === 'waiting'} />
+            )}
+            {id && room.status.toLowerCase() === 'waiting' && (
+              <RoomInvitePanel roomId={id} isHost={isHost} />
+            )}
+          </section>
         </div>
       </div>
     </PageShell>

--- a/apps/web/src/pages/__tests__/RoomPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RoomPage.test.tsx
@@ -241,6 +241,24 @@ afterEach(() => {
 });
 
 describe('RoomPage pregame controls', () => {
+  it('데스크톱 대기방을 참가자 상태, 준비 설정, 채팅과 음성 영역으로 나눈다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    expect(screen.getByRole('heading', { name: '참가자 상태' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '준비 설정' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '채팅과 음성' })).toBeInTheDocument();
+    expect(screen.getByText('준비 상태와 캐릭터 선택을 한 번에 확인합니다.')).toBeInTheDocument();
+    expect(screen.getAllByText('2/6').length).toBeGreaterThan(0);
+    expect(screen.getByText('2/2')).toBeInTheDocument();
+    expect(screen.getAllByText('준비 완료').length).toBeGreaterThan(0);
+  });
+
   it('현재 사용자의 준비 상태를 room.players에서 읽고 HTTP ready mutation에 is_ready를 보낸다', async () => {
     const readyMutate = vi.fn((_variables, options) => {
       options?.onSuccess?.();


### PR DESCRIPTION
## 요약
- v1 대기방 흐름을 참고해 `RoomPage`를 데스크톱 3영역 구조로 재배치했습니다.
- 참가자 상태, 준비/캐릭터 선택, 채팅+음성+초대 영역을 한 화면에서 확인할 수 있게 했습니다.
- `PlayerList`는 실제 voice 런타임 상태를 흉내 내지 않고 준비/캐릭터 상태만 표시하도록 유지했습니다.

Closes #697
Refs #698
Refs #699

## Coverage Plan
- `RoomPage.tsx`: 참가자 상태 / 준비 설정 / 채팅과 음성 section 렌더링, ready/start 상태, character selection 회귀를 `RoomPage.test.tsx`로 검증.
- `PlayerList.tsx`: host/current user, 캐릭터 선택/미선택, 준비/미준비 가시 라벨, `aria-label`, 빈 자리, fake voice badge 부재를 `PlayerList.test.tsx`로 검증.
- `RoomVoicePanel`: #696 voice boundary 유지 확인을 위해 기존 `RoomVoicePanel.test.tsx` focused run에 포함.

## Local validation
- `pnpm --config.store-dir=.pnpm-store --filter @mmp/web test -- src/pages/__tests__/RoomPage.test.tsx src/features/room/components/__tests__/PlayerList.test.tsx src/features/room/components/__tests__/RoomVoicePanel.test.tsx` 통과: 3 files, 19 tests.
- `pnpm --config.store-dir=.pnpm-store --filter @mmp/web typecheck` 통과.
- `scripts/mmp-local-ci.sh quick` 통과: server tests, web lint/typecheck/test/build. 기존 lint/build warning만 존재.

## Browser QA
- `http://127.0.0.1:3001`에서 E2E 계정으로 로그인 후 공개 방의 실제 대기방에 진입했습니다.
- 데스크톱 viewport에서 `참가자 상태`, `준비 설정`, `채팅과 음성` 3영역 렌더링을 Playwright snapshot으로 확인했습니다.
- 스크린샷: `/Users/sabyun/goinfre/muder_platform/.playwright-mcp/issue-697-room-desktop.png`
- 콘솔의 WebSocket 403 및 공개 방 join 409는 로컬 세션/이미 참가한 방 상태에서 발생한 기존 환경 증상으로, 레이아웃 렌더링 회귀로 보지 않았습니다.

## Review
- `mmp-frontend-editor-reviewer`: blocker 없음, #696 LiveKit boundary 유지 확인.
- `mmp-test-coverage-reviewer`: blocker 없음, 직접 `PlayerList` 테스트와 browser QA evidence 충족 확인.
