### PR TITLE
fix(server): 미디어 URL 목록 조회 최적화

### DIFF
--- a/apps/server/internal/domain/editor/media_service.go
+++ b/apps/server/internal/domain/editor/media_service.go
@@ -210,7 +210,7 @@ func (s *mediaService) ListMedia(ctx context.Context, creatorID, themeID uuid.UU
 
 	out := make([]MediaResponse, 0, len(rows))
 	for _, m := range rows {
-		out = append(out, s.toMediaResponse(ctx, m))
+		out = append(out, s.toMediaListResponse(ctx, m))
 	}
 	return out, nil
 }
@@ -1014,6 +1014,40 @@ func (s *mediaService) toMediaResponse(ctx context.Context, m db.ThemeMedium) Me
 		resp.URL = masterURL
 	}
 	return resp
+}
+
+func (s *mediaService) toMediaListResponse(ctx context.Context, m db.ThemeMedium) MediaResponse {
+	resp := toMediaResponse(m)
+	if m.SourceType != SourceTypeFile || !m.StorageKey.Valid || s.storage == nil {
+		return resp
+	}
+
+	key := m.StorageKey.String
+	if m.Type == MediaTypeImage {
+		key = mediaListImageDownloadKey(m)
+	}
+	url, err := s.storage.GenerateDownloadURL(ctx, key, 15*time.Minute)
+	if err != nil {
+		s.logger.Warn().Err(err).Str("media_id", m.ID.String()).Str("storage_key", key).Msg("failed to generate media list URL")
+		return resp
+	}
+	resp.URL = &url
+	if m.Type == MediaTypeImage {
+		resp.ThumbnailURL = &url
+	}
+	return resp
+}
+
+func mediaListImageDownloadKey(m db.ThemeMedium) string {
+	if !m.StorageKey.Valid {
+		return ""
+	}
+	for _, variant := range []string{imageVariantMaster, imageVariantPreview, imageVariantThumbnail} {
+		if m.StorageKey.String == mediaImageVariantKey(m.ThemeID, m.ID, variant) {
+			return mediaImageVariantKey(m.ThemeID, m.ID, imageVariantThumbnail)
+		}
+	}
+	return m.StorageKey.String
 }
 
 func toMediaCategoryResponse(c db.ThemeMediaCategory) MediaCategoryResponse {

--- a/apps/server/internal/domain/editor/media_service_test.go
+++ b/apps/server/internal/domain/editor/media_service_test.go
@@ -630,6 +630,9 @@ type fakeStorageProvider struct {
 	rangeErr            error
 	putErrKeyContains   string
 	putErr              error
+	headCalls           int
+	downloadCalls       int
+	downloadKeys        []string
 }
 
 func newFakeStorageProvider() *fakeStorageProvider {
@@ -658,6 +661,8 @@ func (f *fakeStorageProvider) GenerateUploadURL(_ context.Context, key string, _
 }
 
 func (f *fakeStorageProvider) GenerateDownloadURL(_ context.Context, key string, _ time.Duration) (string, error) {
+	f.downloadCalls++
+	f.downloadKeys = append(f.downloadKeys, key)
 	if f.generateDownloadErr != nil {
 		return "", f.generateDownloadErr
 	}
@@ -677,6 +682,7 @@ func (f *fakeStorageProvider) PutObject(_ context.Context, key string, body io.R
 }
 
 func (f *fakeStorageProvider) HeadObject(_ context.Context, key string) (*storage.ObjectMeta, error) {
+	f.headCalls++
 	if f.headErr != nil {
 		return nil, f.headErr
 	}
@@ -2512,6 +2518,56 @@ func TestMediaService_ListMedia_FilterVariants(t *testing.T) {
 	}
 	if len(byCategory) != 1 || byCategory[0].ID != imageID {
 		t.Fatalf("unexpected category-filtered media: %#v", byCategory)
+	}
+}
+
+func TestMediaService_ListMedia_UsesLightweightImageURLs(t *testing.T) {
+	svc, q, creatorID, themeID := newMediaTestService(t)
+	st := newFakeStorageProvider()
+	svc.storage = st
+	imageID := seedFileMedia(q, themeID, MediaTypeImage)
+	media := q.media[imageID]
+	media.StorageKey = pgtype.Text{String: mediaImageVariantKey(themeID, imageID, imageVariantMaster), Valid: true}
+	q.media[imageID] = media
+	fileID := seedFileMedia(q, themeID, MediaTypeDocument)
+	fileMedia := q.media[fileID]
+	fileMedia.StorageKey = pgtype.Text{String: "themes/" + themeID.String() + "/media/" + fileID.String() + ".pdf", Valid: true}
+	fileMedia.MimeType = pgtype.Text{String: "application/pdf", Valid: true}
+	q.media[fileID] = fileMedia
+
+	mediaList, err := svc.ListMedia(context.Background(), creatorID, themeID, "", nil)
+	if err != nil {
+		t.Fatalf("ListMedia: %v", err)
+	}
+	if len(mediaList) != 2 {
+		t.Fatalf("len(mediaList) = %d, want 2", len(mediaList))
+	}
+	if st.headCalls != 0 {
+		t.Fatalf("HeadObject calls = %d, want 0 for list response", st.headCalls)
+	}
+	if st.downloadCalls != 2 {
+		t.Fatalf("GenerateDownloadURL calls = %d, want one per file-backed row", st.downloadCalls)
+	}
+
+	byID := map[uuid.UUID]MediaResponse{}
+	for _, item := range mediaList {
+		byID[item.ID] = item
+	}
+	imageResp := byID[imageID]
+	thumbnailKey := mediaImageVariantKey(themeID, imageID, imageVariantThumbnail)
+	if imageResp.URL == nil || *imageResp.URL != "https://download.example/"+thumbnailKey {
+		t.Fatalf("image url = %v, want thumbnail URL", imageResp.URL)
+	}
+	if imageResp.ThumbnailURL == nil || *imageResp.ThumbnailURL != *imageResp.URL {
+		t.Fatalf("thumbnail_url = %v, want same lightweight URL as url", imageResp.ThumbnailURL)
+	}
+	if imageResp.MasterURL != nil || imageResp.PreviewURL != nil {
+		t.Fatalf("list response should not generate full variant URLs: %#v", imageResp)
+	}
+
+	fileResp := byID[fileID]
+	if fileResp.URL == nil || *fileResp.URL != "https://download.example/"+fileMedia.StorageKey.String {
+		t.Fatalf("file url = %v, want storage key URL", fileResp.URL)
 	}
 }
 

--- a/apps/server/internal/domain/theme/mocks/mock_service.go
+++ b/apps/server/internal/domain/theme/mocks/mock_service.go
@@ -127,21 +127,6 @@ func (m *MockthemeQueries) EXPECT() *MockthemeQueriesMockRecorder {
 	return m.recorder
 }
 
-// GetMedia mocks base method.
-func (m *MockthemeQueries) GetMedia(ctx context.Context, id uuid.UUID) (db.ThemeMedium, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMedia", ctx, id)
-	ret0, _ := ret[0].(db.ThemeMedium)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMedia indicates an expected call of GetMedia.
-func (mr *MockthemeQueriesMockRecorder) GetMedia(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMedia", reflect.TypeOf((*MockthemeQueries)(nil).GetMedia), ctx, id)
-}
-
 // GetPublishedTheme mocks base method.
 func (m *MockthemeQueries) GetPublishedTheme(ctx context.Context, id uuid.UUID) (db.GetPublishedThemeRow, error) {
 	m.ctrl.T.Helper()
@@ -185,6 +170,21 @@ func (m *MockthemeQueries) GetPublishedThemeCharacters(ctx context.Context, them
 func (mr *MockthemeQueriesMockRecorder) GetPublishedThemeCharacters(ctx, themeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishedThemeCharacters", reflect.TypeOf((*MockthemeQueries)(nil).GetPublishedThemeCharacters), ctx, themeID)
+}
+
+// ListMediaByIDs mocks base method.
+func (m *MockthemeQueries) ListMediaByIDs(ctx context.Context, ids []uuid.UUID) ([]db.ThemeMedium, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMediaByIDs", ctx, ids)
+	ret0, _ := ret[0].([]db.ThemeMedium)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMediaByIDs indicates an expected call of ListMediaByIDs.
+func (mr *MockthemeQueriesMockRecorder) ListMediaByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMediaByIDs", reflect.TypeOf((*MockthemeQueries)(nil).ListMediaByIDs), ctx, ids)
 }
 
 // ListPublishedThemes mocks base method.

--- a/apps/server/internal/domain/theme/service.go
+++ b/apps/server/internal/domain/theme/service.go
@@ -78,7 +78,7 @@ type themeQueries interface {
 	GetPublishedThemeBySlug(ctx context.Context, slug string) (db.GetPublishedThemeBySlugRow, error)
 	ListPublishedThemes(ctx context.Context, arg db.ListPublishedThemesParams) ([]db.ListPublishedThemesRow, error)
 	GetPublishedThemeCharacters(ctx context.Context, themeID uuid.UUID) ([]db.GetPublishedThemeCharactersRow, error)
-	GetMedia(ctx context.Context, id uuid.UUID) (db.ThemeMedium, error)
+	ListMediaByIDs(ctx context.Context, ids []uuid.UUID) ([]db.ThemeMedium, error)
 }
 
 type service struct {
@@ -157,9 +157,10 @@ func (s *service) GetCharacters(ctx context.Context, themeID uuid.UUID) ([]Chara
 		return nil, apperror.Internal("failed to get characters")
 	}
 
+	imageMedia := s.listCharacterImageMedia(ctx, chars)
 	result := make([]CharacterResponse, 0, len(chars))
 	for _, c := range chars {
-		imageURL := s.resolveCharacterImageURL(ctx, c.ThemeID, textToPtr(c.ImageUrl), c.ImageMediaID)
+		imageURL := s.resolveCharacterImageURL(ctx, c.ThemeID, textToPtr(c.ImageUrl), c.ImageMediaID, imageMedia)
 		result = append(result, CharacterResponse{
 			ID:           c.ID,
 			Name:         c.Name,
@@ -172,14 +173,46 @@ func (s *service) GetCharacters(ctx context.Context, themeID uuid.UUID) ([]Chara
 	return result, nil
 }
 
-func (s *service) resolveCharacterImageURL(ctx context.Context, themeID uuid.UUID, currentURL *string, mediaID pgtype.UUID) *string {
+func (s *service) listCharacterImageMedia(ctx context.Context, chars []db.GetPublishedThemeCharactersRow) map[uuid.UUID]db.ThemeMedium {
+	if s.storage == nil {
+		return nil
+	}
+	seen := make(map[uuid.UUID]struct{})
+	ids := make([]uuid.UUID, 0, len(chars))
+	for _, c := range chars {
+		if textToPtr(c.ImageUrl) != nil || !c.ImageMediaID.Valid {
+			continue
+		}
+		id := uuid.UUID(c.ImageMediaID.Bytes)
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	mediaRows, err := s.queries.ListMediaByIDs(ctx, ids)
+	if err != nil {
+		s.logger.Warn().Err(err).Int("media_count", len(ids)).Msg("failed to list character image media")
+		return nil
+	}
+	mediaByID := make(map[uuid.UUID]db.ThemeMedium, len(mediaRows))
+	for _, media := range mediaRows {
+		mediaByID[media.ID] = media
+	}
+	return mediaByID
+}
+
+func (s *service) resolveCharacterImageURL(ctx context.Context, themeID uuid.UUID, currentURL *string, mediaID pgtype.UUID, mediaByID map[uuid.UUID]db.ThemeMedium) *string {
 	if currentURL != nil || !mediaID.Valid || s.storage == nil {
 		return currentURL
 	}
 	id := uuid.UUID(mediaID.Bytes)
-	media, err := s.queries.GetMedia(ctx, id)
-	if err != nil {
-		s.logger.Warn().Err(err).Stringer("media_id", id).Msg("failed to resolve character image media")
+	media, ok := mediaByID[id]
+	if !ok {
+		s.logger.Warn().Stringer("media_id", id).Msg("failed to resolve character image media")
 		return currentURL
 	}
 	if media.ThemeID != themeID {

--- a/apps/server/internal/domain/theme/service_public_character_test.go
+++ b/apps/server/internal/domain/theme/service_public_character_test.go
@@ -17,9 +17,12 @@ import (
 )
 
 type fakePublicThemeQueries struct {
-	theme      db.GetPublishedThemeRow
-	characters []db.GetPublishedThemeCharactersRow
-	media      map[uuid.UUID]db.ThemeMedium
+	theme               db.GetPublishedThemeRow
+	characters          []db.GetPublishedThemeCharactersRow
+	media               map[uuid.UUID]db.ThemeMedium
+	getMediaCalls       int
+	listMediaByIDsCalls int
+	listMediaByIDsIDs   []uuid.UUID
 }
 
 func (f *fakePublicThemeQueries) GetPublishedTheme(context.Context, uuid.UUID) (db.GetPublishedThemeRow, error) {
@@ -67,10 +70,23 @@ func (f *fakePublicThemeQueries) GetPublishedThemeCharacters(context.Context, uu
 }
 
 func (f *fakePublicThemeQueries) GetMedia(_ context.Context, mediaID uuid.UUID) (db.ThemeMedium, error) {
+	f.getMediaCalls++
 	if _, ok := f.media[mediaID]; !ok {
 		return db.ThemeMedium{}, pgx.ErrNoRows
 	}
 	return f.media[mediaID], nil
+}
+
+func (f *fakePublicThemeQueries) ListMediaByIDs(_ context.Context, mediaIDs []uuid.UUID) ([]db.ThemeMedium, error) {
+	f.listMediaByIDsCalls++
+	f.listMediaByIDsIDs = append([]uuid.UUID(nil), mediaIDs...)
+	out := make([]db.ThemeMedium, 0, len(mediaIDs))
+	for _, mediaID := range mediaIDs {
+		if media, ok := f.media[mediaID]; ok {
+			out = append(out, media)
+		}
+	}
+	return out, nil
 }
 
 type fakePublicThemeStorage struct {
@@ -239,6 +255,72 @@ func TestGetCharactersResolvesImageMediaURL(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fakeStorage.headKeys, expectedHeadKeys) {
 		t.Fatalf("HeadObject keys = %v, want %v", fakeStorage.headKeys, expectedHeadKeys)
+	}
+}
+
+func TestGetCharactersBatchLoadsImageMedia(t *testing.T) {
+	themeID := uuid.New()
+	firstMediaID := uuid.New()
+	secondMediaID := uuid.New()
+	firstStorageKey := "themes/" + themeID.String() + "/media/" + firstMediaID.String() + ".png"
+	secondStorageKey := "themes/" + themeID.String() + "/media/" + secondMediaID.String() + ".png"
+	q := &fakePublicThemeQueries{
+		theme: db.GetPublishedThemeRow{ID: themeID, Status: publishedStatus},
+		characters: []db.GetPublishedThemeCharactersRow{
+			{ID: uuid.New(), ThemeID: themeID, Name: "First", ImageMediaID: pgUUID(firstMediaID)},
+			{ID: uuid.New(), ThemeID: themeID, Name: "Second", ImageMediaID: pgUUID(secondMediaID)},
+		},
+		media: map[uuid.UUID]db.ThemeMedium{
+			firstMediaID: {
+				ID:         firstMediaID,
+				ThemeID:    themeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: firstStorageKey, Valid: true},
+			},
+			secondMediaID: {
+				ID:         secondMediaID,
+				ThemeID:    themeID,
+				Type:       "IMAGE",
+				SourceType: "FILE",
+				StorageKey: pgtype.Text{String: secondStorageKey, Valid: true},
+			},
+		},
+	}
+	fakeStorage := &fakePublicThemeStorage{
+		urls: map[string]string{
+			firstStorageKey:  "https://cdn.example.test/" + firstStorageKey,
+			secondStorageKey: "https://cdn.example.test/" + secondStorageKey,
+		},
+		existing: map[string]bool{
+			firstStorageKey:  true,
+			secondStorageKey: true,
+		},
+	}
+	svc := &service{
+		queries: q,
+		storage: fakeStorage,
+		logger:  zerolog.Nop(),
+	}
+
+	chars, err := svc.GetCharacters(context.Background(), themeID)
+	if err != nil {
+		t.Fatalf("GetCharacters returned error: %v", err)
+	}
+	if len(chars) != 2 {
+		t.Fatalf("len(chars) = %d, want 2", len(chars))
+	}
+	if q.getMediaCalls != 0 {
+		t.Fatalf("GetMedia calls = %d, want 0", q.getMediaCalls)
+	}
+	if q.listMediaByIDsCalls != 1 {
+		t.Fatalf("ListMediaByIDs calls = %d, want 1", q.listMediaByIDsCalls)
+	}
+	if !reflect.DeepEqual(q.listMediaByIDsIDs, []uuid.UUID{firstMediaID, secondMediaID}) {
+		t.Fatalf("ListMediaByIDs ids = %v, want first and second media ids", q.listMediaByIDsIDs)
+	}
+	if chars[0].ImageURL == nil || chars[1].ImageURL == nil {
+		t.Fatalf("expected both image URLs to resolve: %#v", chars)
 	}
 }
 


### PR DESCRIPTION
## 요약
- 에디터 ListMedia 목록 응답에서 이미지별 3종 variant HeadObject 확인을 제거하고 file-backed row당 presigned URL 1회만 생성하도록 변경했습니다.
- 공개 캐릭터 API의 image_media_id 조회를 캐릭터별 GetMedia 반복에서 ListMediaByIDs 배치 조회로 바꿨습니다.
- missing object, cross-theme media, 기존 image_url 보존 동작은 그대로 유지했습니다.

## Coverage Plan
- editor MediaService ListMedia: 이미지 variant storage_key일 때 목록 URL은 thumbnail 후보 1개만 생성하고 HeadObject는 호출하지 않는지 단위 테스트로 검증합니다.
- public theme GetCharacters: 여러 캐릭터의 image_media_id를 ListMediaByIDs 1회로 조회하고 기존 fallback 동작을 유지하는지 단위 테스트로 검증합니다.
- generated mock: themeQueries 인터페이스 변경에 맞춰 mock_service.go를 go generate 결과와 일치시킵니다.

## Local validation
- cd apps/server && go test -count=1 ./internal/domain/editor ./internal/domain/theme: 통과
- git diff --check -- apps/server/internal/domain/editor/media_service.go apps/server/internal/domain/editor/media_service_test.go apps/server/internal/domain/theme/service.go apps/server/internal/domain/theme/service_public_character_test.go: 통과
- scripts/mmp-local-ci.sh quick: 통과 (기존 lint warning 및 bundle size warning만 출력)

Refs #722