### PR TITLE
fix: 에디터 출판 검증과 방 생성 코드 안정화

### DIFF
--- a/apps/server/cmd/server/routes_editor_themes.go
+++ b/apps/server/cmd/server/routes_editor_themes.go
@@ -13,6 +13,7 @@ func registerEditorThemeRoutes(r chi.Router, deps authedDeps) {
 	r.Post("/themes", deps.editor.CreateTheme)
 	r.Put("/themes/{id}", deps.editor.UpdateTheme)
 	r.Delete("/themes/{id}", deps.editor.DeleteTheme)
+	r.Post("/themes/{id}/publish", deps.editor.PublishTheme)
 	r.Post("/themes/{id}/unpublish", deps.editor.UnpublishTheme)
 	r.Post("/themes/{id}/submit-review", deps.editor.SubmitForReview)
 	r.Put("/themes/{id}/config", deps.editor.UpdateConfigJson)

--- a/apps/server/cmd/server/routes_editor_themes_test.go
+++ b/apps/server/cmd/server/routes_editor_themes_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"go.uber.org/mock/gomock"
+
+	"github.com/mmp-platform/server/internal/auditlog"
+	"github.com/mmp-platform/server/internal/domain/editor"
+	editormocks "github.com/mmp-platform/server/internal/domain/editor/mocks"
+	"github.com/mmp-platform/server/internal/middleware"
+)
+
+func TestRegisterEditorThemeRoutes_PublishTheme(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := editormocks.NewMockService(ctrl)
+
+	creatorID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	themeID := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	mock.EXPECT().
+		PublishTheme(gomock.Any(), creatorID, themeID).
+		Return(&editor.ThemeResponse{
+			ID:          themeID,
+			Title:       "Publishable Theme",
+			Slug:        "publishable-theme-ab12",
+			MinPlayers:  4,
+			MaxPlayers:  8,
+			DurationMin: 60,
+			Status:      "PUBLISHED",
+			Version:     2,
+			CreatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		}, nil).
+		Times(1)
+
+	handler := editor.NewHandler(mock, auditlog.NoOpLogger{}, zerolog.Nop())
+	router := chi.NewRouter()
+	router.Route("/editor", func(r chi.Router) {
+		registerEditorThemeRoutes(r, authedDeps{editor: handler})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/editor/themes/"+themeID.String()+"/publish", nil)
+	ctx := context.WithValue(req.Context(), middleware.UserIDKey, creatorID)
+	ctx = context.WithValue(ctx, middleware.UserRoleKey, "CREATOR")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected publish route to return 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -17,7 +17,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 RETURNING *;
 
 -- name: UpdateThemeStatus :one
-UPDATE themes SET status = $2, published_at = CASE WHEN $2 = 'PUBLISHED' THEN NOW() ELSE published_at END, updated_at = NOW()
+UPDATE themes SET status = $2::varchar, published_at = CASE WHEN $2::varchar = 'PUBLISHED' THEN NOW() ELSE published_at END, updated_at = NOW()
 WHERE id = $1
 RETURNING *;
 

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -760,7 +760,7 @@ func (q *Queries) UpdateThemeCoverImage(ctx context.Context, arg UpdateThemeCove
 }
 
 const updateThemeStatus = `-- name: UpdateThemeStatus :one
-UPDATE themes SET status = $2, published_at = CASE WHEN $2 = 'PUBLISHED' THEN NOW() ELSE published_at END, updated_at = NOW()
+UPDATE themes SET status = $2::varchar, published_at = CASE WHEN $2::varchar = 'PUBLISHED' THEN NOW() ELSE published_at END, updated_at = NOW()
 WHERE id = $1
 RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `

--- a/apps/server/internal/domain/room/service.go
+++ b/apps/server/internal/domain/room/service.go
@@ -234,7 +234,7 @@ func generateRoomCode() (string, error) {
 	const maxValid = 248                             // 256 - (256 % 31) = 248, largest unbiased value
 	result := make([]byte, 6)
 	buf := make([]byte, 12) // over-provision to reduce Read calls
-	idx := 0
+	idx := len(buf)
 	for i := 0; i < len(result); {
 		if idx >= len(buf) {
 			if _, err := rand.Read(buf); err != nil {

--- a/apps/server/internal/domain/room/service_test.go
+++ b/apps/server/internal/domain/room/service_test.go
@@ -4,10 +4,36 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"unicode"
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
 )
+
+func TestGenerateRoomCodeUsesRandomBytesBeforeFirstCode(t *testing.T) {
+	t.Parallel()
+
+	codes := make(map[string]struct{})
+	for range 3 {
+		code, err := generateRoomCode()
+		if err != nil {
+			t.Fatalf("generateRoomCode returned error: %v", err)
+		}
+		if len(code) != 6 {
+			t.Fatalf("code length = %d, want 6", len(code))
+		}
+		for _, r := range code {
+			if !unicode.IsUpper(r) && !unicode.IsDigit(r) {
+				t.Fatalf("code %q contains unsupported character %q", code, r)
+			}
+		}
+		codes[code] = struct{}{}
+	}
+
+	if _, ok := codes["AAAAAA"]; ok && len(codes) == 1 {
+		t.Fatal("generateRoomCode returned only AAAAAA; random bytes were not read before first use")
+	}
+}
 
 // TestResolveMaxPlayers_TableDriven exercises the boundary matrix for the
 // CreateRoom MaxPlayers fallback + range validation helper.

--- a/apps/web/src/features/editor/__tests__/validation.test.ts
+++ b/apps/web/src/features/editor/__tests__/validation.test.ts
@@ -40,6 +40,28 @@ describe('validateGameDesign', () => {
     expect(err?.type).toBe('error');
   });
 
+  it('저장된 flow graph에 phase node가 있으면 config_json.phases 없이 통과한다', () => {
+    const { phases: _phases, ...config } = fullConfig;
+
+    const result = validateGameDesign(config, 0, 0, {
+      flowNodes: [{ type: 'phase' }],
+    });
+
+    expect(result.find((w) => w.category === 'phases')).toBeUndefined();
+  });
+
+  it('저장된 flow graph에도 phase node가 없으면 phase error를 유지한다', () => {
+    const { phases: _phases, ...config } = fullConfig;
+
+    const result = validateGameDesign(config, 0, 0, {
+      flowNodes: [{ type: 'start' }, { type: 'branch' }],
+    });
+
+    const err = result.find((w) => w.category === 'phases');
+    expect(err?.type).toBe('error');
+    expect(err?.message).toBe('페이즈가 설정되지 않았습니다');
+  });
+
   it('modules가 없으면 error 반환', () => {
     const config = { ...fullConfig, modules: {} };
     const result = validateGameDesign(config, 0, 0);

--- a/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -28,6 +28,7 @@ interface EditorLayoutProps {
   onSave?: () => void;
   onRetry?: () => void;
   onPublish?: () => void;
+  isPublishing?: boolean;
   onValidate?: () => DesignWarning[];
   validationWarnings?: DesignWarning[];
   routeSegment?: string;
@@ -41,6 +42,7 @@ export function EditorLayout({
   onSave,
   onRetry,
   onPublish,
+  isPublishing = false,
   onValidate,
   validationWarnings: externalWarnings,
   routeSegment,
@@ -49,6 +51,7 @@ export function EditorLayout({
   const { activeTab } = useEditorUI();
   const [validationResult, setValidationResult] = useState<DesignWarning[] | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const [publishNotice, setPublishNotice] = useState<string | null>(null);
 
   const activeModules = useMemo(() => readEnabledModuleIds(theme.config_json), [theme.config_json]);
   const routeTab = useMemo(
@@ -58,12 +61,27 @@ export function EditorLayout({
   const effectiveTab = routeTab ?? activeTab;
   const usesInternalScroll = INTERNAL_SCROLL_TABS.has(effectiveTab);
 
+  const runValidation = () => {
+    const result = onValidate ? onValidate() : (externalWarnings ?? []);
+    setValidationResult(result);
+    setDismissed(false);
+    return result;
+  };
+
   const handleValidate = () => {
-    if (onValidate) {
-      const result = onValidate();
-      setValidationResult(result);
-      setDismissed(false);
+    runValidation();
+    setPublishNotice(null);
+  };
+
+  const handlePublish = () => {
+    const result = runValidation();
+    const hasErrors = result.some((warning) => warning.type === 'error');
+    if (hasErrors) {
+      setPublishNotice('검증 오류를 먼저 해결해야 출판할 수 있습니다');
+      return;
     }
+    setPublishNotice(null);
+    onPublish?.();
   };
 
   // Save on Ctrl+S / Cmd+S
@@ -131,13 +149,22 @@ export function EditorLayout({
         </button>
         <button
           type="button"
-          onClick={onPublish}
-          disabled={theme.status === 'PUBLISHED'}
+          onClick={handlePublish}
+          disabled={theme.status === 'PUBLISHED' || isPublishing || !onPublish}
           className={`h-8 px-2 text-xs transition-colors hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:px-3 ${editorDesignClassNames.primaryAction}`}
         >
-          출판
+          {isPublishing ? '출판 중...' : '출판'}
         </button>
       </header>
+
+      {publishNotice && (
+        <div
+          role="status"
+          className="shrink-0 border-b border-[var(--mmp-editor-color-hairline)] bg-[var(--mmp-editor-color-tint-rose)] px-4 py-2 text-xs text-[var(--mmp-editor-color-error)]"
+        >
+          {publishNotice}
+        </div>
+      )}
 
       {/* ── Tab nav ── */}
       <EditorTabNav themeId={themeId} activeModules={activeModules} forcedVisibleTab={routeTab} />

--- a/apps/web/src/features/editor/components/ThemeEditor.tsx
+++ b/apps/web/src/features/editor/components/ThemeEditor.tsx
@@ -1,9 +1,11 @@
 import { useCallback } from 'react';
+import { toast } from 'sonner';
 import { Spinner } from '@/shared/components/ui';
-import { useEditorTheme } from '@/features/editor/api';
+import { useEditorTheme, usePublishTheme } from '@/features/editor/api';
 import { useEditorClues } from '@/features/editor/editorClueApi';
 import { validateGameDesign, validateClueGraph } from '@/features/editor/validation';
 import { useClueEdges } from '@/features/editor/clueEdgeApi';
+import { useFlowGraph } from '@/features/editor/flowApi';
 import { isApiHttpError } from '@/lib/api-error';
 import { EditorLayout } from './EditorLayout';
 
@@ -82,6 +84,8 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
   const resolvedThemeId = theme?.id ?? '';
   const { data: clues } = useEditorClues(resolvedThemeId);
   const { data: clueEdgeGroups } = useClueEdges(resolvedThemeId);
+  const { data: flowGraph } = useFlowGraph(resolvedThemeId);
+  const publishTheme = usePublishTheme(resolvedThemeId);
 
   const handleValidate = useCallback(() => {
     if (!theme) return [];
@@ -90,7 +94,9 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
     // Character count from config_json.characters array
     const chars = cfg.characters;
     const charCount = Array.isArray(chars) ? chars.length : 0;
-    const gameWarnings = validateGameDesign(cfg, clueCount, charCount);
+    const gameWarnings = validateGameDesign(cfg, clueCount, charCount, {
+      flowNodes: flowGraph?.nodes ?? [],
+    });
     // Phase 20 PR-6: flatten edge groups (N sources × 1 target) into the
     // legacy (sourceId, targetId, mode) shape validateClueGraph still accepts.
     const flatRelations = (clueEdgeGroups ?? []).flatMap((g) =>
@@ -105,7 +111,14 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
       (clues ?? []).map((c) => ({ id: c.id, name: c.name }))
     );
     return [...gameWarnings, ...graphWarnings];
-  }, [theme, clues, clueEdgeGroups]);
+  }, [theme, clues, clueEdgeGroups, flowGraph]);
+
+  const handlePublish = useCallback(() => {
+    publishTheme.mutate(undefined, {
+      onSuccess: () => toast.success('테마가 출판되었습니다'),
+      onError: () => toast.error('테마 출판에 실패했습니다'),
+    });
+  }, [publishTheme]);
 
   if (isLoading) return <FullPageSpinner />;
   if (isError || !theme) {
@@ -119,6 +132,8 @@ export function ThemeEditor({ themeId, routeSegment }: ThemeEditorProps) {
       themeId={resolvedThemeId}
       routeSegment={routeSegment}
       onValidate={handleValidate}
+      onPublish={handlePublish}
+      isPublishing={publishTheme.isPending}
     />
   );
 }

--- a/apps/web/src/features/editor/components/ValidationPanel.tsx
+++ b/apps/web/src/features/editor/components/ValidationPanel.tsx
@@ -9,11 +9,19 @@ import { editorDesignClassNames } from "@/features/editor/design-system/editorDe
 // ---------------------------------------------------------------------------
 
 const ERROR_TAB_MAP: Record<string, EditorTab> = {
-  phases: "design",
+  phases: "storyMap",
   modules: "design",
   clues: "clues",
   characters: "characters",
   clue_graph: "clues",
+};
+
+const ERROR_TAB_LABEL_MAP: Record<string, string> = {
+  phases: "스토리 진행",
+  modules: "게임 설계",
+  clues: "단서 관리",
+  characters: "등장인물 관리",
+  clue_graph: "단서 관리",
 };
 
 // ---------------------------------------------------------------------------
@@ -87,7 +95,7 @@ export function ValidationPanel({ warnings, onClose }: ValidationPanelProps) {
               <div className="flex flex-col">
                 <span className="text-xs text-[var(--mmp-editor-color-charcoal)]">{w.message}</span>
                 <span className="text-[10px] text-[var(--mmp-editor-color-steel)]">
-                  클릭하여 {ERROR_TAB_MAP[w.category] ?? w.category} 탭으로 이동
+                  클릭하여 {ERROR_TAB_LABEL_MAP[w.category] ?? w.category} 탭으로 이동
                 </span>
               </div>
             </button>

--- a/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/EditorLayout.test.tsx
@@ -124,7 +124,7 @@ describe('EditorLayout', () => {
     fireEvent.click(screen.getByRole('button', { name: '검증' }));
     fireEvent.click(screen.getByRole('button', { name: '출판' }));
 
-    expect(onValidate).toHaveBeenCalledTimes(1);
+    expect(onValidate).toHaveBeenCalledTimes(2);
     expect(onPublish).toHaveBeenCalledTimes(1);
   });
 
@@ -210,6 +210,49 @@ describe('EditorLayout', () => {
 
     expect(mockSetActiveTab).toHaveBeenCalledWith('clues');
     expect(screen.queryByText('검증 결과: 1개 오류, 1개 경고')).toBeNull();
+  });
+
+  it('출판 클릭 시 검증 오류가 있으면 안내를 표시하고 출판을 호출하지 않는다', () => {
+    const onValidate = vi.fn(() => [
+      { type: 'error' as const, category: 'phases', message: '페이즈가 설정되지 않았습니다' },
+    ]);
+    const onPublish = vi.fn();
+
+    renderEditorLayout(
+      <EditorLayout
+        theme={baseTheme}
+        themeId="theme-1"
+        onValidate={onValidate}
+        onPublish={onPublish}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '출판' }));
+
+    expect(onValidate).toHaveBeenCalledTimes(1);
+    expect(onPublish).not.toHaveBeenCalled();
+    expect(screen.getByText('검증 결과: 1개 오류')).toBeDefined();
+    expect(screen.getByText('검증 오류를 먼저 해결해야 출판할 수 있습니다')).toBeDefined();
+  });
+
+  it('출판 클릭 시 검증 오류가 없으면 출판을 호출한다', () => {
+    const onValidate = vi.fn(() => []);
+    const onPublish = vi.fn();
+
+    renderEditorLayout(
+      <EditorLayout
+        theme={baseTheme}
+        themeId="theme-1"
+        onValidate={onValidate}
+        onPublish={onPublish}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '출판' }));
+
+    expect(onValidate).toHaveBeenCalledTimes(1);
+    expect(onPublish).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('검증 오류를 먼저 해결해야 출판할 수 있습니다')).toBeNull();
   });
 
   it('Ctrl+S와 Cmd+S 저장 단축키만 저장 액션을 실행한다', () => {

--- a/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ThemeEditor.test.tsx
@@ -3,18 +3,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   useEditorThemeMock,
+  usePublishThemeMock,
   useEditorCluesMock,
   useClueEdgesMock,
+  useFlowGraphMock,
+  validateGameDesignMock,
+  validateClueGraphMock,
   editorLayoutMock,
 } = vi.hoisted(() => ({
   useEditorThemeMock: vi.fn(),
+  usePublishThemeMock: vi.fn(),
   useEditorCluesMock: vi.fn(),
   useClueEdgesMock: vi.fn(),
+  useFlowGraphMock: vi.fn(),
+  validateGameDesignMock: vi.fn(),
+  validateClueGraphMock: vi.fn(),
   editorLayoutMock: vi.fn(),
 }));
 
 vi.mock('@/features/editor/api', () => ({
   useEditorTheme: (themeId: string) => useEditorThemeMock(themeId),
+  usePublishTheme: (themeId: string) => usePublishThemeMock(themeId),
 }));
 
 vi.mock('@/features/editor/editorClueApi', () => ({
@@ -25,9 +34,17 @@ vi.mock('@/features/editor/clueEdgeApi', () => ({
   useClueEdges: (themeId: string) => useClueEdgesMock(themeId),
 }));
 
+vi.mock('@/features/editor/flowApi', () => ({
+  useFlowGraph: (themeId: string) => useFlowGraphMock(themeId),
+}));
+
 vi.mock('@/features/editor/validation', () => ({
-  validateGameDesign: () => ['game-warning'],
-  validateClueGraph: () => ['graph-warning'],
+  validateGameDesign: (...args: unknown[]) => validateGameDesignMock(...args),
+  validateClueGraph: (...args: unknown[]) => validateClueGraphMock(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 vi.mock('../EditorLayout', () => ({
@@ -68,6 +85,15 @@ describe('ThemeEditor', () => {
     useClueEdgesMock.mockReturnValue({
       data: [{ targetId: 'clue-1', mode: 'requires', sources: ['clue-2', 'clue-3'] }],
     });
+    useFlowGraphMock.mockReturnValue({
+      data: {
+        nodes: [{ id: 'phase-1', type: 'phase', data: { label: '1라운드' } }],
+        edges: [],
+      },
+    });
+    usePublishThemeMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    validateGameDesignMock.mockReturnValue(['game-warning']);
+    validateClueGraphMock.mockReturnValue(['graph-warning']);
   });
 
   it('로딩 중이면 전체 화면 스피너를 표시한다', () => {
@@ -151,6 +177,32 @@ describe('ThemeEditor', () => {
     expect(props.routeSegment).toBe('modules');
     expect(props.themeId).toBe('theme-1');
     expect(props.onValidate()).toEqual(['game-warning', 'graph-warning']);
+    expect(validateGameDesignMock).toHaveBeenCalledWith(
+      theme.config_json,
+      1,
+      1,
+      expect.objectContaining({
+        flowNodes: [{ id: 'phase-1', type: 'phase', data: { label: '1라운드' } }],
+      })
+    );
+  });
+
+  it('EditorLayout에 direct publish handler와 publish pending 상태를 전달한다', () => {
+    const mutate = vi.fn();
+    usePublishThemeMock.mockReturnValue({ mutate, isPending: true });
+
+    render(<ThemeEditor themeId="theme-1" />);
+
+    const props = editorLayoutMock.mock.calls[0][0] as {
+      onPublish: () => void;
+      isPublishing: boolean;
+    };
+    expect(usePublishThemeMock).toHaveBeenCalledWith('theme-1');
+    expect(props.isPublishing).toBe(true);
+
+    props.onPublish();
+
+    expect(mutate).toHaveBeenCalledWith(undefined, expect.any(Object));
   });
 
   it('slug로 열린 뒤 하위 편집 API에는 응답의 UUID를 사용한다', () => {
@@ -165,6 +217,8 @@ describe('ThemeEditor', () => {
     expect(useEditorThemeMock).toHaveBeenCalledWith('e2e-test-theme');
     expect(useEditorCluesMock).toHaveBeenCalledWith('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
     expect(useClueEdgesMock).toHaveBeenCalledWith('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+    expect(useFlowGraphMock).toHaveBeenCalledWith('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+    expect(usePublishThemeMock).toHaveBeenCalledWith('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
     const props = editorLayoutMock.mock.calls[0][0] as { themeId: string };
     expect(props.themeId).toBe('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
   });

--- a/apps/web/src/features/editor/components/__tests__/ValidationPanel.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ValidationPanel.test.tsx
@@ -26,12 +26,12 @@ describe("ValidationPanel", () => {
     expect(screen.getByText(/검증 통과/)).toBeDefined();
   });
 
-  it("에러 클릭 시 해당 탭으로 이동한다", () => {
+  it("phase 에러 클릭 시 스토리 진행 탭으로 이동한다", () => {
     const onClose = vi.fn();
     const warnings = [makeWarning("error", "phases", "페이즈 없음")];
     render(<ValidationPanel warnings={warnings} onClose={onClose} />);
     fireEvent.click(screen.getByText("페이즈 없음"));
-    expect(mockSetActiveTab).toHaveBeenCalledWith("design");
+    expect(mockSetActiveTab).toHaveBeenCalledWith("storyMap");
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/apps/web/src/features/editor/validation.ts
+++ b/apps/web/src/features/editor/validation.ts
@@ -7,11 +7,22 @@ import {
   readCluePlacement,
   readEnabledModuleIds,
 } from '@/features/editor/utils/configShape';
+import type { FlowNodeResponse, FlowNodeType } from './flowTypes';
 
 export interface DesignWarning {
   type: 'warning' | 'error';
   category: 'phases' | 'clues' | 'characters' | 'modules' | 'clue_graph';
   message: string;
+}
+
+type FlowNodePhaseInput =
+  | Pick<FlowNodeResponse, 'type'>
+  | {
+      type?: FlowNodeType | string;
+    };
+
+export interface ValidateGameDesignOptions {
+  flowNodes?: FlowNodePhaseInput[];
 }
 
 /**
@@ -25,12 +36,15 @@ export function validateGameDesign(
   configJson: Record<string, unknown>,
   clueCount: number,
   characterCount: number,
+  options: ValidateGameDesignOptions = {},
 ): DesignWarning[] {
   const warnings: DesignWarning[] = [];
 
   // ── Phases ──────────────────────────────────────────────────────────────
   const phases = configJson['phases'];
-  if (!Array.isArray(phases) || phases.length === 0) {
+  const hasLegacyPhases = Array.isArray(phases) && phases.length > 0;
+  const hasSavedFlowPhase = (options.flowNodes ?? []).some((node) => node.type === 'phase');
+  if (!hasLegacyPhases && !hasSavedFlowPhase) {
     warnings.push({
       type: 'error',
       category: 'phases',


### PR DESCRIPTION
## 요약
- 에디터 publish route를 서버 라우터에 연결했습니다.
- 출판 버튼이 검증을 먼저 실행하고 오류가 있으면 publish를 막도록 정리했습니다.
- story map flow phase node를 검증 기준에 반영해 legacy phases 부재 오류를 피합니다.
- 방 코드 생성이 첫 호출부터 random bytes를 읽도록 수정했습니다.

Closes #704

## Coverage Plan
- Backend route: `apps/server/cmd/server/routes_editor_themes_test.go`가 `POST /editor/themes/{id}/publish` route 연결을 검증합니다.
- Backend room: `apps/server/internal/domain/room/service_test.go`가 첫 room code 생성 회귀를 검증합니다.
- Frontend validation: `apps/web/src/features/editor/__tests__/validation.test.ts`가 flow phase node 검증 기준을 검증합니다.
- Frontend UI: `EditorLayout`, `ThemeEditor`, `ValidationPanel` component tests가 출판 UX와 검증 안내를 검증합니다.

## Local validation
- `cd apps/server && go test -count=1 ./cmd/server ./internal/domain/room` ✅
- `pnpm --filter @mmp/web test -- src/features/editor/__tests__/validation.test.ts src/features/editor/components/__tests__/EditorLayout.test.tsx src/features/editor/components/__tests__/ThemeEditor.test.tsx src/features/editor/components/__tests__/ValidationPanel.test.tsx` ✅
- `scripts/mmp-local-ci.sh quick` ✅ (`4d857371`, 2026-05-20T07:26:34Z)

## 제외 / 후속
- LiveKit env 주입, 대기방 NPC 필터링, 캐릭터 이미지 URL resolve는 현재 PR에 섞지 않고 후속 대기방 안정화 작업으로 분리합니다.
- 승인 기반 publish workflow는 운영 정책 확정 후 별도 작업으로 남깁니다.
