### PR TITLE
fix: 대기방 재구성 hardening

### DIFF
--- a/apps/server/internal/ws/client.go
+++ b/apps/server/internal/ws/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	conn       *websocket.Conn
 	hub        ClientHub
 	send       chan []byte
+	sendMu     sync.RWMutex
 	seq        uint64 // monotonic server sequence number (atomic)
 	closed     atomic.Bool
 	logger     zerolog.Logger
@@ -216,6 +217,9 @@ func (c *Client) SendMessage(env *Envelope) {
 	}
 
 	// Double-check after marshal — Close() may have fired in the meantime.
+	c.sendMu.RLock()
+	defer c.sendMu.RUnlock()
+
 	if c.closed.Load() {
 		return
 	}
@@ -239,6 +243,8 @@ func (c *Client) Close() {
 		if c.cancel != nil {
 			c.cancel()
 		}
+		c.sendMu.Lock()
+		defer c.sendMu.Unlock()
 		close(c.send)
 		if c.conn != nil {
 			_ = c.conn.Close()

--- a/apps/web/src/features/room/components/HostControls.tsx
+++ b/apps/web/src/features/room/components/HostControls.tsx
@@ -111,16 +111,17 @@ export function HostControls({
         variant="primary"
         size="lg"
         leftIcon={<Play className="h-5 w-5" />}
-        disabled={!canStart}
+        disabled={isStarting}
         isLoading={isStarting}
         onClick={onStartGame}
         className="w-full"
+        aria-describedby={!canStart ? 'host-start-client-checks' : undefined}
       >
         게임 시작
       </Button>
 
       {!canStart && (
-        <p className="text-center text-xs text-[var(--mmp-color-steel)]">
+        <p id="host-start-client-checks" className="text-center text-xs text-[var(--mmp-color-steel)]">
           {!hasMinPlayers
             ? '최소 인원이 충족되지 않았습니다.'
             : !allCharactersSelected

--- a/apps/web/src/features/room/components/RoomChat.tsx
+++ b/apps/web/src/features/room/components/RoomChat.tsx
@@ -68,14 +68,14 @@ export function RoomChat({ roomId, send, headerActions }: RoomChatProps) {
 
   return (
     <Panel padding="none" className="flex h-full flex-col overflow-hidden">
-      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--mmp-color-hairline)] p-3">
-        <div>
+      <div className="flex flex-col items-stretch gap-3 border-b border-[var(--mmp-color-hairline)] p-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 sm:flex-1">
           <h2 className="text-base font-semibold text-[var(--mmp-color-ink)]">대기방 채팅</h2>
-          <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">
+          <p className="mt-1 break-words text-xs text-[var(--mmp-color-steel)]">
             음성 상태를 보면서 메시지를 주고받습니다.
           </p>
         </div>
-        {headerActions && <div className="min-w-0">{headerActions}</div>}
+        {headerActions && <div className="min-w-0 max-w-full sm:w-auto">{headerActions}</div>}
       </div>
 
       {/* 메시지 영역 */}
@@ -87,19 +87,19 @@ export function RoomChat({ roomId, send, headerActions }: RoomChatProps) {
         ) : (
           <div className="flex flex-col gap-2">
             {messages.map((msg, i) => (
-              <div key={`${msg.sender}-${msg.ts}-${i}`} className="flex flex-col">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-xs font-semibold text-[var(--mmp-color-primary)]">
+              <div key={`${msg.sender}-${msg.ts}-${i}`} className="flex min-w-0 flex-col">
+                <div className="flex min-w-0 items-baseline gap-2">
+                  <span className="min-w-0 max-w-[70%] truncate text-xs font-semibold text-[var(--mmp-color-primary)]">
                     {msg.nickname}
                   </span>
-                  <span className="text-[10px] text-[var(--mmp-color-steel)]">
+                  <span className="shrink-0 text-[10px] text-[var(--mmp-color-steel)]">
                     {new Date(msg.ts).toLocaleTimeString("ko-KR", {
                       hour: "2-digit",
                       minute: "2-digit",
                     })}
                   </span>
                 </div>
-                <p className="text-sm text-[var(--mmp-color-charcoal)]">{msg.text}</p>
+                <p className="break-words text-sm text-[var(--mmp-color-charcoal)]">{msg.text}</p>
               </div>
             ))}
             <div ref={messagesEndRef} />
@@ -109,7 +109,7 @@ export function RoomChat({ roomId, send, headerActions }: RoomChatProps) {
 
       {/* 입력 폼 */}
       <div className="flex items-center gap-2 border-t border-[var(--mmp-color-hairline)] p-3">
-        <div className="flex-1">
+        <div className="min-w-0 flex-1">
           <Input
             placeholder="메시지를 입력하세요..."
             value={inputText}

--- a/apps/web/src/features/room/components/RoomHeader.tsx
+++ b/apps/web/src/features/room/components/RoomHeader.tsx
@@ -57,21 +57,21 @@ export function RoomHeader({
   return (
     <Panel className="flex flex-wrap items-center justify-between gap-3">
       {/* 왼쪽: 테마 + 방 코드 */}
-      <div className="flex flex-col gap-1">
-        <h1 className="text-lg font-bold text-[var(--mmp-color-ink)]">{themeTitle}</h1>
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-sm text-[var(--mmp-color-steel)]">#{roomCode}</span>
+      <div className="flex min-w-0 flex-col gap-1">
+        <h1 className="truncate text-lg font-bold text-[var(--mmp-color-ink)]">{themeTitle}</h1>
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 truncate font-mono text-sm text-[var(--mmp-color-steel)]">#{roomCode}</span>
           <Button
             variant="ghost"
-            size="sm"
-            className="h-6 w-6 !p-0"
+            size="md"
+            className="h-10 w-10 shrink-0 !p-0"
             onClick={handleCopyCode}
             aria-label="방 코드 복사"
           >
             {copied ? (
-              <Check className="h-3.5 w-3.5 text-[var(--mmp-color-success)]" />
+              <Check className="h-4 w-4 text-[var(--mmp-color-success)]" />
             ) : (
-              <Copy className="h-3.5 w-3.5" />
+              <Copy className="h-4 w-4" />
             )}
           </Button>
         </div>

--- a/apps/web/src/features/room/components/RoomInvitePanel.tsx
+++ b/apps/web/src/features/room/components/RoomInvitePanel.tsx
@@ -38,13 +38,13 @@ export function RoomInvitePanel({ roomId, isHost }: RoomInvitePanelProps) {
 
   return (
     <Panel className="flex flex-col gap-3">
-      <div className="flex items-center justify-between gap-3">
-        <div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
           <h2 className="flex items-center gap-2 text-sm font-semibold text-[var(--mmp-color-ink)]">
-            <UserPlus className="h-4 w-4" />
-            친구 초대
+            <UserPlus className="h-4 w-4 shrink-0" />
+            <span className="truncate">친구 초대</span>
           </h2>
-          <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">
+          <p className="mt-1 break-words text-xs text-[var(--mmp-color-steel)]">
             방 코드는 헤더에서 복사할 수 있습니다.
           </p>
         </div>
@@ -74,19 +74,19 @@ export function RoomInvitePanel({ roomId, isHost }: RoomInvitePanelProps) {
           아직 초대할 친구가 없습니다. 친구를 추가한 뒤 다시 시도해 주세요.
         </p>
       ) : (
-        <div className="grid gap-2 sm:grid-cols-2">
+        <div className="grid gap-2 sm:grid-cols-[repeat(2,minmax(0,1fr))]">
           {(friends.data ?? []).map((friend) => (
             <label
               key={friend.id}
-              className="flex min-h-10 items-center gap-2 rounded-md border border-[var(--mmp-color-hairline)] px-3 py-2 text-sm text-[var(--mmp-color-charcoal)]"
+              className="flex min-h-10 min-w-0 items-center gap-2 rounded-md border border-[var(--mmp-color-hairline)] px-3 py-2 text-sm text-[var(--mmp-color-charcoal)]"
             >
               <input
                 type="checkbox"
                 checked={selectedFriendIds.includes(friend.id)}
                 onChange={() => toggleFriend(friend.id)}
-                className="h-4 w-4 accent-[var(--mmp-color-primary)]"
+                className="h-4 w-4 shrink-0 accent-[var(--mmp-color-primary)]"
               />
-              <span className="font-medium text-[var(--mmp-color-ink)]">{friend.nickname}</span>
+              <span className="min-w-0 truncate font-medium text-[var(--mmp-color-ink)]">{friend.nickname}</span>
             </label>
           ))}
         </div>

--- a/apps/web/src/features/room/components/RoomVoicePanel.tsx
+++ b/apps/web/src/features/room/components/RoomVoicePanel.tsx
@@ -92,15 +92,15 @@ export function RoomVoicePanel({
     <div
       className={
         variant === 'inline'
-          ? 'flex min-w-[220px] flex-col gap-2'
-          : 'flex flex-col gap-3'
+          ? 'flex min-w-0 flex-col gap-2 sm:min-w-[220px]'
+          : 'flex min-w-0 flex-col gap-3'
       }
     >
       <div className="flex items-center justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <h2 className="flex items-center gap-2 text-sm font-semibold text-[var(--mmp-color-ink)]">
-            <Mic className="h-4 w-4" />
-            음성 채팅
+            <Mic className="h-4 w-4 shrink-0" />
+            <span className="truncate">음성 채팅</span>
           </h2>
           <p className="mt-1 text-xs text-[var(--mmp-color-steel)]">{stateLabel[connectionState]}</p>
         </div>
@@ -110,6 +110,7 @@ export function RoomVoicePanel({
             variant="secondary"
             leftIcon={<PhoneOff className="h-4 w-4" />}
             onClick={handleDisconnect}
+            aria-label="음성 채팅 나가기"
           >
             나가기
           </Button>
@@ -127,7 +128,7 @@ export function RoomVoicePanel({
       </div>
 
       <p
-        className={`text-sm ${
+        className={`break-words text-sm ${
           connectionState === 'error'
             ? 'font-medium text-[var(--mmp-color-error)]'
             : 'text-[var(--mmp-color-steel)]'
@@ -266,10 +267,13 @@ function LiveKitSpeakingOverlay({ playerNameById }: { playerNameById?: Map<strin
 
   useEffect(() => {
     setParticipantVoiceStates(participantVoiceStates);
+  }, [participantVoiceStates, setParticipantVoiceStates]);
+
+  useEffect(() => {
     return () => {
       useVoiceStore.getState().clearParticipantVoiceStates();
     };
-  }, [participantVoiceStates, setParticipantVoiceStates]);
+  }, []);
 
   const speakingParticipants = useMemo(() => {
     const participantByIdentity = new Map<string, VoiceParticipantLike>();
@@ -299,16 +303,16 @@ function LiveKitSpeakingOverlay({ playerNameById }: { playerNameById?: Map<strin
       <div className="mt-2 flex flex-wrap gap-1.5">
         {speakingParticipants.map((participant) => {
           const identity = participant.identity ?? participant.sid ?? 'unknown';
-          const name = playerNameById?.get(identity) ?? participant.name ?? identity;
+          const name = playerNameById?.get(identity) ?? participant.name ?? '음성 참가자';
           const isMuted = participantVoiceStates[identity]?.isMuted ?? false;
 
           return (
             <span
               key={identity}
-              className="inline-flex items-center gap-1 rounded-full bg-[var(--mmp-color-surface)] px-2 py-1 text-xs font-medium text-[var(--mmp-color-charcoal)]"
+              className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full bg-[var(--mmp-color-surface)] px-2 py-1 text-xs font-medium text-[var(--mmp-color-charcoal)]"
             >
-              <Mic className="h-3 w-3 text-[var(--mmp-color-primary)]" />
-              {name}
+              <Mic className="h-3 w-3 shrink-0 text-[var(--mmp-color-primary)]" />
+              <span className="min-w-0 truncate">{name}</span>
               {isMuted && <span className="text-[10px] text-[var(--mmp-color-steel)]">음소거</span>}
             </span>
           );

--- a/apps/web/src/features/room/components/__tests__/RoomVoicePanel.test.tsx
+++ b/apps/web/src/features/room/components/__tests__/RoomVoicePanel.test.tsx
@@ -178,6 +178,58 @@ describe('RoomVoicePanel', () => {
     expect(screen.getByRole('button', { name: /스피커 끄기/ })).toBeEnabled();
   });
 
+  it('does not clear synced participant voice state during LiveKit activity updates', async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: 'token-1',
+      room_name: 'room-room-1-main',
+      livekit_url: 'ws://livekit',
+    });
+    const clearVoiceStatesSpy = vi.spyOn(
+      useVoiceStore.getState(),
+      'clearParticipantVoiceStates'
+    );
+
+    const { rerender } = render(<RoomVoicePanel roomId="room-1" isActive variant="inline" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /입장/ }));
+    await screen.findByTestId('livekit-room');
+
+    act(() => {
+      liveKitRoomProps.current?.onConnected?.();
+    });
+
+    expect(useVoiceStore.getState().participantVoiceStates).not.toEqual({});
+    clearVoiceStatesSpy.mockClear();
+
+    localParticipantState.audioLevel = 0.04;
+    rerender(<RoomVoicePanel roomId="room-1" isActive variant="inline" />);
+
+    expect(clearVoiceStatesSpy).not.toHaveBeenCalled();
+    expect(useVoiceStore.getState().participantVoiceStates).not.toEqual({});
+  });
+
+  it('uses a safe display label when LiveKit participant names cannot be mapped', async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
+      token: 'token-1',
+      room_name: 'room-room-1-main',
+      livekit_url: 'ws://livekit',
+    });
+
+    render(<RoomVoicePanel roomId="room-1" isActive variant="inline" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /입장/ }));
+    await screen.findByTestId('livekit-room');
+
+    act(() => {
+      liveKitRoomProps.current?.onConnected?.();
+    });
+
+    expect(await screen.findByText('말하는 참가자')).toBeInTheDocument();
+    expect(screen.getAllByText(/음성 참가자/).length).toBeGreaterThan(0);
+    expect(screen.queryByText('local-user')).not.toBeInTheDocument();
+    expect(screen.queryByText('remote-user')).not.toBeInTheDocument();
+  });
+
   it('hides the speaking overlay when LiveKit reports no active speakers', async () => {
     localParticipantState.audioLevel = 0;
     silentParticipantsMock.push({
@@ -222,7 +274,7 @@ describe('RoomVoicePanel', () => {
 
     expect(useVoiceStore.getState().participantVoiceStates).not.toEqual({});
 
-    fireEvent.click(await screen.findByRole('button', { name: /나가기/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /음성 채팅 나가기/ }));
 
     expect(useVoiceStore.getState().participantVoiceStates).toEqual({});
   });

--- a/apps/web/src/hooks/__tests__/useVoiceConnection.test.ts
+++ b/apps/web/src/hooks/__tests__/useVoiceConnection.test.ts
@@ -103,6 +103,26 @@ describe("useVoiceConnection", () => {
     expect(useVoiceStore.getState().currentChannel).toBe("room-room-1-main");
   });
 
+  it("sets error state when voice token request fails", async () => {
+    vi.mocked(voiceApi.getTokenForTarget).mockRejectedValue(new Error("token denied"));
+
+    const { result } = renderHook(() =>
+      useVoiceConnection({
+        roomId: "room-1",
+        roomType: "main",
+        autoConnect: false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.connectionDetails).toBeNull();
+    expect(useVoiceStore.getState().connectionState).toBe("error");
+    expect(useVoiceStore.getState().currentChannel).toBeNull();
+  });
+
   it("ignores stale LiveKit callbacks after a user disconnect", async () => {
     vi.mocked(voiceApi.getTokenForTarget).mockResolvedValue({
       token: "token-1",

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -69,7 +69,6 @@ export default function RoomPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const currentUser = useAuthStore(selectUser);
-  const participantVoiceStates = useVoiceStore(selectParticipantVoiceStates);
 
   // 방 정보 쿼리
   const { data: room, isLoading, isError, refetch } = useRoom(id ?? '');
@@ -130,24 +129,6 @@ export default function RoomPage() {
   const playerNameById = useMemo(
     () => new Map(players.map((player) => [player.user_id, player.nickname])),
     [players]
-  );
-  const speakingPlayerIds = useMemo(
-    () =>
-      new Set(
-        players
-          .filter((player) => participantVoiceStates[player.user_id]?.isSpeaking)
-          .map((player) => player.user_id)
-      ),
-    [participantVoiceStates, players]
-  );
-  const mutedPlayerIds = useMemo(
-    () =>
-      new Set(
-        players
-          .filter((player) => participantVoiceStates[player.user_id]?.isMuted)
-          .map((player) => player.user_id)
-      ),
-    [participantVoiceStates, players]
   );
   const selectedByOtherPlayerIds = useMemo(
     () =>
@@ -276,7 +257,7 @@ export default function RoomPage() {
         </div>
 
         {/* 데스크톱 3영역 레이아웃 / 모바일 탭 전환 */}
-        <div className="grid gap-4 lg:grid-cols-[minmax(260px,0.85fr)_minmax(360px,1.15fr)_minmax(320px,1fr)]">
+        <div className="grid gap-4 lg:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.1fr)] xl:grid-cols-[minmax(260px,0.85fr)_minmax(360px,1.15fr)_minmax(320px,1fr)]">
           {/* 참가자 상태 */}
           <section
             aria-labelledby="room-participants-heading"
@@ -294,13 +275,11 @@ export default function RoomPage() {
                   준비 상태와 캐릭터 선택을 한 번에 확인합니다.
                 </p>
               </div>
-              <PlayerList
+              <VoiceAwarePlayerList
                 players={players}
                 maxPlayers={room.max_players}
                 characterNameById={characterNameById}
                 currentUserId={currentUser?.id}
-                speakingPlayerIds={speakingPlayerIds}
-                mutedPlayerIds={mutedPlayerIds}
               />
             </Panel>
 
@@ -332,6 +311,7 @@ export default function RoomPage() {
                   leftIcon={<LogOut className="h-4 w-4" />}
                   onClick={handleLeave}
                   isLoading={leaveRoom.isPending}
+                  aria-label="방 나가기"
                 >
                   나가기
                 </Button>
@@ -390,14 +370,14 @@ export default function RoomPage() {
           {/* 채팅 + 음성 */}
           <section
             aria-labelledby="room-communication-heading"
-            className={`flex flex-col gap-4 ${
+            className={`flex flex-col gap-4 lg:col-span-2 xl:col-span-1 ${
               mobileTab !== 'chat' ? 'hidden md:flex' : 'flex'
             }`}
           >
             <h2 id="room-communication-heading" className="sr-only">
               채팅과 음성
             </h2>
-            <div className="h-[420px] lg:h-[560px]">
+            <div className="h-[560px] md:h-[420px] lg:h-[460px] xl:h-[560px]">
               <RoomChat
                 roomId={id}
                 send={send}
@@ -420,5 +400,48 @@ export default function RoomPage() {
         </div>
       </div>
     </PageShell>
+  );
+}
+
+function VoiceAwarePlayerList({
+  players,
+  maxPlayers,
+  characterNameById,
+  currentUserId,
+}: {
+  players: Parameters<typeof PlayerList>[0]['players'];
+  maxPlayers: number;
+  characterNameById: Map<string, string>;
+  currentUserId?: string;
+}) {
+  const participantVoiceStates = useVoiceStore(selectParticipantVoiceStates);
+  const speakingPlayerIds = useMemo(
+    () =>
+      new Set(
+        players
+          .filter((player) => participantVoiceStates[player.user_id]?.isSpeaking)
+          .map((player) => player.user_id)
+      ),
+    [participantVoiceStates, players]
+  );
+  const mutedPlayerIds = useMemo(
+    () =>
+      new Set(
+        players
+          .filter((player) => participantVoiceStates[player.user_id]?.isMuted)
+          .map((player) => player.user_id)
+      ),
+    [participantVoiceStates, players]
+  );
+
+  return (
+    <PlayerList
+      players={players}
+      maxPlayers={maxPlayers}
+      characterNameById={characterNameById}
+      currentUserId={currentUserId}
+      speakingPlayerIds={speakingPlayerIds}
+      mutedPlayerIds={mutedPlayerIds}
+    />
   );
 }

--- a/apps/web/src/pages/__tests__/RoomPage.test.tsx
+++ b/apps/web/src/pages/__tests__/RoomPage.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
+import { WsEventType } from '@mmp/shared';
 import { useAuthStore } from '@/stores/authStore';
 import { useVoiceStore } from '@/stores/voiceStore';
 
@@ -261,6 +262,63 @@ describe('RoomPage pregame controls', () => {
     expect(screen.getAllByText('준비 완료').length).toBeGreaterThan(0);
   });
 
+  it('방 코드 복사 버튼은 클립보드에 현재 방 코드를 쓴다', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    fireEvent.click(screen.getByRole('button', { name: '방 코드 복사' }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('ABC123');
+    });
+  });
+
+  it('1024px 근처에서는 데스크톱 대기방을 2열로 유지하고 3열은 넓은 화면에서만 사용한다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    const roomGrid = screen.getByRole('heading', { name: '참가자 상태' }).closest('section')
+      ?.parentElement;
+
+    expect(roomGrid?.className).toContain('lg:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.1fr)]');
+    expect(roomGrid?.className).toContain('xl:grid-cols-[minmax(260px,0.85fr)_minmax(360px,1.15fr)_minmax(320px,1fr)]');
+  });
+
+  it('음성 참가자 상태가 바뀌어도 RoomPage 전체를 다시 렌더링하지 않는다', () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+    const callsAfterInitialRender = useRoomMock.mock.calls.length;
+
+    act(() => {
+      useVoiceStore.getState().setParticipantVoiceStates({
+        'user-1': { isSpeaking: true, isMuted: false },
+      });
+    });
+
+    expect(useRoomMock).toHaveBeenCalledTimes(callsAfterInitialRender);
+    expect(screen.getByText('말하는 중')).toBeInTheDocument();
+  });
+
   it('현재 사용자의 준비 상태를 room.players에서 읽고 HTTP ready mutation에 is_ready를 보낸다', async () => {
     const readyMutate = vi.fn((_variables, options) => {
       options?.onSuccess?.();
@@ -366,12 +424,15 @@ describe('RoomPage pregame controls', () => {
     renderRoom();
 
     const startButton = screen.getByRole('button', { name: /게임 시작/ });
-    expect(startButton).toBeDisabled();
+    expect(startButton).toBeEnabled();
     expect(screen.getByText('최소 인원이 충족되지 않았습니다.')).toBeInTheDocument();
 
     fireEvent.click(startButton);
 
-    expect(startMutate).not.toHaveBeenCalled();
+    expect(startMutate).toHaveBeenCalledWith(
+      'room-1',
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    );
   });
 
   it('기존 채팅 탭과 나가기 동작을 유지한다', () => {
@@ -391,7 +452,7 @@ describe('RoomPage pregame controls', () => {
       target: { value: '준비됐어요' },
     });
     fireEvent.click(screen.getByRole('button', { name: /메시지 전송/ }));
-    fireEvent.click(screen.getByRole('button', { name: /나가기/ }));
+    fireEvent.click(screen.getByRole('button', { name: /방 나가기/ }));
 
     expect(sendMock).toHaveBeenCalledWith('chat:send', { room_id: 'room-1', text: '준비됐어요' });
     expect(leaveMutate).toHaveBeenCalledWith(
@@ -399,6 +460,33 @@ describe('RoomPage pregame controls', () => {
       expect.objectContaining({ onSuccess: expect.any(Function) })
     );
     expect(navigateMock).toHaveBeenCalledWith('/lobby');
+  });
+
+  it('대기방 채팅 수신 메시지를 렌더링한다', () => {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'user@example.com', nickname: '참가자', role: 'user' },
+      isAuthenticated: true,
+    });
+    mockRoomPage();
+
+    renderRoom();
+
+    const chatHandler = useWsEventMock.mock.calls.find(
+      ([channel, eventType]) => channel === 'game' && eventType === WsEventType.CHAT_MESSAGE
+    )?.[2] as ((payload: { sender: string; nickname: string; text: string; ts: number }) => void) | undefined;
+
+    act(() => {
+      chatHandler?.({
+        sender: 'user-2',
+        nickname: '긴닉네임참가자',
+        text: '수신된 채팅 메시지입니다.',
+        ts: Date.parse('2026-05-20T05:00:00Z'),
+      });
+    });
+
+    expect(screen.getByText('긴닉네임참가자')).toBeInTheDocument();
+    expect(screen.getByText('수신된 채팅 메시지입니다.')).toBeInTheDocument();
   });
 
   it('호스트 게임 시작 실패 사유를 컨트롤 근처에 표시한다', () => {
@@ -478,14 +566,17 @@ describe('RoomPage pregame controls', () => {
     renderRoom();
 
     const startButton = screen.getByRole('button', { name: /게임 시작/ });
-    expect(startButton).toBeDisabled();
+    expect(startButton).toBeEnabled();
     expect(
       screen.getByText('모든 참가자가 캐릭터를 선택해야 시작할 수 있습니다.')
     ).toBeInTheDocument();
 
     fireEvent.click(startButton);
 
-    expect(startMutate).not.toHaveBeenCalled();
+    expect(startMutate).toHaveBeenCalledWith(
+      'room-1',
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    );
   });
 
   it('호스트는 대기방에서 친구를 선택해 방 초대를 보낼 수 있다', () => {


### PR DESCRIPTION
Closes #699

## 요약
- 대기방 레이아웃을 1024px 구간에서는 2열, xl 이상에서는 3열로 안정화하고 모바일 채팅 헤더/높이/줄바꿈을 보정했습니다.
- 음성 상태 구독을 `RoomPage` 상위에서 분리해 참가자 목록 영역만 갱신되게 하고, LiveKit 참가자 상태 변경 때 cleanup이 반복 실행되지 않도록 effect를 분리했습니다.
- 방 코드 복사, 방 나가기, 음성 나가기, 초대 패널, 호스트 시작 버튼의 접근성/터치/오버플로우를 보강했습니다.
- `local-ci quick`에서 재현된 WebSocket send/close race를 `Client` send lock으로 막았습니다.

## Coverage Plan
- `RoomPage.tsx`: 반응형 2열/3열 클래스, 음성 상태 렌더 범위, 호스트 시작 mutation, 채팅 수신 경로를 `RoomPage.test.tsx`로 검증했습니다.
- `RoomChat.tsx`: 모바일 헤더 stack, 긴 텍스트 줄바꿈, 메시지 수신 렌더를 `RoomPage.test.tsx`와 브라우저 QA로 확인했습니다.
- `RoomVoicePanel.tsx`: LiveKit 상태 변경 cleanup 회귀, 안전한 참가자 표시명, 음성 나가기 접근성 라벨을 `RoomVoicePanel.test.tsx`로 검증했습니다.
- `useVoiceConnection.ts`: token 발급 실패 시 error state와 channel 정리를 `useVoiceConnection.test.ts`로 검증했습니다.
- `apps/server/internal/ws/client.go`: send/close race guard를 `go test -race ./internal/ws`로 검증했습니다.

## Local validation
- `pnpm --filter @mmp/web test -- src/pages/__tests__/RoomPage.test.tsx src/hooks/__tests__/useVoiceConnection.test.ts src/features/room/components/__tests__/RoomVoicePanel.test.tsx src/features/room/components/__tests__/PlayerList.test.tsx` 통과: 4 files / 36 tests
- `pnpm --filter @mmp/web typecheck` 통과
- `go test -race ./internal/ws -run TestJWTPlayerIDExtractorAcceptsAccessToken -count=1` 통과
- `go test -race ./internal/ws -count=1` 통과
- `scripts/mmp-local-ci.sh quick` 통과: 최종 HEAD `3db14902`, web test 214 files / 1945 tests, build 포함 전체 quick 성공
- `git diff --check` 통과

## Browser QA
- URL: `http://127.0.0.1:3002/room/c2c3ffc2-a70e-4cd1-b994-dcbceec0ea6c`
- 계정: `e2e@test.com`
- 확인 뷰포트: desktop 1440, tablet 1024, mobile 390 chat tab
- 증적: `.playwright-mcp/issue-699-desktop-room-final.png`, `.playwright-mcp/issue-699-tablet-1024-room-final.png`, `.playwright-mcp/issue-699-mobile-room-chat-final.png`
- 참고: 3002 Vite dev proxy 환경에서 social/game WebSocket 403/ECONNRESET 로그가 반복됐지만, 로컬 origin/token 조합의 개발 환경 로그이며 대기방 UI 렌더/반응형 검증은 완료했습니다.

## Review evidence
- Frontend reviewer: 1024 레이아웃, 모바일 오버플로우, 접근성 라벨, host start gate 지적 반영.
- Performance reviewer: `participantVoiceStates` 상위 구독 제거, LiveKit cleanup effect 분리 확인.
- Test coverage reviewer: clipboard, chat receive, voice token failure, browser/mobile evidence 요구 반영.
