### PR TITLE
fix: 공개 테마 SQL projection hardening

### DIFF
--- a/apps/server/db/queries/themes.sql
+++ b/apps/server/db/queries/themes.sql
@@ -1,15 +1,70 @@
 -- name: GetTheme :one
 SELECT * FROM themes WHERE id = $1;
 
+-- name: GetPublishedTheme :one
+SELECT
+  id,
+  creator_id,
+  title,
+  slug,
+  description,
+  cover_image,
+  min_players,
+  max_players,
+  duration_min,
+  price,
+  status,
+  version,
+  published_at,
+  created_at,
+  coin_price
+FROM themes
+WHERE id = $1 AND status = 'PUBLISHED';
+
 -- name: GetThemeBySlug :one
 SELECT * FROM themes WHERE slug = $1;
+
+-- name: GetPublishedThemeBySlug :one
+SELECT
+  id,
+  creator_id,
+  title,
+  slug,
+  description,
+  cover_image,
+  min_players,
+  max_players,
+  duration_min,
+  price,
+  status,
+  version,
+  published_at,
+  created_at,
+  coin_price
+FROM themes
+WHERE slug = $1 AND status = 'PUBLISHED';
 
 -- name: ListThemesByCreator :many
 SELECT id, title, status, min_players, max_players, coin_price, version, created_at
 FROM themes WHERE creator_id = $1 ORDER BY created_at DESC;
 
 -- name: ListPublishedThemes :many
-SELECT * FROM themes WHERE status = 'PUBLISHED' ORDER BY published_at DESC LIMIT $1 OFFSET $2;
+SELECT
+  id,
+  creator_id,
+  title,
+  slug,
+  description,
+  cover_image,
+  min_players,
+  max_players,
+  duration_min,
+  price,
+  coin_price
+FROM themes
+WHERE status = 'PUBLISHED'
+ORDER BY published_at DESC
+LIMIT $1 OFFSET $2;
 
 -- name: CreateTheme :one
 INSERT INTO themes (creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, coin_price, config_json)
@@ -17,12 +72,31 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 RETURNING *;
 
 -- name: UpdateThemeStatus :one
-UPDATE themes SET status = $2::varchar, published_at = CASE WHEN $2::varchar = 'PUBLISHED' THEN NOW() ELSE published_at END, updated_at = NOW()
-WHERE id = $1
+UPDATE themes
+SET status = sqlc.arg('status')::varchar,
+    published_at = CASE WHEN sqlc.arg('status')::varchar = 'PUBLISHED' THEN NOW() ELSE published_at END,
+    updated_at = NOW()
+WHERE id = sqlc.arg('id')
 RETURNING *;
 
 -- name: GetThemeCharacters :many
 SELECT * FROM theme_characters WHERE theme_id = $1 ORDER BY sort_order;
+
+-- name: GetPublishedThemeCharacters :many
+SELECT
+  c.id,
+  c.theme_id,
+  c.name,
+  c.description,
+  c.image_url,
+  c.sort_order,
+  c.image_media_id
+FROM theme_characters c
+JOIN themes t ON t.id = c.theme_id
+WHERE c.theme_id = $1
+  AND t.status = 'PUBLISHED'
+  AND c.is_playable = TRUE
+ORDER BY c.sort_order;
 
 -- name: CreateThemeCharacter :one
 INSERT INTO theme_characters (

--- a/apps/server/internal/db/themes.sql.go
+++ b/apps/server/internal/db/themes.sql.go
@@ -181,6 +181,185 @@ func (q *Queries) DeleteThemeCharacter(ctx context.Context, id uuid.UUID) error 
 	return err
 }
 
+const getPublishedTheme = `-- name: GetPublishedTheme :one
+SELECT
+  id,
+  creator_id,
+  title,
+  slug,
+  description,
+  cover_image,
+  min_players,
+  max_players,
+  duration_min,
+  price,
+  status,
+  version,
+  published_at,
+  created_at,
+  coin_price
+FROM themes
+WHERE id = $1 AND status = 'PUBLISHED'
+`
+
+type GetPublishedThemeRow struct {
+	ID          uuid.UUID          `json:"id"`
+	CreatorID   uuid.UUID          `json:"creator_id"`
+	Title       string             `json:"title"`
+	Slug        string             `json:"slug"`
+	Description pgtype.Text        `json:"description"`
+	CoverImage  pgtype.Text        `json:"cover_image"`
+	MinPlayers  int32              `json:"min_players"`
+	MaxPlayers  int32              `json:"max_players"`
+	DurationMin int32              `json:"duration_min"`
+	Price       int32              `json:"price"`
+	Status      string             `json:"status"`
+	Version     int32              `json:"version"`
+	PublishedAt pgtype.Timestamptz `json:"published_at"`
+	CreatedAt   time.Time          `json:"created_at"`
+	CoinPrice   int32              `json:"coin_price"`
+}
+
+func (q *Queries) GetPublishedTheme(ctx context.Context, id uuid.UUID) (GetPublishedThemeRow, error) {
+	row := q.db.QueryRow(ctx, getPublishedTheme, id)
+	var i GetPublishedThemeRow
+	err := row.Scan(
+		&i.ID,
+		&i.CreatorID,
+		&i.Title,
+		&i.Slug,
+		&i.Description,
+		&i.CoverImage,
+		&i.MinPlayers,
+		&i.MaxPlayers,
+		&i.DurationMin,
+		&i.Price,
+		&i.Status,
+		&i.Version,
+		&i.PublishedAt,
+		&i.CreatedAt,
+		&i.CoinPrice,
+	)
+	return i, err
+}
+
+const getPublishedThemeBySlug = `-- name: GetPublishedThemeBySlug :one
+SELECT
+  id,
+  creator_id,
+  title,
+  slug,
+  description,
+  cover_image,
+  min_players,
+  max_players,
+  duration_min,
+  price,
+  status,
+  version,
+  published_at,
+  created_at,
+  coin_price
+FROM themes
+WHERE slug = $1 AND status = 'PUBLISHED'
+`
+
+type GetPublishedThemeBySlugRow struct {
+	ID          uuid.UUID          `json:"id"`
+	CreatorID   uuid.UUID          `json:"creator_id"`
+	Title       string             `json:"title"`
+	Slug        string             `json:"slug"`
+	Description pgtype.Text        `json:"description"`
+	CoverImage  pgtype.Text        `json:"cover_image"`
+	MinPlayers  int32              `json:"min_players"`
+	MaxPlayers  int32              `json:"max_players"`
+	DurationMin int32              `json:"duration_min"`
+	Price       int32              `json:"price"`
+	Status      string             `json:"status"`
+	Version     int32              `json:"version"`
+	PublishedAt pgtype.Timestamptz `json:"published_at"`
+	CreatedAt   time.Time          `json:"created_at"`
+	CoinPrice   int32              `json:"coin_price"`
+}
+
+func (q *Queries) GetPublishedThemeBySlug(ctx context.Context, slug string) (GetPublishedThemeBySlugRow, error) {
+	row := q.db.QueryRow(ctx, getPublishedThemeBySlug, slug)
+	var i GetPublishedThemeBySlugRow
+	err := row.Scan(
+		&i.ID,
+		&i.CreatorID,
+		&i.Title,
+		&i.Slug,
+		&i.Description,
+		&i.CoverImage,
+		&i.MinPlayers,
+		&i.MaxPlayers,
+		&i.DurationMin,
+		&i.Price,
+		&i.Status,
+		&i.Version,
+		&i.PublishedAt,
+		&i.CreatedAt,
+		&i.CoinPrice,
+	)
+	return i, err
+}
+
+const getPublishedThemeCharacters = `-- name: GetPublishedThemeCharacters :many
+SELECT
+  c.id,
+  c.theme_id,
+  c.name,
+  c.description,
+  c.image_url,
+  c.sort_order,
+  c.image_media_id
+FROM theme_characters c
+JOIN themes t ON t.id = c.theme_id
+WHERE c.theme_id = $1
+  AND t.status = 'PUBLISHED'
+  AND c.is_playable = TRUE
+ORDER BY c.sort_order
+`
+
+type GetPublishedThemeCharactersRow struct {
+	ID           uuid.UUID   `json:"id"`
+	ThemeID      uuid.UUID   `json:"theme_id"`
+	Name         string      `json:"name"`
+	Description  pgtype.Text `json:"description"`
+	ImageUrl     pgtype.Text `json:"image_url"`
+	SortOrder    int32       `json:"sort_order"`
+	ImageMediaID pgtype.UUID `json:"image_media_id"`
+}
+
+func (q *Queries) GetPublishedThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]GetPublishedThemeCharactersRow, error) {
+	rows, err := q.db.Query(ctx, getPublishedThemeCharacters, themeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetPublishedThemeCharactersRow{}
+	for rows.Next() {
+		var i GetPublishedThemeCharactersRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThemeID,
+			&i.Name,
+			&i.Description,
+			&i.ImageUrl,
+			&i.SortOrder,
+			&i.ImageMediaID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getTheme = `-- name: GetTheme :one
 SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id FROM themes WHERE id = $1
 `
@@ -413,7 +592,22 @@ func (q *Queries) ListAllThemes(ctx context.Context, arg ListAllThemesParams) ([
 }
 
 const listPublishedThemes = `-- name: ListPublishedThemes :many
-SELECT id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id FROM themes WHERE status = 'PUBLISHED' ORDER BY published_at DESC LIMIT $1 OFFSET $2
+SELECT
+  id,
+  creator_id,
+  title,
+  slug,
+  description,
+  cover_image,
+  min_players,
+  max_players,
+  duration_min,
+  price,
+  coin_price
+FROM themes
+WHERE status = 'PUBLISHED'
+ORDER BY published_at DESC
+LIMIT $1 OFFSET $2
 `
 
 type ListPublishedThemesParams struct {
@@ -421,15 +615,29 @@ type ListPublishedThemesParams struct {
 	Offset int32 `json:"offset"`
 }
 
-func (q *Queries) ListPublishedThemes(ctx context.Context, arg ListPublishedThemesParams) ([]Theme, error) {
+type ListPublishedThemesRow struct {
+	ID          uuid.UUID   `json:"id"`
+	CreatorID   uuid.UUID   `json:"creator_id"`
+	Title       string      `json:"title"`
+	Slug        string      `json:"slug"`
+	Description pgtype.Text `json:"description"`
+	CoverImage  pgtype.Text `json:"cover_image"`
+	MinPlayers  int32       `json:"min_players"`
+	MaxPlayers  int32       `json:"max_players"`
+	DurationMin int32       `json:"duration_min"`
+	Price       int32       `json:"price"`
+	CoinPrice   int32       `json:"coin_price"`
+}
+
+func (q *Queries) ListPublishedThemes(ctx context.Context, arg ListPublishedThemesParams) ([]ListPublishedThemesRow, error) {
 	rows, err := q.db.Query(ctx, listPublishedThemes, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Theme{}
+	items := []ListPublishedThemesRow{}
 	for rows.Next() {
-		var i Theme
+		var i ListPublishedThemesRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.CreatorID,
@@ -441,17 +649,7 @@ func (q *Queries) ListPublishedThemes(ctx context.Context, arg ListPublishedThem
 			&i.MaxPlayers,
 			&i.DurationMin,
 			&i.Price,
-			&i.Status,
-			&i.ConfigJson,
-			&i.Version,
-			&i.PublishedAt,
-			&i.CreatedAt,
-			&i.UpdatedAt,
 			&i.CoinPrice,
-			&i.ReviewNote,
-			&i.ReviewedAt,
-			&i.ReviewedBy,
-			&i.CoverImageMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -760,18 +958,21 @@ func (q *Queries) UpdateThemeCoverImage(ctx context.Context, arg UpdateThemeCove
 }
 
 const updateThemeStatus = `-- name: UpdateThemeStatus :one
-UPDATE themes SET status = $2::varchar, published_at = CASE WHEN $2::varchar = 'PUBLISHED' THEN NOW() ELSE published_at END, updated_at = NOW()
-WHERE id = $1
+UPDATE themes
+SET status = $1::varchar,
+    published_at = CASE WHEN $1::varchar = 'PUBLISHED' THEN NOW() ELSE published_at END,
+    updated_at = NOW()
+WHERE id = $2
 RETURNING id, creator_id, title, slug, description, cover_image, min_players, max_players, duration_min, price, status, config_json, version, published_at, created_at, updated_at, coin_price, review_note, reviewed_at, reviewed_by, cover_image_media_id
 `
 
 type UpdateThemeStatusParams struct {
-	ID     uuid.UUID `json:"id"`
 	Status string    `json:"status"`
+	ID     uuid.UUID `json:"id"`
 }
 
 func (q *Queries) UpdateThemeStatus(ctx context.Context, arg UpdateThemeStatusParams) (Theme, error) {
-	row := q.db.QueryRow(ctx, updateThemeStatus, arg.ID, arg.Status)
+	row := q.db.QueryRow(ctx, updateThemeStatus, arg.Status, arg.ID)
 	var i Theme
 	err := row.Scan(
 		&i.ID,

--- a/apps/server/internal/domain/theme/mocks/mock_service.go
+++ b/apps/server/internal/domain/theme/mocks/mock_service.go
@@ -142,56 +142,56 @@ func (mr *MockthemeQueriesMockRecorder) GetMedia(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMedia", reflect.TypeOf((*MockthemeQueries)(nil).GetMedia), ctx, id)
 }
 
-// GetTheme mocks base method.
-func (m *MockthemeQueries) GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error) {
+// GetPublishedTheme mocks base method.
+func (m *MockthemeQueries) GetPublishedTheme(ctx context.Context, id uuid.UUID) (db.GetPublishedThemeRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTheme", ctx, id)
-	ret0, _ := ret[0].(db.Theme)
+	ret := m.ctrl.Call(m, "GetPublishedTheme", ctx, id)
+	ret0, _ := ret[0].(db.GetPublishedThemeRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTheme indicates an expected call of GetTheme.
-func (mr *MockthemeQueriesMockRecorder) GetTheme(ctx, id any) *gomock.Call {
+// GetPublishedTheme indicates an expected call of GetPublishedTheme.
+func (mr *MockthemeQueriesMockRecorder) GetPublishedTheme(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTheme", reflect.TypeOf((*MockthemeQueries)(nil).GetTheme), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishedTheme", reflect.TypeOf((*MockthemeQueries)(nil).GetPublishedTheme), ctx, id)
 }
 
-// GetThemeBySlug mocks base method.
-func (m *MockthemeQueries) GetThemeBySlug(ctx context.Context, slug string) (db.Theme, error) {
+// GetPublishedThemeBySlug mocks base method.
+func (m *MockthemeQueries) GetPublishedThemeBySlug(ctx context.Context, slug string) (db.GetPublishedThemeBySlugRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThemeBySlug", ctx, slug)
-	ret0, _ := ret[0].(db.Theme)
+	ret := m.ctrl.Call(m, "GetPublishedThemeBySlug", ctx, slug)
+	ret0, _ := ret[0].(db.GetPublishedThemeBySlugRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetThemeBySlug indicates an expected call of GetThemeBySlug.
-func (mr *MockthemeQueriesMockRecorder) GetThemeBySlug(ctx, slug any) *gomock.Call {
+// GetPublishedThemeBySlug indicates an expected call of GetPublishedThemeBySlug.
+func (mr *MockthemeQueriesMockRecorder) GetPublishedThemeBySlug(ctx, slug any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThemeBySlug", reflect.TypeOf((*MockthemeQueries)(nil).GetThemeBySlug), ctx, slug)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishedThemeBySlug", reflect.TypeOf((*MockthemeQueries)(nil).GetPublishedThemeBySlug), ctx, slug)
 }
 
-// GetThemeCharacters mocks base method.
-func (m *MockthemeQueries) GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.ThemeCharacter, error) {
+// GetPublishedThemeCharacters mocks base method.
+func (m *MockthemeQueries) GetPublishedThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.GetPublishedThemeCharactersRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThemeCharacters", ctx, themeID)
-	ret0, _ := ret[0].([]db.ThemeCharacter)
+	ret := m.ctrl.Call(m, "GetPublishedThemeCharacters", ctx, themeID)
+	ret0, _ := ret[0].([]db.GetPublishedThemeCharactersRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetThemeCharacters indicates an expected call of GetThemeCharacters.
-func (mr *MockthemeQueriesMockRecorder) GetThemeCharacters(ctx, themeID any) *gomock.Call {
+// GetPublishedThemeCharacters indicates an expected call of GetPublishedThemeCharacters.
+func (mr *MockthemeQueriesMockRecorder) GetPublishedThemeCharacters(ctx, themeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThemeCharacters", reflect.TypeOf((*MockthemeQueries)(nil).GetThemeCharacters), ctx, themeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishedThemeCharacters", reflect.TypeOf((*MockthemeQueries)(nil).GetPublishedThemeCharacters), ctx, themeID)
 }
 
 // ListPublishedThemes mocks base method.
-func (m *MockthemeQueries) ListPublishedThemes(ctx context.Context, arg db.ListPublishedThemesParams) ([]db.Theme, error) {
+func (m *MockthemeQueries) ListPublishedThemes(ctx context.Context, arg db.ListPublishedThemesParams) ([]db.ListPublishedThemesRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPublishedThemes", ctx, arg)
-	ret0, _ := ret[0].([]db.Theme)
+	ret0, _ := ret[0].([]db.ListPublishedThemesRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apps/server/internal/domain/theme/service.go
+++ b/apps/server/internal/domain/theme/service.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/mmp-platform/server/internal/apperror"
 	"github.com/mmp-platform/server/internal/db"
-	"github.com/mmp-platform/server/internal/engine"
 	"github.com/mmp-platform/server/internal/infra/storage"
 )
 
@@ -69,10 +68,10 @@ type Service interface {
 }
 
 type themeQueries interface {
-	GetTheme(ctx context.Context, id uuid.UUID) (db.Theme, error)
-	GetThemeBySlug(ctx context.Context, slug string) (db.Theme, error)
-	ListPublishedThemes(ctx context.Context, arg db.ListPublishedThemesParams) ([]db.Theme, error)
-	GetThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.ThemeCharacter, error)
+	GetPublishedTheme(ctx context.Context, id uuid.UUID) (db.GetPublishedThemeRow, error)
+	GetPublishedThemeBySlug(ctx context.Context, slug string) (db.GetPublishedThemeBySlugRow, error)
+	ListPublishedThemes(ctx context.Context, arg db.ListPublishedThemesParams) ([]db.ListPublishedThemesRow, error)
+	GetPublishedThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.GetPublishedThemeCharactersRow, error)
 	GetMedia(ctx context.Context, id uuid.UUID) (db.ThemeMedium, error)
 }
 
@@ -97,7 +96,7 @@ func NewServiceWithStorage(queries *db.Queries, storageProvider storage.Provider
 }
 
 func (s *service) GetTheme(ctx context.Context, themeID uuid.UUID) (*ThemeResponse, error) {
-	theme, err := s.queries.GetTheme(ctx, themeID)
+	theme, err := s.queries.GetPublishedTheme(ctx, themeID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, apperror.NotFound("theme not found")
@@ -105,11 +104,11 @@ func (s *service) GetTheme(ctx context.Context, themeID uuid.UUID) (*ThemeRespon
 		s.logger.Error().Err(err).Stringer("theme_id", themeID).Msg("failed to get theme")
 		return nil, apperror.Internal("failed to get theme")
 	}
-	return toPublicThemeResponse(theme)
+	return toThemeResponseFromPublishedTheme(theme), nil
 }
 
 func (s *service) GetThemeBySlug(ctx context.Context, slug string) (*ThemeResponse, error) {
-	theme, err := s.queries.GetThemeBySlug(ctx, slug)
+	theme, err := s.queries.GetPublishedThemeBySlug(ctx, slug)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, apperror.NotFound("theme not found")
@@ -117,7 +116,7 @@ func (s *service) GetThemeBySlug(ctx context.Context, slug string) (*ThemeRespon
 		s.logger.Error().Err(err).Str("slug", slug).Msg("failed to get theme by slug")
 		return nil, apperror.Internal("failed to get theme")
 	}
-	return toPublicThemeResponse(theme)
+	return toThemeResponseFromPublishedThemeBySlug(theme), nil
 }
 
 func (s *service) ListPublished(ctx context.Context, limit, offset int32) ([]ThemeSummary, error) {
@@ -132,25 +131,21 @@ func (s *service) ListPublished(ctx context.Context, limit, offset int32) ([]The
 
 	result := make([]ThemeSummary, len(themes))
 	for i, t := range themes {
-		result[i] = toThemeSummary(t)
+		result[i] = toThemeSummaryFromListRow(t)
 	}
 	return result, nil
 }
 
 func (s *service) GetCharacters(ctx context.Context, themeID uuid.UUID) ([]CharacterResponse, error) {
-	theme, err := s.queries.GetTheme(ctx, themeID)
-	if err != nil {
+	if _, err := s.queries.GetPublishedTheme(ctx, themeID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, apperror.NotFound("theme not found")
 		}
 		s.logger.Error().Err(err).Stringer("theme_id", themeID).Msg("failed to get theme")
 		return nil, apperror.Internal("failed to get characters")
 	}
-	if theme.Status != publishedStatus {
-		return nil, apperror.NotFound("theme not found")
-	}
 
-	chars, err := s.queries.GetThemeCharacters(ctx, themeID)
+	chars, err := s.queries.GetPublishedThemeCharacters(ctx, themeID)
 	if err != nil {
 		s.logger.Error().Err(err).Stringer("theme_id", themeID).Msg("failed to get theme characters")
 		return nil, apperror.Internal("failed to get characters")
@@ -158,22 +153,13 @@ func (s *service) GetCharacters(ctx context.Context, themeID uuid.UUID) ([]Chara
 
 	result := make([]CharacterResponse, 0, len(chars))
 	for _, c := range chars {
-		if !c.IsPlayable {
-			continue
-		}
-		display := engine.ResolveCharacterDisplay(engine.CharacterDisplayBase{
-			Name:         c.Name,
-			ImageURL:     textToPtr(c.ImageUrl),
-			ImageMediaID: pgUUIDToStringPtr(c.ImageMediaID),
-			AliasRules:   engine.ParseCharacterAliasRules(c.AliasRules),
-		}, json.RawMessage(`{}`))
-		display.ImageURL = s.resolveCharacterImageURL(ctx, c.ThemeID, display.ImageURL, c.ImageMediaID)
+		imageURL := s.resolveCharacterImageURL(ctx, c.ThemeID, textToPtr(c.ImageUrl), c.ImageMediaID)
 		result = append(result, CharacterResponse{
 			ID:           c.ID,
-			Name:         display.Name,
+			Name:         c.Name,
 			Description:  textToPtr(c.Description),
-			ImageURL:     display.ImageURL,
-			ImageMediaID: display.ImageMediaID,
+			ImageURL:     imageURL,
+			ImageMediaID: pgUUIDToStringPtr(c.ImageMediaID),
 			SortOrder:    c.SortOrder,
 		})
 	}
@@ -228,7 +214,7 @@ func pgUUIDToStringPtr(value pgtype.UUID) *string {
 	return &id
 }
 
-func toThemeSummary(t db.Theme) ThemeSummary {
+func toThemeSummaryFromListRow(t db.ListPublishedThemesRow) ThemeSummary {
 	return ThemeSummary{
 		ID:          t.ID,
 		Title:       t.Title,
@@ -244,24 +230,48 @@ func toThemeSummary(t db.Theme) ThemeSummary {
 	}
 }
 
-func toThemeResponse(t db.Theme) *ThemeResponse {
+func toThemeResponseFromPublishedTheme(t db.GetPublishedThemeRow) *ThemeResponse {
 	return &ThemeResponse{
-		ThemeSummary: toThemeSummary(t),
-		Status:       t.Status,
-		ConfigJson:   t.ConfigJson,
-		Version:      t.Version,
-		PublishedAt:  timestampToPtr(t.PublishedAt),
-		CreatedAt:    t.CreatedAt,
+		ThemeSummary: ThemeSummary{
+			ID:          t.ID,
+			Title:       t.Title,
+			Slug:        t.Slug,
+			Description: textToPtr(t.Description),
+			CoverImage:  textToPtr(t.CoverImage),
+			MinPlayers:  t.MinPlayers,
+			MaxPlayers:  t.MaxPlayers,
+			DurationMin: t.DurationMin,
+			Price:       t.Price,
+			CoinPrice:   t.CoinPrice,
+			CreatorID:   t.CreatorID,
+		},
+		Status:      t.Status,
+		Version:     t.Version,
+		PublishedAt: timestampToPtr(t.PublishedAt),
+		CreatedAt:   t.CreatedAt,
 	}
 }
 
-func toPublicThemeResponse(t db.Theme) (*ThemeResponse, error) {
-	if t.Status != publishedStatus {
-		return nil, apperror.NotFound("theme not found")
+func toThemeResponseFromPublishedThemeBySlug(t db.GetPublishedThemeBySlugRow) *ThemeResponse {
+	return &ThemeResponse{
+		ThemeSummary: ThemeSummary{
+			ID:          t.ID,
+			Title:       t.Title,
+			Slug:        t.Slug,
+			Description: textToPtr(t.Description),
+			CoverImage:  textToPtr(t.CoverImage),
+			MinPlayers:  t.MinPlayers,
+			MaxPlayers:  t.MaxPlayers,
+			DurationMin: t.DurationMin,
+			Price:       t.Price,
+			CoinPrice:   t.CoinPrice,
+			CreatorID:   t.CreatorID,
+		},
+		Status:      t.Status,
+		Version:     t.Version,
+		PublishedAt: timestampToPtr(t.PublishedAt),
+		CreatedAt:   t.CreatedAt,
 	}
-	resp := toThemeResponse(t)
-	resp.ConfigJson = nil
-	return resp, nil
 }
 
 func textToPtr(t pgtype.Text) *string {

--- a/apps/server/internal/domain/theme/service_public_character_test.go
+++ b/apps/server/internal/domain/theme/service_public_character_test.go
@@ -16,24 +16,52 @@ import (
 )
 
 type fakePublicThemeQueries struct {
-	theme      db.Theme
-	characters []db.ThemeCharacter
+	theme      db.GetPublishedThemeRow
+	characters []db.GetPublishedThemeCharactersRow
 	media      map[uuid.UUID]db.ThemeMedium
 }
 
-func (f *fakePublicThemeQueries) GetTheme(context.Context, uuid.UUID) (db.Theme, error) {
+func (f *fakePublicThemeQueries) GetPublishedTheme(context.Context, uuid.UUID) (db.GetPublishedThemeRow, error) {
 	return f.theme, nil
 }
 
-func (f *fakePublicThemeQueries) GetThemeBySlug(context.Context, string) (db.Theme, error) {
-	return f.theme, nil
+func (f *fakePublicThemeQueries) GetPublishedThemeBySlug(context.Context, string) (db.GetPublishedThemeBySlugRow, error) {
+	return db.GetPublishedThemeBySlugRow{
+		ID:          f.theme.ID,
+		CreatorID:   f.theme.CreatorID,
+		Title:       f.theme.Title,
+		Slug:        f.theme.Slug,
+		Description: f.theme.Description,
+		CoverImage:  f.theme.CoverImage,
+		MinPlayers:  f.theme.MinPlayers,
+		MaxPlayers:  f.theme.MaxPlayers,
+		DurationMin: f.theme.DurationMin,
+		Price:       f.theme.Price,
+		Status:      f.theme.Status,
+		Version:     f.theme.Version,
+		PublishedAt: f.theme.PublishedAt,
+		CreatedAt:   f.theme.CreatedAt,
+		CoinPrice:   f.theme.CoinPrice,
+	}, nil
 }
 
-func (f *fakePublicThemeQueries) ListPublishedThemes(context.Context, db.ListPublishedThemesParams) ([]db.Theme, error) {
-	return []db.Theme{f.theme}, nil
+func (f *fakePublicThemeQueries) ListPublishedThemes(context.Context, db.ListPublishedThemesParams) ([]db.ListPublishedThemesRow, error) {
+	return []db.ListPublishedThemesRow{{
+		ID:          f.theme.ID,
+		CreatorID:   f.theme.CreatorID,
+		Title:       f.theme.Title,
+		Slug:        f.theme.Slug,
+		Description: f.theme.Description,
+		CoverImage:  f.theme.CoverImage,
+		MinPlayers:  f.theme.MinPlayers,
+		MaxPlayers:  f.theme.MaxPlayers,
+		DurationMin: f.theme.DurationMin,
+		Price:       f.theme.Price,
+		CoinPrice:   f.theme.CoinPrice,
+	}}, nil
 }
 
-func (f *fakePublicThemeQueries) GetThemeCharacters(context.Context, uuid.UUID) ([]db.ThemeCharacter, error) {
+func (f *fakePublicThemeQueries) GetPublishedThemeCharacters(context.Context, uuid.UUID) ([]db.GetPublishedThemeCharactersRow, error) {
 	return f.characters, nil
 }
 
@@ -88,31 +116,22 @@ func (*fakePublicThemeStorage) DeleteObjects(context.Context, []string) error {
 	return nil
 }
 
-func TestGetCharactersFiltersNonPlayableAndResolvesImageMediaURL(t *testing.T) {
+func TestGetCharactersResolvesImageMediaURL(t *testing.T) {
 	themeID := uuid.New()
 	playableID := uuid.New()
-	npcID := uuid.New()
 	mediaID := uuid.New()
 	storageKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + ".png"
 	downloadURL := "https://cdn.example.test/" + storageKey
 
 	q := &fakePublicThemeQueries{
-		theme: db.Theme{ID: themeID, Status: publishedStatus},
-		characters: []db.ThemeCharacter{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{
 			{
 				ID:           playableID,
 				ThemeID:      themeID,
 				Name:         "Playable",
-				IsPlayable:   true,
 				SortOrder:    1,
 				ImageMediaID: pgUUID(mediaID),
-			},
-			{
-				ID:         npcID,
-				ThemeID:    themeID,
-				Name:       "NPC",
-				IsPlayable: false,
-				SortOrder:  2,
 			},
 		},
 		media: map[uuid.UUID]db.ThemeMedium{
@@ -161,12 +180,11 @@ func TestGetCharactersPreservesExistingImageURL(t *testing.T) {
 	mediaID := uuid.New()
 	existingURL := "https://static.example.test/character.png"
 	q := &fakePublicThemeQueries{
-		theme: db.Theme{ID: themeID, Status: publishedStatus},
-		characters: []db.ThemeCharacter{{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{{
 			ID:           uuid.New(),
 			ThemeID:      themeID,
 			Name:         "Playable",
-			IsPlayable:   true,
 			ImageUrl:     pgtype.Text{String: existingURL, Valid: true},
 			ImageMediaID: pgUUID(mediaID),
 		}},
@@ -212,12 +230,11 @@ func TestGetCharactersKeepsCharacterWhenImageMediaMissing(t *testing.T) {
 	themeID := uuid.New()
 	mediaID := uuid.New()
 	q := &fakePublicThemeQueries{
-		theme: db.Theme{ID: themeID, Status: publishedStatus},
-		characters: []db.ThemeCharacter{{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{{
 			ID:           uuid.New(),
 			ThemeID:      themeID,
 			Name:         "Playable",
-			IsPlayable:   true,
 			ImageMediaID: pgUUID(mediaID),
 		}},
 		media: map[uuid.UUID]db.ThemeMedium{},
@@ -245,12 +262,11 @@ func TestGetCharactersFallsBackWhenImageObjectMissing(t *testing.T) {
 	mediaID := uuid.New()
 	storageKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + ".png"
 	q := &fakePublicThemeQueries{
-		theme: db.Theme{ID: themeID, Status: publishedStatus},
-		characters: []db.ThemeCharacter{{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{{
 			ID:           uuid.New(),
 			ThemeID:      themeID,
 			Name:         "Playable",
-			IsPlayable:   true,
 			ImageMediaID: pgUUID(mediaID),
 		}},
 		media: map[uuid.UUID]db.ThemeMedium{
@@ -296,12 +312,11 @@ func TestGetCharactersFallsBackWhenImageMediaBelongsToAnotherTheme(t *testing.T)
 	mediaID := uuid.New()
 	storageKey := "themes/" + otherThemeID.String() + "/media/" + mediaID.String() + ".png"
 	q := &fakePublicThemeQueries{
-		theme: db.Theme{ID: themeID, Status: publishedStatus},
-		characters: []db.ThemeCharacter{{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{{
 			ID:           uuid.New(),
 			ThemeID:      themeID,
 			Name:         "Playable",
-			IsPlayable:   true,
 			ImageMediaID: pgUUID(mediaID),
 		}},
 		media: map[uuid.UUID]db.ThemeMedium{

--- a/apps/server/internal/domain/theme/service_test.go
+++ b/apps/server/internal/domain/theme/service_test.go
@@ -117,7 +117,38 @@ func TestGetThemeBySlug_ReturnsPublishedThemeWithoutConfigJson(t *testing.T) {
 	}
 }
 
-func TestGetCharacters_UsesBackendDisplayResolverWithoutLeakingAliasRules(t *testing.T) {
+func TestListPublished_ReturnsPublishedThemesWithoutConfigJson(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID, _ := f.createThemeForUserWithStatus(t, creatorID, "PUBLISHED", json.RawMessage(`{"private":"published-runtime-config"}`))
+	f.createThemeForUserWithStatus(t, creatorID, "DRAFT", json.RawMessage(`{"private":"draft-runtime-config"}`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	got, err := svc.ListPublished(ctx, 20, 0)
+	if err != nil {
+		t.Fatalf("ListPublished: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("published themes len = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].ID != themeID {
+		t.Fatalf("theme id = %s, want %s", got[0].ID, themeID)
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal themes: %v", err)
+	}
+	if jsonContainsKey(t, raw, "config_json") {
+		t.Fatalf("public theme list leaked config_json: %s", string(raw))
+	}
+}
+
+func TestGetCharacters_KeepsBaseDisplayWithoutAliasContextAndDoesNotLeakPrivateFields(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -151,6 +182,30 @@ func TestGetCharacters_UsesBackendDisplayResolverWithoutLeakingAliasRules(t *tes
 	}
 	if jsonContainsKey(t, raw, "alias_rules") || jsonContainsKey(t, raw, "mystery_role") || jsonContainsKey(t, raw, "is_culprit") {
 		t.Fatalf("public characters leaked private fields: %s", string(raw))
+	}
+}
+
+func TestGetCharacters_FiltersNonPlayableCharacters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	f := setupThemeFixture(t)
+	ctx := context.Background()
+	creatorID := f.createUser(t)
+	themeID, _ := f.createThemeForUserWithStatus(t, creatorID, "PUBLISHED", json.RawMessage(`{}`))
+	playableID := f.createCharacter(t, themeID, "플레이어 캐릭터", json.RawMessage(`[]`))
+	f.createCharacterWithPlayable(t, themeID, "NPC 캐릭터", false, json.RawMessage(`[]`))
+
+	svc := NewService(f.q, zerolog.Nop())
+	got, err := svc.GetCharacters(ctx, themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("characters len = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].ID != playableID {
+		t.Fatalf("character id = %s, want %s", got[0].ID, playableID)
 	}
 }
 
@@ -209,10 +264,15 @@ func assertNotFound(t *testing.T, err error) {
 
 func (f *themeFixture) createCharacter(t *testing.T, themeID uuid.UUID, name string, aliasRules json.RawMessage) uuid.UUID {
 	t.Helper()
+	return f.createCharacterWithPlayable(t, themeID, name, true, aliasRules)
+}
+
+func (f *themeFixture) createCharacterWithPlayable(t *testing.T, themeID uuid.UUID, name string, isPlayable bool, aliasRules json.RawMessage) uuid.UUID {
+	t.Helper()
 	row, err := f.pool.Exec(context.Background(), `
-		INSERT INTO theme_characters (theme_id, name, alias_rules)
-		VALUES ($1, $2, $3)
-	`, themeID, name, aliasRules)
+		INSERT INTO theme_characters (theme_id, name, is_playable, alias_rules)
+		VALUES ($1, $2, $3, $4)
+	`, themeID, name, isPlayable, aliasRules)
 	if err != nil {
 		t.Fatalf("create character: %v", err)
 	}


### PR DESCRIPTION
## 요약
- 공개 테마 detail/slug/list 조회를 `SELECT *` 이후 서비스 redaction에서 SQL 단계의 public-safe projection으로 변경했습니다.
- 공개 캐릭터 조회를 PUBLISHED 테마 + playable 캐릭터만 반환하는 SQL projection으로 분리하고 spoiler/private 필드를 원천 선택하지 않게 했습니다.
- sqlc generated query, theme service, mock, focused tests를 함께 갱신했습니다.

Closes #690

## Coverage Plan
- `apps/server/db/queries/themes.sql`: public detail/slug/list/characters projection이 `config_json`, review metadata, spoiler/private character fields를 선택하지 않는지 확인.
- `apps/server/internal/domain/theme/service.go`: public endpoints가 full theme/character row 대신 public row type만 사용하는지 확인.
- `apps/server/internal/domain/theme/service_test.go`: draft/private not found, published response의 `config_json` 미노출, non-playable character 제외, character private field 미노출을 검증.
- `apps/server/internal/domain/theme/service_public_character_test.go`: image media URL resolution과 public character service error path를 갱신된 query contract 기준으로 검증.

## Local validation
- `git diff --check` 통과
- `cd apps/server && go test -count=1 ./internal/db ./internal/domain/theme ./cmd/server` 통과
- `scripts/mmp-local-ci.sh quick` 통과

## Review notes
- Security reviewer: blocker 없음. Public theme/character SQL projection에서 private/spoiler 필드 미선택 확인.
- Backend reviewer: alias display resolver 제거 가능성을 지적했으나, 기존 공개 characters 경로도 빈 context로 resolver를 호출해 base display를 반환했습니다. 이번 PR은 `alias_rules`를 public SQL projection에서 제외하고 테스트 이름으로 해당 호환 조건을 명확히 했습니다.
- `sqlc diff`는 editor/location generated drift를 별도로 보고하지만 이번 PR 범위 파일에는 포함하지 않았습니다.
