### PR TITLE
fix: 이미지 참조 필드 선택 상태 축소

### DIFF
--- a/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
+++ b/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
@@ -54,16 +54,28 @@ export function ImageMediaReferenceField({
     setPreviewFailed(false);
   }, [previewUrl, imageMediaId]);
 
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
-      {imageMediaId ? (
+  const picker = (
+    <MediaPicker
+      open={pickerOpen}
+      onClose={() => setPickerOpen(false)}
+      onSelect={onSelect}
+      themeId={themeId}
+      filterType="IMAGE"
+      selectedId={imageMediaId}
+      title={pickerTitle ?? `${label} 선택`}
+    />
+  );
+
+  if (imageMediaId) {
+    return (
+      <>
         <div className="relative">
           <button
             type="button"
             disabled={disabled}
             onClick={() => setPickerOpen(true)}
             aria-label={`${label} 미리보기`}
-            className={`group relative flex w-full items-center justify-center overflow-hidden rounded-md border border-amber-500/30 bg-slate-950/70 text-left text-sm text-amber-100 hover:border-amber-400/60 disabled:cursor-not-allowed disabled:opacity-70 ${
+            className={`group relative flex w-full items-center justify-center overflow-hidden rounded-lg bg-slate-950/70 text-left text-sm text-amber-100 ring-1 ring-slate-800/80 transition hover:ring-amber-400/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/70 disabled:cursor-not-allowed disabled:opacity-70 ${
               compact ? 'h-24' : 'aspect-[16/10] min-h-32'
             }`}
           >
@@ -87,7 +99,7 @@ export function ImageMediaReferenceField({
                 type="button"
                 onClick={() => setPickerOpen(true)}
                 aria-label={`${label} 교체`}
-                className="rounded-sm px-2 py-1 text-xs font-medium text-amber-100 hover:bg-amber-400/15"
+                className="rounded-sm px-2 py-1 text-xs font-medium text-amber-100 hover:bg-amber-400/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/70"
               >
                 교체
               </button>
@@ -98,7 +110,7 @@ export function ImageMediaReferenceField({
                   onClear();
                 }}
                 aria-label={`${label} 제거`}
-                className="inline-flex items-center gap-1 rounded-sm px-2 py-1 text-xs font-medium text-slate-200 hover:bg-slate-700/80"
+                className="inline-flex items-center gap-1 rounded-sm px-2 py-1 text-xs font-medium text-slate-200 hover:bg-slate-700/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/70"
               >
                 <X className="h-3 w-3" />
                 제거
@@ -106,32 +118,29 @@ export function ImageMediaReferenceField({
             </div>
           ) : null}
         </div>
-      ) : (
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={() => setPickerOpen(true)}
-          className={`flex w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200 disabled:cursor-not-allowed disabled:opacity-70 ${
-            compact ? 'min-h-16' : 'aspect-[16/10]'
-          }`}
-        >
-          {emptyLabel}
-        </button>
-      )}
+        {picker}
+      </>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setPickerOpen(true)}
+        className={`flex w-full items-center justify-center rounded-md border border-dashed border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-400 hover:border-amber-500/50 hover:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/70 disabled:cursor-not-allowed disabled:opacity-70 ${
+          compact ? 'min-h-16' : 'aspect-[16/10]'
+        }`}
+      >
+        {emptyLabel}
+      </button>
 
       {!imageMediaId && legacyImageUrl ? (
         <p className="mt-2 text-xs leading-5 text-slate-500">{legacyHint}</p>
       ) : null}
 
-      <MediaPicker
-        open={pickerOpen}
-        onClose={() => setPickerOpen(false)}
-        onSelect={onSelect}
-        themeId={themeId}
-        filterType="IMAGE"
-        selectedId={imageMediaId}
-        title={pickerTitle ?? `${label} 선택`}
-      />
+      {picker}
     </div>
   );
 }

--- a/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
@@ -69,10 +69,18 @@ describe("ImageMediaReferenceField", () => {
     const tile = screen.getByRole("button", { name: "단서 이미지 미리보기" });
     expect(tile.className).toContain("aspect-[16/10]");
     expect(tile.className).toContain("overflow-hidden");
+    expect(tile.className).toContain("focus-visible:ring-2");
+    expect(tile.parentElement?.className).toBe("relative");
+    expect(tile.parentElement?.parentElement?.className).not.toContain("p-3");
+    expect(tile.parentElement?.parentElement?.className).not.toContain("border-slate-800");
     expect(screen.getByText("교체").parentElement?.className).toContain("absolute");
-    expect(screen.getByRole("button", { name: "단서 이미지 교체" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "단서 이미지 교체" }).className).toContain(
+      "focus-visible:ring-2",
+    );
     expect(screen.queryByText(longName)).toBeNull();
-    expect(screen.getByRole("button", { name: "단서 이미지 제거" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "단서 이미지 제거" }).className).toContain(
+      "focus-visible:ring-2",
+    );
     expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
   });
 
@@ -92,6 +100,29 @@ describe("ImageMediaReferenceField", () => {
     fireEvent.click(screen.getByRole("button", { name: "단서 이미지 제거" }));
 
     expect(onClear).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("미디어 선택")).toBeNull();
+  });
+
+  it("disabled 선택 상태는 overlay action을 숨기고 picker를 열지 않는다", () => {
+    render(
+      <ImageMediaReferenceField
+        themeId="theme-1"
+        label="단서 이미지"
+        imageMediaId="image-1"
+        disabled
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+
+    const tile = screen.getByRole("button", { name: "단서 이미지 미리보기" });
+    expect(tile).toHaveProperty("disabled", true);
+    expect(tile.className).toContain("focus-visible:ring-2");
+    expect(screen.queryByRole("button", { name: "단서 이미지 교체" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "단서 이미지 제거" })).toBeNull();
+
+    fireEvent.click(tile);
+
     expect(screen.queryByText("미디어 선택")).toBeNull();
   });
 


### PR DESCRIPTION
## 요약
- 선택된 이미지 필드에서 바깥 rounded/border/padding 카드 레이아웃을 제거하고 이미지/폴백 표면만 남겼습니다.
- 교체/제거 액션은 이미지 위 우측 오버레이로 유지했습니다.
- 키보드 접근성을 위해 선택 표면, 빈 상태 버튼, 오버레이 버튼에 focus-visible ring을 보강했습니다.

Closes #720

## Coverage Plan
- ImageMediaReferenceField 선택 상태: 외곽 카드 제거, 이미지 표면 크기/클래스, 오버레이 버튼, disabled 상태를 component test로 검증.
- 기존 사용처 영향: ClueForm, CharacterAssignPanel 관련 테스트로 단서/캐릭터 이미지 참조 사용처 회귀 확인.
- 타입 계약: web typecheck로 React prop/class 변경 영향 확인.

## Local validation
- pnpm --filter @mmp/web test -- src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx src/features/editor/components/__tests__/ClueForm.test.tsx src/features/editor/components/design/__tests__/CharacterAssignPanel.test.tsx: 통과 (55 tests)
- pnpm --filter @mmp/web typecheck: 통과
- git diff --check: 통과
- scripts/mmp-local-ci.sh quick: 통과 (HEAD 18737b23)

## Browser QA
- /overview, /characters, /clues에서 빈 이미지 상태가 기존 선택 전 카드 형태로 유지되는 것을 확인했습니다.
- 현재 로컬 fixture에는 선택된 이미지 필드가 없어 선택 상태의 실제 브라우저 표시는 focused test와 독립 리뷰로 보완했습니다.