### PR TITLE
fix: 미디어 이미지 교체 UX 안정화

### DIFF
--- a/apps/server/cmd/server/routes_editor_media.go
+++ b/apps/server/cmd/server/routes_editor_media.go
@@ -20,6 +20,7 @@ func registerEditorMediaRoutes(r chi.Router, deps authedDeps) {
 	r.Get("/media/{id}/download-url", deps.media.GetDownloadURL)
 	r.Get("/media/{id}/references", deps.media.PreviewDeleteMedia)
 	r.Post("/media/{id}/replace-upload-url", deps.media.RequestReplacementUpload)
+	r.Put("/media/{id}/replace-uploads/{uploadID}", deps.media.UploadReplacementObject)
 	r.Post("/media/{id}/replace-confirm", deps.media.ConfirmReplacementUpload)
 	r.Delete("/media/{id}", deps.media.DeleteMedia)
 

--- a/apps/server/internal/domain/editor/media_handler.go
+++ b/apps/server/internal/domain/editor/media_handler.go
@@ -292,6 +292,28 @@ func (h *MediaHandler) RequestReplacementUpload(w http.ResponseWriter, r *http.R
 	httputil.WriteJSON(w, http.StatusCreated, resp)
 }
 
+// UploadReplacementObject handles PUT /editor/media/{id}/replace-uploads/{uploadID}.
+func (h *MediaHandler) UploadReplacementObject(w http.ResponseWriter, r *http.Request) {
+	creatorID := middleware.UserIDFrom(r.Context())
+	mediaID, err := parseUUID(r, "id")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	uploadID, err := parseUUID(r, "uploadID")
+	if err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, MaxMediaFileSize+1)
+	if err := h.svc.UploadReplacementObject(r.Context(), creatorID, mediaID, uploadID, r.Body); err != nil {
+		apperror.WriteError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // ConfirmReplacementUpload handles POST /editor/media/{id}/replace-confirm.
 func (h *MediaHandler) ConfirmReplacementUpload(w http.ResponseWriter, r *http.Request) {
 	creatorID := middleware.UserIDFrom(r.Context())

--- a/apps/server/internal/domain/editor/media_handler_test.go
+++ b/apps/server/internal/domain/editor/media_handler_test.go
@@ -230,6 +230,10 @@ func TestMediaHandler_DeletePreviewAndReplacementUpload(t *testing.T) {
 		Return(&UploadURLResponse{UploadID: uploadID, UploadURL: "https://upload.example/replacement", ExpiresAt: time.Now()}, nil).
 		Times(1)
 	mock.EXPECT().
+		UploadReplacementObject(gomock.Any(), gomock.Any(), mediaID, uploadID, gomock.Any()).
+		Return(nil).
+		Times(1)
+	mock.EXPECT().
 		ConfirmReplacementUpload(gomock.Any(), gomock.Any(), mediaID, ConfirmUploadRequest{UploadID: uploadID}).
 		Return(&MediaResponse{ID: mediaID, ThemeID: uuid.New(), Name: "replaced", Type: MediaTypeImage, SourceType: SourceTypeFile, Tags: []string{}, CreatedAt: time.Now()}, nil).
 		Times(1)
@@ -250,6 +254,13 @@ func TestMediaHandler_DeletePreviewAndReplacementUpload(t *testing.T) {
 	h.RequestReplacementUpload(replaceW, replace)
 	if replaceW.Code != http.StatusCreated {
 		t.Fatalf("expected replacement request 201, got %d: %s", replaceW.Code, replaceW.Body.String())
+	}
+
+	replaceObject := mediaHandlerRequest(http.MethodPut, "/editor/media/"+mediaID.String()+"/replace-uploads/"+uploadID.String(), []byte("png-body"), map[string]string{"id": mediaID.String(), "uploadID": uploadID.String()})
+	replaceObjectW := httptest.NewRecorder()
+	h.UploadReplacementObject(replaceObjectW, replaceObject)
+	if replaceObjectW.Code != http.StatusNoContent {
+		t.Fatalf("expected replacement object upload 204, got %d: %s", replaceObjectW.Code, replaceObjectW.Body.String())
 	}
 
 	confirm := mediaHandlerRequest(http.MethodPost, "/editor/media/"+mediaID.String()+"/replace-confirm", []byte(`{"upload_id":"`+uploadID.String()+`"}`), map[string]string{"id": mediaID.String()})

--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -39,6 +39,7 @@ type MediaService interface {
 	PreviewDeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID) (*MediaDeletePreviewResponse, error)
 	DeleteMedia(ctx context.Context, creatorID, mediaID uuid.UUID, opts DeleteMediaOptions) error
 	RequestReplacementUpload(ctx context.Context, creatorID, mediaID uuid.UUID, req RequestMediaReplacementUploadRequest) (*UploadURLResponse, error)
+	UploadReplacementObject(ctx context.Context, creatorID, mediaID, uploadID uuid.UUID, body io.Reader) error
 	ConfirmReplacementUpload(ctx context.Context, creatorID, mediaID uuid.UUID, req ConfirmUploadRequest) (*MediaResponse, error)
 	GetEditorMediaDownloadURL(ctx context.Context, creatorID, mediaID uuid.UUID) (*MediaDownloadURLResponse, error)
 	GetMediaPlayURL(ctx context.Context, sessionID, mediaID uuid.UUID) (string, error)

--- a/apps/server/internal/domain/editor/media_service_replace.go
+++ b/apps/server/internal/domain/editor/media_service_replace.go
@@ -69,6 +69,55 @@ func (s *mediaService) RequestReplacementUpload(ctx context.Context, creatorID, 
 	return &UploadURLResponse{UploadID: pending.ID, UploadURL: uploadURL, ExpiresAt: time.Now().Add(expiry)}, nil
 }
 
+func (s *mediaService) UploadReplacementObject(ctx context.Context, creatorID, mediaID, uploadID uuid.UUID, body io.Reader) error {
+	if err := s.requireStorage(); err != nil {
+		return err
+	}
+	pending, err := s.q.GetMediaReplacementUploadWithOwner(ctx, db.GetMediaReplacementUploadWithOwnerParams{
+		ID:        uploadID,
+		CreatorID: creatorID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperror.NotFound("replacement upload not found")
+		}
+		s.logger.Error().Err(err).Str("upload_id", uploadID.String()).Msg("failed to get replacement upload")
+		return apperror.Internal("failed to get replacement upload")
+	}
+	if pending.MediaID != mediaID {
+		return apperror.NotFound("replacement upload not found")
+	}
+	if pending.FileSize <= 0 || pending.FileSize > MaxMediaFileSize {
+		return apperror.New(apperror.ErrMediaTooLarge, 422, "file exceeds maximum size")
+	}
+	payload, err := io.ReadAll(io.LimitReader(body, pending.FileSize+1))
+	if err != nil {
+		return apperror.Internal("failed to read upload body")
+	}
+	if int64(len(payload)) != pending.FileSize {
+		cleanupCtx, cancel := storageCleanupContext(ctx)
+		defer cancel()
+		_ = s.storage.DeleteObject(cleanupCtx, pending.StorageKey)
+		return apperror.New(apperror.ErrMediaTooLarge, 422, "uploaded file size mismatch")
+	}
+	if err := s.storage.PutObject(ctx, pending.StorageKey, bytes.NewReader(payload), pending.MimeType, pending.FileSize); err != nil {
+		s.logger.Error().Err(err).Str("storage_key", pending.StorageKey).Msg("failed to upload replacement object through server")
+		return apperror.Internal("failed to upload replacement object")
+	}
+	meta, err := s.storage.HeadObject(ctx, pending.StorageKey)
+	if err != nil {
+		s.logger.Error().Err(err).Str("storage_key", pending.StorageKey).Msg("failed to verify server-uploaded replacement object")
+		return apperror.Internal("failed to verify upload")
+	}
+	if meta.Size != pending.FileSize {
+		cleanupCtx, cancel := storageCleanupContext(ctx)
+		defer cancel()
+		_ = s.storage.DeleteObject(cleanupCtx, pending.StorageKey)
+		return apperror.New(apperror.ErrMediaTooLarge, 422, "uploaded file size mismatch")
+	}
+	return nil
+}
+
 func (s *mediaService) ConfirmReplacementUpload(ctx context.Context, creatorID, mediaID uuid.UUID, req ConfirmUploadRequest) (*MediaResponse, error) {
 	if err := s.requireStorage(); err != nil {
 		return nil, err

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -2762,6 +2762,53 @@ func TestMediaService_ReplacementUpload_PreservesMediaIDAndDeletesOldObject(t *t
 	}
 }
 
+func TestMediaService_UploadReplacementObject_StoresPendingReplacementBody(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	mediaID := seedFileMedia(q, themeID, MediaTypeImage)
+	body := tinyPNG(t)
+	upload, err := svc.RequestReplacementUpload(context.Background(), creatorID, mediaID, RequestMediaReplacementUploadRequest{
+		MimeType: "image/png",
+		FileSize: int64(len(body)),
+	})
+	if err != nil {
+		t.Fatalf("RequestReplacementUpload: %v", err)
+	}
+	pending := q.replacements[upload.UploadID]
+
+	if err := svc.UploadReplacementObject(context.Background(), creatorID, mediaID, upload.UploadID, bytes.NewReader(body)); err != nil {
+		t.Fatalf("UploadReplacementObject: %v", err)
+	}
+
+	if got := string(st.objects[pending.StorageKey]); got != string(body) {
+		t.Fatalf("replacement object body mismatch")
+	}
+}
+
+func TestMediaService_UploadReplacementObject_SizeMismatchCleansObject(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	mediaID := seedFileMedia(q, themeID, MediaTypeImage)
+	body := tinyPNG(t)
+	upload, err := svc.RequestReplacementUpload(context.Background(), creatorID, mediaID, RequestMediaReplacementUploadRequest{
+		MimeType: "image/png",
+		FileSize: int64(len(body)),
+	})
+	if err != nil {
+		t.Fatalf("RequestReplacementUpload: %v", err)
+	}
+	pending := q.replacements[upload.UploadID]
+
+	err = svc.UploadReplacementObject(context.Background(), creatorID, mediaID, upload.UploadID, strings.NewReader("too-small"))
+
+	assertMediaAppCode(t, err, apperror.ErrMediaTooLarge)
+	if _, ok := st.objects[pending.StorageKey]; ok {
+		t.Fatalf("mismatched replacement object should be cleaned")
+	}
+}
+
 func TestMediaService_Delete_FileMediaBestEffortStorageCleanup(t *testing.T) {
 	svc, q, creatorID, themeID := newMediaTestService(t)
 	st := newFakeStorageProvider()

--- a/apps/server/internal/domain/editor/mock_media_service_test.go
+++ b/apps/server/internal/domain/editor/mock_media_service_test.go
@@ -301,6 +301,20 @@ func (mr *MockMediaServiceMockRecorder) UploadObject(ctx, creatorID, themeID, up
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadObject", reflect.TypeOf((*MockMediaService)(nil).UploadObject), ctx, creatorID, themeID, uploadID, body)
 }
 
+// UploadReplacementObject mocks base method.
+func (m *MockMediaService) UploadReplacementObject(ctx context.Context, creatorID, mediaID, uploadID uuid.UUID, body io.Reader) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadReplacementObject", ctx, creatorID, mediaID, uploadID, body)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadReplacementObject indicates an expected call of UploadReplacementObject.
+func (mr *MockMediaServiceMockRecorder) UploadReplacementObject(ctx, creatorID, mediaID, uploadID, body any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadReplacementObject", reflect.TypeOf((*MockMediaService)(nil).UploadReplacementObject), ctx, creatorID, mediaID, uploadID, body)
+}
+
 // MockmediaQueries is a mock of mediaQueries interface.
 type MockmediaQueries struct {
 	ctrl     *gomock.Controller

--- a/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
+++ b/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
@@ -3,7 +3,7 @@ import { Image, X } from 'lucide-react';
 
 import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
 import { useMediaDownloadUrl, useMediaList, type MediaResponse } from '@/features/editor/mediaApi';
-import { getMediaThumbnailUrl, MediaTypeIcon } from './mediaVisuals';
+import { getMediaThumbnailUrl, hasPublicMediaUrl, MediaTypeIcon } from './mediaVisuals';
 
 interface ImageMediaReferenceFieldProps {
   themeId: string;
@@ -36,8 +36,9 @@ export function ImageMediaReferenceField({
   const [previewFailed, setPreviewFailed] = useState(false);
   const { data: images = [] } = useMediaList(themeId, 'IMAGE');
   const selectedImage = images.find((media) => media.id === imageMediaId) ?? null;
+  const hasPublicImageUrl = selectedImage ? hasPublicMediaUrl(selectedImage) : false;
   const shouldLoadFileImagePreview =
-    selectedImage?.type === 'IMAGE' && selectedImage.source_type === 'FILE' && !selectedImage.url;
+    selectedImage?.type === 'IMAGE' && selectedImage.source_type === 'FILE' && !hasPublicImageUrl;
   const { data: fileImagePreview } = useMediaDownloadUrl(
     shouldLoadFileImagePreview ? selectedImage.id : undefined,
   );
@@ -77,25 +78,27 @@ export function ImageMediaReferenceField({
           type="button"
           disabled={disabled}
           onClick={() => setPickerOpen(true)}
-          className="flex w-full items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-2 text-left text-sm text-amber-100 hover:bg-amber-500/15 disabled:cursor-not-allowed disabled:opacity-70"
+          aria-label={`${label} 교체`}
+          className={`group relative flex w-full items-center justify-center overflow-hidden rounded-md border border-amber-500/30 bg-slate-950/70 text-left text-sm text-amber-100 hover:border-amber-400/60 disabled:cursor-not-allowed disabled:opacity-70 ${
+            compact ? 'h-24' : 'aspect-[16/10] min-h-32'
+          }`}
         >
-          <span className="flex min-w-0 items-center gap-2">
-            <span className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-md border border-amber-500/25 bg-slate-950/70">
-              {shouldRenderPreview ? (
-                <img
-                  src={previewUrl ?? undefined}
-                  alt={`${selectedImage?.name ?? '선택된 이미지'} 미리보기`}
-                  className="h-full w-full object-contain"
-                  loading="lazy"
-                  onError={() => setPreviewFailed(true)}
-                />
-              ) : (
-                <MediaTypeIcon type="IMAGE" size="sm" />
-              )}
+          {shouldRenderPreview ? (
+            <img
+              src={previewUrl ?? undefined}
+              alt={`${selectedImage?.name ?? '선택된 이미지'} 미리보기`}
+              className="h-full w-full object-contain"
+              loading="lazy"
+              onError={() => setPreviewFailed(true)}
+            />
+          ) : (
+            <span className="flex h-full w-full items-center justify-center">
+              <MediaTypeIcon type="IMAGE" size="sm" />
             </span>
-            <span className="truncate">{selectedImage?.name ?? '선택된 이미지'}</span>
+          )}
+          <span className="absolute right-2 top-2 rounded-md bg-slate-950/85 px-2 py-1 text-xs font-medium text-amber-100 shadow-sm ring-1 ring-amber-400/30">
+            교체
           </span>
-          <span className="shrink-0 text-xs text-amber-200/70">교체</span>
         </button>
       ) : (
         <button

--- a/apps/web/src/features/editor/components/media/MediaCard.tsx
+++ b/apps/web/src/features/editor/components/media/MediaCard.tsx
@@ -7,6 +7,7 @@ import {
   getMediaThumbnailUrl,
   getMediaTypeBadgeClass,
   getMediaTypeBadgeLabel,
+  hasPublicMediaUrl,
   MediaTypeIcon,
 } from "./mediaVisuals";
 
@@ -72,8 +73,9 @@ export function MediaCard({
 }: MediaCardProps) {
   const [thumbnailFailed, setThumbnailFailed] = useState(false);
   const isYouTube = media.source_type === "YOUTUBE";
+  const hasPublicImageUrl = hasPublicMediaUrl(media);
   const shouldLoadFileImagePreview =
-    media.type === "IMAGE" && media.source_type === "FILE" && !media.url;
+    media.type === "IMAGE" && media.source_type === "FILE" && !hasPublicImageUrl;
   const { data: fileImagePreview } = useMediaDownloadUrl(
     shouldLoadFileImagePreview ? media.id : undefined,
   );
@@ -103,7 +105,7 @@ export function MediaCard({
         }
       }}
       aria-pressed={selectionMode ? checked : selected}
-      className={`group relative flex cursor-pointer flex-col overflow-hidden text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mmp-editor-color-primary)] ${
+      className={`group relative flex h-56 min-h-56 w-full min-w-0 cursor-pointer flex-col overflow-hidden text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mmp-editor-color-primary)] ${
         selected
           ? `${editorDesignClassNames.listItem} ${editorDesignClassNames.listItemActive}`
           : editorDesignClassNames.listItem
@@ -126,7 +128,7 @@ export function MediaCard({
       )}
 
       {/* Thumbnail */}
-      <div className="relative mx-auto mt-2 flex aspect-square w-24 items-center justify-center rounded-md bg-[var(--mmp-editor-color-surface-soft)] p-2 sm:w-28">
+      <div className="relative flex h-32 w-full shrink-0 items-center justify-center bg-[var(--mmp-editor-color-surface-soft)] p-2">
         {shouldRenderImagePreview ? (
           <img
             src={thumbnailUrl}
@@ -176,8 +178,8 @@ export function MediaCard({
       </div>
 
       {/* Body */}
-      <div className="flex flex-col gap-1.5 px-2.5 py-2">
-        <div className="flex items-center justify-between gap-2">
+      <div className="flex h-24 min-h-0 flex-col gap-1.5 px-2.5 py-2">
+        <div className="flex h-5 shrink-0 items-center justify-between gap-2">
           <span
             className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-mono font-semibold uppercase ${badgeClass}`}
           >
@@ -190,9 +192,9 @@ export function MediaCard({
         <p className="line-clamp-2 min-h-[2rem] text-xs font-medium leading-4 text-[var(--mmp-editor-color-charcoal)]">
           {media.name}
         </p>
-        {media.tags.length > 0 && (
-          <p className="truncate text-[10px] text-[var(--mmp-editor-color-slate)]">{media.tags.slice(0, 3).join(", ")}</p>
-        )}
+        <p className="h-4 truncate text-[10px] text-[var(--mmp-editor-color-slate)]">
+          {media.tags.length > 0 ? media.tags.slice(0, 3).join(", ") : ""}
+        </p>
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/media/MediaPicker.tsx
+++ b/apps/web/src/features/editor/components/media/MediaPicker.tsx
@@ -16,7 +16,7 @@ import {
   type MediaResponse,
   type MediaType,
 } from "@/features/editor/mediaApi";
-import { getMediaThumbnailUrl } from "./mediaVisuals";
+import { getMediaThumbnailUrl, hasPublicMediaUrl } from "./mediaVisuals";
 
 export interface MediaPickerProps {
   open: boolean;
@@ -149,5 +149,5 @@ export function MediaPicker({
 }
 
 function needsDownloadUrlThumbnail(media: MediaResponse) {
-  return media.type === "IMAGE" && media.source_type === "FILE" && !media.url;
+  return media.type === "IMAGE" && media.source_type === "FILE" && !hasPublicMediaUrl(media);
 }

--- a/apps/web/src/features/editor/components/media/MediaReplaceModal.tsx
+++ b/apps/web/src/features/editor/components/media/MediaReplaceModal.tsx
@@ -131,6 +131,7 @@ export function MediaReplaceModal({
     try {
       const replaced = await replaceMediaFile({
         file,
+        mediaId: media.id,
         requestReplacementUpload: requestReplacementMutation.mutateAsync,
         confirmReplacementUpload: confirmReplacementMutation.mutateAsync,
         onProgress: (nextProgress) => {

--- a/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
@@ -48,6 +48,56 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("ImageMediaReferenceField", () => {
+  it("선택 상태는 고정 이미지 타일과 이미지 위 교체 배지를 사용한다", () => {
+    const longName = "아주 긴 파일 이름이 레이아웃을 밀어내면 안 되는 단서 이미지 파일.webp";
+    useMediaListMock.mockReturnValue({
+      data: [{ ...imageMedia, name: longName, preview_url: "https://cdn.example/preview.webp" }],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <ImageMediaReferenceField
+        themeId="theme-1"
+        label="단서 이미지"
+        imageMediaId="image-1"
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+
+    const tile = screen.getByRole("button", { name: "단서 이미지 교체" });
+    expect(tile.className).toContain("aspect-[16/10]");
+    expect(tile.className).toContain("overflow-hidden");
+    expect(screen.getByText("교체").className).toContain("absolute");
+    expect(screen.queryByText(longName)).toBeNull();
+    expect(screen.getByRole("button", { name: /제거/ })).toBeDefined();
+    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("공개 master_url이 있으면 다운로드 URL 없이 선택 이미지 프리뷰를 보여준다", () => {
+    useMediaListMock.mockReturnValue({
+      data: [{ ...imageMedia, master_url: "https://cdn.example/master.webp" }],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <ImageMediaReferenceField
+        themeId="theme-1"
+        label="단서 이미지"
+        imageMediaId="image-1"
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+
+    const preview = screen.getByAltText("우산걸이 미리보기") as HTMLImageElement;
+    expect(preview.getAttribute("src")).toBe("https://cdn.example/master.webp");
+    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
+    expect(useMediaDownloadUrlMock).not.toHaveBeenCalledWith("image-1");
+  });
+
   it("선택된 FILE 이미지는 다운로드 URL로 프리뷰를 보여준다", () => {
     render(
       <ImageMediaReferenceField

--- a/apps/web/src/features/editor/components/media/__tests__/MediaCard.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaCard.test.tsx
@@ -66,8 +66,9 @@ describe("MediaCard", () => {
     expect(image).not.toBeNull();
     expect(image.getAttribute("src")).toBe("https://example.com/clue.webp");
     expect(image.className).toContain("object-contain");
-    expect(image.parentElement?.className).toContain("aspect-square");
-    expect(image.parentElement?.className).toContain("w-24");
+    expect(image.parentElement?.className).toContain("h-32");
+    expect(image.parentElement?.className).toContain("w-full");
+    expect(screen.getByRole("button", { name: /단서 사진/ }).className).toContain("h-56");
 
     fireEvent.error(image);
     expect(screen.getByLabelText("이미지")).toBeDefined();
@@ -90,6 +91,24 @@ describe("MediaCard", () => {
     expect(image.getAttribute("src")).toBe("https://example.com/thumbnail.webp");
     expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
     expect(useMediaDownloadUrlMock).not.toHaveBeenCalledWith("image-optimized-1");
+  });
+
+  it("master_url만 있는 이미지는 다운로드 fallback 없이 master 이미지를 사용한다", () => {
+    renderCard({
+      ...baseMedia,
+      id: "image-master-1",
+      name: "마스터 단서 사진",
+      type: "IMAGE",
+      url: undefined,
+      master_url: "https://example.com/master.webp",
+      mime_type: "image/webp",
+    });
+
+    const image = document.querySelector("img") as HTMLImageElement;
+    expect(image).not.toBeNull();
+    expect(image.getAttribute("src")).toBe("https://example.com/master.webp");
+    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
+    expect(useMediaDownloadUrlMock).not.toHaveBeenCalledWith("image-master-1");
   });
 
   it("업로드 이미지는 임시 다운로드 URL로 preview를 보여준다", () => {
@@ -127,8 +146,8 @@ describe("MediaCard", () => {
     });
 
     expect(screen.getByTestId("media-preview-face")).toBeDefined();
-    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("aspect-square");
-    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("w-24");
+    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("h-32");
+    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("w-full");
     expect(screen.getByLabelText("영상")).toBeDefined();
     expect(screen.getAllByText("영상").length).toBeGreaterThan(0);
     expect(document.querySelector("img")).toBeNull();
@@ -176,5 +195,20 @@ describe("MediaCard", () => {
     const card = screen.getByRole("button", { name: /오프닝 BGM/ });
     expect(card.className).toContain("mmp-editor-list-item");
     expect(card.className).toContain("mmp-editor-list-item-active");
+  });
+
+  it("긴 이름과 긴 태그도 고정 카드/하단 영역 안에 제한한다", () => {
+    renderCard({
+      ...baseMedia,
+      name: "매우 긴 미디어 이름이 여러 줄로 들어와도 카드 전체 높이를 바꾸면 안 됩니다",
+      tags: ["긴태그".repeat(12), "두번째태그".repeat(8), "세번째태그".repeat(8), "숨겨질태그"],
+    });
+
+    const card = screen.getByRole("button", { name: /매우 긴 미디어 이름/ });
+    expect(card.className).toContain("h-56");
+    expect(card.className).toContain("min-w-0");
+    expect(screen.getByText(/매우 긴 미디어 이름/).className).toContain("line-clamp-2");
+    expect(screen.getByText(/긴태그/).className).toContain("truncate");
+    expect(screen.getByText(/긴태그/).parentElement?.className).toContain("h-24");
   });
 });

--- a/apps/web/src/features/editor/components/media/__tests__/mediaVisuals.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/mediaVisuals.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { getMediaPreviewUrl, getMediaThumbnailUrl, hasPublicMediaUrl } from "../mediaVisuals";
+import type { MediaResponse } from "@/features/editor/mediaApi";
+
+const imageMedia: MediaResponse = {
+  id: "image-1",
+  theme_id: "theme-1",
+  name: "단서 이미지",
+  type: "IMAGE",
+  source_type: "FILE",
+  tags: [],
+  sort_order: 1,
+  created_at: "2026-05-20T00:00:00Z",
+};
+
+describe("mediaVisuals", () => {
+  it("thumbnail은 thumbnail, preview, master, url 순서로 선택한다", () => {
+    expect(
+      getMediaThumbnailUrl({
+        ...imageMedia,
+        url: "https://cdn.example/original.webp",
+        master_url: "https://cdn.example/master.webp",
+        preview_url: "https://cdn.example/preview.webp",
+        thumbnail_url: "https://cdn.example/thumb.webp",
+      }),
+    ).toBe("https://cdn.example/thumb.webp");
+
+    expect(
+      getMediaThumbnailUrl({
+        ...imageMedia,
+        url: "https://cdn.example/original.webp",
+        master_url: "https://cdn.example/master.webp",
+      }),
+    ).toBe("https://cdn.example/master.webp");
+  });
+
+  it("preview는 preview, master, url, thumbnail 순서로 선택한다", () => {
+    expect(
+      getMediaPreviewUrl({
+        ...imageMedia,
+        url: "https://cdn.example/original.webp",
+        master_url: "https://cdn.example/master.webp",
+        preview_url: "https://cdn.example/preview.webp",
+        thumbnail_url: "https://cdn.example/thumb.webp",
+      }),
+    ).toBe("https://cdn.example/preview.webp");
+
+    expect(
+      getMediaPreviewUrl({
+        ...imageMedia,
+        thumbnail_url: "https://cdn.example/thumb.webp",
+      }),
+    ).toBe("https://cdn.example/thumb.webp");
+  });
+
+  it("YouTube thumbnail 동작은 기존처럼 YouTube 이미지 URL을 우선한다", () => {
+    expect(
+      getMediaThumbnailUrl({
+        ...imageMedia,
+        source_type: "YOUTUBE",
+        type: "VIDEO",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        master_url: "https://cdn.example/master.webp",
+      }),
+    ).toBe("https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg");
+  });
+
+  it("공개 URL 존재 여부는 thumbnail, preview, master, url을 모두 인정한다", () => {
+    expect(hasPublicMediaUrl({ ...imageMedia })).toBe(false);
+    expect(hasPublicMediaUrl({ ...imageMedia, master_url: "https://cdn.example/master.webp" })).toBe(true);
+    expect(hasPublicMediaUrl({ ...imageMedia, thumbnail_url: "https://cdn.example/thumb.webp" })).toBe(true);
+  });
+});

--- a/apps/web/src/features/editor/components/media/mediaVisuals.tsx
+++ b/apps/web/src/features/editor/components/media/mediaVisuals.tsx
@@ -1,4 +1,4 @@
-import { FileAudio, FileText, Film, Image, Mic, Music, Sparkles, Volume2 } from "lucide-react";
+import { FileAudio, FileText, Film, Image, Mic, Music, Volume2 } from "lucide-react";
 
 import { extractYouTubeVideoId } from "@/features/audio/YouTubePlayer";
 import type { MediaResponse, MediaType } from "@/features/editor/mediaApi";
@@ -29,20 +29,32 @@ export function getMediaTypeBadgeLabel(type: MediaType): string {
   return TYPE_LABEL[type] ?? type;
 }
 
-export function getMediaThumbnailUrl(media: Pick<MediaResponse, "source_type" | "type" | "url" | "thumbnail_url" | "preview_url">): string | null {
+export function hasPublicMediaUrl(
+  media: Pick<MediaResponse, "url" | "master_url" | "preview_url" | "thumbnail_url">,
+): boolean {
+  return Boolean(media.thumbnail_url || media.preview_url || media.master_url || media.url);
+}
+
+export function getMediaThumbnailUrl(
+  media: Pick<MediaResponse, "source_type" | "type" | "url" | "master_url" | "thumbnail_url" | "preview_url">,
+): string | null {
   if (media.source_type === "YOUTUBE" && media.url) {
     const youtubeId = extractYouTubeVideoId(media.url);
     return youtubeId ? `https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg` : null;
   }
   if (media.type === "IMAGE" && media.thumbnail_url) return media.thumbnail_url;
   if (media.type === "IMAGE" && media.preview_url) return media.preview_url;
+  if (media.type === "IMAGE" && media.master_url) return media.master_url;
   if (media.type === "IMAGE" && media.url) return media.url;
   return null;
 }
 
-export function getMediaPreviewUrl(media: Pick<MediaResponse, "source_type" | "type" | "url" | "preview_url" | "thumbnail_url">): string | null {
+export function getMediaPreviewUrl(
+  media: Pick<MediaResponse, "source_type" | "type" | "url" | "master_url" | "preview_url" | "thumbnail_url">,
+): string | null {
   if (media.source_type === "YOUTUBE" && media.url) return getMediaThumbnailUrl(media);
   if (media.type === "IMAGE" && media.preview_url) return media.preview_url;
+  if (media.type === "IMAGE" && media.master_url) return media.master_url;
   if (media.type === "IMAGE" && media.url) return media.url;
   if (media.type === "IMAGE" && media.thumbnail_url) return media.thumbnail_url;
   return null;

--- a/apps/web/src/features/editor/mediaApi.ts
+++ b/apps/web/src/features/editor/mediaApi.ts
@@ -333,6 +333,15 @@ export interface ServerUploadFileParams {
   signal?: AbortSignal;
 }
 
+export interface ServerReplacementUploadFileParams {
+  mediaId: string;
+  uploadId: string;
+  file: File;
+  contentType?: string;
+  onProgress?: (percent: number) => void;
+  signal?: AbortSignal;
+}
+
 /** Default putFile implementation using XHR for progress events. */
 export function defaultPutFile(params: PutFileParams): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -379,6 +388,54 @@ export function defaultUploadFileViaServer(params: ServerUploadFileParams): Prom
     xhr.open(
       "PUT",
       `/api/v1/editor/themes/${params.themeId}/media/uploads/${params.uploadId}`,
+      true,
+    );
+    const contentType = params.contentType ?? params.file.type;
+    if (contentType) {
+      xhr.setRequestHeader("Content-Type", contentType);
+    }
+    const accessToken = useAuthStore.getState().accessToken;
+    if (accessToken) {
+      xhr.setRequestHeader("Authorization", `Bearer ${accessToken}`);
+    }
+
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable && params.onProgress) {
+        params.onProgress(Math.round((e.loaded / e.total) * 100));
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve();
+      } else {
+        reject(new Error(`업로드 실패: HTTP ${xhr.status}`));
+      }
+    };
+    xhr.onerror = () => reject(new Error("업로드 네트워크 오류"));
+    xhr.onabort = () => reject(new Error("업로드가 취소되었습니다"));
+
+    if (params.signal) {
+      if (params.signal.aborted) {
+        xhr.abort();
+        reject(new Error("업로드가 취소되었습니다"));
+        return;
+      }
+      params.signal.addEventListener("abort", () => xhr.abort());
+    }
+
+    xhr.send(params.file);
+  });
+}
+
+export function defaultUploadReplacementFileViaServer(
+  params: ServerReplacementUploadFileParams,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open(
+      "PUT",
+      `/api/v1/editor/media/${params.mediaId}/replace-uploads/${params.uploadId}`,
       true,
     );
     const contentType = params.contentType ?? params.file.type;

--- a/apps/web/src/features/editor/mediaReplaceUpload.test.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.test.ts
@@ -24,6 +24,7 @@ describe("replaceMediaFile", () => {
 
     const result = await replaceMediaFile({
       file,
+      mediaId: "media-1",
       requestReplacementUpload,
       confirmReplacementUpload,
       putFile,
@@ -71,6 +72,7 @@ describe("replaceMediaFile", () => {
 
     await replaceMediaFile({
       file,
+      mediaId: "media-2",
       requestReplacementUpload,
       confirmReplacementUpload,
       putFile,
@@ -79,6 +81,51 @@ describe("replaceMediaFile", () => {
 
     expect(putFile).toHaveBeenCalledTimes(2);
     expect(confirmReplacementUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it("PUT 재시도가 모두 실패하면 서버 경유 replacement upload 후 confirm한다", async () => {
+    const file = new File(["image"], "evidence.png", { type: "image/png" });
+    const requestReplacementUpload = vi.fn().mockResolvedValue({
+      upload_id: "replace-upload-fallback",
+      upload_url: "https://upload.example.com/fallback",
+      expires_at: "2026-05-07T00:00:00Z",
+    });
+    const putFile = vi.fn().mockRejectedValue(new Error("업로드 네트워크 오류"));
+    const uploadReplacementViaServer = vi.fn().mockResolvedValue(undefined);
+    const confirmReplacementUpload = vi.fn().mockResolvedValue({
+      id: "media-1",
+      name: "증거 사진",
+      type: "IMAGE",
+      source_type: "FILE",
+      tags: [],
+      sort_order: 1,
+      created_at: "2026-05-07T00:00:00Z",
+    });
+    const onProgress = vi.fn();
+
+    await replaceMediaFile({
+      file,
+      mediaId: "media-1",
+      requestReplacementUpload,
+      confirmReplacementUpload,
+      putFile,
+      uploadReplacementViaServer,
+      onProgress,
+      maxAttempts: 2,
+      retryBaseDelayMs: 0,
+    });
+
+    expect(putFile).toHaveBeenCalledTimes(2);
+    expect(uploadReplacementViaServer).toHaveBeenCalledWith({
+      mediaId: "media-1",
+      uploadId: "replace-upload-fallback",
+      file,
+      contentType: "image/png",
+      onProgress,
+    });
+    expect(confirmReplacementUpload).toHaveBeenCalledWith({
+      upload_id: "replace-upload-fallback",
+    });
   });
 
   it("취소된 PUT 실패는 재시도하지 않고 confirm도 호출하지 않는다", async () => {
@@ -99,6 +146,7 @@ describe("replaceMediaFile", () => {
     await expect(
       replaceMediaFile({
         file,
+        mediaId: "media-abort",
         requestReplacementUpload,
         confirmReplacementUpload,
         putFile,
@@ -122,6 +170,7 @@ describe("replaceMediaFile", () => {
     await expect(
       replaceMediaFile({
         file,
+        mediaId: "media-cancelled",
         requestReplacementUpload,
         confirmReplacementUpload,
         putFile,
@@ -151,6 +200,7 @@ describe("replaceMediaFile", () => {
     await expect(
       replaceMediaFile({
         file,
+        mediaId: "media-cancel-before-confirm",
         requestReplacementUpload,
         confirmReplacementUpload,
         putFile,
@@ -171,6 +221,7 @@ describe("replaceMediaFile", () => {
     await expect(
       replaceMediaFile({
         file,
+        mediaId: "media-invalid-attempts",
         requestReplacementUpload,
         confirmReplacementUpload,
         putFile,

--- a/apps/web/src/features/editor/mediaReplaceUpload.ts
+++ b/apps/web/src/features/editor/mediaReplaceUpload.ts
@@ -1,14 +1,17 @@
 import {
+  defaultUploadReplacementFileViaServer,
   defaultPutFile,
   type ConfirmUploadRequest,
   type MediaResponse,
   type PutFileParams,
   type RequestReplacementUploadRequest,
+  type ServerReplacementUploadFileParams,
   type UploadUrlResponse,
 } from "@/features/editor/mediaApi";
 
 export interface ReplaceMediaFileParams {
   file: File;
+  mediaId: string;
   requestReplacementUpload: (
     req: RequestReplacementUploadRequest,
   ) => Promise<UploadUrlResponse>;
@@ -18,6 +21,9 @@ export interface ReplaceMediaFileParams {
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
   putFile?: (params: PutFileParams) => Promise<void>;
+  uploadReplacementViaServer?: (
+    params: ServerReplacementUploadFileParams,
+  ) => Promise<void>;
   mimeType?: string;
   maxAttempts?: number;
   retryBaseDelayMs?: number;
@@ -42,9 +48,11 @@ export async function replaceMediaFile(
     onProgress,
     signal,
     putFile = defaultPutFile,
+    uploadReplacementViaServer = defaultUploadReplacementFileViaServer,
     mimeType,
     maxAttempts = 3,
     retryBaseDelayMs = 200,
+    mediaId,
   } = params;
   if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
     throw new Error("maxAttempts는 1 이상의 정수여야 합니다");
@@ -85,7 +93,14 @@ export async function replaceMediaFile(
     }
   }
   if (lastError) {
-    throw lastError;
+    await uploadReplacementViaServer({
+      mediaId,
+      uploadId: uploadUrl.upload_id,
+      file,
+      contentType: effectiveMimeType,
+      onProgress,
+      signal,
+    });
   }
 
   throwIfAborted(signal);


### PR DESCRIPTION
## 요약

Closes #715
Refs #716

- 미디어 교체 업로드가 브라우저의 직접 R2 PUT에서 실패할 때 백엔드 경유 fallback으로 이어지도록 기존 미완료 변경까지 포함해 안정화했습니다.
- `ImageMediaReferenceField`를 선택된 이미지 카드가 아닌 이미지 전용 타일로 정리하고, 교체 액션은 이미지 위 오버레이 배지 형태로 보이게 했습니다.
- `MediaCard`는 내용 길이와 태그 유무에 따라 카드 높이가 흔들리지 않도록 고정 높이/고정 이미지 영역/텍스트 clamp를 적용했습니다.
- 미디어 URL 선택 우선순위에 `master_url`을 포함하고, 공개 URL이 이미 있으면 불필요한 download URL fallback 호출을 하지 않도록 정리했습니다.

## Coverage Plan

- 이미지 참조 필드: 선택/교체/삭제, public URL 우선 렌더, fallback URL 호출 조건을 컴포넌트 테스트로 검증했습니다.
- 미디어 카드: fixed-size layout, image/video/audio fallback, public URL 우선 렌더를 컴포넌트 테스트로 검증했습니다.
- 미디어 URL helper: thumbnail/preview/master/url 우선순위와 public URL 판정을 unit test로 검증했습니다.
- 교체 업로드 fallback: 프론트 API 테스트와 백엔드 editor domain/server focused test로 직접 업로드 실패 후 fallback 경로를 검증했습니다.

## Local validation

- `pnpm --filter @mmp/web test -- src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx src/features/editor/components/media/__tests__/MediaCard.test.tsx src/features/editor/components/media/__tests__/mediaVisuals.test.tsx`: pass
- `pnpm --filter @mmp/web test -- src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx src/features/editor/components/media/__tests__/MediaCard.test.tsx src/features/editor/components/media/__tests__/mediaVisuals.test.tsx src/features/editor/components/media/__tests__/mediaReplaceUpload.test.ts src/features/editor/api/__tests__/mediaApi.test.ts`: pass, 59 tests
- `pnpm --filter @mmp/web typecheck`: pass
- `(cd apps/server && go test ./internal/domain/editor)`: pass
- `(cd apps/server && go test ./cmd/server)`: pass
- `scripts/mmp-local-ci.sh quick`: pass on final HEAD `a86d2782`

## Browser QA

- `http://localhost:8080/health`: OK
- `http://localhost:3000`: OK
- E2E 계정으로 `/editor/1f86ab3d-b51c-4d5f-a461-1188fec15fb9/media` 진입 후 MediaCard가 `200x224` fixed card로 렌더되는 것을 확인했습니다.
- 호텔 테마 `/editor/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/media`는 현재 계정 권한상 "테마 편집 권한이 없습니다"로 막혀 실제 R2 `master_url` 이미지는 브라우저에서 직접 확인하지 못했습니다. 이 경로는 `master_url` 컴포넌트 테스트와 download fallback skip 테스트로 보강했습니다.

## Review notes

- 독립 frontend review에서 blocker는 없었습니다.
- 기존 `MediaCard`의 카드 전체 `role=button` 내부에 checkbox/preview button이 들어가는 접근성 구조는 이번 변경의 신규 회귀가 아니어서 follow-up #716으로 분리했습니다.