### PR TITLE
feat(web): 대기방 커뮤니케이션 허브 통합

### DIFF
--- a/apps/web/src/features/room/components/PlayerList.tsx
+++ b/apps/web/src/features/room/components/PlayerList.tsx
@@ -1,4 +1,4 @@
-import { Crown, CheckCircle, Circle, UserPlus } from 'lucide-react';
+import { Crown, CheckCircle, Circle, UserPlus, Mic, MicOff } from 'lucide-react';
 import { Badge } from '@/shared/components/ui';
 import type { RoomPlayer } from '@/features/lobby/api';
 
@@ -11,6 +11,8 @@ interface PlayerListProps {
   maxPlayers: number;
   characterNameById?: Map<string, string>;
   currentUserId?: string;
+  speakingPlayerIds?: Set<string>;
+  mutedPlayerIds?: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -22,11 +24,15 @@ function PlayerCard({
   index,
   characterName,
   isCurrentUser,
+  isSpeaking,
+  isMuted,
 }: {
   player: RoomPlayer;
   index: number;
   characterName?: string;
   isCurrentUser?: boolean;
+  isSpeaking?: boolean;
+  isMuted?: boolean;
 }) {
   const readyLabel = player.is_ready ? '준비 완료' : '미준비';
 
@@ -85,6 +91,18 @@ function PlayerCard({
               {readyLabel}
             </Badge>
           )}
+          {isSpeaking && (
+            <Badge variant="success" size="sm">
+              <Mic className="mr-1 h-3 w-3" />
+              말하는 중
+            </Badge>
+          )}
+          {isMuted && (
+            <Badge variant="default" size="sm">
+              <MicOff className="mr-1 h-3 w-3" />
+              음소거
+            </Badge>
+          )}
         </div>
       </div>
 
@@ -128,6 +146,8 @@ export function PlayerList({
   maxPlayers,
   characterNameById,
   currentUserId,
+  speakingPlayerIds,
+  mutedPlayerIds,
 }: PlayerListProps) {
   const emptySlots = Math.max(0, maxPlayers - players.length);
 
@@ -142,6 +162,8 @@ export function PlayerList({
             player.character_id ? characterNameById?.get(player.character_id) : undefined
           }
           isCurrentUser={player.user_id === currentUserId}
+          isSpeaking={speakingPlayerIds?.has(player.user_id) ?? false}
+          isMuted={mutedPlayerIds?.has(player.user_id) ?? false}
         />
       ))}
       {Array.from({ length: emptySlots }, (_, i) => (

--- a/apps/web/src/features/room/components/RoomChat.tsx
+++ b/apps/web/src/features/room/components/RoomChat.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
 import { Send } from "lucide-react";
 import { WsEventType } from "@mmp/shared";
 import { Button, Input, Panel } from "@/shared/components/ui";
@@ -20,13 +20,14 @@ interface RoomChatProps {
   roomId: string;
   /** WS send 함수 */
   send: <T>(type: string, payload: T) => void;
+  headerActions?: ReactNode;
 }
 
 // ---------------------------------------------------------------------------
 // RoomChat
 // ---------------------------------------------------------------------------
 
-export function RoomChat({ roomId, send }: RoomChatProps) {
+export function RoomChat({ roomId, send, headerActions }: RoomChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputText, setInputText] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -67,6 +68,16 @@ export function RoomChat({ roomId, send }: RoomChatProps) {
 
   return (
     <Panel padding="none" className="flex h-full flex-col overflow-hidden">
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--mmp-color-hairline)] p-3">
+        <div>
+          <h2 className="text-base font-semibold text-[var(--mmp-color-ink)]">대기방 채팅</h2>
+          <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">
+            음성 상태를 보면서 메시지를 주고받습니다.
+          </p>
+        </div>
+        {headerActions && <div className="min-w-0">{headerActions}</div>}
+      </div>
+
       {/* 메시지 영역 */}
       <div className="flex-1 overflow-y-auto p-4">
         {messages.length === 0 ? (

--- a/apps/web/src/features/room/components/RoomVoicePanel.tsx
+++ b/apps/web/src/features/room/components/RoomVoicePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import {
   LiveKitRoom,
   RoomAudioRenderer,
@@ -14,6 +14,19 @@ import { Button, Panel } from '@/shared/components/ui';
 interface RoomVoicePanelProps {
   roomId: string;
   isActive: boolean;
+  variant?: 'panel' | 'inline';
+  playerNameById?: Map<string, string>;
+}
+
+interface VoiceParticipantLike {
+  identity?: string;
+  sid?: string;
+  name?: string;
+  audioLevel?: number;
+  isSpeaking?: boolean;
+  isMicrophoneEnabled?: boolean;
+  setMicrophoneEnabled?: (enabled: boolean) => Promise<void>;
+  audioTrackPublications?: Map<string, { isMuted?: boolean }>;
 }
 
 const stateLabel = {
@@ -23,11 +36,17 @@ const stateLabel = {
   error: '연결 실패',
 } as const;
 
-export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
+export function RoomVoicePanel({
+  roomId,
+  isActive,
+  variant = 'panel',
+  playerNameById,
+}: RoomVoicePanelProps) {
   const connectionState = useVoiceStore(selectVoiceConnectionState);
   const isMuted = useVoiceStore(selectIsMuted);
   const isSpeakerMuted = useVoiceStore(selectIsSpeakerMuted);
   const resetVoice = useVoiceStore((state) => state.reset);
+  const clearParticipantVoiceStates = useVoiceStore((state) => state.clearParticipantVoiceStates);
   const {
     connectionDetails,
     connect,
@@ -45,15 +64,17 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
   useEffect(() => {
     if (isActive) return;
     void disconnect();
+    clearParticipantVoiceStates();
     resetVoice();
-  }, [disconnect, isActive, resetVoice]);
+  }, [clearParticipantVoiceStates, disconnect, isActive, resetVoice]);
 
   useEffect(() => {
     return () => {
       void disconnect();
+      clearParticipantVoiceStates();
       resetVoice();
     };
-  }, [disconnect, resetVoice]);
+  }, [clearParticipantVoiceStates, disconnect, resetVoice]);
 
   const canDisconnect = connectionState === 'connected' || connectionState === 'connecting';
   const helperText = useMemo(() => {
@@ -62,9 +83,19 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
     if (connectionState === 'connected') return '음성 채팅에 연결되어 있습니다.';
     return '대기방 참가자만 음성 채팅에 들어갈 수 있습니다.';
   }, [connectionState, isActive]);
+  const handleDisconnect = useCallback(() => {
+    clearParticipantVoiceStates();
+    void disconnect();
+  }, [clearParticipantVoiceStates, disconnect]);
 
-  return (
-    <Panel className="flex flex-col gap-3">
+  const content = (
+    <div
+      className={
+        variant === 'inline'
+          ? 'flex min-w-[220px] flex-col gap-2'
+          : 'flex flex-col gap-3'
+      }
+    >
       <div className="flex items-center justify-between gap-3">
         <div>
           <h2 className="flex items-center gap-2 text-sm font-semibold text-[var(--mmp-color-ink)]">
@@ -78,7 +109,7 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
             size="sm"
             variant="secondary"
             leftIcon={<PhoneOff className="h-4 w-4" />}
-            onClick={() => void disconnect()}
+            onClick={handleDisconnect}
           >
             나가기
           </Button>
@@ -119,6 +150,7 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
         >
           <RoomAudioRenderer muted={isSpeakerMuted} />
           <LiveKitVoiceControls />
+          <LiveKitSpeakingOverlay playerNameById={playerNameById} />
         </LiveKitRoom>
       ) : (
         <div className="flex flex-wrap gap-2">
@@ -140,13 +172,19 @@ export function RoomVoicePanel({ roomId, isActive }: RoomVoicePanelProps) {
           </Button>
         </div>
       )}
-    </Panel>
+    </div>
   );
+
+  if (variant === 'inline') {
+    return content;
+  }
+
+  return <Panel className="flex flex-col gap-3">{content}</Panel>;
 }
 
 function LiveKitVoiceControls() {
   const participants = useParticipants();
-  const { localParticipant } = useLocalParticipant();
+  const { localParticipant } = useLocalParticipant() as { localParticipant: VoiceParticipantLike };
   const connectionState = useVoiceStore(selectVoiceConnectionState);
   const isMuted = useVoiceStore(selectIsMuted);
   const isSpeakerMuted = useVoiceStore(selectIsSpeakerMuted);
@@ -157,7 +195,7 @@ function LiveKitVoiceControls() {
   const handleToggleMute = async () => {
     const nextMuted = !isMuted;
     try {
-      await localParticipant.setMicrophoneEnabled(!nextMuted);
+      await localParticipant.setMicrophoneEnabled?.(!nextMuted);
       toggleStoreMute();
     } catch {
       setConnectionState('error');
@@ -190,6 +228,91 @@ function LiveKitVoiceControls() {
         >
           {isSpeakerMuted ? '스피커 켜기' : '스피커 끄기'}
         </Button>
+      </div>
+    </div>
+  );
+}
+
+function LiveKitSpeakingOverlay({ playerNameById }: { playerNameById?: Map<string, string> }) {
+  const participants = useParticipants() as VoiceParticipantLike[];
+  const { localParticipant } = useLocalParticipant() as { localParticipant?: VoiceParticipantLike };
+  const setParticipantVoiceStates = useVoiceStore((state) => state.setParticipantVoiceStates);
+
+  const participantVoiceStates = useMemo(() => {
+    const participantByIdentity = new Map<string, VoiceParticipantLike>();
+    const voiceStates: Record<string, { isSpeaking: boolean; isMuted: boolean }> = {};
+
+    for (const participant of [localParticipant, ...participants]) {
+      const identity = participant?.identity ?? participant?.sid;
+      if (!identity) continue;
+      participantByIdentity.set(identity, participant);
+    }
+
+    for (const participant of participantByIdentity.values()) {
+      const identity = participant.identity ?? participant.sid;
+      if (!identity) continue;
+      const publications = Array.from(participant.audioTrackPublications?.values() ?? []);
+
+      voiceStates[identity] = {
+        isSpeaking: Boolean(participant.isSpeaking) || (participant.audioLevel ?? 0) > 0.01,
+        isMuted:
+          participant.isMicrophoneEnabled === false ||
+          (publications.length > 0 && publications.every((publication) => publication.isMuted)),
+      };
+    }
+
+    return voiceStates;
+  }, [localParticipant, participants]);
+
+  useEffect(() => {
+    setParticipantVoiceStates(participantVoiceStates);
+    return () => {
+      useVoiceStore.getState().clearParticipantVoiceStates();
+    };
+  }, [participantVoiceStates, setParticipantVoiceStates]);
+
+  const speakingParticipants = useMemo(() => {
+    const participantByIdentity = new Map<string, VoiceParticipantLike>();
+
+    for (const participant of [localParticipant, ...participants]) {
+      const identity = participant?.identity ?? participant?.sid;
+      if (!identity) continue;
+      participantByIdentity.set(identity, participant);
+    }
+
+    return Array.from(participantByIdentity.values()).filter((participant) => {
+      const identity = participant.identity ?? participant.sid;
+      return identity ? participantVoiceStates[identity]?.isSpeaking : false;
+    });
+  }, [localParticipant, participantVoiceStates, participants]);
+
+  if (speakingParticipants.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-label="말하는 참가자"
+      className="rounded-md border border-[var(--mmp-color-hairline)] bg-[var(--mmp-color-muted)]/50 p-2"
+    >
+      <p className="text-xs font-semibold text-[var(--mmp-color-ink)]">말하는 참가자</p>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {speakingParticipants.map((participant) => {
+          const identity = participant.identity ?? participant.sid ?? 'unknown';
+          const name = playerNameById?.get(identity) ?? participant.name ?? identity;
+          const isMuted = participantVoiceStates[identity]?.isMuted ?? false;
+
+          return (
+            <span
+              key={identity}
+              className="inline-flex items-center gap-1 rounded-full bg-[var(--mmp-color-surface)] px-2 py-1 text-xs font-medium text-[var(--mmp-color-charcoal)]"
+            >
+              <Mic className="h-3 w-3 text-[var(--mmp-color-primary)]" />
+              {name}
+              {isMuted && <span className="text-[10px] text-[var(--mmp-color-steel)]">음소거</span>}
+            </span>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/features/room/components/__tests__/PlayerList.test.tsx
+++ b/apps/web/src/features/room/components/__tests__/PlayerList.test.tsx
@@ -72,4 +72,18 @@ describe('PlayerList', () => {
     expect(screen.queryByText('음소거')).not.toBeInTheDocument();
     expect(screen.queryByText('말하는 중')).not.toBeInTheDocument();
   });
+
+  it('renders voice speaking and mute states only when live voice state is supplied', () => {
+    render(
+      <PlayerList
+        players={players}
+        maxPlayers={3}
+        speakingPlayerIds={new Set(['user-1'])}
+        mutedPlayerIds={new Set(['user-2'])}
+      />
+    );
+
+    expect(screen.getByText('말하는 중')).toBeInTheDocument();
+    expect(screen.getByText('음소거')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/room/components/__tests__/RoomVoicePanel.test.tsx
+++ b/apps/web/src/features/room/components/__tests__/RoomVoicePanel.test.tsx
@@ -11,6 +11,8 @@ const {
   liveKitRoomProps,
   microphoneEnabledMock,
   participantsMock,
+  silentParticipantsMock,
+  localParticipantState,
 } = vi.hoisted(() => ({
   liveKitRoomProps: { current: null as null | {
     onConnected?: () => void;
@@ -19,9 +21,22 @@ const {
   } },
   microphoneEnabledMock: vi.fn(),
   participantsMock: [
-    { identity: 'local-user' },
-    { identity: 'remote-user' },
+    { identity: 'local-user', sid: 'local-sid', audioLevel: 0.02, isMicrophoneEnabled: true },
+    {
+      identity: 'remote-user',
+      sid: 'remote-sid',
+      audioLevel: 0.04,
+      audioTrackPublications: new Map([['audio', { isMuted: false }]]),
+    },
   ],
+  silentParticipantsMock: [] as Array<{
+    identity: string;
+    sid: string;
+    audioLevel: number;
+    isMicrophoneEnabled?: boolean;
+    audioTrackPublications?: Map<string, { isMuted: boolean }>;
+  }>,
+  localParticipantState: { audioLevel: 0.02 },
 }));
 
 vi.mock('@livekit/components-react', () => ({
@@ -37,9 +52,13 @@ vi.mock('@livekit/components-react', () => ({
   RoomAudioRenderer: ({ muted }: { muted?: boolean }) => (
     <div data-muted={muted ? 'true' : 'false'} data-testid="room-audio-renderer" />
   ),
-  useParticipants: () => participantsMock,
+  useParticipants: () => (silentParticipantsMock.length > 0 ? silentParticipantsMock : participantsMock),
   useLocalParticipant: () => ({
     localParticipant: {
+      identity: 'local-user',
+      sid: 'local-sid',
+      audioLevel: localParticipantState.audioLevel,
+      isMicrophoneEnabled: true,
       setMicrophoneEnabled: microphoneEnabledMock,
     },
   }),
@@ -55,6 +74,8 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   liveKitRoomProps.current = null;
+  silentParticipantsMock.length = 0;
+  localParticipantState.audioLevel = 0.02;
   useVoiceStore.getState().reset();
 });
 
@@ -116,5 +137,93 @@ describe('RoomVoicePanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /스피커 끄기/ }));
 
     expect(screen.getByTestId('room-audio-renderer')).toHaveAttribute('data-muted', 'true');
+  });
+
+  it('renders compact header controls and a speaking overlay for the communication hub', async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: 'token-1',
+      room_name: 'room-room-1-main',
+      livekit_url: 'ws://livekit',
+    });
+
+    render(
+      <RoomVoicePanel
+        roomId="room-1"
+        isActive
+        variant="inline"
+        playerNameById={
+          new Map([
+            ['local-user', '나참가자'],
+            ['remote-user', '원격참가자'],
+          ])
+        }
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /입장/ }));
+    await screen.findByTestId('livekit-room');
+
+    act(() => {
+      liveKitRoomProps.current?.onConnected?.();
+    });
+
+    expect(await screen.findByText('말하는 참가자')).toBeInTheDocument();
+    expect(screen.getByText('나참가자')).toBeInTheDocument();
+    expect(screen.getByText('원격참가자')).toBeInTheDocument();
+    expect(useVoiceStore.getState().participantVoiceStates).toMatchObject({
+      'local-user': { isSpeaking: true, isMuted: false },
+      'remote-user': { isSpeaking: true, isMuted: false },
+    });
+    expect(screen.getByRole('button', { name: /마이크 끄기/ })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /스피커 끄기/ })).toBeEnabled();
+  });
+
+  it('hides the speaking overlay when LiveKit reports no active speakers', async () => {
+    localParticipantState.audioLevel = 0;
+    silentParticipantsMock.push({
+      identity: 'remote-user',
+      sid: 'remote-sid',
+      audioLevel: 0,
+      audioTrackPublications: new Map([['audio', { isMuted: false }]]),
+    });
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: 'token-1',
+      room_name: 'room-room-1-main',
+      livekit_url: 'ws://livekit',
+    });
+
+    render(<RoomVoicePanel roomId="room-1" isActive variant="inline" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /입장/ }));
+    await screen.findByTestId('livekit-room');
+
+    act(() => {
+      liveKitRoomProps.current?.onConnected?.();
+    });
+
+    expect(screen.queryByText('말하는 참가자')).not.toBeInTheDocument();
+  });
+
+  it('clears participant voice state when leaving voice chat', async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: 'token-1',
+      room_name: 'room-room-1-main',
+      livekit_url: 'ws://livekit',
+    });
+
+    render(<RoomVoicePanel roomId="room-1" isActive variant="inline" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /입장/ }));
+    await screen.findByTestId('livekit-room');
+
+    act(() => {
+      liveKitRoomProps.current?.onConnected?.();
+    });
+
+    expect(useVoiceStore.getState().participantVoiceStates).not.toEqual({});
+
+    fireEvent.click(await screen.findByRole('button', { name: /나가기/ }));
+
+    expect(useVoiceStore.getState().participantVoiceStates).toEqual({});
   });
 });

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -14,6 +14,7 @@ import { WsEventType } from '@mmp/shared';
 import { useWsClient } from '@/hooks/useWsClient';
 import { useWsEvent } from '@/hooks/useWsEvent';
 import { useAuthStore, selectUser } from '@/stores/authStore';
+import { useVoiceStore, selectParticipantVoiceStates } from '@/stores/voiceStore';
 import { Alert, Button, LoadingState, PageShell, Panel } from '@/shared/components/ui';
 import {
   PlayerList,
@@ -68,6 +69,7 @@ export default function RoomPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const currentUser = useAuthStore(selectUser);
+  const participantVoiceStates = useVoiceStore(selectParticipantVoiceStates);
 
   // 방 정보 쿼리
   const { data: room, isLoading, isError, refetch } = useRoom(id ?? '');
@@ -120,9 +122,32 @@ export default function RoomPage() {
   const allCharactersSelected =
     players.length > 0 && players.every((player) => Boolean(player.character_id));
   const selectedCharacterCount = players.filter((player) => Boolean(player.character_id)).length;
+  const isWaitingRoom = room?.status.toLowerCase() === 'waiting';
   const characterNameById = useMemo(
     () => new Map((themeCharacters.data ?? []).map((character) => [character.id, character.name])),
     [themeCharacters.data]
+  );
+  const playerNameById = useMemo(
+    () => new Map(players.map((player) => [player.user_id, player.nickname])),
+    [players]
+  );
+  const speakingPlayerIds = useMemo(
+    () =>
+      new Set(
+        players
+          .filter((player) => participantVoiceStates[player.user_id]?.isSpeaking)
+          .map((player) => player.user_id)
+      ),
+    [participantVoiceStates, players]
+  );
+  const mutedPlayerIds = useMemo(
+    () =>
+      new Set(
+        players
+          .filter((player) => participantVoiceStates[player.user_id]?.isMuted)
+          .map((player) => player.user_id)
+      ),
+    [participantVoiceStates, players]
   );
   const selectedByOtherPlayerIds = useMemo(
     () =>
@@ -274,6 +299,8 @@ export default function RoomPage() {
                 maxPlayers={room.max_players}
                 characterNameById={characterNameById}
                 currentUserId={currentUser?.id}
+                speakingPlayerIds={speakingPlayerIds}
+                mutedPlayerIds={mutedPlayerIds}
               />
             </Panel>
 
@@ -371,12 +398,22 @@ export default function RoomPage() {
               채팅과 음성
             </h2>
             <div className="h-[420px] lg:h-[560px]">
-              <RoomChat roomId={id} send={send} />
+              <RoomChat
+                roomId={id}
+                send={send}
+                headerActions={
+                  id ? (
+                    <RoomVoicePanel
+                      roomId={id}
+                      isActive={isWaitingRoom}
+                      variant="inline"
+                      playerNameById={playerNameById}
+                    />
+                  ) : null
+                }
+              />
             </div>
-            {id && (
-              <RoomVoicePanel roomId={id} isActive={room.status.toLowerCase() === 'waiting'} />
-            )}
-            {id && room.status.toLowerCase() === 'waiting' && (
+            {id && isWaitingRoom && (
               <RoomInvitePanel roomId={id} isHost={isHost} />
             )}
           </section>

--- a/apps/web/src/pages/__tests__/RoomPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RoomPage.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { useAuthStore } from '@/stores/authStore';
+import { useVoiceStore } from '@/stores/voiceStore';
 
 const {
   navigateMock,
@@ -238,6 +239,7 @@ afterEach(() => {
     isAuthenticated: false,
     isLoading: false,
   });
+  useVoiceStore.getState().reset();
 });
 
 describe('RoomPage pregame controls', () => {
@@ -565,5 +567,36 @@ describe('RoomPage pregame controls', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: '입장' }));
     expect(connect).toHaveBeenCalled();
+  });
+
+  it('채팅 영역 헤더에서 음성 입장 제어를 함께 제공한다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    expect(screen.getByRole('heading', { name: '대기방 채팅' })).toBeInTheDocument();
+    expect(screen.getByText('음성 상태를 보면서 메시지를 주고받습니다.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '입장' })).toBeInTheDocument();
+  });
+
+  it('음성 참가자 상태를 참가자 카드 배지에 반영한다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    useVoiceStore.getState().setParticipantVoiceStates({
+      'user-1': { isSpeaking: true, isMuted: false },
+      'host-1': { isSpeaking: false, isMuted: true },
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    expect(screen.getByText('말하는 중')).toBeInTheDocument();
+    expect(screen.getByText('음소거')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/stores/voiceStore.ts
+++ b/apps/web/src/stores/voiceStore.ts
@@ -12,6 +12,7 @@ export interface VoiceState {
   isPanelOpen: boolean;
   isBottomSheetOpen: boolean;
   connectionState: "disconnected" | "connecting" | "connected" | "error";
+  participantVoiceStates: Record<string, { isSpeaking: boolean; isMuted: boolean }>;
 }
 
 export interface VoiceActions {
@@ -22,6 +23,8 @@ export interface VoiceActions {
   togglePanel: () => void;
   toggleBottomSheet: () => void;
   setConnectionState: (state: VoiceState["connectionState"]) => void;
+  setParticipantVoiceStates: (states: VoiceState["participantVoiceStates"]) => void;
+  clearParticipantVoiceStates: () => void;
   reset: () => void;
 }
 
@@ -37,6 +40,7 @@ const initialState: VoiceState = {
   isPanelOpen: true,
   isBottomSheetOpen: false,
   connectionState: "disconnected",
+  participantVoiceStates: {},
 };
 
 // ---------------------------------------------------------------------------
@@ -74,6 +78,14 @@ export const useVoiceStore = create<VoiceState & VoiceActions>()((set) => ({
     set({ connectionState: state });
   },
 
+  setParticipantVoiceStates: (states) => {
+    set({ participantVoiceStates: states });
+  },
+
+  clearParticipantVoiceStates: () => {
+    set({ participantVoiceStates: {} });
+  },
+
   reset: () => {
     set(initialState);
   },
@@ -90,3 +102,4 @@ export const selectIsSpeakerMuted = (s: VoiceState) => s.isSpeakerMuted;
 export const selectIsPanelOpen = (s: VoiceState) => s.isPanelOpen;
 export const selectIsBottomSheetOpen = (s: VoiceState) => s.isBottomSheetOpen;
 export const selectVoiceConnectionState = (s: VoiceState) => s.connectionState;
+export const selectParticipantVoiceStates = (s: VoiceState) => s.participantVoiceStates;


### PR DESCRIPTION
## 요약
- `RoomChat`을 커뮤니케이션 허브로 확장해 채팅 헤더 안에서 음성 입장/나가기, 마이크, 스피커 상태를 제어합니다.
- LiveKit 참가자 상태에서 speaking overlay를 만들고, 같은 상태를 참가자 카드의 `말하는 중` / `음소거` 배지로 연결합니다.
- 음성 연결 해제, 방 비활성화, 컴포넌트 unmount 시 참가자 음성 상태를 정리해 stale 배지를 방지합니다.

Closes #698
Refs #699

## Coverage Plan
- `RoomChat.tsx`: 기존 메시지 렌더링/입력 흐름 유지, 헤더 슬롯으로 음성 컨트롤 주입.
- `RoomVoicePanel.tsx`: `panel` 기본 모드는 유지하고 `inline` 모드, speaking overlay, disconnect cleanup 경로 추가.
- `PlayerList.tsx` / `RoomPage.tsx`: `voiceStore.participantVoiceStates` -> 참가자 카드 배지 연결 검증.
- `voiceStore.ts`: 참가자별 speaking/mute 상태 저장 및 clear action 검증.

## Local validation
- `pnpm --filter @mmp/web test -- src/pages/__tests__/RoomPage.test.tsx src/features/room/components/__tests__/RoomVoicePanel.test.tsx src/features/room/components/__tests__/PlayerList.test.tsx src/hooks/__tests__/useVoiceConnection.test.ts` -> pass, 29 tests.
- `pnpm --filter @mmp/web typecheck` -> pass.
- `scripts/mmp-local-ci.sh quick` -> pass. 첫 실행은 `apps/server/internal/ws` race detector가 `TestUpgrade_DevAllowsConfiguredLoopbackOrigins`에서 일시 실패했으나, 해당 테스트 단독 재실행은 pass였고 quick 재실행도 pass.

## Browser QA
- URL: `http://127.0.0.1:3001/room/c2c3ffc2-a70e-4cd1-b994-dcbceec0ea6c`
- 로그인: `e2e@test.com` 계정으로 대기방 진입.
- 확인: 채팅 헤더 안에 `대기방 채팅` 설명과 `음성 채팅` 컨트롤이 함께 표시됨. `입장` 버튼 클릭 가능. 로컬 LiveKit/token 환경에서는 `/api/v1/voice/token` 400으로 `연결 실패` fallback이 표시되며 레이아웃 겹침 없음.
- Screenshot evidence: `.playwright-mcp/issue-698-communication-hub-desktop.png`.

## Review evidence
- `mmp-frontend-editor-reviewer`: stale `participantVoiceStates` cleanup blocker 발견 후 수정 완료.
- `mmp-test-coverage-reviewer`: RoomPage 통합 테스트, silent overlay 테스트, disconnect cleanup 테스트 gap 발견 후 수정 완료.