### PR TITLE
fix: 미디어 이미지 오버레이 UX 보정

### DIFF
--- a/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
+++ b/apps/web/src/features/editor/components/__tests__/ClueForm.test.tsx
@@ -237,7 +237,7 @@ describe('ClueForm', () => {
       <ClueForm themeId="theme-1" clue={existing} isOpen onClose={onClose} />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: '제거' }));
+    fireEvent.click(screen.getByRole('button', { name: '단서 이미지 제거' }));
     fireEvent.submit(document.getElementById('clue-form')!);
 
     expect(updateMutate).toHaveBeenCalledTimes(1);

--- a/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
+++ b/apps/web/src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx
@@ -618,7 +618,7 @@ describe('CharacterAssignPanel', () => {
 
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: '홍길동 선택' }));
-    fireEvent.click(screen.getByRole('button', { name: '제거' }));
+    fireEvent.click(screen.getByRole('button', { name: '프로필 이미지 제거' }));
 
     expect(updateCharacterMutateMock).toHaveBeenCalledWith({
       characterId: 'char-1',

--- a/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
+++ b/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Image, X } from 'lucide-react';
+import { X } from 'lucide-react';
 
 import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
 import { useMediaDownloadUrl, useMediaList, type MediaResponse } from '@/features/editor/mediaApi';
@@ -56,50 +56,56 @@ export function ImageMediaReferenceField({
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-300">
-          <Image className="h-3.5 w-3.5 text-amber-400" />
-          {label}
-        </div>
-        {imageMediaId && !disabled ? (
+      {imageMediaId ? (
+        <div className="relative">
           <button
             type="button"
-            onClick={onClear}
-            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+            disabled={disabled}
+            onClick={() => setPickerOpen(true)}
+            aria-label={`${label} 미리보기`}
+            className={`group relative flex w-full items-center justify-center overflow-hidden rounded-md border border-amber-500/30 bg-slate-950/70 text-left text-sm text-amber-100 hover:border-amber-400/60 disabled:cursor-not-allowed disabled:opacity-70 ${
+              compact ? 'h-24' : 'aspect-[16/10] min-h-32'
+            }`}
           >
-            <X className="h-3 w-3" />
-            제거
+            {shouldRenderPreview ? (
+              <img
+                src={previewUrl ?? undefined}
+                alt={`${selectedImage?.name ?? '선택된 이미지'} 미리보기`}
+                className="h-full w-full object-contain"
+                loading="lazy"
+                onError={() => setPreviewFailed(true)}
+              />
+            ) : (
+              <span className="flex h-full w-full items-center justify-center">
+                <MediaTypeIcon type="IMAGE" size="sm" />
+              </span>
+            )}
           </button>
-        ) : null}
-      </div>
-
-      {imageMediaId ? (
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={() => setPickerOpen(true)}
-          aria-label={`${label} 교체`}
-          className={`group relative flex w-full items-center justify-center overflow-hidden rounded-md border border-amber-500/30 bg-slate-950/70 text-left text-sm text-amber-100 hover:border-amber-400/60 disabled:cursor-not-allowed disabled:opacity-70 ${
-            compact ? 'h-24' : 'aspect-[16/10] min-h-32'
-          }`}
-        >
-          {shouldRenderPreview ? (
-            <img
-              src={previewUrl ?? undefined}
-              alt={`${selectedImage?.name ?? '선택된 이미지'} 미리보기`}
-              className="h-full w-full object-contain"
-              loading="lazy"
-              onError={() => setPreviewFailed(true)}
-            />
-          ) : (
-            <span className="flex h-full w-full items-center justify-center">
-              <MediaTypeIcon type="IMAGE" size="sm" />
-            </span>
-          )}
-          <span className="absolute right-2 top-2 rounded-md bg-slate-950/85 px-2 py-1 text-xs font-medium text-amber-100 shadow-sm ring-1 ring-amber-400/30">
-            교체
-          </span>
-        </button>
+          {!disabled ? (
+            <div className="absolute right-2 top-2 flex items-center gap-1 rounded-md bg-slate-950/85 p-1 shadow-sm ring-1 ring-amber-400/30">
+              <button
+                type="button"
+                onClick={() => setPickerOpen(true)}
+                aria-label={`${label} 교체`}
+                className="rounded-sm px-2 py-1 text-xs font-medium text-amber-100 hover:bg-amber-400/15"
+              >
+                교체
+              </button>
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onClear();
+                }}
+                aria-label={`${label} 제거`}
+                className="inline-flex items-center gap-1 rounded-sm px-2 py-1 text-xs font-medium text-slate-200 hover:bg-slate-700/80"
+              >
+                <X className="h-3 w-3" />
+                제거
+              </button>
+            </div>
+          ) : null}
+        </div>
       ) : (
         <button
           type="button"

--- a/apps/web/src/features/editor/components/media/MediaCard.tsx
+++ b/apps/web/src/features/editor/components/media/MediaCard.tsx
@@ -105,7 +105,7 @@ export function MediaCard({
         }
       }}
       aria-pressed={selectionMode ? checked : selected}
-      className={`group relative flex h-56 min-h-56 w-full min-w-0 cursor-pointer flex-col overflow-hidden text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mmp-editor-color-primary)] ${
+      className={`group relative flex h-56 min-h-56 w-full min-w-0 cursor-pointer overflow-hidden text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mmp-editor-color-primary)] ${
         selected
           ? `${editorDesignClassNames.listItem} ${editorDesignClassNames.listItemActive}`
           : editorDesignClassNames.listItem
@@ -127,8 +127,8 @@ export function MediaCard({
         </div>
       )}
 
-      {/* Thumbnail */}
-      <div className="relative flex h-32 w-full shrink-0 items-center justify-center bg-[var(--mmp-editor-color-surface-soft)] p-2">
+      {/* Preview surface */}
+      <div className="relative flex h-full w-full items-center justify-center bg-[var(--mmp-editor-color-surface-soft)]">
         {shouldRenderImagePreview ? (
           <img
             src={thumbnailUrl}
@@ -140,7 +140,7 @@ export function MediaCard({
         ) : (
           <div
             data-testid="media-preview-face"
-            className={`flex h-full w-full flex-col items-center justify-center gap-1 rounded-sm border ${getPreviewSurfaceClass(
+            className={`flex h-full w-full flex-col items-center justify-center gap-1 border ${getPreviewSurfaceClass(
               media.type,
             )}`}
           >
@@ -175,26 +175,24 @@ export function MediaCard({
             )}
           </button>
         )}
-      </div>
 
-      {/* Body */}
-      <div className="flex h-24 min-h-0 flex-col gap-1.5 px-2.5 py-2">
-        <div className="flex h-5 shrink-0 items-center justify-between gap-2">
-          <span
-            className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-mono font-semibold uppercase ${badgeClass}`}
-          >
-            {badgeLabel}
-          </span>
-          {duration && (
-            <span className="text-[10px] font-mono text-[var(--mmp-editor-color-steel)]">{duration}</span>
-          )}
+        {/* Metadata gradient overlay */}
+        <div className="absolute inset-x-0 bottom-0 flex min-h-24 flex-col justify-end gap-1.5 bg-gradient-to-t from-black/85 via-black/55 to-transparent px-2.5 pb-2 pt-10 text-white">
+          <div className="flex min-h-5 items-center justify-between gap-2">
+            <span
+              className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-mono font-semibold uppercase ${badgeClass}`}
+            >
+              {badgeLabel}
+            </span>
+            {duration && <span className="text-[10px] font-mono text-white/75">{duration}</span>}
+          </div>
+          <p className="line-clamp-2 min-h-[2rem] text-xs font-medium leading-4 text-white">
+            {media.name}
+          </p>
+          <p className="h-4 truncate text-[10px] text-white/65">
+            {media.tags.length > 0 ? media.tags.slice(0, 3).join(", ") : ""}
+          </p>
         </div>
-        <p className="line-clamp-2 min-h-[2rem] text-xs font-medium leading-4 text-[var(--mmp-editor-color-charcoal)]">
-          {media.name}
-        </p>
-        <p className="h-4 truncate text-[10px] text-[var(--mmp-editor-color-slate)]">
-          {media.tags.length > 0 ? media.tags.slice(0, 3).join(", ") : ""}
-        </p>
       </div>
     </div>
   );

--- a/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
@@ -48,7 +48,7 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("ImageMediaReferenceField", () => {
-  it("선택 상태는 고정 이미지 타일과 이미지 위 교체 배지를 사용한다", () => {
+  it("선택 상태는 이미지 타일 위 overlay group에 교체와 제거를 항상 표시한다", () => {
     const longName = "아주 긴 파일 이름이 레이아웃을 밀어내면 안 되는 단서 이미지 파일.webp";
     useMediaListMock.mockReturnValue({
       data: [{ ...imageMedia, name: longName, preview_url: "https://cdn.example/preview.webp" }],
@@ -66,13 +66,33 @@ describe("ImageMediaReferenceField", () => {
       />,
     );
 
-    const tile = screen.getByRole("button", { name: "단서 이미지 교체" });
+    const tile = screen.getByRole("button", { name: "단서 이미지 미리보기" });
     expect(tile.className).toContain("aspect-[16/10]");
     expect(tile.className).toContain("overflow-hidden");
-    expect(screen.getByText("교체").className).toContain("absolute");
+    expect(screen.getByText("교체").parentElement?.className).toContain("absolute");
+    expect(screen.getByRole("button", { name: "단서 이미지 교체" })).toBeDefined();
     expect(screen.queryByText(longName)).toBeNull();
-    expect(screen.getByRole("button", { name: /제거/ })).toBeDefined();
+    expect(screen.getByRole("button", { name: "단서 이미지 제거" })).toBeDefined();
     expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("overlay 제거 버튼은 picker를 열지 않고 onClear만 호출한다", () => {
+    const onClear = vi.fn();
+
+    render(
+      <ImageMediaReferenceField
+        themeId="theme-1"
+        label="단서 이미지"
+        imageMediaId="image-1"
+        onSelect={vi.fn()}
+        onClear={onClear}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "단서 이미지 제거" }));
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("미디어 선택")).toBeNull();
   });
 
   it("공개 master_url이 있으면 다운로드 URL 없이 선택 이미지 프리뷰를 보여준다", () => {

--- a/apps/web/src/features/editor/components/media/__tests__/MediaCard.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaCard.test.tsx
@@ -66,7 +66,7 @@ describe("MediaCard", () => {
     expect(image).not.toBeNull();
     expect(image.getAttribute("src")).toBe("https://example.com/clue.webp");
     expect(image.className).toContain("object-contain");
-    expect(image.parentElement?.className).toContain("h-32");
+    expect(image.parentElement?.className).toContain("h-full");
     expect(image.parentElement?.className).toContain("w-full");
     expect(screen.getByRole("button", { name: /단서 사진/ }).className).toContain("h-56");
 
@@ -146,7 +146,7 @@ describe("MediaCard", () => {
     });
 
     expect(screen.getByTestId("media-preview-face")).toBeDefined();
-    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("h-32");
+    expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("h-full");
     expect(screen.getByTestId("media-preview-face").parentElement?.className).toContain("w-full");
     expect(screen.getByLabelText("영상")).toBeDefined();
     expect(screen.getAllByText("영상").length).toBeGreaterThan(0);
@@ -197,7 +197,7 @@ describe("MediaCard", () => {
     expect(card.className).toContain("mmp-editor-list-item-active");
   });
 
-  it("긴 이름과 긴 태그도 고정 카드/하단 영역 안에 제한한다", () => {
+  it("긴 이름과 긴 태그도 고정 카드/하단 gradient overlay 안에 제한한다", () => {
     renderCard({
       ...baseMedia,
       name: "매우 긴 미디어 이름이 여러 줄로 들어와도 카드 전체 높이를 바꾸면 안 됩니다",
@@ -209,6 +209,6 @@ describe("MediaCard", () => {
     expect(card.className).toContain("min-w-0");
     expect(screen.getByText(/매우 긴 미디어 이름/).className).toContain("line-clamp-2");
     expect(screen.getByText(/긴태그/).className).toContain("truncate");
-    expect(screen.getByText(/긴태그/).parentElement?.className).toContain("h-24");
+    expect(screen.getByText(/긴태그/).parentElement?.className).toContain("bg-gradient-to-t");
   });
 });


### PR DESCRIPTION
## 요약
- 선택된 이미지 필드는 텍스트 행을 제거하고 이미지 위 overlay로 교체/제거를 노출했습니다.
- 미디어 카드는 하단 본문을 제거하고 전체 이미지를 유지한 채 타입/이름/태그를 하단 gradient overlay로 표시합니다.
- overlay 버튼 접근성 이름을 구분하고, 기존 제거 동작 테스트를 새 라벨에 맞게 갱신했습니다.

## Coverage Plan
- ImageMediaReferenceField 선택 상태: 이미지 미리보기, overlay 교체/제거, 제거 시 picker 미오픈을 unit test로 검증합니다.
- MediaCard 카드 높이/이미지 surface/metadata overlay: 고정 높이와 gradient overlay를 unit test로 검증합니다.
- 기존 clue/character image clear 흐름: ClueForm, CharacterAssignPanel 테스트로 회귀를 검증합니다.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx src/features/editor/components/media/__tests__/MediaCard.test.tsx src/features/editor/components/__tests__/ClueForm.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx: pass (62 tests)
- scripts/mmp-local-ci.sh quick: pass on 34acc9b9
- Browser QA: /editor/.../media에서 카드가 200x224 고정 높이와 full image surface + gradient overlay로 렌더링됨을 확인했습니다.

Closes #718