### PR TITLE
fix: 대기방 캐릭터 이미지 media_id 해석 복구

### DIFF
--- a/apps/server/internal/domain/theme/service.go
+++ b/apps/server/internal/domain/theme/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,6 +22,11 @@ const (
 	mediaTypeImage = "IMAGE"
 	sourceTypeFile = "FILE"
 	mediaURLTTL    = 15 * time.Minute
+)
+const (
+	imageVariantMaster    = "master"
+	imageVariantPreview   = "preview"
+	imageVariantThumbnail = "thumbnail"
 )
 
 // ThemeSummary is the compact representation used in list endpoints.
@@ -187,23 +193,61 @@ func (s *service) resolveCharacterImageURL(ctx context.Context, themeID uuid.UUI
 	if media.Type != mediaTypeImage || media.SourceType != sourceTypeFile || !media.StorageKey.Valid {
 		return currentURL
 	}
-	if _, err := s.storage.HeadObject(ctx, media.StorageKey.String); err != nil {
-		if errors.Is(err, storage.ErrObjectNotFound) {
-			s.logger.Warn().Stringer("media_id", id).Str("storage_key", media.StorageKey.String).Msg("character image media object not found")
+
+	for _, key := range characterImageCandidateKeys(media.ThemeID, media.ID, media.StorageKey.String) {
+		if _, err := s.storage.HeadObject(ctx, key); err != nil {
+			if errors.Is(err, storage.ErrObjectNotFound) {
+				continue
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				s.logger.Warn().Err(err).Stringer("media_id", id).Str("storage_key", key).Msg("character image media verification cancelled")
+				return currentURL
+			}
+			s.logger.Warn().Err(err).Stringer("media_id", id).Str("storage_key", key).Msg("failed to verify character image media")
+			continue
+		}
+		url, err := s.storage.GenerateDownloadURL(ctx, key, mediaURLTTL)
+		if err != nil {
+			s.logger.Warn().Err(err).Stringer("media_id", id).Str("storage_key", key).Msg("failed to generate character image URL")
 			return currentURL
 		}
-		s.logger.Warn().Err(err).Stringer("media_id", id).Str("storage_key", media.StorageKey.String).Msg("failed to verify character image media")
-		return currentURL
+		if url == "" {
+			return currentURL
+		}
+		return &url
 	}
-	url, err := s.storage.GenerateDownloadURL(ctx, media.StorageKey.String, mediaURLTTL)
-	if err != nil {
-		s.logger.Warn().Err(err).Stringer("media_id", id).Str("storage_key", media.StorageKey.String).Msg("failed to generate character image URL")
-		return currentURL
+
+	s.logger.Warn().Stringer("media_id", id).Str("storage_key", media.StorageKey.String).Msg("character image media object not found")
+	return currentURL
+}
+
+func characterImageCandidateKeys(themeID, mediaID uuid.UUID, storageKey string) []string {
+	return dedupeStrings([]string{
+		characterImageVariantKey(themeID, mediaID, imageVariantPreview),
+		characterImageVariantKey(themeID, mediaID, imageVariantMaster),
+		characterImageVariantKey(themeID, mediaID, imageVariantThumbnail),
+		storageKey,
+	})
+}
+
+func characterImageVariantKey(themeID, mediaID uuid.UUID, variant string) string {
+	return fmt.Sprintf("themes/%s/media/%s/%s.webp", themeID.String(), mediaID.String(), variant)
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
 	}
-	if url == "" {
-		return currentURL
-	}
-	return &url
+	return out
 }
 
 func pgUUIDToStringPtr(value pgtype.UUID) *string {

--- a/apps/server/internal/domain/theme/service_public_character_test.go
+++ b/apps/server/internal/domain/theme/service_public_character_test.go
@@ -3,6 +3,7 @@ package theme
 import (
 	"context"
 	"io"
+	"reflect"
 	"testing"
 	"time"
 
@@ -76,6 +77,8 @@ type fakePublicThemeStorage struct {
 	urls       map[string]string
 	existing   map[string]bool
 	headErrors map[string]error
+	headKeys   []string
+	urlKeys    []string
 	headCalls  int
 	urlCalls   int
 }
@@ -86,6 +89,7 @@ func (f fakePublicThemeStorage) GenerateUploadURL(context.Context, string, strin
 
 func (f *fakePublicThemeStorage) GenerateDownloadURL(_ context.Context, key string, _ time.Duration) (string, error) {
 	f.urlCalls++
+	f.urlKeys = append(f.urlKeys, key)
 	return f.urls[key], nil
 }
 
@@ -95,6 +99,7 @@ func (*fakePublicThemeStorage) PutObject(context.Context, string, io.Reader, str
 
 func (f *fakePublicThemeStorage) HeadObject(_ context.Context, key string) (*storage.ObjectMeta, error) {
 	f.headCalls++
+	f.headKeys = append(f.headKeys, key)
 	if err := f.headErrors[key]; err != nil {
 		return nil, err
 	}
@@ -114,6 +119,59 @@ func (*fakePublicThemeStorage) DeleteObject(context.Context, string) error {
 
 func (*fakePublicThemeStorage) DeleteObjects(context.Context, []string) error {
 	return nil
+}
+
+func TestGetCharactersResolvesImageMediaPreviewVariantURL(t *testing.T) {
+	themeID := uuid.New()
+	mediaID := uuid.New()
+	storageKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + ".png"
+	previewKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + "/preview.webp"
+	downloadURL := "https://cdn.example.test/" + previewKey
+
+	q := &fakePublicThemeQueries{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{{
+			ID:           uuid.New(),
+			ThemeID:      themeID,
+			Name:         "Playable",
+			ImageMediaID: pgUUID(mediaID),
+		}},
+		media: map[uuid.UUID]db.ThemeMedium{
+			mediaID: {
+				ID:         mediaID,
+				ThemeID:    themeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: storageKey, Valid: true},
+			},
+		},
+	}
+	fakeStorage := &fakePublicThemeStorage{
+		urls:     map[string]string{previewKey: downloadURL},
+		existing: map[string]bool{previewKey: true},
+	}
+	svc := &service{
+		queries: q,
+		storage: fakeStorage,
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 1 {
+		t.Fatalf("len(chars) = %d, want 1", len(chars))
+	}
+	if chars[0].ImageURL == nil || *chars[0].ImageURL != downloadURL {
+		t.Fatalf("image_url = %v, want preview variant %q", chars[0].ImageURL, downloadURL)
+	}
+	if fakeStorage.urlCalls != 1 || fakeStorage.urlKeys[0] != previewKey {
+		t.Fatalf("GenerateDownloadURL calls=%d keys=%v, want once for preview", fakeStorage.urlCalls, fakeStorage.urlKeys)
+	}
+	if !reflect.DeepEqual(fakeStorage.headKeys, []string{previewKey}) {
+		t.Fatalf("HeadObject keys = %v, want preview only", fakeStorage.headKeys)
+	}
 }
 
 func TestGetCharactersResolvesImageMediaURL(t *testing.T) {
@@ -167,11 +225,20 @@ func TestGetCharactersResolvesImageMediaURL(t *testing.T) {
 	if chars[0].ImageURL == nil || *chars[0].ImageURL != downloadURL {
 		t.Fatalf("image_url = %v, want %q", chars[0].ImageURL, downloadURL)
 	}
-	if fakeStorage.headCalls != 1 {
-		t.Fatalf("HeadObject calls = %d, want 1", fakeStorage.headCalls)
+	if fakeStorage.headCalls != 4 {
+		t.Fatalf("HeadObject calls = %d, want 4", fakeStorage.headCalls)
 	}
 	if fakeStorage.urlCalls != 1 {
 		t.Fatalf("GenerateDownloadURL calls = %d, want 1", fakeStorage.urlCalls)
+	}
+	expectedHeadKeys := []string{
+		"themes/" + themeID.String() + "/media/" + mediaID.String() + "/preview.webp",
+		"themes/" + themeID.String() + "/media/" + mediaID.String() + "/master.webp",
+		"themes/" + themeID.String() + "/media/" + mediaID.String() + "/thumbnail.webp",
+		storageKey,
+	}
+	if !reflect.DeepEqual(fakeStorage.headKeys, expectedHeadKeys) {
+		t.Fatalf("HeadObject keys = %v, want %v", fakeStorage.headKeys, expectedHeadKeys)
 	}
 }
 
@@ -298,8 +365,58 @@ func TestGetCharactersFallsBackWhenImageObjectMissing(t *testing.T) {
 	if chars[0].ImageURL != nil {
 		t.Fatalf("image_url = %v, want nil fallback for missing object", *chars[0].ImageURL)
 	}
-	if fakeStorage.headCalls != 1 {
-		t.Fatalf("HeadObject calls = %d, want 1", fakeStorage.headCalls)
+	if fakeStorage.headCalls != 4 {
+		t.Fatalf("HeadObject calls = %d, want 4", fakeStorage.headCalls)
+	}
+	if fakeStorage.urlCalls != 0 {
+		t.Fatalf("GenerateDownloadURL calls = %d, want 0", fakeStorage.urlCalls)
+	}
+}
+
+func TestGetCharactersStopsResolvingImageMediaOnRequestCancellation(t *testing.T) {
+	themeID := uuid.New()
+	mediaID := uuid.New()
+	storageKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + ".png"
+	previewKey := "themes/" + themeID.String() + "/media/" + mediaID.String() + "/preview.webp"
+	q := &fakePublicThemeQueries{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{{
+			ID:           uuid.New(),
+			ThemeID:      themeID,
+			Name:         "Playable",
+			ImageMediaID: pgUUID(mediaID),
+		}},
+		media: map[uuid.UUID]db.ThemeMedium{
+			mediaID: {
+				ID:         mediaID,
+				ThemeID:    themeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: storageKey, Valid: true},
+			},
+		},
+	}
+	fakeStorage := &fakePublicThemeStorage{
+		headErrors: map[string]error{previewKey: context.Canceled},
+	}
+	svc := &service{
+		queries: q,
+		storage: fakeStorage,
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 1 {
+		t.Fatalf("len(chars) = %d, want 1", len(chars))
+	}
+	if chars[0].ImageURL != nil {
+		t.Fatalf("image_url = %v, want nil fallback for cancelled request", *chars[0].ImageURL)
+	}
+	if !reflect.DeepEqual(fakeStorage.headKeys, []string{previewKey}) {
+		t.Fatalf("HeadObject keys = %v, want cancellation to stop after preview", fakeStorage.headKeys)
 	}
 	if fakeStorage.urlCalls != 0 {
 		t.Fatalf("GenerateDownloadURL calls = %d, want 0", fakeStorage.urlCalls)


### PR DESCRIPTION
## 요약

- public characters API가 `image_media_id` 기반 이미지 media를 editor variant 규칙과 맞춰 해석하도록 보강했습니다.
- `preview -> master -> thumbnail -> storage_key` 순서로 실제 존재하는 object만 확인하고, `HeadObject` 성공 후에만 `image_url`을 생성합니다.
- 기존 legacy `image_url`, cross-theme guard, non-image/source guard, object missing fallback은 유지했습니다.

Closes #711
Refs #712

## 범위

- Backend only: `apps/server/internal/domain/theme/service.go`
- Test: `apps/server/internal/domain/theme/service_public_character_test.go`
- R2 object copy/rename/delete나 DB `storage_key` 대량 재작성은 하지 않았습니다. 실제 R2/DB 정합성 문제는 #712로 분리했습니다.

## Coverage Plan

- `image_media_id`가 같은 theme의 image file media이고 preview variant가 있으면 `image_url` 반환
- preview/master/thumbnail이 없고 원본 `storage_key`만 있으면 원본 URL 반환
- object missing이면 `image_url=null` 유지
- 기존 `image_url`이 있으면 storage 호출 없이 보존
- 요청 취소/타임아웃은 candidate 순회를 중단
- 프론트 `CharacterSelectionPanel`은 기존 image/null fallback 테스트로 회귀 확인

## Local validation

- `cd apps/server && go test ./internal/domain/theme -run 'TestGetCharacters|PublicCharacter' -count=1` PASS
- `pnpm --filter @mmp/web test -- CharacterSelectionPanel` PASS
- `scripts/mmp-local-ci.sh quick` PASS at HEAD `75aef4d2`
  - 기존 lint/build warning은 있었지만 error 없이 완료됐습니다.

## 후속

- #712: 실제 R2 bucket object와 `theme_media.storage_key` 정합성 감사 및 복구
