### PR TITLE
fix(server): R2 이미지 variant 백필 audit 도구 추가

### DIFF
--- a/apps/server/cmd/media-storage-audit/main.go
+++ b/apps/server/cmd/media-storage-audit/main.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -18,24 +23,30 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/chai2010/webp"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/image/draw"
 
 	appconfig "github.com/mmp-platform/server/internal/config"
 	"github.com/mmp-platform/server/internal/infra/postgres"
 )
 
 const defaultHeadTimeout = 10 * time.Second
+const imageVariantMimeType = "image/webp"
+const imageVariantQuality = 86
 
 type options struct {
 	themeID        string
 	envFile        string
 	format         string
 	includeObjects bool
+	apply          bool
 }
 
 type mediaRow struct {
 	ID         uuid.UUID
+	ThemeID    uuid.UUID
 	Name       string
 	StorageKey sql.NullString
 	MimeType   sql.NullString
@@ -58,12 +69,20 @@ type keyStatus struct {
 }
 
 type mediaAudit struct {
-	MediaID       string      `json:"media_id"`
-	MediaName     string      `json:"media_name"`
-	DBStorageKey  string      `json:"db_storage_key,omitempty"`
-	CharacterRefs []string    `json:"character_refs"`
-	Status        string      `json:"status"`
-	Candidates    []keyStatus `json:"candidates"`
+	MediaID            string      `json:"media_id"`
+	MediaName          string      `json:"media_name"`
+	DBStorageKey       string      `json:"db_storage_key,omitempty"`
+	CharacterRefs      []string    `json:"character_refs"`
+	Status             string      `json:"status"`
+	IsLegacy           bool        `json:"is_legacy"`
+	BackfillEligible   bool        `json:"backfill_eligible"`
+	BackfillSourceKey  string      `json:"backfill_source_key,omitempty"`
+	MissingVariantKeys []string    `json:"missing_variant_keys,omitempty"`
+	MissingObjects     []string    `json:"missing_objects,omitempty"`
+	Applied            bool        `json:"applied"`
+	ApplyError         string      `json:"apply_error,omitempty"`
+	CleanupError       string      `json:"cleanup_error,omitempty"`
+	Candidates         []keyStatus `json:"candidates"`
 }
 
 type auditReport struct {
@@ -75,12 +94,53 @@ type auditReport struct {
 }
 
 type auditSummary struct {
-	MediaCount           int `json:"media_count"`
-	CharacterRefCount    int `json:"character_ref_count"`
-	AvailableMediaCount  int `json:"available_media_count"`
-	MissingAllMediaCount int `json:"missing_all_media_count"`
-	UnmatchedObjectCount int `json:"unmatched_object_count"`
+	MediaCount            int `json:"media_count"`
+	CharacterRefCount     int `json:"character_ref_count"`
+	AvailableMediaCount   int `json:"available_media_count"`
+	MissingAllMediaCount  int `json:"missing_all_media_count"`
+	UnmatchedObjectCount  int `json:"unmatched_object_count"`
+	LegacyMediaCount      int `json:"legacy_media_count"`
+	VariantCompleteCount  int `json:"variant_complete_count"`
+	BackfillEligibleCount int `json:"backfill_eligible_count"`
+	MissingObjectCount    int `json:"missing_object_count"`
+	BackfilledCount       int `json:"backfilled_count"`
+	BackfillFailedCount   int `json:"backfill_failed_count"`
 }
+
+type auditStorage interface {
+	HeadObject(ctx context.Context, key string) keyStatus
+	ListObjectKeys(ctx context.Context, prefix string) ([]string, error)
+}
+
+type backfillStorage interface {
+	GetObject(ctx context.Context, key string, size int64) ([]byte, error)
+	PutObject(ctx context.Context, key string, body []byte, contentType string) error
+	DeleteObjects(ctx context.Context, keys []string) error
+}
+
+type mediaFileUpdater interface {
+	UpdateMediaFile(ctx context.Context, media mediaRow, nextStorageKey string, nextFileSize int64, nextMimeType string) error
+}
+
+type s3ObjectStore struct {
+	client *s3.Client
+	bucket string
+}
+
+type pgMediaFileUpdater struct {
+	pool *pgxpool.Pool
+}
+
+type imageVariant struct {
+	Name        string
+	Key         string
+	Body        []byte
+	ContentType string
+}
+
+type imageVariantBuilder func(themeID, mediaID uuid.UUID, declaredMime string, payload []byte) ([]imageVariant, error)
+
+var errObjectMissing = errors.New("object missing")
 
 func main() {
 	if err := run(context.Background(), os.Args[1:]); err != nil {
@@ -126,7 +186,8 @@ func run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	report, err := auditThemeMedia(ctx, pool, client, cfg.R2BucketName, themeID, opts.includeObjects)
+	store := s3ObjectStore{client: client, bucket: cfg.R2BucketName}
+	report, err := auditThemeMedia(ctx, pool, store, pgMediaFileUpdater{pool: pool}, themeID, opts.includeObjects, opts.apply)
 	if err != nil {
 		return err
 	}
@@ -149,6 +210,7 @@ func parseFlags(args []string) options {
 	fs.StringVar(&opts.envFile, "env-file", ".env", "dotenv file to load before reading environment")
 	fs.StringVar(&opts.format, "format", "text", "output format: text or json")
 	fs.BoolVar(&opts.includeObjects, "include-objects", true, "list R2 objects under the theme media prefix to report unmatched keys")
+	fs.BoolVar(&opts.apply, "apply", false, "write missing image variants to R2 and reconcile DB storage metadata")
 	_ = fs.Parse(args)
 	return opts
 }
@@ -224,7 +286,7 @@ func newR2Client(ctx context.Context, cfg *appconfig.Config) (*s3.Client, error)
 	}), nil
 }
 
-func auditThemeMedia(ctx context.Context, pool *pgxpool.Pool, client *s3.Client, bucket string, themeID uuid.UUID, includeObjects bool) (auditReport, error) {
+func auditThemeMedia(ctx context.Context, pool *pgxpool.Pool, storage auditStorage, updater mediaFileUpdater, themeID uuid.UUID, includeObjects bool, apply bool) (auditReport, error) {
 	mediaRows, err := fetchImageMedia(ctx, pool, themeID)
 	if err != nil {
 		return auditReport{}, err
@@ -257,36 +319,57 @@ func auditThemeMedia(ctx context.Context, pool *pgxpool.Pool, client *s3.Client,
 		hasAvailable := false
 		for _, candidate := range candidates {
 			allCandidateKeys[candidate.Key] = struct{}{}
-			status := headKey(ctx, client, bucket, candidate.Key)
+			status := storage.HeadObject(ctx, candidate.Key)
 			status.Kind = candidate.Kind
 			if status.Exists {
 				hasAvailable = true
 			}
 			statuses = append(statuses, status)
 		}
-		status := "missing_all"
+
+		audit := planMediaBackfill(themeID, media, statuses)
 		if hasAvailable {
-			status = "available"
 			report.Summary.AvailableMediaCount++
 		} else {
 			report.Summary.MissingAllMediaCount++
 		}
+		if audit.IsLegacy {
+			report.Summary.LegacyMediaCount++
+		}
+		if len(audit.MissingVariantKeys) == 0 {
+			report.Summary.VariantCompleteCount++
+		}
+		if audit.BackfillEligible {
+			report.Summary.BackfillEligibleCount++
+		}
+		report.Summary.MissingObjectCount += len(audit.MissingObjects)
 
 		refLabels := refsByMedia[media.ID]
 		sort.Strings(refLabels)
-		report.Media = append(report.Media, mediaAudit{
-			MediaID:       media.ID.String(),
-			MediaName:     media.Name,
-			DBStorageKey:  media.StorageKey.String,
-			CharacterRefs: refLabels,
-			Status:        status,
-			Candidates:    statuses,
-		})
+		audit.CharacterRefs = refLabels
+		if apply {
+			backfillStore, ok := storage.(backfillStorage)
+			if !ok {
+				audit.ApplyError = "storage backend does not support backfill writes"
+			} else {
+				audit, err = applyMediaBackfill(ctx, backfillStore, updater, themeID, media, audit, buildImageVariants)
+				if err != nil {
+					audit.ApplyError = redactError(err)
+				}
+			}
+			if audit.Applied {
+				report.Summary.BackfilledCount++
+			}
+			if audit.ApplyError != "" {
+				report.Summary.BackfillFailedCount++
+			}
+		}
+		report.Media = append(report.Media, audit)
 	}
 
 	if includeObjects {
 		prefix := fmt.Sprintf("themes/%s/media/", themeID)
-		objects, err := listObjectKeys(ctx, client, bucket, prefix)
+		objects, err := storage.ListObjectKeys(ctx, prefix)
 		if err != nil {
 			return auditReport{}, err
 		}
@@ -305,9 +388,271 @@ func auditThemeMedia(ctx context.Context, pool *pgxpool.Pool, client *s3.Client,
 	return report, nil
 }
 
+func planMediaBackfill(themeID uuid.UUID, media mediaRow, statuses []keyStatus) mediaAudit {
+	masterKey := imageVariantKey(themeID, media.ID, "master")
+	previewKey := imageVariantKey(themeID, media.ID, "preview")
+	thumbnailKey := imageVariantKey(themeID, media.ID, "thumbnail")
+	variantKeys := []string{masterKey, previewKey, thumbnailKey}
+	statusByKey := make(map[string]keyStatus, len(statuses))
+	anyExists := false
+	for _, status := range statuses {
+		statusByKey[status.Key] = status
+		if status.Exists {
+			anyExists = true
+		}
+	}
+
+	audit := mediaAudit{
+		MediaID:      media.ID.String(),
+		MediaName:    media.Name,
+		DBStorageKey: media.StorageKey.String,
+		IsLegacy:     media.StorageKey.String != masterKey || media.MimeType.String != imageVariantMimeType,
+		Candidates:   statuses,
+	}
+	for _, key := range variantKeys {
+		if !statusByKey[key].Exists {
+			audit.MissingVariantKeys = append(audit.MissingVariantKeys, key)
+			audit.MissingObjects = append(audit.MissingObjects, key)
+		}
+	}
+
+	if statusByKey[masterKey].Exists {
+		audit.BackfillEligible = true
+		audit.BackfillSourceKey = masterKey
+	} else if media.StorageKey.String != "" && statusByKey[media.StorageKey.String].Exists {
+		audit.BackfillEligible = true
+		audit.BackfillSourceKey = media.StorageKey.String
+	} else if media.StorageKey.String != "" {
+		audit.MissingObjects = appendIfMissing(audit.MissingObjects, media.StorageKey.String)
+	}
+
+	switch {
+	case audit.IsLegacy && audit.BackfillEligible:
+		audit.Status = "legacy_backfill_eligible"
+	case audit.IsLegacy:
+		audit.Status = "missing_source"
+	case !anyExists:
+		audit.Status = "missing_all"
+	case len(audit.MissingVariantKeys) > 0 && audit.BackfillEligible:
+		audit.Status = "variant_backfill_eligible"
+	case len(audit.MissingVariantKeys) > 0:
+		audit.Status = "missing_source"
+	default:
+		audit.Status = "variant_complete"
+	}
+	sort.Strings(audit.MissingObjects)
+	return audit
+}
+
+func applyMediaBackfill(ctx context.Context, storage backfillStorage, updater mediaFileUpdater, themeID uuid.UUID, media mediaRow, audit mediaAudit, build imageVariantBuilder) (mediaAudit, error) {
+	if !audit.BackfillEligible {
+		return audit, nil
+	}
+	masterKey := imageVariantKey(themeID, media.ID, "master")
+	if !audit.IsLegacy && len(audit.MissingVariantKeys) == 0 {
+		return audit, nil
+	}
+
+	existingSizes := existingVariantSizes(audit.Candidates)
+	missing := stringSet(audit.MissingVariantKeys)
+	generatedByKey := map[string]imageVariant{}
+	if len(missing) > 0 {
+		sourceSize := sourceObjectSize(audit.BackfillSourceKey, media, audit.Candidates)
+		payload, err := storage.GetObject(ctx, audit.BackfillSourceKey, sourceSize)
+		if err != nil {
+			return audit, fmt.Errorf("read source object %s: %w", audit.BackfillSourceKey, err)
+		}
+		variants, err := build(themeID, media.ID, sourceMimeType(audit.BackfillSourceKey, media, audit.Candidates), payload)
+		if err != nil {
+			return audit, err
+		}
+		for _, variant := range variants {
+			generatedByKey[variant.Key] = variant
+		}
+	}
+
+	written := make([]string, 0, len(missing))
+	for _, key := range audit.MissingVariantKeys {
+		variant, ok := generatedByKey[key]
+		if !ok {
+			return failAfterCleanup(ctx, storage, audit, written, fmt.Errorf("missing generated variant for %s", key))
+		}
+		if err := storage.PutObject(ctx, variant.Key, variant.Body, variant.ContentType); err != nil {
+			return failAfterCleanup(ctx, storage, audit, written, fmt.Errorf("write variant %s: %w", variant.Key, err))
+		}
+		written = append(written, variant.Key)
+	}
+
+	totalSize, err := reconciledVariantSize([]string{
+		masterKey,
+		imageVariantKey(themeID, media.ID, "preview"),
+		imageVariantKey(themeID, media.ID, "thumbnail"),
+	}, existingSizes, generatedByKey)
+	if err != nil {
+		return failAfterCleanup(ctx, storage, audit, written, err)
+	}
+	if err := updater.UpdateMediaFile(ctx, media, masterKey, totalSize, imageVariantMimeType); err != nil {
+		return failAfterCleanup(ctx, storage, audit, written, fmt.Errorf("update media row: %w", err))
+	}
+	audit.Applied = true
+	audit.Status = "backfilled"
+	return audit, nil
+}
+
+func failAfterCleanup(ctx context.Context, storage backfillStorage, audit mediaAudit, written []string, cause error) (mediaAudit, error) {
+	if cleanupErr := storage.DeleteObjects(ctx, written); cleanupErr != nil {
+		audit.CleanupError = redactError(cleanupErr)
+		return audit, fmt.Errorf("%w; cleanup generated variants: %v", cause, cleanupErr)
+	}
+	return audit, cause
+}
+
+func appendIfMissing(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func existingVariantSizes(statuses []keyStatus) map[string]int64 {
+	out := make(map[string]int64, len(statuses))
+	for _, status := range statuses {
+		if status.Exists {
+			out[status.Key] = status.Size
+		}
+	}
+	return out
+}
+
+func sourceObjectSize(sourceKey string, media mediaRow, statuses []keyStatus) int64 {
+	for _, status := range statuses {
+		if status.Key == sourceKey && status.Size > 0 {
+			return status.Size
+		}
+	}
+	if media.StorageKey.String == sourceKey && media.FileSize.Valid {
+		return media.FileSize.Int64
+	}
+	return 0
+}
+
+func sourceMimeType(sourceKey string, media mediaRow, statuses []keyStatus) string {
+	for _, status := range statuses {
+		if status.Key == sourceKey && status.ContentType != "" {
+			return status.ContentType
+		}
+	}
+	if media.MimeType.Valid && media.MimeType.String != "" {
+		return media.MimeType.String
+	}
+	for _, status := range statuses {
+		if status.ContentType != "" {
+			return status.ContentType
+		}
+	}
+	return imageVariantMimeType
+}
+
+func reconciledVariantSize(keys []string, existing map[string]int64, generated map[string]imageVariant) (int64, error) {
+	var total int64
+	for _, key := range keys {
+		if size, ok := existing[key]; ok {
+			total += size
+			continue
+		}
+		variant, ok := generated[key]
+		if !ok {
+			return 0, fmt.Errorf("missing variant size for %s", key)
+		}
+		total += int64(len(variant.Body))
+	}
+	return total, nil
+}
+
+func buildImageVariants(themeID, mediaID uuid.UUID, declaredMime string, payload []byte) ([]imageVariant, error) {
+	img, err := decodeImage(declaredMime, payload)
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+	specs := []struct {
+		name string
+		max  int
+	}{
+		{name: "master", max: 2048},
+		{name: "preview", max: 1280},
+		{name: "thumbnail", max: 360},
+	}
+	variants := make([]imageVariant, 0, len(specs))
+	for _, spec := range specs {
+		encoded, err := encodeWebP(resizeImageToMax(img, spec.max))
+		if err != nil {
+			return nil, fmt.Errorf("encode %s variant: %w", spec.name, err)
+		}
+		variants = append(variants, imageVariant{
+			Name:        spec.name,
+			Key:         imageVariantKey(themeID, mediaID, spec.name),
+			Body:        encoded,
+			ContentType: imageVariantMimeType,
+		})
+	}
+	return variants, nil
+}
+
+func decodeImage(declaredMime string, payload []byte) (image.Image, error) {
+	reader := bytes.NewReader(payload)
+	switch declaredMime {
+	case "image/jpeg":
+		return jpeg.Decode(reader)
+	case "image/png":
+		return png.Decode(reader)
+	case "image/webp":
+		return webp.Decode(reader)
+	default:
+		return nil, fmt.Errorf("unsupported image MIME %s", declaredMime)
+	}
+}
+
+func resizeImageToMax(src image.Image, maxDimension int) image.Image {
+	bounds := src.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+	if width <= 0 || height <= 0 || maxDimension <= 0 {
+		return src
+	}
+	if width <= maxDimension && height <= maxDimension {
+		return src
+	}
+	nextWidth := maxDimension
+	nextHeight := maxDimension
+	if width >= height {
+		nextHeight = max(1, height*maxDimension/width)
+	} else {
+		nextWidth = max(1, width*maxDimension/height)
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, nextWidth, nextHeight))
+	draw.CatmullRom.Scale(dst, dst.Bounds(), src, bounds, draw.Over, nil)
+	return dst
+}
+
+func encodeWebP(img image.Image) ([]byte, error) {
+	var buf bytes.Buffer
+	err := webp.Encode(&buf, img, &webp.Options{Quality: imageVariantQuality, Exact: true})
+	return buf.Bytes(), err
+}
+
 func fetchImageMedia(ctx context.Context, pool *pgxpool.Pool, themeID uuid.UUID) ([]mediaRow, error) {
 	rows, err := pool.Query(ctx, `
-SELECT id, name, storage_key, mime_type, file_size
+SELECT id, theme_id, name, storage_key, mime_type, file_size
 FROM theme_media
 WHERE theme_id = $1
   AND type = 'IMAGE'
@@ -322,7 +667,7 @@ ORDER BY sort_order, created_at, name
 	var media []mediaRow
 	for rows.Next() {
 		var row mediaRow
-		if err := rows.Scan(&row.ID, &row.Name, &row.StorageKey, &row.MimeType, &row.FileSize); err != nil {
+		if err := rows.Scan(&row.ID, &row.ThemeID, &row.Name, &row.StorageKey, &row.MimeType, &row.FileSize); err != nil {
 			return nil, fmt.Errorf("scan image media: %w", err)
 		}
 		media = append(media, row)
@@ -393,12 +738,12 @@ func imageVariantKey(themeID, mediaID uuid.UUID, variant string) string {
 	return fmt.Sprintf("themes/%s/media/%s/%s.webp", themeID, mediaID, variant)
 }
 
-func headKey(ctx context.Context, client *s3.Client, bucket string, key string) keyStatus {
+func (s s3ObjectStore) HeadObject(ctx context.Context, key string) keyStatus {
 	headCtx, cancel := context.WithTimeout(ctx, defaultHeadTimeout)
 	defer cancel()
 
-	resp, err := client.HeadObject(headCtx, &s3.HeadObjectInput{
-		Bucket: aws.String(bucket),
+	resp, err := s.client.HeadObject(headCtx, &s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
@@ -418,6 +763,61 @@ func headKey(ctx context.Context, client *s3.Client, bucket string, key string) 
 	return status
 }
 
+func (s s3ObjectStore) GetObject(ctx context.Context, key string, size int64) ([]byte, error) {
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	}
+	if size > 0 {
+		input.Range = aws.String(fmt.Sprintf("bytes=0-%d", size-1))
+	}
+	resp, err := s.client.GetObject(ctx, input)
+	if err != nil {
+		if isS3NotFound(err) {
+			return nil, errObjectMissing
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if size > 0 {
+		return io.ReadAll(io.LimitReader(resp.Body, size+1))
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func (s s3ObjectStore) PutObject(ctx context.Context, key string, body []byte, contentType string) error {
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(s.bucket),
+		Key:           aws.String(key),
+		Body:          bytes.NewReader(body),
+		ContentType:   aws.String(contentType),
+		ContentLength: aws.Int64(int64(len(body))),
+	})
+	return err
+}
+
+func (s s3ObjectStore) DeleteObjects(ctx context.Context, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	objects := make([]types.ObjectIdentifier, 0, len(keys))
+	for _, key := range keys {
+		objects = append(objects, types.ObjectIdentifier{Key: aws.String(key)})
+	}
+	resp, err := s.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(s.bucket),
+		Delete: &types.Delete{Objects: objects, Quiet: aws.Bool(true)},
+	})
+	if err != nil {
+		return err
+	}
+	if len(resp.Errors) > 0 {
+		first := resp.Errors[0]
+		return fmt.Errorf("%d objects failed to delete, first error: %s", len(resp.Errors), aws.ToString(first.Message))
+	}
+	return nil
+}
+
 func isS3NotFound(err error) bool {
 	var notFound *types.NotFound
 	var noSuchKey *types.NoSuchKey
@@ -435,12 +835,12 @@ func redactError(err error) string {
 	return msg
 }
 
-func listObjectKeys(ctx context.Context, client *s3.Client, bucket string, prefix string) ([]string, error) {
+func (s s3ObjectStore) ListObjectKeys(ctx context.Context, prefix string) ([]string, error) {
 	var keys []string
 	var token *string
 	for {
-		resp, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(bucket),
+		resp, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(s.bucket),
 			Prefix:            aws.String(prefix),
 			ContinuationToken: token,
 		})
@@ -459,20 +859,74 @@ func listObjectKeys(ctx context.Context, client *s3.Client, bucket string, prefi
 	return keys, nil
 }
 
+func (p pgMediaFileUpdater) UpdateMediaFile(ctx context.Context, media mediaRow, nextStorageKey string, nextFileSize int64, nextMimeType string) error {
+	tag, err := p.pool.Exec(ctx, `
+UPDATE theme_media
+SET source_type = 'FILE',
+    url = NULL,
+    storage_key = $4,
+    file_size = $5,
+    mime_type = $6,
+    duration = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND theme_id = $2
+  AND type = 'IMAGE'
+  AND source_type = 'FILE'
+  AND storage_key IS NOT DISTINCT FROM $3
+`, media.ID, media.ThemeID, nullableStringValue(media.StorageKey), nextStorageKey, nextFileSize, nextMimeType)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("media row not found or changed since audit")
+	}
+	return nil
+}
+
+func nullableStringValue(value sql.NullString) any {
+	if !value.Valid {
+		return nil
+	}
+	return value.String
+}
+
 func printTextReport(report auditReport) {
 	fmt.Printf("Theme: %s\n", report.ThemeID)
 	fmt.Printf("Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
-	fmt.Printf("Summary: media=%d character_refs=%d available=%d missing_all=%d unmatched_objects=%d\n\n",
+	fmt.Printf("Summary: media=%d character_refs=%d available=%d missing_all=%d unmatched_objects=%d legacy=%d variant_complete=%d backfill_eligible=%d missing_objects=%d backfilled=%d backfill_failed=%d\n\n",
 		report.Summary.MediaCount,
 		report.Summary.CharacterRefCount,
 		report.Summary.AvailableMediaCount,
 		report.Summary.MissingAllMediaCount,
 		report.Summary.UnmatchedObjectCount,
+		report.Summary.LegacyMediaCount,
+		report.Summary.VariantCompleteCount,
+		report.Summary.BackfillEligibleCount,
+		report.Summary.MissingObjectCount,
+		report.Summary.BackfilledCount,
+		report.Summary.BackfillFailedCount,
 	)
 	for _, media := range report.Media {
 		fmt.Printf("- media %s (%s): %s\n", media.MediaID, media.MediaName, media.Status)
 		if media.DBStorageKey != "" {
 			fmt.Printf("  db_storage_key: %s\n", media.DBStorageKey)
+		}
+		fmt.Printf("  legacy=%v backfill_eligible=%v applied=%v\n", media.IsLegacy, media.BackfillEligible, media.Applied)
+		if media.BackfillSourceKey != "" {
+			fmt.Printf("  backfill_source_key: %s\n", media.BackfillSourceKey)
+		}
+		if len(media.MissingVariantKeys) > 0 {
+			fmt.Printf("  missing_variant_keys: %s\n", strings.Join(media.MissingVariantKeys, ", "))
+		}
+		if len(media.MissingObjects) > 0 {
+			fmt.Printf("  missing_objects: %s\n", strings.Join(media.MissingObjects, ", "))
+		}
+		if media.ApplyError != "" {
+			fmt.Printf("  apply_error: %s\n", media.ApplyError)
+		}
+		if media.CleanupError != "" {
+			fmt.Printf("  cleanup_error: %s\n", media.CleanupError)
 		}
 		if len(media.CharacterRefs) > 0 {
 			fmt.Printf("  character_refs: %s\n", strings.Join(media.CharacterRefs, ", "))

--- a/apps/server/cmd/media-storage-audit/main_test.go
+++ b/apps/server/cmd/media-storage-audit/main_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -58,3 +62,313 @@ func TestCandidateKeysDedupesStorageKey(t *testing.T) {
 		t.Fatalf("candidateKeys() = %#v, want %#v", got, want)
 	}
 }
+
+func TestParseFlagsDefaultsToDryRunAndRequiresApplyOptIn(t *testing.T) {
+	dryRun := parseFlags([]string{"--theme-id", "c4a4b5ac-51c3-41c9-872e-d701d44ceee7"})
+	if dryRun.apply {
+		t.Fatal("default apply = true, want false")
+	}
+
+	apply := parseFlags([]string{"--theme-id", "c4a4b5ac-51c3-41c9-872e-d701d44ceee7", "--apply"})
+	if !apply.apply {
+		t.Fatal("--apply did not opt into writes")
+	}
+}
+
+func TestPlanMediaBackfillMarksLegacyEligibleFromOriginalObject(t *testing.T) {
+	themeID := uuid.MustParse("c4a4b5ac-51c3-41c9-872e-d701d44ceee7")
+	mediaID := uuid.MustParse("4b8a98b1-7d60-4941-b715-cfd2427fce4c")
+	legacyKey := "themes/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/media/4b8a98b1-7d60-4941-b715-cfd2427fce4c/uploads/original.jpg"
+
+	audit := planMediaBackfill(themeID, mediaRow{
+		ID:         mediaID,
+		Name:       "legacy portrait",
+		StorageKey: nullString(legacyKey),
+		MimeType:   nullString("image/jpeg"),
+		FileSize:   nullInt64(1234),
+	}, []keyStatus{
+		{Kind: "preview", Key: imageVariantKey(themeID, mediaID, "preview"), Exists: false},
+		{Kind: "master", Key: imageVariantKey(themeID, mediaID, "master"), Exists: false},
+		{Kind: "thumbnail", Key: imageVariantKey(themeID, mediaID, "thumbnail"), Exists: false},
+		{Kind: "db_storage_key", Key: legacyKey, Exists: true, Size: 1234, ContentType: "image/jpeg"},
+	})
+
+	if !audit.IsLegacy {
+		t.Fatal("IsLegacy = false, want true")
+	}
+	if !audit.BackfillEligible {
+		t.Fatal("BackfillEligible = false, want true")
+	}
+	if audit.BackfillSourceKey != legacyKey {
+		t.Fatalf("BackfillSourceKey = %q, want %q", audit.BackfillSourceKey, legacyKey)
+	}
+	if audit.Status != "legacy_backfill_eligible" {
+		t.Fatalf("Status = %q, want legacy_backfill_eligible", audit.Status)
+	}
+	wantMissing := []string{
+		imageVariantKey(themeID, mediaID, "master"),
+		imageVariantKey(themeID, mediaID, "preview"),
+		imageVariantKey(themeID, mediaID, "thumbnail"),
+	}
+	if !reflect.DeepEqual(audit.MissingVariantKeys, wantMissing) {
+		t.Fatalf("MissingVariantKeys = %#v, want %#v", audit.MissingVariantKeys, wantMissing)
+	}
+}
+
+func TestPlanMediaBackfillReportsMissingSourceAsIneligible(t *testing.T) {
+	themeID := uuid.MustParse("c4a4b5ac-51c3-41c9-872e-d701d44ceee7")
+	mediaID := uuid.MustParse("4b8a98b1-7d60-4941-b715-cfd2427fce4c")
+	legacyKey := "themes/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/media/4b8a98b1-7d60-4941-b715-cfd2427fce4c/uploads/original.jpg"
+
+	audit := planMediaBackfill(themeID, mediaRow{
+		ID:         mediaID,
+		Name:       "missing portrait",
+		StorageKey: nullString(legacyKey),
+		MimeType:   nullString("image/jpeg"),
+		FileSize:   nullInt64(1234),
+	}, []keyStatus{
+		{Kind: "preview", Key: imageVariantKey(themeID, mediaID, "preview"), Exists: false},
+		{Kind: "master", Key: imageVariantKey(themeID, mediaID, "master"), Exists: false},
+		{Kind: "thumbnail", Key: imageVariantKey(themeID, mediaID, "thumbnail"), Exists: false},
+		{Kind: "db_storage_key", Key: legacyKey, Exists: false},
+	})
+
+	if audit.BackfillEligible {
+		t.Fatal("BackfillEligible = true, want false")
+	}
+	if audit.BackfillSourceKey != "" {
+		t.Fatalf("BackfillSourceKey = %q, want empty", audit.BackfillSourceKey)
+	}
+	if audit.Status != "missing_source" {
+		t.Fatalf("Status = %q, want missing_source", audit.Status)
+	}
+	if len(audit.MissingObjects) == 0 {
+		t.Fatal("MissingObjects is empty, want source and variant keys reported")
+	}
+}
+
+func TestApplyMediaBackfillWritesVariantsBeforeDBAndSkipsExistingObjects(t *testing.T) {
+	ctx := context.Background()
+	themeID := uuid.MustParse("c4a4b5ac-51c3-41c9-872e-d701d44ceee7")
+	mediaID := uuid.MustParse("4b8a98b1-7d60-4941-b715-cfd2427fce4c")
+	masterKey := imageVariantKey(themeID, mediaID, "master")
+	legacyKey := "themes/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/media/4b8a98b1-7d60-4941-b715-cfd2427fce4c/uploads/original.jpg"
+	store := &fakeBackfillStorage{
+		objects: map[string][]byte{
+			legacyKey: []byte("source"),
+			masterKey: []byte("existing-master"),
+		},
+	}
+	db := &fakeBackfillDB{}
+	audit := mediaAudit{
+		MediaID:           mediaID.String(),
+		DBStorageKey:      legacyKey,
+		IsLegacy:          true,
+		BackfillEligible:  true,
+		BackfillSourceKey: legacyKey,
+		MissingVariantKeys: []string{
+			imageVariantKey(themeID, mediaID, "preview"),
+			imageVariantKey(themeID, mediaID, "thumbnail"),
+		},
+		Candidates: []keyStatus{
+			{Kind: "master", Key: masterKey, Exists: true, Size: int64(len("existing-master")), ContentType: imageVariantMimeType},
+		},
+	}
+
+	applied, err := applyMediaBackfill(ctx, store, db, themeID, mediaRow{ID: mediaID, ThemeID: themeID, StorageKey: nullString(legacyKey)}, audit, fakeBuildVariants)
+	if err != nil {
+		t.Fatalf("applyMediaBackfill() error = %v", err)
+	}
+	if !applied.Applied {
+		t.Fatal("Applied = false, want true")
+	}
+	if db.storageKey != masterKey {
+		t.Fatalf("updated storage key = %q, want %q", db.storageKey, masterKey)
+	}
+	if db.mimeType != imageVariantMimeType {
+		t.Fatalf("updated mime type = %q, want %q", db.mimeType, imageVariantMimeType)
+	}
+	if db.fileSize != int64(len("existing-master")+len("preview-body")+len("thumbnail-body")) {
+		t.Fatalf("updated file size = %d, want sum of master and generated variants", db.fileSize)
+	}
+	if _, ok := store.objects[masterKey]; !ok {
+		t.Fatal("existing master was deleted")
+	}
+	if bytes.Equal(store.objects[masterKey], []byte("master-body")) {
+		t.Fatal("existing master was overwritten")
+	}
+	if len(store.deleted) != 0 {
+		t.Fatalf("deleted keys = %v, want none", store.deleted)
+	}
+}
+
+func TestApplyMediaBackfillCleansNewVariantsWhenDBUpdateFails(t *testing.T) {
+	ctx := context.Background()
+	themeID := uuid.MustParse("c4a4b5ac-51c3-41c9-872e-d701d44ceee7")
+	mediaID := uuid.MustParse("4b8a98b1-7d60-4941-b715-cfd2427fce4c")
+	legacyKey := "themes/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/media/4b8a98b1-7d60-4941-b715-cfd2427fce4c/uploads/original.jpg"
+	store := &fakeBackfillStorage{objects: map[string][]byte{legacyKey: []byte("source")}}
+	db := &fakeBackfillDB{err: errors.New("db down")}
+	audit := mediaAudit{
+		MediaID:           mediaID.String(),
+		DBStorageKey:      legacyKey,
+		IsLegacy:          true,
+		BackfillEligible:  true,
+		BackfillSourceKey: legacyKey,
+		MissingVariantKeys: []string{
+			imageVariantKey(themeID, mediaID, "master"),
+			imageVariantKey(themeID, mediaID, "preview"),
+			imageVariantKey(themeID, mediaID, "thumbnail"),
+		},
+	}
+
+	_, err := applyMediaBackfill(ctx, store, db, themeID, mediaRow{ID: mediaID, ThemeID: themeID, StorageKey: nullString(legacyKey)}, audit, fakeBuildVariants)
+	if err == nil {
+		t.Fatal("applyMediaBackfill() error = nil, want error")
+	}
+	if _, ok := store.objects[legacyKey]; !ok {
+		t.Fatal("source object was deleted")
+	}
+	for _, key := range audit.MissingVariantKeys {
+		if _, ok := store.objects[key]; ok {
+			t.Fatalf("new variant %s was not cleaned up", key)
+		}
+	}
+	if len(store.deleted) != 3 {
+		t.Fatalf("deleted keys = %v, want three generated variants", store.deleted)
+	}
+}
+
+func TestApplyMediaBackfillReportsCleanupFailure(t *testing.T) {
+	ctx := context.Background()
+	themeID := uuid.MustParse("c4a4b5ac-51c3-41c9-872e-d701d44ceee7")
+	mediaID := uuid.MustParse("4b8a98b1-7d60-4941-b715-cfd2427fce4c")
+	legacyKey := "themes/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/media/4b8a98b1-7d60-4941-b715-cfd2427fce4c/uploads/original.jpg"
+	store := &fakeBackfillStorage{
+		objects:   map[string][]byte{legacyKey: []byte("source")},
+		deleteErr: errors.New("r2 delete down"),
+	}
+	db := &fakeBackfillDB{err: errors.New("db down")}
+	audit := mediaAudit{
+		MediaID:           mediaID.String(),
+		DBStorageKey:      legacyKey,
+		IsLegacy:          true,
+		BackfillEligible:  true,
+		BackfillSourceKey: legacyKey,
+		MissingVariantKeys: []string{
+			imageVariantKey(themeID, mediaID, "master"),
+		},
+	}
+
+	applied, err := applyMediaBackfill(ctx, store, db, themeID, mediaRow{ID: mediaID, ThemeID: themeID, StorageKey: nullString(legacyKey)}, audit, fakeBuildVariants)
+	if err == nil {
+		t.Fatal("applyMediaBackfill() error = nil, want error")
+	}
+	if applied.CleanupError == "" {
+		t.Fatal("CleanupError is empty, want cleanup failure in report")
+	}
+}
+
+func TestApplyMediaBackfillTreatsStaleRowUpdateAsFailure(t *testing.T) {
+	ctx := context.Background()
+	themeID := uuid.MustParse("c4a4b5ac-51c3-41c9-872e-d701d44ceee7")
+	mediaID := uuid.MustParse("4b8a98b1-7d60-4941-b715-cfd2427fce4c")
+	legacyKey := "themes/c4a4b5ac-51c3-41c9-872e-d701d44ceee7/media/4b8a98b1-7d60-4941-b715-cfd2427fce4c/uploads/original.jpg"
+	store := &fakeBackfillStorage{objects: map[string][]byte{legacyKey: []byte("source")}}
+	db := &fakeBackfillDB{
+		wantAuditedStorageKey: "different-key",
+		errOnStale:            errors.New("media row not found or changed since audit"),
+	}
+	audit := mediaAudit{
+		MediaID:           mediaID.String(),
+		DBStorageKey:      legacyKey,
+		IsLegacy:          true,
+		BackfillEligible:  true,
+		BackfillSourceKey: legacyKey,
+		MissingVariantKeys: []string{
+			imageVariantKey(themeID, mediaID, "master"),
+		},
+	}
+
+	_, err := applyMediaBackfill(ctx, store, db, themeID, mediaRow{ID: mediaID, ThemeID: themeID, StorageKey: nullString(legacyKey)}, audit, fakeBuildVariants)
+	if err == nil {
+		t.Fatal("applyMediaBackfill() error = nil, want stale row error")
+	}
+	if len(store.deleted) != 1 {
+		t.Fatalf("deleted keys = %v, want generated variant cleanup after stale row", store.deleted)
+	}
+}
+
+func nullString(value string) sqlNullString {
+	return sqlNullString{String: value, Valid: true}
+}
+
+func nullInt64(value int64) sqlNullInt64 {
+	return sqlNullInt64{Int64: value, Valid: true}
+}
+
+type fakeBackfillStorage struct {
+	objects   map[string][]byte
+	deleted   []string
+	deleteErr error
+}
+
+func (f *fakeBackfillStorage) GetObject(_ context.Context, key string, _ int64) ([]byte, error) {
+	body, ok := f.objects[key]
+	if !ok {
+		return nil, errObjectMissing
+	}
+	return append([]byte(nil), body...), nil
+}
+
+func (f *fakeBackfillStorage) PutObject(_ context.Context, key string, body []byte, _ string) error {
+	if f.objects == nil {
+		f.objects = make(map[string][]byte)
+	}
+	f.objects[key] = append([]byte(nil), body...)
+	return nil
+}
+
+func (f *fakeBackfillStorage) DeleteObjects(_ context.Context, keys []string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	for _, key := range keys {
+		delete(f.objects, key)
+		f.deleted = append(f.deleted, key)
+	}
+	return nil
+}
+
+type fakeBackfillDB struct {
+	storageKey            string
+	mimeType              string
+	fileSize              int64
+	err                   error
+	wantAuditedStorageKey string
+	errOnStale            error
+}
+
+func (f *fakeBackfillDB) UpdateMediaFile(_ context.Context, media mediaRow, storageKey string, fileSize int64, mimeType string) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.wantAuditedStorageKey != "" && media.StorageKey.String != f.wantAuditedStorageKey {
+		return f.errOnStale
+	}
+	f.storageKey = storageKey
+	f.fileSize = fileSize
+	f.mimeType = mimeType
+	return nil
+}
+
+func fakeBuildVariants(themeID, mediaID uuid.UUID, _ string, _ []byte) ([]imageVariant, error) {
+	return []imageVariant{
+		{Name: "master", Key: imageVariantKey(themeID, mediaID, "master"), Body: []byte("master-body"), ContentType: imageVariantMimeType},
+		{Name: "preview", Key: imageVariantKey(themeID, mediaID, "preview"), Body: []byte("preview-body"), ContentType: imageVariantMimeType},
+		{Name: "thumbnail", Key: imageVariantKey(themeID, mediaID, "thumbnail"), Body: []byte("thumbnail-body"), ContentType: imageVariantMimeType},
+	}, nil
+}
+
+type sqlNullString = sql.NullString
+type sqlNullInt64 = sql.NullInt64


### PR DESCRIPTION
## 요약
- R2 이미지 media row를 dry-run으로 진단하고, 명시적 `--apply`에서만 variant를 백필하는 `media-storage-audit` 경로를 추가했습니다.
- 백필은 master/preview/thumbnail WebP variant를 기준으로 보고하고, DB update는 감사 당시 `storage_key`가 유지된 row에만 적용합니다.
- 실패 시 이번 실행에서 새로 쓴 variant cleanup을 시도하고, cleanup 실패도 `cleanup_error`로 report에 노출합니다.

## 범위
- PR1 범위: `apps/server/cmd/media-storage-audit` command/test only
- API `image_url` 복구, `ListMedia` 최적화, frontend lazy loading은 후속 PR 범위입니다.
- Redis, scheduler/asynq, R2 bucket 설정 변경, legacy original object 삭제는 제외했습니다.

## Coverage Plan
- `main.go`: dry-run 기본값, `--apply` opt-in, legacy/missing/variant status planning, R2 write cleanup, stale row DB guard, DeleteObjects partial failure handling
- `main_test.go`: flag opt-in, eligible/ineligible planning, existing variant skip, DB failure cleanup, cleanup failure report, stale row update block

## Local validation
- `cd apps/server && go test -count=1 ./cmd/media-storage-audit` 통과
- `git diff --check -- apps/server/cmd/media-storage-audit/main.go apps/server/cmd/media-storage-audit/main_test.go` 통과
- `scripts/mmp-local-ci.sh quick` 통과
- 쓰기 없는 dry-run 통과: local Docker DB + R2, `--apply` 미사용
  - summary: `media_count=82`, `character_ref_count=5`, `available_media_count=77`, `missing_all_media_count=5`, `legacy_media_count=76`, `variant_complete_count=1`, `backfill_eligible_count=77`, `backfilled_count=0`, `backfill_failed_count=0`

## 후속 메모
- target theme의 character ref 5개는 모두 `missing_all` / `backfill_eligible=false`입니다. 같은 prefix 아래 unmatched object도 없어, 이번 PR의 백필 도구만으로 캐릭터 이미지가 즉시 복구되지는 않습니다. 후속 PR에서 public character resolver/ListMedia 최적화와 별도 media reconcile 판단을 이어갑니다.

Refs #722