### PR TITLE
fix(web): 이미지 선택기 지연 로딩

### DIFF
--- a/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
+++ b/apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { X } from 'lucide-react';
 
 import { MediaPicker } from '@/features/editor/components/media/MediaPicker';
-import { useMediaDownloadUrl, useMediaList, type MediaResponse } from '@/features/editor/mediaApi';
-import { getMediaThumbnailUrl, hasPublicMediaUrl, MediaTypeIcon } from './mediaVisuals';
+import { useMediaDownloadUrl, type MediaResponse } from '@/features/editor/mediaApi';
+import { MediaTypeIcon } from './mediaVisuals';
 
 interface ImageMediaReferenceFieldProps {
   themeId: string;
@@ -34,27 +34,15 @@ export function ImageMediaReferenceField({
 }: ImageMediaReferenceFieldProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [previewFailed, setPreviewFailed] = useState(false);
-  const { data: images = [] } = useMediaList(themeId, 'IMAGE');
-  const selectedImage = images.find((media) => media.id === imageMediaId) ?? null;
-  const hasPublicImageUrl = selectedImage ? hasPublicMediaUrl(selectedImage) : false;
-  const shouldLoadFileImagePreview =
-    selectedImage?.type === 'IMAGE' && selectedImage.source_type === 'FILE' && !hasPublicImageUrl;
-  const { data: fileImagePreview } = useMediaDownloadUrl(
-    shouldLoadFileImagePreview ? selectedImage.id : undefined,
-  );
-  const previewUrl = selectedImage
-    ? getMediaThumbnailUrl({
-        ...selectedImage,
-        url: selectedImage.url ?? fileImagePreview?.url,
-      })
-    : null;
+  const { data: fileImagePreview } = useMediaDownloadUrl(imageMediaId ?? undefined);
+  const previewUrl = fileImagePreview?.url ?? null;
   const shouldRenderPreview = Boolean(previewUrl) && !previewFailed;
 
   useEffect(() => {
     setPreviewFailed(false);
   }, [previewUrl, imageMediaId]);
 
-  const picker = (
+  const picker = pickerOpen ? (
     <MediaPicker
       open={pickerOpen}
       onClose={() => setPickerOpen(false)}
@@ -64,7 +52,7 @@ export function ImageMediaReferenceField({
       selectedId={imageMediaId}
       title={pickerTitle ?? `${label} 선택`}
     />
-  );
+  ) : null;
 
   if (imageMediaId) {
     return (
@@ -82,7 +70,7 @@ export function ImageMediaReferenceField({
             {shouldRenderPreview ? (
               <img
                 src={previewUrl ?? undefined}
-                alt={`${selectedImage?.name ?? '선택된 이미지'} 미리보기`}
+                alt={`${label} 미리보기`}
                 className="h-full w-full object-contain"
                 loading="lazy"
                 onError={() => setPreviewFailed(true)}

--- a/apps/web/src/features/editor/components/media/MediaPicker.tsx
+++ b/apps/web/src/features/editor/components/media/MediaPicker.tsx
@@ -51,12 +51,13 @@ export function MediaPicker({
     [useCase],
   );
   const queryType = filterType ?? (allowedTypes.length === 1 ? allowedTypes[0] : undefined);
+  const activeThemeId = open ? themeId : "";
   const { data: media = [], isLoading } = useMediaList(
-    themeId,
+    activeThemeId,
     queryType,
     categoryId ?? undefined,
   );
-  const { data: categories = [] } = useMediaCategories(themeId);
+  const { data: categories = [] } = useMediaCategories(activeThemeId);
 
   useEffect(() => {
     if (!open) {

--- a/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx
@@ -49,13 +49,6 @@ afterEach(() => cleanup());
 
 describe("ImageMediaReferenceField", () => {
   it("선택 상태는 이미지 타일 위 overlay group에 교체와 제거를 항상 표시한다", () => {
-    const longName = "아주 긴 파일 이름이 레이아웃을 밀어내면 안 되는 단서 이미지 파일.webp";
-    useMediaListMock.mockReturnValue({
-      data: [{ ...imageMedia, name: longName, preview_url: "https://cdn.example/preview.webp" }],
-      isLoading: false,
-      isError: false,
-    });
-
     render(
       <ImageMediaReferenceField
         themeId="theme-1"
@@ -77,11 +70,11 @@ describe("ImageMediaReferenceField", () => {
     expect(screen.getByRole("button", { name: "단서 이미지 교체" }).className).toContain(
       "focus-visible:ring-2",
     );
-    expect(screen.queryByText(longName)).toBeNull();
     expect(screen.getByRole("button", { name: "단서 이미지 제거" }).className).toContain(
       "focus-visible:ring-2",
     );
-    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
+    expect(useMediaListMock).not.toHaveBeenCalled();
+    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith("image-1");
   });
 
   it("overlay 제거 버튼은 picker를 열지 않고 onClear만 호출한다", () => {
@@ -126,13 +119,7 @@ describe("ImageMediaReferenceField", () => {
     expect(screen.queryByText("미디어 선택")).toBeNull();
   });
 
-  it("공개 master_url이 있으면 다운로드 URL 없이 선택 이미지 프리뷰를 보여준다", () => {
-    useMediaListMock.mockReturnValue({
-      data: [{ ...imageMedia, master_url: "https://cdn.example/master.webp" }],
-      isLoading: false,
-      isError: false,
-    });
-
+  it("선택된 이미지는 전체 IMAGE 목록 없이 단건 다운로드 URL로 프리뷰를 보여준다", () => {
     render(
       <ImageMediaReferenceField
         themeId="theme-1"
@@ -143,27 +130,10 @@ describe("ImageMediaReferenceField", () => {
       />,
     );
 
-    const preview = screen.getByAltText("우산걸이 미리보기") as HTMLImageElement;
-    expect(preview.getAttribute("src")).toBe("https://cdn.example/master.webp");
-    expect(useMediaDownloadUrlMock).toHaveBeenCalledWith(undefined);
-    expect(useMediaDownloadUrlMock).not.toHaveBeenCalledWith("image-1");
-  });
-
-  it("선택된 FILE 이미지는 다운로드 URL로 프리뷰를 보여준다", () => {
-    render(
-      <ImageMediaReferenceField
-        themeId="theme-1"
-        label="단서 이미지"
-        imageMediaId="image-1"
-        onSelect={vi.fn()}
-        onClear={vi.fn()}
-      />,
-    );
-
-    expect(useMediaListMock).toHaveBeenCalledWith("theme-1", "IMAGE");
+    expect(useMediaListMock).not.toHaveBeenCalled();
     expect(useMediaDownloadUrlMock).toHaveBeenCalledWith("image-1");
 
-    const preview = screen.getByAltText("우산걸이 미리보기") as HTMLImageElement;
+    const preview = screen.getByAltText("단서 이미지 미리보기") as HTMLImageElement;
     expect(preview.getAttribute("src")).toBe("https://download.example/umbrella.webp");
   });
 
@@ -178,9 +148,9 @@ describe("ImageMediaReferenceField", () => {
       />,
     );
 
-    fireEvent.error(screen.getByAltText("우산걸이 미리보기"));
+    fireEvent.error(screen.getByAltText("단서 이미지 미리보기"));
 
     screen.getByLabelText("이미지");
-    expect(screen.queryByAltText("우산걸이 미리보기")).toBeNull();
+    expect(screen.queryByAltText("단서 이미지 미리보기")).toBeNull();
   });
 });

--- a/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
+++ b/apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx
@@ -140,6 +140,9 @@ describe("MediaPicker", () => {
       />,
     );
     expect(container.firstChild).toBeNull();
+    expect(useMediaListMock).toHaveBeenCalledWith("", undefined, undefined);
+    expect(useMediaCategoriesMock).toHaveBeenCalledWith("");
+    expect(useMediaDownloadUrlsMock).toHaveBeenCalledWith([]);
   });
 
   it("열렸을 때 미디어 목록을 렌더링한다", () => {


### PR DESCRIPTION
## 요약
- ImageMediaReferenceField가 렌더 직후 전체 IMAGE 미디어 목록을 조회하지 않도록 제거했습니다.
- 선택된 이미지 프리뷰는 media id 단건 download-url만 사용하고, 전체 목록은 picker를 실제로 열 때 MediaPicker가 가져오도록 유지했습니다.
- MediaPicker가 닫혀 있을 때 media/categories query가 비활성화되도록 activeThemeId를 빈 값으로 전달합니다.

## Coverage Plan
- ImageMediaReferenceField: 선택된 이미지가 있어도 전체 IMAGE 목록을 호출하지 않고 단건 download-url만 호출하는지 컴포넌트 테스트로 검증합니다.
- MediaPicker: 닫힌 상태에서는 렌더링이 없고 media/categories/download-url batch가 비활성화되는지 테스트로 검증합니다.
- quick gate: 전체 로컬 quick 검증으로 lint/typecheck/test/build까지 확인합니다.

## Local validation
- pnpm --filter @mmp/web test -- --run src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx src/features/editor/components/media/__tests__/MediaPicker.test.tsx: 통과 (2 files / 22 tests)
- git diff --check -- apps/web/src/features/editor/components/media/ImageMediaReferenceField.tsx apps/web/src/features/editor/components/media/MediaPicker.tsx apps/web/src/features/editor/components/media/__tests__/ImageMediaReferenceField.test.tsx apps/web/src/features/editor/components/media/__tests__/MediaPicker.test.tsx: 통과
- scripts/mmp-local-ci.sh quick: 통과 (기존 lint warning 및 bundle size warning만 출력)

Refs #722