### PR TITLE
fix: 대기방 음성·캐릭터 선택 안정화

### DIFF
--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -158,7 +158,6 @@ func main() {
 	// authSvc and the WS auth handler.
 	revokeRepo := auth.NewRevokeRepo(queries)
 	profileSvc := profile.NewService(queries, logger)
-	themeSvc := theme.NewService(queries, logger)
 	flowSvc := flow.NewService(pool, logger)
 	flowHandler := flow.NewHandler(flowSvc)
 
@@ -201,6 +200,7 @@ func main() {
 		storageProvider = localStorageProvider
 		logger.Warn().Str("base_dir", cfg.StorageLocalBaseDir).Msg("local file storage provider initialized (dev only — do not use in production)")
 	}
+	themeSvc := theme.NewServiceWithStorage(queries, storageProvider, logger)
 	editorSvc := editor.NewServiceWithStorage(queries, pool, logger, storageProvider)
 	mediaSvc := editor.NewMediaService(queries, pool, storageProvider, logger)
 	mediaHandler := editor.NewMediaHandler(mediaSvc)

--- a/apps/server/internal/domain/theme/mocks/mock_service.go
+++ b/apps/server/internal/domain/theme/mocks/mock_service.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	uuid "github.com/google/uuid"
+	db "github.com/mmp-platform/server/internal/db"
 	theme "github.com/mmp-platform/server/internal/domain/theme"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -100,4 +101,103 @@ func (m *MockService) ListPublished(ctx context.Context, limit, offset int32) ([
 func (mr *MockServiceMockRecorder) ListPublished(ctx, limit, offset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublished", reflect.TypeOf((*MockService)(nil).ListPublished), ctx, limit, offset)
+}
+
+// MockthemeQueries is a mock of themeQueries interface.
+type MockthemeQueries struct {
+	ctrl     *gomock.Controller
+	recorder *MockthemeQueriesMockRecorder
+	isgomock struct{}
+}
+
+// MockthemeQueriesMockRecorder is the mock recorder for MockthemeQueries.
+type MockthemeQueriesMockRecorder struct {
+	mock *MockthemeQueries
+}
+
+// NewMockthemeQueries creates a new mock instance.
+func NewMockthemeQueries(ctrl *gomock.Controller) *MockthemeQueries {
+	mock := &MockthemeQueries{ctrl: ctrl}
+	mock.recorder = &MockthemeQueriesMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockthemeQueries) EXPECT() *MockthemeQueriesMockRecorder {
+	return m.recorder
+}
+
+// GetMedia mocks base method.
+func (m *MockthemeQueries) GetMedia(ctx context.Context, id uuid.UUID) (db.ThemeMedium, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMedia", ctx, id)
+	ret0, _ := ret[0].(db.ThemeMedium)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMedia indicates an expected call of GetMedia.
+func (mr *MockthemeQueriesMockRecorder) GetMedia(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMedia", reflect.TypeOf((*MockthemeQueries)(nil).GetMedia), ctx, id)
+}
+
+// GetTheme mocks base method.
+func (m *MockthemeQueries) GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTheme", ctx, id)
+	ret0, _ := ret[0].(db.Theme)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTheme indicates an expected call of GetTheme.
+func (mr *MockthemeQueriesMockRecorder) GetTheme(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTheme", reflect.TypeOf((*MockthemeQueries)(nil).GetTheme), ctx, id)
+}
+
+// GetThemeBySlug mocks base method.
+func (m *MockthemeQueries) GetThemeBySlug(ctx context.Context, slug string) (db.Theme, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetThemeBySlug", ctx, slug)
+	ret0, _ := ret[0].(db.Theme)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetThemeBySlug indicates an expected call of GetThemeBySlug.
+func (mr *MockthemeQueriesMockRecorder) GetThemeBySlug(ctx, slug any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThemeBySlug", reflect.TypeOf((*MockthemeQueries)(nil).GetThemeBySlug), ctx, slug)
+}
+
+// GetThemeCharacters mocks base method.
+func (m *MockthemeQueries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.ThemeCharacter, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetThemeCharacters", ctx, themeID)
+	ret0, _ := ret[0].([]db.ThemeCharacter)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetThemeCharacters indicates an expected call of GetThemeCharacters.
+func (mr *MockthemeQueriesMockRecorder) GetThemeCharacters(ctx, themeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThemeCharacters", reflect.TypeOf((*MockthemeQueries)(nil).GetThemeCharacters), ctx, themeID)
+}
+
+// ListPublishedThemes mocks base method.
+func (m *MockthemeQueries) ListPublishedThemes(ctx context.Context, arg db.ListPublishedThemesParams) ([]db.Theme, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPublishedThemes", ctx, arg)
+	ret0, _ := ret[0].([]db.Theme)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPublishedThemes indicates an expected call of ListPublishedThemes.
+func (mr *MockthemeQueriesMockRecorder) ListPublishedThemes(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublishedThemes", reflect.TypeOf((*MockthemeQueries)(nil).ListPublishedThemes), ctx, arg)
 }

--- a/apps/server/internal/domain/theme/service.go
+++ b/apps/server/internal/domain/theme/service.go
@@ -14,9 +14,15 @@ import (
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
 	"github.com/mmp-platform/server/internal/engine"
+	"github.com/mmp-platform/server/internal/infra/storage"
 )
 
 const publishedStatus = "PUBLISHED"
+const (
+	mediaTypeImage = "IMAGE"
+	sourceTypeFile = "FILE"
+	mediaURLTTL    = 15 * time.Minute
+)
 
 // ThemeSummary is the compact representation used in list endpoints.
 type ThemeSummary struct {
@@ -62,15 +68,30 @@ type Service interface {
 	GetCharacters(ctx context.Context, themeID uuid.UUID) ([]CharacterResponse, error)
 }
 
+type themeQueries interface {
+	GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error)
+	GetThemeBySlug(ctx context.Context, slug string) (db.Theme, error)
+	ListPublishedThemes(ctx context.Context, arg db.ListPublishedThemesParams) ([]db.Theme, error)
+	GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.ThemeCharacter, error)
+	GetMedia(ctx context.Context, id uuid.UUID) (db.ThemeMedium, error)
+}
+
 type service struct {
-	queries *db.Queries
+	queries themeQueries
+	storage storage.Provider
 	logger  zerolog.Logger
 }
 
 // NewService creates a new theme service.
 func NewService(queries *db.Queries, logger zerolog.Logger) Service {
+	return NewServiceWithStorage(queries, nil, logger)
+}
+
+// NewServiceWithStorage creates a theme service that can resolve public file media URLs.
+func NewServiceWithStorage(queries *db.Queries, storageProvider storage.Provider, logger zerolog.Logger) Service {
 	return &service{
 		queries: queries,
+		storage: storageProvider,
 		logger:  logger.With().Str("domain", "theme").Logger(),
 	}
 }
@@ -135,24 +156,68 @@ func (s *service) GetCharacters(ctx context.Context, themeID uuid.UUID) ([]Chara
 		return nil, apperror.Internal("failed to get characters")
 	}
 
-	result := make([]CharacterResponse, len(chars))
-	for i, c := range chars {
+	result := make([]CharacterResponse, 0, len(chars))
+	for _, c := range chars {
+		if !c.IsPlayable {
+			continue
+		}
 		display := engine.ResolveCharacterDisplay(engine.CharacterDisplayBase{
 			Name:         c.Name,
 			ImageURL:     textToPtr(c.ImageUrl),
 			ImageMediaID: pgUUIDToStringPtr(c.ImageMediaID),
 			AliasRules:   engine.ParseCharacterAliasRules(c.AliasRules),
 		}, json.RawMessage(`{}`))
-		result[i] = CharacterResponse{
+		display.ImageURL = s.resolveCharacterImageURL(ctx, c.ThemeID, display.ImageURL, c.ImageMediaID)
+		result = append(result, CharacterResponse{
 			ID:           c.ID,
 			Name:         display.Name,
 			Description:  textToPtr(c.Description),
 			ImageURL:     display.ImageURL,
 			ImageMediaID: display.ImageMediaID,
 			SortOrder:    c.SortOrder,
-		}
+		})
 	}
 	return result, nil
+}
+
+func (s *service) resolveCharacterImageURL(ctx context.Context, themeID uuid.UUID, currentURL *string, mediaID pgtype.UUID) *string {
+	if currentURL != nil || !mediaID.Valid || s.storage == nil {
+		return currentURL
+	}
+	id := uuid.UUID(mediaID.Bytes)
+	media, err := s.queries.GetMedia(ctx, id)
+	if err != nil {
+		s.logger.Warn().Err(err).Stringer("media_id", id).Msg("failed to resolve character image media")
+		return currentURL
+	}
+	if media.ThemeID != themeID {
+		s.logger.Warn().
+			Stringer("media_id", id).
+			Stringer("media_theme_id", media.ThemeID).
+			Stringer("character_theme_id", themeID).
+			Msg("character image media belongs to another theme")
+		return currentURL
+	}
+	if media.Type != mediaTypeImage || media.SourceType != sourceTypeFile || !media.StorageKey.Valid {
+		return currentURL
+	}
+	if _, err := s.storage.HeadObject(ctx, media.StorageKey.String); err != nil {
+		if errors.Is(err, storage.ErrObjectNotFound) {
+			s.logger.Warn().Stringer("media_id", id).Str("storage_key", media.StorageKey.String).Msg("character image media object not found")
+			return currentURL
+		}
+		s.logger.Warn().Err(err).Stringer("media_id", id).Str("storage_key", media.StorageKey.String).Msg("failed to verify character image media")
+		return currentURL
+	}
+	url, err := s.storage.GenerateDownloadURL(ctx, media.StorageKey.String, mediaURLTTL)
+	if err != nil {
+		s.logger.Warn().Err(err).Stringer("media_id", id).Str("storage_key", media.StorageKey.String).Msg("failed to generate character image URL")
+		return currentURL
+	}
+	if url == "" {
+		return currentURL
+	}
+	return &url
 }
 
 func pgUUIDToStringPtr(value pgtype.UUID) *string {

--- a/apps/server/internal/domain/theme/service_public_character_test.go
+++ b/apps/server/internal/domain/theme/service_public_character_test.go
@@ -1,0 +1,347 @@
+package theme
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog"
+
+	"github.com/mmp-platform/server/internal/db"
+	"github.com/mmp-platform/server/internal/infra/storage"
+)
+
+type fakePublicThemeQueries struct {
+	theme      db.Theme
+	characters []db.ThemeCharacter
+	media      map[uuid.UUID]db.ThemeMedium
+}
+
+func (f *fakePublicThemeQueries) GetTheme(context.Context, uuid.UUID) (db.Theme, error) {
+	return f.theme, nil
+}
+
+func (f *fakePublicThemeQueries) GetThemeBySlug(context.Context, string) (db.Theme, error) {
+	return f.theme, nil
+}
+
+func (f *fakePublicThemeQueries) ListPublishedThemes(context.Context, db.ListPublishedThemesParams) ([]db.Theme, error) {
+	return []db.Theme{f.theme}, nil
+}
+
+func (f *fakePublicThemeQueries) GetThemeCharacters(context.Context, uuid.UUID) ([]db.ThemeCharacter, error) {
+	return f.characters, nil
+}
+
+func (f *fakePublicThemeQueries) GetMedia(_ context.Context, mediaID uuid.UUID) (db.ThemeMedium, error) {
+	if _, ok := f.media[mediaID]; !ok {
+		return db.ThemeMedium{}, pgx.ErrNoRows
+	}
+	return f.media[mediaID], nil
+}
+
+type fakePublicThemeStorage struct {
+	urls       map[string]string
+	existing   map[string]bool
+	headErrors map[string]error
+	headCalls  int
+	urlCalls   int
+}
+
+func (f fakePublicThemeStorage) GenerateUploadURL(context.Context, string, string, int64, time.Duration) (string, error) {
+	return "", nil
+}
+
+func (f *fakePublicThemeStorage) GenerateDownloadURL(_ context.Context, key string, _ time.Duration) (string, error) {
+	f.urlCalls++
+	return f.urls[key], nil
+}
+
+func (*fakePublicThemeStorage) PutObject(context.Context, string, io.Reader, string, int64) error {
+	return nil
+}
+
+func (f *fakePublicThemeStorage) HeadObject(_ context.Context, key string) (*storage.ObjectMeta, error) {
+	f.headCalls++
+	if err := f.headErrors[key]; err != nil {
+		return nil, err
+	}
+	if !f.existing[key] {
+		return nil, storage.ErrObjectNotFound
+	}
+	return &storage.ObjectMeta{Key: key, ContentType: "image/png", Size: 1024}, nil
+}
+
+func (*fakePublicThemeStorage) GetObjectRange(context.Context, string, int64, int64) (io.ReadCloser, error) {
+	return nil, storage.ErrObjectNotFound
+}
+
+func (*fakePublicThemeStorage) DeleteObject(context.Context, string) error {
+	return nil
+}
+
+func (*fakePublicThemeStorage) DeleteObjects(context.Context, []string) error {
+	return nil
+}
+
+func TestGetCharactersFiltersNonPlayableAndResolvesImageMediaURL(t *testing.T) {
+	themeID := uuid.New()
+	playableID := uuid.New()
+	npcID := uuid.New()
+	mediaID := uuid.New()
+	storageKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + ".png"
+	downloadURL := "https://cdn.example.test/" + storageKey
+
+	q := &fakePublicThemeQueries{
+		theme: db.Theme{ID: themeID, Status: publishedStatus},
+		characters: []db.ThemeCharacter{
+			{
+				ID:           playableID,
+				ThemeID:      themeID,
+				Name:         "Playable",
+				IsPlayable:   true,
+				SortOrder:    1,
+				ImageMediaID: pgUUID(mediaID),
+			},
+			{
+				ID:         npcID,
+				ThemeID:    themeID,
+				Name:       "NPC",
+				IsPlayable: false,
+				SortOrder:  2,
+			},
+		},
+		media: map[uuid.UUID]db.ThemeMedium{
+			mediaID: {
+				ID:         mediaID,
+				ThemeID:    themeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: storageKey, Valid: true},
+			},
+		},
+	}
+	fakeStorage := &fakePublicThemeStorage{
+		urls:     map[string]string{storageKey: downloadURL},
+		existing: map[string]bool{storageKey: true},
+	}
+	svc := &service{
+		queries: q,
+		storage: fakeStorage,
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 1 {
+		t.Fatalf("len(chars) = %d, want 1: %+v", len(chars), chars)
+	}
+	if chars[0].ID != playableID {
+		t.Fatalf("returned character ID = %s, want %s", chars[0].ID, playableID)
+	}
+	if chars[0].ImageURL == nil || *chars[0].ImageURL != downloadURL {
+		t.Fatalf("image_url = %v, want %q", chars[0].ImageURL, downloadURL)
+	}
+	if fakeStorage.headCalls != 1 {
+		t.Fatalf("HeadObject calls = %d, want 1", fakeStorage.headCalls)
+	}
+	if fakeStorage.urlCalls != 1 {
+		t.Fatalf("GenerateDownloadURL calls = %d, want 1", fakeStorage.urlCalls)
+	}
+}
+
+func TestGetCharactersPreservesExistingImageURL(t *testing.T) {
+	themeID := uuid.New()
+	mediaID := uuid.New()
+	existingURL := "https://static.example.test/character.png"
+	q := &fakePublicThemeQueries{
+		theme: db.Theme{ID: themeID, Status: publishedStatus},
+		characters: []db.ThemeCharacter{{
+			ID:           uuid.New(),
+			ThemeID:      themeID,
+			Name:         "Playable",
+			IsPlayable:   true,
+			ImageUrl:     pgtype.Text{String: existingURL, Valid: true},
+			ImageMediaID: pgUUID(mediaID),
+		}},
+		media: map[uuid.UUID]db.ThemeMedium{
+			mediaID: {
+				ID:         mediaID,
+				ThemeID:    themeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: "unused", Valid: true},
+			},
+		},
+	}
+	fakeStorage := &fakePublicThemeStorage{
+		urls:     map[string]string{"unused": "https://cdn.example.test/unused"},
+		existing: map[string]bool{"unused": true},
+	}
+	svc := &service{
+		queries: q,
+		storage: fakeStorage,
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 1 {
+		t.Fatalf("len(chars) = %d, want 1", len(chars))
+	}
+	if chars[0].ImageURL == nil || *chars[0].ImageURL != existingURL {
+		t.Fatalf("image_url = %v, want existing %q", chars[0].ImageURL, existingURL)
+	}
+	if fakeStorage.headCalls != 0 {
+		t.Fatalf("HeadObject calls = %d, want 0", fakeStorage.headCalls)
+	}
+	if fakeStorage.urlCalls != 0 {
+		t.Fatalf("GenerateDownloadURL calls = %d, want 0", fakeStorage.urlCalls)
+	}
+}
+
+func TestGetCharactersKeepsCharacterWhenImageMediaMissing(t *testing.T) {
+	themeID := uuid.New()
+	mediaID := uuid.New()
+	q := &fakePublicThemeQueries{
+		theme: db.Theme{ID: themeID, Status: publishedStatus},
+		characters: []db.ThemeCharacter{{
+			ID:           uuid.New(),
+			ThemeID:      themeID,
+			Name:         "Playable",
+			IsPlayable:   true,
+			ImageMediaID: pgUUID(mediaID),
+		}},
+		media: map[uuid.UUID]db.ThemeMedium{},
+	}
+	svc := &service{
+		queries: q,
+		storage: &fakePublicThemeStorage{},
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 1 {
+		t.Fatalf("len(chars) = %d, want 1", len(chars))
+	}
+	if chars[0].ImageURL != nil {
+		t.Fatalf("image_url = %v, want nil fallback", *chars[0].ImageURL)
+	}
+}
+
+func TestGetCharactersFallsBackWhenImageObjectMissing(t *testing.T) {
+	themeID := uuid.New()
+	mediaID := uuid.New()
+	storageKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + ".png"
+	q := &fakePublicThemeQueries{
+		theme: db.Theme{ID: themeID, Status: publishedStatus},
+		characters: []db.ThemeCharacter{{
+			ID:           uuid.New(),
+			ThemeID:      themeID,
+			Name:         "Playable",
+			IsPlayable:   true,
+			ImageMediaID: pgUUID(mediaID),
+		}},
+		media: map[uuid.UUID]db.ThemeMedium{
+			mediaID: {
+				ID:         mediaID,
+				ThemeID:    themeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: storageKey, Valid: true},
+			},
+		},
+	}
+	fakeStorage := &fakePublicThemeStorage{
+		urls: map[string]string{storageKey: "https://cdn.example.test/" + storageKey},
+	}
+	svc := &service{
+		queries: q,
+		storage: fakeStorage,
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 1 {
+		t.Fatalf("len(chars) = %d, want 1", len(chars))
+	}
+	if chars[0].ImageURL != nil {
+		t.Fatalf("image_url = %v, want nil fallback for missing object", *chars[0].ImageURL)
+	}
+	if fakeStorage.headCalls != 1 {
+		t.Fatalf("HeadObject calls = %d, want 1", fakeStorage.headCalls)
+	}
+	if fakeStorage.urlCalls != 0 {
+		t.Fatalf("GenerateDownloadURL calls = %d, want 0", fakeStorage.urlCalls)
+	}
+}
+
+func TestGetCharactersFallsBackWhenImageMediaBelongsToAnotherTheme(t *testing.T) {
+	themeID := uuid.New()
+	otherThemeID := uuid.New()
+	mediaID := uuid.New()
+	storageKey := "themes/" + otherThemeID.String() + "/media/" + mediaID.String() + ".png"
+	q := &fakePublicThemeQueries{
+		theme: db.Theme{ID: themeID, Status: publishedStatus},
+		characters: []db.ThemeCharacter{{
+			ID:           uuid.New(),
+			ThemeID:      themeID,
+			Name:         "Playable",
+			IsPlayable:   true,
+			ImageMediaID: pgUUID(mediaID),
+		}},
+		media: map[uuid.UUID]db.ThemeMedium{
+			mediaID: {
+				ID:         mediaID,
+				ThemeID:    otherThemeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: storageKey, Valid: true},
+			},
+		},
+	}
+	fakeStorage := &fakePublicThemeStorage{
+		urls:     map[string]string{storageKey: "https://cdn.example.test/" + storageKey},
+		existing: map[string]bool{storageKey: true},
+	}
+	svc := &service{
+		queries: q,
+		storage: fakeStorage,
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 1 {
+		t.Fatalf("len(chars) = %d, want 1", len(chars))
+	}
+	if chars[0].ImageURL != nil {
+		t.Fatalf("image_url = %v, want nil fallback for cross-theme media", *chars[0].ImageURL)
+	}
+	if fakeStorage.headCalls != 0 {
+		t.Fatalf("HeadObject calls = %d, want 0", fakeStorage.headCalls)
+	}
+	if fakeStorage.urlCalls != 0 {
+		t.Fatalf("GenerateDownloadURL calls = %d, want 0", fakeStorage.urlCalls)
+	}
+}
+
+func pgUUID(id uuid.UUID) pgtype.UUID {
+	return pgtype.UUID{Bytes: id, Valid: true}
+}

--- a/apps/web/src/features/room/components/__tests__/CharacterSelectionPanel.test.tsx
+++ b/apps/web/src/features/room/components/__tests__/CharacterSelectionPanel.test.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CharacterSelectionPanel } from '../CharacterSelectionPanel';
+import type { ThemeCharacterSummary } from '@/features/lobby/api';
+
+const baseCharacter: ThemeCharacterSummary = {
+  id: 'character-detective',
+  name: '탐정',
+  description: '사건의 진실을 좇는 손님',
+  image_url: null,
+  image_media_id: null,
+  sort_order: 1,
+};
+
+function renderPanel(characters: ThemeCharacterSummary[]) {
+  return render(
+    <CharacterSelectionPanel
+      characters={characters}
+      selectedCharacterId={null}
+      selectedByOtherPlayerIds={new Set()}
+      onSelect={vi.fn()}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CharacterSelectionPanel', () => {
+  it('renders a character portrait image when image_url is available', () => {
+    const portraitUrl = 'https://cdn.example.test/characters/detective.webp';
+    const { container } = renderPanel([{ ...baseCharacter, image_url: portraitUrl }]);
+
+    const portrait = container.querySelector('img');
+
+    expect(screen.getByRole('button', { name: /탐정/ })).toBeInTheDocument();
+    expect(portrait).toBeInTheDocument();
+    expect(portrait).toHaveAttribute('src', portraitUrl);
+  });
+
+  it('keeps the fallback icon when image_url is missing even if image_media_id exists', () => {
+    const { container } = renderPanel([
+      { ...baseCharacter, image_url: null, image_media_id: 'media-detective' },
+    ]);
+
+    const characterButton = screen.getByRole('button', { name: /탐정/ });
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(characterButton.querySelector('svg[aria-hidden="true"]')).toBeInTheDocument();
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
       R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-}
       R2_BUCKET_NAME: ${R2_BUCKET_NAME:-}
       R2_PUBLIC_URL: ${R2_PUBLIC_URL:-}
+      LIVEKIT_URL: ${LIVEKIT_URL:-}
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/docs/plans/2026-05-20-waiting-room-stabilization/checklist.md
+++ b/docs/plans/2026-05-20-waiting-room-stabilization/checklist.md
@@ -1,0 +1,64 @@
+# Waiting Room Stabilization
+
+Issue: #706
+Seed: `.git/mmp-workflow/seeds/issue-706.json`
+
+## Goal
+
+Make the pre-game waiting room usable before game start:
+
+- LiveKit uses the real provider when root `.env` contains LiveKit values.
+- Character selection only exposes playable characters.
+- Playable character images render in the waiting room.
+
+## Scope
+
+- [ ] Explicitly pass `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` to the server container in `docker-compose.yml`.
+- [ ] Avoid whole-file `env_file: .env` injection.
+- [ ] Verify waiting-room `/api/v1/voice/token` returns a non-empty `livekit_url` when LiveKit env exists.
+- [ ] Filter public theme characters to playable characters only.
+- [ ] Preserve editor-side NPC visibility.
+- [ ] Resolve character `image_media_id` to public `image_url` for playable characters.
+- [ ] Keep `CharacterSelectionPanel` as an `image_url` consumer with a safe fallback.
+- [ ] Preserve ready/start/chat and both `room_id` and `session_id` voice token paths.
+
+## Out Of Scope
+
+- [ ] Whisper expansion.
+- [ ] Voice moderation or push-to-talk.
+- [ ] Durable voice preferences.
+- [ ] NPC management UI redesign.
+- [ ] Media upload/storage pipeline redesign.
+- [ ] Friend invite UX implementation.
+
+## Agent Plan
+
+- [ ] Backend lane owns `docker-compose.yml`, voice env/provider verification, public character filtering, and media URL resolve.
+- [ ] Frontend lane owns `CharacterSelectionPanel`, `RoomPage`, and lobby API type updates after the backend contract is fixed.
+- [ ] Validation lane owns focused commands and browser evidence only.
+- [ ] Reviewer lanes independently review backend, frontend, and coverage after the final implementation fix.
+
+## Stop Conditions
+
+- [ ] A lane needs to expose LiveKit secrets in logs, PR text, or frontend code.
+- [ ] A lane proposes `env_file: .env` whole-file injection.
+- [ ] Editor APIs stop showing NPC/non-playable characters.
+- [ ] Existing gameplay `session_id` voice token path regresses.
+- [ ] Multiple lanes need to edit the same shared contract file at once.
+- [ ] Final validation or review has not rerun after the last fix.
+
+## Coverage Plan
+
+- [ ] Backend voice tests cover configured LiveKit token response and existing session token compatibility.
+- [ ] Backend theme tests cover playable-only public character listing.
+- [ ] Backend media/character tests cover `image_media_id` to `image_url` resolution and missing-media fallback.
+- [ ] Frontend tests cover image rendering, fallback, and NPC absence in the character selection surface.
+- [ ] Browser QA covers voice token network response, image render, NPC absence, ready/start/chat smoke.
+
+## Validation Commands
+
+- [ ] `cd apps/server && go test -count=1 ./internal/domain/theme ./internal/domain/voice ./internal/domain/room ./cmd/server`
+- [ ] `pnpm --filter @mmp/web test -- src/features/room/components/__tests__/CharacterSelectionPanel.test.tsx src/pages/__tests__/RoomPage.test.tsx`
+- [ ] `pnpm --filter @mmp/web typecheck`
+- [ ] `scripts/mmp-local-ci.sh quick`
+

--- a/docs/plans/2026-05-20-waiting-room-stabilization/checklist.md
+++ b/docs/plans/2026-05-20-waiting-room-stabilization/checklist.md
@@ -13,52 +13,52 @@ Make the pre-game waiting room usable before game start:
 
 ## Scope
 
-- [ ] Explicitly pass `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` to the server container in `docker-compose.yml`.
-- [ ] Avoid whole-file `env_file: .env` injection.
-- [ ] Verify waiting-room `/api/v1/voice/token` returns a non-empty `livekit_url` when LiveKit env exists.
-- [ ] Filter public theme characters to playable characters only.
-- [ ] Preserve editor-side NPC visibility.
-- [ ] Resolve character `image_media_id` to public `image_url` for playable characters.
-- [ ] Keep `CharacterSelectionPanel` as an `image_url` consumer with a safe fallback.
-- [ ] Preserve ready/start/chat and both `room_id` and `session_id` voice token paths.
+- [x] Explicitly pass `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` to the server container in `docker-compose.yml`.
+- [x] Avoid whole-file `env_file: .env` injection.
+- [x] Verify waiting-room `/api/v1/voice/token` returns a non-empty `livekit_url` when LiveKit env exists.
+- [x] Filter public theme characters to playable characters only.
+- [x] Preserve editor-side NPC visibility.
+- [x] Resolve character `image_media_id` to public `image_url` for playable characters when the storage object exists.
+- [x] Fall back safely when `image_media_id` points to missing storage objects.
+- [x] Keep `CharacterSelectionPanel` as an `image_url` consumer with a safe fallback.
+- [x] Preserve ready/start/chat and both `room_id` and `session_id` voice token paths.
 
 ## Out Of Scope
 
-- [ ] Whisper expansion.
-- [ ] Voice moderation or push-to-talk.
-- [ ] Durable voice preferences.
-- [ ] NPC management UI redesign.
-- [ ] Media upload/storage pipeline redesign.
-- [ ] Friend invite UX implementation.
+- [x] Confirmed excluded: Whisper expansion.
+- [x] Confirmed excluded: Voice moderation or push-to-talk.
+- [x] Confirmed excluded: Durable voice preferences.
+- [x] Confirmed excluded: NPC management UI redesign.
+- [x] Confirmed excluded: Media upload/storage pipeline redesign.
+- [x] Confirmed excluded: Friend invite UX implementation.
 
 ## Agent Plan
 
-- [ ] Backend lane owns `docker-compose.yml`, voice env/provider verification, public character filtering, and media URL resolve.
-- [ ] Frontend lane owns `CharacterSelectionPanel`, `RoomPage`, and lobby API type updates after the backend contract is fixed.
-- [ ] Validation lane owns focused commands and browser evidence only.
-- [ ] Reviewer lanes independently review backend, frontend, and coverage after the final implementation fix.
+- [x] Backend lane owns `docker-compose.yml`, voice env/provider verification, public character filtering, and media URL resolve.
+- [x] Frontend lane owns `CharacterSelectionPanel`, `RoomPage`, and lobby API type updates after the backend contract is fixed.
+- [x] Validation lane owns focused commands and browser evidence only.
+- [x] Reviewer lanes independently review backend, frontend, and coverage after the final implementation fix.
 
 ## Stop Conditions
 
-- [ ] A lane needs to expose LiveKit secrets in logs, PR text, or frontend code.
-- [ ] A lane proposes `env_file: .env` whole-file injection.
-- [ ] Editor APIs stop showing NPC/non-playable characters.
-- [ ] Existing gameplay `session_id` voice token path regresses.
-- [ ] Multiple lanes need to edit the same shared contract file at once.
-- [ ] Final validation or review has not rerun after the last fix.
+- [x] No lane exposed LiveKit secrets in logs, PR text, or frontend code.
+- [x] No lane proposed `env_file: .env` whole-file injection.
+- [x] Editor APIs keep showing NPC/non-playable characters.
+- [x] Existing gameplay `session_id` voice token path did not regress in focused tests.
+- [x] No multiple lanes edited the same shared contract file at once.
+- [x] Final validation and review reran after the last fix.
 
 ## Coverage Plan
 
-- [ ] Backend voice tests cover configured LiveKit token response and existing session token compatibility.
-- [ ] Backend theme tests cover playable-only public character listing.
-- [ ] Backend media/character tests cover `image_media_id` to `image_url` resolution and missing-media fallback.
-- [ ] Frontend tests cover image rendering, fallback, and NPC absence in the character selection surface.
-- [ ] Browser QA covers voice token network response, image render, NPC absence, ready/start/chat smoke.
+- [x] Backend voice tests cover configured LiveKit token response and existing session token compatibility.
+- [x] Backend theme tests cover playable-only public character listing.
+- [x] Backend media/character tests cover `image_media_id` to `image_url` resolution and missing-media fallback.
+- [x] Frontend tests cover image rendering, fallback, and NPC absence in the character selection surface.
+- [x] Browser QA covers voice token network response, character image/fallback behavior, NPC absence, and chat/voice smoke.
 
 ## Validation Commands
 
-- [ ] `cd apps/server && go test -count=1 ./internal/domain/theme ./internal/domain/voice ./internal/domain/room ./cmd/server`
-- [ ] `pnpm --filter @mmp/web test -- src/features/room/components/__tests__/CharacterSelectionPanel.test.tsx src/pages/__tests__/RoomPage.test.tsx`
-- [ ] `pnpm --filter @mmp/web typecheck`
-- [ ] `scripts/mmp-local-ci.sh quick`
-
+- [x] `cd apps/server && go test -count=1 ./internal/domain/theme ./internal/domain/voice ./internal/domain/room ./cmd/server`
+- [x] `pnpm --filter @mmp/web test -- src/features/room/components/__tests__/CharacterSelectionPanel.test.tsx src/pages/__tests__/RoomPage.test.tsx`
+- [x] `pnpm --filter @mmp/web typecheck`
+- [x] `scripts/mmp-local-ci.sh quick`


### PR DESCRIPTION
## 요약
- Docker Compose 서버 컨테이너에 LiveKit 환경변수를 명시적으로 전달해 대기방 음성 토큰이 실제 LiveKit URL과 토큰을 반환하게 했습니다.
- 공개 캐릭터 목록에서 NPC/non-playable 캐릭터를 제외하고, 플레이 가능한 캐릭터의 image_media_id를 안전하게 image_url로 해석합니다.
- 저장소 객체가 없거나 다른 테마의 media를 가리키는 경우 깨진 presigned URL을 내려주지 않고 기존 fallback UI를 유지합니다.

## Coverage Plan
- apps/server/internal/domain/theme/service.go: playable-only 필터, image_media_id URL 해석, missing object fallback, cross-theme media 차단을 backend unit test로 커버했습니다.
- apps/server/cmd/server/main.go 및 docker-compose.yml: LiveKit env 전달과 storage provider 기반 theme service 초기화를 API smoke와 local-ci quick으로 확인했습니다.
- apps/web/src/features/room/components/CharacterSelectionPanel.tsx: image_url 렌더링과 image_media_id만 있는 fallback 동작을 component test로 커버했습니다.
- 기존 room/voice/session 경로는 focused backend/web tests와 quick local CI로 회귀 확인했습니다.

## Local validation
- `cd apps/server && go test -count=1 ./internal/domain/theme ./internal/domain/voice ./internal/domain/room ./cmd/server`
- `pnpm --filter @mmp/web test -- src/features/room/components/__tests__/CharacterSelectionPanel.test.tsx src/pages/__tests__/RoomPage.test.tsx`
- `pnpm --filter @mmp/web typecheck`
- `scripts/mmp-local-ci.sh quick`
- Browser QA: 대기방에서 NPC `전업` 미노출, 캐릭터 fallback 표시, LiveKit voice token 200 및 연결됨 상태, 채팅 패널 표시를 확인했습니다.

## 참고
- 현재 로컬 데이터의 일부 character media storage key는 실제 객체가 없어 이미지 대신 fallback이 표시됩니다. 이 PR은 깨진 URL을 노출하지 않도록 막고, 객체가 존재하면 image_url이 렌더링되는 경로를 보장합니다. 실제 초상화 파일 복구/재업로드는 별도 media 데이터 정비 범위입니다.

Closes #706